### PR TITLE
[BugFix] Fix delete LOCATION_MISMATCH redundant replica bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -94,6 +94,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1151,11 +1152,30 @@ public class TabletScheduler extends FrontendDaemon {
             // won't delete location mismatched replica.
             return false;
         }
+
+        Set<Pair<String, String>> matchedLocations = new HashSet<>();
+        Replica dupReplica = null;
+        //1. delete the unmatched replica
         for (Replica replica : tabletCtx.getReplicas()) {
             if (!TabletChecker.isLocationMatch(replica.getBackendId(), tabletCtx.getRequiredLocation())) {
                 deleteReplicaInternal(tabletCtx, replica, "location mismatch", force);
                 return true;
+            } else {
+                Backend backend = systemInfoService.getBackend(replica.getBackendId());
+                if (backend != null) {
+                    Pair<String, String> location = backend.getSingleLevelLocationKV();
+                    if (location != null && matchedLocations.contains(location)) {
+                        dupReplica = replica;
+                    } else {
+                        matchedLocations.add(location);
+                    }
+                }
             }
+        }
+
+        //2. delete the duplicate location replica
+        if (dupReplica != null) {
+            deleteReplicaInternal(tabletCtx, dupReplica, "duplicate location", force);
         }
 
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1176,6 +1176,7 @@ public class TabletScheduler extends FrontendDaemon {
         //2. delete the duplicate location replica
         if (dupReplica != null) {
             deleteReplicaInternal(tabletCtx, dupReplica, "duplicate location", force);
+            return true;
         }
 
         return false;


### PR DESCRIPTION
## Why I'm doing:
There are 6 backends with location tags:
be1 rack:rack1
be2 rack:rack1
be3 rack:rack2
be4 rack:rack2
be5 rack:rack3
be6 rack:rack3

And a table with `"labels.location" = "rack:rack1,rack:rack2,rack:rack3"`

If a tablet's 3 replicas is stored on be1, be2, be3. one replica should be migrated to be5/be6 from be1/be2. But the redundant replica deleted is not be1/be2, causing clone/delete Repeated execution.

## What I'm doing:
The duplicate location replica should be deleted in `deleteLocationMismatchReplica`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
