### PR TITLE
[Doc] unlisted English

### DIFF
--- a/docs/docusaurus/sidebars.json
+++ b/docs/docusaurus/sidebars.json
@@ -84,6 +84,8 @@
                         "id": "deployment/shared_data/shared_data"
                     },
                     "items": [
+                        "deployment/shared_data/hdfs",
+                        "deployment/shared_data/other",
                         "deployment/shared_data/s3",
                         "deployment/shared_data/gcs",
                         "deployment/shared_data/azure",


### PR DESCRIPTION
We have a few docs that are only published in the Chinese docs. These are specific to Chinese cloud providers or HDFS use cases. This PR adds them to the sidebar nav. They will not show up in the English docs as there are stub files in the English doc source that have `unlisted: true` in the frontmatter.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
