### PR TITLE
[Enhancement] Handle stream load asynchronously to avoid blocking http server on BE

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -248,6 +248,9 @@ include_directories(${AWSSDK_INCLUDE_DIRS})
 add_library(libevent STATIC IMPORTED)
 set_target_properties(libevent PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libevent.a)
 
+add_library(libevent_pthreads STATIC IMPORTED)
+set_target_properties(libevent_pthreads PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libevent_pthreads.a)
+
 add_library(openssl STATIC IMPORTED)
 set_target_properties(openssl PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libssl.a)
 
@@ -851,6 +854,7 @@ set(STARROCKS_DEPENDENCIES
     # Otherwise, he will use the lz4 Library in librdkafka
     lz4
     libevent
+    libevent_pthreads
     curl
     libz
     libbz2

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -377,6 +377,7 @@ CONF_Int32(be_http_port, "8040");
 CONF_Alias(be_http_port, webserver_port);
 // Number of http workers in BE
 CONF_Int32(be_http_num_workers, "48");
+CONF_Bool(be_http_enable_pthread, true);
 // Period to update rate counters and sampling counters in ms.
 CONF_mInt32(periodic_counter_update_period_ms, "500");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1300,8 +1300,8 @@ CONF_mBool(enable_stream_load_verbose_log, "false");
 CONF_mBool(enable_stream_load_async_handle, "true");
 CONF_mInt32(stream_load_async_handle_thread_pool_num_min, "0");
 CONF_mInt32(stream_load_async_handle_thread_pool_num_max, "48");
-CONF_mInt32(stream_load_async_handle_thread_pool_queue_size, "102400");
-CONF_mInt32(stream_load_async_handle_thread_pool_idle_time_ms, "2000");
+CONF_Int32(stream_load_async_handle_thread_pool_queue_size, "102400");
+CONF_Int32(stream_load_async_handle_thread_pool_idle_time_ms, "2000");
 
 CONF_mInt32(get_txn_status_internal_sec, "30");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -377,7 +377,7 @@ CONF_Int32(be_http_port, "8040");
 CONF_Alias(be_http_port, webserver_port);
 // Number of http workers in BE
 CONF_Int32(be_http_num_workers, "48");
-CONF_Bool(be_http_enable_pthread, true);
+CONF_Bool(be_http_enable_pthread, "true");
 // Period to update rate counters and sampling counters in ms.
 CONF_mInt32(periodic_counter_update_period_ms, "500");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1297,6 +1297,11 @@ CONF_mBool(enable_http_stream_load_limit, "false");
 CONF_mInt32(finish_publish_version_internal, "100");
 
 CONF_mBool(enable_stream_load_verbose_log, "false");
+CONF_mBool(enable_stream_load_async_handle, "true");
+CONF_mInt32(stream_load_async_handle_thread_pool_num_min, "0");
+CONF_mInt32(stream_load_async_handle_thread_pool_num_max, "48");
+CONF_mInt32(stream_load_async_handle_thread_pool_queue_size, "102400");
+CONF_mInt32(stream_load_async_handle_thread_pool_idle_time_ms, "2000");
 
 CONF_mInt32(get_txn_status_internal_sec, "30");
 

--- a/be/src/http/CMakeLists.txt
+++ b/be/src/http/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(Webserver STATIC
   http_status.cpp
   http_parser.cpp
   http_stream_channel.cpp
+  stream_load_http_executor.cpp
   web_page_handler.cpp
   monitor_action.cpp
   default_path_handlers.cpp

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -128,9 +128,6 @@ static bool is_format_support_streaming(TFileFormatType::type format) {
 static Status stream_load_put_internal(const TStreamLoadPutRequest& request, int32_t rpc_timeout_ms,
                                        TStreamLoadPutResult* result);
 
-StreamLoadAction::StreamLoadAction(ExecEnv* exec_env, ConcurrentLimiter* limiter)
-        : StreamLoadAction(exec_env, limiter, nullptr) {}
-
 StreamLoadAction::StreamLoadAction(ExecEnv* exec_env, ConcurrentLimiter* limiter,
                                    StreamLoadHttpExecutor* stream_load_http_executor)
         : _exec_env(exec_env),

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -52,9 +52,9 @@ class StreamLoadHttpExecutor;
 
 class StreamLoadAction : public HttpHandler {
 public:
-    explicit StreamLoadAction(ExecEnv* exec_env, ConcurrentLimiter* limiter);
     explicit StreamLoadAction(ExecEnv* exec_env, ConcurrentLimiter* limiter,
-                              StreamLoadHttpExecutor* stream_load_http_executor);
+                              StreamLoadHttpExecutor* stream_load_http_executor = nullptr);
+
     ~StreamLoadAction() override;
 
     void handle(HttpRequest* req) override;

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -48,10 +48,13 @@ class ExecEnv;
 class Status;
 class StreamLoadContext;
 class ConcurrentLimiter;
+class StreamLoadHttpExecutor;
 
 class StreamLoadAction : public HttpHandler {
 public:
     explicit StreamLoadAction(ExecEnv* exec_env, ConcurrentLimiter* limiter);
+    explicit StreamLoadAction(ExecEnv* exec_env, ConcurrentLimiter* limiter,
+                              StreamLoadHttpExecutor* stream_load_http_executor);
     ~StreamLoadAction() override;
 
     void handle(HttpRequest* req) override;
@@ -65,7 +68,8 @@ public:
 
 private:
     Status _on_header(HttpRequest* http_req, StreamLoadContext* ctx);
-    Status _handle(StreamLoadContext* ctx);
+    void _handle(HttpRequest* req, StreamLoadContext* ctx);
+    Status _finalize(StreamLoadContext* ctx);
     Status _data_saved_path(HttpRequest* req, std::string* file_path);
     Status _execute_plan_fragment(StreamLoadContext* ctx);
     Status _process_put(HttpRequest* http_req, StreamLoadContext* ctx);
@@ -73,6 +77,7 @@ private:
 private:
     ExecEnv* _exec_env;
     ConcurrentLimiter* _http_concurrent_limiter = nullptr;
+    StreamLoadHttpExecutor* _stream_load_http_executor;
 };
 
 } // namespace starrocks

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -85,10 +85,6 @@ static TFileFormatType::type parse_stream_load_format(const std::string& format_
     return TFileFormatType::FORMAT_UNKNOWN;
 }
 
-TransactionManagerAction::TransactionManagerAction(ExecEnv* exec_env) {
-    this(exec_env, nullptr);
-}
-
 TransactionManagerAction::TransactionManagerAction(ExecEnv* exec_env, StreamLoadHttpExecutor* stream_load_http_executor)
         : _exec_env(exec_env), _stream_load_http_executor(stream_load_http_executor) {}
 

--- a/be/src/http/action/transaction_stream_load.h
+++ b/be/src/http/action/transaction_stream_load.h
@@ -28,18 +28,22 @@ class ExecEnv;
 class Status;
 class StreamLoadContext;
 class TStreamLoadPutRequest;
+class StreamLoadHttpExecutor;
 
 class TransactionManagerAction : public HttpHandler {
 public:
     explicit TransactionManagerAction(ExecEnv* exec_env);
+    explicit TransactionManagerAction(ExecEnv* exec_env, StreamLoadHttpExecutor* stream_load_http_executor);
     ~TransactionManagerAction() override;
 
     void handle(HttpRequest* req) override;
 
 private:
+    void _handle_prepare_and_commit(HttpRequest* req);
     void _send_error_reply(HttpRequest* req, const Status& st);
 
     ExecEnv* _exec_env;
+    StreamLoadHttpExecutor* _stream_load_http_executor;
 };
 
 class TransactionStreamLoadAction : public HttpHandler {

--- a/be/src/http/action/transaction_stream_load.h
+++ b/be/src/http/action/transaction_stream_load.h
@@ -32,8 +32,7 @@ class StreamLoadHttpExecutor;
 
 class TransactionManagerAction : public HttpHandler {
 public:
-    explicit TransactionManagerAction(ExecEnv* exec_env);
-    explicit TransactionManagerAction(ExecEnv* exec_env, StreamLoadHttpExecutor* stream_load_http_executor);
+    explicit TransactionManagerAction(ExecEnv* exec_env, StreamLoadHttpExecutor* stream_load_http_executor = nullptr);
     ~TransactionManagerAction() override;
 
     void handle(HttpRequest* req) override;

--- a/be/src/http/action/update_config_action.h
+++ b/be/src/http/action/update_config_action.h
@@ -40,13 +40,17 @@
 
 #include "http/http_handler.h"
 #include "runtime/exec_env.h"
+#include "service/service_be/http_service.h"
 
 namespace starrocks {
 
 // Update BE config.
 class UpdateConfigAction : public HttpHandler {
 public:
-    explicit UpdateConfigAction(ExecEnv* exec_env) : _exec_env(exec_env) { _instance.store(this); }
+    explicit UpdateConfigAction(ExecEnv* exec_env, HttpServiceBE* http_server = nullptr)
+            : _exec_env(exec_env), _http_server(http_server) {
+        _instance.store(this);
+    }
     ~UpdateConfigAction() override = default;
 
     void handle(HttpRequest* req) override;
@@ -59,6 +63,7 @@ public:
 private:
     static std::atomic<UpdateConfigAction*> _instance;
     ExecEnv* _exec_env;
+    HttpServiceBE* _http_server;
     std::once_flag _once_flag;
     std::unordered_map<std::string, std::function<void()>> _config_callback;
 };

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -91,7 +91,7 @@ static int on_connection(struct evhttp_request* req, void* param) {
     return 0;
 }
 
-// Create bufferevent used for multi-threads, so set flat to BEV_OPT_THREADSAFE
+// Create bufferevent used for multi-threads, so set flag to BEV_OPT_THREADSAFE
 static struct bufferevent* bufferevent_create_cb(struct event_base* base, void* args) {
     return bufferevent_socket_new(base, -1, BEV_OPT_THREADSAFE);
 }

--- a/be/src/http/stream_load_http_executor.cpp
+++ b/be/src/http/stream_load_http_executor.cpp
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/stream_load_http_executor.h"
+
+namespace starrocks {
+
+Status StreamLoadHttpExecutor::init() {
+    return ThreadPoolBuilder("http_load_io")
+            .set_min_threads(config::stream_load_async_handle_thread_pool_num_min)
+            .set_max_threads(config::stream_load_async_handle_thread_pool_num_max)
+            .set_max_queue_size(config::stream_load_async_handle_thread_pool_queue_size)
+            .set_idle_timeout(MonoDelta::FromMilliseconds(config::stream_load_async_handle_thread_pool_idle_time_ms))
+            .build(&_thread_pool);
+}
+
+void StreamLoadHttpExecutor::stop() {
+    if (_thread_pool) {
+        _thread_pool->shutdown();
+    }
+}
+
+} // namespace starrocks

--- a/be/src/http/stream_load_http_executor.cpp
+++ b/be/src/http/stream_load_http_executor.cpp
@@ -14,15 +14,22 @@
 
 #include "http/stream_load_http_executor.h"
 
+#include "util/starrocks_metrics.h"
+
 namespace starrocks {
 
 Status StreamLoadHttpExecutor::init() {
-    return ThreadPoolBuilder("http_load_io")
-            .set_min_threads(config::stream_load_async_handle_thread_pool_num_min)
-            .set_max_threads(config::stream_load_async_handle_thread_pool_num_max)
-            .set_max_queue_size(config::stream_load_async_handle_thread_pool_queue_size)
-            .set_idle_timeout(MonoDelta::FromMilliseconds(config::stream_load_async_handle_thread_pool_idle_time_ms))
-            .build(&_thread_pool);
+    Status st = ThreadPoolBuilder("stream_load_http")
+                        .set_min_threads(config::stream_load_async_handle_thread_pool_num_min)
+                        .set_max_threads(config::stream_load_async_handle_thread_pool_num_max)
+                        .set_max_queue_size(config::stream_load_async_handle_thread_pool_queue_size)
+                        .set_idle_timeout(
+                                MonoDelta::FromMilliseconds(config::stream_load_async_handle_thread_pool_idle_time_ms))
+                        .build(&_thread_pool);
+    if (st.ok()) {
+        REGISTER_THREAD_POOL_METRICS(stream_load_http, _thread_pool.get());
+    }
+    return st;
 }
 
 void StreamLoadHttpExecutor::stop() {

--- a/be/src/http/stream_load_http_executor.h
+++ b/be/src/http/stream_load_http_executor.h
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "util/threadpool.h"
+
+namespace starrocks {
+
+class StreamLoadHttpExecutor {
+public:
+    StreamLoadHttpExecutor() = default;
+    ~StreamLoadHttpExecutor() = default;
+
+    Status init();
+
+    void stop();
+
+    ThreadPool* thread_pool() { return _thread_pool.get(); }
+
+private:
+    std::unique_ptr<ThreadPool> _thread_pool;
+};
+
+} // namespace starrocks

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -247,7 +247,7 @@ Status HttpServiceBE::start() {
     _ev_http_server->register_handler(HttpMethod::GET, "/api/compaction/running", show_running_action);
     _http_handlers.emplace_back(show_running_action);
 
-    auto* update_config_action = new UpdateConfigAction(_env);
+    auto* update_config_action = new UpdateConfigAction(_env, this);
     _ev_http_server->register_handler(HttpMethod::POST, "/api/update_config", update_config_action);
     _http_handlers.emplace_back(update_config_action);
 

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -83,6 +83,7 @@ HttpServiceBE::~HttpServiceBE() {
 }
 
 void HttpServiceBE::stop() {
+    _stream_load_http_executor->stop();
     _ev_http_server->stop();
 }
 
@@ -110,7 +111,7 @@ Status HttpServiceBE::start() {
     // PrepreTransaction:   POST /api/transaction/prepare
     //
     // ListTransactions:    POST /api/transaction/list
-    auto* transaction_manager_action = new TransactionManagerAction(_env);
+    auto* transaction_manager_action = new TransactionManagerAction(_env, _stream_load_http_executor.get());
     _ev_http_server->register_handler(HttpMethod::POST, "/api/transaction/{txn_op}", transaction_manager_action);
     _ev_http_server->register_handler(HttpMethod::PUT, "/api/transaction/{txn_op}", transaction_manager_action);
     _http_handlers.emplace_back(transaction_manager_action);

--- a/be/src/service/service_be/http_service.h
+++ b/be/src/service/service_be/http_service.h
@@ -45,6 +45,7 @@ class ExecEnv;
 class EvHttpServer;
 class HttpHandler;
 class WebPageHandler;
+class StreamLoadHttpExecutor;
 
 // HTTP service for StarRocks BE
 class HttpServiceBE {
@@ -65,6 +66,7 @@ private:
     std::vector<HttpHandler*> _http_handlers;
 
     std::unique_ptr<ConcurrentLimiter> _http_concurrent_limiter;
+    std::unique_ptr<StreamLoadHttpExecutor> _stream_load_http_executor;
 };
 
 } // namespace starrocks

--- a/be/src/service/service_be/http_service.h
+++ b/be/src/service/service_be/http_service.h
@@ -57,6 +57,8 @@ public:
     void stop();
     void join();
 
+    StreamLoadHttpExecutor* stream_load_http_executor() { return _stream_load_http_executor.get(); }
+
 private:
     ExecEnv* _env;
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -347,6 +347,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(segment_flush);
     METRICS_DEFINE_THREAD_POOL(update_apply);
     METRICS_DEFINE_THREAD_POOL(pk_index_compaction);
+    METRICS_DEFINE_THREAD_POOL(stream_load_http);
 
     METRIC_DEFINE_UINT_GAUGE(load_rpc_threadpool_size, MetricUnit::NOUNIT);
 


### PR DESCRIPTION
## Why I'm doing:
currently stream load is handled in the http server main thread, and the http server may be blocked if stream load is slow. As a result, http server can't deal with other http requests, such as metrics which leads to BE dead on grafana but it's actually alive. 

## What I'm doing:
1. configure libevent http server to work in multiple threads. refer to https://github.com/libevent/libevent/issues/429
2. for stream load, receive data in main thread, and handle it in a separate thread pool

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
