### PR TITLE
[BugFix] Fix QueryContextManager clear_thread crash

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -375,8 +375,8 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
             // lookup query context for the second chance in sc_map
             if (sc_it != sc_map.end()) {
                 auto ctx = std::move(sc_it->second);
-                RETURN_NULL_IF_CTX_CANCELLED(ctx);
                 sc_map.erase(sc_it);
+                RETURN_NULL_IF_CTX_CANCELLED(ctx);
                 auto* raw_ctx_ptr = ctx.get();
                 context_map.emplace(query_id, std::move(ctx));
                 return raw_ctx_ptr;


### PR DESCRIPTION
introduced by #47868

```
*** Aborted at 1724997275 (unix time) try "date -d @1724997275" if you are using GNU date ***
PC: @          0x5debccb starrocks::pipeline::QueryContextManager::_clean_slot_unlocked(unsigned long, std::vector<std::shared_ptr<starrocks::pipeline::QueryContext>, std::allocator<std::shared_ptr<starrocks::pipeline::QueryContext> > >&)
*** SIGSEGV (@0x68) received by PID 6669 (TID 0x7f1959fe6640) from PID 104; stack trace: ***
    @     0x7f19793aaf68 (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x99f67)
    @          0xefd0d19 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f197a3ae916 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x7f197a3b460b JVM_handle_linux_signal
    @     0x7f197a3a746c signalHandler(int, siginfo_t*, void*)
    @     0x7f1979353520 (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x4251f)
    @          0x5debccb starrocks::pipeline::QueryContextManager::_clean_slot_unlocked(unsigned long, std::vector<std::shared_ptr<starrocks::pipeline::QueryContext>, std::allocator<std::shared_ptr<starrocks::pipeline::QueryContext> > >&)
    @          0x5debf27 starrocks::pipeline::QueryContextManager::_clean_query_contexts()
    @          0x5dec191 starrocks::pipeline::QueryContextManager::_clean_func(starrocks::pipeline::QueryContextManager*)
    @          0x5df245b std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(starrocks::pipeline::QueryContextManager*), starrocks::pipeline::QueryContextManager*> > >::_M_run()
    @         0x115c1d44 execute_native_thread_routine
    @     0x7f19793a5b43 (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x94b42)
    @     0x7f1979437a00 (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x1269ff)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
