### PR TITLE
[BugFix] Fix del and dcg handling in TDE cloud native

### DIFF
--- a/be/src/storage/delta_column_group.h
+++ b/be/src/storage/delta_column_group.h
@@ -35,7 +35,7 @@ public:
     DeltaColumnGroup() {}
     ~DeltaColumnGroup() {}
     void init(int64_t version, const std::vector<std::vector<ColumnUID>>& column_ids,
-              const std::vector<std::string>& column_files);
+              const std::vector<std::string>& column_files, const std::vector<std::string>& encryption_metas = {});
     Status load(int64_t version, const char* data, size_t length);
     Status load(int64_t version, const DeltaColumnGroupVerPB& dcg_ver_pb);
     std::string save() const;
@@ -92,6 +92,8 @@ public:
 
     const std::vector<std::string>& relative_column_files() const { return _column_files; }
 
+    const std::vector<std::string>& encryption_metas() const { return _encryption_metas; }
+
 private:
     void _calc_memory_usage();
 
@@ -99,6 +101,7 @@ private:
     int64_t _version = 0;
     std::vector<std::vector<ColumnUID>> _column_uids;
     std::vector<std::string> _column_files;
+    std::vector<std::string> _encryption_metas;
     size_t _memory_usage = 0;
 };
 

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -531,8 +531,14 @@ Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pke
     std::unique_ptr<Column> pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
     // Iterate all del files and insert into index.
-    for (const auto& del : rowset->metadata().del_files()) {
-        ASSIGN_OR_RETURN(auto read_file, fs::new_random_access_file(_tablet_mgr->del_location(_tablet_id, del.name())));
+    for (int del_idx = 0; del_idx < rowset->metadata().del_files_size(); ++del_idx) {
+        const auto& del = rowset->metadata().del_files(del_idx);
+        RandomAccessFileOptions ropts;
+        if (!del.encryption_meta().empty()) {
+            ASSIGN_OR_RETURN(ropts.encryption_info, KeyCache::instance().unwrap_encryption_meta(del.encryption_meta()));
+        }
+        ASSIGN_OR_RETURN(auto read_file,
+                         fs::new_random_access_file(ropts, _tablet_mgr->del_location(_tablet_id, del.name())));
         ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
         // serialize to column
         auto pkc = pk_column->clone();

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -40,7 +40,7 @@ public:
     // append delvec to builder's buffer
     void append_delvec(const DelVectorPtr& delvec, uint32_t segment_id);
     // append delta column group to builder
-    void append_dcg(uint32_t rssid, const std::vector<std::string>& filenames,
+    void append_dcg(uint32_t rssid, const std::vector<std::pair<std::string, std::string>>& file_with_encryption_metas,
                     const std::vector<std::vector<ColumnUID>>& unique_column_id_list);
     // handle txn log
     void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, FileInfo>& replace_segments,

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -275,7 +275,8 @@ Status SegmentMetaCollecter::_collect_dict(ColumnId cid, Column* column, Logical
     }
 
     if (words.size() > DICT_DECODE_MAX_SIZE) {
-        return Status::GlobalDictError("global dict greater than DICT_DECODE_MAX_SIZE");
+        return Status::GlobalDictError(fmt::format("global dict size:{} greater than DICT_DECODE_MAX_SIZE:{}",
+                                                   words.size(), DICT_DECODE_MAX_SIZE));
     }
 
     // array<string> has none dict, return directly

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -485,6 +485,9 @@ StatusOr<std::shared_ptr<Segment>> Segment::new_dcg_segment(const DeltaColumnGro
         tablet_schema = TabletSchema::create_with_uid(_tablet_schema.schema(), dcg.column_ids()[idx]);
     }
     FileInfo info{.path = dcg.column_files(parent_name(_segment_file_info.path))[idx]};
+    if (idx < dcg.encryption_metas().size()) {
+        info.encryption_meta = dcg.encryption_metas()[idx];
+    }
     return Segment::open(_fs, info, 0, tablet_schema, nullptr);
 }
 

--- a/be/test/storage/delta_column_group_test.cpp
+++ b/be/test/storage/delta_column_group_test.cpp
@@ -16,11 +16,14 @@
 
 #include <gtest/gtest.h>
 
+#include "fs/key_cache.h"
+
 namespace starrocks {
 
 TEST(TestDeltaColumnGroup, testLoad) {
+    auto ep = KeyCache::instance().create_plain_random_encryption_meta_pair().value();
     DeltaColumnGroup dcg;
-    dcg.init(100, {{1, 10, 100}}, {"abc0.cols"});
+    dcg.init(100, {{1, 10, 100}}, {"abc0.cols"}, {ep.encryption_meta});
     std::string pb_str = dcg.save();
     DeltaColumnGroup new_dcg;
     ASSERT_TRUE(new_dcg.load(100, pb_str.data(), pb_str.length()).ok());
@@ -36,11 +39,16 @@ TEST(TestDeltaColumnGroup, testLoad) {
             ASSERT_TRUE(v1[i][j] == v2[i][j]);
         }
     }
+    DeltaColumnGroup dcg2;
+    dcg2.init(100, {{2, 12}}, {"abc1.cols"}, {ep.encryption_meta});
+    dcg.merge_by_version(dcg2, "tmp", RowsetId(100, 100), 100);
+    ASSERT_EQ(2, dcg.encryption_metas().size());
 };
 
 TEST(TestDeltaColumnGroup, testGet) {
+    auto ep = KeyCache::instance().create_plain_random_encryption_meta_pair().value();
     DeltaColumnGroup dcg;
-    dcg.init(100, {{10, 1, 100}}, {"abc.cols"});
+    dcg.init(100, {{10, 1, 100}}, {"abc.cols"}, {ep.encryption_meta});
     ASSERT_TRUE(0 == dcg.get_column_idx(10).first);
     ASSERT_TRUE(0 == dcg.get_column_idx(10).second);
 
@@ -58,6 +66,7 @@ TEST(TestDeltaColumnGroup, testGet) {
 };
 
 TEST(TestDeltaColumnGroup, testGC) {
+    auto ep = KeyCache::instance().create_plain_random_encryption_meta_pair().value();
     // test1
     {
         // 1 -> {1, 2, 3}
@@ -68,9 +77,14 @@ TEST(TestDeltaColumnGroup, testGC) {
         DeltaColumnGroupList dcgs;
         for (ColumnUID i = 1; i <= 20; i++) {
             DeltaColumnGroup dcg;
-            dcg.init((int64_t)i, {{i, i + 1, i + 2}}, {"abc.cols"});
+            dcg.init((int64_t)i, {{i, i + 1, i + 2}}, {"abc.cols"}, {ep.encryption_meta});
             dcgs.push_back(std::make_shared<DeltaColumnGroup>(dcg));
         }
+        DeltaColumnGroupListPB pb;
+        DeltaColumnGroupListSerializer::serialize_delta_column_group_list(dcgs, &pb);
+        DeltaColumnGroupList dcgs_deserialized;
+        DeltaColumnGroupListSerializer::deserialize_delta_column_group_list(pb, &dcgs_deserialized);
+        ASSERT_EQ(dcgs.size(), dcgs_deserialized.size());
         const std::string path = "/asd/";
         std::vector<std::string> clear_files;
         DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 10, path, &garbage_dcgs,
@@ -94,7 +108,7 @@ TEST(TestDeltaColumnGroup, testGC) {
         DeltaColumnGroupList dcgs;
         for (uint32_t i = 1; i <= 20; i++) {
             DeltaColumnGroup dcg;
-            dcg.init((int64_t)i, {{1, 2, 3}}, {"abc.cols"});
+            dcg.init((int64_t)i, {{1, 2, 3}}, {"abc.cols"}, {ep.encryption_meta});
             dcgs.push_back(std::make_shared<DeltaColumnGroup>(dcg));
         }
         const std::string path = "/asd/";
@@ -121,7 +135,7 @@ TEST(TestDeltaColumnGroup, testGC) {
         for (ColumnUID i = 1; i <= 20; i++) {
             DeltaColumnGroup dcg;
             ColumnUID shift = i % 2;
-            dcg.init((int64_t)i, {{1 + shift, 2 + shift, 3 + shift}}, {"abc.cols"});
+            dcg.init((int64_t)i, {{1 + shift, 2 + shift, 3 + shift}}, {"abc.cols"}, {ep.encryption_meta});
             dcgs.push_back(std::make_shared<DeltaColumnGroup>(dcg));
         }
         const std::string path = "/asd/";
@@ -149,7 +163,7 @@ TEST(TestDeltaColumnGroup, testGC) {
         for (ColumnUID i = 1; i <= 20; i++) {
             DeltaColumnGroup dcg;
             ColumnUID shift = i % 3;
-            dcg.init((int64_t)i, {{1 + shift, 2 + shift, 3 + shift}}, {"abc.cols"});
+            dcg.init((int64_t)i, {{1 + shift, 2 + shift, 3 + shift}}, {"abc.cols"}, {ep.encryption_meta});
             dcgs.push_back(std::make_shared<DeltaColumnGroup>(dcg));
         }
         const std::string path = "/asd/";
@@ -168,6 +182,7 @@ TEST(TestDeltaColumnGroup, testGC) {
 };
 
 TEST(TestDeltaColumnGroup, testDeltaColumnGroupVerPBLoad) {
+    auto ep = KeyCache::instance().create_plain_random_encryption_meta_pair().value();
     // version 10 -> aaa.cols -> <3, 4>
     // version 11 -> bbb.cols -> <5, 6>
     // version 12 -> ccc.cols -> <7, 8>
@@ -178,6 +193,9 @@ TEST(TestDeltaColumnGroup, testDeltaColumnGroupVerPBLoad) {
     dcg_ver.add_column_files("aaa.cols");
     dcg_ver.add_column_files("bbb.cols");
     dcg_ver.add_column_files("ccc.cols");
+    dcg_ver.add_encryption_metas(ep.encryption_meta);
+    dcg_ver.add_encryption_metas(ep.encryption_meta);
+    dcg_ver.add_encryption_metas(ep.encryption_meta);
     DeltaColumnGroupColumnIdsPB unique_cids;
     unique_cids.add_column_ids(3);
     unique_cids.add_column_ids(4);

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -274,9 +274,9 @@ TEST_F(MetaFileTest, test_dcg) {
         rowset_metadata.add_segments("bbb.dat");
         TxnLogPB_OpWrite op_write;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
-        std::vector<std::string> filenames;
-        filenames.push_back("aaa.cols");
-        filenames.push_back("bbb.cols");
+        std::vector<std::pair<std::string, std::string>> filenames;
+        filenames.emplace_back("aaa.cols", "");
+        filenames.emplace_back("bbb.cols", "");
         std::vector<std::vector<ColumnUID>> unique_column_id_list;
         unique_column_id_list.push_back({3, 4, 5});
         unique_column_id_list.push_back({6, 7, 8});
@@ -294,8 +294,8 @@ TEST_F(MetaFileTest, test_dcg) {
         rowset_metadata.add_segments("ccc.dat");
         TxnLogPB_OpWrite op_write;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
-        std::vector<std::string> filenames;
-        filenames.push_back("ccc.cols");
+        std::vector<std::pair<std::string, std::string>> filenames;
+        filenames.emplace_back("ccc.cols", "");
         std::vector<std::vector<ColumnUID>> unique_column_id_list;
         unique_column_id_list.push_back({4, 7});
         builder.append_dcg(110, filenames, unique_column_id_list);
@@ -313,8 +313,8 @@ TEST_F(MetaFileTest, test_dcg) {
         rowset_metadata.add_segments("ddd.dat");
         TxnLogPB_OpWrite op_write;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
-        std::vector<std::string> filenames;
-        filenames.push_back("ddd.cols");
+        std::vector<std::pair<std::string, std::string>> filenames;
+        filenames.emplace_back("ddd.cols", "");
         std::vector<std::vector<ColumnUID>> unique_column_id_list;
         unique_column_id_list.push_back({3, 5});
         builder.append_dcg(110, filenames, unique_column_id_list);

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -42,6 +42,7 @@
 #include "column/datum_tuple.h"
 #include "common/logging.h"
 #include "fs/fs_memory.h"
+#include "fs/key_cache.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
@@ -272,6 +273,14 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
         column.set_default_value("10");
         r = segment->new_column_iterator_or_default(column, nullptr);
         ASSERT_TRUE(r.ok()) << r.status();
+    }
+    // test new_dcg_segment
+    {
+        auto ep = KeyCache::instance().create_plain_random_encryption_meta_pair().value();
+        DeltaColumnGroup dcg;
+        dcg.init(1, {{1}}, {"abc0.cols"}, {ep.encryption_meta});
+        auto r = segment->new_dcg_segment(dcg, 0, nullptr);
+        ASSERT_FALSE(r.ok());
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -1153,6 +1153,11 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
+            case OperationType.OP_ADD_KEY: {
+                data = new Text(Text.readBinary(in));
+                isRead = true;
+                break;
+            }
             default: {
                 if (Config.ignore_unknown_log_id) {
                     LOG.warn("UNKNOWN Operation Type {}", opCode);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -1190,6 +1190,12 @@ public class EditLog {
                     GlobalStateMgr.getCurrentState().getMetaRecoveryDaemon().recoverPartitionVersion(info);
                     break;
                 }
+                case OperationType.OP_ADD_KEY: {
+                    Text keyJson = (Text) journal.getData();
+                    EncryptionKeyPB keyPB = GsonUtils.GSON.fromJson(keyJson.toString(), EncryptionKeyPB.class);
+                    GlobalStateMgr.getCurrentState().getKeyMgr().replayAddKey(keyPB);
+                    break;
+                }
                 default: {
                     if (Config.ignore_unknown_log_id) {
                         LOG.warn("UNKNOWN Operation Type {}", opCode);

--- a/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
@@ -14,11 +14,17 @@
 
 package com.starrocks.persist;
 
+import com.starrocks.common.io.DataOutputBuffer;
 import com.starrocks.common.io.Text;
+import com.starrocks.encryption.KeyMgr;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.journal.JournalInconsistentException;
 import com.starrocks.journal.JournalTask;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.proto.EncryptionAlgorithmPB;
+import com.starrocks.proto.EncryptionKeyPB;
+import com.starrocks.proto.EncryptionKeyTypePB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.system.Frontend;
@@ -30,6 +36,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
@@ -172,6 +180,42 @@ public class EditLogTest {
         Frontend updatedfFe = updatedFrontends.get(0);
         Assert.assertEquals("testHost", updatedfFe.getHost());
         Assert.assertTrue(updatedfFe.getEditLogPort() == 1000);
+    }
+
+    @Test
+    public void testOpAddKeyJournalEntity() throws Exception {
+        EncryptionKeyPB pb = new EncryptionKeyPB();
+        pb.setId(KeyMgr.DEFAULT_MASTER_KYE_ID);
+        pb.algorithm = EncryptionAlgorithmPB.AES_128;
+        pb.plainKey = new byte[16];
+        pb.type = EncryptionKeyTypePB.NORMAL_KEY;
+        pb.createTime = 3L;
+        DataOutputBuffer buffer = new DataOutputBuffer(1024);
+        JournalEntity entity = new JournalEntity();
+        entity.setOpCode(OperationType.OP_ADD_KEY);
+        entity.setData(new Text(GsonUtils.GSON.toJson(pb)));
+        entity.write(buffer);
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(buffer.getData()));
+        JournalEntity replayEntry = new JournalEntity();
+        replayEntry.readFields(in);
+        Assert.assertEquals(OperationType.OP_ADD_KEY, replayEntry.getOpCode());
+    }
+
+    @Test
+    public void testOpAddKey() throws Exception {
+        GlobalStateMgr mgr = mockGlobalStateMgr();
+        EncryptionKeyPB pb = new EncryptionKeyPB();
+        pb.setId(KeyMgr.DEFAULT_MASTER_KYE_ID);
+        pb.algorithm = EncryptionAlgorithmPB.AES_128;
+        pb.plainKey = new byte[16];
+        pb.type = EncryptionKeyTypePB.NORMAL_KEY;
+        pb.createTime = 3L;
+        JournalEntity journal = new JournalEntity();
+        journal.setOpCode(OperationType.OP_ADD_KEY);
+        journal.setData(new Text(GsonUtils.GSON.toJson(pb)));
+        EditLog editLog = new EditLog(null);
+        editLog.loadJournal(mgr, journal);
+        Assert.assertEquals(1, mgr.getKeyMgr().numKeys());
     }
 
     @Test

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -59,6 +59,7 @@ message DeltaColumnGroupVerPB {
     repeated string column_files = 2;
     // To do conflict check with compaction task
     repeated int64 versions = 3;
+    repeated bytes encryption_metas = 4;
 }
 
 message DeltaColumnGroupMetadataPB {
@@ -84,6 +85,7 @@ message DelfileWithRowsetId {
     //      there are <DELETE, DELETE> in a transaction, so the `op_offset` of this DELETE is 0.
     //      And rssid of them will be rowset_id + [0, 0].
     optional uint32 op_offset = 3;
+    optional bytes encryption_meta = 4;
 }
 
 message RowsetMetadataPB {

--- a/gensrc/proto/olap_common.proto
+++ b/gensrc/proto/olap_common.proto
@@ -60,6 +60,7 @@ message OldDeltaColumnGroupPB {
 message DeltaColumnGroupPB {
     repeated DeltaColumnGroupColumnIdsPB column_ids = 1;
     repeated string column_files = 2;
+    repeated bytes encryption_metas = 3;
 }
 
 message DeltaColumnGroupListPB {


### PR DESCRIPTION
## Why I'm doing:

TDE doesn't handle del files and dcg files encryption/decryption properly currently 

```
*** Aborted at 1724665338 (unix time) try "date -d @1724665338" if you are using GNU date ***
PC: @          0x5e1649e starrocks::serde::(anonymous namespace)::read_raw(unsigned char const*, void*, unsigned long)
*** SIGSEGV (@0x7f01faf0d004) received by PID 2666 (TID 0x7f02366df700) from PID 18446744073624670212; stack trace: ***
    @     0x7f02da98820b __pthread_once_slow
    @          0x79bc560 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f02db80154f os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x7f02db8073b8 JVM_handle_linux_signal
    @     0x7f02db7f8db8 signalHandler(int, siginfo_t*, void*)
    @     0x7f02da991630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x5e1649e starrocks::serde::(anonymous namespace)::read_raw(unsigned char const*, void*, unsigned long)
    @          0x5e1c430 starrocks::ColumnVisitorMutableAdapter<starrocks::serde::(anonymous namespace)::ColumnDeserializingVisitor>::visit(starrocks::BinaryColumnBase<unsigned int>*)
    @          0x34fad5c starrocks::ColumnFactory<starrocks::Column, starrocks::BinaryColumnBase<unsigned int>, starrocks::Column>::accept_mutable(starrocks::ColumnVisitorMutable*)
    @          0x5e1bbd7 starrocks::serde::ColumnArraySerde::deserialize(unsigned char const*, starrocks::Column*, bool, int)
    @          0x6217676 starrocks::lake::LakePersistentIndex::load_dels(std::shared_ptr<starrocks::lake::Rowset> const&, starrocks::Schema const&, long)
    @          0x62196d9 starrocks::lake::LakePersistentIndex::load_from_lake_tablet(starrocks::lake::TabletManager*, std::shared_ptr<starrocks::TabletMetadataPB const> const&, long, starrocks::lake::MetaFileBuilder const*)
    @          0x61e2378 starrocks::lake::LakePrimaryIndex::_do_lake_load(starrocks::lake::TabletManager*, std::shared_ptr<starrocks::TabletMetadataPB const> const&, long, starrocks::lake::MetaFileBuilder const*)
    @          0x61e3cff starrocks::lake::LakePrimaryIndex::lake_load(starrocks::lake::TabletManager*, std::shared_ptr<starrocks::TabletMetadataPB const> const&, long, starrocks::lake::MetaFileBuilder const*)
    @          0x61c02f4 starrocks::lake::UpdateManager::prepare_primary_index(std::shared_ptr<starrocks::TabletMetadataPB const> const&, starrocks::lake::MetaFileBuilder*, long, long, std::unique_ptr<std::lock_guard<std::shared_timed_mutex>, std::default_delete<std::lock_guard<st<C0><B9><A8>^R
    @          0x6206a1c std::_Function_handler<starrocks::Status (), starrocks::lake::PrimaryKeyTxnLogApplier::apply(starrocks::TxnLogPB const&)::{lambda()#2}>::_M_invoke(std::_Any_data const&)
    @          0x6206fe5 starrocks::lake::PrimaryKeyTxnLogApplier::check_and_recover(std::function<starrocks::Status ()> const&)
    @          0x6209689 starrocks::lake::PrimaryKeyTxnLogApplier::apply(starrocks::TxnLogPB const&)
    @          0x61b03c6 starrocks::lake::publish_version(starrocks::lake::TabletManager*, long, long, long, std::vector<starrocks::TxnInfoPB, std::allocator<starrocks::TxnInfoPB> > const&)
    @          0x3784597 starrocks::LakeServiceImpl::publish_version(google::protobuf::RpcController*, starrocks::PublishVersionRequest const*, starrocks::PublishVersionResponse*, google::protobuf::Closure*)::{lambda()#1}::operator()() const
    @          0x37860aa std::_Function_handler<void (), starrocks::ConcurrencyLimitedThreadPoolToken::submit_func(std::function<void ()>, std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >)::{lambda()#1}>::_M_invoke<C0><B9><A8>^R
    @          0x382b0fb starrocks::ThreadPool::dispatch_thread()
    @          0x3824626 starrocks::Thread::supervise_thread(void*)
    @     0x7f02da989ea5 start_thread
    @     0x7f02d9d8ab0d __clone
```

## What I'm doing:

Add del/dcg encryption/decryption hanlding for cloud native TDE

Fixes https://github.com/StarRocks/StarRocksTest/issues/8459
Fixes https://github.com/StarRocks/StarRocksTest/issues/8471

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
