### PR TITLE
[Fix]Fix aws.s3.xxx invalid even IcebergAwsClientFactory is set as client.factory

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
@@ -16,6 +16,7 @@ package com.starrocks.credential;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
+import com.starrocks.connector.share.iceberg.IcebergAwsClientFactory;
 import com.starrocks.credential.aliyun.AliyunCloudConfigurationProvider;
 import com.starrocks.credential.aws.AWSCloudConfigurationProvider;
 import com.starrocks.credential.aws.AWSCloudCredential;
@@ -26,6 +27,7 @@ import com.starrocks.credential.hdfs.StrictHDFSCloudConfigurationProvider;
 import com.starrocks.credential.tencent.TencentCloudConfigurationProvider;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 
 import java.util.HashMap;
@@ -89,7 +91,12 @@ public class CloudConfigurationFactory {
         String sessionSk = properties.getOrDefault(S3FileIOProperties.SECRET_ACCESS_KEY, null);
         String sessionToken = properties.getOrDefault(S3FileIOProperties.SESSION_TOKEN, null);
         String region = properties.getOrDefault(AwsClientProperties.CLIENT_REGION, null);
-        if (sessionAk != null && sessionSk != null && sessionToken != null && region != null) {
+        String clientFactory = properties.getOrDefault(AwsProperties.CLIENT_FACTORY, null);
+        String icebergAwsClientFactoryClassName = IcebergAwsClientFactory.class.getSimpleName();
+        if (clientFactory != null && clientFactory.contains(icebergAwsClientFactoryClassName)) {
+            return buildCloudConfigurationForStorage(copiedProperties);
+        }
+        if (sessionAk != null && sessionSk != null && sessionToken != null && region != null){
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_ACCESS_KEY, sessionAk);
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_SECRET_KEY, sessionSk);
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_SESSION_TOKEN, sessionToken);

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
@@ -96,7 +96,7 @@ public class CloudConfigurationFactory {
         if (clientFactory != null && clientFactory.contains(icebergAwsClientFactoryClassName)) {
             return buildCloudConfigurationForStorage(copiedProperties);
         }
-        if (sessionAk != null && sessionSk != null && sessionToken != null && region != null){
+        if (sessionAk != null && sessionSk != null && sessionToken != null && region != null) {
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_ACCESS_KEY, sessionAk);
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_SECRET_KEY, sessionSk);
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_SESSION_TOKEN, sessionToken);


### PR DESCRIPTION
## Why I'm doing:
we would like to make aws.s3.xxx parameters valid, so we specify  ("client.factory"="com.starrocks.connector.iceberg.IcebergAwsClientFactory").
But it turns out that aws client still uses aws session token instead of aws credentials that we set in catalog's params.
## What I'm doing:

Fix aws.s3.xxx invalid even IcebergAwsClientFactory is set as client.factory

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
