### PR TITLE
[Enhancement] Rewrite `&>>` in a portable way

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -219,7 +219,7 @@ if [ ${RUN_LOG_CONSOLE} -eq 1 ] ; then
     export GLOG_logtostderr=1
 else
     # redirect stdout/stderr to ${LOG_FILE}
-    exec &>> ${LOG_FILE}
+    exec >> ${LOG_FILE} 2>&1
 fi
 
 echo "start time: $(date), server uptime: $(uptime)"

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -225,7 +225,7 @@ if [ ${RUN_LOG_CONSOLE} -eq 1 ] ; then
     echo -e "\nsys_log_to_console = true" >> $STARROCKS_HOME/conf/fe.conf
 else
     # redirect all subsequent commands' stdout/stderr into $LOG_FILE
-    exec &>> $LOG_FILE
+    exec >> $LOG_FILE 2>&1
 fi
 
 echo "using java version $JAVA_VERSION"


### PR DESCRIPTION
* `&>>` is a bash4 feature, rewrite it as `>> {file} 2>&1` for earlier version bash

## Why I'm doing:

## What I'm doing:

Fixes #50505

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
