### PR TITLE
[BugFix] Fix dead lock in RuntimeState::log_error

### DIFF
--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -262,7 +262,7 @@ void RuntimeState::log_error(const Status& status) {
         return;
     }
 
-    log_error(status);
+    log_error(status.message());
 }
 
 void RuntimeState::get_unreported_errors(std::vector<std::string>* new_errors) {


### PR DESCRIPTION
## Why I'm doing:

```
5 tids: 814,817,819,825,833
         0x7e6ea98  starrocks::RuntimeState::log_error(starrocks::Status const&)
         0x7eaf680  starrocks::pipeline::ExchangeSinkOperator::set_finishing(starrocks::RuntimeState*)
         0x550130c  starrocks::pipeline::PipelineDriver::_mark_operator_finishing(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
         0x5502ce8  starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
         0x7e4e6e8  starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
         0x81649ec  starrocks::ThreadPool::dispatch_thread()
         0x815dc5c  starrocks::Thread::supervise_thread(void*)
    0xffff838fd5c8  (/usr/lib/aarch64-linux-gnu/libc.so.6+0x7d5c8)
    0xffff83965edc  (/usr/lib/aarch64-linux-gnu/libc.so.6+0xe5edc)
```

Introduced by #38027. `log_error` calls itself.

I would add a test with error injection later.

```cpp
void RuntimeState::log_error(const Status& status) {
    if (status.ok()) {
        return;
    }

    log_error(status);
}
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
