### PR TITLE
[BugFix] fix _total_consumed_bytes in MemCacheManager

### DIFF
--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -93,6 +93,7 @@ private:
                 _reserved_bytes = prev_reserved;
                 _cache_size -= size;
                 _allocated_cache_size -= size;
+                _total_consumed_bytes -= size;
                 _try_consume_mem_size = size;
             };
             if (_cache_size >= BATCH_SIZE) {
@@ -132,6 +133,7 @@ private:
                 } else {
                     _cache_size -= size;
                     _allocated_cache_size -= size;
+                    _total_consumed_bytes -= size;
                     _try_consume_mem_size = size;
                     tls_exceed_mem_tracker = limit_tracker;
                     return false;
@@ -162,6 +164,7 @@ private:
         void release(int64_t size) {
             _cache_size -= size;
             _deallocated_cache_size += size;
+            _total_consumed_bytes -= size;
             if (_cache_size <= -BATCH_SIZE) {
                 commit(false);
             }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

we only update _total_consumed_bytes in `MemCacheManager::consume`, but release and failure_handler ignored it before, so I fix it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
