### PR TITLE
[Enhancement][Refactor] introduce allocator to column buffer

### DIFF
--- a/be/src/column/adaptive_nullable_column.cpp
+++ b/be/src/column/adaptive_nullable_column.cpp
@@ -140,38 +140,38 @@ bool AdaptiveNullableColumn::append_nulls(size_t count) {
     return true;
 }
 
-bool AdaptiveNullableColumn::append_strings(const Buffer<Slice>& strs) {
+bool AdaptiveNullableColumn::append_strings(const Slice* data, size_t size) {
     if (_data_column->is_binary()) {
         switch (_state) {
         case State::kUninitialized: {
             _state = State::kNotConstant;
-            std::ignore = _data_column->append_strings(strs);
-            _size = strs.size();
+            std::ignore = _data_column->append_strings(data, size);
+            _size = size;
             break;
         }
         case State::kNotConstant: {
-            std::ignore = _data_column->append_strings(strs);
-            _size += strs.size();
+            std::ignore = _data_column->append_strings(data, size);
+            _size += size;
             break;
         }
         case State::kMaterialized: {
-            std::ignore = _data_column->append_strings(strs);
-            null_column_data().resize(_null_column->size() + strs.size(), 0);
+            std::ignore = _data_column->append_strings(data, size);
+            null_column_data().resize(_null_column->size() + size, 0);
             DCHECK_EQ(_null_column->size(), _data_column->size());
             break;
         }
         default: {
             materialized_nullable();
-            std::ignore = _data_column->append_strings(strs);
-            null_column_data().resize(_null_column->size() + strs.size(), 0);
+            std::ignore = _data_column->append_strings(data, size);
+            null_column_data().resize(_null_column->size() + size, 0);
             DCHECK_EQ(_null_column->size(), _data_column->size());
             break;
         }
         }
     } else {
         materialized_nullable();
-        if (_data_column->append_strings(strs)) {
-            null_column_data().resize(_null_column->size() + strs.size(), 0);
+        if (_data_column->append_strings(data, size)) {
+            null_column_data().resize(_null_column->size() + size, 0);
             return true;
         }
         DCHECK_EQ(_null_column->size(), _data_column->size());
@@ -180,20 +180,20 @@ bool AdaptiveNullableColumn::append_strings(const Buffer<Slice>& strs) {
     return true;
 }
 
-bool AdaptiveNullableColumn::append_strings_overflow(const Buffer<Slice>& strs, size_t max_length) {
+bool AdaptiveNullableColumn::append_strings_overflow(const Slice* data, size_t size, size_t max_length) {
     materialized_nullable();
-    if (_data_column->append_strings_overflow(strs, max_length)) {
-        null_column_data().resize(_null_column->size() + strs.size(), 0);
+    if (_data_column->append_strings_overflow(data, size, max_length)) {
+        null_column_data().resize(_null_column->size() + size, 0);
         return true;
     }
     DCHECK_EQ(_null_column->size(), _data_column->size());
     return false;
 }
 
-bool AdaptiveNullableColumn::append_continuous_strings(const Buffer<Slice>& strs) {
+bool AdaptiveNullableColumn::append_continuous_strings(const Slice* data, size_t size) {
     materialized_nullable();
-    if (_data_column->append_continuous_strings(strs)) {
-        null_column_data().resize(_null_column->size() + strs.size(), 0);
+    if (_data_column->append_continuous_strings(data, size)) {
+        null_column_data().resize(_null_column->size() + size, 0);
         return true;
     }
     DCHECK_EQ(_null_column->size(), _data_column->size());

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -291,7 +291,6 @@ public:
         return _data_column->has_large_column();
     }
 
-    // bool append_strings(const Buffer<Slice>& strs) override;
     bool append_strings(const Slice* data, size_t size) override;
 
     bool append_strings_overflow(const Slice* data, size_t size, size_t max_length) override;

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -291,11 +291,12 @@ public:
         return _data_column->has_large_column();
     }
 
-    bool append_strings(const Buffer<Slice>& strs) override;
+    // bool append_strings(const Buffer<Slice>& strs) override;
+    bool append_strings(const Slice* data, size_t size) override;
 
-    bool append_strings_overflow(const Buffer<Slice>& strs, size_t max_length) override;
+    bool append_strings_overflow(const Slice* data, size_t size, size_t max_length) override;
 
-    bool append_continuous_strings(const Buffer<Slice>& strs) override;
+    bool append_continuous_strings(const Slice* data, size_t size) override;
 
     bool append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) override;
 
@@ -523,7 +524,7 @@ public:
         }
     }
 
-    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override {
+    ColumnPtr replicate(const Buffer<uint32_t>& offsets) override {
         materialized_nullable();
         return NullableColumn::replicate(offsets);
     }

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -97,8 +97,6 @@ public:
 
     bool append_nulls(size_t count) override;
 
-    bool append_strings(const Buffer<Slice>& strs) override { return false; }
-
     size_t append_numbers(const void* buff, size_t length) override { return -1; }
 
     void append_value_multiple_times(const void* value, size_t count) override;

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -198,11 +198,11 @@ public:
         _slices_cache = false;
     }
 
-    bool append_strings(const Buffer<Slice>& strs) override;
+    bool append_strings(const Slice* data, size_t size) override;
 
-    bool append_strings_overflow(const Buffer<Slice>& strs, size_t max_length) override;
+    bool append_strings_overflow(const Slice* data, size_t size, size_t max_length) override;
 
-    bool append_continuous_strings(const Buffer<Slice>& strs) override;
+    bool append_continuous_strings(const Slice* data, size_t size) override;
 
     bool append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) override;
 
@@ -220,7 +220,7 @@ public:
         _slices_cache = false;
     }
 
-    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+    ColumnPtr replicate(const Buffer<uint32_t>& offsets) override;
 
     void fill_default(const Filter& filter) override;
 

--- a/be/src/column/column.cpp
+++ b/be/src/column/column.cpp
@@ -66,7 +66,7 @@ StatusOr<ColumnPtr> Column::upgrade_helper_func(ColumnPtr* col) {
     }
 }
 
-bool Column::empty_null_in_complex_column(const Filter& null_data, const std::vector<uint32_t>& offsets) {
+bool Column::empty_null_in_complex_column(const Filter& null_data, const Buffer<uint32_t>& offsets) {
     DCHECK(null_data.size() == this->size());
     if (!is_array() && !is_map()) {
         throw std::runtime_error("empty_null_in_complex_column() only works for array and map column.");

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -167,7 +167,7 @@ public:
     // for example: column(1,2)->replicate({0,2,5}) = column(1,1,2,2,2)
     // FixedLengthColumn, BinaryColumn and ConstColumn override this function for better performance.
     // TODO(fzh): optimize replicate() for ArrayColumn, ObjectColumn and others.
-    virtual ColumnPtr replicate(const std::vector<uint32_t>& offsets) {
+    virtual ColumnPtr replicate(const Buffer<uint32_t>& offsets) {
         auto dest = this->clone_empty();
         auto dest_size = offsets.size() - 1;
         DCHECK(this->size() >= dest_size) << "The size of the source column is less when duplicating it.";
@@ -201,7 +201,9 @@ public:
     // This function will copy the [3, 2] row of src to this column.
     virtual void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) = 0;
 
-    void append_selective(const Column& src, const Buffer<uint32_t>& indexes) {
+    template <typename Container, typename T = Container::value_type>
+    typename std::enable_if<std::is_same<T, uint32_t>::value, void>::type append_selective(const Column& src,
+                                                                                           const Container& indexes) {
         return append_selective(src, indexes.data(), 0, static_cast<uint32_t>(indexes.size()));
     }
 
@@ -213,19 +215,38 @@ public:
     // Return false if this is a non-nullable column, i.e, if `is_nullable` return false.
     virtual bool append_nulls(size_t count) = 0;
 
+    template <typename Container, typename T = Container::value_type>
+    bool append_strings(const Container& strs) {
+        static_assert(std::is_same<T, Slice>::value, "Container::value_type must be Slice");
+        return append_strings(strs.data(), strs.size());
+    }
     // Append multiple strings into this column.
     // Return false if the column is not a binary column.
-    [[nodiscard]] virtual bool append_strings(const Buffer<Slice>& strs) = 0;
+    [[nodiscard]] virtual bool append_strings(const Slice* data, size_t size) { return false; }
 
     // Like append_strings. To achieve higher performance, this function will read 16 bytes out of
     // bounds. So the caller must make sure that no invalid address access exception occurs for
     // out-of-bounds reads
-    [[nodiscard]] virtual bool append_strings_overflow(const Buffer<Slice>& strs, size_t max_length) { return false; }
+    template <typename Container, typename T = Container::value_type>
+    bool append_strings_overflow(const Container& strs, size_t max_length) {
+        static_assert(std::is_same<T, Slice>::value, "Container::value_type must be Slice");
+        return append_strings_overflow(strs.data(), strs.size(), max_length);
+    }
+
+    [[nodiscard]] virtual bool append_strings_overflow(const Slice* data, size_t size, size_t max_length) {
+        return false;
+    }
 
     // Like `append_strings` but the corresponding storage of each slice is adjacent to the
     // next one's, the implementation can take advantage of this feature, e.g, copy the whole
     // memory at once.
-    [[nodiscard]] virtual bool append_continuous_strings(const Buffer<Slice>& strs) { return append_strings(strs); }
+    template <typename Container, typename T = Container::value_type>
+    [[nodiscard]] bool append_continuous_strings(const Container& strs) {
+        static_assert(std::is_same<T, Slice>::value, "Container::value_type must be Slice");
+        return append_continuous_strings(strs.data(), strs.size());
+    }
+
+    [[nodiscard]] virtual bool append_continuous_strings(const Slice* data, size_t size) { return false; }
 
     [[nodiscard]] virtual bool append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) {
         return false;
@@ -316,7 +337,7 @@ public:
     inline size_t filter(const Filter& filter, size_t count) { return filter_range(filter, 0, count); }
 
     // get rid of the case where the map/array is null but the map/array'elements are not empty.
-    bool empty_null_in_complex_column(const Filter& null_data, const std::vector<uint32_t>& offsets);
+    bool empty_null_in_complex_column(const Filter& null_data, const Buffer<uint32_t>& offsets);
 
     // FIXME: Many derived implementation assume |to| equals to size().
     virtual size_t filter_range(const Filter& filter, size_t from, size_t to) = 0;

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -246,7 +246,9 @@ public:
         return append_continuous_strings(strs.data(), strs.size());
     }
 
-    [[nodiscard]] virtual bool append_continuous_strings(const Slice* data, size_t size) { return false; }
+    [[nodiscard]] virtual bool append_continuous_strings(const Slice* data, size_t size) {
+        return append_strings(data, size);
+    }
 
     [[nodiscard]] virtual bool append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) {
         return false;

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -201,9 +201,9 @@ public:
     // This function will copy the [3, 2] row of src to this column.
     virtual void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) = 0;
 
-    template <typename Container, typename T = Container::value_type>
-    typename std::enable_if<std::is_same<T, uint32_t>::value, void>::type append_selective(const Column& src,
-                                                                                           const Container& indexes) {
+    template <typename Container, typename T = typename Container::value_type>
+    void append_selective(const Column& src, const Container& indexes) {
+        static_assert(std::is_same<T, uint32_t>::value, "The type of indexes must be uint32_t");
         return append_selective(src, indexes.data(), 0, static_cast<uint32_t>(indexes.size()));
     }
 
@@ -215,7 +215,7 @@ public:
     // Return false if this is a non-nullable column, i.e, if `is_nullable` return false.
     virtual bool append_nulls(size_t count) = 0;
 
-    template <typename Container, typename T = Container::value_type>
+    template <typename Container, typename T = typename Container::value_type>
     bool append_strings(const Container& strs) {
         static_assert(std::is_same<T, Slice>::value, "Container::value_type must be Slice");
         return append_strings(strs.data(), strs.size());
@@ -227,7 +227,7 @@ public:
     // Like append_strings. To achieve higher performance, this function will read 16 bytes out of
     // bounds. So the caller must make sure that no invalid address access exception occurs for
     // out-of-bounds reads
-    template <typename Container, typename T = Container::value_type>
+    template <typename Container, typename T = typename Container::value_type>
     bool append_strings_overflow(const Container& strs, size_t max_length) {
         static_assert(std::is_same<T, Slice>::value, "Container::value_type must be Slice");
         return append_strings_overflow(strs.data(), strs.size(), max_length);
@@ -240,7 +240,7 @@ public:
     // Like `append_strings` but the corresponding storage of each slice is adjacent to the
     // next one's, the implementation can take advantage of this feature, e.g, copy the whole
     // memory at once.
-    template <typename Container, typename T = Container::value_type>
+    template <typename Container, typename T = typename Container::value_type>
     [[nodiscard]] bool append_continuous_strings(const Container& strs) {
         static_assert(std::is_same<T, Slice>::value, "Container::value_type must be Slice");
         return append_continuous_strings(strs.data(), strs.size());

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -52,7 +52,7 @@ void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index,
     append(src, index, size);
 }
 
-ColumnPtr ConstColumn::replicate(const std::vector<uint32_t>& offsets) {
+ColumnPtr ConstColumn::replicate(const Buffer<uint32_t>& offsets) {
     return ConstColumn::create(this->_data->clone_shared(), offsets.back());
 }
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -110,7 +110,7 @@ public:
 
     void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
-    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+    ColumnPtr replicate(const Buffer<uint32_t>& offsets) override;
 
     bool append_nulls(size_t count) override {
         DCHECK_GT(count, 0);
@@ -125,8 +125,6 @@ public:
             return false;
         }
     }
-
-    bool append_strings(const Buffer<Slice>& strs) override { return false; }
 
     size_t append_numbers(const void* buff, size_t length) override { return -1; }
 

--- a/be/src/column/field.h
+++ b/be/src/column/field.h
@@ -83,7 +83,7 @@ public:
               _agg_state_desc(rhs._agg_state_desc),
               _name(rhs._name),
               _type(rhs._type),
-              _sub_fields(rhs._sub_fields ? new Buffer<Field>(*rhs._sub_fields) : nullptr),
+              _sub_fields(rhs._sub_fields ? new std::vector<Field>(*rhs._sub_fields) : nullptr),
               _short_key_length(rhs._short_key_length),
               _flags(rhs._flags),
               _uid(rhs._uid) {}
@@ -111,7 +111,7 @@ public:
             _agg_state_desc = rhs._agg_state_desc;
             _short_key_length = rhs._short_key_length;
             _flags = rhs._flags;
-            _sub_fields = rhs._sub_fields ? new Buffer<Field>(*rhs._sub_fields) : nullptr;
+            _sub_fields = rhs._sub_fields ? new std::vector<Field>(*rhs._sub_fields) : nullptr;
             _uid = rhs._uid;
         }
         return *this;

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -62,7 +62,7 @@ void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, ui
 
 //TODO(fzh): optimize copy using SIMD
 template <typename T>
-ColumnPtr FixedLengthColumnBase<T>::replicate(const std::vector<uint32_t>& offsets) {
+ColumnPtr FixedLengthColumnBase<T>::replicate(const Buffer<uint32_t>& offsets) {
     auto dest = this->clone_empty();
     auto& dest_data = down_cast<FixedLengthColumnBase<T>&>(*dest);
     dest_data._data.resize(offsets.back());
@@ -86,7 +86,7 @@ void FixedLengthColumnBase<T>::fill_default(const Filter& filter) {
 }
 
 template <typename T>
-Status FixedLengthColumnBase<T>::fill_range(const Buffer<T>& ids, const std::vector<uint8_t>& filter) {
+Status FixedLengthColumnBase<T>::fill_range(const std::vector<T>& ids, const Filter& filter) {
     DCHECK_EQ(filter.size(), _data.size());
     size_t j = 0;
     for (size_t i = 0; i < _data.size(); ++i) {

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -124,8 +124,6 @@ public:
 
     [[nodiscard]] bool append_nulls(size_t count __attribute__((unused))) override { return false; }
 
-    [[nodiscard]] bool append_strings(const Buffer<Slice>& slices __attribute__((unused))) override { return false; }
-
     [[nodiscard]] bool contain_value(size_t start, size_t end, T value) const {
         DCHECK_LE(start, end);
         DCHECK_LE(start, _data.size());
@@ -158,11 +156,11 @@ public:
         _data.resize(_data.size() + count, DefaultValueGenerator<ValueType>::next_value());
     }
 
-    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+    ColumnPtr replicate(const Buffer<uint32_t>& offsets) override;
 
     void fill_default(const Filter& filter) override;
 
-    Status fill_range(const Buffer<T>& ids, const std::vector<uint8_t>& filter);
+    Status fill_range(const std::vector<T>& ids, const Filter& filter);
 
     void update_rows(const Column& src, const uint32_t* indexes) override;
 

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -86,8 +86,6 @@ public:
 
     bool append_nulls(size_t count) override;
 
-    bool append_strings(const Buffer<Slice>& strs) override { return false; }
-
     size_t append_numbers(const void* buff, size_t length) override { return -1; }
 
     void append_value_multiple_times(const void* value, size_t count) override;

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -136,7 +136,7 @@ void NullableColumn::append_value_multiple_times(const Column& src, uint32_t ind
     DCHECK_EQ(_null_column->size(), _data_column->size());
 }
 
-ColumnPtr NullableColumn::replicate(const std::vector<uint32_t>& offsets) {
+ColumnPtr NullableColumn::replicate(const Buffer<uint32_t>& offsets) {
     return NullableColumn::create(this->_data_column->replicate(offsets),
                                   std::dynamic_pointer_cast<NullColumn>(this->_null_column->replicate(offsets)));
 }
@@ -152,27 +152,27 @@ bool NullableColumn::append_nulls(size_t count) {
     return true;
 }
 
-bool NullableColumn::append_strings(const Buffer<Slice>& strs) {
-    if (_data_column->append_strings(strs)) {
-        null_column_data().resize(_null_column->size() + strs.size(), 0);
+bool NullableColumn::append_strings(const Slice* data, size_t size) {
+    if (_data_column->append_strings(data, size)) {
+        null_column_data().resize(_null_column->size() + size, 0);
         return true;
     }
     DCHECK_EQ(_null_column->size(), _data_column->size());
     return false;
 }
 
-bool NullableColumn::append_strings_overflow(const Buffer<Slice>& strs, size_t max_length) {
-    if (_data_column->append_strings_overflow(strs, max_length)) {
-        null_column_data().resize(_null_column->size() + strs.size(), 0);
+bool NullableColumn::append_strings_overflow(const Slice* data, size_t size, size_t max_length) {
+    if (_data_column->append_strings_overflow(data, size, max_length)) {
+        null_column_data().resize(_null_column->size() + size, 0);
         return true;
     }
     DCHECK_EQ(_null_column->size(), _data_column->size());
     return false;
 }
 
-bool NullableColumn::append_continuous_strings(const Buffer<Slice>& strs) {
-    if (_data_column->append_continuous_strings(strs)) {
-        null_column_data().resize(_null_column->size() + strs.size(), 0);
+bool NullableColumn::append_continuous_strings(const Slice* data, size_t size) {
+    if (_data_column->append_continuous_strings(data, size)) {
+        null_column_data().resize(_null_column->size() + size, 0);
         return true;
     }
     DCHECK_EQ(_null_column->size(), _data_column->size());

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -148,11 +148,11 @@ public:
 
     bool has_large_column() const override { return _data_column->has_large_column(); }
 
-    bool append_strings(const Buffer<Slice>& strs) override;
+    bool append_strings(const Slice* data, size_t size) override;
 
-    bool append_strings_overflow(const Buffer<Slice>& strs, size_t max_length) override;
+    bool append_strings_overflow(const Slice* data, size_t size, size_t max_length) override;
 
-    bool append_continuous_strings(const Buffer<Slice>& strs) override;
+    bool append_continuous_strings(const Slice* data, size_t size) override;
 
     bool append_continuous_fixed_length_strings(const char* data, size_t size, int fixed_length) override;
 
@@ -248,7 +248,7 @@ public:
         _has_null = true;
         return true;
     }
-    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+    ColumnPtr replicate(const Buffer<uint32_t>& offsets) override;
 
     size_t memory_usage() const override {
         return _data_column->memory_usage() + _null_column->memory_usage() + sizeof(bool);

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -111,9 +111,10 @@ void ObjectColumn<T>::append_value_multiple_times(const starrocks::Column& src, 
 }
 
 template <typename T>
-bool ObjectColumn<T>::append_strings(const Buffer<starrocks::Slice>& strs) {
-    _pool.reserve(_pool.size() + strs.size());
-    for (const Slice& s : strs) {
+bool ObjectColumn<T>::append_strings(const Slice* data, size_t size) {
+    _pool.reserve(_pool.size() + size);
+    for (size_t i = 0; i < size; i++) {
+        const auto& s = data[i];
         _pool.emplace_back(s);
     }
 

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -101,7 +101,7 @@ public:
 
     bool append_nulls(size_t count) override { return false; }
 
-    bool append_strings(const Buffer<Slice>& strs) override;
+    bool append_strings(const Slice* data, size_t size) override;
 
     size_t append_numbers(const void* buff, size_t length) override { return -1; }
 

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -194,10 +194,6 @@ bool StructColumn::append_nulls(size_t count) {
     return true;
 }
 
-bool StructColumn::append_strings(const Buffer<Slice>& strs) {
-    return false;
-}
-
 size_t StructColumn::append_numbers(const void* buff, size_t length) {
     return -1;
 }

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -112,8 +112,6 @@ public:
 
     [[nodiscard]] bool append_nulls(size_t count) override;
 
-    [[nodiscard]] bool append_strings(const Buffer<Slice>& strs) override;
-
     [[nodiscard]] size_t append_numbers(const void* buff, size_t length) override;
 
     void append_value_multiple_times(const void* value, size_t count) override;

--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -17,6 +17,8 @@
 #include <memory>
 #include <vector>
 
+#include "runtime/memory/column_allocator.h"
+
 namespace starrocks {
 
 class DecimalV2Value;
@@ -36,9 +38,12 @@ class Column;
 class Schema;
 struct ProtobufChunkMeta;
 
+template <typename T>
+class ColumnAllocator;
+
 // We may change the Buffer implementation in the future.
 template <typename T>
-using Buffer = std::vector<T>;
+using Buffer = std::vector<T, ColumnAllocator<T>>;
 
 class ArrayColumn;
 class MapColumn;

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -80,7 +80,7 @@ private:
     // The conjuncts couldn't push down to storage engine
     std::vector<ExprContext*> _not_push_down_conjuncts;
     PredicateTree _non_pushdown_pred_tree;
-    std::vector<uint8_t> _selection;
+    Filter _selection;
 
     ObjectPool _obj_pool;
 

--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -364,7 +364,6 @@ struct AggHashMapWithOneStringKeyWithNullable
     using Base = AggHashMapWithKey<HashMap, Self>;
     using KeyType = typename HashMap::key_type;
     using Iterator = typename HashMap::iterator;
-    // using ResultVector = typename std::vector<Slice>;
     using ResultVector = Buffer<Slice>;
 
     template <class... Args>
@@ -590,7 +589,6 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
     using Base = AggHashMapWithKey<HashMap, AggHashMapWithSerializedKey<HashMap>>;
     using KeyType = typename HashMap::key_type;
     using Iterator = typename HashMap::iterator;
-    // using ResultVector = typename std::vector<Slice>;
     using ResultVector = Buffer<Slice>;
 
     template <class... Args>

--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -116,8 +116,7 @@ struct AggHashMapWithKey {
 
     template <typename Func>
     void build_hash_map_with_selection(size_t chunk_size, const Columns& key_columns, MemPool* pool,
-                                       Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
-                                       std::vector<uint8_t>* not_founds) {
+                                       Func&& allocate_func, Buffer<AggDataPtr>* agg_states, Filter* not_founds) {
         return static_cast<Impl*>(this)->template compute_agg_states<Func, false, true>(
                 chunk_size, key_columns, pool, std::forward<Func>(allocate_func), agg_states, not_founds);
     }
@@ -125,7 +124,7 @@ struct AggHashMapWithKey {
     template <typename Func>
     void build_hash_map_with_selection_and_allocation(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                                       Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
-                                                      std::vector<uint8_t>* not_founds) {
+                                                      Filter* not_founds) {
         return static_cast<Impl*>(this)->template compute_agg_states<Func, true, true>(
                 chunk_size, key_columns, pool, std::forward<Func>(allocate_func), agg_states, not_founds);
     }
@@ -155,7 +154,7 @@ struct AggHashMapWithOneNumberKeyWithNullable
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
-                            Buffer<AggDataPtr>* agg_states, std::vector<uint8_t>* not_founds) {
+                            Buffer<AggDataPtr>* agg_states, Filter* not_founds) {
         if constexpr (is_nullable) {
             return this->template compute_agg_states_nullable<Func, allocate_and_compute_state, compute_not_founds>(
                     chunk_size, key_columns, pool, std::forward<Func>(allocate_func), agg_states, not_founds);
@@ -169,7 +168,7 @@ struct AggHashMapWithOneNumberKeyWithNullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_states_non_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                                          Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
-                                                         std::vector<uint8_t>* not_founds) {
+                                                         Filter* not_founds) {
         DCHECK(!key_columns[0]->is_nullable());
         auto column = down_cast<ColumnType*>(key_columns[0].get());
 
@@ -194,7 +193,7 @@ struct AggHashMapWithOneNumberKeyWithNullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                                      Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
-                                                     std::vector<uint8_t>* not_founds) {
+                                                     Filter* not_founds) {
         // Assign not_founds vector when needs compute not founds.
         if constexpr (compute_not_founds) {
             DCHECK(not_founds);
@@ -232,7 +231,7 @@ struct AggHashMapWithOneNumberKeyWithNullable
     // prefetch branch better performance in case with larger hash tables
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_prefetch(ColumnType* column, Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
-                                              std::vector<uint8_t>* not_founds) {
+                                              Filter* not_founds) {
         AGG_HASH_MAP_PRECOMPUTE_HASH_VALUES(column, AGG_HASH_MAP_DEFAULT_PREFETCH_DIST);
         for (size_t i = 0; i < column_size; i++) {
             AGG_HASH_MAP_PREFETCH_HASH_VALUE();
@@ -263,7 +262,7 @@ struct AggHashMapWithOneNumberKeyWithNullable
     // prefetch branch better performance in case with small hash tables
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_noprefetch(ColumnType* column, Buffer<AggDataPtr>* agg_states,
-                                                Func&& allocate_func, std::vector<uint8_t>* not_founds) {
+                                                Func&& allocate_func, Filter* not_founds) {
         size_t num_rows = column->size();
         for (size_t i = 0; i < num_rows; i++) {
             FieldType key = column->get_data()[i];
@@ -291,7 +290,7 @@ struct AggHashMapWithOneNumberKeyWithNullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_through_null_data(size_t chunk_size, NullableColumn* nullable_column,
                                                        Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
-                                                       std::vector<uint8_t>* not_founds) {
+                                                       Filter* not_founds) {
         auto* data_column = down_cast<ColumnType*>(nullable_column->data_column().get());
         const auto& null_data = nullable_column->null_column_data();
         for (size_t i = 0; i < chunk_size; i++) {
@@ -313,7 +312,7 @@ struct AggHashMapWithOneNumberKeyWithNullable
 
     template <typename Func, bool compute_not_founds>
     void _handle_data_key_column(ColumnType* data_column, size_t row, Func&& allocate_func,
-                                 Buffer<AggDataPtr>* agg_states, std::vector<uint8_t>* not_founds) {
+                                 Buffer<AggDataPtr>* agg_states, Filter* not_founds) {
         auto key = data_column->get_data()[row];
         auto iter = this->hash_map.lazy_emplace(key, [&](const auto& ctor) {
             if constexpr (compute_not_founds) {
@@ -327,7 +326,7 @@ struct AggHashMapWithOneNumberKeyWithNullable
     }
 
     void _handle_data_key_column_without_allocate(ColumnType* data_column, size_t row, Buffer<AggDataPtr>* agg_states,
-                                                  std::vector<uint8_t>* not_founds) {
+                                                  Filter* not_founds) {
         auto key = data_column->get_data()[row];
         if (auto iter = this->hash_map.find(key); iter != this->hash_map.end()) {
             (*agg_states)[row] = iter->second;
@@ -365,7 +364,8 @@ struct AggHashMapWithOneStringKeyWithNullable
     using Base = AggHashMapWithKey<HashMap, Self>;
     using KeyType = typename HashMap::key_type;
     using Iterator = typename HashMap::iterator;
-    using ResultVector = typename std::vector<Slice>;
+    // using ResultVector = typename std::vector<Slice>;
+    using ResultVector = Buffer<Slice>;
 
     template <class... Args>
     AggHashMapWithOneStringKeyWithNullable(Args&&... args) : Base(std::forward<Args>(args)...) {}
@@ -374,7 +374,7 @@ struct AggHashMapWithOneStringKeyWithNullable
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
-                            Buffer<AggDataPtr>* agg_states, std::vector<uint8_t>* not_founds) {
+                            Buffer<AggDataPtr>* agg_states, Filter* not_founds) {
         if constexpr (is_nullable) {
             return this->template compute_agg_states_nullable<Func, allocate_and_compute_state, compute_not_founds>(
                     chunk_size, key_columns, pool, std::forward<Func>(allocate_func), agg_states, not_founds);
@@ -388,7 +388,7 @@ struct AggHashMapWithOneStringKeyWithNullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_states_non_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                                          Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
-                                                         std::vector<uint8_t>* not_founds) {
+                                                         Filter* not_founds) {
         DCHECK(key_columns[0]->is_binary());
         auto column = down_cast<BinaryColumn*>(key_columns[0].get());
 
@@ -411,7 +411,7 @@ struct AggHashMapWithOneStringKeyWithNullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_states_nullable(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                                      Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
-                                                     std::vector<uint8_t>* not_founds) {
+                                                     Filter* not_founds) {
         // Assign not_founds vector when needs compute not founds.
         if constexpr (compute_not_founds) {
             DCHECK(not_founds);
@@ -448,7 +448,7 @@ struct AggHashMapWithOneStringKeyWithNullable
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_prefetch(BinaryColumn* column, Buffer<AggDataPtr>* agg_states, MemPool* pool,
-                                              Func&& allocate_func, std::vector<uint8_t>* not_founds) {
+                                              Func&& allocate_func, Filter* not_founds) {
         AGG_HASH_MAP_PRECOMPUTE_HASH_VALUES(column, AGG_HASH_MAP_DEFAULT_PREFETCH_DIST);
         for (size_t i = 0; i < column_size; i++) {
             AGG_HASH_MAP_PREFETCH_HASH_VALUE();
@@ -479,7 +479,7 @@ struct AggHashMapWithOneStringKeyWithNullable
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_noprefetch(BinaryColumn* column, Buffer<AggDataPtr>* agg_states, MemPool* pool,
-                                                Func&& allocate_func, std::vector<uint8_t>* not_founds) {
+                                                Func&& allocate_func, Filter* not_founds) {
         size_t num_rows = column->size();
         for (size_t i = 0; i < num_rows; i++) {
             auto key = column->get_slice(i);
@@ -510,7 +510,7 @@ struct AggHashMapWithOneStringKeyWithNullable
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_through_null_data(size_t chunk_size, NullableColumn* nullable_column,
                                                        Buffer<AggDataPtr>* agg_states, MemPool* pool,
-                                                       Func&& allocate_func, std::vector<uint8_t>* not_founds) {
+                                                       Func&& allocate_func, Filter* not_founds) {
         auto* data_column = down_cast<BinaryColumn*>(nullable_column->data_column().get());
         const auto& null_data = nullable_column->null_column_data();
         for (size_t i = 0; i < chunk_size; i++) {
@@ -533,7 +533,7 @@ struct AggHashMapWithOneStringKeyWithNullable
 
     template <typename Func, bool compute_not_founds>
     void _handle_data_key_column(BinaryColumn* data_column, size_t row, MemPool* pool, Func&& allocate_func,
-                                 Buffer<AggDataPtr>* agg_states, std::vector<uint8_t>* not_founds) {
+                                 Buffer<AggDataPtr>* agg_states, Filter* not_founds) {
         auto key = data_column->get_slice(row);
         auto iter = this->hash_map.lazy_emplace(key, [&](const auto& ctor) {
             if constexpr (compute_not_founds) {
@@ -549,7 +549,7 @@ struct AggHashMapWithOneStringKeyWithNullable
     }
 
     void _handle_data_key_column_without_allocate(BinaryColumn* data_column, size_t row, Buffer<AggDataPtr>* agg_states,
-                                                  std::vector<uint8_t>* not_founds) {
+                                                  Filter* not_founds) {
         auto key = data_column->get_slice(row);
         if (auto iter = this->hash_map.find(key); iter != this->hash_map.end()) {
             (*agg_states)[row] = iter->second;
@@ -564,13 +564,13 @@ struct AggHashMapWithOneStringKeyWithNullable
             auto* nullable_column = down_cast<NullableColumn*>(key_columns[0].get());
             auto* column = down_cast<BinaryColumn*>(nullable_column->mutable_data_column());
             keys.resize(chunk_size);
-            column->append_strings(keys);
+            column->append_strings(keys.data(), keys.size());
             nullable_column->null_column_data().resize(chunk_size);
         } else {
             DCHECK(!null_key_data);
             auto* column = down_cast<BinaryColumn*>(key_columns[0].get());
             keys.resize(chunk_size);
-            column->append_strings(keys);
+            column->append_strings(keys.data(), keys.size());
         }
     }
 
@@ -590,7 +590,8 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
     using Base = AggHashMapWithKey<HashMap, AggHashMapWithSerializedKey<HashMap>>;
     using KeyType = typename HashMap::key_type;
     using Iterator = typename HashMap::iterator;
-    using ResultVector = typename std::vector<Slice>;
+    // using ResultVector = typename std::vector<Slice>;
+    using ResultVector = Buffer<Slice>;
 
     template <class... Args>
     AggHashMapWithSerializedKey(int chunk_size, Args&&... args)
@@ -603,7 +604,7 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
-                            Buffer<AggDataPtr>* agg_states, std::vector<uint8_t>* not_founds) {
+                            Buffer<AggDataPtr>* agg_states, Filter* not_founds) {
         slice_sizes.assign(_chunk_size, 0);
         // Assign not_founds vector when needs compute not founds.
         if constexpr (compute_not_founds) {
@@ -637,7 +638,7 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_states_by_rows(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                                     Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
-                                                    std::vector<uint8_t>* not_founds, size_t max_serialize_each_row) {
+                                                    Filter* not_founds, size_t max_serialize_each_row) {
         for (size_t i = 0; i < chunk_size; ++i) {
             auto serialize_cursor = buffer;
             for (const auto& key_column : key_columns) {
@@ -674,7 +675,7 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_states_by_cols(size_t chunk_size, const Columns& key_columns, MemPool* pool,
                                                     Func&& allocate_func, Buffer<AggDataPtr>* agg_states,
-                                                    std::vector<uint8_t>* not_founds, size_t max_serialize_each_row) {
+                                                    Filter* not_founds, size_t max_serialize_each_row) {
         uint32_t cur_max_one_row_size = get_max_serialize_size(key_columns);
         if (UNLIKELY(cur_max_one_row_size > max_one_row_size)) {
             max_one_row_size = cur_max_one_row_size;
@@ -792,7 +793,7 @@ struct AggHashMapWithSerializedKeyFixedSize
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_prefetch(size_t chunk_size, const Columns& key_columns,
                                               Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
-                                              std::vector<uint8_t>* not_founds) {
+                                              Filter* not_founds) {
         auto* buffer = reinterpret_cast<uint8_t*>(caches.data());
         for (const auto& key_column : key_columns) {
             key_column->serialize_batch(buffer, slice_sizes, chunk_size, max_fixed_size);
@@ -836,7 +837,7 @@ struct AggHashMapWithSerializedKeyFixedSize
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     ALWAYS_NOINLINE void compute_agg_noprefetch(size_t chunk_size, const Columns& key_columns,
                                                 Buffer<AggDataPtr>* agg_states, Func&& allocate_func,
-                                                std::vector<uint8_t>* not_founds) {
+                                                Filter* not_founds) {
         constexpr int key_size = sizeof(FixedSizeSliceKey);
         auto* buffer = reinterpret_cast<uint8_t*>(caches.data());
         for (const auto& key_column : key_columns) {
@@ -871,7 +872,7 @@ struct AggHashMapWithSerializedKeyFixedSize
 
     template <typename Func, bool allocate_and_compute_state, bool compute_not_founds>
     void compute_agg_states(size_t chunk_size, const Columns& key_columns, MemPool* pool, Func&& allocate_func,
-                            Buffer<AggDataPtr>* agg_states, std::vector<uint8_t>* not_founds) {
+                            Buffer<AggDataPtr>* agg_states, Filter* not_founds) {
         DCHECK(fixed_byte_size != -1);
         slice_sizes.assign(chunk_size, 0);
         // Assign not_founds vector when needs compute not founds.
@@ -923,7 +924,8 @@ struct AggHashMapWithSerializedKeyFixedSize
     Buffer<uint32_t> slice_sizes;
     std::unique_ptr<MemPool> mem_pool;
     ResultVector results;
-    std::vector<Slice> tmp_slices;
+    Buffer<Slice> tmp_slices;
+    // std::vector<Slice> tmp_slices;
 
     int32_t _chunk_size;
 };

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -312,7 +312,7 @@ public:
     const AggHashMapVariant& hash_map_variant() { return _hash_map_variant; }
     const AggHashSetVariant& hash_set_variant() { return _hash_set_variant; }
     std::any& it_hash() { return _it_hash; }
-    const std::vector<uint8_t>& streaming_selection() { return _streaming_selection; }
+    const Filter& streaming_selection() { return _streaming_selection; }
     RuntimeProfile::Counter* agg_compute_timer() { return _agg_stat->agg_compute_timer; }
     RuntimeProfile::Counter* agg_expr_timer() { return _agg_stat->agg_function_compute_timer; }
     RuntimeProfile::Counter* streaming_timer() { return _agg_stat->streaming_timer; }
@@ -498,7 +498,7 @@ protected:
     AggrMode _aggr_mode = AM_DEFAULT;
     bool _is_passthrough = false;
     bool _is_pending_reset_state = false;
-    std::vector<uint8_t> _streaming_selection;
+    Filter _streaming_selection;
 
     bool _has_udaf = false;
 

--- a/be/src/exec/chunks_sorter.cpp
+++ b/be/src/exec/chunks_sorter.cpp
@@ -41,7 +41,7 @@ static void get_compare_results_colwise(size_t rows_to_sort, Columns& order_by_c
     size_t order_by_column_size = order_by_columns.size();
 
     for (size_t i = 0; i < dats_segment_size; i++) {
-        std::vector<Datum> rhs_values;
+        Buffer<Datum> rhs_values;
         auto& segment = data_segments[i];
         for (size_t col_idx = 0; col_idx < order_by_column_size; col_idx++) {
             rhs_values.push_back(order_by_columns[col_idx]->get(rows_to_sort));

--- a/be/src/exec/except_hash_set.h
+++ b/be/src/exec/except_hash_set.h
@@ -54,7 +54,7 @@ template <typename HashSet>
 class ExceptHashSet {
 public:
     using Iterator = typename HashSet::iterator;
-    using KeyVector = std::vector<Slice>;
+    using KeyVector = Buffer<Slice>;
 
     /// Used to allocate memory for serializing columns to the key.
     struct BufferState {

--- a/be/src/exec/intersect_hash_set.h
+++ b/be/src/exec/intersect_hash_set.h
@@ -52,7 +52,7 @@ template <typename HashSet>
 class IntersectHashSet {
 public:
     using Iterator = typename HashSet::iterator;
-    using KeyVector = typename std::vector<Slice>;
+    using KeyVector = Buffer<Slice>;
 
     IntersectHashSet() = default;
 

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -102,8 +102,8 @@ struct JoinHashTableItems {
     //TODO: memory continues problem?
     ChunkPtr build_chunk = nullptr;
     Columns key_columns;
-    Buffer<HashTableSlotDescriptor> build_slots;
-    Buffer<HashTableSlotDescriptor> probe_slots;
+    std::vector<HashTableSlotDescriptor> build_slots;
+    std::vector<HashTableSlotDescriptor> probe_slots;
     // A hash value is the bucket index of the hash map. "JoinHashTableItems.first" is the
     // buckets of the hash map, and it holds the index of the first key value saved in each bucket,
     // while other keys can be found by following the indices saved in

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -25,6 +25,7 @@
 #include "column/adaptive_nullable_column.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
 #include "exec/json_parser.h"
 #include "exprs/cast_expr.h"
 #include "exprs/column_ref.h"
@@ -587,7 +588,7 @@ Status JsonReader::_construct_row_without_jsonpath(simdjson::ondemand::object* r
             if (UNLIKELY(i == _op_col_index)) {
                 // special treatment for __op column, fill default value '0' rather than null
                 if (column->is_binary()) {
-                    std::ignore = column->append_strings(std::vector{Slice{"0"}});
+                    std::ignore = column->append_strings(std::vector<Slice>{Slice{"0"}});
                 } else {
                     column->append_datum(Datum((uint8_t)0));
                 }
@@ -614,7 +615,8 @@ Status JsonReader::_construct_row_with_jsonpath(simdjson::ondemand::object* row,
             if (strcmp(column_name, "__op") == 0) {
                 // special treatment for __op column, fill default value '0' rather than null
                 if (column->is_binary()) {
-                    column->append_strings(std::vector{Slice{"0"}});
+                    Slice s{"0"};
+                    column->append_strings(&s, 1);
                 } else {
                     column->append_datum(Datum((uint8_t)0));
                 }
@@ -646,7 +648,8 @@ Status JsonReader::_construct_row_with_jsonpath(simdjson::ondemand::object* row,
                 if (strcmp(column_name, "__op") == 0) {
                     // special treatment for __op column, fill default value '0' rather than null
                     if (column->is_binary()) {
-                        column->append_strings(std::vector{Slice{"0"}});
+                        Slice s{"0"};
+                        column->append_strings(&s, 1);
                     } else {
                         column->append_datum(Datum((uint8_t)0));
                     }

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
@@ -117,10 +117,9 @@ Status MemLimitedChunkQueue::push(const ChunkPtr& chunk) {
     _tail->cells.emplace_back(cell);
     _tail->memory_usage += chunk->memory_usage();
 
+#ifndef BE_TEST
     size_t in_memory_rows = _total_accumulated_rows - _flushed_accumulated_rows + _current_load_rows;
     size_t in_memory_bytes = _total_accumulated_bytes - _flushed_accumulated_bytes + _current_load_bytes;
-
-#ifndef BE_TEST
     _peak_memory_rows_counter->set(in_memory_rows);
     _peak_memory_bytes_counter->set(in_memory_bytes);
 #endif

--- a/be/src/exec/pipeline/nljoin/nljoin_context.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.cpp
@@ -188,7 +188,7 @@ void NLJoinContext::_notify_runtime_filter_collector(RuntimeState* state) {
                            std::make_unique<RuntimeFilterCollector>(RuntimeInFilterList{}, RuntimeBloomFilterList{}));
 }
 
-bool NLJoinContext::finish_probe(int32_t driver_seq, const std::vector<uint8_t>& build_match_flags) {
+bool NLJoinContext::finish_probe(int32_t driver_seq, const Filter& build_match_flags) {
     std::lock_guard guard(_join_stage_mutex);
 
     ++_num_post_probers;
@@ -210,7 +210,7 @@ bool NLJoinContext::finish_probe(int32_t driver_seq, const std::vector<uint8_t>&
     return is_last;
 }
 
-const std::vector<uint8_t> NLJoinContext::get_shared_build_match_flag() const {
+const Filter NLJoinContext::get_shared_build_match_flag() const {
     DCHECK_EQ(_num_post_probers, _num_left_probers) << "all probers should share their states";
     std::lock_guard guard(_join_stage_mutex);
     return _shared_build_match_flag;

--- a/be/src/exec/pipeline/nljoin/nljoin_context.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.h
@@ -177,9 +177,9 @@ public:
     bool is_right_finished() const { return _all_right_finished.load(std::memory_order_acquire); }
 
     // Return true if it's the last prober, which need to perform the right join task
-    bool finish_probe(int32_t driver_seq, const std::vector<uint8_t>& build_match_flags);
+    bool finish_probe(int32_t driver_seq, const Filter& build_match_flags);
 
-    const std::vector<uint8_t> get_shared_build_match_flag() const;
+    const Filter get_shared_build_match_flag() const;
 
     const SpillProcessChannelFactoryPtr& spill_channel_factory() { return _spill_process_factory_ptr; }
     NLJoinBuildChunkStreamBuilder& builder() { return _build_stream_builder; }
@@ -206,7 +206,7 @@ private:
     std::vector<ChunkPtr> _build_chunks; // Normalized chunks of _input_chunks
     int _build_chunk_desired_size = 0;
     int _num_post_probers = 0;
-    std::vector<uint8_t> _shared_build_match_flag;
+    Filter _shared_build_match_flag;
 
     // conjuncts in cross join, used for generate runtime_filter
     std::vector<ExprContext*> _rf_conjuncts_ctx;

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -548,7 +548,7 @@ void NLJoinProbeOperator::_permute_left_join(const ChunkPtr& chunk, size_t probe
 
 // Permute build side for right join
 Status NLJoinProbeOperator::_permute_right_join(size_t chunk_size) {
-    const std::vector<uint8_t>& build_match_flag = _cross_join_context->get_shared_build_match_flag();
+    const Filter& build_match_flag = _cross_join_context->get_shared_build_match_flag();
     if (!SIMD::contain_zero(build_match_flag)) {
         return Status::OK();
     }

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
@@ -123,7 +123,7 @@ private:
     size_t _prev_chunk_start = 0;
     size_t _prev_chunk_size = 0;
     size_t _build_row_current = 0;
-    mutable std::vector<uint8_t> _self_build_match_flag;
+    mutable Filter _self_build_match_flag;
 
     // Probe states
     ChunkPtr _probe_chunk = nullptr;
@@ -167,7 +167,7 @@ private:
     const RowDescriptor& _left_row_desc;
     const RowDescriptor& _right_row_desc;
 
-    Buffer<SlotDescriptor*> _col_types;
+    std::vector<SlotDescriptor*> _col_types;
     size_t _probe_column_count = 0;
     size_t _build_column_count = 0;
 

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.h
@@ -177,7 +177,7 @@ private:
     const RowDescriptor& _left_row_desc;
     const RowDescriptor& _right_row_desc;
 
-    Buffer<SlotDescriptor*> _col_types;
+    std::vector<SlotDescriptor*> _col_types;
     size_t _probe_column_count = 0;
     size_t _build_column_count = 0;
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -78,7 +78,7 @@ private:
     TInternalScanRange* _scan_range;
 
     PredicateTree _non_pushdown_pred_tree;
-    std::vector<uint8_t> _selection;
+    Filter _selection;
 
     ObjectPool _obj_pool;
     TabletSharedPtr _tablet;

--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -165,7 +165,8 @@ private:
 //
 class AppendWithMask : public ColumnVisitorMutableAdapter<AppendWithMask> {
 public:
-    using SelMask = std::vector<uint8_t>;
+    using SelMask = Filter;
+
     AppendWithMask(Column* column, SelMask sel_mask, size_t selected_size)
             : ColumnVisitorMutableAdapter(this),
               _column(column),
@@ -214,7 +215,7 @@ public:
         }
         DCHECK_EQ(_selected_size, offsets);
         datas.resize(_selected_size);
-        column->append_strings(datas);
+        column->append_strings(datas.data(), datas.size());
         return Status::OK();
     }
 
@@ -326,7 +327,7 @@ StatusOr<ChunkPtr> SortedStreamingAggregator::streaming_compute_agg_state(size_t
     RETURN_IF_ERROR(_update_states(chunk_size, is_update_phase));
 
     // selector[i] == 0 means selected
-    std::vector<uint8_t> selector(chunk_size);
+    Filter selector(chunk_size);
     size_t selected_size = _init_selector(selector, chunk_size);
 
     // finalize state
@@ -373,7 +374,7 @@ StatusOr<ChunkPtr> SortedStreamingAggregator::streaming_compute_distinct(size_t 
 
     RETURN_IF_ERROR(_compute_group_by(chunk_size));
     // selector[i] == 0 means selected
-    std::vector<uint8_t> selector(chunk_size);
+    Filter selector(chunk_size);
     size_t selected_size = _init_selector(selector, chunk_size);
     auto res_group_by_columns = _create_group_by_columns(chunk_size);
     RETURN_IF_ERROR(_build_group_by_columns(chunk_size, selected_size, selector, res_group_by_columns));
@@ -390,7 +391,7 @@ StatusOr<ChunkPtr> SortedStreamingAggregator::streaming_compute_distinct(size_t 
     return result_chunk;
 }
 
-size_t SortedStreamingAggregator::_init_selector(std::vector<uint8_t>& selector, size_t chunk_size) {
+size_t SortedStreamingAggregator::_init_selector(Filter& selector, size_t chunk_size) {
     size_t selected_size = 0;
     {
         SCOPED_TIMER(_agg_stat->agg_compute_timer);
@@ -409,7 +410,7 @@ Status SortedStreamingAggregator::_compute_group_by(size_t chunk_size) {
     // _cmp_vector[i] = group[i - 1].equals(group[i])
     // _cmp_vector[i] == 0 means group[i - 1].equals(group[i])
     _cmp_vector.assign(chunk_size, 0);
-    const std::vector<uint8_t> dummy;
+    const Buffer<uint8_t> dummy;
     SCOPED_TIMER(_agg_stat->agg_compute_timer);
     for (size_t i = 0; i < _group_by_columns.size(); ++i) {
         ColumnSelfComparator cmp(_last_columns[i], _cmp_vector, dummy);
@@ -438,7 +439,7 @@ Status SortedStreamingAggregator::_update_states(size_t chunk_size, bool is_upda
         }
 
         // only create the state when selector == 0
-        std::vector<uint8_t> create_selector(chunk_size);
+        Filter create_selector(chunk_size);
         for (size_t i = 0; i < _cmp_vector.size(); ++i) {
             create_selector[i] = _cmp_vector[i] == 0;
         }
@@ -469,7 +470,7 @@ Status SortedStreamingAggregator::_update_states(size_t chunk_size, bool is_upda
     return Status::OK();
 }
 
-Status SortedStreamingAggregator::_get_agg_result_columns(size_t chunk_size, const std::vector<uint8_t>& selector,
+Status SortedStreamingAggregator::_get_agg_result_columns(size_t chunk_size, const Buffer<uint8_t>& selector,
                                                           Columns& agg_result_columns) {
     TRY_CATCH_ALLOC_SCOPE_START()
     auto use_intermediate = _use_intermediate_as_output();
@@ -497,7 +498,7 @@ Status SortedStreamingAggregator::_get_agg_result_columns(size_t chunk_size, con
     return Status::OK();
 }
 
-void SortedStreamingAggregator::_close_group_by(size_t chunk_size, const std::vector<uint8_t>& selector) {
+void SortedStreamingAggregator::_close_group_by(size_t chunk_size, const Filter& selector) {
     // close stage
     SCOPED_TIMER(_agg_stat->state_destroy_timer);
     if (_cmp_vector[0] != 0 && _last_state) {
@@ -511,8 +512,7 @@ void SortedStreamingAggregator::_close_group_by(size_t chunk_size, const std::ve
 }
 
 Status SortedStreamingAggregator::_build_group_by_columns(size_t chunk_size, size_t selected_size,
-                                                          const std::vector<uint8_t>& selector,
-                                                          Columns& agg_group_by_columns) {
+                                                          const Filter& selector, Columns& agg_group_by_columns) {
     SCOPED_TIMER(_agg_stat->agg_append_timer);
     if (_cmp_vector[0] != 0 && !_last_columns.empty() && !_last_columns.back()->empty()) {
         for (size_t i = 0; i < agg_group_by_columns.size(); ++i) {

--- a/be/src/exec/sorted_streaming_aggregator.h
+++ b/be/src/exec/sorted_streaming_aggregator.h
@@ -42,13 +42,12 @@ private:
     Status _update_states(size_t chunk_size, bool is_update_phase);
     // init selector by _cmp_vector
     // return selected_size (distinct num_rows)
-    size_t _init_selector(std::vector<uint8_t>& selector, size_t chunk_size);
+    size_t _init_selector(Filter& selector, size_t chunk_size);
 
-    Status _get_agg_result_columns(size_t chunk_size, const std::vector<uint8_t>& selector,
-                                   Columns& agg_result_columns);
-    void _close_group_by(size_t chunk_size, const std::vector<uint8_t>& selector);
+    Status _get_agg_result_columns(size_t chunk_size, const Filter& selector, Columns& agg_result_columns);
+    void _close_group_by(size_t chunk_size, const Filter& selector);
 
-    Status _build_group_by_columns(size_t chunk_size, size_t selected_size, const std::vector<uint8_t>& selector,
+    Status _build_group_by_columns(size_t chunk_size, size_t selected_size, const Filter& selector,
                                    Columns& agg_group_by_columns);
 
     AggDataPtr _last_state = nullptr;

--- a/be/src/exec/sorting/compare_column.cpp
+++ b/be/src/exec/sorting/compare_column.cpp
@@ -327,7 +327,7 @@ int compare_column(const ColumnPtr& column, CompareVector& cmp_vector, Datum rhs
     return compare.get_equal_count();
 }
 
-void compare_columns(const Columns& columns, std::vector<int8_t>& cmp_vector, const std::vector<Datum>& rhs_values,
+void compare_columns(const Columns& columns, CompareVector& cmp_vector, const Buffer<Datum>& rhs_values,
                      const SortDescs& sort_desc) {
     if (columns.empty()) {
         return;

--- a/be/src/exec/sorting/sort_permute.h
+++ b/be/src/exec/sorting/sort_permute.h
@@ -141,6 +141,6 @@ private:
 };
 
 // Compare result of column, value must be -1,0,1
-using CompareVector = std::vector<int8_t>;
+using CompareVector = Buffer<int8_t>;
 
 } // namespace starrocks

--- a/be/src/exec/sorting/sorting.h
+++ b/be/src/exec/sorting/sorting.h
@@ -75,8 +75,8 @@ Status sort_vertical_chunks(const std::atomic<bool>& cancel, const std::vector<C
 // Compare the column with the `rhs_value`, which must have the some type with column.
 // @param cmp_result compare result is written into this array, value must within -1,0,1
 // @param rhs_value the compare value
-int compare_column(const ColumnPtr& column, std::vector<int8_t>& cmp_result, Datum rhs_value, const SortDesc& desc);
-void compare_columns(const Columns& columns, std::vector<int8_t>& cmp_result, const std::vector<Datum>& rhs_values,
+int compare_column(const ColumnPtr& column, Buffer<int8_t>& cmp_result, Datum rhs_value, const SortDesc& desc);
+void compare_columns(const Columns& columns, Buffer<int8_t>& cmp_result, const Buffer<Datum>& rhs_values,
                      const SortDescs& sort_desc);
 
 // Build tie by comparison of adjacent rows in column.

--- a/be/src/exec/stream/aggregate/agg_group_state.cpp
+++ b/be/src/exec/stream/aggregate/agg_group_state.cpp
@@ -133,9 +133,8 @@ Status AggGroupState::open(RuntimeState* state) {
     return Status::OK();
 }
 
-Status AggGroupState::process_chunk(size_t chunk_size, const Columns& group_by_columns,
-                                    const Buffer<uint8_t>& keys_not_in_map, const StreamRowOp* ops,
-                                    const std::vector<std::vector<ColumnPtr>>& agg_columns,
+Status AggGroupState::process_chunk(size_t chunk_size, const Columns& group_by_columns, const Filter& keys_not_in_map,
+                                    const StreamRowOp* ops, const std::vector<std::vector<ColumnPtr>>& agg_columns,
                                     std::vector<std::vector<const Column*>>& raw_columns,
                                     const Buffer<AggDataPtr>& agg_group_state) const {
     DCHECK(!_agg_states.empty());
@@ -253,7 +252,7 @@ Status AggGroupState::output_changes(size_t chunk_size, const Columns& group_by_
             RETURN_IF_ERROR(agg_state->output_detail(chunk_size, agg_group_state, detail_cols, result_count.get()));
 
             auto result_count_data = reinterpret_cast<Int64Column*>(result_count.get())->get_data();
-            std::vector<uint32_t> replicate_offsets;
+            Buffer<uint32_t> replicate_offsets;
             replicate_offsets.reserve(result_count_data.size() + 1);
             int offset = 0;
             for (auto count : result_count_data) {

--- a/be/src/exec/stream/aggregate/agg_state_data.cpp
+++ b/be/src/exec/stream/aggregate/agg_state_data.cpp
@@ -22,7 +22,7 @@
 
 namespace starrocks::stream {
 
-Status AggStateData::allocate_intermediate_state(size_t chunk_size, const std::vector<uint8_t>& keys_not_in_map,
+Status AggStateData::allocate_intermediate_state(size_t chunk_size, const Filter& keys_not_in_map,
                                                  const StateTableResult* state_result,
                                                  const Buffer<AggGroupStatePtr>& agg_group_state) const {
     DCHECK(state_result);

--- a/be/src/exec/stream/aggregate/agg_state_data.h
+++ b/be/src/exec/stream/aggregate/agg_state_data.h
@@ -53,7 +53,7 @@ public:
 
     // Restore intermediate state if needed by using last run state table's results from
     // result/intermediate state table.
-    Status allocate_intermediate_state(size_t chunk_size, const std::vector<uint8_t>& keys_not_in_map,
+    Status allocate_intermediate_state(size_t chunk_size, const Filter& keys_not_in_map,
                                        const StateTableResult* state_result,
                                        const Buffer<AggGroupStatePtr>& agg_group_state) const;
 

--- a/be/src/exec/stream/state/mem_state_table.cpp
+++ b/be/src/exec/stream/state/mem_state_table.cpp
@@ -97,7 +97,7 @@ Status MemStateTable::_append_datum_row_to_chunk(const DatumRow& v_row, ChunkPtr
     return Status::OK();
 }
 
-Status MemStateTable::seek(const Columns& keys, const std::vector<uint8_t>& selection, StateTableResult& values) const {
+Status MemStateTable::seek(const Columns& keys, const Filter& selection, StateTableResult& values) const {
     DCHECK_LT(0, keys.size());
     auto num_rows = keys[0]->size();
     DCHECK_EQ(selection.size(), num_rows);

--- a/be/src/exec/stream/state/mem_state_table.h
+++ b/be/src/exec/stream/state/mem_state_table.h
@@ -68,7 +68,7 @@ public:
     Status open(RuntimeState* state) override;
 
     Status seek(const Columns& keys, StateTableResult& values) const override;
-    Status seek(const Columns& keys, const std::vector<uint8_t>& selection, StateTableResult& values) const override;
+    Status seek(const Columns& keys, const Filter& selection, StateTableResult& values) const override;
 
     Status seek(const Columns& keys, const std::vector<std::string>& projection_columns,
                 StateTableResult& values) const override;

--- a/be/src/exec/stream/state/state_table.h
+++ b/be/src/exec/stream/state/state_table.h
@@ -50,7 +50,7 @@ public:
     virtual Status seek(const Columns& keys, StateTableResult& values) const = 0;
 
     // Seek with selection, only seek values when selection's flag is true.
-    virtual Status seek(const Columns& keys, const std::vector<uint8_t>& selection, StateTableResult& values) const = 0;
+    virtual Status seek(const Columns& keys, const Filter& selection, StateTableResult& values) const = 0;
 
     // If `projection_columns` is not empty, only output all needed projection_columns in values.
     virtual Status seek(const Columns& keys, const std::vector<std::string>& projection_columns,

--- a/be/src/exec/tablet_scanner.h
+++ b/be/src/exec/tablet_scanner.h
@@ -87,7 +87,7 @@ private:
     ObjectPool _pool;
     std::vector<ExprContext*> _conjunct_ctxs;
     PredicateTree _pred_tree;
-    std::vector<uint8_t> _selection;
+    Filter _selection;
 
     // for release memory.
     using PredicatePtr = std::unique_ptr<ColumnPredicate>;

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -764,9 +764,9 @@ Status OlapTableSink::_fill_auto_increment_id_internal(Chunk* chunk, SlotDescrip
     }
 
     ColumnPtr& data_col = std::dynamic_pointer_cast<NullableColumn>(col)->data_column();
-    std::vector<uint8_t> filter(std::dynamic_pointer_cast<NullableColumn>(col)->immutable_null_column_data());
+    Filter filter(std::dynamic_pointer_cast<NullableColumn>(col)->immutable_null_column_data());
 
-    std::vector<uint8_t> init_filter(chunk->num_rows(), 0);
+    Filter init_filter(chunk->num_rows(), 0);
 
     if (_keys_type == TKeysType::PRIMARY_KEYS && _output_tuple_desc->slots().back()->col_name() == "__op") {
         size_t op_column_id = chunk->num_columns() - 1;
@@ -1062,7 +1062,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
         case TYPE_DECIMALV2: {
             column = ColumnHelper::get_data_column(column);
             auto* decimal = down_cast<DecimalColumn*>(column);
-            std::vector<DecimalV2Value>& datas = decimal->get_data();
+            Buffer<DecimalV2Value>& datas = decimal->get_data();
             int scale = desc->type().scale;
             for (size_t j = 0; j < num_rows; ++j) {
                 if (_validate_selection[j] == VALID_SEL_OK) {

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -117,7 +117,7 @@ public:
     virtual void destroy(FunctionContext* ctx, AggDataPtr __restrict ptr) const = 0;
 
     virtual void batch_create_with_selection(FunctionContext* ctx, size_t chunk_size, Buffer<AggDataPtr>& states,
-                                             size_t state_offset, const std::vector<uint8_t>& selection) const {
+                                             size_t state_offset, const Filter& selection) const {
         for (size_t i = 0; i < chunk_size; i++) {
             if (selection[i] == 0) {
                 create(ctx, states[i] + state_offset);
@@ -126,7 +126,7 @@ public:
     }
 
     virtual void batch_destroy_with_selection(FunctionContext* ctx, size_t chunk_size, Buffer<AggDataPtr>& states,
-                                              size_t state_offset, const std::vector<uint8_t>& selection) const {
+                                              size_t state_offset, const Filter& selection) const {
         for (size_t i = 0; i < chunk_size; i++) {
             if (selection[i] == 0) {
                 destroy(ctx, states[i] + state_offset);
@@ -136,7 +136,7 @@ public:
 
     virtual void batch_finalize_with_selection(FunctionContext* ctx, size_t chunk_size,
                                                const Buffer<AggDataPtr>& agg_states, size_t state_offset, Column* to,
-                                               const std::vector<uint8_t>& selection) const {
+                                               const Filter& selection) const {
         for (size_t i = 0; i < chunk_size; i++) {
             if (selection[i] == 0) {
                 this->finalize_to_column(ctx, agg_states[i] + state_offset, to);
@@ -146,7 +146,7 @@ public:
 
     virtual void batch_serialize_with_selection(FunctionContext* ctx, size_t chunk_size,
                                                 const Buffer<AggDataPtr>& agg_states, size_t state_offset, Column* to,
-                                                const std::vector<uint8_t>& selection) const {
+                                                const Filter& selection) const {
         for (size_t i = 0; i < chunk_size; i++) {
             if (selection[i] == 0) {
                 this->serialize_to_column(ctx, agg_states[i] + state_offset, to);
@@ -162,8 +162,7 @@ public:
 
     // filter[i] = 0, will be update
     virtual void update_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset,
-                                          const Column** columns, AggDataPtr* states,
-                                          const std::vector<uint8_t>& filter) const = 0;
+                                          const Column** columns, AggDataPtr* states, const Filter& filter) const = 0;
 
     // update result to single state
     virtual void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
@@ -204,8 +203,7 @@ public:
 
     // filter[i] = 0, will be merged
     virtual void merge_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset,
-                                         const Column* column, AggDataPtr* states,
-                                         const std::vector<uint8_t>& filter) const = 0;
+                                         const Column* column, AggDataPtr* states, const Filter& filter) const = 0;
 
     // Merge some continuous portion of a chunk to a given state.
     // This will be useful for sorted streaming aggregation.
@@ -315,7 +313,7 @@ template <typename State, typename Derived>
 class AggregateFunctionBatchHelper : public AggregateFunctionStateHelper<State> {
 public:
     void batch_create_with_selection(FunctionContext* ctx, size_t chunk_size, Buffer<AggDataPtr>& states,
-                                     size_t state_offset, const std::vector<uint8_t>& selection) const override {
+                                     size_t state_offset, const Filter& selection) const override {
         for (size_t i = 0; i < chunk_size; i++) {
             if (selection[i] == 0) {
                 static_cast<const Derived*>(this)->create(ctx, states[i] + state_offset);
@@ -324,7 +322,7 @@ public:
     }
 
     void batch_destroy_with_selection(FunctionContext* ctx, size_t chunk_size, Buffer<AggDataPtr>& states,
-                                      size_t state_offset, const std::vector<uint8_t>& selection) const override {
+                                      size_t state_offset, const Filter& selection) const override {
         if constexpr (AggregateFunctionStateHelper<State>::pod_state()) {
             // nothing TODO
         } else {
@@ -337,8 +335,7 @@ public:
     }
 
     void batch_finalize_with_selection(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
-                                       size_t state_offset, Column* to,
-                                       const std::vector<uint8_t>& selection) const override {
+                                       size_t state_offset, Column* to, const Filter& selection) const override {
         for (size_t i = 0; i < chunk_size; i++) {
             if (selection[i] == 0) {
                 static_cast<const Derived*>(this)->finalize_to_column(ctx, agg_states[i] + state_offset, to);
@@ -347,8 +344,7 @@ public:
     }
 
     void batch_serialize_with_selection(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
-                                        size_t state_offset, Column* to,
-                                        const std::vector<uint8_t>& selection) const override {
+                                        size_t state_offset, Column* to, const Filter& selection) const override {
         for (size_t i = 0; i < chunk_size; i++) {
             if (selection[i] == 0) {
                 static_cast<const Derived*>(this)->serialize_to_column(ctx, agg_states[i] + state_offset, to);
@@ -364,7 +360,7 @@ public:
     }
 
     void update_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
-                                  AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
+                                  AggDataPtr* states, const Filter& filter) const override {
         for (size_t i = 0; i < chunk_size; i++) {
             // TODO: optimize with simd ?
             if (filter[i] == 0) {
@@ -388,7 +384,7 @@ public:
     }
 
     void merge_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column* column,
-                                 AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
+                                 AggDataPtr* states, const Filter& filter) const override {
         for (size_t i = 0; i < chunk_size; i++) {
             // TODO: optimize with simd ?
             if (filter[i] == 0) {

--- a/be/src/exprs/agg/bitmap_agg.h
+++ b/be/src/exprs/agg/bitmap_agg.h
@@ -38,7 +38,7 @@ public:
         }
     }
 
-    bool check_valid(const std::vector<InputCppType>& values, size_t count) const {
+    bool check_valid(const Buffer<InputCppType>& values, size_t count) const {
         for (size_t i = 0; i < count; i++) {
             auto value = values[i];
             if (!(value >= 0 && value <= std::numeric_limits<uint64_t>::max())) {

--- a/be/src/exprs/agg/count.h
+++ b/be/src/exprs/agg/count.h
@@ -129,8 +129,7 @@ public:
     }
 
     void batch_finalize_with_selection(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
-                                       size_t state_offset, Column* to,
-                                       const std::vector<uint8_t>& selection) const override {
+                                       size_t state_offset, Column* to, const Filter& selection) const override {
         DCHECK(to->is_numeric());
         int64_t values[chunk_size];
         size_t selected_length = 0;
@@ -180,7 +179,7 @@ public:
     }
 
     void update_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
-                                  AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
+                                  AggDataPtr* states, const Filter& filter) const override {
         if (columns[0]->has_null()) {
             const auto* nullable_column = down_cast<const NullableColumn*>(columns[0]);
             const uint8_t* null_data = nullable_column->immutable_null_column_data().data();

--- a/be/src/exprs/agg/group_concat.h
+++ b/be/src/exprs/agg/group_concat.h
@@ -544,7 +544,7 @@ public:
         // if i-th row is null, set nullable_array[x][i] = null, otherwise, set array[x][i]=src[x][i]
         std::vector<ArrayColumn*> arrays(columns.size());
         std::vector<NullData*> array_nulls(columns.size());
-        std::vector<std::vector<uint32_t>*> array_offsets(columns.size());
+        std::vector<Buffer<uint32_t>*> array_offsets(columns.size());
         std::vector<NullableColumn*> nullable_arrays(columns.size());
         auto old_size = columns[0]->size();
         for (auto j = 0; j < columns.size(); ++j) {

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -214,7 +214,7 @@ public:
     }
 
     void update_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
-                                  AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
+                                  AggDataPtr* states, const Filter& filter) const override {
         auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
         std::vector<DirectByteBuffer> buffers;
         std::vector<jobject> args;
@@ -320,7 +320,7 @@ public:
     }
 
     void merge_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column* column,
-                                 AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
+                                 AggDataPtr* states, const Filter& filter) const override {
         // batch merge
         auto& helper = JVMFunctionHelper::getInstance();
 

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -274,7 +274,7 @@ public:
     }
 
     void merge_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column* column,
-                                 AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
+                                 AggDataPtr* states, const Filter& filter) const override {
         for (size_t i = 0; i < chunk_size; i++) {
             // TODO: optimize with simd ?
             if (filter[i] == 0) {
@@ -412,7 +412,7 @@ public:
     }
 
     void update_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
-                                  AggDataPtr* states, const std::vector<uint8_t>& selection) const override {
+                                  AggDataPtr* states, const Filter& selection) const override {
         // Scalar function compute will return non-nullable column
         // for nullable column when the real whole chunk data all not-null.
         if (columns[0]->is_nullable()) {
@@ -738,7 +738,7 @@ public:
     }
 
     void merge_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column* column,
-                                 AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
+                                 AggDataPtr* states, const Filter& filter) const override {
         auto fast_call_path = [&](const Column* data_column) {
             for (size_t i = 0; i < chunk_size; ++i) {
                 if (filter[i] == 0) {
@@ -836,7 +836,7 @@ public:
     }
 
     void update_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** columns,
-                                  AggDataPtr* states, const std::vector<uint8_t>& selection) const override {
+                                  AggDataPtr* states, const Filter& selection) const override {
         auto column_size = ctx->get_num_args();
         for (size_t i = 0; i < column_size; i++) {
             if (columns[i]->only_null()) {

--- a/be/src/exprs/agg/percentile_cont.h
+++ b/be/src/exprs/agg/percentile_cont.h
@@ -57,7 +57,7 @@ struct PercentileState {
     using GridType = typename PercentileStateTypes<LT>::GridType;
 
     void update(CppType item) { items.emplace_back(item); }
-    void update_batch(const std::vector<CppType>& vec) {
+    void update_batch(const Buffer<CppType>& vec) {
         size_t old_size = items.size();
         items.resize(old_size + vec.size());
         memcpy(items.data() + old_size, vec.data(), vec.size() * sizeof(CppType));
@@ -523,7 +523,7 @@ struct LowCardPercentileState {
     constexpr int static ser_header = 0x3355 | LT << 16;
     void update(CppType item) { items[item]++; }
 
-    void update_batch(const std::vector<CppType>& vec) {
+    void update_batch(const Buffer<CppType>& vec) {
         for (const auto& item : vec) {
             items[item]++;
         }

--- a/be/src/exprs/agg/sum.h
+++ b/be/src/exprs/agg/sum.h
@@ -158,8 +158,7 @@ public:
     }
 
     void batch_finalize_with_selection(FunctionContext* ctx, size_t chunk_size, const Buffer<AggDataPtr>& agg_states,
-                                       size_t state_offset, Column* to,
-                                       const std::vector<uint8_t>& selection) const override {
+                                       size_t state_offset, Column* to, const Filter& selection) const override {
         DCHECK(to->is_numeric());
         ResultType values[chunk_size];
         size_t selected_lengh = 0;

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -33,7 +33,7 @@ class WindowFunction : public AggregateFunctionStateHelper<State> {
     }
 
     void merge_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column* column,
-                                 AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
+                                 AggDataPtr* states, const Filter& filter) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 
@@ -53,7 +53,7 @@ class WindowFunction : public AggregateFunctionStateHelper<State> {
     }
 
     void update_batch_selectively(FunctionContext* ctx, size_t chunk_size, size_t state_offset, const Column** column,
-                                  AggDataPtr* states, const std::vector<uint8_t>& filter) const override {
+                                  AggDataPtr* states, const Filter& filter) const override {
         DCHECK(false) << "Shouldn't call this method for window function!";
     }
 

--- a/be/src/exprs/array_element_expr.cpp
+++ b/be/src/exprs/array_element_expr.cpp
@@ -74,7 +74,7 @@ public:
             }
         }
 
-        std::vector<uint8_t> null_flags;
+        NullData null_flags;
         raw::make_room(&null_flags, num_rows);
 
         // Construct null flags.

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -607,7 +607,7 @@ protected:
             return;
         }
 
-        auto null_first_fn = [src_null_column](size_t i) -> bool { return src_null_column.get_data()[i] == 1; };
+        auto null_first_fn = [&src_null_column](size_t i) -> bool { return src_null_column.get_data()[i] == 1; };
 
         auto begin_of_not_null =
                 std::partition(sort_index->begin() + start, sort_index->begin() + start + count, null_first_fn);

--- a/be/src/exprs/like_predicate.cpp
+++ b/be/src/exprs/like_predicate.cpp
@@ -349,7 +349,7 @@ StatusOr<ColumnPtr> LikePredicate::constant_substring_fn(FunctionContext* contex
         size_t type_size = res->type_size();
         memset(res->mutable_raw_data(), 1, res->size() * type_size);
     } else {
-        const std::vector<uint32_t>& offsets = haystack->get_offset();
+        const Buffer<uint32_t>& offsets = haystack->get_offset();
         res->resize(haystack->size());
 
         const char* begin = haystack->get_slice(0).data;

--- a/be/src/exprs/locate.cpp
+++ b/be/src/exprs/locate.cpp
@@ -79,7 +79,7 @@ ColumnPtr haystack_vector_and_needle_const(const ColumnPtr& haystack_ptr, const 
         start_pos = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(start_pos_expansion);
     }
 
-    const std::vector<uint32_t>& offsets = haystack->get_offset();
+    const Buffer<uint32_t>& offsets = haystack->get_offset();
     Slice needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_ptr);
     auto res = RunTimeColumnType<TYPE_INT>::create();
     res->resize(haystack->size());

--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -254,7 +254,7 @@ void MapFunctions::_filter_map_items(const MapColumn* src_column, const ColumnPt
     } else {
         filter = down_cast<ArrayColumn*>(raw_filter.get());
     }
-    std::vector<uint32_t> indexes;
+    Buffer<uint32_t> indexes;
     // only keep the elements whose filter is not null and not 0.
     for (size_t i = 0; i < src_column->size(); ++i) {
         if (dest_null_map == nullptr || !dest_null_map->get_data()[i]) {         // dest_null_map[i] is not null

--- a/be/src/exprs/split.cpp
+++ b/be/src/exprs/split.cpp
@@ -148,7 +148,7 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
             }
             array_offsets->append(offset);
 
-            array_binary_column->append_continuous_strings(v);
+            array_binary_column->append_continuous_strings(v.data(), v.size());
         } else {
             //row_nums * 5 is an estimated value, because the true value cannot be obtained for the time being here
             array_binary_column->reserve(row_nums * 5, haystack_columns->get_bytes().size());

--- a/be/src/exprs/table_function/list_rowsets.cpp
+++ b/be/src/exprs/table_function/list_rowsets.cpp
@@ -74,7 +74,7 @@ static void fill_rowset_row(Columns& columns, const RowsetMetadataPB& rowset) {
         opts.pretty_json = false;
         std::string json;
         (void)json2pb::ProtoMessageToJson(rowset.delete_predicate(), &json, opts);
-        (void)columns[5]->append_strings({json});
+        (void)columns[5]->append_strings(std::vector<Slice>{Slice{json}});
     }
 }
 

--- a/be/src/exprs/table_function/subdivide_bitmap.h
+++ b/be/src/exprs/table_function/subdivide_bitmap.h
@@ -45,7 +45,7 @@ public:
         return Status::OK();
     }
 
-    void process_row(const std::vector<BitmapValue*>& src_bitmap_col, SrcSizeCppType batch_size, size_t row,
+    void process_row(const Buffer<BitmapValue*>& src_bitmap_col, SrcSizeCppType batch_size, size_t row,
                      Column* dst_bitmap_col, UInt32Column* dst_offset_col, uint32_t* compact_offset) const {
         auto* bitmap = src_bitmap_col[row];
 

--- a/be/src/formats/disk_range.hpp
+++ b/be/src/formats/disk_range.hpp
@@ -15,6 +15,7 @@
 #pragma once
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <vector>
 

--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -116,7 +116,7 @@ public:
         return _cur_decoder->get_dict_values(column);
     }
 
-    Status get_dict_values(const std::vector<int32_t>& dict_codes, const NullableColumn& nulls, Column* column) {
+    Status get_dict_values(const Buffer<int32_t>& dict_codes, const NullableColumn& nulls, Column* column) {
         RETURN_IF_ERROR(_try_load_dictionary());
         return _cur_decoder->get_dict_values(dict_codes, nulls, column);
     }

--- a/be/src/formats/parquet/encoding.h
+++ b/be/src/formats/parquet/encoding.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <vector>
 
+#include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "gen_cpp/parquet_types.h"
 #include "utils.h"
@@ -60,8 +61,7 @@ public:
 
     virtual Status get_dict_values(Column* column) { return Status::NotSupported("get_dict_values is not supported"); }
 
-    virtual Status get_dict_values(const std::vector<int32_t>& dict_codes, const NullableColumn& nulls,
-                                   Column* column) {
+    virtual Status get_dict_values(const Buffer<int32_t>& dict_codes, const NullableColumn& nulls, Column* column) {
         return Status::NotSupported("get_dict_values is not supported");
     }
 

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -19,6 +19,7 @@
 
 #include "column/column.h"
 #include "column/column_helper.h"
+#include "column/nullable_column.h"
 #include "common/status.h"
 #include "formats/parquet/encoding.h"
 #include "simd/simd.h"
@@ -187,9 +188,8 @@ public:
         return Status::OK();
     }
 
-    Status get_dict_values(const std::vector<int32_t>& dict_codes, const NullableColumn& nulls,
-                           Column* column) override {
-        const std::vector<uint8_t>& null_data = nulls.immutable_null_column_data();
+    Status get_dict_values(const Buffer<int32_t>& dict_codes, const NullableColumn& nulls, Column* column) override {
+        const NullData& null_data = nulls.immutable_null_column_data();
         bool has_null = nulls.has_null();
         bool all_null = false;
 
@@ -295,7 +295,6 @@ private:
     std::vector<Slice> _dict;
     std::vector<uint32_t> _indexes;
     std::vector<Slice> _slices;
-
     size_t _max_value_length = 0;
 };
 

--- a/be/src/formats/parquet/stored_column_reader.h
+++ b/be/src/formats/parquet/stored_column_reader.h
@@ -70,8 +70,7 @@ public:
 
     virtual Status get_dict_values(Column* column) = 0;
 
-    virtual Status get_dict_values(const std::vector<int32_t>& dict_codes, const NullableColumn& nulls,
-                                   Column* column) = 0;
+    virtual Status get_dict_values(const Buffer<int32_t>& dict_codes, const NullableColumn& nulls, Column* column) = 0;
 
     virtual Status load_dictionary_page() { return Status::InternalError("Not supported load_dictionary_page"); }
 
@@ -98,8 +97,7 @@ public:
 
     Status get_dict_values(Column* column) override { return _reader->get_dict_values(column); }
 
-    Status get_dict_values(const std::vector<int32_t>& dict_codes, const NullableColumn& nulls,
-                           Column* column) override {
+    Status get_dict_values(const Buffer<int32_t>& dict_codes, const NullableColumn& nulls, Column* column) override {
         return _reader->get_dict_values(dict_codes, nulls, column);
     }
 

--- a/be/src/formats/parquet/stored_column_reader_with_index.h
+++ b/be/src/formats/parquet/stored_column_reader_with_index.h
@@ -61,8 +61,7 @@ public:
 
     Status get_dict_values(Column* column) override { return _inner_reader->get_dict_values(column); }
 
-    Status get_dict_values(const std::vector<int32_t>& dict_codes, const NullableColumn& nulls,
-                           Column* column) override {
+    Status get_dict_values(const Buffer<int32_t>& dict_codes, const NullableColumn& nulls, Column* column) override {
         return _inner_reader->get_dict_values(dict_codes, nulls, column);
     }
 

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -75,6 +75,7 @@ set(RUNTIME_FILES
     memory/roaring_hook.cpp
     memory/system_allocator.cpp
     memory/mem_chunk_allocator.cpp
+    memory/column_allocator.cpp
     chunk_cursor.cpp
     sorted_chunks_merger.cpp
     tablets_channel.cpp

--- a/be/src/runtime/global_dict/miscs.cpp
+++ b/be/src/runtime/global_dict/miscs.cpp
@@ -40,7 +40,7 @@ std::pair<std::shared_ptr<NullableColumn>, std::vector<int32_t>> extract_column_
         slices.emplace_back(slice);
         codes.emplace_back(code);
     }
-    res->append_strings(slices);
+    res->append_strings(slices.data(), slices.size());
     res->set_null(0);
     return std::make_pair(std::move(res), std::move(codes));
 }

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -202,7 +202,7 @@ private:
     }
 
     // res[i] = mapping[index[i]]
-    std::vector<uint32_t> _code_convert(const std::vector<int32_t>& index, const std::vector<int16_t>& mapping) {
+    std::vector<uint32_t> _code_convert(const Buffer<int32_t>& index, const std::vector<int16_t>& mapping) {
         std::vector<uint32_t> res(index.size());
         SIMDGather::gather(res.data(), mapping.data(), index.data(), mapping.size(), index.size());
         return res;

--- a/be/src/runtime/memory/column_allocator.cpp
+++ b/be/src/runtime/memory/column_allocator.cpp
@@ -1,0 +1,21 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/memory/column_allocator.h"
+
+namespace starrocks {
+
+MemHookAllocator kDefaultColumnAllocator = MemHookAllocator{};
+
+}

--- a/be/src/runtime/memory/column_allocator.h
+++ b/be/src/runtime/memory/column_allocator.h
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <glog/logging.h>
+
+#include <memory>
+
+#include "runtime/memory/mem_hook_allocator.h"
+
+namespace starrocks {
+
+extern MemHookAllocator kDefaultColumnAllocator;
+inline thread_local Allocator* tls_column_allocator = &kDefaultColumnAllocator;
+
+template <class T>
+class ColumnAllocator {
+public:
+    typedef T value_type;
+    typedef size_t size_type;
+    using propagate_on_container_copy_assignment = std::true_type; // for consistency
+    using propagate_on_container_move_assignment = std::true_type; // to avoid the pessimization
+    using propagate_on_container_swap = std::true_type;            // to avoid the undefined behavior
+
+    template <typename U>
+    struct rebind {
+        using other = ColumnAllocator<U>;
+    };
+    ColumnAllocator() = default;
+    template <class U>
+    ColumnAllocator(const ColumnAllocator<U>& other) {}
+
+    ~ColumnAllocator() = default;
+
+    T* allocate(size_t n) {
+        DCHECK(tls_column_allocator != nullptr);
+        return static_cast<T*>(tls_column_allocator->alloc(n * sizeof(T)));
+    }
+
+    void deallocate(T* ptr, size_t n) {
+        DCHECK(tls_column_allocator != nullptr);
+        tls_column_allocator->free(ptr);
+    }
+
+    ColumnAllocator& operator=(const ColumnAllocator& rhs) = default;
+
+    template <class U>
+    ColumnAllocator& operator=(const ColumnAllocator<U>& rhs) {
+        return *this;
+    }
+
+    bool operator==(const ColumnAllocator& rhs) const { return true; }
+
+    bool operator!=(const ColumnAllocator& rhs) const { return false; }
+
+    void swap(ColumnAllocator& rhs) {}
+};
+
+class ThreadLocalColumnAllocatorSetter {
+public:
+    ThreadLocalColumnAllocatorSetter(Allocator* allocator) {
+        _prev = tls_column_allocator;
+        tls_column_allocator = allocator;
+    }
+    ~ThreadLocalColumnAllocatorSetter() { tls_column_allocator = _prev; }
+
+private:
+    Allocator* _prev = nullptr;
+};
+} // namespace starrocks

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -178,7 +178,7 @@ public:
     static const uint8_t* deserialize(const uint8_t* buff, FixedLengthColumnBase<T>* column, const int encode_level) {
         uint32_t size = 0;
         buff = read_little_endian_32(buff, &size);
-        std::vector<T>& data = column->get_data();
+        auto& data = column->get_data();
         raw::make_room(&data, size / sizeof(T));
         if (EncodeContext::enable_encode_integer(encode_level) && size >= ENCODE_SIZE_LIMIT) {
             if (sizeof(T) == 4 && sorted) { // only support sorted 32-bit integers
@@ -290,7 +290,7 @@ template <typename T>
 class ObjectColumnSerde {
 public:
     static int64_t max_serialized_size(const ObjectColumn<T>& column) {
-        const std::vector<T>& pool = column.get_pool();
+        const auto& pool = column.get_pool();
         int64_t size = sizeof(uint32_t);
         for (const auto& obj : pool) {
             size += sizeof(uint64_t);
@@ -313,7 +313,7 @@ public:
         uint32_t num_objects = 0;
         buff = read_little_endian_32(buff, &num_objects);
         column->reset_column();
-        std::vector<T>& pool = column->get_pool();
+        auto& pool = column->get_pool();
         pool.reserve(num_objects);
         for (int i = 0; i < num_objects; i++) {
             uint64_t serialized_size = 0;
@@ -331,7 +331,7 @@ public:
 class JsonColumnSerde {
 public:
     static int64_t max_serialized_size(const JsonColumn& column) {
-        const std::vector<JsonValue>& pool = column.get_pool();
+        const auto& pool = column.get_pool();
         int64_t size = 0;
         size += sizeof(uint32_t); // format_version
         size += sizeof(uint32_t); // num_objects
@@ -366,7 +366,7 @@ public:
         CHECK_EQ(actual_version, kJsonMetaDefaultFormatVersion) << "Only format_version=1 is supported";
 
         column->reset_column();
-        std::vector<JsonValue>& pool = column->get_pool();
+        auto& pool = column->get_pool();
         pool.reserve(num_objects);
         for (int i = 0; i < num_objects; i++) {
             uint64_t serialized_size = 0;

--- a/be/src/simd/simd.h
+++ b/be/src/simd/simd.h
@@ -94,14 +94,14 @@ count_zero(const T* data, size_t size) {
     return count;
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline size_t count_zero(const Container& nums) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t) || sizeof(T) == sizeof(uint32_t)),
                   "only 8-bit or 32-bit integral types are supported");
     return count_zero(nums.data(), nums.size());
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline size_t count_zero(const Container& nums, size_t size) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t) || sizeof(T) == sizeof(uint32_t)),
                   "only 8-bit or 32-bit integral types are supported");
@@ -115,7 +115,7 @@ inline size_t count_nonzero(const T* data, size_t size) {
     return size - count_zero(data, size);
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline size_t count_nonzero(const Container& nums) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t) || sizeof(T) == sizeof(uint32_t)),
                   "only 8-bit or 32-bit integral types are supported");
@@ -123,7 +123,7 @@ inline size_t count_nonzero(const Container& nums) {
 }
 
 // NOTE: memchr is much faster than a plain SIMD implementation
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline static size_t find_byte(const Container& list, size_t start, size_t count, T byte) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
                   "only 8-bit integral types are supported");
@@ -139,7 +139,7 @@ inline static size_t find_byte(const Container& list, size_t start, size_t count
     return (T*)p - list.data();
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline static size_t find_byte(const Container& list, size_t start, T byte) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
                   "only 8-bit integral types are supported");
@@ -155,56 +155,56 @@ inline static size_t find_byte(const Container& list, size_t start, T byte) {
 }
 
 // Find position for zero byte, return size of list if not found
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline size_t find_zero(const Container& list, size_t start) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
                   "only 8-bit integral types are supported");
     return find_byte(list, start, static_cast<T>(0));
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline size_t find_zero(const Container& list, size_t start, size_t count) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
                   "only 8-bit integral types are supported");
     return find_byte(list, start, count, static_cast<T>(0));
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline size_t find_nonzero(const Container& list, size_t start) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
                   "only 8-bit integral types are supported");
     return find_byte(list, start, static_cast<T>(1));
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline size_t find_nonzero(const Container& list, size_t start, size_t count) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
                   "only 8-bit integral types are supported");
     return find_byte(list, start, count, static_cast<T>(1));
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline bool contain_zero(const Container& list) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
                   "only 8-bit integral types are supported");
     return find_zero(list, 0) < list.size();
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline bool contain_nonzero(const Container& list) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
                   "only 8-bit integral types are supported");
     return find_nonzero(list, 0) < list.size();
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline bool contain_nonzero(const Container& list, size_t start) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
                   "only 8-bit integral types are supported");
     return find_nonzero(list, start) < list.size();
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline bool contain_nonzero(const Container& list, size_t start, size_t count) {
     static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
                   "only 8-bit integral types are supported");

--- a/be/src/simd/simd.h
+++ b/be/src/simd/simd.h
@@ -16,7 +16,10 @@
 
 #include <cstdint>
 #include <cstring>
+#include <type_traits>
 #include <vector>
+
+#include "column/column.h"
 #ifdef __SSE2__
 #include <emmintrin.h>
 #elif defined(__ARM_NEON) && defined(__aarch64__)
@@ -26,14 +29,16 @@
 
 namespace SIMD {
 
-// Count the number of zeros of 8-bit signed integers.
-inline size_t count_zero(const int8_t* data, size_t size) {
+// Count the number of zeros of 8-bit integers.
+template <typename T>
+inline typename std::enable_if<std::is_same<T, int8_t>::value || std::is_same<T, uint8_t>::value, size_t>::type
+count_zero(const T* data, size_t size) {
     size_t count = 0;
-    const int8_t* end = data + size;
+    const T* end = data + size;
 
 #if defined(__SSE2__) && defined(__POPCNT__)
     const __m128i zero16 = _mm_setzero_si128();
-    const int8_t* end64 = data + (size / 64 * 64);
+    const T* end64 = data + (size / 64 * 64);
 
     for (; data < end64; data += 64) {
         count += __builtin_popcountll(static_cast<uint64_t>(_mm_movemask_epi8(_mm_cmpeq_epi8(
@@ -56,14 +61,17 @@ inline size_t count_zero(const int8_t* data, size_t size) {
     return count;
 }
 
-inline size_t count_zero(const uint32_t* data, size_t size) {
+// Count the number of zeros of 32-bit integers.
+template <typename T>
+inline typename std::enable_if<std::is_same<T, int32_t>::value || std::is_same<T, uint32_t>::value, size_t>::type
+count_zero(const T* data, size_t size) {
     size_t count = 0;
-    const uint32_t* end = data + size;
+    const T* end = data + size;
 
 #if defined(__SSE2__) && defined(__POPCNT__)
     // count per 16 int
     const __m128i zero16 = _mm_setzero_si128();
-    const uint32_t* end16 = data + (size / 16 * 16);
+    const T* end16 = data + (size / 16 * 16);
 
     for (; data < end16; data += 16) {
         count += __builtin_popcountll(static_cast<uint64_t>(_mm_movemask_ps(_mm_cvtepi32_ps(_mm_cmpeq_epi32(
@@ -86,52 +94,40 @@ inline size_t count_zero(const uint32_t* data, size_t size) {
     return count;
 }
 
-inline size_t count_zero(const std::vector<uint32_t>& nums) {
+template <typename Container, typename T = Container::value_type>
+inline size_t count_zero(const Container& nums) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t) || sizeof(T) == sizeof(uint32_t)),
+                  "only 8-bit or 32-bit integral types are supported");
     return count_zero(nums.data(), nums.size());
 }
 
-inline size_t count_nonzero(const std::vector<uint32_t>& nums) {
-    return nums.size() - count_zero(nums.data(), nums.size());
-}
-
-// Count the number of zeros of 8-bit unsigned integers.
-inline size_t count_zero(const uint8_t* data, size_t size) {
-    return count_zero(reinterpret_cast<const int8_t*>(data), size);
-}
-
-inline size_t count_zero(const std::vector<int8_t>& nums) {
-    return count_zero(nums.data(), nums.size());
-}
-
-inline size_t count_zero(const std::vector<uint8_t>& nums, size_t size) {
+template <typename Container, typename T = Container::value_type>
+inline size_t count_zero(const Container& nums, size_t size) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t) || sizeof(T) == sizeof(uint32_t)),
+                  "only 8-bit or 32-bit integral types are supported");
     return count_zero(nums.data(), size);
 }
 
-inline size_t count_zero(const std::vector<uint8_t>& nums) {
-    return count_zero(nums.data(), nums.size());
-}
-
-// Count the number of nonzeros of 8-bit signed integers.
-inline size_t count_nonzero(const int8_t* data, size_t size) {
+template <typename T>
+inline size_t count_nonzero(const T* data, size_t size) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t) || sizeof(T) == sizeof(uint32_t)),
+                  "only 8-bit or 32-bit integral types are supported");
     return size - count_zero(data, size);
 }
 
-// Count the number of nonzeros of 8-bit unsigned integers.
-inline size_t count_nonzero(const uint8_t* data, size_t size) {
-    return size - count_zero(data, size);
-}
-
-inline size_t count_nonzero(const std::vector<uint8_t>& list) {
-    return count_nonzero(list.data(), list.size());
-}
-
-inline size_t count_nonzero(const std::vector<int8_t>& list) {
-    return count_nonzero(list.data(), list.size());
+template <typename Container, typename T = Container::value_type>
+inline size_t count_nonzero(const Container& nums) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t) || sizeof(T) == sizeof(uint32_t)),
+                  "only 8-bit or 32-bit integral types are supported");
+    return count_nonzero(nums.data(), nums.size());
 }
 
 // NOTE: memchr is much faster than a plain SIMD implementation
-template <class T>
-inline static size_t find_byte(const std::vector<T>& list, size_t start, size_t count, T byte) {
+template <typename Container, typename T = Container::value_type>
+inline static size_t find_byte(const Container& list, size_t start, size_t count, T byte) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
+                  "only 8-bit integral types are supported");
+
     if (start >= list.size()) {
         return start;
     }
@@ -143,8 +139,11 @@ inline static size_t find_byte(const std::vector<T>& list, size_t start, size_t 
     return (T*)p - list.data();
 }
 
-template <class T>
-inline static size_t find_byte(const std::vector<T>& list, size_t start, T byte) {
+template <typename Container, typename T = Container::value_type>
+inline static size_t find_byte(const Container& list, size_t start, T byte) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
+                  "only 8-bit integral types are supported");
+
     if (start >= list.size()) {
         return start;
     }
@@ -156,39 +155,59 @@ inline static size_t find_byte(const std::vector<T>& list, size_t start, T byte)
 }
 
 // Find position for zero byte, return size of list if not found
-inline size_t find_zero(const std::vector<uint8_t>& list, size_t start) {
-    return find_byte<uint8_t>(list, start, 0);
+template <typename Container, typename T = Container::value_type>
+inline size_t find_zero(const Container& list, size_t start) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
+                  "only 8-bit integral types are supported");
+    return find_byte(list, start, static_cast<T>(0));
 }
 
-inline size_t find_nonzero(const std::vector<uint8_t>& list, size_t start) {
-    return find_byte<uint8_t>(list, start, 1);
+template <typename Container, typename T = Container::value_type>
+inline size_t find_zero(const Container& list, size_t start, size_t count) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
+                  "only 8-bit integral types are supported");
+    return find_byte(list, start, count, static_cast<T>(0));
 }
 
-inline size_t find_nonzero(const std::vector<uint8_t>& list, size_t start, size_t count) {
-    return find_byte<uint8_t>(list, start, count, 1);
+template <typename Container, typename T = Container::value_type>
+inline size_t find_nonzero(const Container& list, size_t start) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
+                  "only 8-bit integral types are supported");
+    return find_byte(list, start, static_cast<T>(1));
 }
 
-inline size_t find_zero(const std::vector<int8_t>& list, size_t start) {
-    return find_byte<int8_t>(list, start, 0);
+template <typename Container, typename T = Container::value_type>
+inline size_t find_nonzero(const Container& list, size_t start, size_t count) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
+                  "only 8-bit integral types are supported");
+    return find_byte(list, start, count, static_cast<T>(1));
 }
 
-inline size_t find_zero(const std::vector<uint8_t>& list, size_t start, size_t count) {
-    return find_byte<uint8_t>(list, start, count, 0);
-}
-
-inline bool contain_zero(const std::vector<uint8_t>& list) {
+template <typename Container, typename T = Container::value_type>
+inline bool contain_zero(const Container& list) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
+                  "only 8-bit integral types are supported");
     return find_zero(list, 0) < list.size();
 }
 
-inline bool contain_nonzero(const std::vector<uint8_t>& list) {
+template <typename Container, typename T = Container::value_type>
+inline bool contain_nonzero(const Container& list) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
+                  "only 8-bit integral types are supported");
     return find_nonzero(list, 0) < list.size();
 }
 
-inline bool contain_nonzero(const std::vector<uint8_t>& list, size_t start) {
+template <typename Container, typename T = Container::value_type>
+inline bool contain_nonzero(const Container& list, size_t start) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
+                  "only 8-bit integral types are supported");
     return find_nonzero(list, start) < list.size();
 }
 
-inline bool contain_nonzero(const std::vector<uint8_t>& list, size_t start, size_t count) {
+template <typename Container, typename T = Container::value_type>
+inline bool contain_nonzero(const Container& list, size_t start, size_t count) {
+    static_assert(std::is_integral<T>::value && (sizeof(T) == sizeof(uint8_t)),
+                  "only 8-bit integral types are supported");
     size_t pos = find_nonzero(list, start, count);
     return pos < list.size() && pos < start + count;
 }

--- a/be/src/storage/column_in_predicate.cpp
+++ b/be/src/storage/column_in_predicate.cpp
@@ -387,7 +387,7 @@ public:
     template <LogicOp Op>
     inline void t_evaluate(const Column* column, uint8_t* sel, uint16_t from, uint16_t to) const {
         const Int32Column* dict_code_column = down_cast<const Int32Column*>(ColumnHelper::get_data_column(column));
-        std::vector<int32_t> data = dict_code_column->get_data();
+        const auto& data = dict_code_column->get_data();
         Filter filter(to - from, 1);
 
         if (column->has_null()) {

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -846,7 +846,7 @@ Status DeltaWriter::_fill_auto_increment_id(const Chunk& chunk) {
     // 2. probe index
     RETURN_IF_ERROR(_tablet->updates()->get_rss_rowids_by_pk(_tablet.get(), *upserts, nullptr, &rss_rowids));
 
-    std::vector<uint8_t> filter;
+    Filter filter;
     uint32_t gen_num = 0;
     for (unsigned long v : rss_rowids) {
         uint32_t rssid = v >> 32;

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -566,7 +566,7 @@ Status DeltaWriterImpl::fill_auto_increment_id(const Chunk& chunk) {
         st = tablet.update_mgr()->get_rowids_from_pkindex(tablet.id(), metadata->version(), upserts, &rss_rowids, true);
     }
 
-    std::vector<uint8_t> filter;
+    Filter filter;
     uint32_t gen_num = 0;
     // There are two cases we should allocate full id for this chunk for simplicity:
     // 1. We can not get the tablet meta from cache.

--- a/be/src/storage/row_source_mask.cpp
+++ b/be/src/storage/row_source_mask.cpp
@@ -143,7 +143,7 @@ Status RowSourceMaskBuffer::_serialize_masks() {
         PLOG(WARNING) << "fail to write masks size to mask file. write size=" << w_size;
         return Status::InternalError("fail to write masks size to mask file");
     }
-    const std::vector<uint16_t>& data = _mask_column->get_data();
+    const auto& data = _mask_column->get_data();
     w_size = ::write(_tmp_file_fd, data.data(), data.size() * sizeof(data[0]));
     if (w_size != data.size() * sizeof(data[0])) {
         PLOG(WARNING) << "fail to write masks to mask file. write size=" << w_size;
@@ -162,7 +162,7 @@ Status RowSourceMaskBuffer::_deserialize_masks() {
         return Status::InternalError("fail to read masks size from mask file");
     }
 
-    std::vector<uint16_t> content;
+    Buffer<uint16_t> content;
     raw::stl_vector_resize_uninitialized(&content, num_rows);
     r_size = ::read(_tmp_file_fd, content.data(), content.size() * sizeof(content[0]));
     if (r_size != content.size() * sizeof(content[0])) {

--- a/be/src/storage/rowset/binary_prefix_page.cpp
+++ b/be/src/storage/rowset/binary_prefix_page.cpp
@@ -304,25 +304,25 @@ Status BinaryPrefixPageDecoder<Type>::next_batch(const SparseRange<>& range, Col
     if constexpr (Type == TYPE_CHAR) {
         while (to_read > 0) {
             RETURN_IF_ERROR(seek_to_position_in_page(iter.begin()));
-            bool ok = dst->append_strings({_current_value});
+            bool ok = dst->append_strings(std::vector<Slice>{_current_value});
             DCHECK(ok);
             Range<> r = iter.next(to_read);
             for (size_t i = 1; i < r.span_size(); ++i) {
                 RETURN_IF_ERROR(_next_value(&_current_value));
                 size_t len = strnlen(reinterpret_cast<const char*>(_current_value.data()), _current_value.size());
-                (void)dst->append_strings({Slice(_current_value.data(), len)});
+                (void)dst->append_strings(std::vector<Slice>{Slice(_current_value.data(), len)});
             }
             to_read -= r.span_size();
         }
     } else {
         while (to_read > 0) {
             RETURN_IF_ERROR(seek_to_position_in_page(iter.begin()));
-            bool ok = dst->append_strings({_current_value});
+            bool ok = dst->append_strings(std::vector<Slice>{_current_value});
             DCHECK(ok);
             Range<> r = iter.next(to_read);
             for (size_t i = 1; i < r.span_size(); ++i) {
                 RETURN_IF_ERROR(_next_value(&_current_value));
-                (void)dst->append_strings({_current_value});
+                (void)dst->append_strings(std::vector<Slice>{_current_value});
             }
             to_read -= r.span_size();
         }

--- a/be/src/testutil/column_test_helper.h
+++ b/be/src/testutil/column_test_helper.h
@@ -37,7 +37,7 @@ public:
             return data;
         } else if constexpr (std::is_same_v<T, Slice>) {
             auto data = BinaryColumn::create();
-            data->append_strings(values);
+            data->append_strings(values.data(), values.size());
             return data;
         } else if constexpr (std::is_same_v<T, double>) {
             auto data = DoubleColumn ::create();

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -869,7 +869,7 @@ std::string BitmapValue::to_string() const {
 }
 
 // Append values to array
-void BitmapValue::to_array(std::vector<int64_t>* array) const {
+void BitmapValue::to_array(Buffer<int64_t>* array) const {
     switch (_type) {
     case EMPTY:
         break;

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -47,6 +47,7 @@
 #include <string>
 #include <utility>
 
+#include "column/vectorized_fwd.h"
 #include "common/config.h"
 #include "common/logging.h"
 #include "types/bitmap_value_detail.h"
@@ -175,7 +176,7 @@ public:
     std::string to_string() const;
 
     // Append values to array
-    void to_array(std::vector<int64_t>* array) const;
+    void to_array(Buffer<int64_t>* array) const;
 
     size_t serialize(uint8_t* dst) const;
 

--- a/be/src/util/raw_container.h
+++ b/be/src/util/raw_container.h
@@ -20,6 +20,8 @@
 #include <utility>
 #include <vector>
 
+#include "runtime/memory/column_allocator.h"
+
 namespace starrocks::raw {
 
 // RawAllocator allocates `trailing` more object(not bytes) than caller required,
@@ -154,11 +156,14 @@ using RawVector = std::vector<T, RawAllocator<T, 0>>;
 template <class T>
 using RawVectorPad16 = std::vector<T, RawAllocator<T, 16>>;
 
-template <class T>
-inline void make_room(std::vector<T>* v, size_t n) {
+template <typename Container, typename T = Container::value_type>
+inline typename std::enable_if<
+        std::is_same<Container, std::vector<typename Container::value_type, typename Container::allocator_type>>::value,
+        void>::type
+make_room(Container* v, size_t n) {
     RawVector<T> rv;
     rv.resize(n);
-    v->swap(reinterpret_cast<std::vector<T>&>(rv));
+    v->swap(reinterpret_cast<Container&>(rv));
 }
 
 inline void make_room(std::string* s, size_t n) {
@@ -167,8 +172,11 @@ inline void make_room(std::string* s, size_t n) {
     s->swap(reinterpret_cast<std::string&>(rs));
 }
 
-template <typename T>
-inline void stl_vector_resize_uninitialized(std::vector<T>* vec, size_t new_size) {
+template <typename Container, typename T = Container::value_type>
+inline typename std::enable_if<
+        std::is_same<Container, std::vector<typename Container::value_type, typename Container::allocator_type>>::value,
+        void>::type
+stl_vector_resize_uninitialized(Container* vec, size_t new_size) {
     ((RawVector<T>*)vec)->resize(new_size);
 }
 

--- a/be/src/util/raw_container.h
+++ b/be/src/util/raw_container.h
@@ -156,7 +156,7 @@ using RawVector = std::vector<T, RawAllocator<T, 0>>;
 template <class T>
 using RawVectorPad16 = std::vector<T, RawAllocator<T, 16>>;
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline typename std::enable_if<
         std::is_same<Container, std::vector<typename Container::value_type, typename Container::allocator_type>>::value,
         void>::type
@@ -172,7 +172,7 @@ inline void make_room(std::string* s, size_t n) {
     s->swap(reinterpret_cast<std::string&>(rs));
 }
 
-template <typename Container, typename T = Container::value_type>
+template <typename Container, typename T = typename Container::value_type>
 inline typename std::enable_if<
         std::is_same<Container, std::vector<typename Container::value_type, typename Container::allocator_type>>::value,
         void>::type

--- a/be/test/column/avx_numeric_column.h
+++ b/be/test/column/avx_numeric_column.h
@@ -22,7 +22,7 @@
 namespace starrocks {
 class AvxNumericColumn {
 public:
-    void avx256_filter(const std::vector<int32_t>& data, const std::vector<uint8_t>& filter, size_t result_size_hint,
+    void avx256_filter(const std::vector<int32_t>& data, const Filter& filter, size_t result_size_hint,
                        std::vector<int32_t>& result) {
         const int32_t* d_data = data.data();
         const uint8_t* f_data = filter.data();

--- a/be/test/column/avx_numeric_column_test.cpp
+++ b/be/test/column/avx_numeric_column_test.cpp
@@ -26,7 +26,7 @@ static int max_size = 20480 * 2;
 
 TEST(AvxTest, seqFilterTest) {
     std::vector<int32_t> data;
-    std::vector<uint8_t> filter;
+    Filter filter;
 
     for (int i = 0; i < max_size / 2; ++i) {
         data.push_back(i);
@@ -59,7 +59,7 @@ TEST(AvxTest, seqFilterTest) {
 
 TEST(AvxTest, seqProgmaFilterTest) {
     std::vector<int32_t> data;
-    std::vector<uint8_t> filter;
+    Filter filter;
 
     for (int i = 0; i < max_size / 2; ++i) {
         data.push_back(i);
@@ -92,7 +92,7 @@ TEST(AvxTest, seqProgmaFilterTest) {
 
 TEST(AvxTest, seqAvxFilterTest) {
     std::vector<int32_t> data;
-    std::vector<uint8_t> filter;
+    Filter filter;
 
     for (int i = 0; i < max_size / 2; ++i) {
         data.push_back(i);
@@ -124,7 +124,7 @@ TEST(AvxTest, seqAvxFilterTest) {
 
 TEST(AvxTest, randomFilterTest) {
     std::vector<int32_t> data;
-    std::vector<uint8_t> filter;
+    Filter filter;
 
     for (int i = 0; i < max_size; ++i) {
         data.push_back(i);
@@ -152,7 +152,7 @@ TEST(AvxTest, randomFilterTest) {
 
 TEST(AvxTest, randomProgmaFilterTest) {
     std::vector<int32_t> data;
-    std::vector<uint8_t> filter;
+    Filter filter;
 
     for (int i = 0; i < max_size; ++i) {
         data.push_back(i);
@@ -180,7 +180,7 @@ TEST(AvxTest, randomProgmaFilterTest) {
 
 TEST(AvxTest, randomAvxFilterTest) {
     std::vector<int32_t> data;
-    std::vector<uint8_t> filter;
+    Filter filter;
 
     for (int i = 0; i < max_size; ++i) {
         data.push_back(i);

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -142,7 +142,7 @@ PARALLEL_TEST(BinaryColumnTest, test_filter) {
     column->filter(filter);
     ASSERT_EQ(50, column->size());
 
-    std::vector<Slice>& slices = column->get_data();
+    const auto& slices = column->get_data();
 
     for (int i = 0; i < 50; ++i) {
         ASSERT_EQ(std::to_string(i * 2 + 1), slices[i].to_string());
@@ -153,7 +153,7 @@ PARALLEL_TEST(BinaryColumnTest, test_filter) {
 PARALLEL_TEST(BinaryColumnTest, test_append_strings) {
     std::vector<Slice> values{{"hello"}, {"starrocks"}};
     auto c1 = BinaryColumn::create();
-    ASSERT_TRUE(c1->append_strings(values));
+    ASSERT_TRUE(c1->append_strings(values.data(), values.size()));
     ASSERT_EQ(values.size(), c1->size());
     for (size_t i = 0; i < values.size(); i++) {
         ASSERT_EQ(values[i], c1->get_data()[i]);
@@ -161,7 +161,7 @@ PARALLEL_TEST(BinaryColumnTest, test_append_strings) {
 
     // Nullable BinaryColumn
     auto c2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    ASSERT_TRUE(c2->append_strings(values));
+    ASSERT_TRUE(c2->append_strings(values.data(), values.size()));
     ASSERT_EQ(values.size(), c2->size());
     auto* c = reinterpret_cast<BinaryColumn*>(c2->mutable_data_column());
     for (size_t i = 0; i < values.size(); i++) {
@@ -219,8 +219,8 @@ PARALLEL_TEST(BinaryColumnTest, test_compare_at) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
     auto c1 = BinaryColumn::create();
     auto c2 = BinaryColumn::create();
-    c1->append_strings(strings);
-    c2->append_strings(strings);
+    c1->append_strings(strings.data(), strings.size());
+    c2->append_strings(strings.data(), strings.size());
     for (size_t i = 0; i < strings.size(); i++) {
         ASSERT_EQ(0, c1->compare_at(i, i, *c2, -1));
         ASSERT_EQ(0, c2->compare_at(i, i, *c1, -1));
@@ -317,8 +317,8 @@ PARALLEL_TEST(BinaryColumnTest, test_assign) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
     auto c1 = BinaryColumn::create();
     auto c2 = BinaryColumn::create();
-    c1->append_strings(strings);
-    c2->append_strings(strings);
+    c1->append_strings(strings.data(), strings.size());
+    c2->append_strings(strings.data(), strings.size());
 
     c1->assign(c1->size(), 0);
     for (size_t i = 0; i < strings.size(); i++) {
@@ -335,7 +335,7 @@ PARALLEL_TEST(BinaryColumnTest, test_assign) {
 PARALLEL_TEST(BinaryColumnTest, test_reset_column) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
     auto c1 = BinaryColumn::create();
-    c1->append_strings(strings);
+    c1->append_strings(strings.data(), strings.size());
     c1->set_delete_state(DEL_PARTIAL_SATISFIED);
 
     c1->reset_column();
@@ -348,7 +348,7 @@ PARALLEL_TEST(BinaryColumnTest, test_reset_column) {
 PARALLEL_TEST(BinaryColumnTest, test_swap_column) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
     auto c1 = BinaryColumn::create();
-    c1->append_strings(strings);
+    c1->append_strings(strings.data(), strings.size());
     c1->set_delete_state(DEL_PARTIAL_SATISFIED);
 
     auto c2 = BinaryColumn::create();

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -168,7 +168,7 @@ TEST(FixedLengthColumnTest, test_append_strings) {
     auto c1 = Int32Column::create();
     auto nullable_c1 = NullableColumn::create(c1, NullColumn::create());
     ASSERT_FALSE(c1->append_strings(values));
-    ASSERT_FALSE(nullable_c1->append_strings(values));
+    ASSERT_FALSE(nullable_c1->append_strings(values.data(), values.size()));
 }
 
 // NOLINTNEXTLINE
@@ -633,7 +633,7 @@ TEST(FixedLengthColumnTest, test_fill_range) {
     ASSERT_EQ(values.size(), c1->size());
 
     std::vector<int64_t> ids{0, 0, 0};
-    std::vector<uint8_t> filter{1, 0, 1, 0, 1};
+    Filter filter{1, 0, 1, 0, 1};
     ASSERT_TRUE(c1->fill_range(ids, filter).ok());
 
     auto* p = reinterpret_cast<const int64_t*>(c1->raw_data());

--- a/be/test/column/object_column_test.cpp
+++ b/be/test/column/object_column_test.cpp
@@ -189,7 +189,7 @@ TEST(ObjectColumnTest, HLL_test_reset_column) {
     c->append(HyperLogLog());
     c->append(HyperLogLog());
     c->append(HyperLogLog());
-    const std::vector<HyperLogLog*>& data = c->get_data();
+    const auto& data = c->get_data();
     ASSERT_EQ(3, data.size());
     c->set_delete_state(DEL_PARTIAL_SATISFIED);
 

--- a/be/test/exec/agg_hash_map_test.cpp
+++ b/be/test/exec/agg_hash_map_test.cpp
@@ -200,7 +200,7 @@ public:
         return col;
     };
 
-    void CheckNotFounds(const std::vector<uint8_t>& not_founds, const std::vector<uint8_t>& exp_datas) {
+    void CheckNotFounds(const Filter& not_founds, const std::vector<uint8_t>& exp_datas) {
         DCHECK_EQ(not_founds.size(), exp_datas.size());
         for (auto i = 0; i < not_founds.size(); i++) {
             VLOG_ROW << "i:" << i << ", not_found:" << (int)not_founds[i] << ", expect:" << (int)exp_datas[i];
@@ -219,7 +219,8 @@ public:
         TestAggHashMapKey key(chunk_size, &statis);
         Buffer<AggDataPtr> agg_states(chunk_size);
         MemPool pool;
-        std::vector<uint8_t> not_founds;
+        Filter not_founds;
+
         // For fixed size key, need set key's fixed size
         if constexpr (std::is_same_v<TestAggHashMapKey,
                                      AggHashMapWithSerializedKeyFixedSize<FixedSize16SliceAggHashMap<PhmapSeed1>>>) {

--- a/be/test/exec/chunks_sorter_test.cpp
+++ b/be/test/exec/chunks_sorter_test.cpp
@@ -1040,8 +1040,8 @@ TEST_F(ChunksSorterTest, find_zero) {
 }
 
 TEST_F(ChunksSorterTest, test_compare_column) {
-    std::vector<int8_t> cmp_vector;
-    std::vector<Datum> rhs_values;
+    CompareVector cmp_vector;
+    Buffer<Datum> rhs_values;
 
     rhs_values.emplace_back(int32_t(1));
 
@@ -1059,7 +1059,7 @@ TEST_F(ChunksSorterTest, test_compare_column) {
     desc_null_last.descs.emplace_back(false, false);
     compare_columns(Columns{nullable_column}, cmp_vector, rhs_values, desc_null_last);
 
-    std::vector<int8_t> expected = {0, -1, 1, 1};
+    CompareVector expected = {0, -1, 1, 1};
     EXPECT_EQ(cmp_vector, expected);
 
     // test asc null last

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -100,7 +100,7 @@ protected:
     void check_empty_hash_map(TJoinOp::type join_type, int num_probe_rows, int32_t expect_num_rows,
                               int32_t expect_num_colums);
 
-    void sort_results_from_coroutine(std::vector<uint32_t>& pid, std::vector<uint32_t>& bid, int size) {
+    void sort_results_from_coroutine(Buffer<uint32_t>& pid, Buffer<uint32_t>& bid, int size) {
         std::vector<std::pair<int, int>> zipped;
         for (auto i = 0; i < size; i++) {
             zipped.push_back(std::make_pair(pid[i], bid[i]));

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -138,7 +138,7 @@ template <>
 ColumnPtr gen_input_column1<Slice>() {
     auto column = BinaryColumn::create();
     std::vector<Slice> strings{{"ddd"}, {"ddd"}, {"eeeee"}, {"ff"}, {"ff"}, {"ddd"}};
-    column->append_strings(strings);
+    column->append_strings(strings.data(), strings.size());
     return column;
 }
 
@@ -146,7 +146,7 @@ template <>
 ColumnPtr gen_input_column2<Slice>() {
     auto column2 = BinaryColumn::create();
     std::vector<Slice> strings2{{"kkk"}, {"k"}, {"kk"}, {"kkk"}};
-    column2->append_strings(strings2);
+    column2->append_strings(strings2.data(), strings2.size());
     return column2;
 }
 
@@ -688,7 +688,7 @@ TEST_F(AggregateTest, test_maxby) {
     }
     auto varchar_column = BinaryColumn::create();
     std::vector<Slice> strings{{"aaa"}, {"ddd"}, {"zzzz"}, {"ff"}, {"ff"}, {"ddd"}, {"ddd"}, {"ddd"}, {"ddd"}, {""}};
-    varchar_column->append_strings(strings);
+    varchar_column->append_strings(strings.data(), strings.size());
     Columns columns;
     columns.emplace_back(int_column);
     columns.emplace_back(varchar_column);
@@ -744,7 +744,7 @@ TEST_F(AggregateTest, test_minby) {
     }
     auto varchar_column = BinaryColumn::create();
     std::vector<Slice> strings{{"ccc"}, {"aaa"}, {"ddd"}, {"zzzz"}, {"ff"}, {"ff"}, {"ddd"}, {"ddd"}, {"ddd"}, {"ddd"}};
-    varchar_column->append_strings(strings);
+    varchar_column->append_strings(strings.data(), strings.size());
     Columns columns;
     columns.emplace_back(int_column);
     columns.emplace_back(varchar_column);
@@ -804,7 +804,7 @@ TEST_F(AggregateTest, test_maxby_with_nullable_aggregator) {
     }
     auto varchar_column = BinaryColumn::create();
     std::vector<Slice> strings{{"aaa"}, {"ddd"}, {"zzzz"}, {"ff"}, {"ff"}, {"ddd"}, {"ddd"}, {"ddd"}, {"ddd"}, {""}};
-    varchar_column->append_strings(strings);
+    varchar_column->append_strings(strings.data(), strings.size());
     Columns columns;
     columns.emplace_back(int_column);
     columns.emplace_back(varchar_column);
@@ -869,7 +869,7 @@ TEST_F(AggregateTest, test_minby_with_nullable_aggregator) {
     }
     auto varchar_column = BinaryColumn::create();
     std::vector<Slice> strings{{"xxx"}, {"aaa"}, {"ddd"}, {"zzzz"}, {"ff"}, {"ff"}, {"ddd"}, {"ddd"}, {"ddd"}, {"ddd"}};
-    varchar_column->append_strings(strings);
+    varchar_column->append_strings(strings.data(), strings.size());
     Columns columns;
     columns.emplace_back(int_column);
     columns.emplace_back(varchar_column);

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -1140,11 +1140,11 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSingle) {
         auto v = std::static_pointer_cast<BitmapColumn>(ptr);
         ASSERT_EQ(10, v->size());
 
-        std::vector<int64_t> expect_array;
+        Buffer<int64_t> expect_array;
         expect_array.push_back(1);
 
         for (int j = 0; j < v->size(); ++j) {
-            std::vector<int64_t> array;
+            Buffer<int64_t> array;
             v->get_data()[j]->to_array(&array);
             ASSERT_EQ(expect_array, array);
         }
@@ -1213,12 +1213,12 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapSet) {
         auto v = std::static_pointer_cast<BitmapColumn>(ptr);
         ASSERT_EQ(10, v->size());
 
-        std::vector<int64_t> expect_array;
+        Buffer<int64_t> expect_array;
         expect_array.push_back(1);
         expect_array.push_back(2);
 
         for (int j = 0; j < v->size(); ++j) {
-            std::vector<int64_t> array;
+            Buffer<int64_t> array;
             v->get_data()[j]->to_array(&array);
             ASSERT_EQ(expect_array, array);
         }
@@ -1290,13 +1290,13 @@ TEST_F(VectorizedCastExprTest, stringCastBitmapMap) {
         auto v = std::static_pointer_cast<BitmapColumn>(ptr);
         ASSERT_EQ(10, v->size());
 
-        std::vector<int64_t> expect_array;
+        Buffer<int64_t> expect_array;
         expect_array.push_back(1);
         expect_array.push_back(342);
         expect_array.push_back(2222);
 
         for (int j = 0; j < v->size(); ++j) {
-            std::vector<int64_t> array;
+            Buffer<int64_t> array;
             v->get_data()[j]->to_array(&array);
             ASSERT_EQ(expect_array, array);
         }

--- a/be/test/formats/csv/string_converter_test.cpp
+++ b/be/test/formats/csv/string_converter_test.cpp
@@ -199,7 +199,8 @@ TEST_F(StringConverterTest, test_read_large_quoted_string04) {
 TEST_F(StringConverterTest, test_write_string) {
     auto conv = csv::get_converter(_type, false);
     auto col = ColumnHelper::create_column(_type, false);
-    (void)col->append_strings({"aaaaaaaaaaaa", "bbbbbbbb", "\"\"", "ccccc"});
+    std::vector<Slice> strings = {"aaaaaaaaaaaa", "bbbbbbbb", "\"\"", "ccccc"};
+    (void)col->append_strings(strings.data(), strings.size());
 
     csv::OutputStreamString buff;
     ASSERT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());

--- a/be/test/formats/csv/varbinary_converter_test.cpp
+++ b/be/test/formats/csv/varbinary_converter_test.cpp
@@ -100,7 +100,7 @@ TEST_F(VarBinaryConverterTest, test_read_large_binary02) {
 TEST_F(VarBinaryConverterTest, test_write_string) {
     auto conv = csv::get_converter(_type, false);
     auto col = ColumnHelper::create_column(_type, false);
-    (void)col->append_strings({"aaaaaaaaaaaa", "bbbbbbbb", "", "ccccc"});
+    (void)col->append_strings(std::vector<Slice>{"aaaaaaaaaaaa", "bbbbbbbb", "", "ccccc"});
 
     csv::OutputStreamString buff;
     EXPECT_TRUE(conv->write_string(&buff, *col, 0, Converter::Options()).ok());

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -498,8 +498,8 @@ TEST_F(OrcChunkReaderTest, SkipRowGroups) {
 }
 
 template <int ORC_PRECISION, int ORC_SCALE, typename ValueType>
-std::vector<DecimalV2Value> convert_orc_to_starrocks_decimalv2(RuntimeState* state, ObjectPool* pool,
-                                                               const std::vector<ValueType>& values) {
+Buffer<DecimalV2Value> convert_orc_to_starrocks_decimalv2(RuntimeState* state, ObjectPool* pool,
+                                                          const Buffer<ValueType>& values) {
     std::cout << "orc precision=" << ORC_PRECISION << " scale=" << ORC_SCALE << std::endl;
     if constexpr (std::is_same_v<ValueType, int64_t>) {
         static_assert(ORC_PRECISION <= 18);
@@ -579,7 +579,7 @@ std::vector<DecimalV2Value> convert_orc_to_starrocks_decimalv2(RuntimeState* sta
 }
 
 TEST_F(OrcChunkReaderTest, TestDecimal64) {
-    const std::vector<int64_t> orc_values = {
+    const Buffer<int64_t> orc_values = {
             0,
             1,
             -1,
@@ -593,7 +593,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal64) {
             999'999'999'000'000'000,
     };
 
-    auto check_results = [](const std::vector<const char*>& exp, const std::vector<DecimalV2Value>& real) {
+    auto check_results = [](const Buffer<const char*>& exp, const Buffer<DecimalV2Value>& real) {
         ASSERT_EQ(exp.size(), real.size());
         for (int i = 0; i < exp.size(); i++) {
             EXPECT_EQ(exp[i], real[i].to_string());
@@ -602,7 +602,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal64) {
 
     ObjectPool pool;
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "0.000000001",
                 "-0.000000001",
@@ -619,7 +619,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal64) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",           "0.00000001",           "-0.00000001", "0.00000123",          "1230",
                 "-9.99999999", "-9999999999.99999999", "9.99999999",  "9999999999.99999999", "10",
                 "9999999990",
@@ -628,7 +628,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal64) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "0.0000001",
                 "-0.0000001",
@@ -645,7 +645,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal64) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "1",
                 "-1",
@@ -662,7 +662,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal64) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "0",
                 "0",
@@ -679,7 +679,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal64) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "0",
                 "0",
@@ -696,7 +696,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal64) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",           "0",           "0",          "0",          "0.00000123", "-0.000000009", "-9.999999999",
                 "0.000000009", "9.999999999", "0.00000001", "9.99999999",
         };
@@ -706,7 +706,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal64) {
 }
 
 TEST_F(OrcChunkReaderTest, TestDecimal128) {
-    const std::vector<int128_t> orc_values = {
+    const Buffer<int128_t> orc_values = {
             (int128_t)0,
             (int128_t)1,
             (int128_t)-1,
@@ -722,7 +722,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
             (int128_t)999'999'999'000'000'000,
     };
 
-    auto check_results = [](const std::vector<const char*>& exp, const std::vector<DecimalV2Value>& real) {
+    auto check_results = [](const Buffer<const char*>& exp, const Buffer<DecimalV2Value>& real) {
         ASSERT_EQ(exp.size(), real.size());
         for (int i = 0; i < exp.size(); i++) {
             EXPECT_EQ(exp[i], real[i].to_string());
@@ -731,7 +731,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
 
     ObjectPool pool;
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "0.000000001",
                 "-0.000000001",
@@ -748,7 +748,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "0.00000001",
                 "-0.00000001",
@@ -765,7 +765,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "0.0000001",
                 "-0.0000001",
@@ -782,7 +782,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "1",
                 "-1",
@@ -799,7 +799,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "0",
                 "0",
@@ -816,7 +816,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0",
                 "0",
                 "0",
@@ -833,7 +833,7 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
         check_results(exp, real);
     }
     {
-        std::vector<const char*> exp = {
+        Buffer<const char*> exp = {
                 "0", "0", "0", "0", "0", "0", "-9.999999999", "0", "9.999999999", "0", "0.000000009",
         };
         auto real = convert_orc_to_starrocks_decimalv2<27, 26>(_runtime_state.get(), &pool, orc_values);
@@ -841,11 +841,9 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
     }
 }
 
-std::vector<TimestampValue> convert_orc_to_starrocks_timestamp(RuntimeState* state, ObjectPool* pool,
-                                                               const std::string& reader_tz,
-                                                               const std::string& write_tz,
-                                                               const std::vector<int64_t>& values,
-                                                               const bool isInstant) {
+Buffer<TimestampValue> convert_orc_to_starrocks_timestamp(RuntimeState* state, ObjectPool* pool,
+                                                          const std::string& reader_tz, const std::string& write_tz,
+                                                          const Buffer<int64_t>& values, const bool isInstant) {
     const char* filename = "orc_scanner_test_timestamp.orc";
     std::filesystem::remove(filename);
     ORC_UNIQUE_PTR<orc::OutputStream> outStream = orc::writeLocalFile(filename);
@@ -917,7 +915,7 @@ std::vector<TimestampValue> convert_orc_to_starrocks_timestamp(RuntimeState* sta
 
 TEST_F(OrcChunkReaderTest, TestTimestamp) {
     // clang-format off
-    const std::vector<int64_t> orc_values = {
+    const Buffer<int64_t> orc_values = {
             // 2021.5.25 1:18:40 GMT
             // 2021.5.25 9:18:40 Asia/Shanghai
             1621905520,
@@ -935,7 +933,7 @@ TEST_F(OrcChunkReaderTest, TestTimestamp) {
     // clang-format on
     {
         // Instant Timestamp
-        const std::vector<std::string> exp_values = {
+        const Buffer<std::string> exp_values = {
                 "2021-05-25 09:18:40",
                 "1970-01-01 08:00:00",
                 "1702-06-01 04:01:35",
@@ -952,7 +950,7 @@ TEST_F(OrcChunkReaderTest, TestTimestamp) {
     {
         // Timestamp
         // Instant Timestamp
-        const std::vector<std::string> exp_values = {
+        const Buffer<std::string> exp_values = {
                 "2021-05-25 01:18:40",
                 "1970-01-01 00:00:00",
                 "1702-05-31 19:55:52",

--- a/be/test/serde/column_array_serde_test.cpp
+++ b/be/test/serde/column_array_serde_test.cpp
@@ -220,7 +220,7 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
     auto c1 = BinaryColumn::create();
     auto c2 = BinaryColumn::create();
-    c1->append_strings(strings);
+    c1->append_strings(strings.data(), strings.size());
 
     ASSERT_EQ(c1->byte_size() + sizeof(uint32_t) * 2, ColumnArraySerde::max_serialized_size(*c1));
 
@@ -247,7 +247,7 @@ PARALLEL_TEST(ColumnArraySerdeTest, large_binary_column) {
     std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
     auto c1 = LargeBinaryColumn::create();
     auto c2 = LargeBinaryColumn::create();
-    c1->append_strings(strings);
+    c1->append_strings(strings.data(), strings.size());
 
     ASSERT_EQ(c1->byte_size() + sizeof(uint64_t) * 2, ColumnArraySerde::max_serialized_size(*c1));
 

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -475,7 +475,7 @@ protected:
         nc->reserve(count);
         down_cast<BinaryColumn*>(nc->data_column().get())->get_data().reserve(count * s1.size());
         for (size_t i = 0; i < count; i += 8) {
-            (void)col->append_strings({s1, s2, s3, s4, s5, s6, s7, s8});
+            (void)col->append_strings(std::vector<Slice>{s1, s2, s3, s4, s5, s6, s7, s8});
 
             std::next_permutation(s1.begin(), s1.end());
             std::next_permutation(s2.begin(), s2.end());

--- a/be/test/types/bitmap_value_test.cpp
+++ b/be/test/types/bitmap_value_test.cpp
@@ -719,23 +719,23 @@ TEST_F(BitmapValueTest, bitmap_to_string) {
 }
 
 TEST_F(BitmapValueTest, bitmap_to_array) {
-    std::vector<int64_t> array_1;
+    Buffer<int64_t> array_1;
     _empty_bitmap.to_array(&array_1);
     ASSERT_EQ(array_1.size(), 0);
 
-    std::vector<int64_t> array_2;
+    Buffer<int64_t> array_2;
     _single_bitmap.to_array(&array_2);
     ASSERT_EQ(array_2.size(), 1);
     ASSERT_EQ(array_2[0], 0);
 
-    std::vector<int64_t> array_3;
+    Buffer<int64_t> array_3;
     _medium_bitmap.to_array(&array_3);
     ASSERT_EQ(array_3.size(), 14);
     for (size_t i = 0; i < 14; i++) {
         ASSERT_EQ(array_3[i], i);
     }
 
-    std::vector<int64_t> array_4;
+    Buffer<int64_t> array_4;
     _large_bitmap.to_array(&array_4);
     ASSERT_EQ(array_4.size(), 64);
     for (size_t i = 0; i < 64; i++) {
@@ -743,7 +743,7 @@ TEST_F(BitmapValueTest, bitmap_to_array) {
     }
 
     // append multi times
-    std::vector<int64_t> array_5;
+    Buffer<int64_t> array_5;
     _large_bitmap.to_array(&array_5);
     ASSERT_EQ(array_5.size(), 64);
 


### PR DESCRIPTION
## Why I'm doing:

After introducing Allocator, we can accurately count the memory of most `AggregateState`, but `group_concat/array_agg` cannot do this because their state contains Column, and there is no low-cost way to get the memory usage of Column (the overhead of frequent calls to the `memory_usage` interface is too high).

## What I'm doing:

In this pr, I introduced an allocator for column buffer to solve the above problems.

Main changes:

1. introduce `ColumnAllocator` which is  compatible with stl containers as the memory allocator of Buffer. It allocates memory through MemHookAllocator by default, and the behavior remains the same as before.In the future, we can set tls_column_allocator in a specific code block to count the memory changes of Column

2. change the Buffer type from `std::vector<T>` to `std::vector<T, ColumnAllocator>`

since `std::vector<T>` and `std::vector<T, Alloc>` are considered different types by the compiler, some refactoring work need to  be done to make some interfaces compatible with the processing of these two types:

1. refactored the relevant interfaces in `simd.h` and `raw_container.h` using template

2. column-related changes:

- change the original append_selective, append_strings, append_strings_overflow, and append_continuous_strings to non-virtual template functions so that they can handle different types of containers and maintain compatibility with existing usage scenario

-  remove some unnecessary function overrides, such as `MapColumn::append_strings`

Other works: 

1. fix some unreasonable alias usage, such as the type of `col_type` in `nljoin_probe_operator.h`, which should use `std::vector` instead of `Buffer`

2. when using `Filter`, try to use `Filter` alias instead of `std::vector<uint8_t>`, which will facilitate replacing Buffer implementation in the future.

## TODO

after this change is applied, in the short term, I will support memory counting for `array_agg/group_concat` state.

In the  long term, we can replace Buffer with our own implementation to better manage memory



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
