### PR TITLE
[BugFix] In a concurrency scenario, after a tablet is deleted, its corresponding data directory still exists.

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1006,6 +1006,68 @@ Status TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* tabl
     return Status::OK();
 }
 
+void TabletManager::sweep_shutdown_tablet(const DroppedTabletInfo& info, std::vector<DroppedTabletInfo>& finished_tablets) {
+    auto& tablet = info.tablet;
+    // The current thread has two references: _shutdown_tablets[i] and tablets_to_checks[i], check
+    // if there is another thread has reference to the tablet, and if so, does not remove the tablet for now.
+    if (tablet.use_count() > 2) {
+        return;
+    }
+
+    if (tablet->updates() != nullptr) {
+        Status st = tablet->updates()->check_and_remove_rowset();
+        if (!st.ok()) {
+            LOG(WARNING) << "there are some rowsets still been referenced, drop tablet: " << tablet->tablet_id()
+                         << " later";
+            return;
+        }
+    }
+
+    bool remove_meta = false;
+    TabletMeta tablet_meta;
+    Status st = TabletMetaManager::get_tablet_meta(tablet->data_dir(), tablet->tablet_id(), tablet->schema_hash(),
+                                                   &tablet_meta);
+    if (st.ok()) {
+        if (tablet_meta.tablet_uid() != tablet->tablet_uid()) {
+            finished_tablets.push_back(info);
+            LOG(INFO) << "Skipped remove tablet " << tablet_meta.tablet_id() << ": uid mismatch";
+            return;
+        }
+        if (tablet_meta.tablet_state() != TABLET_SHUTDOWN) { // This should not happen.
+            finished_tablets.push_back(info);
+            LOG(ERROR) << "Cannot remove normal state tablet " << tablet_meta.tablet_id();
+            return;
+        }
+        remove_meta = true;
+    } else if (!st.is_not_found()) {
+        LOG(ERROR) << "Fail to get tablet meta: " << st;
+        return;
+    }
+
+    if (info.flag == kMoveFilesToTrash) {
+        st = _move_tablet_directories_to_trash(tablet);
+    } else if (info.flag == kDeleteFiles) {
+        st = _remove_tablet_directories(tablet);
+    } else {
+        finished_tablets.push_back(info);
+        LOG(WARNING) << "Invalid flag " << info.flag;
+        return;
+    }
+
+    if (st.ok() || st.is_not_found()) {
+        finished_tablets.push_back(info);
+        LOG(INFO) << ((info.flag == kMoveFilesToTrash) ? "Moved " : " Removed ") << tablet->tablet_id_path();
+    } else {
+        remove_meta = false;
+        LOG(WARNING) << "Fail to remove or move " << tablet->tablet_id_path() << " :" << st;
+    }
+
+    if (remove_meta) {
+        st = _remove_tablet_meta(tablet);
+        LOG_IF(ERROR, !st.ok()) << "Fail to remove tablet meta of tablet " << tablet->tablet_id() << ": " << st;
+    }
+}
+
 Status TabletManager::start_trash_sweep() {
     {
         // we use this vector to save all tablet ptr for saving lock time.
@@ -1028,83 +1090,53 @@ Status TabletManager::start_trash_sweep() {
     }
 
     std::vector<DroppedTabletInfo> tablets_to_check;
+    std::vector<DroppedTabletInfo> tablets_redundant_to_check;
     {
         std::shared_lock l(_shutdown_tablets_lock);
         tablets_to_check.reserve(_shutdown_tablets.size());
         for (auto& [tablet_id, info] : _shutdown_tablets) {
             tablets_to_check.emplace_back(info);
         }
+
+        while (!_shutdown_tablets_redundant_queue.empty()) {
+            auto info = _shutdown_tablets_redundant_queue.front();
+            tablets_redundant_to_check.emplace_back(std::move(info));
+            _shutdown_tablets_redundant_queue.pop_front();
+        }
     }
 
-    std::vector<TTabletId> finished_tablets;
+    std::vector<DroppedTabletInfo> finished_tablets;
+    std::vector<DroppedTabletInfo> finished_tablets_redundant;
     finished_tablets.reserve(tablets_to_check.size());
+    finished_tablets_redundant.reserve(tablets_redundant_to_check.size());
 
     for (const auto& info : tablets_to_check) {
-        auto& tablet = info.tablet;
-        // The current thread has two references: _shutdown_tablets[i] and tablets_to_checks[i], check
-        // if there is another thread has reference to the tablet, and if so, does not remove the tablet for now.
-        if (tablet.use_count() > 2) {
-            continue;
-        }
-
-        if (tablet->updates() != nullptr) {
-            Status st = tablet->updates()->check_and_remove_rowset();
-            if (!st.ok()) {
-                LOG(WARNING) << "there are some rowsets still been referenced, drop tablet: " << tablet->tablet_id()
-                             << " later";
-                continue;
-            }
-        }
-
-        bool remove_meta = false;
-        TabletMeta tablet_meta;
-        Status st = TabletMetaManager::get_tablet_meta(tablet->data_dir(), tablet->tablet_id(), tablet->schema_hash(),
-                                                       &tablet_meta);
-        if (st.ok()) {
-            if (tablet_meta.tablet_uid() != tablet->tablet_uid()) {
-                finished_tablets.push_back(tablet->tablet_id());
-                LOG(INFO) << "Skipped remove tablet " << tablet_meta.tablet_id() << ": uid mismatch";
-                continue;
-            }
-            if (tablet_meta.tablet_state() != TABLET_SHUTDOWN) { // This should not happen.
-                finished_tablets.push_back(tablet->tablet_id());
-                LOG(ERROR) << "Cannot remove normal state tablet " << tablet_meta.tablet_id();
-                continue;
-            }
-            remove_meta = true;
-        } else if (!st.is_not_found()) {
-            LOG(ERROR) << "Fail to get tablet meta: " << st;
-            break;
-        }
-
-        if (info.flag == kMoveFilesToTrash) {
-            st = _move_tablet_directories_to_trash(tablet);
-        } else if (info.flag == kDeleteFiles) {
-            st = _remove_tablet_directories(tablet);
-        } else {
-            finished_tablets.push_back(tablet->tablet_id());
-            LOG(WARNING) << "Invalid flag " << info.flag;
-            continue;
-        }
-
-        if (st.ok() || st.is_not_found()) {
-            finished_tablets.push_back(tablet->tablet_id());
-            LOG(INFO) << ((info.flag == kMoveFilesToTrash) ? "Moved " : " Removed ") << tablet->tablet_id_path();
-        } else {
-            remove_meta = false;
-            LOG(WARNING) << "Fail to remove or move " << tablet->tablet_id_path() << " :" << st;
-        }
-
-        if (remove_meta) {
-            st = _remove_tablet_meta(tablet);
-            LOG_IF(ERROR, !st.ok()) << "Fail to remove tablet meta of tablet " << tablet->tablet_id() << ": " << st;
-        }
+        sweep_shutdown_tablet(info, finished_tablets);
+    }
+    for (const auto& info : tablets_redundant_to_check) {
+        sweep_shutdown_tablet(info, finished_tablets_redundant);
     }
 
-    if (!finished_tablets.empty()) {
+    if (!finished_tablets.empty() || !finished_tablets_redundant.empty()) {
         std::unique_lock l(_shutdown_tablets_lock);
-        for (auto tablet_id : finished_tablets) {
-            _shutdown_tablets.erase(tablet_id);
+        for (auto tablet_info_finished : finished_tablets) {
+            auto& tablet_finished = tablet_info_finished.tablet;
+            _shutdown_tablets.erase(tablet_finished->tablet_id());
+        }
+
+        for (auto& tablet_info : tablets_redundant_to_check) {
+            auto& tablet = tablet_info.tablet;
+            bool is_finished_tablet = false;
+            for (auto tablet_info_finished : finished_tablets_redundant) {
+                auto& tablet_finished = tablet_info_finished.tablet;
+                if (tablet->tablet_uid() == tablet_finished->tablet_uid()) {
+                    is_finished_tablet = true;
+                    break;
+                }
+            }
+            if (!is_finished_tablet) {
+                _shutdown_tablets_redundant_queue.push_back(std::move(tablet_info));
+            }
         }
     }
     return Status::OK();
@@ -1791,7 +1823,9 @@ void TabletManager::_add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabl
                 LOG(WARNING) << "Fail to remove previous table meta, id: " << tablet_id << " status: " << st;
             }
         }
+        auto drop_info_redundant = iter->second;
         _shutdown_tablets.erase(iter);
+        _shutdown_tablets_redundant_queue.push_back(std::move(drop_info_redundant));
     }
     _shutdown_tablets.emplace(tablet_id, drop_info);
 }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1120,15 +1120,15 @@ Status TabletManager::start_trash_sweep() {
 
     if (!finished_tablets.empty() || !finished_tablets_redundant.empty()) {
         std::unique_lock l(_shutdown_tablets_lock);
-        for (auto tablet_info_finished : finished_tablets) {
+        for (const auto& tablet_info_finished : finished_tablets) {
             auto& tablet_finished = tablet_info_finished.tablet;
             _shutdown_tablets.erase(tablet_finished->tablet_id());
         }
 
-        for (auto& tablet_info : tablets_redundant_to_check) {
+        for (const auto& tablet_info : tablets_redundant_to_check) {
             auto& tablet = tablet_info.tablet;
             bool is_finished_tablet = false;
-            for (auto tablet_info_finished : finished_tablets_redundant) {
+            for (const auto& tablet_info_finished : finished_tablets_redundant) {
                 auto& tablet_finished = tablet_info_finished.tablet;
                 if (tablet->tablet_uid() == tablet_finished->tablet_uid()) {
                     is_finished_tablet = true;

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1006,7 +1006,8 @@ Status TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* tabl
     return Status::OK();
 }
 
-void TabletManager::sweep_shutdown_tablet(const DroppedTabletInfo& info, std::vector<DroppedTabletInfo>& finished_tablets) {
+void TabletManager::sweep_shutdown_tablet(const DroppedTabletInfo& info,
+                                          std::vector<DroppedTabletInfo>& finished_tablets) {
     auto& tablet = info.tablet;
     // The current thread has two references: _shutdown_tablets[i] and tablets_to_checks[i], check
     // if there is another thread has reference to the tablet, and if so, does not remove the tablet for now.

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -271,6 +271,7 @@ private:
     // make sure use this function to add shutdown tablets
     // caller should acquire _shutdown_tablets_lock
     void _add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabletInfo&& drop_info);
+    void sweep_shutdown_tablet(const DroppedTabletInfo& info, std::vector<DroppedTabletInfo>& finished_tablets)
 
     static Status _remove_tablet_meta(const TabletSharedPtr& tablet);
     static Status _remove_tablet_directories(const TabletSharedPtr& tablet);
@@ -282,11 +283,12 @@ private:
 
     // Protect _partition_tablet_map, should not be obtained before _tablet_map_lock to avoid deadlock
     mutable std::shared_mutex _partition_tablet_map_lock;
-    // Protect _shutdown_tablets, should not be obtained before _tablet_map_lock to avoid deadlock
+    // Protect _shutdown_tablets/_shutdown_tablets_redundant_queue, should not be obtained before _tablet_map_lock to avoid deadlock
     mutable std::shared_mutex _shutdown_tablets_lock;
     // partition_id => tablet_info
     std::map<int64_t, std::set<TabletInfo>> _partition_tablet_map;
     std::map<int64_t, DroppedTabletInfo> _shutdown_tablets;
+    std::deque<DroppedTabletInfo> _shutdown_tablets_redundant_queue;
 
     std::mutex _tablet_stat_mutex;
     // cache to save tablets' statistics, such as data-size and row-count

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -271,7 +271,7 @@ private:
     // make sure use this function to add shutdown tablets
     // caller should acquire _shutdown_tablets_lock
     void _add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabletInfo&& drop_info);
-    void sweep_shutdown_tablet(const DroppedTabletInfo& info, std::vector<DroppedTabletInfo>& finished_tablets)
+    void sweep_shutdown_tablet(const DroppedTabletInfo& info, std::vector<DroppedTabletInfo>& finished_tablets);
 
     static Status _remove_tablet_meta(const TabletSharedPtr& tablet);
     static Status _remove_tablet_directories(const TabletSharedPtr& tablet);

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -283,12 +283,12 @@ private:
 
     // Protect _partition_tablet_map, should not be obtained before _tablet_map_lock to avoid deadlock
     mutable std::shared_mutex _partition_tablet_map_lock;
-    // Protect _shutdown_tablets/_shutdown_tablets_redundant_queue, should not be obtained before _tablet_map_lock to avoid deadlock
+    // Protect _shutdown_tablets/_shutdown_tablets_redundant_map, should not be obtained before _tablet_map_lock to avoid deadlock
     mutable std::shared_mutex _shutdown_tablets_lock;
     // partition_id => tablet_info
     std::map<int64_t, std::set<TabletInfo>> _partition_tablet_map;
     std::map<int64_t, DroppedTabletInfo> _shutdown_tablets;
-    std::deque<DroppedTabletInfo> _shutdown_tablets_redundant_queue;
+    std::map<TabletUid, DroppedTabletInfo> _shutdown_tablets_redundant_map;
 
     std::mutex _tablet_stat_mutex;
     // cache to save tablets' statistics, such as data-size and row-count


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #50383

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
