### PR TITLE
[BugFix] tolerate partial failure of full statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1890,6 +1890,11 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static long statistic_collect_too_many_version_sleep = 600000; // 10min
+
+    @ConfField(mutable = true, comment = "Tolerate some percent of failure for a large table, it will not affect " +
+            "the job status but improve the robustness")
+    public static double statistic_full_statistics_failure_tolerance_ratio = 0.05;
+
     /**
      * Enable full statistics collection
      */

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -132,7 +132,12 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             List<String> params = Lists.newArrayList();
             List<Expr> row = Lists.newArrayList();
 
-            String partitionName = StringEscapeUtils.escapeSql(table.getPartition(data.getPartitionId()).getName());
+            Partition partition = table.getPartition(data.getPartitionId());
+            if (partition == null) {
+                // The partition is dropped during analyze, we just need to skip it
+                continue;
+            }
+            String partitionName = StringEscapeUtils.escapeSql(partition.getName());
 
             params.add(String.valueOf(table.getId()));
             params.add(String.valueOf(data.getPartitionId()));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -83,7 +83,6 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
 
     @Override
     public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
-        long finishedSQLNum = 0;
         int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
         List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
         long totalCollectSQL = collectSQLList.size();
@@ -96,6 +95,8 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         // dop will be set to 1 to meet the requirements of the degree of parallelism.
         // If the number of unions is less than the degree of parallelism,
         // dop should be adjusted appropriately to use enough cpu cores
+        long finishedSQLNum = 0;
+        long failedNum = 0;
         for (List<String> sqlUnion : collectSQLList) {
             if (sqlUnion.size() < parallelism) {
                 context.getSessionVariable().setPipelineDop(parallelism / sqlUnion.size());
@@ -105,7 +106,27 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
 
             String sql = Joiner.on(" UNION ALL ").join(sqlUnion);
 
-            collectStatisticSync(sql, context);
+            try {
+                collectStatisticSync(sql, context);
+            } catch (Exception e) {
+                failedNum++;
+                LOG.warn("collect statistics task failed in job: {}, {}", this, sql, e);
+
+                double failureRatio = 1.0 * failedNum / collectSQLList.size();
+                if (collectSQLList.size() < 100) {
+                    // too few tasks, just fail this job
+                    throw e;
+                } else if (failureRatio > Config.statistic_full_statistics_failure_tolerance_ratio) {
+                    // many tasks, tolerate partial failure
+                    String message = String.format("collect statistic job failed due to " +
+                                    "too many failed tasks: %d/%d, the last failure is %s",
+                            failedNum, collectSQLList.size(), e);
+                    LOG.warn(message, e);
+                    throw new RuntimeException(message, e);
+                } else {
+                    continue;
+                }
+            }
             finishedSQLNum++;
             analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);
             GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
@@ -132,6 +153,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             List<String> params = Lists.newArrayList();
             List<Expr> row = Lists.newArrayList();
 
+            // FIXME: CME
             Partition partition = table.getPartition(data.getPartitionId());
             if (partition == null) {
                 // The partition is dropped during analyze, we just need to skip it


### PR DESCRIPTION
## Why I'm doing:
1. Frequent `INSERT OVERWRITE` introduces a bad case for statistics:
  1. The INSERT OVERWRITE is consider as a kind of SCHEMA-CHANGE, since it updates the partition information
  2. Then the planner might fail due to the schema-change
  3. Then the full statistics job might fail due to some sql planning failure


## What I'm doing:
1. Fix an NPE in full statistics job
2. Tolerate partial failure of full statistics 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

