### PR TITLE
[BugFix] fix schema scan node crash in ASAN mode

### DIFF
--- a/be/src/exec/schema_scan_node.cpp
+++ b/be/src/exec/schema_scan_node.cpp
@@ -302,8 +302,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> SchemaScanNode::decompos
         pipeline::PipelineBuilderContext* context) {
     auto exec_group = context->find_exec_group_by_plan_node_id(_id);
     context->set_current_execution_group(exec_group);
-    // the dop of SchemaScanOperator should always be 1.
-    size_t dop = 1;
+    size_t dop = context->dop_of_source_operator(_id);
 
     size_t buffer_capacity = pipeline::ScanOperator::max_buffer_capacity() * dop;
     pipeline::ChunkBufferLimiterPtr buffer_limiter = std::make_unique<pipeline::DynamicChunkBufferLimiter>(

--- a/test/sql/test_scan/R/test_schema_scan_asan_crash
+++ b/test/sql/test_scan/R/test_schema_scan_asan_crash
@@ -1,0 +1,15 @@
+-- name: test_schema_scan_asan_crash
+set enable_shared_scan = true;
+-- result:
+-- !result
+set pipeline_dop = 8;
+-- result:
+-- !result
+[UC] select count(*) from information_schema.loads;
+-- result:
+115
+-- !result
+select 1;
+-- result:
+1
+-- !result

--- a/test/sql/test_scan/T/test_schema_scan_asan_crash
+++ b/test/sql/test_scan/T/test_schema_scan_asan_crash
@@ -1,0 +1,9 @@
+-- name: test_schema_scan_asan_crash
+
+set enable_shared_scan = true;
+set pipeline_dop = 8;
+
+-- BE crashes in ASAN mode.
+[UC] select count(*) from information_schema.loads;
+
+select 1;


### PR DESCRIPTION
## Why I'm doing:
It's introduced in https://github.com/StarRocks/starrocks/pull/31124

The general things are:
- Because schema node does not have scan ranges, when creating morsel queue factory, we set dop = 1
- But after adding the previous PR,  we force to set dop morsel queue factory = cpu/2
- then create schema operator factory, we manually specify dop=1, corresponding balanced chunk buffer output operator = 1
- Because morel queue factory dop = cpu/2, in `decompose_scan_node_to_pipeline` forces the scan operator dop to be set based on the morsel queue factory dop.

So at the end:
- the balanced chunk bufferthink that there was only one output operator
- but in fact there were cpu/2 scan operators running on it.

This problem can only be encountered if you have ASAN and shared_scan turned on.

## What I'm doing:

Don't force dop = 1, instead respect to dop of morsel queue factory

Fixes https://github.com/StarRocks/starrocks/issues/50353

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
