### PR TITLE
[BugFix] Don't put mv table properties into mv's task properties

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
@@ -32,7 +32,6 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.StorageVolumeMgr;
 import com.starrocks.statistic.StatsConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -155,7 +154,6 @@ public class LakeMaterializedView extends MaterializedView {
         sb.append(storageProperties.get(PropertyAnalyzer.PROPERTIES_ENABLE_ASYNC_WRITE_BACK)).append("\"");
 
         // storage_volume
-        StorageVolumeMgr svm = GlobalStateMgr.getCurrentState().getStorageVolumeMgr();
         String volume = GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolumeNameOfTable(id);
         sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(
                 PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME).append("\" = \"").append(volume).append("\"");

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -103,6 +103,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
+import static com.starrocks.scheduler.TaskRun.MV_ID;
 
 /**
  * Core logic of materialized view refresh task run
@@ -113,7 +114,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private static final Logger LOG = LogManager.getLogger(PartitionBasedMvRefreshProcessor.class);
     private static final AtomicLong STMT_ID_GENERATOR = new AtomicLong(0);
 
-    public static final String MV_ID = "mvId";
     // session.enable_spill
     public static final String MV_SESSION_ENABLE_SPILL =
             PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX + SessionVariable.ENABLE_SPILL;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -41,6 +41,8 @@ import com.starrocks.warehouse.Warehouse;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.starrocks.scheduler.TaskRun.MV_ID;
+
 // TaskBuilder is responsible for converting Stmt to Task Class
 // and also responsible for generating taskId and taskName
 public class TaskBuilder {
@@ -154,9 +156,9 @@ public class TaskBuilder {
         task.setDbName(dbName);
 
         Map<String, String> taskProperties = Maps.newHashMap();
-        taskProperties.put(PartitionBasedMvRefreshProcessor.MV_ID,
-                String.valueOf(materializedView.getId()));
-        taskProperties.putAll(materializedView.getProperties());
+        taskProperties.put(MV_ID, String.valueOf(materializedView.getId()));
+        // Don't put mv table properties into task properties since mv refresh doesn't need them, and the properties
+        // will cause task run's meta-data too large.
         // In PropertyAnalyzer.analyzeMVProperties, it removed the warehouse property, because
         // it only keeps session started properties
         Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr()
@@ -181,7 +183,7 @@ public class TaskBuilder {
         task.setSource(Constants.TaskSource.MV);
         task.setDbName(dbName);
         String mvId = String.valueOf(materializedView.getId());
-        previousTaskProperties.put(PartitionBasedMvRefreshProcessor.MV_ID, mvId);
+        previousTaskProperties.put(MV_ID, mvId);
         task.setProperties(previousTaskProperties);
         task.setDefinition(materializedView.getTaskDefinition());
         task.setPostRun(getAnalyzeMVStmt(materializedView.getName()));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.StringLiteral;
@@ -41,6 +42,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -48,10 +50,18 @@ public class TaskRun implements Comparable<TaskRun> {
 
     private static final Logger LOG = LogManager.getLogger(TaskRun.class);
 
+    public static final String MV_ID = "mvId";
     public static final String PARTITION_START = "PARTITION_START";
     public static final String PARTITION_END = "PARTITION_END";
     public static final String FORCE = "FORCE";
     public static final String START_TASK_RUN_ID = "START_TASK_RUN_ID";
+    // All properties that can be set in TaskRun
+    public static final Set<String> TASK_RUN_PROPERTIES =
+            ImmutableSet.of(
+                    MV_ID, PARTITION_START, PARTITION_END,
+                    FORCE, START_TASK_RUN_ID);
+
+    // Only used in FE's UT
     public static final String IS_TEST = "__IS_TEST__";
     private boolean isKilled = false;
 
@@ -160,7 +170,7 @@ public class TaskRun implements Comparable<TaskRun> {
 
         try {
             // NOTE: mvId is set in Task's properties when creating
-            long mvId = Long.parseLong(properties.get(PartitionBasedMvRefreshProcessor.MV_ID));
+            long mvId = Long.parseLong(properties.get(MV_ID));
             Database database = GlobalStateMgr.getCurrentState().getDb(ctx.getDatabase());
             if (database == null) {
                 LOG.warn("database {} do not exist when refreshing materialized view:{}", ctx.getDatabase(), mvId);
@@ -227,12 +237,9 @@ public class TaskRun implements Comparable<TaskRun> {
         // NOTE: Ensure the thread local connect context is always the same with the newest ConnectContext.
         // NOTE: Ensure this thread local is removed after this method to avoid memory leak in JVM.
         runCtx.setThreadLocalInfo();
-        LOG.info("[QueryId:{}] [ThreadLocal QueryId: {}] start to execute task run, task_id:{}",
-                runCtx.getQueryId(), ConnectContext.get() == null ? "" : ConnectContext.get().getQueryId(), taskId);
 
         Map<String, String> newProperties = refreshTaskProperties(runCtx);
         properties.putAll(newProperties);
-
         Map<String, String> taskRunContextProperties = Maps.newHashMap();
         runCtx.resetSessionVariable();
         if (properties != null) {
@@ -246,6 +253,9 @@ public class TaskRun implements Comparable<TaskRun> {
                 }
             }
         }
+        LOG.info("[QueryId:{}] [ThreadLocal QueryId: {}] start to execute task run, task_id:{}, " +
+                        "taskRunContextProperties:{}", runCtx.getQueryId(),
+                ConnectContext.get() == null ? "" : ConnectContext.get().getQueryId(), taskId, taskRunContextProperties);
         // If this is the first task run of the job, use its uuid as the job id.
         taskRunContext.setTaskRunId(taskRunId);
         taskRunContext.setCtx(runCtx);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -216,5 +216,4 @@ public class TaskRunHistory {
         LOG.warn("Too much task metadata triggers forced task_run GC, " +
                 "size before GC:{}, size after GC:{}.", beforeSize, getTaskRunCount());
     }
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -413,7 +413,7 @@ public class AlterMaterializedViewTest {
         }
 
         // foreground active
-        starRocksAssert.refreshMV("refresh materialized view " + mvName);
+        starRocksAssert.refreshMV("refresh materialized view " + mvName + " with sync mode");
         Assert.assertTrue(mv.isActive());
 
         // clear the grace period and active it again

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -76,7 +76,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.MV_ID;
+import static com.starrocks.scheduler.TaskRun.MV_ID;
 import static com.starrocks.sql.plan.PlanTestBase.cleanupEphemeralMVs;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)


### PR DESCRIPTION
## Why I'm doing:
There are still bugs after PR https://github.com/StarRocks/starrocks/pull/50295 , `information_schema.task_run` will throw exceptions in Cloud Env.
- `buildMvTask`  will put all table properties into task which will cause task run history table deserialized error.

## What I'm doing:
- Don't put mv table properties into mv's task properties in `buildMvTask` .
- To be compatible with old task runs, filter out unnecessary properties to avoid json content too large and deserialize error in `addHistories`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
