### PR TITLE
[BugFix] skip add the alias into fieldMapping when order by expr not referenced this alias

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -26,6 +26,7 @@ import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.LimitElement;
 import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
 import com.starrocks.common.TreeNode;
@@ -114,10 +115,10 @@ public class QueryTransformer {
                         Iterables.concat(queryBlock.getOutputExpression(),
                                 queryBlock.getOrderSourceExpressions(),
                                 queryBlock.getOrderByAnalytic()),
-                        queryBlock.getOutputExprInOrderByScope(),
+                        queryBlock,
                         outputNames,
                         builder.getFieldMappings(),
-                        queryBlock.getOrderScope(), true);
+                        true);
 
             } else {
                 // requires both output and source fields to be visible if there is no aggregation or distinct
@@ -125,10 +126,10 @@ public class QueryTransformer {
                 // in the outputExpression.
                 builder = projectForOrder(builder,
                         Iterables.concat(queryBlock.getOutputExpression(), queryBlock.getOrderByAnalytic()),
-                        queryBlock.getOutputExprInOrderByScope(),
+                        queryBlock,
                         queryBlock.getColumnOutputNames(),
                         builder.getFieldMappings(),
-                        queryBlock.getOrderScope(), queryBlock.isDistinct());
+                        queryBlock.isDistinct());
             }
         }
 
@@ -169,10 +170,12 @@ public class QueryTransformer {
 
     private OptExprBuilder projectForOrder(OptExprBuilder subOpt,
                                            Iterable<Expr> outputExpression,
-                                           List<Integer> outputExprInOrderByScope,
+                                           SelectRelation queryBlock,
                                            List<String> outputNames,
-                                           List<ColumnRefOperator> sourceExpression, Scope scope,
+                                           List<ColumnRefOperator> sourceExpression,
                                            boolean withAggregation) {
+        List<Integer> outputExprInOrderByScope = queryBlock.getOutputExprInOrderByScope();
+        Scope scope = queryBlock.getOrderScope();
         ExpressionMapping outputTranslations = new ExpressionMapping(scope);
         Map<ColumnRefOperator, ScalarOperator> projections = Maps.newHashMap();
 
@@ -190,10 +193,31 @@ public class QueryTransformer {
             projections.put(columnRefOperator, scalarOperator);
 
             if (outputExprInOrderByScope.contains(outputExprIdx)) {
-                outputTranslations.putWithSymbol(expression,
-                        new SlotRef(null, outputNames.get(outputExprIdx)), columnRefOperator);
+                outputTranslations.put(expression, columnRefOperator);
+                TableName resolveTableName = queryBlock.getResolveTableName();
+                if (expression instanceof SlotRef) {
+                    resolveTableName = queryBlock.getRelation().getResolveTableName();
+                }
+                SlotRef alias = new SlotRef(resolveTableName, outputNames.get(outputExprIdx));
+                // order by expr may reference the alias. We need put the alias into the fieldMappings or the
+                // expressionToColumns.
+                // if the alias not be used in the order by expr like:
+                // select v1 cc, v2 cc from tbl order by v3. We just add the slotRef(cc) to columnRefOperator in the
+                // expressionToColumns to ensure this projection can output v1 with alias cc, v2 with alias cc and v3.
+                // We don't need to ensure the uniqueness of the alias in the fieldMappings.
+                // if the alias used in the order by expr like:
+                // select v1 v3, v2 cc from (select abs(v1) v1, abs(v2) v2, v3 from t0) t1 order by t1.v3.
+                // order by expr t1.v3 referenced the v1 with alias v3, we need set the fieldMappings to ensure order by
+                // expr can be resolved.
+                if (scope.getRelationFields().resolveFields(alias).size() > 1) {
+                    outputTranslations.getExpressionToColumns()
+                            .put(new SlotRef(resolveTableName, outputNames.get(outputExprIdx)), columnRefOperator);
+                } else {
+                    outputTranslations.put(alias, columnRefOperator);
+                }
+
             } else {
-                outputTranslations.putWithSymbol(expression, expression, columnRefOperator);
+                outputTranslations.put(expression, columnRefOperator);
             }
             outputExprIdx++;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -693,7 +693,7 @@ class OrderByTest extends PlanTestBase {
         List<Arguments> list = Lists.newArrayList();
         list.add(Arguments.of("select *, v1, abs(v1) v1 from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select distinct *, v1, abs(v1) v1 from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
-        list.add(Arguments.of("select distinct abs(v1) v1, * from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct abs(v1) v1, * from t0  order by 1", "order by: <slot 4> 4: abs ASC"));
         list.add(Arguments.of("select * from t0 order by 1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select abs(v1) v1, * from t0  order by 1", "order by: <slot 4> 4: abs ASC"));
         list.add(Arguments.of("select distinct * from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -678,12 +678,22 @@ class OrderByTest extends PlanTestBase {
         assertContains(plan, expectedPlan);
     }
 
+    @ParameterizedTest
+    @MethodSource("duplicateAliasSql")
+    void testDuplicateAlias(String sql, String expectedPlan) throws Exception {
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, expectedPlan);
+    }
+
     private static Stream<Arguments> allOrderBySql() {
         return Stream.concat(successToStrictSql(), failToStrictSql());
     }
 
     private static Stream<Arguments> successToStrictSql() {
         List<Arguments> list = Lists.newArrayList();
+        list.add(Arguments.of("select *, v1, abs(v1) v1 from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct *, v1, abs(v1) v1 from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct abs(v1) v1, * from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select * from t0 order by 1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select abs(v1) v1, * from t0  order by 1", "order by: <slot 4> 4: abs ASC"));
         list.add(Arguments.of("select distinct * from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
@@ -705,9 +715,6 @@ class OrderByTest extends PlanTestBase {
 
     private static Stream<Arguments> failToStrictSql() {
         List<Arguments> list = Lists.newArrayList();
-        list.add(Arguments.of("select *, v1, abs(v1) v1 from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
-        list.add(Arguments.of("select distinct *, v1, abs(v1) v1 from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
-        list.add(Arguments.of("select distinct abs(v1) v1, * from t0  order by 1", "order by: <slot 4> 4: abs ASC"));
         list.add(Arguments.of("select distinct *, v1, abs(v1) v1 from t0  order by v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select v1, max(v2) v1 from t0 group by v1  order by abs(v1)", "order by: <slot 5> 5: abs ASC"));
         list.add(Arguments.of("select max(v2) v1, v1 from t0 group by v1  order by abs(v1)", "order by: <slot 5> 5: abs ASC"));
@@ -715,10 +722,42 @@ class OrderByTest extends PlanTestBase {
         list.add(Arguments.of("select max(v2) v2, v2 from t0 group by v2  order by max(v2)", "order by: <slot 4> 4: max ASC"));
         list.add(Arguments.of("select upper(v1) v1, *, v1 from t0 order by v1", "order by: <slot 4> 4: upper ASC"));
         list.add(Arguments.of("select *, v1, upper(v1) v1 from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
-        list.add(Arguments.of("select distinct upper(v1) v1, *, v1 from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct  v1, *, upper(v1) v1 from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct upper(v1) v1, *, v1 from t0 order by v1", "order by: <slot 4> 4: upper ASC"));
         list.add(Arguments.of("select distinct *, v1, upper(v1) v1 from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select distinct abs(v1) v1, v1 from t0 order by v1", "order by: <slot 4> 4: abs ASC"));
 
+        return list.stream();
+    }
+
+    private static Stream<Arguments> duplicateAliasSql() {
+        List<Arguments> list = Lists.newArrayList();
+        list.add(Arguments.of("select *, v1 cc, v2 cc from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select v1 cc, abs(v2) cc from t0 order by v1 ", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct v1 cc, v2 cc from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select v1 cc, v2 cc, abs(v3) ccc from t0 order by abs(ccc)", "order by: <slot 5> 5: abs ASC"));
+        list.add(Arguments.of("select count(v1) cnt, count(v2) cnt from t0 group by v3 order by abs(v3)",
+                "3:SORT\n" +
+                        "  |  order by: <slot 6> 6: abs ASC\n" +
+                        "  |  offset: 0\n" +
+                        "  |  \n" +
+                        "  2:Project\n" +
+                        "  |  <slot 4> : 4: count\n" +
+                        "  |  <slot 5> : 5: count\n" +
+                        "  |  <slot 6> : abs(3: v3)"));
+        list.add(Arguments.of("select v1 cc, v2 cc from (select abs(v1) v1, abs(v2) v2, v3 from t0) t1 order by v3",
+                "2:SORT\n" +
+                        "  |  order by: <slot 3> 3: v3 ASC\n" +
+                        "  |  offset: 0\n" +
+                        "  |  \n" +
+                        "  1:Project\n" +
+                        "  |  <slot 3> : 3: v3\n" +
+                        "  |  <slot 4> : abs(1: v1)\n" +
+                        "  |  <slot 5> : abs(2: v2)"));
+        list.add(Arguments.of("select v1 v3, v2 cc from (select abs(v1) v1, abs(v2) v2, v3 from t0) t1 order by t1.v3",
+                "order by: <slot 4> 4: abs ASC"));
+        list.add(Arguments.of("select v1, v2 cc from (select abs(v1) v1, abs(v2) v2, v3 from t0) t1 order by t1.v3",
+                "order by: <slot 3> 3: v3 ASC"));
         return list.stream();
     }
 }


### PR DESCRIPTION
## Why I'm doing:
failed to execute `select v1 cc, v2 cc from tbl order by v3` with error info `column cc is ambiguous`
## What I'm doing:
order by expr may reference the alias. We need put the alias into the fieldMappings or the expressionToColumns.
if the alias not be used in the order by expr like:
`select v1 cc, v2 cc from tbl order by v3`
We just add the slotRef(cc) to columnRefOperator in the
expressionToColumns to ensure this projection can output v1 with alias cc, v2 with alias cc and v3.
We don't need to ensure the uniqueness of the alias in the fieldMappings.

if the alias used in the order by expr like:
`select v1 v3, v2 cc from (select abs(v1) v1, abs(v2) v2, v3 from t0) t1 order by t1.v3`
order by expr t1.v3 referenced the v1 with alias v3, we need set the fieldMappings to ensure order by
expr can be resolved.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [x] 2.5
