### PR TITLE
[BugFix] Make DiskRange more robust

### DIFF
--- a/be/src/formats/disk_range.hpp
+++ b/be/src/formats/disk_range.hpp
@@ -24,7 +24,7 @@ class DiskRange {
 public:
     DiskRange(const int64_t off, const int64_t len) : _offset(off), _length(len) {
         DCHECK(off >= 0);
-        DCHECK(len > 0);
+        DCHECK(len >= 0);
     }
 
     /**

--- a/be/test/formats/disk_range_test.cpp
+++ b/be/test/formats/disk_range_test.cpp
@@ -41,6 +41,33 @@ TEST(DiskRangeTest, TestMergeTinyDiskRanges) {
     EXPECT_EQ(900 * KB, merged_disk_ranges.at(0).length());
 }
 
+// unordered DiskRange + DiskRange's length = 0 + duplicate DiskRange + Overlap DiskRange
+TEST(DiskRangeTest, TestDiskRangesRobust) {
+    std::vector<DiskRange> disk_ranges{};
+    constexpr int64_t KB = 1024;
+    // unordered
+    disk_ranges.emplace_back(800 * KB, 100 * KB);
+    // duplicate
+    disk_ranges.emplace_back(0, 1 * KB);
+    disk_ranges.emplace_back(0, 1 * KB);
+    disk_ranges.emplace_back(0, 1 * KB);
+    // overlap
+    disk_ranges.emplace_back(10 * KB, 30 * KB);
+    disk_ranges.emplace_back(15 * KB, 45 * KB);
+    disk_ranges.emplace_back(850 * KB, 150 * KB);
+    // length = 0 + duplicate
+    disk_ranges.emplace_back(40 * KB, 0 * KB);
+    disk_ranges.emplace_back(900 * KB, 0 * KB);
+    disk_ranges.emplace_back(900 * KB, 0 * KB);
+    disk_ranges.emplace_back(900 * KB, 0 * KB);
+    std::vector<DiskRange> merged_disk_ranges{};
+    DiskRangeHelper::merge_adjacent_disk_ranges(disk_ranges, config::io_coalesce_read_max_distance_size,
+                                                config::io_coalesce_read_max_buffer_size, merged_disk_ranges);
+    EXPECT_EQ(1, merged_disk_ranges.size());
+    EXPECT_EQ(0, merged_disk_ranges.at(0).offset());
+    EXPECT_EQ(1000 * KB, merged_disk_ranges.at(0).length());
+}
+
 TEST(DiskRangeTest, TestMergeBigDiskRanges) {
     std::vector<DiskRange> disk_ranges{};
     constexpr int64_t MB = 1024 * 1024;


### PR DESCRIPTION
## Why I'm doing:
fix
```bash
F20240902 10:42:06.521790 140410446833216 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.529613 140412836673088 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.530820 140401931732544 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.531649 140411812456000 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.556953 140412575598144 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.578787 140406570870336 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.582307 140402072311360 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.594428 140403699021376 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.606786 140408759887424 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.675194 140409482864192 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.690246 140403578525248 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.693099 140409362368064 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.704161 140407976662592 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.715183 140407735670336 disk_range.hpp:27] Check failed: len > 0 F20240902 10:42:06.716459 140409282037312 disk_range.hpp:27] Check failed: len > 0 
PC: @     0x7fb7b98519fc pthread_kill
*** SIGABRT (@0x3ea0005d73a) received by PID 382778 (TID 0x7fb28a712640) from PID 382778; stack trace: ***
    @         0x25541616 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fb7b9854ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x25540e59 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fb7b97fd520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7fb7b98519fc pthread_kill
    @     0x7fb7b97fd476 raise
    @     0x7fb7b97e37f3 abort
    @         0x13bad94a starrocks::failure_function()
    @         0x255345ee google::LogMessage::Fail()
    @         0x25535869 google::LogMessageFatal::~LogMessageFatal()
    @         0x15999714 starrocks::DiskRange::DiskRange(long, long)
    @         0x159e6f80 decltype (::new ((void*)(0)) starrocks::DiskRange((declval<unsigned long&>)(), (declval<unsigned long>)())) std::construct_at<starrocks::DiskRange, unsigned long&, unsigned long>(starrocks::DiskRange*, unsigned long&, unsigned long&&)
    @         0x159e7001 void std::allocator_traits<std::allocator<starrocks::DiskRange> >::construct<starrocks::DiskRange, unsigned long&, unsigned long>(std::allocator<starrocks::DiskRange>&, starrocks::DiskRange*, unsigned long&, unsigned long&&)
    @         0x159e59e7 starrocks::DiskRange& std::vector<starrocks::DiskRange, std::allocator<starrocks::DiskRange> >::emplace_back<unsigned long&, unsigned long>(unsigned long&, unsigned long&&)
    @         0x159dc3ae starrocks::CacheSelectScanner::_fetch_orc()
    @         0x159d9beb starrocks::CacheSelectScanner::do_get_next(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x1594d9fe starrocks::HdfsScanner::get_next(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x14083285 starrocks::connector::HiveDataSource::get_next(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x166b9c04 starrocks::pipeline::ConnectorChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x165cf4c8 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @         0x1661e928 auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const
    @         0x1662554b void std::__invoke_impl<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>(std::__invoke_other, starrocks::pipeline::ScanOperator::_trigger_next_scan(starroB
    @         0x166253d0 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>, void>::type std::__invoke_r<void, starrocks::pipeline::ScanOperator::_trB
    @         0x16624eff std::_Function_handler<void (starrocks::workgroup::YieldContext&), starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const&, starrocks::workgroup::YieldContext&)
    @         0x16bdba65 std::function<void (starrocks::workgroup::YieldContext&)>::operator()(starrocks::workgroup::YieldContext&) const
    @         0x16bdab17 starrocks::workgroup::ScanTask::run()
    @         0x16d58432 starrocks::workgroup::ScanExecutor::worker_thread()
    @         0x16d57a86 starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x16d59ede void std::__invoke_impl<void, starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}&)
    @         0x16d59ae5 std::enable_if<is_invocable_r_v<void, starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}&>(starrocks::workgroup::ScanExecutor::initialize(B
    @         0x16d59639 std::_Function_handler<void (), starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x13a824ce std::function<void ()>::operator()() const
start time: Mon Sep  2 10:50:55 AM CST 2024, server uptime:  10:50:55 up 21 days,  8:53, 42 users,  load average: 47.04, 39.69, 21.51
I
```

Because ORC's stream length may be equal to 0, we have to ensure that DiskRange is robust.

## What I'm doing:
fix it

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
