### PR TITLE
[Feature] Introduce dedicated_cpu_cores for resource group

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -14,15 +14,18 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.thrift.TWorkGroupType;
 
-import java.util.ArrayList;
+import java.text.DecimalFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 public class ResourceGroup {
@@ -35,6 +38,8 @@ public class ResourceGroup {
     public static final String PLAN_CPU_COST_RANGE = "plan_cpu_cost_range";
     public static final String PLAN_MEM_COST_RANGE = "plan_mem_cost_range";
     public static final String CPU_CORE_LIMIT = "cpu_core_limit";
+    public static final String CPU_WEIGHT = "cpu_weight";
+    public static final String DEDICATED_CPU_CORES = "dedicated_cpu_cores";
     public static final String MAX_CPU_CORES = "max_cpu_cores";
     public static final String MEM_LIMIT = "mem_limit";
     public static final String BIG_QUERY_MEM_LIMIT = "big_query_mem_limit";
@@ -61,29 +66,92 @@ public class ResourceGroup {
         DEFAULT_MV_WG.setName(DEFAULT_MV_RESOURCE_GROUP_NAME);
     }
 
-    public static final ShowResultSetMetaData META_DATA =
-            ShowResultSetMetaData.builder()
-                    .addColumn(new Column("name", ScalarType.createVarchar(100)))
-                    .addColumn(new Column("id", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("cpu_core_limit", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("mem_limit", ScalarType.createVarchar(200)))
-                    .addColumn(new Column(MAX_CPU_CORES, ScalarType.createVarchar(200)))
-                    .addColumn(new Column("big_query_cpu_second_limit", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("big_query_scan_rows_limit", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("big_query_mem_limit", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("concurrency_limit", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("spill_mem_limit_threshold", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("type", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("classifiers", ScalarType.createVarchar(1024)))
-                    .build();
+    private static class ColumnMeta {
+        public ColumnMeta(Column column, BiFunction<ResourceGroup, ResourceGroupClassifier, String> valueSupplier) {
+            this(column, valueSupplier, true);
+        }
+
+        public ColumnMeta(Column column, BiFunction<ResourceGroup, ResourceGroupClassifier, String> valueSupplier,
+                          boolean visible) {
+            this.column = column;
+            this.valueSupplier = valueSupplier;
+            this.visible = visible;
+        }
+
+        private final Column column;
+        private final BiFunction<ResourceGroup, ResourceGroupClassifier, String> valueSupplier;
+        private final boolean visible;
+    }
+
+    private static final List<ColumnMeta> COLUMN_METAS = ImmutableList.of(
+            new ColumnMeta(
+                    new Column("name", ScalarType.createVarchar(100)),
+                    (rg, classifier) -> rg.getName()),
+            new ColumnMeta(
+                    new Column("id", ScalarType.createVarchar(200)),
+                    (rg, classifier) -> "" + rg.getId()),
+            new ColumnMeta(
+                    new Column(CPU_WEIGHT, ScalarType.createVarchar(200)),
+                    (rg, classifier) -> "" + rg.getCpuWeight()),
+            new ColumnMeta(
+                    new Column(DEDICATED_CPU_CORES, ScalarType.createVarchar(200)),
+                    (rg, classifier) -> "" + rg.getNormalizedDedicatedCpuCores()),
+            new ColumnMeta(
+                    new Column(MEM_LIMIT, ScalarType.createVarchar(200)),
+                    (rg, classifier) -> (rg.getMemLimit() * 100) + "%"),
+            new ColumnMeta(
+                    new Column(MAX_CPU_CORES, ScalarType.createVarchar(200)),
+                    (rg, classifier) -> "" + rg.getMaxCpuCores(), false),
+            new ColumnMeta(
+                    new Column(BIG_QUERY_CPU_SECOND_LIMIT, ScalarType.createVarchar(200)),
+                    (rg, classifier) -> "" + Objects.requireNonNullElse(rg.getBigQueryCpuSecondLimit(), 0)),
+            new ColumnMeta(
+                    new Column(BIG_QUERY_SCAN_ROWS_LIMIT, ScalarType.createVarchar(200)),
+                    (rg, classifier) -> "" + Objects.requireNonNullElse(rg.getBigQueryScanRowsLimit(), 0)),
+            new ColumnMeta(
+                    new Column(BIG_QUERY_MEM_LIMIT, ScalarType.createVarchar(200)),
+                    (rg, classifier) -> "" + Objects.requireNonNullElse(rg.getBigQueryMemLimit(), 0)),
+            new ColumnMeta(
+                    new Column(CONCURRENCY_LIMIT, ScalarType.createVarchar(200)),
+                    (rg, classifier) -> "" + rg.getConcurrencyLimit()),
+            new ColumnMeta(
+                    new Column(SPILL_MEM_LIMIT_THRESHOLD, ScalarType.createVarchar(200)),
+                    (rg, classifier) -> new DecimalFormat("#.##").format(
+                            Objects.requireNonNullElse(rg.getSpillMemLimitThreshold(), 1.0) * 100) + "%"),
+            new ColumnMeta(
+                    new Column(GROUP_TYPE, ScalarType.createVarchar(200)),
+                    (rg, classifier) -> rg.getResourceGroupType().name().substring("WG_".length()), false),
+            new ColumnMeta(
+                    new Column("classifiers", ScalarType.createVarchar(1024)),
+                    (rg, classifier) -> classifier.toString())
+    );
+
+    public static final ShowResultSetMetaData META_DATA;
+    public static final ShowResultSetMetaData VERBOSE_META_DATA;
+
+    static {
+        ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
+        COLUMN_METAS.stream()
+                .filter(meta -> meta.visible)
+                .forEach(item -> builder.addColumn(item.column));
+        META_DATA = builder.build();
+
+        ShowResultSetMetaData.Builder verboseBuilder = ShowResultSetMetaData.builder();
+        COLUMN_METAS.forEach(item -> verboseBuilder.addColumn(item.column));
+        VERBOSE_META_DATA = verboseBuilder.build();
+    }
+
     @SerializedName(value = "classifiers")
     List<ResourceGroupClassifier> classifiers;
     @SerializedName(value = "name")
     private String name;
     @SerializedName(value = "id")
     private long id;
+
     @SerializedName(value = "cpuCoreLimit")
-    private Integer cpuCoreLimit;
+    private Integer cpuWeight;
+    @SerializedName(value = "dedicatedCpuCores")
+    private Integer dedicatedCpuCores;
 
     @SerializedName(value = "maxCpuCores")
     private Integer maxCpuCores;
@@ -108,42 +176,18 @@ public class ResourceGroup {
     public ResourceGroup() {
     }
 
-    private List<String> showClassifier(ResourceGroupClassifier classifier) {
-        List<String> row = new ArrayList<>();
-        row.add(this.name);
-        row.add("" + this.id);
-        row.add("" + cpuCoreLimit);
-        row.add("" + (memLimit * 100) + "%");
-        row.add("" + maxCpuCores);
-        if (bigQueryCpuSecondLimit != null) {
-            row.add("" + bigQueryCpuSecondLimit);
-        } else {
-            row.add("" + 0);
-        }
-        if (bigQueryScanRowsLimit != null) {
-            row.add("" + bigQueryScanRowsLimit);
-        } else {
-            row.add("" + 0);
-        }
-        if (bigQueryMemLimit != null) {
-            row.add("" + bigQueryMemLimit);
-        } else {
-            row.add("" + 0);
-        }
-        row.add("" + concurrencyLimit);
-        if (spillMemLimitThreshold != null) {
-            row.add("" + (spillMemLimitThreshold * 100) + "%");
-        } else {
-            row.add("" + "100%");
-        }
-        row.add("" + resourceGroupType.name().substring("WG_".length()));
-        row.add(classifier.toString());
-        return row;
+    private List<String> showClassifier(ResourceGroupClassifier classifier, boolean verbose) {
+        return COLUMN_METAS.stream()
+                .filter(meta -> verbose || meta.visible)
+                .map(meta -> meta.valueSupplier.apply(this, classifier))
+                .collect(Collectors.toList());
     }
 
-    public List<List<String>> showVisible(String user, List<String> activeRoles, String ip) {
-        return classifiers.stream().filter(c -> c.isVisible(user, activeRoles, ip))
-                .map(this::showClassifier).collect(Collectors.toList());
+    public List<List<String>> showVisible(String user, List<String> activeRoles, String ip, boolean verbose) {
+        return classifiers.stream()
+                .filter(c -> c.isVisible(user, activeRoles, ip))
+                .map(c -> showClassifier(c, verbose))
+                .collect(Collectors.toList());
     }
 
     public long getVersion() {
@@ -154,11 +198,13 @@ public class ResourceGroup {
         this.version = version;
     }
 
-    public List<List<String>> show() {
+    public List<List<String>> show(boolean verbose) {
         if (classifiers.isEmpty()) {
-            return Collections.singletonList(showClassifier(new ResourceGroupClassifier()));
+            return Collections.singletonList(showClassifier(new ResourceGroupClassifier(), verbose));
         }
-        return classifiers.stream().map(this::showClassifier).collect(Collectors.toList());
+        return classifiers.stream()
+                .map(c -> showClassifier(c, verbose))
+                .collect(Collectors.toList());
     }
 
     public String getName() {
@@ -181,8 +227,8 @@ public class ResourceGroup {
         TWorkGroup twg = new TWorkGroup();
         twg.setName(name);
         twg.setId(id);
-        if (cpuCoreLimit != null) {
-            twg.setCpu_core_limit(cpuCoreLimit);
+        if (cpuWeight != null) {
+            twg.setCpu_core_limit(cpuWeight);
         }
         if (memLimit != null) {
             twg.setMem_limit(memLimit);
@@ -214,16 +260,39 @@ public class ResourceGroup {
         if (resourceGroupType != null) {
             twg.setWorkgroup_type(resourceGroupType);
         }
+
+        twg.setDedicated_cpu_cores(getNormalizedDedicatedCpuCores());
+
         twg.setVersion(version);
         return twg;
     }
 
-    public Integer getCpuCoreLimit() {
-        return cpuCoreLimit;
+    public Integer getCpuWeight() {
+        return cpuWeight;
     }
 
-    public void setCpuCoreLimit(int cpuCoreLimit) {
-        this.cpuCoreLimit = cpuCoreLimit;
+    public void setCpuWeight(int cpuWeight) {
+        this.cpuWeight = cpuWeight;
+    }
+
+    public Integer getDedicatedCpuCores() {
+        return dedicatedCpuCores;
+    }
+
+    public int getNormalizedDedicatedCpuCores() {
+        if (dedicatedCpuCores != null && dedicatedCpuCores > 0) {
+            return dedicatedCpuCores;
+        }
+        // For compatibility, resource group of deprecated type `short_query` uses `cpu_weight` (the original `cpu_core_limit`)
+        // as the reserved cores.
+        if (resourceGroupType == TWorkGroupType.WG_SHORT_QUERY && cpuWeight != null && cpuWeight > 0) {
+            return cpuWeight;
+        }
+        return 0;
+    }
+
+    public void setDedicatedCpuCores(Integer dedicatedCpuCores) {
+        this.dedicatedCpuCores = dedicatedCpuCores;
     }
 
     public boolean isMaxCpuCoresEffective() {
@@ -321,6 +390,18 @@ public class ResourceGroup {
     @Override
     public int hashCode() {
         return Objects.hash(id, version);
+    }
+
+    public static void validateCpuParameters(Integer cpuWeight, Integer dedicatedCpuCores) {
+        if ((cpuWeight == null || cpuWeight <= 0) && (dedicatedCpuCores == null || dedicatedCpuCores <= 0)) {
+            throw new SemanticException(String.format("property '%s' or '%s' must be positive",
+                    ResourceGroup.CPU_WEIGHT, ResourceGroup.DEDICATED_CPU_CORES));
+        }
+        if ((cpuWeight != null && cpuWeight > 0) && (dedicatedCpuCores != null && dedicatedCpuCores > 0)) {
+            throw new SemanticException(
+                    String.format("property '%s' and '%s' cannot be present and positive at the same time",
+                            ResourceGroup.CPU_WEIGHT, ResourceGroup.DEDICATED_CPU_CORES));
+        }
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -70,7 +70,7 @@ public class ResourceGroupMgr implements Writable {
     private static final Logger LOG = LogManager.getLogger(ResourceGroupMgr.class);
 
     private static final String EXCEED_TOTAL_DEDICATED_CPU_CORES_ERR_MSG =
-            "The sum of %s of all the resource groups cannot exceed %d";
+            "the sum of %s of all the resource groups cannot exceed %d";
     public static final String SHORT_QUERY_SET_DEDICATED_CPU_CORES_ERR_MSG =
             "'short_query' ResourceGroup cannot set 'dedicated_cpu_cores', " +
                     "since it use 'cpu_weight' as 'dedicated_cpu_cores'";

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -35,10 +35,12 @@ import com.starrocks.privilege.PrivilegeException;
 import com.starrocks.privilege.RolePrivilegeCollectionV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterResourceGroupStmt;
 import com.starrocks.sql.ast.CreateResourceGroupStmt;
 import com.starrocks.sql.ast.DropResourceGroupStmt;
 import com.starrocks.sql.ast.ShowResourceGroupStmt;
+import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.thrift.TWorkGroupOp;
 import com.starrocks.thrift.TWorkGroupOpType;
@@ -66,6 +68,13 @@ import java.util.stream.Collectors;
 // WorkGroupMgr is employed by GlobalStateMgr to manage WorkGroup in FE.
 public class ResourceGroupMgr implements Writable {
     private static final Logger LOG = LogManager.getLogger(ResourceGroupMgr.class);
+
+    private static final String EXCEED_TOTAL_DEDICATED_CPU_CORES_ERR_MSG =
+            "The sum of %s of all the resource groups cannot exceed %d";
+    public static final String SHORT_QUERY_SET_DEDICATED_CPU_CORES_ERR_MSG =
+            "'short_query' ResourceGroup cannot set 'dedicated_cpu_cores', " +
+                    "since it use 'cpu_weight' as 'dedicated_cpu_cores'";
+
     private final Map<String, ResourceGroup> resourceGroupMap = new HashMap<>();
 
     // Record the current short_query resource group.
@@ -78,6 +87,7 @@ public class ResourceGroupMgr implements Writable {
     private final Map<Long, Map<Long, TWorkGroup>> activeResourceGroupsPerBe = new HashMap<>();
     private final Map<Long, Long> minVersionPerBe = new HashMap<>();
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private int sumDedicatedCpuCores = 0;
 
     private void readLock() {
         lock.readLock().lock();
@@ -126,6 +136,13 @@ public class ResourceGroupMgr implements Writable {
                 throw new DdlException("This type Resource Group need define classifiers.");
             }
 
+            if (wg.getNormalizedDedicatedCpuCores() > 0 && sumDedicatedCpuCores + wg.getNormalizedDedicatedCpuCores() >=
+                    BackendResourceStat.getInstance().getAvgNumHardwareCoresOfBe()) {
+                throw new DdlException(String.format(EXCEED_TOTAL_DEDICATED_CPU_CORES_ERR_MSG,
+                        ResourceGroup.DEDICATED_CPU_CORES,
+                        BackendResourceStat.getInstance().getAvgNumHardwareCoresOfBe() - 1));
+            }
+
             wg.setId(GlobalStateMgr.getCurrentState().getNextId());
             wg.setVersion(wg.getId());
             for (ResourceGroupClassifier classifier : wg.getClassifiers()) {
@@ -149,10 +166,11 @@ public class ResourceGroupMgr implements Writable {
 
         List<List<String>> rows;
         if (stmt.getName() != null) {
-            rows = GlobalStateMgr.getCurrentState().getResourceGroupMgr().showOneResourceGroup(stmt.getName());
+            rows = GlobalStateMgr.getCurrentState().getResourceGroupMgr().showOneResourceGroup(
+                    stmt.getName(), stmt.isVerbose());
         } else {
             rows = GlobalStateMgr.getCurrentState().getResourceGroupMgr()
-                    .showAllResourceGroups(ConnectContext.get(), stmt.isListAll());
+                    .showAllResourceGroups(ConnectContext.get(), stmt.isVerbose(), stmt.isListAll());
         }
         return rows;
     }
@@ -202,33 +220,37 @@ public class ResourceGroupMgr implements Writable {
         }
     }
 
-    public List<List<String>> showAllResourceGroups(ConnectContext ctx, Boolean isListAll) {
+    public List<List<String>> showAllResourceGroups(ConnectContext ctx, boolean verbose, boolean isListAll) {
         readLock();
         try {
             List<ResourceGroup> resourceGroupList = new ArrayList<>(resourceGroupMap.values());
             if (isListAll || ConnectContext.get() == null) {
                 resourceGroupList.sort(Comparator.comparing(ResourceGroup::getName));
-                return resourceGroupList.stream().map(ResourceGroup::show)
-                        .flatMap(Collection::stream).collect(Collectors.toList());
+                return resourceGroupList.stream()
+                        .map(rg -> rg.show(verbose))
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toList());
             } else {
                 String user = getUnqualifiedUser(ctx);
                 List<String> activeRoles = getUnqualifiedRole(ctx);
                 String remoteIp = ctx.getRemoteIP();
-                return resourceGroupList.stream().map(rg -> rg.showVisible(user, activeRoles, remoteIp))
-                        .flatMap(Collection::stream).collect(Collectors.toList());
+                return resourceGroupList.stream()
+                        .map(rg -> rg.showVisible(user, activeRoles, remoteIp, verbose))
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toList());
             }
         } finally {
             readUnlock();
         }
     }
 
-    public List<List<String>> showOneResourceGroup(String name) {
+    public List<List<String>> showOneResourceGroup(String name, boolean verbose) {
         readLock();
         try {
             if (!resourceGroupMap.containsKey(name)) {
                 return Collections.emptyList();
             } else {
-                return resourceGroupMap.get(name).show();
+                return resourceGroupMap.get(name).show(verbose);
             }
         } finally {
             readUnlock();
@@ -289,11 +311,7 @@ public class ResourceGroupMgr implements Writable {
     public ResourceGroup getResourceGroup(String name) {
         readLock();
         try {
-            if (resourceGroupMap.containsKey(name)) {
-                return resourceGroupMap.get(name);
-            } else {
-                return null;
-            }
+            return resourceGroupMap.getOrDefault(name, null);
         } finally {
             readUnlock();
         }
@@ -348,10 +366,41 @@ public class ResourceGroupMgr implements Writable {
                 wg.getClassifiers().addAll(newAddedClassifiers);
             } else if (cmd instanceof AlterResourceGroupStmt.AlterProperties) {
                 ResourceGroup changedProperties = stmt.getChangedProperties();
-                Integer cpuCoreLimit = changedProperties.getCpuCoreLimit();
-                if (cpuCoreLimit != null) {
-                    wg.setCpuCoreLimit(cpuCoreLimit);
+
+                Integer cpuWeight = changedProperties.getCpuWeight();
+                if (cpuWeight == null) {
+                    cpuWeight = wg.getCpuWeight();
                 }
+                Integer dedicatedCpuCores = changedProperties.getDedicatedCpuCores();
+                if (dedicatedCpuCores == null) {
+                    dedicatedCpuCores = wg.getDedicatedCpuCores();
+                }
+
+                ResourceGroup.validateCpuParameters(cpuWeight, dedicatedCpuCores);
+
+                if (dedicatedCpuCores != null && dedicatedCpuCores > 0) {
+                    if (sumDedicatedCpuCores + dedicatedCpuCores - wg.getNormalizedDedicatedCpuCores() >=
+                            BackendResourceStat.getInstance().getAvgNumHardwareCoresOfBe()) {
+                        throw new DdlException(String.format(EXCEED_TOTAL_DEDICATED_CPU_CORES_ERR_MSG,
+                                ResourceGroup.DEDICATED_CPU_CORES,
+                                BackendResourceStat.getInstance().getAvgNumHardwareCoresOfBe() - 1));
+                    }
+                    if (wg.getResourceGroupType() == TWorkGroupType.WG_SHORT_QUERY) {
+                        throw new SemanticException(SHORT_QUERY_SET_DEDICATED_CPU_CORES_ERR_MSG);
+                    }
+                }
+                // NOTE that validate cpu parameters should be called before setting properties.
+
+                if (cpuWeight != null) {
+                    wg.setCpuWeight(cpuWeight);
+                }
+
+                if (dedicatedCpuCores != null) {
+                    sumDedicatedCpuCores -= wg.getNormalizedDedicatedCpuCores();
+                    wg.setDedicatedCpuCores(dedicatedCpuCores);
+                    sumDedicatedCpuCores += wg.getNormalizedDedicatedCpuCores();
+                }
+
                 Integer maxCpuCores = changedProperties.getMaxCpuCores();
                 if (maxCpuCores != null) {
                     wg.setMaxCpuCores(maxCpuCores);
@@ -474,6 +523,7 @@ public class ResourceGroupMgr implements Writable {
         if (wg.getResourceGroupType() == TWorkGroupType.WG_SHORT_QUERY) {
             shortQueryResourceGroup = null;
         }
+        sumDedicatedCpuCores -= wg.getNormalizedDedicatedCpuCores();
     }
 
     private void addResourceGroupInternal(ResourceGroup wg) {
@@ -485,6 +535,7 @@ public class ResourceGroupMgr implements Writable {
         if (wg.getResourceGroupType() == TWorkGroupType.WG_SHORT_QUERY) {
             shortQueryResourceGroup = wg;
         }
+        sumDedicatedCpuCores += wg.getNormalizedDedicatedCpuCores();
     }
 
     public List<TWorkGroupOp> getResourceGroupsNeedToDeliver(Long beId) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterResourceGroupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterResourceGroupStmt.java
@@ -77,7 +77,8 @@ public class AlterResourceGroupStmt extends DdlStmt {
             if (changedProperties.getResourceGroupType() != null) {
                 throw new SemanticException("type of ResourceGroup is immutable");
             }
-            if (changedProperties.getCpuCoreLimit() == null &&
+            if (changedProperties.getCpuWeight() == null &&
+                    changedProperties.getDedicatedCpuCores() == null &&
                     changedProperties.getMemLimit() == null &&
                     changedProperties.getConcurrencyLimit() == null &&
                     changedProperties.getMaxCpuCores() == null &&
@@ -85,9 +86,9 @@ public class AlterResourceGroupStmt extends DdlStmt {
                     changedProperties.getBigQueryMemLimit() == null &&
                     changedProperties.getBigQueryScanRowsLimit() == null &&
                     changedProperties.getSpillMemLimitThreshold() == null) {
-                throw new SemanticException("At least one of ('cpu_core_limit', 'mem_limit', 'max_cpu_cores', " +
-                        "'concurrency_limit','big_query_mem_limit', 'big_query_scan_rows_limit', 'big_query_cpu_second_limit'" +
-                        "'spill_mem_limit_threshold', " +
+                throw new SemanticException("At least one of ('cpu_weight','dedicated_cpu_cores','mem_limit'," +
+                        "'max_cpu_cores','concurrency_limit','big_query_mem_limit', 'big_query_scan_rows_limit'," +
+                        "'big_query_cpu_second_limit','spill_mem_limit_threshold') " +
                         "should be specified");
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateResourceGroupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateResourceGroupStmt.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.Predicate;
@@ -26,6 +25,8 @@ import com.starrocks.thrift.TWorkGroupType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import static com.starrocks.catalog.ResourceGroupMgr.SHORT_QUERY_SET_DEDICATED_CPU_CORES_ERR_MSG;
 
 // ReesourceGroup create statement format
 // create resource group [if not exists] [or replace] <name>
@@ -88,9 +89,14 @@ public class CreateResourceGroupStmt extends DdlStmt {
         if (resourceGroup.getResourceGroupType() == null) {
             resourceGroup.setResourceGroupType(TWorkGroupType.WG_NORMAL);
         }
-        if (resourceGroup.getCpuCoreLimit() == null) {
-            throw new SemanticException("property 'cpu_core_limit' is absent");
+
+        if (resourceGroup.getResourceGroupType() == TWorkGroupType.WG_SHORT_QUERY &&
+                (resourceGroup.getDedicatedCpuCores() != null && resourceGroup.getDedicatedCpuCores() > 0)) {
+            throw new SemanticException(SHORT_QUERY_SET_DEDICATED_CPU_CORES_ERR_MSG);
         }
+
+        ResourceGroup.validateCpuParameters(resourceGroup.getCpuWeight(), resourceGroup.getDedicatedCpuCores());
+
         if (resourceGroup.getMemLimit() == null) {
             throw new SemanticException("property 'mem_limit' is absent");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowResourceGroupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowResourceGroupStmt.java
@@ -30,23 +30,28 @@ import com.starrocks.sql.parser.NodePosition;
 public class ShowResourceGroupStmt extends ShowStmt {
     private final String name;
     private final boolean listAll;
+    private final boolean verbose;
 
-    public ShowResourceGroupStmt(String name, boolean listAll) {
-        this(name, listAll, NodePosition.ZERO);
-    }
-
-    public ShowResourceGroupStmt(String name, boolean listAll, NodePosition pos) {
+    public ShowResourceGroupStmt(String name, boolean listAll, boolean verbose, NodePosition pos) {
         super(pos);
         this.name = name;
         this.listAll = listAll;
+        this.verbose = verbose;
     }
 
     public boolean isListAll() {
         return listAll;
     }
 
+    public boolean isVerbose() {
+        return verbose;
+    }
+
     @Override
     public ShowResultSetMetaData getMetaData() {
+        if (verbose) {
+            return ResourceGroup.VERBOSE_META_DATA;
+        }
         return ResourceGroup.META_DATA;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2677,10 +2677,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitShowResourceGroupStatement(StarRocksParser.ShowResourceGroupStatementContext context) {
         NodePosition pos = createPos(context);
         if (context.GROUPS() != null) {
-            return new ShowResourceGroupStmt(null, context.ALL() != null, pos);
+            return new ShowResourceGroupStmt(null, context.ALL() != null, context.VERBOSE() != null, pos);
         } else {
             Identifier identifier = (Identifier) visit(context.identifier());
-            return new ShowResourceGroupStmt(identifier.getValue(), false, pos);
+            return new ShowResourceGroupStmt(identifier.getValue(), false, context.VERBOSE() != null, pos);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1294,8 +1294,8 @@ alterResourceGroupStatement
     ;
 
 showResourceGroupStatement
-    : SHOW RESOURCE GROUP identifier
-    | SHOW RESOURCE GROUPS ALL?
+    : SHOW VERBOSE? RESOURCE GROUP identifier
+    | SHOW VERBOSE? RESOURCE GROUPS ALL?
     ;
 
 showResourceGroupUsageStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ResourceGroupStmtTest {
     private static final Pattern idPattern = Pattern.compile("\\bid=(\\b\\d+\\b)");
     private static StarRocksAssert starRocksAssert;
-    private String createRg1Sql = "create resource group rg1\n" +
+    private final String createRg1Sql = "create resource group rg1\n" +
             "to\n" +
             "    (user='rg1_user1', role='rg1_role1', query_type in ('select'), source_ip='192.168.2.1/24'),\n" +
             "    (user='rg1_user2', query_type in ('select'), source_ip='192.168.3.1/24'),\n" +
@@ -56,7 +56,7 @@ public class ResourceGroupStmtTest {
             "    'concurrency_limit' = '11',\n" +
             "    'type' = 'normal'\n" +
             ");";
-    private String createRg1IfNotExistsSql = "create resource group if not exists rg1\n" +
+    private final String createRg1IfNotExistsSql = "create resource group if not exists rg1\n" +
             "to\n" +
             "    (user='rg1_if_not_exists', role='rg1_role1', query_type in ('select'), source_ip='192.168.2.1/24')\n" +
             "with (\n" +
@@ -67,7 +67,7 @@ public class ResourceGroupStmtTest {
             "    'type' = 'normal'\n" +
             ");";
 
-    private String createRg1OrReplaceSql = "create resource group or replace rg1\n" +
+    private final String createRg1OrReplaceSql = "create resource group or replace rg1\n" +
             "to\n" +
             "    (user='rg1_or_replace', role='rg1_role1', query_type in ('select'), source_ip='192.168.2.1/24')\n" +
             "with (\n" +
@@ -78,7 +78,7 @@ public class ResourceGroupStmtTest {
             "    'type' = 'normal'\n" +
             ");";
 
-    private String createRg1IfNotExistsOrReplaceSql = "create resource group if not exists or replace rg1\n" +
+    private final String createRg1IfNotExistsOrReplaceSql = "create resource group if not exists or replace rg1\n" +
             "to\n" +
             "    (user='rg1_if_not_exists_or_replace', role='rg1_role1', " +
             "query_type in ('select'), source_ip='192" +
@@ -91,7 +91,7 @@ public class ResourceGroupStmtTest {
             "    'type' = 'normal'\n" +
             ");";
 
-    private String createRg2Sql = "create resource group rg2\n" +
+    private final String createRg2Sql = "create resource group rg2\n" +
             "to\n" +
             "    (role='rg2_role1', query_type in ('select' ), source_ip='192.168.5.1/24'),\n" +
             "    (role='rg2_role2', source_ip='192.168.6.1/24'),\n" +
@@ -112,7 +112,7 @@ public class ResourceGroupStmtTest {
             "    'concurrency_limit' = '10',\n" +
             "    'type' = 'normal'\n" +
             ");";
-    private String createRg4Sql = "create resource group rg4\n" +
+    private final String createRg4Sql = "create resource group rg4\n" +
             "to\n" +
             "     (source_ip='192.168.7.1/24')\n" +
             "with (\n" +
@@ -124,7 +124,7 @@ public class ResourceGroupStmtTest {
             "   'big_query_cpu_second_limit'='1024',\n" +
             "    'type' = 'normal'\n" +
             ");";
-    private String createRg5Sql = "create resource group rg5\n" +
+    private final String createRg5Sql = "create resource group rg5\n" +
             "to\n" +
             "     (`db`='db1')\n" +
             "with (\n" +
@@ -133,7 +133,7 @@ public class ResourceGroupStmtTest {
             "    'concurrency_limit' = '10',\n" +
             "    'type' = 'normal'\n" +
             ");";
-    private String createRg6Sql = "create resource group rg6\n" +
+    private final String createRg6Sql = "create resource group rg6\n" +
             "to\n" +
             "    (query_type in ('insert'), source_ip='192.168.6.1/24')\n" +
             "with (\n" +
@@ -143,7 +143,7 @@ public class ResourceGroupStmtTest {
             "    'type' = 'normal'\n" +
             ");";
 
-    private String createRg7Sql = "create resource group rg7\n" +
+    private final String createRg7Sql = "create resource group rg7\n" +
             "to\n" +
             "    (query_type in ('select'), source_ip='192.168.6.1/24')\n" +
             "with (\n" +
@@ -164,7 +164,7 @@ public class ResourceGroupStmtTest {
             "    'type' = 'short_query'\n" +
             ");";
 
-    private String createMVRg = "create resource group if not exists mv_rg" +
+    private final String createMVRg = "create resource group if not exists mv_rg" +
             "   with (" +
             "   'cpu_core_limit' = '10'," +
             "   'mem_limit' = '20%'," +
@@ -192,11 +192,11 @@ public class ResourceGroupStmtTest {
         List<String> lines = rows.stream().map(
                 row -> {
                     row.remove(1);
-                    return String.join("|",
+                    return java.lang.String.join("|",
                             row.toArray(new String[0])).replaceAll("id=\\d+(,\\s+)?", "");
                 }
         ).collect(Collectors.toList());
-        return String.join("\n", lines.toArray(new String[0]));
+        return java.lang.String.join("\n", lines.toArray(new String[0]));
     }
 
     private static String getClassifierId(String classifierStr) {
@@ -218,35 +218,35 @@ public class ResourceGroupStmtTest {
         for (String name : rgNames) {
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP " + name);
         }
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         Assert.assertTrue(rows.toString(), rows.isEmpty());
     }
 
     private void assertResourceGroupNotExist(String wg) {
         Assert.assertThrows(ERROR_NO_RG_ERROR.formatErrorMsg(wg), SemanticException.class,
-                () -> starRocksAssert.executeResourceGroupShowSql("show resource group " + wg));
+                () -> starRocksAssert.executeResourceGroupShowSql("show verbose resource group " + wg));
     }
 
     @Test
     public void testCreateResourceGroup() throws Exception {
         createResourceGroups();
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String result = rowsToString(rows);
         String expect = "" +
-                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
-                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
-                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
-                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_user4)\n" +
-                "rg2|30|50.0%|null|0|0|0|20|100%|NORMAL|(weight=3.475, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
-                "rg2|30|50.0%|null|0|0|0|20|100%|NORMAL|(weight=2.375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
-                "rg2|30|50.0%|null|0|0|0|20|100%|NORMAL|(weight=1.0, role=rg2_role3)\n" +
-                "rg3|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
-                "rg3|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=1.1, query_type in (SELECT))\n" +
-                "rg4|25|80.0%|null|1024|1024|1024|10|100%|NORMAL|(weight=1.375, source_ip=192.168.7.1/24)\n" +
-                "rg5|25|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
-                "rg6|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
-                "rg7|32|80.0%|null|0|0|0|10|30.0%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
-                "rt_rg1|25|80.0%|null|0|0|0|10|100%|SHORT_QUERY|(weight=1.0, user=rt_rg_user)";
+                "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
+                "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
+                "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
+                "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_user4)\n" +
+                "rg2|30|0|50.0%|null|0|0|0|20|100%|NORMAL|(weight=3.475, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
+                "rg2|30|0|50.0%|null|0|0|0|20|100%|NORMAL|(weight=2.375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
+                "rg2|30|0|50.0%|null|0|0|0|20|100%|NORMAL|(weight=1.0, role=rg2_role3)\n" +
+                "rg3|32|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rg3|32|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=1.1, query_type in (SELECT))\n" +
+                "rg4|25|0|80.0%|null|1024|1024|1024|10|100%|NORMAL|(weight=1.375, source_ip=192.168.7.1/24)\n" +
+                "rg5|25|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
+                "rg6|32|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
+                "rg7|32|0|80.0%|null|0|0|0|10|30%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rt_rg1|25|25|80.0%|null|0|0|0|10|100%|SHORT_QUERY|(weight=1.0, user=rt_rg_user)";
         Assert.assertEquals(expect, result);
         dropResourceGroups();
     }
@@ -258,19 +258,19 @@ public class ResourceGroupStmtTest {
         assertResourceGroupNotExist("rg1");
 
         starRocksAssert.executeResourceGroupDdlSql(createRg1IfNotExistsSql);
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg1");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg1");
         Assert.assertEquals(rows.size(), 1);
         String actual = rowsToString(rows);
         Assert.assertTrue(actual.contains("rg1_if_not_exists"));
 
         starRocksAssert.executeResourceGroupDdlSql(createRg1OrReplaceSql);
-        rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg1");
+        rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg1");
         Assert.assertEquals(rows.size(), 1);
         actual = rowsToString(rows);
         Assert.assertTrue(actual.contains("rg1_or_replace"));
 
         starRocksAssert.executeResourceGroupDdlSql(createRg1IfNotExistsSql);
-        rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg1");
+        rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg1");
         Assert.assertEquals(rows.size(), 1);
         actual = rowsToString(rows);
         Assert.assertTrue(actual.contains("rg1_or_replace"));
@@ -279,13 +279,13 @@ public class ResourceGroupStmtTest {
         assertResourceGroupNotExist("rg1");
 
         starRocksAssert.executeResourceGroupDdlSql(createRg1OrReplaceSql);
-        rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg1");
+        rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg1");
         Assert.assertEquals(rows.size(), 1);
         actual = rowsToString(rows);
         Assert.assertTrue(actual.contains("rg1_or_replace"));
 
         starRocksAssert.executeResourceGroupDdlSql(createRg1IfNotExistsOrReplaceSql);
-        rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg1");
+        rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg1");
         Assert.assertEquals(rows.size(), 1);
         actual = rowsToString(rows);
         System.out.println(actual);
@@ -365,7 +365,7 @@ public class ResourceGroupStmtTest {
     @Test
     public void testAlterResourceGroupDropManyClassifiers() throws Exception {
         createResourceGroups();
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String rgName = rows.get(0).get(0);
         List<String> classifierIds = rows.stream().filter(row -> row.get(0).equals(rgName))
                 .map(row -> getClassifierId(row.get(row.size() - 1))).collect(Collectors.toList());
@@ -378,7 +378,7 @@ public class ResourceGroupStmtTest {
         String alterSql = String.format("ALTER RESOURCE GROUP %s DROP (%s)", rgName, ids);
         starRocksAssert.executeResourceGroupDdlSql(alterSql);
         String expect = rowsToString(rows);
-        rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String actual = rowsToString(rows);
         Assert.assertEquals(expect, actual);
         dropResourceGroups();
@@ -387,7 +387,7 @@ public class ResourceGroupStmtTest {
     @Test
     public void testAlterResourceGroupDropOneClassifier() throws Exception {
         createResourceGroups();
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         Random rand = new Random();
         Map<String, Integer> classifierCount = new HashMap<>();
         rows.forEach(row -> classifierCount
@@ -412,7 +412,7 @@ public class ResourceGroupStmtTest {
             starRocksAssert.executeResourceGroupDdlSql(alterSql);
         }
         String expect = rowsToString(rows);
-        rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String actual = rowsToString(rows);
         Assert.assertEquals(expect, actual);
         dropResourceGroups();
@@ -421,7 +421,7 @@ public class ResourceGroupStmtTest {
     @Test
     public void testAlterResourceGroupDropAllClassifier() throws Exception {
         createResourceGroups();
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String rgName = "rg2";
         rows = rows.stream().peek(row -> {
             if (row.get(0).equals(rgName)) {
@@ -431,7 +431,7 @@ public class ResourceGroupStmtTest {
         String alterSql = String.format("ALTER RESOURCE GROUP %s DROP ALL", rgName);
         starRocksAssert.executeResourceGroupDdlSql(alterSql);
         String expect = rowsToString(rows);
-        rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String actual = rowsToString(rows);
         Assert.assertEquals(expect, actual);
         dropResourceGroups();
@@ -446,7 +446,7 @@ public class ResourceGroupStmtTest {
                 "   (user='rg1_user5', role='rg1_role5', source_ip='192.168.4.1/16')";
 
         starRocksAssert.executeResourceGroupDdlSql(sql);
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("SHOW RESOURCE GROUP rg1");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg1");
         String result = rowsToString(rows);
         Assert.assertTrue(result.contains("rg1_user5"));
         dropResourceGroups();
@@ -463,7 +463,7 @@ public class ResourceGroupStmtTest {
                 "   (source_ip='192.169.6.1/16');\n";
 
         starRocksAssert.executeResourceGroupDdlSql(sql);
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("SHOW RESOURCE GROUP rg2");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg2");
         String result = rowsToString(rows);
         Assert.assertTrue(result.contains("rg2_user4"));
         Assert.assertTrue(result.contains("rg2_role5"));
@@ -476,9 +476,9 @@ public class ResourceGroupStmtTest {
         starRocksAssert.executeResourceGroupDdlSql(createRg1Sql);
 
         starRocksAssert.executeResourceGroupDdlSql("ALTER RESOURCE GROUP rg1 DROP ALL;");
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg1");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg1");
         String actual = rowsToString(rows);
-        String expect = "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=0.0)";
+        String expect = "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=0.0)";
         Assert.assertEquals(expect, actual);
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
@@ -571,12 +571,12 @@ public class ResourceGroupStmtTest {
         starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));
         starRocksAssert.getCtx().setRemoteIP(remoteIp);
         List<List<String>> rows = GlobalStateMgr.getCurrentState().getResourceGroupMgr().showAllResourceGroups(
-                starRocksAssert.getCtx(), false);
+                starRocksAssert.getCtx(), true, false);
         String result = rowsToString(rows);
         String expect = "" +
-                "rg5|25|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
-                "rg1|10|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
-                "rg3|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=1.1, query_type in (SELECT))";
+                "rg5|25|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
+                "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
+                "rg3|32|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=1.1, query_type in (SELECT))";
         Assert.assertEquals(expect, result);
         dropResourceGroups();
     }
@@ -629,23 +629,23 @@ public class ResourceGroupStmtTest {
         for (String sql : sqls) {
             starRocksAssert.executeResourceGroupDdlSql(sql);
         }
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("SHOW RESOURCE GROUPS all");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String result = rowsToString(rows);
         String expect = "" +
-                "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
-                "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
-                "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
-                "rg1|21|20.0%|4|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_user4)\n" +
-                "rg2|30|37.0%|null|0|0|0|20|100%|NORMAL|(weight=3.475, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
-                "rg2|30|37.0%|null|0|0|0|20|100%|NORMAL|(weight=2.375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
-                "rg2|30|37.0%|null|0|0|0|20|100%|NORMAL|(weight=1.0, role=rg2_role3)\n" +
-                "rg3|32|80.0%|3|0|0|0|23|100%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
-                "rg3|32|80.0%|3|0|0|0|23|100%|NORMAL|(weight=1.1, query_type in (SELECT))\n" +
-                "rg4|13|41.0%|null|1024|1024|1024|23|100%|NORMAL|(weight=1.375, source_ip=192.168.7.1/24)\n" +
-                "rg5|25|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
-                "rg6|32|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
-                "rg7|32|80.0%|null|0|0|0|10|30.0%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
-                "rt_rg1|25|80.0%|null|0|0|0|10|100%|SHORT_QUERY|(weight=1.0, user=rt_rg_user)";
+                "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
+                "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
+                "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
+                "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_user4)\n" +
+                "rg2|30|0|37.0%|null|0|0|0|20|100%|NORMAL|(weight=3.475, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
+                "rg2|30|0|37.0%|null|0|0|0|20|100%|NORMAL|(weight=2.375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
+                "rg2|30|0|37.0%|null|0|0|0|20|100%|NORMAL|(weight=1.0, role=rg2_role3)\n" +
+                "rg3|32|0|80.0%|3|0|0|0|23|100%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rg3|32|0|80.0%|3|0|0|0|23|100%|NORMAL|(weight=1.1, query_type in (SELECT))\n" +
+                "rg4|13|0|41.0%|null|1024|1024|1024|23|100%|NORMAL|(weight=1.375, source_ip=192.168.7.1/24)\n" +
+                "rg5|25|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
+                "rg6|32|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
+                "rg7|32|0|80.0%|null|0|0|0|10|30%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rt_rg1|25|25|80.0%|null|0|0|0|10|100%|SHORT_QUERY|(weight=1.0, user=rt_rg_user)";
         Assert.assertEquals(expect, result);
         dropResourceGroups();
     }
@@ -873,9 +873,10 @@ public class ResourceGroupStmtTest {
         {
             String sql = String.format(createSQLTemplate, numCores);
             starRocksAssert.executeResourceGroupDdlSql(sql);
-            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg_valid_max_cpu_cores");
+            List<List<String>> rows =
+                    starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_valid_max_cpu_cores");
             String actual = rowsToString(rows);
-            String expect = "rg_valid_max_cpu_cores|32|20.0%|17|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
+            String expect = "rg_valid_max_cpu_cores|32|0|20.0%|17|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
             Assert.assertEquals(expect, actual);
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg_valid_max_cpu_cores");
         }
@@ -883,9 +884,10 @@ public class ResourceGroupStmtTest {
         {
             String sql = String.format(createSQLTemplate, numCores - 1);
             starRocksAssert.executeResourceGroupDdlSql(sql);
-            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg_valid_max_cpu_cores");
+            List<List<String>> rows =
+                    starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_valid_max_cpu_cores");
             String actual = rowsToString(rows);
-            String expect = "rg_valid_max_cpu_cores|31|20.0%|17|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
+            String expect = "rg_valid_max_cpu_cores|31|0|20.0%|17|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
             Assert.assertEquals(expect, actual);
         }
 
@@ -906,18 +908,20 @@ public class ResourceGroupStmtTest {
         {
             String sql = String.format(alterSQLTemplate, numCores);
             starRocksAssert.executeResourceGroupDdlSql(sql);
-            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg_valid_max_cpu_cores");
+            List<List<String>> rows =
+                    starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_valid_max_cpu_cores");
             String actual = rowsToString(rows);
-            String expect = "rg_valid_max_cpu_cores|31|20.0%|32|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
+            String expect = "rg_valid_max_cpu_cores|31|0|20.0%|32|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
             Assert.assertEquals(expect, actual);
         }
 
         {
             String sql = String.format(alterSQLTemplate, numCores - 2);
             starRocksAssert.executeResourceGroupDdlSql(sql);
-            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg_valid_max_cpu_cores");
+            List<List<String>> rows =
+                    starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_valid_max_cpu_cores");
             String actual = rowsToString(rows);
-            String expect = "rg_valid_max_cpu_cores|31|20.0%|30|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
+            String expect = "rg_valid_max_cpu_cores|31|0|20.0%|30|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
             Assert.assertEquals(expect, actual);
         }
 
@@ -1032,22 +1036,23 @@ public class ResourceGroupStmtTest {
 
         List<TestCase> testCases = ImmutableList.of(
                 new TestCase("[1.12345678901234567,10.2)", "[2, 100.2)",
-                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[1.1234567890123457, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[1.1234567890123457, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
                 new TestCase("[1.1,10.2)", "[2, 100.2)",
-                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[1.1, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[1.1, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
 
                 new TestCase("[-1,10)", "[2, 100)",
-                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[-1.0, 10.0), plan_mem_cost_range=[2.0, 100.0))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[-1.0, 10.0), plan_mem_cost_range=[2.0, 100.0))"),
                 new TestCase("[0, 10)", "[0, 100)",
-                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
                 new TestCase(" [ 0,  10) ", "  [ 0,  100  )  ",
-                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))")
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))")
         );
         for (TestCase c : testCases) {
             String createSQL = String.format(createSQLTemplate, c.planCpuCostRange, c.PlanMemCostRange);
             starRocksAssert.executeResourceGroupDdlSql(createSQL);
 
-            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg_valid_plan_cost_range");
+            List<List<String>> rows =
+                    starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_valid_plan_cost_range");
             String actual = rowsToString(rows);
             Assert.assertEquals(c.expectedOutput, actual);
 
@@ -1088,21 +1093,21 @@ public class ResourceGroupStmtTest {
 
         List<TestCase> testCases = ImmutableList.of(
                 new TestCase("[1.12345678901234567,10.2)", "[2, 100.2)",
-                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
-                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.1234567890123457, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.1234567890123457, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
                 new TestCase("[1.1,10.2)", "[2, 100.2)",
-                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
-                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.1, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.1, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
 
                 new TestCase("[-1,10)", "[2, 100)",
-                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
-                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[-1.0, 10.0), plan_mem_cost_range=[2.0, 100.0))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[-1.0, 10.0), plan_mem_cost_range=[2.0, 100.0))"),
                 new TestCase("[0, 10)", "[0, 100)",
-                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
-                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
                 new TestCase(" [ 0,  10) ", "  [ 0,  100  )  ",
-                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
-                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))")
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))")
         );
         for (TestCase c : testCases) {
             starRocksAssert.executeResourceGroupDdlSql(createSQL);
@@ -1110,7 +1115,8 @@ public class ResourceGroupStmtTest {
             String alterSQL = String.format(alterTemplate, c.planCpuCostRange, c.PlanMemCostRange);
             starRocksAssert.executeResourceGroupDdlSql(alterSQL);
 
-            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg_valid_plan_cost_range");
+            List<List<String>> rows =
+                    starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_valid_plan_cost_range");
             String actual = rowsToString(rows);
             Assert.assertEquals(c.expectedOutput, actual);
 
@@ -1259,13 +1265,13 @@ public class ResourceGroupStmtTest {
                 "   'type' = 'normal'" +
                 "   );";
         String showResult =
-                "rg1|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.0, 2.0), plan_mem_cost_range=[-100.0, 1000.0))\n" +
-                        "rg2|32|30.0%|null|0|0|0|31|100%|NORMAL|(weight=2.0, user=rg1_user, plan_mem_cost_range=[0.0, 2000.0))";
+                "rg1|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.0, 2.0), plan_mem_cost_range=[-100.0, 1000.0))\n" +
+                        "rg2|32|0|30.0%|null|0|0|0|31|100%|NORMAL|(weight=2.0, user=rg1_user, plan_mem_cost_range=[0.0, 2000.0))";
 
         starRocksAssert.executeResourceGroupDdlSql(createSQL1);
         starRocksAssert.executeResourceGroupDdlSql(createSQL2);
         {
-            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
             String actual = rowsToString(rows);
             Assert.assertEquals(showResult, actual);
         }
@@ -1278,7 +1284,7 @@ public class ResourceGroupStmtTest {
 
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg2");
-            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
             Assert.assertTrue(rows.isEmpty());
 
             try (ByteArrayInputStream bufferInput = new ByteArrayInputStream(bufferOutput.toByteArray());
@@ -1287,7 +1293,7 @@ public class ResourceGroupStmtTest {
             }
         }
         {
-            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
             String actual = rowsToString(rows);
             Assert.assertEquals(showResult, actual);
         }
@@ -1353,12 +1359,12 @@ public class ResourceGroupStmtTest {
         starRocksAssert.executeResourceGroupDdlSql(createSQL2);
         starRocksAssert.executeResourceGroupDdlSql(createSQL3);
 
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String actual = rowsToString(rows);
         String expected =
-                "rg1|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=2.0, plan_cpu_cost_range=[11.0, 12.0), plan_mem_cost_range=[-100.0, 11000.0))\n" +
-                        "rg2|16|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_cpu_cost_range=[21.0, 22.0))\n" +
-                        "rg3|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_mem_cost_range=[-100.0, 31000.0))";
+                "rg1|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=2.0, plan_cpu_cost_range=[11.0, 12.0), plan_mem_cost_range=[-100.0, 11000.0))\n" +
+                        "rg2|16|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_cpu_cost_range=[21.0, 22.0))\n" +
+                        "rg3|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_mem_cost_range=[-100.0, 31000.0))";
         Assert.assertEquals(expected, actual);
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
@@ -1385,10 +1391,343 @@ public class ResourceGroupStmtTest {
                 "    'mem_limit' = '20%'\n" +
                 ");";
         starRocksAssert.executeResourceGroupDdlSql(createSQL);
-        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         assertThat(rowsToString(rows)).isEqualTo(
-                "rg1|10|20.0%|8|0|0|0|null|100%|NORMAL|(weight=1.5, source_ip=192.168.2.1/32)");
+                "rg1|10|0|20.0%|8|0|0|0|null|100%|NORMAL|(weight=1.5, source_ip=192.168.2.1/32)");
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
     }
+
+    @Test
+    public void testGetDedicateCpuCores() throws Exception {
+        starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rg1\n" +
+                "TO (user='rg1_user')\n" +
+                "WITH (" +
+                "   'mem_limit' = '20%'," +
+                "   'cpu_weight' = '17'" +
+                ");");
+        starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rg2\n" +
+                "TO (user='rg2_user')\n" +
+                "WITH (" +
+                "   'mem_limit' = '20%'," +
+                "   'dedicated_cpu_cores' = '16'" +
+                ");");
+        starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rt_rg1\n" +
+                "TO (user='rt_rg1_user')\n" +
+                "WITH (" +
+                "   'mem_limit' = '20%'," +
+                "   'cpu_weight' = '15'," +
+                "   'type' = 'short_query'" +
+                ");");
+
+        List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+        assertThat(rowsToString(rows)).isEqualTo("rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
+                "rg2|null|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)\n" +
+                "rt_rg1|15|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rt_rg1_user)");
+
+        starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
+        starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg2");
+        starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rt_rg1");
+    }
+
+    @Test
+    public void testValidateCpuParametersForCreate() throws Exception {
+        {
+            String sql = "CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'cpu_weight' = '17'," +
+                    "   'dedicated_cpu_cores' = '17'" +
+                    ");";
+            Assert.assertThrows("property 'cpu_weight' and 'dedicated_cpu_cores' cannot be present and positive at the same time",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+            String sql = "CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'cpu_weight' = '0'," +
+                    "   'dedicated_cpu_cores' = '0'" +
+                    ");";
+            Assert.assertThrows("property 'cpu_weight' or 'dedicated_cpu_cores' must be positive",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+            String sql = "CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'" +
+                    ");";
+            Assert.assertThrows("property 'cpu_weight' or 'dedicated_cpu_cores' must be positive",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+            String sql = "CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'dedicated_cpu_cores' = '32'" +
+                    ");";
+            Assert.assertThrows("dedicated_cpu_cores should range from 0 to 31",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+            String sql = "CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'cpu_weight' = '17'," +
+                    "   'dedicated_cpu_cores' = '0'" +
+                    ");";
+            starRocksAssert.executeResourceGroupDdlSql(sql);
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
+        }
+
+        {
+            String sql = "CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'cpu_weight' = '17'" +
+                    ");";
+            starRocksAssert.executeResourceGroupDdlSql(sql);
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
+        }
+
+        {
+            String sql = "CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'cpu_weight' = '0'," +
+                    "   'dedicated_cpu_cores' = '17'" +
+                    ");";
+            starRocksAssert.executeResourceGroupDdlSql(sql);
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("rg1|0|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
+        }
+
+        {
+            String sql = "CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'dedicated_cpu_cores' = '17'" +
+                    ");";
+            starRocksAssert.executeResourceGroupDdlSql(sql);
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("rg1|null|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
+        }
+    }
+
+    @Test
+    public void testValidateCpuParametersForAlter() throws Exception {
+        {
+            String sql = "CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'cpu_weight' = '17'" +
+                    ");";
+            starRocksAssert.executeResourceGroupDdlSql(sql);
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+        }
+
+        {
+            String sql = "ALTER resource group rg1 \n" +
+                    "WITH (\n" +
+                    "   'cpu_weight' = '16'," +
+                    "   'dedicated_cpu_cores' = '15'" +
+                    ")";
+            Assert.assertThrows("property 'cpu_weight' and 'dedicated_cpu_cores' cannot be present and positive at the same time",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+            String sql = "ALTER resource group rg1 \n" +
+                    "WITH (\n" +
+                    "   'dedicated_cpu_cores' = '15'" +
+                    ")";
+            Assert.assertThrows("property 'cpu_weight' and 'dedicated_cpu_cores' cannot be present and positive at the same time",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+
+            String sql = "ALTER resource group rg1 \n" +
+                    "WITH (\n" +
+                    "   'cpu_weight' = '0'," +
+                    "   'dedicated_cpu_cores' = '0'" +
+                    ")";
+            Assert.assertThrows("property 'cpu_weight' or 'dedicated_cpu_cores' must be positive",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+
+            String sql = "ALTER resource group rg1 \n" +
+                    "WITH (\n" +
+                    "   'cpu_weight' = '0'" +
+                    ")";
+            Assert.assertThrows("property 'cpu_weight' or 'dedicated_cpu_cores' must be positive",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+            String sql = "ALTER resource group rg1 \n" +
+                    "WITH (\n" +
+                    "   'cpu_weight' = '0'," +
+                    "   'dedicated_cpu_cores' = '32'" +
+                    ")";
+            Assert.assertThrows("dedicated_cpu_cores should range from 0 to 31",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+            String sql = "ALTER resource group rg1 \n" +
+                    "WITH (\n" +
+                    "   'cpu_weight' = '0'," +
+                    "   'dedicated_cpu_cores' = '16'" +
+                    ")";
+            starRocksAssert.executeResourceGroupDdlSql(sql);
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("rg1|0|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+        }
+
+        {
+            String sql = "ALTER resource group rg1 \n" +
+                    "WITH (\n" +
+                    "   'cpu_weight' = '15'," +
+                    "   'dedicated_cpu_cores' = '0'" +
+                    ")";
+            starRocksAssert.executeResourceGroupDdlSql(sql);
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("rg1|15|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+        }
+
+        starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
+    }
+
+    @Test
+    public void testValidateDedicatedCpuCoresWithShortQuery() throws Exception {
+        {
+            String sql = "CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'dedicated_cpu_cores' = '17'," +
+                    "   'type' = 'short_query'" +
+                    ");";
+            Assert.assertThrows(
+                    "'short_query' ResourceGroup cannot set 'dedicated_cpu_cores', since it use 'cpu_weight' as 'dedicated_cpu_cores'",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+            starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'cpu_weight' = '17'," +
+                    "   'type' = 'short_query'" +
+                    ");");
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("rg1|17|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+
+            String sql = "ALTER resource group rg1 \n" +
+                    "WITH (\n" +
+                    "   'dedicated_cpu_cores' = '16'" +
+                    ")";
+            Assert.assertThrows(
+                    "'short_query' ResourceGroup cannot set 'dedicated_cpu_cores', since it use 'cpu_weight' as 'dedicated_cpu_cores'",
+                    SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
+        }
+    }
+
+
+    @Test
+    public void testValidateSumDedicatedCpuCores() throws Exception {
+        {
+            starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rg1\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'dedicated_cpu_cores' = '16'" +
+                    ");");
+            starRocksAssert.executeResourceGroupDdlSql("CREATE RESOURCE GROUP rg2\n" +
+                    "TO (user='rg2_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'dedicated_cpu_cores' = '15'" +
+                    ");");
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("rg1|null|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
+                    "rg2|null|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
+        }
+
+        {
+            String sql = "ALTER resource group rg1 \n" +
+                    "WITH (\n" +
+                    "   'dedicated_cpu_cores' = '17'" +
+                    ")";
+            Assert.assertThrows(
+                    "The sum of dedicated_cpu_cores of all the resource groups cannot exceed 31",
+                    DdlException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        {
+            String sql = "ALTER resource group rg1 \n" +
+                    "WITH (\n" +
+                    "   'dedicated_cpu_cores' = '14'" +
+                    ")";
+            starRocksAssert.executeResourceGroupDdlSql(sql);
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("rg1|null|14|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
+                    "rg2|null|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
+        }
+
+        {
+            String sql = "CREATE RESOURCE GROUP rg3\n" +
+                    "TO (user='rg1_user')\n" +
+                    "WITH (" +
+                    "   'mem_limit' = '20%'," +
+                    "   'dedicated_cpu_cores' = '3'" +
+                    ");";
+            Assert.assertThrows(
+                    "The sum of dedicated_cpu_cores of all the resource groups cannot exceed 31",
+                    DdlException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+
+        starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
+        starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg2");
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -1697,7 +1697,7 @@ public class ResourceGroupStmtTest {
                     "   'dedicated_cpu_cores' = '17'" +
                     ")";
             Assert.assertThrows(
-                    "The sum of dedicated_cpu_cores of all the resource groups cannot exceed 31",
+                    "the sum of dedicated_cpu_cores of all the resource groups cannot exceed 31",
                     DdlException.class,
                     () -> starRocksAssert.executeResourceGroupDdlSql(sql));
         }
@@ -1721,7 +1721,7 @@ public class ResourceGroupStmtTest {
                     "   'dedicated_cpu_cores' = '3'" +
                     ");";
             Assert.assertThrows(
-                    "The sum of dedicated_cpu_cores of all the resource groups cannot exceed 31",
+                    "the sum of dedicated_cpu_cores of all the resource groups cannot exceed 31",
                     DdlException.class,
                     () -> starRocksAssert.executeResourceGroupDdlSql(sql));
         }

--- a/gensrc/thrift/WorkGroup.thrift
+++ b/gensrc/thrift/WorkGroup.thrift
@@ -39,6 +39,8 @@ struct TWorkGroup {
   13: optional i64 big_query_cpu_second_limit
   14: optional double spill_mem_limit_threshold
 
+  15: optional i32 dedicated_cpu_cores
+
   100: optional i32 max_cpu_cores
 }
 


### PR DESCRIPTION
## Why I'm doing:


Introduce the `dedicated_cpu_cores` property for resource groups, which indicates the following two implications:
- **Exclusive:** The specified number of `dedicated_cpu_cores` will be reserved exclusively for this resource group, preventing other resource groups from utilizing these CPU cores, even when they are idle.
- **LIMIT:** This resource group is restricted to using only the `dedicated_cpu_cores` it has been allocated. Even if other resource groups have idle CPU resources, this resource group cannot access them.

Additionally, the original `cpu_core_limit` property is renamed to `cpu_weight`.

**Constraints on the `dedicated_cpu_cores` Parameter:**
- For a given resource group, only one of `dedicated_cpu_cores` or `cpu_weight` can be a positive value, whether during the creation of the resource group or when altering its properties.
- The total sum of `dedicated_cpu_cores` across all resource groups must not exceed `num_be_cpu_cores-1`. The maximum value is set to `num_be_cpu_cores-1` rather than `num_be_cpu_cores` to reserve some CPU resources for other groups.

**Compatibility with the `short_query` Resource Group:**
Previously, we had resource groups with a `type` of `short_query`, where `cpu_core_limit` (now `cpu_weight`) represented dynamically reserved CPU cores. To maintain compatibility:
- The `short_query` resource group will use `cpu_weight` in place of `dedicated_cpu_cores`.
- The `short_query` resource group cannot set a positive value for `dedicated_cpu_cores` to avoid ambiguity and complexity.

**Introduce the `SHOW VERBOSE RESOURCE GROUPS` command, with the following changes:**
- In the original `SHOW RESOURCE GROUPS`, the `type` and `max_cpu_cores` fields will no longer be displayed.
- The `type` and `max_cpu_cores` fields will only be shown in `SHOW VERBOSE RESOURCE GROUPS`.
- Furthermore, for the `short_query` resource group, the `dedicated_cpu_cores` field will display the value of `cpu_weight`.

Here are some usage examples:
```sql
> CREATE RESOURCE GROUP rg1 
TO (user='rg1_user') 
WITH ( 
    'cpu_weight' = '3',
    'dedicated_cpu_cores' = '3',
    'mem_limit' = '20%'
);

ERROR: property 'cpu_weight' and 'dedicated_cpu_cores' cannot be present and positive at the same time


> CREATE RESOURCE GROUP rg1 
TO (user='rg1_user') 
WITH ( 
    'mem_limit' = '20%'
);

ERROR: property 'cpu_weight' or 'dedicated_cpu_cores' must be positive

> CREATE RESOURCE GROUP rg1 
TO (user='rg1_user') 
WITH ( 
    'cpu_weight' = '0',
    'dedicated_cpu_cores' = '0',
    'mem_limit' = '20%'
);

ERROR: property 'cpu_weight' or 'dedicated_cpu_cores' must be positive


> CREATE RESOURCE GROUP rg1 
TO (user='rg1_user') 
WITH ( 
    'dedicated_cpu_cores' = '100',
    'mem_limit' = '20%'
);

ERROR: dedicated_cpu_cores should range from 0 to 31


> CREATE RESOURCE GROUP rg1 
TO (user='rg1_user') 
WITH ( 
    'dedicated_cpu_cores' = '3',
    'mem_limit' = '20%'
);

> ALTER RESORUCE GROUP rg1 WITH (
    'dedicated_cpu_cores' = '3',
    'cpu_weight' = '3',
);

ERROR: property 'cpu_weight' and 'dedicated_cpu_cores' cannot be present and positive at the same time

> ALTER RESORUCE GROUP rg1 WITH (
    'dedicated_cpu_cores' = '0',
    'cpu_weight' = '0',
);

ERROR: property 'cpu_weight' or 'dedicated_cpu_cores' must be positive


> CREATE RESOURCE GROUP rg2 
TO (user='rg1_user') 
WITH ( 
    'dedicated_cpu_cores' = '29',
    'mem_limit' = '20%'
);

ERROR: The sum of dedicated_cpu_cores of all the resource groups cannot exceed 31

> CREATE RESOURCE GROUP rg2 
TO (user='rg1_user') 
WITH ( 
    'dedicated_cpu_cores' = '3',
    'mem_limit' = '20%',
    'type' = 'short_query'
);

ERROR: short_query' ResourceGroup cannot set 'dedicated_cpu_cores', since it use 'cpu_weight' as 'dedicated_cpu_cores'
```

## What I'm doing:

Relates to #49965.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
