### PR TITLE
[Enhancement] support adaptive partition hash join

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1247,6 +1247,8 @@ CONF_String(rocksdb_db_options_string, "create_if_missing=true;create_missing_co
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
 // only used for test. default: 128M
 CONF_mInt64(streaming_agg_limited_memory_size, "134217728");
+// mem limit for partition hash join probe side buffer
+CONF_mInt64(partition_hash_join_probe_limit_size, "134217728");
 // pipeline streaming aggregate chunk buffer size
 CONF_mInt32(streaming_agg_chunk_buffer_size, "1024");
 CONF_mInt64(wait_apply_time, "6000"); // 6s

--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -14,12 +14,21 @@
 
 #include "exec/hash_join_components.h"
 
+#include <deque>
 #include <memory>
+#include <numeric>
 
 #include "column/vectorized_fwd.h"
+#include "common/logging.h"
+#include "common/object_pool.h"
 #include "exec/hash_joiner.h"
 #include "exec/join_hash_map.h"
+#include "exprs/agg/distinct.h"
+#include "exprs/expr_context.h"
 #include "gutil/casts.h"
+#include "runtime/descriptors.h"
+#include "util/cpu_info.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 
@@ -28,12 +37,16 @@ public:
     SingleHashJoinProberImpl(HashJoiner& hash_joiner) : HashJoinProberImpl(hash_joiner) {}
     ~SingleHashJoinProberImpl() override = default;
     bool probe_chunk_empty() const override { return _probe_chunk == nullptr; }
+    Status on_input_finished(RuntimeState* state) override { return Status::OK(); }
     Status push_probe_chunk(RuntimeState* state, ChunkPtr&& chunk) override;
     StatusOr<ChunkPtr> probe_chunk(RuntimeState* state) override;
     StatusOr<ChunkPtr> probe_remain(RuntimeState* state, bool* has_remain) override;
-    void reset() override {
+    void reset(RuntimeState* runtime_state) override {
         _probe_chunk.reset();
         _current_probe_has_remain = false;
+        if (_hash_table != nullptr) {
+            _hash_table->reset_probe_state(runtime_state);
+        }
     }
     void set_ht(JoinHashTable* hash_table) { _hash_table = hash_table; }
 
@@ -85,6 +98,228 @@ void HashJoinProber::attach(HashJoinBuilder* builder, const HashJoinProbeMetrics
     _impl = builder->create_prober();
 }
 
+struct PartitionChunkChannel {
+    std::deque<ChunkPtr> chunks;
+    bool _processing = false;
+
+    bool processing() const { return _processing; }
+    void set_processing(bool processing) { _processing = processing; }
+
+    ChunkPtr pull() {
+        auto chunk = std::move(chunks.front());
+        chunks.pop_front();
+        return chunk;
+    }
+
+    void push(ChunkPtr&& chunk) { chunks.emplace_back(std::move(chunk)); }
+
+    const ChunkPtr& back() { return chunks.back(); }
+
+    bool is_full() const { return chunks.size() >= 4; }
+
+    bool is_empty() const { return chunks.empty() || chunks.front()->is_empty(); }
+
+    bool not_empty() const { return !is_empty(); }
+};
+
+class PartitionedHashJoinProberImpl final : public HashJoinProberImpl {
+public:
+    PartitionedHashJoinProberImpl(HashJoiner& hash_joiner) : HashJoinProberImpl(hash_joiner) {}
+    ~PartitionedHashJoinProberImpl() override = default;
+    bool probe_chunk_empty() const override;
+    Status on_input_finished(RuntimeState* state) override;
+    Status push_probe_chunk(RuntimeState* state, ChunkPtr&& chunk) override;
+    StatusOr<ChunkPtr> probe_chunk(RuntimeState* state) override;
+    StatusOr<ChunkPtr> probe_remain(RuntimeState* state, bool* has_remain) override;
+    void reset(RuntimeState* runtime_state) override;
+    void set_probers(std::vector<std::unique_ptr<SingleHashJoinProberImpl>>&& probers) {
+        _probers = std::move(probers);
+        _partition_input_channels.resize(_probers.size());
+    }
+
+private:
+    bool _all_input_finished = false;
+    int32_t _remain_partition_idx = 0;
+    std::vector<std::unique_ptr<SingleHashJoinProberImpl>> _probers;
+    std::vector<PartitionChunkChannel> _partition_input_channels;
+};
+
+bool PartitionedHashJoinProberImpl::probe_chunk_empty() const {
+    auto& probers = _probers;
+    size_t num_partitions = probers.size();
+
+    if (!_all_input_finished) {
+        for (size_t i = 0; i < num_partitions; ++i) {
+            if (!probers[i]->probe_chunk_empty() || _partition_input_channels[i].processing()) {
+                return false;
+            }
+        }
+    } else {
+        for (size_t i = 0; i < num_partitions; ++i) {
+            if (!probers[i]->probe_chunk_empty() || _partition_input_channels[i].not_empty()) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+Status PartitionedHashJoinProberImpl::on_input_finished(RuntimeState* runtime_state) {
+    SCOPED_TIMER(_hash_joiner.probe_metrics().partition_probe_overhead);
+    _all_input_finished = true;
+    auto& probers = _probers;
+    size_t num_partitions = probers.size();
+
+    for (size_t i = 0; i < num_partitions; ++i) {
+        if (_partition_input_channels[i].is_empty()) {
+            continue;
+        }
+        if (!probers[i]->probe_chunk_empty()) {
+            continue;
+        }
+        RETURN_IF_ERROR(probers[i]->push_probe_chunk(runtime_state, _partition_input_channels[i].pull()));
+    }
+    return Status::OK();
+}
+
+Status PartitionedHashJoinProberImpl::push_probe_chunk(RuntimeState* state, ChunkPtr&& chunk) {
+    SCOPED_TIMER(_hash_joiner.probe_metrics().partition_probe_overhead);
+    auto& probers = _probers;
+    auto& partition_keys = _hash_joiner.probe_expr_ctxs();
+
+    size_t num_rows = chunk->num_rows();
+    size_t num_partitions = probers.size();
+    size_t num_partition_cols = partition_keys.size();
+
+    std::vector<ColumnPtr> partition_columns(num_partition_cols);
+    for (size_t i = 0; i < num_partition_cols; ++i) {
+        ASSIGN_OR_RETURN(partition_columns[i], partition_keys[i]->evaluate(chunk.get()));
+    }
+    std::vector<uint32_t> hash_values;
+    {
+        hash_values.assign(num_rows, HashUtil::FNV_SEED);
+
+        for (const ColumnPtr& column : partition_columns) {
+            column->fnv_hash(hash_values.data(), 0, num_rows);
+        }
+        // find partition id
+        for (size_t i = 0; i < hash_values.size(); ++i) {
+            hash_values[i] = HashUtil::fmix32(hash_values[i]) & (num_partitions - 1);
+        }
+    }
+
+    const auto& partitions = hash_values;
+
+    std::vector<uint32_t> selection;
+    selection.resize(chunk->num_rows());
+
+    std::vector<int32_t> channel_row_idx_start_points;
+    channel_row_idx_start_points.assign(num_partitions + 1, 0);
+
+    for (uint32_t i : partitions) {
+        channel_row_idx_start_points[i]++;
+    }
+
+    for (int32_t i = 1; i <= channel_row_idx_start_points.size() - 1; ++i) {
+        channel_row_idx_start_points[i] += channel_row_idx_start_points[i - 1];
+    }
+
+    for (int32_t i = chunk->num_rows() - 1; i >= 0; --i) {
+        selection[channel_row_idx_start_points[partitions[i]] - 1] = i;
+        channel_row_idx_start_points[partitions[i]]--;
+    }
+    _partition_input_channels.resize(num_partitions);
+
+    for (size_t i = 0; i < num_partitions; ++i) {
+        auto from = channel_row_idx_start_points[i];
+        auto size = channel_row_idx_start_points[i + 1] - from;
+        if (size == 0) {
+            continue;
+        }
+
+        if (_partition_input_channels[i].is_empty()) {
+            _partition_input_channels[i].push(chunk->clone_empty());
+        }
+
+        if (_partition_input_channels[i].back()->num_rows() + size <= 4096) {
+            _partition_input_channels[i].back()->append_selective(*chunk, selection.data(), from, size);
+        } else {
+            _partition_input_channels[i].push(chunk->clone_empty());
+            _partition_input_channels[i].back()->append_selective(*chunk, selection.data(), from, size);
+        }
+
+        if (_partition_input_channels[i].is_full()) {
+            _partition_input_channels[i].set_processing(true);
+            RETURN_IF_ERROR(probers[i]->push_probe_chunk(state, _partition_input_channels[i].pull()));
+        }
+    }
+
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> PartitionedHashJoinProberImpl::probe_chunk(RuntimeState* state) {
+    auto& probers = _probers;
+    size_t num_partitions = probers.size();
+    if (_all_input_finished) {
+        for (size_t i = 0; i < num_partitions; ++i) {
+            if (probers[i]->probe_chunk_empty() && _partition_input_channels[i].is_empty()) {
+                continue;
+            }
+            if (probers[i]->probe_chunk_empty()) {
+                RETURN_IF_ERROR(probers[i]->push_probe_chunk(state, _partition_input_channels[i].pull()));
+            }
+            auto chunk = std::make_shared<Chunk>();
+            ASSIGN_OR_RETURN(chunk, probers[i]->probe_chunk(state))
+            return chunk;
+        }
+    } else {
+        for (size_t i = 0; i < num_partitions; ++i) {
+            if (probers[i]->probe_chunk_empty() && !_partition_input_channels[i].processing()) {
+                continue;
+            }
+            if (probers[i]->probe_chunk_empty()) {
+                RETURN_IF_ERROR(probers[i]->push_probe_chunk(state, _partition_input_channels[i].pull()));
+            }
+            _partition_input_channels[i].set_processing(_partition_input_channels[i].chunks.size() > 1);
+            auto chunk = std::make_shared<Chunk>();
+            ASSIGN_OR_RETURN(chunk, probers[i]->probe_chunk(state))
+            return chunk;
+        }
+    }
+    CHECK(false);
+
+    return nullptr;
+}
+
+StatusOr<ChunkPtr> PartitionedHashJoinProberImpl::probe_remain(RuntimeState* state, bool* has_remain) {
+    auto& probers = _probers;
+    size_t num_partitions = probers.size();
+    while (_remain_partition_idx < num_partitions) {
+        auto chunk = std::make_shared<Chunk>();
+        bool sub_map_has_remain = false;
+        ASSIGN_OR_RETURN(chunk, probers[_remain_partition_idx]->probe_remain(state, &sub_map_has_remain));
+        if (!sub_map_has_remain) {
+            _remain_partition_idx++;
+        }
+        if (chunk->is_empty()) {
+            continue;
+        }
+        *has_remain = true;
+        return chunk;
+    }
+
+    *has_remain = false;
+    return nullptr;
+}
+
+void PartitionedHashJoinProberImpl::reset(RuntimeState* runtime_state) {
+    _probers.clear();
+    _partition_input_channels.clear();
+    _all_input_finished = false;
+    _remain_partition_idx = 0;
+}
+
 void SingleHashJoinBuilder::create(const HashTableParam& param) {
     _ht.create(param);
 }
@@ -97,11 +332,6 @@ void SingleHashJoinBuilder::close() {
 void SingleHashJoinBuilder::reset(const HashTableParam& param) {
     close();
     create(param);
-}
-
-void SingleHashJoinBuilder::reset_probe(RuntimeState* state) {
-    _key_columns.clear();
-    _ht.reset_probe_state(state);
 }
 
 bool SingleHashJoinBuilder::anti_join_key_column_has_null() const {
@@ -153,6 +383,382 @@ void SingleHashJoinBuilder::clone_readable(HashJoinBuilder* builder) {
 
 ChunkPtr SingleHashJoinBuilder::convert_to_spill_schema(const ChunkPtr& chunk) const {
     return _ht.convert_to_spill_schema(chunk);
+}
+
+class AdaptivePartitionHashJoinBuilder final : public HashJoinBuilder {
+public:
+    AdaptivePartitionHashJoinBuilder(HashJoiner& hash_joiner);
+    ~AdaptivePartitionHashJoinBuilder() override = default;
+
+    void create(const HashTableParam& param) override;
+
+    void close() override;
+
+    void reset(const HashTableParam& param) override;
+
+    Status do_append_chunk(const ChunkPtr& chunk) override;
+
+    Status build(RuntimeState* state) override;
+
+    bool anti_join_key_column_has_null() const override;
+
+    int64_t ht_mem_usage() const override;
+
+    void get_build_info(size_t* bucket_size, float* avg_keys_per_bucket) override;
+
+    size_t get_output_probe_column_count() const override;
+    size_t get_output_build_column_count() const override;
+
+    void visitHt(const std::function<void(JoinHashTable*)>& visitor) override;
+
+    std::unique_ptr<HashJoinProberImpl> create_prober() override;
+
+    void clone_readable(HashJoinBuilder* builder) override;
+
+    ChunkPtr convert_to_spill_schema(const ChunkPtr& chunk) const override;
+
+private:
+    size_t _estimated_row_size(const HashTableParam& param) const;
+    size_t _estimated_probe_cost(const HashTableParam& param) const;
+    size_t _estimated_build_cost(size_t build_row_size, int cache_level) const;
+    void _adjust_partition_rows(size_t build_row_size);
+
+    void _init_partition_nums(const HashTableParam& param);
+    Status _convert_to_single_partition();
+    Status _append_chunk_to_partitions(const ChunkPtr& chunk);
+
+private:
+    std::vector<std::unique_ptr<SingleHashJoinBuilder>> _builders;
+
+    size_t _partition_num = 0;
+    size_t _partition_join_min_rows = 0;
+    size_t _partition_join_max_rows = 0;
+
+    size_t _probe_estimated_costs = 0;
+
+    size_t _fit_L2_cache_max_rows = 0;
+    size_t _fit_L3_cache_max_rows = 0;
+
+    size_t _L2_cache_size = 0;
+    size_t _L3_cache_size = 0;
+
+    size_t _pushed_chunks = 0;
+};
+
+AdaptivePartitionHashJoinBuilder::AdaptivePartitionHashJoinBuilder(HashJoiner& hash_joiner)
+        : HashJoinBuilder(hash_joiner) {
+    const size_t DEFAULT_L2_CACHE_SIZE = 1 * 1024 * 1024;
+    const size_t DEFAULT_L3_CACHE_SIZE = 32 * 1024 * 1024;
+    const auto& cache_sizes = CpuInfo::get_cache_sizes();
+    _L2_cache_size = cache_sizes[CpuInfo::L2_CACHE];
+    _L3_cache_size = cache_sizes[CpuInfo::L3_CACHE];
+    _L2_cache_size = _L2_cache_size ? _L2_cache_size : DEFAULT_L2_CACHE_SIZE;
+    _L3_cache_size = _L3_cache_size ? _L3_cache_size : DEFAULT_L3_CACHE_SIZE;
+}
+
+size_t AdaptivePartitionHashJoinBuilder::_estimated_row_size(const HashTableParam& param) const {
+    size_t estimated_each_row = 0;
+
+    for (auto* tuple : param.build_row_desc->tuple_descriptors()) {
+        for (auto slot : tuple->slots()) {
+            if (param.build_output_slots.contains(slot->id())) {
+                estimated_each_row += get_size_of_fixed_length_type(slot->type().type);
+                estimated_each_row += type_estimated_overhead_bytes(slot->type().type);
+            }
+        }
+    }
+
+    // for hash table bucket
+    estimated_each_row += 4;
+
+    return estimated_each_row;
+}
+
+// We could use a better estimation model.
+size_t AdaptivePartitionHashJoinBuilder::_estimated_probe_cost(const HashTableParam& param) const {
+    size_t size = 0;
+
+    for (auto* tuple : param.probe_row_desc->tuple_descriptors()) {
+        for (auto slot : tuple->slots()) {
+            if (param.probe_output_slots.contains(slot->id())) {
+                size += get_size_of_fixed_length_type(slot->type().type);
+                size += type_estimated_overhead_bytes(slot->type().type);
+            }
+        }
+    }
+    // we define probe cost is bytes size * 6
+    return size * 6;
+}
+
+size_t AdaptivePartitionHashJoinBuilder::_estimated_build_cost(size_t build_row_size, int cache_level) const {
+    if (cache_level == 0) {
+        return build_row_size / 2;
+    } else if (cache_level == 1) {
+        return build_row_size;
+    } else {
+        return build_row_size * 2;
+    }
+}
+
+void AdaptivePartitionHashJoinBuilder::_adjust_partition_rows(size_t build_row_size) {
+    _fit_L2_cache_max_rows = _L2_cache_size / build_row_size;
+    _fit_L3_cache_max_rows = _L3_cache_size / build_row_size;
+
+    // If the hash table is smaller than the L2 cache. we don't think partition hash join is needed.
+    _partition_join_min_rows = _fit_L2_cache_max_rows;
+    // If the hash table after partition can't be loaded to L3. we don't think partition hash join is needed.
+    _partition_join_max_rows = _fit_L3_cache_max_rows * _partition_num;
+
+    if (_probe_estimated_costs + _estimated_build_cost(build_row_size, 0) < _estimated_build_cost(build_row_size, 1)) {
+        // overhead after hash table partitioning + probe extra cost < cost before partitioning
+        // nothing to do
+    } else if (_probe_estimated_costs + _estimated_build_cost(build_row_size, 1) <
+               _estimated_build_cost(build_row_size, 2)) {
+        // It is only after this that performance gains can be realized beyond the L3 cache.
+        _partition_join_min_rows = _fit_L3_cache_max_rows;
+    } else {
+        // Partitioned joins don't have performance gains. Not using partition hash join.
+        _partition_num = 1;
+    }
+
+    VLOG_OPERATOR << "TRACE:"
+                  << "partition_num=" << _partition_num << " partition_join_min_rows=" << _partition_join_min_rows
+                  << " partition_join_max_rows=" << _partition_join_max_rows;
+    VLOG_OPERATOR << "TRACE"
+                  << " probe cost=" << _probe_estimated_costs
+                  << " build cost=" << _estimated_build_cost(build_row_size, 0)
+                  << " build cost L2=" << _estimated_build_cost(build_row_size, 1)
+                  << " build cost L3=" << _estimated_build_cost(build_row_size, 2);
+}
+
+void AdaptivePartitionHashJoinBuilder::_init_partition_nums(const HashTableParam& param) {
+    _partition_num = 16;
+
+    size_t estimated_bytes_each_row = _estimated_row_size(param);
+
+    _probe_estimated_costs = _estimated_probe_cost(param);
+
+    _adjust_partition_rows(estimated_bytes_each_row);
+
+    COUNTER_SET(_hash_joiner.build_metrics().partition_nums, (int64_t)_partition_num);
+}
+
+void AdaptivePartitionHashJoinBuilder::create(const HashTableParam& param) {
+    _init_partition_nums(param);
+    for (size_t i = 0; i < _partition_num; ++i) {
+        _builders.emplace_back(std::make_unique<SingleHashJoinBuilder>(_hash_joiner));
+        _builders.back()->create(param);
+    }
+}
+
+void AdaptivePartitionHashJoinBuilder::close() {
+    for (auto& builder : _builders) {
+        builder->close();
+    }
+    _builders.clear();
+    _partition_num = 0;
+    _partition_join_min_rows = 0;
+    _partition_join_max_rows = 0;
+    _probe_estimated_costs = 0;
+    _fit_L2_cache_max_rows = 0;
+    _fit_L3_cache_max_rows = 0;
+    _pushed_chunks = 0;
+}
+
+void AdaptivePartitionHashJoinBuilder::reset(const HashTableParam& param) {
+    close();
+    create(param);
+}
+
+bool AdaptivePartitionHashJoinBuilder::anti_join_key_column_has_null() const {
+    return std::any_of(_builders.begin(), _builders.end(),
+                       [](const auto& builder) { return builder->anti_join_key_column_has_null(); });
+}
+
+void AdaptivePartitionHashJoinBuilder::get_build_info(size_t* bucket_size, float* avg_keys_per_bucket) {
+    size_t total_bucket_size = 0;
+    float total_keys_per_bucket = 0;
+    for (const auto& builder : _builders) {
+        size_t bucket_size = 0;
+        float keys_per_bucket = 0;
+        builder->get_build_info(&bucket_size, &keys_per_bucket);
+        total_bucket_size += bucket_size;
+        total_keys_per_bucket += keys_per_bucket;
+    }
+    *bucket_size = total_bucket_size;
+    *avg_keys_per_bucket = total_keys_per_bucket / _builders.size();
+}
+
+size_t AdaptivePartitionHashJoinBuilder::get_output_probe_column_count() const {
+    return _builders[0]->get_output_probe_column_count();
+}
+
+size_t AdaptivePartitionHashJoinBuilder::get_output_build_column_count() const {
+    return _builders[0]->get_output_build_column_count();
+}
+
+int64_t AdaptivePartitionHashJoinBuilder::ht_mem_usage() const {
+    return std::accumulate(_builders.begin(), _builders.end(), 0L,
+                           [](int64_t sum, const auto& builder) { return sum + builder->ht_mem_usage(); });
+}
+
+Status AdaptivePartitionHashJoinBuilder::_convert_to_single_partition() {
+    // merge all partition data to the first partition
+    for (size_t i = 1; i < _partition_num; ++i) {
+        _builders[0]->hash_table().merge_ht(_builders[i]->hash_table());
+    }
+    _builders.resize(1);
+    _partition_num = 1;
+    return Status::OK();
+}
+
+Status AdaptivePartitionHashJoinBuilder::_append_chunk_to_partitions(const ChunkPtr& chunk) {
+    const std::vector<ExprContext*>& build_partition_keys = _hash_joiner.build_expr_ctxs();
+
+    size_t num_rows = chunk->num_rows();
+    size_t num_partitions = _builders.size();
+    size_t num_partition_cols = build_partition_keys.size();
+
+    std::vector<ColumnPtr> partition_columns(num_partition_cols);
+    for (size_t i = 0; i < num_partition_cols; ++i) {
+        ASSIGN_OR_RETURN(partition_columns[i], build_partition_keys[i]->evaluate(chunk.get()));
+    }
+    std::vector<uint32_t> hash_values;
+    {
+        hash_values.assign(num_rows, HashUtil::FNV_SEED);
+
+        for (const ColumnPtr& column : partition_columns) {
+            column->fnv_hash(hash_values.data(), 0, num_rows);
+        }
+        // find partition id
+        for (size_t i = 0; i < hash_values.size(); ++i) {
+            hash_values[i] = HashUtil::fmix32(hash_values[i]) & (num_partitions - 1);
+        }
+    }
+
+    const auto& partitions = hash_values;
+
+    std::vector<uint32_t> selection;
+    selection.resize(chunk->num_rows());
+
+    std::vector<int32_t> channel_row_idx_start_points;
+    channel_row_idx_start_points.assign(num_partitions + 1, 0);
+
+    for (uint32_t i : partitions) {
+        channel_row_idx_start_points[i]++;
+    }
+
+    for (int32_t i = 1; i <= channel_row_idx_start_points.size() - 1; ++i) {
+        channel_row_idx_start_points[i] += channel_row_idx_start_points[i - 1];
+    }
+
+    for (int32_t i = chunk->num_rows() - 1; i >= 0; --i) {
+        selection[channel_row_idx_start_points[partitions[i]] - 1] = i;
+        channel_row_idx_start_points[partitions[i]]--;
+    }
+
+    for (size_t i = 0; i < num_partitions; ++i) {
+        auto from = channel_row_idx_start_points[i];
+        auto size = channel_row_idx_start_points[i + 1] - from;
+        if (size == 0) {
+            continue;
+        }
+        // TODO: make builder implements append with selective
+        auto partition_chunk = chunk->clone_empty();
+        partition_chunk->append_selective(*chunk, selection.data(), from, size);
+        RETURN_IF_ERROR(_builders[i]->append_chunk(std::move(partition_chunk)));
+    }
+    return Status::OK();
+}
+
+Status AdaptivePartitionHashJoinBuilder::do_append_chunk(const ChunkPtr& chunk) {
+    if (_partition_num > 1 && hash_table_row_count() > _partition_join_max_rows) {
+        RETURN_IF_ERROR(_convert_to_single_partition());
+    }
+
+    if (_partition_num > 1 && ++_pushed_chunks % 8 == 0) {
+        size_t build_row_size = ht_mem_usage() / hash_table_row_count();
+        _adjust_partition_rows(build_row_size);
+        if (_partition_num == 1) {
+            RETURN_IF_ERROR(_convert_to_single_partition());
+        }
+    }
+
+    if (_partition_num > 1) {
+        RETURN_IF_ERROR(_append_chunk_to_partitions(chunk));
+    } else {
+        RETURN_IF_ERROR(_builders[0]->do_append_chunk(chunk));
+    }
+
+    return Status::OK();
+}
+
+ChunkPtr AdaptivePartitionHashJoinBuilder::convert_to_spill_schema(const ChunkPtr& chunk) const {
+    return _builders[0]->convert_to_spill_schema(chunk);
+}
+
+Status AdaptivePartitionHashJoinBuilder::build(RuntimeState* state) {
+    DCHECK_EQ(_partition_num, _builders.size());
+
+    if (_partition_num > 1 && hash_table_row_count() < _partition_join_min_rows) {
+        RETURN_IF_ERROR(_convert_to_single_partition());
+    }
+
+    for (auto& builder : _builders) {
+        RETURN_IF_ERROR(builder->build(state));
+    }
+    _ready = true;
+    return Status::OK();
+}
+
+void AdaptivePartitionHashJoinBuilder::visitHt(const std::function<void(JoinHashTable*)>& visitor) {
+    for (auto& builder : _builders) {
+        builder->visitHt(visitor);
+    }
+}
+
+std::unique_ptr<HashJoinProberImpl> AdaptivePartitionHashJoinBuilder::create_prober() {
+    DCHECK_EQ(_partition_num, _builders.size());
+
+    if (_partition_num == 1) {
+        return _builders[0]->create_prober();
+    } else {
+        std::vector<std::unique_ptr<SingleHashJoinProberImpl>> sub_probers;
+        auto prober = std::make_unique<PartitionedHashJoinProberImpl>(_hash_joiner);
+        sub_probers.resize(_partition_num);
+        for (size_t i = 0; i < _builders.size(); ++i) {
+            sub_probers[i].reset(down_cast<SingleHashJoinProberImpl*>(_builders[i]->create_prober().release()));
+        }
+        prober->set_probers(std::move(sub_probers));
+        return prober;
+    }
+}
+
+void AdaptivePartitionHashJoinBuilder::clone_readable(HashJoinBuilder* builder) {
+    for (auto& builder : _builders) {
+        DCHECK(builder->ready());
+    }
+    DCHECK(_ready);
+    DCHECK_EQ(_partition_num, _builders.size());
+    auto other = down_cast<AdaptivePartitionHashJoinBuilder*>(builder);
+    other->_builders.clear();
+    other->_partition_num = _partition_num;
+    other->_partition_join_max_rows = _partition_join_max_rows;
+    other->_partition_join_min_rows = _partition_join_min_rows;
+    other->_ready = _ready;
+    for (size_t i = 0; i < _partition_num; ++i) {
+        other->_builders.emplace_back(std::make_unique<SingleHashJoinBuilder>(_hash_joiner));
+        _builders[i].get()->clone_readable(other->_builders[i].get());
+    }
+}
+
+HashJoinBuilder* HashJoinBuilderFactory::create(ObjectPool* pool, const HashJoinBuildOptions& options,
+                                                HashJoiner& hash_joiner) {
+    if (options.enable_partitioned_hash_join) {
+        return pool->add(new AdaptivePartitionHashJoinBuilder(hash_joiner));
+    } else {
+        return pool->add(new SingleHashJoinBuilder(hash_joiner));
+    }
 }
 
 } // namespace starrocks

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -145,6 +145,9 @@ Status HashJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (tnode.hash_join_node.__isset.late_materialization) {
         _enable_late_materialization = tnode.hash_join_node.late_materialization;
     }
+    if (tnode.hash_join_node.__isset.enable_partition_hash_join) {
+        _enable_partition_hash_join = tnode.hash_join_node.enable_partition_hash_join;
+    }
     return Status::OK();
 }
 
@@ -203,6 +206,7 @@ void HashJoinNode::_init_hash_table_param(HashTableParam* param) {
     param->build_output_slots = _output_slots;
     param->probe_output_slots = _output_slots;
     param->enable_late_materialization = _enable_late_materialization;
+    param->enable_partition_hash_join = _enable_partition_hash_join;
 
     std::set<SlotId> predicate_slots;
     for (ExprContext* expr_context : _conjunct_ctxs) {
@@ -472,7 +476,8 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     HashJoinerParam param(pool, _hash_join_node, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
                           _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(), child(0)->row_desc(),
                           child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(), _build_runtime_filters,
-                          _output_slots, _output_slots, _distribution_mode, false, _enable_late_materialization);
+                          _output_slots, _output_slots, _distribution_mode, false, _enable_late_materialization,
+                          _enable_partition_hash_join);
     auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(param);
 
     // Create a shared RefCountedRuntimeFilterCollector

--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -115,6 +115,7 @@ private:
 
     bool _is_push_down = false;
     bool _enable_late_materialization = false;
+    bool _enable_partition_hash_join = false;
 
     JoinHashTable _ht;
 

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -280,6 +280,7 @@ struct HashTableProbeState {
 struct HashTableParam {
     bool with_other_conjunct = false;
     bool enable_late_materialization = false;
+    bool enable_partition_hash_join = false;
     TJoinOp::type join_type = TJoinOp::INNER_JOIN;
     const RowDescriptor* build_row_desc = nullptr;
     const RowDescriptor* probe_row_desc = nullptr;
@@ -833,6 +834,7 @@ public:
     Status lazy_output(RuntimeState* state, ChunkPtr* probe_chunk, ChunkPtr* result_chunk);
 
     void append_chunk(const ChunkPtr& chunk, const Columns& key_columns);
+    void merge_ht(const JoinHashTable& ht);
     // convert input column to spill schema order
     ChunkPtr convert_to_spill_schema(const ChunkPtr& chunk) const;
 

--- a/be/src/exec/mor_processor.cpp
+++ b/be/src/exec/mor_processor.cpp
@@ -48,7 +48,7 @@ Status IcebergMORProcessor::init(RuntimeState* runtime_state, const MORParams& p
             std::vector<ExprContext*>(), std::vector<ExprContext*>(), *_build_row_desc, *_probe_row_desc,
             TPlanNodeType::HDFS_SCAN_NODE, TPlanNodeType::HDFS_SCAN_NODE, true,
             std::list<RuntimeFilterBuildDescriptor*>(), std::set<SlotId>(), probe_output_slot_ids,
-            TJoinDistributionMode::PARTITIONED, true, false));
+            TJoinDistributionMode::PARTITIONED, true, false, false));
 
     _hash_joiner = _pool.add(new HashJoiner(*param));
     RETURN_IF_ERROR(_hash_joiner->prepare_builder(runtime_state, _runtime_profile));

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -87,7 +87,7 @@ StatusOr<ChunkPtr> HashJoinProbeOperator::pull_chunk(RuntimeState* state) {
 }
 
 Status HashJoinProbeOperator::set_finishing(RuntimeState* state) {
-    RETURN_IF_ERROR(_join_prober->probe_input_finished());
+    RETURN_IF_ERROR(_join_prober->probe_input_finished(state));
     _join_prober->enter_post_probe_phase();
     return Status::OK();
 }

--- a/be/src/util/cpu_info.h
+++ b/be/src/util/cpu_info.h
@@ -82,6 +82,18 @@ public:
 
     static std::string debug_string();
 
+    static const std::vector<long>& get_cache_sizes() {
+        static std::vector<long> cache_sizes;
+        static std::vector<long> cache_line_sizes;
+
+        if (cache_sizes.empty()) {
+            cache_sizes.resize(NUM_CACHE_LEVELS);
+            cache_line_sizes.resize(NUM_CACHE_LEVELS);
+            _get_cache_info(cache_sizes.data(), cache_line_sizes.data());
+        }
+        return cache_sizes;
+    }
+
 private:
     /// Initialize NUMA-related state - called from Init();
     static void _init_numa();

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3146,4 +3146,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static int thrift_max_recursion_depth = 64;
+
+    @ConfField(mutable = true)
+    public static double partition_hash_join_min_cardinality_rate = 0.3;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -42,6 +42,7 @@ import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.thrift.TEqJoinCondition;
 import com.starrocks.thrift.THashJoinNode;
 import com.starrocks.thrift.TNormalHashJoinNode;
@@ -115,9 +116,12 @@ public class HashJoinNode extends JoinNode {
             msg.hash_join_node.setBuild_runtime_filters(
                     RuntimeFilterDescription.toThriftRuntimeFilterDescriptions(buildRuntimeFilters));
         }
+        SessionVariable sv = ConnectContext.get().getSessionVariable();
+
         msg.hash_join_node.setLate_materialization(enableLateMaterialization);
-        msg.hash_join_node.setBuild_runtime_filters_from_planner(
-                ConnectContext.get().getSessionVariable().getEnableGlobalRuntimeFilter());
+        msg.hash_join_node.setEnable_partition_hash_join(sv.enablePartitionHashJoin());
+        msg.hash_join_node.setBuild_runtime_filters_from_planner(sv.getEnableGlobalRuntimeFilter());
+
         if (partitionExprs != null) {
             msg.hash_join_node.setPartition_exprs(Expr.treesToThrift(partitionExprs));
         }
@@ -128,8 +132,7 @@ public class HashJoinNode extends JoinNode {
         }
 
         if (getCanLocalShuffle()) {
-            msg.hash_join_node.setInterpolate_passthrough(
-                    ConnectContext.get().getSessionVariable().isHashJoinInterpolatePassthrough());
+            msg.hash_join_node.setInterpolate_passthrough(sv.isHashJoinInterpolatePassthrough());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -292,6 +292,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             "enable_filter_unused_columns_in_scan_stage";
 
     public static final String JOIN_LATE_MATERIALIZATION = "join_late_materialization";
+    public static final String ENABLE_PARTITION_HASH_JOIN = "enable_partition_hash_join";
 
     public static final String ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER =
             "enable_prune_column_after_index_filter";
@@ -1238,6 +1239,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = JOIN_LATE_MATERIALIZATION)
     private boolean joinLateMaterialization = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_PARTITION_HASH_JOIN)
+    private boolean enablePartitionHashJoin = false;
 
     @VariableMgr.VarAttr(name = ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER, flag = VariableMgr.INVISIBLE)
     private boolean enablePruneColumnAfterIndexFilter = true;
@@ -2865,6 +2869,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isJoinLateMaterialization() {
         return joinLateMaterialization;
+    }
+
+    public boolean enablePartitionHashJoin() {
+        return enablePartitionHashJoin;
     }
 
     public void disableTrimOnlyFilteredColumnsInScanStage() {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -670,6 +670,7 @@ struct THashJoinNode {
   // used in pipeline engine
   55: optional bool interpolate_passthrough = false
   56: optional bool late_materialization = false
+  57: optional bool enable_partition_hash_join = false
 }
 
 struct TMergeJoinNode {


### PR DESCRIPTION
## Why I'm doing:

When the hash table is larger, the performance of outputting the right table is worse. In this PR, we achieve performance improvement by splitting the hash table right table so that a single hash table size can fit into the cache.

But partition hash join requires the probe side to do an additional shuffle. So this can lead to negative optimization if the probe side has a large number of columns.
So we made an adaptive model.
```
OutputBuildColumnTime
2s958ms[max=3s142ms, min=2s764ms]
PartitionProbeOverhead
11s758ms[max=12s628ms, min=10s862ms]
```

We define the shuffle cost of the probe side as A, the cost of the output hash table after partitioning as B1, and the cost of the output hash table before partitioning as B2.
A partition hash join is used only if A + B1< B2.


## Partition hash join test

Query SQL pattern (8C 16G):

Run 5 times to get the best result, using the appearance catalog


# Case output the right table, the cardinality is different

```SQL
with supplier as (
    SELECT
        generate_series as s_suppkey,
        concat("Supplier#", s_suppkey) as s_name,
        repeat('x', 10) as s_address,
        repeat('a', 10) as s_city,
        repeat('b', 14) as s_nation,
        repeat('c', 11) as s_region,
        repeat('p', 11) as s_phone
    FROM
        TABLE(generate_series(1, 200000))
)
select
    count(s_city),
    count(s_nation),
    count(s_region),
    count(s_name),
    count(s_address),
    count(s_phone)
from
    lineorder
    join supplier on lo_suppkey % 200000 = s_suppkey;
```

| right table ndv | baseline, broadcast | partition=32,broadcast,stageing=4 |
| --------------- | ------------------- | --------------------------------- |
| 20              | 4.45                | 4.24                              |
| 200             | 4.09                | 4.59                              |
| 2000            | 4.31                | 4.53                              |
| 20000           | 5.34                | 4.73                              |
| 200000          | 11.51               | 6.64                              |

# Case outputs the right table and the left table at the same time

```SQL
with supplier as (
    SELECT
        generate_series as s_suppkey,
        concat("Supplier#", s_suppkey) as s_name,
        repeat('x', 10) as s_address,
        repeat('a', 10) as s_city,
        repeat('b', 14) as s_nation,
        repeat('c', 11) as s_region,
        repeat('p', 11) as s_phone
    FROM
        TABLE(generate_series(1, 200000))
)
select
    count(s_city),
    count(s_nation),
    count(s_region),
    count(s_name),
    count(s_address),
    count(s_phone),
    count(lo_linenumber),
    count(lo_custkey),
    count(lo_partkey),
    count(lo_suppkey),
    count(lo_shippriority),
    count(lo_quantity),
    count(lo_extendedprice),
    count(lo_ordtotalprice),
    count(lo_discount),
    count(lo_revenue),
    count(lo_supplycost),
    count(lo_tax),
    count(lo_commitdate),
    count(lo_orderdate),
    count(p1),
    count(p2),
    count(p3),
    count(p4),
    count(p5),
    count(p6),
    count(p7),
    count(p8),
    count(p9),
    count(p10),
    count(p11),
    count(p12),
    count(p13),
    count(p14),
    count(p15),
    count(p16),
    count(lo_orderkey)
from
    (
        select
            *,
            lo_orderkey + 1 p1,
            lo_orderkey + 2 p2,
            lo_orderkey + 3 p3,
            lo_orderkey + 4 p4,
            lo_orderkey + 5 p5,
            lo_orderkey + 6 p6,
            lo_orderkey + 7 p7,
            lo_orderkey + 8 p8,
            lo_orderkey + 9 p9,
            lo_orderkey + 10 p10,
            lo_orderkey + 11 p11,
            lo_orderkey + 12 p12,
            lo_orderkey + 13 p13,
            lo_orderkey + 14 p14,
            lo_orderkey + 15 p15,
            lo_orderkey + 16 p16
        from
            lineorder
    ) x
    join supplier on lo_suppkey % 200000 = s_suppkey;
```

| probe int cnts | baseline, broadcast | partition=16,broadcast,staging=4 |
| -------------- | ------------------- | -------------------------------- |
| 1              | 12.42               | 7.52                             |
| 2              | 13.06               | 7.8                              |
| 4              | 14.79               | 9.35                             |
| 8              | 15.66               | 11.37                            |
| 15             | 17.43               | 15.56                            |
| 31             | 20.18               | 26.17                            |

# Case outputs the right table, which has many columns.

```SQL
with supplier as (
    SELECT
        generate_series as s_suppkey,
        repeat('p', 16) as s_phone1,
        repeat('x', 16) as s_phone2,
        repeat('y', 16) as s_phone3,
        repeat('j', 16) as s_phone4,
        repeat('m', 16) as s_phone5,
        repeat('l', 16) as s_phone6,
        repeat('t', 16) as s_phone7,
        repeat('u', 16) as s_phone8,
        repeat('v', 16) as s_phone9,
        repeat('d', 16) as s_phone10,
        repeat('w', 16) as s_phone11,
        repeat('a', 16) as s_phone12,
        repeat('c', 16) as s_phone13,
        repeat('i', 16) as s_phone14,
        repeat('g', 16) as s_phone15,
        repeat('aa', 8) as s_phone16,
        repeat('bb', 8) as s_phone17,
        repeat('cc', 8) as s_phone18,
        repeat('dd', 8) as s_phone19,
        repeat('ee', 8) as s_phone20,
        repeat('ff', 8) as s_phone21,
        repeat('gg', 8) as s_phone22,
        repeat('hh', 8) as s_phone23,
        repeat('ii', 8) as s_phone24,
        repeat('jj', 8) as s_phone25,
        repeat('kk', 8) as s_phone26,
        repeat('ll', 8) as s_phone27,
        repeat('mm', 8) as s_phone28,
        repeat('nn', 8) as s_phone29,
        repeat('pp', 8) as s_phone30,
        repeat('qq', 8) as s_phone31,
        repeat('x', 16) as s_phone
    FROM
        TABLE(generate_series(1, 200000))
)
select
    count(s_phone1),
    count(s_phone2),
    count(s_phone3),
    count(s_phone4),
    count(s_phone5),
    count(s_phone6),
    count(s_phone7),
    count(s_phone8),
    count(s_phone9),
    count(s_phone10),
    count(s_phone11),
    count(s_phone12),
    count(s_phone13),
    count(s_phone14),
    count(s_phone15),
    count(s_phone16),
    count(s_phone17),
    count(s_phone18),
    count(s_phone19),
    count(s_phone20),
    count(s_phone21),
    count(s_phone22),
    count(s_phone23),
    count(s_phone24),
    count(s_phone25),
    count(s_phone26),
    count(s_phone27),
    count(s_phone28),
    count(s_phone29),
    count(s_phone30),
    count(s_phone31),
    count(s_phone)
from
    lineorder
    join supplier on lo_suppkey % 200000 = s_suppkey;
```


| right table string cnts | baseline, broadcast | partition=16,broadcast,staging=4 |
| ----------------------- | ------------------- | -------------------------------- |
| 1                       | 3.33                | 3.27                             |
| 2                       | 4.54                | 3.77                             |
| 4                       | 6.22                | 4.5                              |
| 8                       | 15.67               | 7.43                             |
| 16                      | 36.02               | 15.62                            |
| 32                      | 1 min 15.93         | 29.48                            |

# The table on the right has a higher cardinality: 160W.

```SQL
select
    count(p_name),
    count(p_mfgr),
    count(p_category),
    count(p_brand),
    count(p_color),
    count(p_container)
from
    lineorder
    join part on lo_partkey = p_partkey;
```

| join ndv | baseline, broadcast | partition=16,broadcast,staging=4 |
| --------- | ------------------- | -------------------------------- |
| 160000    | 33.14               | 16.53                            |


# Join + AGG

```SQL
select
    count(cn),
    count(cm),
    count(cc),
    count(cb),
    count(cp),
    count(ci)
from
    (
        select
            count(p_name) cn,
            count(p_mfgr) cm,
            count(p_category) cc,
            count(p_brand) cb,
            count(p_color) cp,
            count(p_container) ci
        from
            lineorder
            join part on lo_partkey = p_partkey
        group by
            p_name,
            p_mfgr,
            p_category,
            p_color,
            p_container
    ) tb;
```

|      | baseline | partition=16,staging =4 |
| ---- | -------- | ----------------------- |
|      | 49.99    | 36.24                   |

# Project pollution cache

```SQL
select
    bitmap_agg(lo_custkey),    
    bitmap_agg(lo_linenumber),
    bitmap_agg(lo_partkey),
    bitmap_agg(lo_orderkey),
    count(p_name) cn,
    count(p_mfgr) cm,
    count(p_category) cc,
    count(p_brand) cb,
    count(p_color) cp,
    count(p_container) ci
from
    lineorder
    join part on lo_partkey = p_partkey;
```

|      | baseline | partition=16,staging =4 | partition=32, staging = 4 |      |
| ---- | -------- | ----------------------- | ------------------------- | ---- |
|      | 42.17    | 36.24                   |                           |      |

# Right table ultra high base: 20M

8C 16C supports outputting up to two columns of the right table, otherwise it will OOM.

```SQL
select count(r.lo_custkey),count(r.lo_partkey) from lineorder l join [shuffle] lineorder r on l. lo_orderkey = r.lo_orderkey and l.lo_linenumber=r.lo_linenumber;select count(r.lo_custkey),count(r.lo_partkey) from lineorder l join [shuffle] lineorder r on l. lo_orderkey = r.lo_orderkey and l.lo_linenumber=r.lo_linenumber;
```

| output build columns | baseline | partition=16,staging =4 |
| -------------- | -------- | ----------------------- |
| 1              | 16.15    | 15.93                   |
| 2              | 18.31    | 18.17                   |

# Lazy materialize

```SQL
select sum(lo_revenue), count(lo_shipmode), count(p_name), count(p_mfgr),  count(p_category), count(p_brand), count(p_color), count(p_type), count(p_size), count(p_container) from lineorder join part     
on lo_partkey=p_partkey 
where (p_size+lo_linenumber)>50;
```

|      | baseline | baseline-lazy materialize | partition=16, staging = 4 | partition=16, staging = 4, lazy-materialize |
| ---- | -------- | ------------------------- | ------------------------- | ------------------------------------------- |
|      | 42.22    | 8.06                      | 25.47                     | 10.14                                       |



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
