### PR TITLE
[Enhancement] Add current_date as default value function for starrocks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
@@ -25,7 +25,8 @@ import java.util.Set;
 
 public class DefaultExpr {
 
-    public static final Set<String> SUPPORTED_DEFAULT_FNS = ImmutableSet.of("now()", "uuid()", "uuid_numeric()");
+    public static final Set<String> SUPPORTED_DEFAULT_FNS = ImmutableSet.of("now()", "uuid()", "uuid_numeric()",
+            "current_date()");
 
     @SerializedName("expr")
     private String expr;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
@@ -116,6 +116,8 @@ public class ColumnDef implements ParseNode {
         // default value for date type CURRENT_TIMESTAMP
         public static DefaultValueDef CURRENT_TIMESTAMP_VALUE = new DefaultValueDef(true,
                 new FunctionCallExpr("now", new ArrayList<>()));
+        public static final DefaultValueDef CURRENT_DATE_VALUE = new DefaultValueDef(true,
+                new FunctionCallExpr("current_date", new ArrayList<>()));
     }
 
     private static final Set<String> CHARSET_NAMES;
@@ -484,6 +486,10 @@ public class ColumnDef implements ParseNode {
             // default function current_timestamp currently only support DATETIME type.
             if (FunctionSet.NOW.equalsIgnoreCase(functionName) && type.getPrimitiveType() != PrimitiveType.DATETIME) {
                 throw new AnalysisException(String.format("Default function now() for type %s is not supported", type));
+            }
+            // default function current_date currently only support DATE type.
+            if (FunctionSet.CURRENT_DATE.equalsIgnoreCase(functionName) && type.getPrimitiveType() != PrimitiveType.DATE) {
+                throw new AnalysisException(String.format("Default function current_date() for type %s is not supported", type));
             }
             // default function uuid currently only support VARCHAR type.
             if (FunctionSet.UUID.equalsIgnoreCase(functionName) && type.getPrimitiveType() != PrimitiveType.VARCHAR) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1034,6 +1034,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 defaultValueDef = ColumnDef.DefaultValueDef.NULL_DEFAULT_VALUE;
             } else if (defaultDescContext.CURRENT_TIMESTAMP() != null) {
                 defaultValueDef = ColumnDef.DefaultValueDef.CURRENT_TIMESTAMP_VALUE;
+            } else if (defaultDescContext.CURRENT_DATE() != null) {
+                defaultValueDef = ColumnDef.DefaultValueDef.CURRENT_DATE_VALUE;
             } else if (defaultDescContext.qualifiedName() != null) {
                 String functionName = defaultDescContext.qualifiedName().getText().toLowerCase();
                 defaultValueDef = new ColumnDef.DefaultValueDef(true,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -385,7 +385,7 @@ charsetName
     ;
 
 defaultDesc
-    : DEFAULT (string | NULL | CURRENT_TIMESTAMP | '(' qualifiedName '(' ')' ')')
+    : DEFAULT (string | NULL | CURRENT_TIMESTAMP | CURRENT_DATE | '(' qualifiedName '(' ')' ')')
     ;
 
 generatedColumnDesc

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -778,6 +778,27 @@ public class CreateTableTest {
     }
 
     @Test
+    public void testCreateTableDefaultCurrentDate() throws Exception {
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.useDatabase("test");
+        String sql = "CREATE TABLE `test_create_default_current_date` (\n" +
+                "    k1 int,\n" +
+                "    ts datetime NOT NULL DEFAULT CURRENT_DATE\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 2\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\",\n" +
+                "    \"in_memory\" = \"false\"\n" +
+                ");";
+        starRocksAssert.withTable(sql);
+        final Table table = starRocksAssert.getCtx().getGlobalStateMgr().getLocalMetastore().getDb(connectContext.getDatabase())
+                .getTable("test_create_default_current_date");
+        Assert.assertEquals(2, table.getColumns().size());
+    }
+
+    @Test
     public void testCreateTableDefaultUUID() throws Exception {
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.useDatabase("test");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -783,7 +783,7 @@ public class CreateTableTest {
         starRocksAssert.useDatabase("test");
         String sql = "CREATE TABLE `test_create_default_current_date` (\n" +
                 "    k1 int,\n" +
-                "    ts datetime NOT NULL DEFAULT CURRENT_DATE\n" +
+                "    ts date NOT NULL DEFAULT CURRENT_DATE\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`k1`)\n" +
                 "COMMENT \"OLAP\"\n" +


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Add current_date as default value function for starrocks
```
MySQL [test]> CREATE TABLE IF NOT EXISTS test_date (k TINYINT, v1 DATE NOT NULL DEFAULT CURRENT_DATE, v2 INT) UNIQUE KEY(K) DISTRIBUTED BY HASH(k) PROPERTIES("replication_num" = "1");
Query OK, 0 rows affected (0.046 sec)

MySQL [test]> insert into test_date(k,v2) values(1,2);
Query OK, 1 row affected (0.488 sec)
{'label':'insert_59dfb5d5-675c-11ef-9627-02420a1fd64c', 'status':'VISIBLE', 'txnId':'7016'}

MySQL [test]> select * from test_date;
+------+------------------+------+
| k    | v1                 | v2   |
+------+------------------+------+
|    1 | 2024-08-31 |    2 |
+------+------------------+------+
1 row in set (0.014 sec)

```

Fixes #50509 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5