### PR TITLE
[Enhancement] limit tablet write request size

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -703,8 +703,8 @@ CONF_Int32(metric_late_materialization_ratio, "1000");
 
 // Max batched bytes for each transmit request. (256KB)
 CONF_Int64(max_transmit_batched_bytes, "262144");
-// max chunk size for each tablet write request. (1MB)
-CONF_mInt64(max_tablet_write_chunk_bytes, "1048576");
+// max chunk size for each tablet write request. (128MB)
+CONF_mInt64(max_tablet_write_chunk_bytes, "134217728");
 
 CONF_Int16(bitmap_max_filter_items, "30");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -704,6 +704,10 @@ CONF_Int32(metric_late_materialization_ratio, "1000");
 // Max batched bytes for each transmit request. (256KB)
 CONF_Int64(max_transmit_batched_bytes, "262144");
 // max chunk size for each tablet write request. (512MB)
+// see: https://github.com/StarRocks/starrocks/pull/50302
+// NOTE: If there are a large number of columns when loading,
+// a too small max_tablet_write_chunk_bytes may cause more frequent RPCs, which may affect performance.
+// In this case, we can try to increase the value to avoid the problem.
 CONF_mInt64(max_tablet_write_chunk_bytes, "536870912");
 
 CONF_Int16(bitmap_max_filter_items, "30");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -703,6 +703,8 @@ CONF_Int32(metric_late_materialization_ratio, "1000");
 
 // Max batched bytes for each transmit request. (256KB)
 CONF_Int64(max_transmit_batched_bytes, "262144");
+// max chunk size for each tablet write request. (1MB)
+CONF_mInt64(max_tablet_write_chunk_bytes, "1048576");
 
 CONF_Int16(bitmap_max_filter_items, "30");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -703,8 +703,8 @@ CONF_Int32(metric_late_materialization_ratio, "1000");
 
 // Max batched bytes for each transmit request. (256KB)
 CONF_Int64(max_transmit_batched_bytes, "262144");
-// max chunk size for each tablet write request. (128MB)
-CONF_mInt64(max_tablet_write_chunk_bytes, "134217728");
+// max chunk size for each tablet write request. (512MB)
+CONF_mInt64(max_tablet_write_chunk_bytes, "536870912");
 
 CONF_Int16(bitmap_max_filter_items, "30");
 

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -467,8 +467,8 @@ Status NodeChannel::add_chunk(Chunk* input, const std::vector<int64_t>& tablet_i
         }
     }
 
-    if (_cur_chunk->num_rows() < _runtime_state->chunk_size() &&
-        _cur_chunk_mem_usage < config::max_tablet_write_chunk_bytes) {
+    if (_cur_chunk->num_rows() <= 0 || (_cur_chunk->num_rows() < _runtime_state->chunk_size() &&
+                                        _cur_chunk_mem_usage < config::max_tablet_write_chunk_bytes)) {
         // 2. chunk not full
         if (_request_queue.empty()) {
             return Status::OK();
@@ -520,8 +520,8 @@ Status NodeChannel::add_chunks(Chunk* input, const std::vector<std::vector<int64
         }
     }
 
-    if (_cur_chunk->num_rows() < _runtime_state->chunk_size() &&
-        _cur_chunk_mem_usage < config::max_tablet_write_chunk_bytes) {
+    if (_cur_chunk->num_rows() <= 0 || (_cur_chunk->num_rows() < _runtime_state->chunk_size() &&
+                                        _cur_chunk_mem_usage < config::max_tablet_write_chunk_bytes)) {
         // 2. chunk not full
         if (_request_queue.empty()) {
             return Status::OK();

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -415,6 +415,20 @@ bool NodeChannel::is_full() {
     return false;
 }
 
+void NodeChannel::_reset_cur_chunk(Chunk* input) {
+    int64_t before_consumed_bytes = CurrentThread::current().get_consumed_bytes();
+    _cur_chunk = input->clone_empty_with_slot();
+    int64_t after_consumed_bytes = CurrentThread::current().get_consumed_bytes();
+    _cur_chunk_mem_usage = after_consumed_bytes - before_consumed_bytes;
+}
+
+void NodeChannel::_append_data_to_cur_chunk(const Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
+    int64_t before_consumed_bytes = CurrentThread::current().get_consumed_bytes();
+    _cur_chunk->append_selective(src, indexes, from, size);
+    int64_t after_consumed_bytes = CurrentThread::current().get_consumed_bytes();
+    _cur_chunk_mem_usage += after_consumed_bytes - before_consumed_bytes;
+}
+
 Status NodeChannel::add_chunk(Chunk* input, const std::vector<int64_t>& tablet_ids,
                               const std::vector<uint32_t>& indexes, uint32_t from, uint32_t size) {
     if (_cancelled || _closed) {
@@ -423,7 +437,7 @@ Status NodeChannel::add_chunk(Chunk* input, const std::vector<int64_t>& tablet_i
 
     DCHECK(_rpc_request.requests_size() == 1);
     if (UNLIKELY(_cur_chunk == nullptr)) {
-        _cur_chunk = input->clone_empty_with_slot();
+        _reset_cur_chunk(input);
     }
 
     if (is_full()) {
@@ -436,7 +450,7 @@ Status NodeChannel::add_chunk(Chunk* input, const std::vector<int64_t>& tablet_i
     SCOPED_TIMER(_ts_profile->pack_chunk_timer);
     // 1. append data
     if (_where_clause == nullptr) {
-        _cur_chunk->append_selective(*input, indexes.data(), from, size);
+        _append_data_to_cur_chunk(*input, indexes.data(), from, size);
         auto req = _rpc_request.mutable_requests(0);
         for (size_t i = 0; i < size; ++i) {
             req->add_tablet_ids(tablet_ids[indexes[from + i]]);
@@ -445,14 +459,15 @@ Status NodeChannel::add_chunk(Chunk* input, const std::vector<int64_t>& tablet_i
         std::vector<uint32_t> filtered_indexes;
         RETURN_IF_ERROR(_filter_indexes_with_where_expr(input, indexes, filtered_indexes));
         size_t filter_size = filtered_indexes.size();
-        _cur_chunk->append_selective(*input, filtered_indexes.data(), from, filter_size);
+        _append_data_to_cur_chunk(*input, filtered_indexes.data(), from, filter_size);
+
         auto req = _rpc_request.mutable_requests(0);
         for (size_t i = 0; i < filter_size; ++i) {
             req->add_tablet_ids(tablet_ids[filtered_indexes[from + i]]);
         }
     }
 
-    if (_cur_chunk->num_rows() < _runtime_state->chunk_size()) {
+    if (_cur_chunk->num_rows() < _runtime_state->chunk_size() && _cur_chunk_mem_usage < config::max_tablet_write_chunk_bytes) {
         // 2. chunk not full
         if (_request_queue.empty()) {
             return Status::OK();
@@ -462,7 +477,7 @@ Status NodeChannel::add_chunk(Chunk* input, const std::vector<int64_t>& tablet_i
         // 3. chunk full push back to queue
         _mem_tracker->consume(_cur_chunk->memory_usage());
         _request_queue.emplace_back(std::move(_cur_chunk), _rpc_request);
-        _cur_chunk = input->clone_empty_with_slot();
+        _reset_cur_chunk(input);
         _rpc_request.mutable_requests(0)->clear_tablet_ids();
     }
 
@@ -483,7 +498,7 @@ Status NodeChannel::add_chunks(Chunk* input, const std::vector<std::vector<int64
 
     DCHECK(index_tablet_ids.size() == _rpc_request.requests_size());
     if (UNLIKELY(_cur_chunk == nullptr)) {
-        _cur_chunk = input->clone_empty_with_slot();
+        _reset_cur_chunk(input);
     }
 
     if (is_full()) {
@@ -493,8 +508,10 @@ Status NodeChannel::add_chunks(Chunk* input, const std::vector<std::vector<int64
     }
 
     SCOPED_TIMER(_ts_profile->pack_chunk_timer);
+
     // 1. append data
-    _cur_chunk->append_selective(*input, indexes.data(), from, size);
+    _append_data_to_cur_chunk(*input, indexes.data(), from, size);
+
     for (size_t index_i = 0; index_i < index_tablet_ids.size(); ++index_i) {
         auto req = _rpc_request.mutable_requests(index_i);
         for (size_t i = from; i < size; ++i) {
@@ -502,7 +519,7 @@ Status NodeChannel::add_chunks(Chunk* input, const std::vector<std::vector<int64
         }
     }
 
-    if (_cur_chunk->num_rows() < _runtime_state->chunk_size()) {
+    if (_cur_chunk->num_rows() < _runtime_state->chunk_size() && _cur_chunk_mem_usage < config::max_tablet_write_chunk_bytes) {
         // 2. chunk not full
         if (_request_queue.empty()) {
             return Status::OK();
@@ -512,7 +529,7 @@ Status NodeChannel::add_chunks(Chunk* input, const std::vector<std::vector<int64
         // 3. chunk full push back to queue
         _mem_tracker->consume(_cur_chunk->memory_usage());
         _request_queue.emplace_back(std::move(_cur_chunk), _rpc_request);
-        _cur_chunk = input->clone_empty_with_slot();
+        _reset_cur_chunk(input);
         for (size_t index_i = 0; index_i < index_tablet_ids.size(); ++index_i) {
             _rpc_request.mutable_requests(index_i)->clear_tablet_ids();
         }
@@ -567,6 +584,7 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             _mem_tracker->consume(_cur_chunk->memory_usage());
             _request_queue.emplace_back(std::move(_cur_chunk), _rpc_request);
             _cur_chunk = nullptr;
+            _cur_chunk_mem_usage = 0;
         }
 
         // try to send chunk in queue first

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -419,7 +419,7 @@ void NodeChannel::_reset_cur_chunk(Chunk* input) {
     int64_t before_consumed_bytes = CurrentThread::current().get_consumed_bytes();
     _cur_chunk = input->clone_empty_with_slot();
     int64_t after_consumed_bytes = CurrentThread::current().get_consumed_bytes();
-    _cur_chunk_mem_usage = after_consumed_bytes - before_consumed_bytes;
+    _cur_chunk_mem_usage += after_consumed_bytes - before_consumed_bytes;
 }
 
 void NodeChannel::_append_data_to_cur_chunk(const Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size) {

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -467,7 +467,8 @@ Status NodeChannel::add_chunk(Chunk* input, const std::vector<int64_t>& tablet_i
         }
     }
 
-    if (_cur_chunk->num_rows() < _runtime_state->chunk_size() && _cur_chunk_mem_usage < config::max_tablet_write_chunk_bytes) {
+    if (_cur_chunk->num_rows() < _runtime_state->chunk_size() &&
+        _cur_chunk_mem_usage < config::max_tablet_write_chunk_bytes) {
         // 2. chunk not full
         if (_request_queue.empty()) {
             return Status::OK();
@@ -519,7 +520,8 @@ Status NodeChannel::add_chunks(Chunk* input, const std::vector<std::vector<int64
         }
     }
 
-    if (_cur_chunk->num_rows() < _runtime_state->chunk_size() && _cur_chunk_mem_usage < config::max_tablet_write_chunk_bytes) {
+    if (_cur_chunk->num_rows() < _runtime_state->chunk_size() &&
+        _cur_chunk_mem_usage < config::max_tablet_write_chunk_bytes) {
         // 2. chunk not full
         if (_request_queue.empty()) {
             return Status::OK();

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -186,6 +186,9 @@ private:
     Status _filter_indexes_with_where_expr(Chunk* input, const std::vector<uint32_t>& indexes,
                                            std::vector<uint32_t>& filtered_indexes);
 
+    void _reset_cur_chunk(Chunk* input);
+    void _append_data_to_cur_chunk(const Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size);
+
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
 
     OlapTableSink* _parent = nullptr;
@@ -236,6 +239,7 @@ private:
     size_t _max_parallel_request_size = 1;
     std::vector<ReusableClosure<PTabletWriterAddBatchResult>*> _add_batch_closures;
     std::unique_ptr<Chunk> _cur_chunk;
+    int64_t _cur_chunk_mem_usage = 0;
 
     PTabletWriterAddChunksRequest _rpc_request;
     using AddMultiChunkReq = std::pair<std::unique_ptr<Chunk>, PTabletWriterAddChunksRequest>;


### PR DESCRIPTION
## Why I'm doing:
When there are large chunks during the load process, the following error may be returned due to exceeding the size limit of protobuf.
![img_v3_02e4_eddde0ab-db20-4044-99a3-d6c6a82baf6g](https://github.com/user-attachments/assets/7fd8ec87-7611-4462-a992-7c96f686f139)

NodeChannel currently only aggregates batches based on the function of the chunk, but does not take into account the size of the chunk.
![img_v3_02e4_9f4f7683-ef85-49db-b315-5a3647cb863g](https://github.com/user-attachments/assets/c6a9de30-a1cc-4394-8f4c-77350339ebac)


## What I'm doing:
In this PR, I have added chunk mem usage check to avoid generating large pb requests for load tasks

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
