### PR TITLE
[BugFix] Fix BDBJE handshake bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -199,7 +199,7 @@ public class BDBEnvironment {
         replicationConfig
                 .setConfigParam(ReplicationConfig.REPLICA_TIMEOUT, Config.bdbje_heartbeat_timeout_second + " s");
         replicationConfig
-                .setConfigParam(ReplicationConfig.FEEDER_TIMEOUT, (10 + Config.bdbje_heartbeat_timeout_second) + " s");
+                .setConfigParam(ReplicationConfig.FEEDER_TIMEOUT, Config.bdbje_heartbeat_timeout_second + " s");
         replicationConfig
                 .setConfigParam(ReplicationConfig.REPLAY_COST_PERCENT,
                         String.valueOf(Config.bdbje_replay_cost_percent));

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -299,7 +299,7 @@ under the License.
             <dependency>
                 <groupId>com.starrocks</groupId>
                 <artifactId>starrocks-bdb-je</artifactId>
-                <version>18.3.18</version>
+                <version>18.3.19</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/de.jflex/jflex -->


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Upgrade starrocks-bdb-je version to 18.3.19.
Change the FEEDER_TIMEOUT same to REPLICA_TIMEOUT. PR #21274 tried to fix the bug by setting different values, but it didn't work.

Fixes #
```
A replica with the name: xxx is already active with the Feeder:null HANDSHAKE_ERROR: Error during the handshake between two nodes. xxxxxx
        at com.sleepycat.je.rep.stream.ReplicaFeederHandshake.negotiateProtocol(ReplicaFeederHandshake.java:198)
        at com.sleepycat.je.rep.stream.ReplicaFeederHandshake.execute(ReplicaFeederHandshake.java:250)
        at com.sleepycat.je.rep.impl.node.Replica.initReplicaLoop(Replica.java:710)
        at com.sleepycat.je.rep.impl.node.Replica.runReplicaLoopInternal(Replica.java:486)
        at com.sleepycat.je.rep.impl.node.Replica.runReplicaLoop(Replica.java:413)
        at com.sleepycat.je.rep.impl.node.RepNode.run(RepNode.java:1871)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
