### PR TITLE
[BugFix] Add table level lock for createPartitionProcess RPC

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -93,6 +93,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.ProfileManager;
+import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -2182,7 +2183,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         AddPartitionClause addPartitionClause;
         List<String> partitionColNames = Lists.newArrayList();
-        try {
+        try (AutoCloseableLock ignore = new AutoCloseableLock(new Locker(), db, Lists.newArrayList(table.getId()),
+                LockType.READ)) {
             addPartitionClause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(olapTable,
                     request.partition_values);
             PartitionDesc partitionDesc = addPartitionClause.getPartitionDesc();
@@ -2258,8 +2260,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             if (txnState.getWarehouseId() != WarehouseManager.DEFAULT_WAREHOUSE_ID) {
                 ctx.setCurrentWarehouseId(txnState.getWarehouseId());
             }
-            AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(olapTable);
-            analyzer.analyze(ctx, addPartitionClause);
+            try (AutoCloseableLock ignore = new AutoCloseableLock(new Locker(), db, Lists.newArrayList(table.getId()),
+                    LockType.READ)) {
+                AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(olapTable);
+                analyzer.analyze(ctx, addPartitionClause);
+            }
             state.getLocalMetastore().addPartitions(ctx, db, olapTable.getName(), addPartitionClause);
         } catch (Exception e) {
             LOG.warn("failed to cancel alter operation", e);


### PR DESCRIPTION
## Why I'm doing:
The execution of analyzer should be protected by lock.

## What I'm doing:

Fixes 
```
2024-08-27 12:58:31.390+08:00 WARN (thrift-server-pool-54|572) [FrontendServiceImpl.createPartitionProcess():2340] failed to cancel alter operation
java.util.ConcurrentModificationException: null
        at java.util.HashMap.forEach(HashMap.java:1340) ~[?:?]
        at com.starrocks.catalog.ListPartitionInfo.getPartitionIds(ListPartitionInfo.java:228) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.CatalogUtils.checkPartitionValuesExistForAddListPartition(CatalogUtils.java:273) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AlterTableClauseAnalyzer.analyzeAddPartition(AlterTableClauseAnalyzer.java:1138) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AlterTableClauseAnalyzer.visitAddPartitionClause(AlterTableClauseAnalyzer.java:1085) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AlterTableClauseAnalyzer.visitAddPartitionClause(AlterTableClauseAnalyzer.java:120) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AddPartitionClause.accept(AddPartitionClause.java:80) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:71) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AlterTableClauseAnalyzer.analyze(AlterTableClauseAnalyzer.java:128) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.createPartitionProcess(FrontendServiceImpl.java:2337) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.createPartition(FrontendServiceImpl.java:2200) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$createPartition.getResult(FrontendService.java:5781) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$createPartition.getResult(FrontendService.java:5758) ~[starrocks-fe.jar:?]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
