### PR TITLE
[Feature]Use jprotobuf-precompile-plugin for starrocks

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -77,9 +77,12 @@ if [[ -z ${JAVA_HOME} ]]; then
     if command -v javac &> /dev/null; then
         export JAVA_HOME="$(dirname $(dirname $(readlink -f $(which javac))))"
         echo "Infered JAVA_HOME=$JAVA_HOME"
+    elif command -v java &> /dev/null; then
+        export JAVA_HOME="$(dirname $(dirname $(readlink -f $(which java))))"
     else
       cat << EOF
-Error: The environment variable JAVA_HOME is not set. The FE program requires JDK version $MIN_JDK_VERSION or higher in order to run.
+Error: The environment variable JAVA_HOME is not set, and neither JDK or JRE is found.
+The FE program requires JDK/JRE version $MIN_JDK_VERSION  or higher in order to run.
 Please take the following steps to resolve this issue:
 1. Install OpenJDK $MIN_JDK_VERSION or higher using your Linux distribution's package manager,
    or following the openjdk installation instructions at https://openjdk.org/install/
@@ -87,19 +90,11 @@ Please take the following steps to resolve this issue:
    For example:
    export JAVA_HOME=/usr/lib/jvm/java-$MIN_JDK_VERSION
 3. Try running this script again.
+Note: If you are using a JRE environment, you should set your JAVA_HOME to your JRE directory.
+For full development tools, JDK is recommended.
 EOF
       exit 1
     fi
-fi
-
-# cannot be jre
-if [ ! -f "$JAVA_HOME/bin/javac" ]; then
-  cat << EOF
-Error: It appears that your JAVA_HOME environment variable is pointing to a non-JDK path: $JAVA_HOME
-The FE program requires the full JDK to be installed and configured properly. Please check that JAVA_HOME
-is set to the installation directory of JDK $MIN_JDK_VERSION or higher, rather than the JRE installation directory.
-EOF
-  exit 1
 fi
 
 JAVA=$JAVA_HOME/bin/java

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -231,6 +231,16 @@ under the License.
         <dependency>
             <groupId>com.baidu</groupId>
             <artifactId>jprotobuf-precompile-plugin</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf-rpc-common -->
@@ -577,6 +587,10 @@ under the License.
                 <exclusion>
                     <artifactId>orc-core</artifactId>
                     <groupId>org.apache.orc</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -1037,7 +1051,7 @@ under the License.
             <plugin>
                 <groupId>com.baidu</groupId>
                 <artifactId>jprotobuf-precompile-plugin</artifactId>
-                <version>2.2.6</version>
+                <version>2.2.12</version>
                 <configuration>
                     <filterClassPackage>com.starrocks</filterClassPackage>
                     <generateProtoFile>true</generateProtoFile>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -227,6 +227,12 @@ under the License.
             <classifier>jar-with-dependencies</classifier>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf-precompile-plugin -->
+        <dependency>
+            <groupId>com.baidu</groupId>
+            <artifactId>jprotobuf-precompile-plugin</artifactId>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf-rpc-common -->
         <dependency>
             <groupId>com.baidu</groupId>
@@ -567,13 +573,18 @@ under the License.
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
-            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <artifactId>orc-core</artifactId>
                     <groupId>org.apache.orc</groupId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!--  https://mvnrepository.com/artifact/org.apache.spark/spark-catalyst_2.12 -->
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_2.12</artifactId>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.uuid/java-uuid-generator -->
@@ -1022,6 +1033,25 @@ under the License.
     <build>
         <finalName>starrocks-fe</finalName>
         <plugins>
+            <!-- fe proto precompile plugin-->
+            <plugin>
+                <groupId>com.baidu</groupId>
+                <artifactId>jprotobuf-precompile-plugin</artifactId>
+                <version>2.2.6</version>
+                <configuration>
+                    <filterClassPackage>com.starrocks</filterClassPackage>
+                    <generateProtoFile>true</generateProtoFile>
+                    <compileDependencies>true</compileDependencies>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>precompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- fe ut coverage-->
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -1148,7 +1178,7 @@ under the License.
                         <id>generate-sources</id>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="ant.python" value="${python}"/>
                                 <mkdir dir="${basedir}/target/generated-sources/proto"/>
                                 <exec executable="${java.home}/bin/java">
@@ -1202,7 +1232,7 @@ under the License.
                                     <arg value="--java"/>
                                     <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
                                 </exec>
-                            </tasks>
+                            </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -589,8 +589,8 @@ under the License.
                     <groupId>org.apache.orc</groupId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-mapreduce</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -595,6 +595,17 @@ under the License.
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.orc</groupId>
+            <artifactId>orc-mapreduce</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!--  https://mvnrepository.com/artifact/org.apache.spark/spark-catalyst_2.12 -->
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BrpcProxy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BrpcProxy.java
@@ -15,8 +15,6 @@
 
 package com.starrocks.rpc;
 
-import com.baidu.bjf.remoting.protobuf.utils.JDKCompilerHelper;
-import com.baidu.bjf.remoting.protobuf.utils.compiler.JdkCompiler;
 import com.baidu.jprotobuf.pbrpc.client.ProtobufRpcProxy;
 import com.baidu.jprotobuf.pbrpc.transport.RpcClient;
 import com.baidu.jprotobuf.pbrpc.transport.RpcClientOptions;
@@ -30,17 +28,6 @@ public class BrpcProxy {
     // TODO: Eviction
     private final ConcurrentHashMap<TNetworkAddress, PBackendService> backendServiceMap;
     private final ConcurrentHashMap<TNetworkAddress, LakeService> lakeServiceMap;
-
-    static {
-        String javaMajorVersion = "11";
-        try {
-            javaMajorVersion = System.getProperty("java.version").split("\\.")[0];
-        } catch (Exception e) {
-            // ignore
-        }
-        JDKCompilerHelper
-                .setCompiler(new JdkCompiler(JdkCompiler.class.getClassLoader(), javaMajorVersion));
-    }
 
     public BrpcProxy() {
         final RpcClientOptions rpcOptions = new RpcClientOptions();

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -348,6 +348,7 @@ under the License.
                 <groupId>com.baidu</groupId>
                 <artifactId>jprotobuf-precompile-plugin</artifactId>
                 <version>2.2.12</version>
+                <scope>provided</scope>
             </dependency>
 
             <dependency>
@@ -431,6 +432,14 @@ under the License.
                 <artifactId>netty-all</artifactId>
                 <!--same with hadoop 3.4.0-->
                 <version>4.1.100.Final</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/org.apache.orc/orc-mapreduce/1.8.7 -->
+            <dependency>
+                <groupId>org.apache.orc</groupId>
+                <artifactId>orc-mapreduce</artifactId>
+                <version>1.8.7</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -343,6 +343,13 @@ under the License.
                 <version>1.9</version>
             </dependency>
 
+            <!-- https://mvnrepository.com/artifact/com.baidu/jprotobuf-precompile-plugin -->
+            <dependency>
+                <groupId>com.baidu</groupId>
+                <artifactId>jprotobuf-precompile-plugin</artifactId>
+                <version>2.2.6</version>
+            </dependency>
+
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
@@ -543,7 +550,6 @@ under the License.
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-sql_2.12</artifactId>
                 <version>${spark.version}</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-catalyst -->
@@ -551,7 +557,6 @@ under the License.
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-catalyst_2.12</artifactId>
                 <version>${spark.version}</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/io.trino.hive/hive-apache -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -347,7 +347,7 @@ under the License.
             <dependency>
                 <groupId>com.baidu</groupId>
                 <artifactId>jprotobuf-precompile-plugin</artifactId>
-                <version>2.2.6</version>
+                <version>2.2.12</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Why I'm doing:
The jprotobuf code generation plug-in used by StarRocks provides a pre-compiled alternative, eliminating the need for runtime code generation via the JDK’s compilation API. This improvement enhances the efficiency of RPC information transmission.
## What I'm doing:
Add the precompile plugin to the pom file and modify the current compilation check.
Fixes #50684 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
