### PR TITLE
[BugFix]  Fix apply retry task lost

### DIFF
--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -939,8 +939,8 @@ void* StorageEngine::_schedule_apply_thread_callback(void* arg) {
             auto time_point = std::chrono::steady_clock::now();
             while (!_bg_worker_stopped.load(std::memory_order_consume) && !_schedule_apply_tasks.empty() &&
                    _schedule_apply_tasks.top().first <= time_point) {
-                _schedule_apply_tasks.pop();
                 auto tablet_id = _schedule_apply_tasks.top().second;
+                _schedule_apply_tasks.pop();
                 auto tablet = _tablet_manager->get_tablet(tablet_id);
                 if (tablet == nullptr || tablet->updates() == nullptr) {
                     continue;


### PR DESCRIPTION
## Why I'm doing:
In `_schedule_apply_thread_callback`, we first pop task and access the top element, and it will cause apply task lost.

## What I'm doing:
Fix the bug and access the top element before pop.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
