### PR TITLE
[Enhancement][Build] Static link libbfd library

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -773,6 +773,8 @@ endif()
 
 set(WL_START_GROUP "-Wl,--start-group")
 set(WL_END_GROUP "-Wl,--end-group")
+set(WL_LINK_STATIC "-Wl,-Bstatic")
+set(WL_LINK_DYNAMIC "-Wl,-Bdynamic")
 
 # Set starrocks libraries
 set(STARROCKS_LINK_LIBS
@@ -963,7 +965,8 @@ if (NOT ("${MAKE_TEST}" STREQUAL "ON" AND "${BUILD_FOR_SANITIZE}" STREQUAL "ON")
 endif()
 
 set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS}
-    -lresolv -lbfd -liberty -lc -lm -ldl -rdynamic -pthread -Wl,-wrap=__cxa_throw
+    ${WL_LINK_STATIC} -lbfd
+    ${WL_LINK_DYNAMIC} -lresolv -liberty -lc -lm -ldl -rdynamic -pthread -Wl,-wrap=__cxa_throw
 )
 
 # link gcov if WITH_GCOV is on


### PR DESCRIPTION
## Why I'm doing:
static link to libbfd library, avoid running system installing libbinutils as required step.

$ldd starrocks_be
        linux-vdso.so.1 (0x00007ffea2f83000)
        libjvm.so => not found
        libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x0000710a0eed3000)
        libbfd-2.38-system.so => /lib/x86_64-linux-gnu/libbfd-2.38-system.so (0x0000710a0ed5b000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000710a0ec74000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000710a0ea4c000)
        /lib64/ld-linux-x86-64.so.2 (0x0000710a0eeed000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x0000710a0ea2e000)

## What I'm doing:
static link to libbfd library, avoid running system installing libbinutils as required step.

ldd output after static linking
$ldd starrocks_be
        linux-vdso.so.1 (0x00007fff87e93000)
        libjvm.so => not found
        libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007a2f80d38000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007a2f80c51000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007a2f80a29000)
        /lib64/ld-linux-x86-64.so.2 (0x00007a2f80d52000)

Fixes #50511

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
