### PR TITLE
[Enhancement] Partial update support const expr

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -77,6 +77,9 @@ void OlapTableIndexSchema::to_protobuf(POlapTableIndexSchema* pindex) const {
     if (column_param != nullptr) {
         column_param->to_protobuf(pindex->mutable_column_param());
     }
+    for (auto& [name, value] : column_to_value) {
+        pindex->mutable_column_to_value()->insert({name, value});
+    }
 }
 
 Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
@@ -120,6 +123,12 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
         } else {
             index->schema_id = p_index.id();
         }
+
+        
+        for (auto& entry : p_index.column_to_value()) {
+            index->column_to_value.insert({entry.first, entry.second});
+        }
+        
         _indexes.emplace_back(index);
     }
 
@@ -172,6 +181,12 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema, RuntimeS
         } else {
             // schema id is same with index id in previous version, for compatibility
             index->schema_id = t_index.id;
+        }
+
+        if (t_index.__isset.column_to_value) {
+            for (auto& entry : t_index.column_to_value) {
+                index->column_to_value.insert({entry.first, entry.second});
+            }
         }
         _indexes.emplace_back(index);
     }

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -77,8 +77,8 @@ void OlapTableIndexSchema::to_protobuf(POlapTableIndexSchema* pindex) const {
     if (column_param != nullptr) {
         column_param->to_protobuf(pindex->mutable_column_param());
     }
-    for (auto& [name, value] : column_to_value) {
-        pindex->mutable_column_to_value()->insert({name, value});
+    for (auto& [name, value] : column_to_expr_value) {
+        pindex->mutable_column_to_expr_value()->insert({name, value});
     }
 }
 
@@ -124,11 +124,10 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
             index->schema_id = p_index.id();
         }
 
-        
-        for (auto& entry : p_index.column_to_value()) {
-            index->column_to_value.insert({entry.first, entry.second});
+        for (auto& entry : p_index.column_to_expr_value()) {
+            index->column_to_expr_value.insert({entry.first, entry.second});
         }
-        
+
         _indexes.emplace_back(index);
     }
 
@@ -183,9 +182,9 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema, RuntimeS
             index->schema_id = t_index.id;
         }
 
-        if (t_index.__isset.column_to_value) {
-            for (auto& entry : t_index.column_to_value) {
-                index->column_to_value.insert({entry.first, entry.second});
+        if (t_index.__isset.column_to_expr_value) {
+            for (auto& entry : t_index.column_to_expr_value) {
+                index->column_to_expr_value.insert({entry.first, entry.second});
             }
         }
         _indexes.emplace_back(index);

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -49,6 +50,7 @@ struct OlapTableIndexSchema {
     int32_t schema_hash;
     OlapTableColumnParam* column_param;
     ExprContext* where_clause = nullptr;
+    std::map<std::string, std::string> column_to_value;
 
     void to_protobuf(POlapTableIndexSchema* pindex) const;
 };

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -50,7 +50,7 @@ struct OlapTableIndexSchema {
     int32_t schema_hash;
     OlapTableColumnParam* column_param;
     ExprContext* where_clause = nullptr;
-    std::map<std::string, std::string> column_to_value;
+    std::map<std::string, std::string> column_to_expr_value;
 
     void to_protobuf(POlapTableIndexSchema* pindex) const;
 };

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -233,6 +233,7 @@ private:
     lake::DeltaWriterFinishMode _finish_mode{lake::DeltaWriterFinishMode::kWriteTxnLog};
     TxnLogCollector _txn_log_collector;
     std::set<int64_t> _immutable_partition_ids;
+    std::map<string, string> _column_to_expr_value;
 
     // Profile counters
     // Number of tablets
@@ -300,6 +301,16 @@ Status LakeTabletsChannel::open(const PTabletWriterOpenRequest& params, PTabletW
         _num_remaining_senders.store(params.num_senders(), std::memory_order_release);
         _num_initial_senders.store(params.num_senders(), std::memory_order_release);
     }
+
+    for (auto& index_schema : params.schema().indexes()) {
+        if (index_schema.id() != _index_id) {
+            continue;
+        }
+        for (auto& entry : index_schema.column_to_expr_value()) {
+            _column_to_expr_value.insert({entry.first, entry.second});
+        }
+    }
+
     RETURN_IF_ERROR(_create_delta_writers(params, false));
 
     for (auto& [id, writer] : _delta_writers) {
@@ -673,6 +684,7 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
                                               .set_mem_tracker(_mem_tracker)
                                               .set_schema_id(schema_id)
                                               .set_partial_update_mode(params.partial_update_mode())
+                                              .set_column_to_expr_value(&_column_to_expr_value)
                                               .build());
         _delta_writers.emplace(tablet.tablet_id(), std::move(writer));
         tablet_ids.emplace_back(tablet.tablet_id());

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -109,10 +109,10 @@ Status LocalTabletsChannel::open(const PTabletWriterOpenRequest& params, PTablet
         if (index_schema.id() != _index_id) {
             continue;
         }
-        for (auto& entry : index_schema.column_to_value()) {
-            _column_to_value.insert({entry.first, entry.second});
+        for (auto& entry : index_schema.column_to_expr_value()) {
+            _column_to_expr_value.insert({entry.first, entry.second});
         }
-    }    
+    }
 
     RETURN_IF_ERROR(_open_all_writers(params));
 
@@ -668,7 +668,7 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
         options.write_quorum = params.write_quorum();
         options.miss_auto_increment_column = params.miss_auto_increment_column();
         options.ptable_schema_param = &(params.schema());
-        options.column_to_value = &(_column_to_value);
+        options.column_to_expr_value = &(_column_to_expr_value);
         if (params.is_replicated_storage()) {
             for (auto& replica : tablet.replicas()) {
                 options.replicas.emplace_back(replica);
@@ -866,6 +866,7 @@ Status LocalTabletsChannel::incremental_open(const PTabletWriterOpenRequest& par
         options.miss_auto_increment_column = params.miss_auto_increment_column();
         options.ptable_schema_param = &(params.schema());
         options.immutable_tablet_size = params.immutable_tablet_size();
+        options.column_to_expr_value = &(_column_to_expr_value);
         if (params.is_replicated_storage()) {
             for (auto& replica : tablet.replicas()) {
                 options.replicas.emplace_back(replica);

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -105,6 +105,14 @@ Status LocalTabletsChannel::open(const PTabletWriterOpenRequest& params, PTablet
         _num_remaining_senders.store(params.num_senders(), std::memory_order_release);
         _num_initial_senders.store(params.num_senders(), std::memory_order_release);
     }
+    for (auto& index_schema : params.schema().indexes()) {
+        if (index_schema.id() != _index_id) {
+            continue;
+        }
+        for (auto& entry : index_schema.column_to_value()) {
+            _column_to_value.insert({entry.first, entry.second});
+        }
+    }    
 
     RETURN_IF_ERROR(_open_all_writers(params));
 
@@ -660,6 +668,7 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
         options.write_quorum = params.write_quorum();
         options.miss_auto_increment_column = params.miss_auto_increment_column();
         options.ptable_schema_param = &(params.schema());
+        options.column_to_value = &(_column_to_value);
         if (params.is_replicated_storage()) {
             for (auto& replica : tablet.replicas()) {
                 options.replicas.emplace_back(replica);

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -223,7 +223,7 @@ private:
 
     std::set<int64_t> _immutable_partition_ids;
 
-    std::map<string, string> _column_to_value;
+    std::map<string, string> _column_to_expr_value;
 
     // Profile counters
     // replicated_storage=false, the number of tablets

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -223,6 +223,8 @@ private:
 
     std::set<int64_t> _immutable_partition_ids;
 
+    std::map<string, string> _column_to_value;
+
     // Profile counters
     // replicated_storage=false, the number of tablets
     // replicated_storage=true, the number of primary tablets

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -308,7 +308,7 @@ Status DeltaWriter::_init() {
         writer_context.full_tablet_schema = _tablet_schema;
         writer_context.is_partial_update = true;
         writer_context.partial_update_mode = _opt.partial_update_mode;
-        writer_context.column_to_value = _opt.column_to_value;
+        writer_context.column_to_expr_value = _opt.column_to_expr_value;
         _tablet_schema = partial_update_schema;
     } else {
         if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && !_opt.merge_condition.empty()) {

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -308,6 +308,7 @@ Status DeltaWriter::_init() {
         writer_context.full_tablet_schema = _tablet_schema;
         writer_context.is_partial_update = true;
         writer_context.partial_update_mode = _opt.partial_update_mode;
+        writer_context.column_to_value = _opt.column_to_value;
         _tablet_schema = partial_update_schema;
     } else {
         if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && !_opt.merge_condition.empty()) {

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -71,7 +71,7 @@ struct DeltaWriterOptions {
     // If you need to access it after intialization, please make sure the pointer is valid.
     const POlapTableSchemaParam* ptable_schema_param = nullptr;
     int64_t immutable_tablet_size = 0;
-    std::map<string, string>* column_to_expr_value;
+    std::map<string, string>* column_to_expr_value = nullptr;
 };
 
 enum State {

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -71,6 +71,7 @@ struct DeltaWriterOptions {
     // If you need to access it after intialization, please make sure the pointer is valid.
     const POlapTableSchemaParam* ptable_schema_param = nullptr;
     int64_t immutable_tablet_size = 0;
+    std::map<string, string>* column_to_value;
 };
 
 enum State {

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -71,7 +71,7 @@ struct DeltaWriterOptions {
     // If you need to access it after intialization, please make sure the pointer is valid.
     const POlapTableSchemaParam* ptable_schema_param = nullptr;
     int64_t immutable_tablet_size = 0;
-    std::map<string, string>* column_to_value;
+    std::map<string, string>* column_to_expr_value;
 };
 
 enum State {

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -350,6 +350,7 @@ StatusOr<AsyncDeltaWriterBuilder::AsyncDeltaWriterPtr> AsyncDeltaWriterBuilder::
                                           .set_miss_auto_increment_column(_miss_auto_increment_column)
                                           .set_schema_id(_schema_id)
                                           .set_partial_update_mode(_partial_update_mode)
+                                          .set_column_to_expr_value(_column_to_expr_value)
                                           .build());
     auto impl = new AsyncDeltaWriterImpl(std::move(writer));
     return std::make_unique<AsyncDeltaWriter>(impl);

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -186,6 +186,11 @@ public:
         return *this;
     }
 
+    AsyncDeltaWriterBuilder& set_column_to_expr_value(const std::map<std::string, std::string>* column_to_expr_value) {
+        _column_to_expr_value = column_to_expr_value;
+        return *this;
+    }
+
     StatusOr<AsyncDeltaWriterPtr> build();
 
 private:
@@ -201,6 +206,7 @@ private:
     std::string _merge_condition{};
     bool _miss_auto_increment_column{false};
     PartialUpdateMode _partial_update_mode{PartialUpdateMode::ROW_MODE};
+    const std::map<std::string, std::string>* _column_to_expr_value{nullptr};
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -199,7 +199,7 @@ private:
 
     int64_t _last_write_ts = 0;
 
-    const std::map<string, string>* _column_to_expr_value;
+    const std::map<string, string>* _column_to_expr_value = nullptr;
 };
 
 bool DeltaWriterImpl::is_immutable() const {

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -76,7 +76,8 @@ public:
                              const std::vector<SlotDescriptor*>* slots, std::string merge_condition,
                              bool miss_auto_increment_column, int64_t table_id, int64_t immutable_tablet_size,
                              MemTracker* mem_tracker, int64_t max_buffer_size, int64_t schema_id,
-                             const PartialUpdateMode& partial_update_mode)
+                             const PartialUpdateMode& partial_update_mode,
+                             const std::map<string, string>* column_to_expr_value)
             : _tablet_manager(tablet_manager),
               _tablet_id(tablet_id),
               _txn_id(txn_id),
@@ -89,7 +90,8 @@ public:
               _immutable_tablet_size(immutable_tablet_size),
               _merge_condition(std::move(merge_condition)),
               _miss_auto_increment_column(miss_auto_increment_column),
-              _partial_update_mode(partial_update_mode) {}
+              _partial_update_mode(partial_update_mode),
+              _column_to_expr_value(column_to_expr_value) {}
 
     ~DeltaWriterImpl() = default;
 
@@ -196,6 +198,8 @@ private:
     bool _partial_schema_with_sort_key_conflict = false;
 
     int64_t _last_write_ts = 0;
+
+    const std::map<string, string>* _column_to_expr_value;
 };
 
 bool DeltaWriterImpl::is_immutable() const {
@@ -494,6 +498,11 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
             }
             // handle partial update
             op_write->mutable_txn_meta()->set_partial_update_mode(_partial_update_mode);
+            if (_column_to_expr_value != nullptr) {
+                for (auto& [name, value] : (*_column_to_expr_value)) {
+                    op_write->mutable_txn_meta()->mutable_column_to_expr_value()->insert({name, value});
+                }
+            }
         }
         // handle condition update
         if (_merge_condition != "") {
@@ -762,7 +771,7 @@ StatusOr<DeltaWriterBuilder::DeltaWriterPtr> DeltaWriterBuilder::build() {
     }
     auto impl = new DeltaWriterImpl(_tablet_mgr, _tablet_id, _txn_id, _partition_id, _slots, _merge_condition,
                                     _miss_auto_increment_column, _table_id, _immutable_tablet_size, _mem_tracker,
-                                    _max_buffer_size, _schema_id, _partial_update_mode);
+                                    _max_buffer_size, _schema_id, _partial_update_mode, _column_to_expr_value);
     return std::make_unique<DeltaWriter>(impl);
 }
 

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -182,6 +182,11 @@ public:
         return *this;
     }
 
+    DeltaWriterBuilder& set_column_to_expr_value(const std::map<std::string, std::string>* column_to_expr_value) {
+        _column_to_expr_value = column_to_expr_value;
+        return *this;
+    }
+
     StatusOr<DeltaWriterPtr> build();
 
 private:
@@ -198,6 +203,7 @@ private:
     int64_t _max_buffer_size{0};
     bool _miss_auto_increment_column{false};
     PartialUpdateMode _partial_update_mode{PartialUpdateMode::ROW_MODE};
+    const std::map<std::string, std::string>* _column_to_expr_value;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -203,7 +203,7 @@ private:
     int64_t _max_buffer_size{0};
     bool _miss_auto_increment_column{false};
     PartialUpdateMode _partial_update_mode{PartialUpdateMode::ROW_MODE};
-    const std::map<std::string, std::string>* _column_to_expr_value;
+    const std::map<std::string, std::string>* _column_to_expr_value{nullptr};
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/pk_tablet_writer.h
+++ b/be/src/storage/lake/pk_tablet_writer.h
@@ -56,6 +56,7 @@ protected:
 private:
     std::unique_ptr<RowsetTxnMetaPB> _rowset_txn_meta;
     std::unique_ptr<RowsMapperBuilder> _rows_mapper_builder;
+    const std::map<std::string, std::string>* _column_to_expr_value = nullptr;
 };
 
 class VerticalPkTabletWriter : public VerticalGeneralTabletWriter {

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -190,6 +190,7 @@ private:
     // to be destructed after segment iters
     OlapReaderStatistics _stats;
     std::vector<ChunkIteratorPtr> _segment_iters;
+    std::map<string, string> _column_to_expr_value;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetUpdateState& o) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -502,14 +502,12 @@ Status UpdateManager::get_column_values(const RowsetUpdateStateParams& params, s
         for (auto i = 0; i < column_ids.size(); ++i) {
             const TabletColumn& tablet_column = params.tablet_schema->column(column_ids[i]);
             bool has_default_value = tablet_column.has_default_value();
-            std::string default_value;
+            std::string default_value = has_default_value ? tablet_column.default_value() : "";
             if (column_to_expr_value != nullptr) {
                 auto iter = column_to_expr_value->find(std::string(tablet_column.name()));
                 if (iter != column_to_expr_value->end()) {
                     has_default_value = true;
                     default_value = iter->second;
-                } else if (has_default_value) {
-                    default_value = tablet_column.default_value();
                 }
             }
             if (has_default_value) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -491,6 +491,7 @@ Status UpdateManager::get_rowids_from_pkindex(int64_t tablet_id, int64_t base_ve
 Status UpdateManager::get_column_values(const RowsetUpdateStateParams& params, std::vector<uint32_t>& column_ids,
                                         bool with_default, std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                                         vector<std::unique_ptr<Column>>* columns,
+                                        const std::map<string, string>* column_to_expr_value,
                                         AutoIncrementPartialUpdateState* auto_increment_state) {
     TRACE_COUNTER_SCOPE_LATENCY_US("get_column_values_latency_us");
     std::stringstream cost_str;
@@ -500,12 +501,22 @@ Status UpdateManager::get_column_values(const RowsetUpdateStateParams& params, s
     if (with_default && auto_increment_state == nullptr) {
         for (auto i = 0; i < column_ids.size(); ++i) {
             const TabletColumn& tablet_column = params.tablet_schema->column(column_ids[i]);
-            if (tablet_column.has_default_value()) {
+            bool has_default_value = tablet_column.has_default_value();
+            std::string default_value;
+            if (column_to_expr_value != nullptr) {
+                auto iter = column_to_expr_value->find(std::string(tablet_column.name()));
+                if (iter != column_to_expr_value->end()) {
+                    has_default_value = true;
+                    default_value = iter->second;
+                } else if (has_default_value) {
+                    default_value = tablet_column.default_value();
+                }
+            }
+            if (has_default_value) {
                 const TypeInfoPtr& type_info = get_type_info(tablet_column);
                 std::unique_ptr<DefaultValueColumnIterator> default_value_iter =
-                        std::make_unique<DefaultValueColumnIterator>(
-                                tablet_column.has_default_value(), tablet_column.default_value(),
-                                tablet_column.is_nullable(), type_info, tablet_column.length(), 1);
+                        std::make_unique<DefaultValueColumnIterator>(true, default_value, tablet_column.is_nullable(),
+                                                                     type_info, tablet_column.length(), 1);
                 ColumnIteratorOptions iter_opts;
                 RETURN_IF_ERROR(default_value_iter->init(iter_opts));
                 RETURN_IF_ERROR(default_value_iter->fetch_values_by_rowid(nullptr, 1, (*columns)[i].get()));

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -116,6 +116,7 @@ public:
     Status get_column_values(const RowsetUpdateStateParams& params, std::vector<uint32_t>& column_ids,
                              bool with_default, std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                              vector<std::unique_ptr<Column>>* columns,
+                             const std::map<string, string>* column_to_expr_value = nullptr,
                              AutoIncrementPartialUpdateState* auto_increment_state = nullptr);
     // get delvec by version
     Status get_del_vec(const TabletSegmentId& tsid, int64_t version, const MetaFileBuilder* builder, bool fill_cache,

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -201,9 +201,9 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
             }
             // set partial update mode
             _rowset_txn_meta_pb->set_partial_update_mode(_context.partial_update_mode);
-            if (_context.column_to_value != nullptr) {
-                for (auto& [name, value] : (*_context.column_to_value)) {
-                    _rowset_txn_meta_pb->mutable_column_to_values()->insert({name, value});
+            if (_context.column_to_expr_value != nullptr) {
+                for (auto& [name, value] : (*_context.column_to_expr_value)) {
+                    _rowset_txn_meta_pb->mutable_column_to_expr_value()->insert({name, value});
                 }
             }
             *_rowset_meta_pb->mutable_txn_meta() = *_rowset_txn_meta_pb;

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -203,6 +203,7 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
             _rowset_txn_meta_pb->set_partial_update_mode(_context.partial_update_mode);
             if (_context.column_to_expr_value != nullptr) {
                 for (auto& [name, value] : (*_context.column_to_expr_value)) {
+                    LOG(INFO) << "rowset writer set column";
                     _rowset_txn_meta_pb->mutable_column_to_expr_value()->insert({name, value});
                 }
             }

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -201,6 +201,11 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
             }
             // set partial update mode
             _rowset_txn_meta_pb->set_partial_update_mode(_context.partial_update_mode);
+            if (_context.column_to_value != nullptr) {
+                for (auto& [name, value] : (*_context.column_to_value)) {
+                    _rowset_txn_meta_pb->mutable_column_to_values()->insert({name, value});
+                }
+            }
             *_rowset_meta_pb->mutable_txn_meta() = *_rowset_txn_meta_pb;
         } else if (!_context.merge_condition.empty()) {
             _rowset_txn_meta_pb->set_merge_condition(_context.merge_condition);

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -203,7 +203,6 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
             _rowset_txn_meta_pb->set_partial_update_mode(_context.partial_update_mode);
             if (_context.column_to_expr_value != nullptr) {
                 for (auto& [name, value] : (*_context.column_to_expr_value)) {
-                    LOG(INFO) << "rowset writer set column";
                     _rowset_txn_meta_pb->mutable_column_to_expr_value()->insert({name, value});
                 }
             }

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -98,7 +98,7 @@ public:
     // is compaction job
     bool is_compaction = false;
 
-    std::map<string, string>* column_to_value = nullptr;
+    std::map<string, string>* column_to_expr_value = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -97,6 +97,8 @@ public:
     bool is_pk_compaction = false;
     // is compaction job
     bool is_compaction = false;
+
+    std::map<string, string>* column_to_value = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -191,6 +191,11 @@ Status RowsetColumnUpdateState::_prepare_partial_update_states(Tablet* tablet, R
         return Status::OK();
     }
 
+    const auto& txn_meta = rowset->rowset_meta()->get_meta_pb_without_schema().txn_meta();
+    for (auto& entry : txn_meta.column_to_values()) {
+        _column_to_value.insert({entry.first, entry.second});
+    }
+
     EditVersion read_version;
     TRY_CATCH_BAD_ALLOC(_upserts[start_idx]->src_rss_rowids.resize(_upserts[start_idx]->upserts_size()));
     int64_t t_start = MonotonicMillis();
@@ -521,11 +526,21 @@ Status RowsetColumnUpdateState::_fill_default_columns(const TabletSchemaCSPtr& t
                                                       vector<std::shared_ptr<Column>>* columns) {
     for (auto i = 0; i < column_ids.size(); ++i) {
         const TabletColumn& tablet_column = tablet_schema->column(column_ids[i]);
-        if (tablet_column.has_default_value()) {
+
+        bool has_default_value = tablet_column.has_default_value();
+        std::string default_value;
+        auto iter = _column_to_value.find(std::string(tablet_column.name()));
+        if (iter != _column_to_value.end()) {
+            has_default_value = true;
+            default_value = iter->second;
+        } else if (has_default_value) {
+            default_value = tablet_column.default_value();
+        }
+        if (has_default_value) {
             const TypeInfoPtr& type_info = get_type_info(tablet_column);
             std::unique_ptr<DefaultValueColumnIterator> default_value_iter =
                     std::make_unique<DefaultValueColumnIterator>(
-                            tablet_column.has_default_value(), tablet_column.default_value(),
+                            true, default_value,
                             tablet_column.is_nullable(), type_info, tablet_column.length(), row_cnt);
             ColumnIteratorOptions iter_opts;
             RETURN_IF_ERROR(default_value_iter->init(iter_opts));

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -528,13 +528,11 @@ Status RowsetColumnUpdateState::_fill_default_columns(const TabletSchemaCSPtr& t
         const TabletColumn& tablet_column = tablet_schema->column(column_ids[i]);
 
         bool has_default_value = tablet_column.has_default_value();
-        std::string default_value;
+        std::string default_value = has_default_value ? tablet_column.default_value() : "";
         auto iter = _column_to_expr_value.find(std::string(tablet_column.name()));
         if (iter != _column_to_expr_value.end()) {
             has_default_value = true;
             default_value = iter->second;
-        } else if (has_default_value) {
-            default_value = tablet_column.default_value();
         }
         if (has_default_value) {
             const TypeInfoPtr& type_info = get_type_info(tablet_column);

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -246,6 +246,7 @@ private:
     // when generate delta column group finish, these fields will be filled
     bool _finalize_finished = false;
     std::map<uint32_t, DeltaColumnGroupPtr> _rssid_to_delta_column_group;
+    std::map<string, string> _column_to_value;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetColumnUpdateState& o) {

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -246,7 +246,7 @@ private:
     // when generate delta column group finish, these fields will be filled
     bool _finalize_finished = false;
     std::map<uint32_t, DeltaColumnGroupPtr> _rssid_to_delta_column_group;
-    std::map<string, string> _column_to_value;
+    std::map<string, string> _column_to_expr_value;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetColumnUpdateState& o) {

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -372,6 +372,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
     int64_t t_start = MonotonicMillis();
     const auto& txn_meta = rowset->rowset_meta()->get_meta_pb_without_schema().txn_meta();
 
+    _column_to_expr_value.clear();
     for (auto& entry : txn_meta.column_to_expr_value()) {
         _column_to_expr_value.insert({entry.first, entry.second});
     }

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -372,8 +372,8 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
     int64_t t_start = MonotonicMillis();
     const auto& txn_meta = rowset->rowset_meta()->get_meta_pb_without_schema().txn_meta();
 
-    for (auto& entry : txn_meta.column_to_values()) {
-        _column_to_value.insert({entry.first, entry.second});
+    for (auto& entry : txn_meta.column_to_expr_value()) {
+        _column_to_expr_value.insert({entry.first, entry.second});
     }
 
     std::vector<uint32_t> update_column_uids(txn_meta.partial_update_column_unique_ids().begin(),
@@ -425,7 +425,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
     total_rows += _partial_update_states[idx].src_rss_rowids.size();
     RETURN_IF_ERROR(tablet->updates()->get_column_values(
             read_column_ids, _partial_update_states[idx].read_version.major_number(), num_default > 0, rowids_by_rssid,
-            &read_columns, nullptr, tablet_schema, &_column_to_value));
+            &read_columns, nullptr, tablet_schema, &_column_to_expr_value));
     for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
         _partial_update_states[idx].write_columns[col_idx]->append_selective(*read_columns[col_idx], idxes.data(), 0,
                                                                              idxes.size());
@@ -514,10 +514,9 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(Tablet* 
         }
     }
 
-    RETURN_IF_ERROR(tablet->updates()->get_column_values(column_id, latest_applied_version.major_number(), new_rows > 0,
-                                                         rowids_by_rssid, &read_column,
-                                                         &_auto_increment_partial_update_states[idx], tablet_schema,
-                                                         &_column_to_value));
+    RETURN_IF_ERROR(tablet->updates()->get_column_values(
+            column_id, latest_applied_version.major_number(), new_rows > 0, rowids_by_rssid, &read_column,
+            &_auto_increment_partial_update_states[idx], tablet_schema, &_column_to_expr_value));
 
     _auto_increment_partial_update_states[idx].write_column->append_selective(*read_column[0], idxes.data(), 0,
                                                                               idxes.size());
@@ -650,7 +649,7 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
         DCHECK_EQ(conflict_idxes.size(), read_idxes.size());
         RETURN_IF_ERROR(tablet->updates()->get_column_values(read_column_ids, latest_applied_version.major_number(),
                                                              num_default > 0, rowids_by_rssid, &read_columns, nullptr,
-                                                             tablet_schema, &_column_to_value));
+                                                             tablet_schema, &_column_to_expr_value));
 
         for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
             std::unique_ptr<Column> new_write_column =

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -372,6 +372,10 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
     int64_t t_start = MonotonicMillis();
     const auto& txn_meta = rowset->rowset_meta()->get_meta_pb_without_schema().txn_meta();
 
+    for (auto& entry : txn_meta.column_to_values()) {
+        _column_to_value.insert({entry.first, entry.second});
+    }
+
     std::vector<uint32_t> update_column_uids(txn_meta.partial_update_column_unique_ids().begin(),
                                              txn_meta.partial_update_column_unique_ids().end());
     std::set<uint32_t> update_columns_set(update_column_uids.begin(), update_column_uids.end());
@@ -421,7 +425,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
     total_rows += _partial_update_states[idx].src_rss_rowids.size();
     RETURN_IF_ERROR(tablet->updates()->get_column_values(
             read_column_ids, _partial_update_states[idx].read_version.major_number(), num_default > 0, rowids_by_rssid,
-            &read_columns, nullptr, tablet_schema));
+            &read_columns, nullptr, tablet_schema, &_column_to_value));
     for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
         _partial_update_states[idx].write_columns[col_idx]->append_selective(*read_columns[col_idx], idxes.data(), 0,
                                                                              idxes.size());
@@ -512,7 +516,8 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(Tablet* 
 
     RETURN_IF_ERROR(tablet->updates()->get_column_values(column_id, latest_applied_version.major_number(), new_rows > 0,
                                                          rowids_by_rssid, &read_column,
-                                                         &_auto_increment_partial_update_states[idx], tablet_schema));
+                                                         &_auto_increment_partial_update_states[idx], tablet_schema,
+                                                         &_column_to_value));
 
     _auto_increment_partial_update_states[idx].write_column->append_selective(*read_column[0], idxes.data(), 0,
                                                                               idxes.size());
@@ -645,7 +650,7 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
         DCHECK_EQ(conflict_idxes.size(), read_idxes.size());
         RETURN_IF_ERROR(tablet->updates()->get_column_values(read_column_ids, latest_applied_version.major_number(),
                                                              num_default > 0, rowids_by_rssid, &read_columns, nullptr,
-                                                             tablet_schema));
+                                                             tablet_schema, &_column_to_value));
 
         for (size_t col_idx = 0; col_idx < read_column_ids.size(); col_idx++) {
             std::unique_ptr<Column> new_write_column =

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -190,7 +190,7 @@ private:
     std::vector<PartialUpdateState> _partial_update_states;
 
     std::vector<AutoIncrementPartialUpdateState> _auto_increment_partial_update_states;
-    std::map<string, string> _column_to_value;
+    std::map<string, string> _column_to_expr_value;
 
     RowsetUpdateState(const RowsetUpdateState&) = delete;
     const RowsetUpdateState& operator=(const RowsetUpdateState&) = delete;

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -190,6 +190,7 @@ private:
     std::vector<PartialUpdateState> _partial_update_states;
 
     std::vector<AutoIncrementPartialUpdateState> _auto_increment_partial_update_states;
+    std::map<string, string> _column_to_value;
 
     RowsetUpdateState(const RowsetUpdateState&) = delete;
     const RowsetUpdateState& operator=(const RowsetUpdateState&) = delete;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5147,7 +5147,7 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
                                         bool with_default, std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                                         vector<std::unique_ptr<Column>>* columns, void* state,
                                         const TabletSchemaCSPtr& read_tablet_schema,
-                                        const std::map<string, string>* column_to_values) {
+                                        const std::map<string, string>* column_to_expr_value) {
     std::vector<uint32_t> unique_column_ids;
     for (unsigned int column_id : column_ids) {
         const TabletColumn& tablet_column = read_tablet_schema->column(column_id);
@@ -5174,9 +5174,9 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
             const TabletColumn& tablet_column = read_tablet_schema->column(column_ids[i]);
             bool has_default_value = tablet_column.has_default_value();
             std::string default_value;
-            if (column_to_values != nullptr) {
-                auto iter = column_to_values->find(std::string(tablet_column.name()));
-                if (iter != column_to_values->end()) {
+            if (column_to_expr_value != nullptr) {
+                auto iter = column_to_expr_value->find(std::string(tablet_column.name()));
+                if (iter != column_to_expr_value->end()) {
                     has_default_value = true;
                     default_value = iter->second;
                 } else if (has_default_value) {
@@ -5186,9 +5186,8 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
             if (has_default_value) {
                 const TypeInfoPtr& type_info = get_type_info(tablet_column);
                 std::unique_ptr<DefaultValueColumnIterator> default_value_iter =
-                        std::make_unique<DefaultValueColumnIterator>(
-                                true, default_value,
-                                tablet_column.is_nullable(), type_info, tablet_column.length(), 1);
+                        std::make_unique<DefaultValueColumnIterator>(true, default_value, tablet_column.is_nullable(),
+                                                                     type_info, tablet_column.length(), 1);
                 ColumnIteratorOptions iter_opts;
                 RETURN_IF_ERROR(default_value_iter->init(iter_opts));
                 RETURN_IF_ERROR(default_value_iter->fetch_values_by_rowid(nullptr, 1, (*columns)[i].get()));

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5146,7 +5146,8 @@ static StatusOr<std::unique_ptr<ColumnIterator>> new_dcg_column_iterator(GetDelt
 Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids, int64_t read_version,
                                         bool with_default, std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                                         vector<std::unique_ptr<Column>>* columns, void* state,
-                                        const TabletSchemaCSPtr& read_tablet_schema) {
+                                        const TabletSchemaCSPtr& read_tablet_schema,
+                                        const std::map<string, string>* column_to_values) {
     std::vector<uint32_t> unique_column_ids;
     for (unsigned int column_id : column_ids) {
         const TabletColumn& tablet_column = read_tablet_schema->column(column_id);
@@ -5171,11 +5172,22 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
     if (with_default && state == nullptr) {
         for (auto i = 0; i < column_ids.size(); ++i) {
             const TabletColumn& tablet_column = read_tablet_schema->column(column_ids[i]);
-            if (tablet_column.has_default_value()) {
+            bool has_default_value = tablet_column.has_default_value();
+            std::string default_value;
+            if (column_to_values != nullptr) {
+                auto iter = column_to_values->find(std::string(tablet_column.name()));
+                if (iter != column_to_values->end()) {
+                    has_default_value = true;
+                    default_value = iter->second;
+                } else if (has_default_value) {
+                    default_value = tablet_column.default_value();
+                }
+            }
+            if (has_default_value) {
                 const TypeInfoPtr& type_info = get_type_info(tablet_column);
                 std::unique_ptr<DefaultValueColumnIterator> default_value_iter =
                         std::make_unique<DefaultValueColumnIterator>(
-                                tablet_column.has_default_value(), tablet_column.default_value(),
+                                true, default_value,
                                 tablet_column.is_nullable(), type_info, tablet_column.length(), 1);
                 ColumnIteratorOptions iter_opts;
                 RETURN_IF_ERROR(default_value_iter->init(iter_opts));

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5173,14 +5173,12 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
         for (auto i = 0; i < column_ids.size(); ++i) {
             const TabletColumn& tablet_column = read_tablet_schema->column(column_ids[i]);
             bool has_default_value = tablet_column.has_default_value();
-            std::string default_value;
+            std::string default_value = has_default_value ? tablet_column.default_value() : "";
             if (column_to_expr_value != nullptr) {
                 auto iter = column_to_expr_value->find(std::string(tablet_column.name()));
                 if (iter != column_to_expr_value->end()) {
                     has_default_value = true;
                     default_value = iter->second;
-                } else if (has_default_value) {
-                    default_value = tablet_column.default_value();
                 }
             }
             if (has_default_value) {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -306,7 +306,8 @@ public:
     Status get_column_values(const std::vector<uint32_t>& column_ids, int64_t read_version, bool with_default,
                              std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                              vector<std::unique_ptr<Column>>* columns, void* state,
-                             const TabletSchemaCSPtr& tablet_schema);
+                             const TabletSchemaCSPtr& tablet_schema,
+                             const std::map<string, string>* column_to_values = nullptr);
 
     Status get_rss_rowids_by_pk(Tablet* tablet, const Column& keys, EditVersion* read_version,
                                 std::vector<uint64_t>* rss_rowids, int64_t timeout_ms = 0);

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -307,7 +307,7 @@ public:
                              std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                              vector<std::unique_ptr<Column>>* columns, void* state,
                              const TabletSchemaCSPtr& tablet_schema,
-                             const std::map<string, string>* column_to_values = nullptr);
+                             const std::map<string, string>* column_to_expr_value = nullptr);
 
     Status get_rss_rowids_by_pk(Tablet* tablet, const Column& keys, EditVersion* read_version,
                                 std::vector<uint64_t>* rss_rowids, int64_t timeout_ms = 0);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
@@ -121,7 +121,7 @@ public class DictionaryCacheSink extends DataSink {
             columnsDesc.add(tColumn);
         }
         TOlapTableColumnParam columnParam = new TOlapTableColumnParam(columnsDesc, columnSortKeyUids, 0);
-        TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(0, columns, 0);
+        TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(0, columns, 0, null);
         indexSchema.setColumn_param(columnParam);
         schemaParam.addToIndexes(indexSchema);
         return schemaParam;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
@@ -121,7 +121,7 @@ public class DictionaryCacheSink extends DataSink {
             columnsDesc.add(tColumn);
         }
         TOlapTableColumnParam columnParam = new TOlapTableColumnParam(columnsDesc, columnSortKeyUids, 0);
-        TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(0, columns, 0, null);
+        TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(0, columns, 0);
         indexSchema.setColumn_param(columnParam);
         schemaParam.addToIndexes(indexSchema);
         return schemaParam;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -358,6 +358,7 @@ public class OlapTableSink extends DataSink {
             List<String> columns = Lists.newArrayList();
             List<TColumn> columnsDesc = Lists.newArrayList();
             List<Integer> columnSortKeyUids = Lists.newArrayList();
+            Map<String, String> column_to_value = new HashMap<>();
             columns.addAll(indexMeta
                     .getSchema()
                     .stream()
@@ -368,6 +369,9 @@ public class OlapTableSink extends DataSink {
                 tColumn.setColumn_name(column.getColumnId().getId());
                 column.setIndexFlag(tColumn, table.getIndexes(), table.getBfColumnIds());
                 columnsDesc.add(tColumn);
+                if (column.getDefaultExpr() != null) {
+                    column_to_value.put(column.getColumnId().getId(), column.calculatedDefaultValue());
+                }
             }
             if (indexMeta.getSortKeyUniqueIds() != null) {
                 columnSortKeyUids.addAll(indexMeta.getSortKeyUniqueIds());
@@ -380,7 +384,7 @@ public class OlapTableSink extends DataSink {
             TOlapTableColumnParam columnParam = new TOlapTableColumnParam(columnsDesc, columnSortKeyUids,
                     indexMeta.getShortKeyColumnCount());
             TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(pair.getKey(), columns,
-                    indexMeta.getSchemaHash());
+                    indexMeta.getSchemaHash(), column_to_value);
             indexSchema.setColumn_param(columnParam);
             indexSchema.setSchema_id(indexMeta.getSchemaId());
             schemaParam.addToIndexes(indexSchema);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -369,7 +369,7 @@ public class OlapTableSink extends DataSink {
                 tColumn.setColumn_name(column.getColumnId().getId());
                 column.setIndexFlag(tColumn, table.getIndexes(), table.getBfColumnIds());
                 columnsDesc.add(tColumn);
-                if (column.getDefaultExpr() != null) {
+                if (column.getDefaultExpr() != null && column.calculatedDefaultValue() != null) {
                     columnToExprValue.put(column.getColumnId().getId(), column.calculatedDefaultValue());
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -358,7 +358,7 @@ public class OlapTableSink extends DataSink {
             List<String> columns = Lists.newArrayList();
             List<TColumn> columnsDesc = Lists.newArrayList();
             List<Integer> columnSortKeyUids = Lists.newArrayList();
-            Map<String, String> column_to_value = new HashMap<>();
+            Map<String, String> columnToExprValue = new HashMap<>();
             columns.addAll(indexMeta
                     .getSchema()
                     .stream()
@@ -370,7 +370,7 @@ public class OlapTableSink extends DataSink {
                 column.setIndexFlag(tColumn, table.getIndexes(), table.getBfColumnIds());
                 columnsDesc.add(tColumn);
                 if (column.getDefaultExpr() != null) {
-                    column_to_value.put(column.getColumnId().getId(), column.calculatedDefaultValue());
+                    columnToExprValue.put(column.getColumnId().getId(), column.calculatedDefaultValue());
                 }
             }
             if (indexMeta.getSortKeyUniqueIds() != null) {
@@ -384,7 +384,7 @@ public class OlapTableSink extends DataSink {
             TOlapTableColumnParam columnParam = new TOlapTableColumnParam(columnsDesc, columnSortKeyUids,
                     indexMeta.getShortKeyColumnCount());
             TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(pair.getKey(), columns,
-                    indexMeta.getSchemaHash(), column_to_value);
+                    indexMeta.getSchemaHash(), columnToExprValue);
             indexSchema.setColumn_param(columnParam);
             indexSchema.setSchema_id(indexMeta.getSchemaId());
             schemaParam.addToIndexes(indexSchema);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -384,9 +384,10 @@ public class OlapTableSink extends DataSink {
             TOlapTableColumnParam columnParam = new TOlapTableColumnParam(columnsDesc, columnSortKeyUids,
                     indexMeta.getShortKeyColumnCount());
             TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(pair.getKey(), columns,
-                    indexMeta.getSchemaHash(), columnToExprValue);
+                    indexMeta.getSchemaHash());
             indexSchema.setColumn_param(columnParam);
             indexSchema.setSchema_id(indexMeta.getSchemaId());
+            indexSchema.setColumn_to_expr_value(columnToExprValue);
             schemaParam.addToIndexes(indexSchema);
             if (indexMeta.getWhereClause() != null) {
                 String dbName = MetaUtils.getDatabase(dbId).getFullName();

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -75,7 +75,7 @@ message POlapTableIndexSchema {
     required int32 schema_hash = 3;
     optional POlapTableColumnParam column_param = 4;
     optional int64 schema_id = 5;
-    map<string, string> column_to_value = 6;
+    map<string, string> column_to_expr_value = 6;
 };
 
 message POlapTableSchemaParam {

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -75,6 +75,7 @@ message POlapTableIndexSchema {
     required int32 schema_hash = 3;
     optional POlapTableColumnParam column_param = 4;
     optional int64 schema_id = 5;
+    map<string, string> column_to_value = 6;
 };
 
 message POlapTableSchemaParam {

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -106,7 +106,7 @@ message RowsetTxnMetaPB {
     // auto increment column unique id
     optional int32 auto_increment_partial_update_column_uid = 7;
     // the value of the column express
-    map<string, string> column_to_values = 8;
+    map<string, string> column_to_expr_value = 8;
 }
 
 message RowsetMetaPB {

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -105,6 +105,8 @@ message RowsetTxnMetaPB {
     optional PartialUpdateMode partial_update_mode = 6;
     // auto increment column unique id
     optional int32 auto_increment_partial_update_column_uid = 7;
+    // the value of the column express
+    map<string, string> column_to_values = 8;
 }
 
 message RowsetMetaPB {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -282,7 +282,7 @@ struct TOlapTableIndexSchema {
     4: optional TOlapTableColumnParam column_param
     5: optional Exprs.TExpr where_clause
     6: optional i64 schema_id // schema id
-    7: map<string, string> column_to_value
+    7: map<string, string> column_to_expr_value
 }
 
 struct TOlapTableSchemaParam {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -282,6 +282,7 @@ struct TOlapTableIndexSchema {
     4: optional TOlapTableColumnParam column_param
     5: optional Exprs.TExpr where_clause
     6: optional i64 schema_id // schema id
+    7: map<string, string> column_to_value
 }
 
 struct TOlapTableSchemaParam {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -282,7 +282,7 @@ struct TOlapTableIndexSchema {
     4: optional TOlapTableColumnParam column_param
     5: optional Exprs.TExpr where_clause
     6: optional i64 schema_id // schema id
-    7: map<string, string> column_to_expr_value
+    7: optional map<string, string> column_to_expr_value
 }
 
 struct TOlapTableSchemaParam {

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update
@@ -132,3 +132,76 @@ select * from tab3;
 300	k3_300	300	300	300	v4_300	v5_300
 200	k2_200	200	200	200	v4_200	v5_200
 -- !result
+-- name: test_partial_update_with_expr
+create database test_partial_update_with_expr;
+-- result:
+-- !result
+use test_partial_update_with_expr;
+-- result:
+-- !result
+CREATE TABLE `tab1` (
+  `k1` bigint(20) NOT NULL COMMENT "",
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` datetime NULL DEFAULT CURRENT_TIMESTAMP COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (101, 1, 1, '2024-08-27 00:00:00');
+-- result:
+-- !result
+insert into tab1 values (201, 2, 2, '2024-08-27 00:00:00');
+-- result:
+-- !result
+select count(1) from tab1 where 'v3' is not null;
+-- result:
+2
+-- !result
+insert into tab1 (k1, v1, v2) values (301, 3, 3);
+-- result:
+-- !result
+select count(1) from tab1 where 'v3' is not null;
+-- result:
+3
+-- !result
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_5.csv -XPUT -H partial_update:true -H label:stream_load_partial_update_123433 -H column_separator:, -H columns:k1,v1,v2 ${url}/api/test_partial_update_with_expr/tab1/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select count(1) from tab1 where 'v3' is not null;
+-- result:
+5
+-- !result
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:stream_load_partial_update_123434 -H column_separator:, -H columns:k1,v1,v2 ${url}/api/test_partial_update_with_expr/tab1/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select count(1) from tab1 where 'v3' is not null;
+-- result:
+7
+-- !result
+drop database test_partial_update_with_expr;
+-- result:
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update
@@ -66,3 +66,41 @@ select * from tab3;
 
 update tab3 set v1 = 1111, v2 = (select sum(tab2.v2) from tab2);
 select * from tab3;
+
+
+-- name: test_partial_update_with_expr
+create database test_partial_update_with_expr;
+use test_partial_update_with_expr;
+CREATE TABLE `tab1` (
+  `k1` bigint(20) NOT NULL COMMENT "",
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` datetime NULL DEFAULT CURRENT_TIMESTAMP COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into tab1 values (101, 1, 1, '2024-08-27 00:00:00');
+insert into tab1 values (201, 2, 2, '2024-08-27 00:00:00');
+
+select count(1) from tab1 where 'v3' is not null;
+insert into tab1 (k1, v1, v2) values (301, 3, 3);
+select count(1) from tab1 where 'v3' is not null;
+
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_partial_update_5.csv -XPUT -H partial_update:true -H label:stream_load_partial_update_123433 -H column_separator:, -H columns:k1,v1,v2 ${url}/api/test_partial_update_with_expr/tab1/_stream_load
+sync;
+select count(1) from tab1 where 'v3' is not null;
+
+shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/stream_load/sr_auto_increment_partial_update_only.csv -XPUT -H partial_update:true  -H partial_update_mode:column -H label:stream_load_partial_update_123434 -H column_separator:, -H columns:k1,v1,v2 ${url}/api/test_partial_update_with_expr/tab1/_stream_load
+sync;
+select count(1) from tab1 where 'v3' is not null;
+
+
+
+drop database test_partial_update_with_expr;


### PR DESCRIPTION
## Why I'm doing:
Partial update does not support expression currently. If an expression column is not specified in the update, we will fill it with the default value instead of calculating it based on the expression.

## What I'm doing:
Support partial update with expr and we only support default expr can be calculated like `now()` and does not support the expr for a batch of every row different like `uuid()`. If the default expr is `uuid()`, the behavior is not changed.
e.g.
```
 CREATE TABLE `test` (
  `k1` bigint(20) NOT NULL COMMENT "",
  `v1` bigint(20) NOT NULL COMMENT "",
  `v2` datetime NULL DEFAULT CURRENT_TIMESTAMP COMMENT ""
) ENGINE=OLAP
PRIMARY KEY(`k1`)
DISTRIBUTED BY HASH(`k1`) BUCKETS 1
PROPERTIES (
"compression" = "LZ4",
"enable_persistent_index" = "true",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
);
insert into test values (1,1,'2024-08-27 00:00:00');
insert into test (k1,v1) values(2,2);
select * from test;
```

before this pr, the result is
```
mysql> select * from test;
+------+------+---------------------+
| k1   | v1   | v2                  |
+------+------+---------------------+
|    2 |    2 | NULL                |
|    1 |    1 | 2024-08-27 00:00:00 |
+------+------+---------------------+
2 rows in set (0.02 sec)
```

after this pr:
```
mysql> select * from test;
+------+------+---------------------+
| k1   | v1   | v2                  |
+------+------+---------------------+
|    1 |    1 | 2024-08-27 00:00:00 |
|    2 |    2 | 2024-08-27 19:02:23 |
+------+------+---------------------+
2 rows in set (0.01 sec)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
