### PR TITLE
[BugFix] fix wrong plan when duplicate alias is same as the column name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1478,11 +1478,7 @@ public class QueryAnalyzer {
                 if (item.getAlias() == null) {
                     continue;
                 }
-                // Ignore c1 as c1
-                if (item.getExpr() instanceof SlotRef &&
-                        alias.equalsIgnoreCase(((SlotRef) item.getExpr()).getColumnName())) {
-                    continue;
-                }
+
                 // Alias is case-insensitive
                 Expr lastAssociatedExpr = aliases.putIfAbsent(alias.toLowerCase(), item.getExpr());
                 if (lastAssociatedExpr != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1483,7 +1483,8 @@ public class QueryAnalyzer {
                 Expr lastAssociatedExpr = aliases.putIfAbsent(alias.toLowerCase(), item.getExpr());
                 if (lastAssociatedExpr != null) {
                     // Duplicate alias is allowed, eg: select a.v1 as v, a.v2 as v from t0 a,
-                    // But it should not be ambiguous, eg: select a.v1 as v, a.v2 as v from t0 a order by v
+                    // But it should be ambiguous when the alias is used in the order by expr,
+                    // eg: select a.v1 as v, a.v2 as v from t0 a order by v
                     aliasesMaybeAmbiguous.add(alias.toLowerCase());
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectUsingAliasTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectUsingAliasTest.java
@@ -227,6 +227,24 @@ public class SelectUsingAliasTest extends PlanTestBase {
                 "FROM test.t0");
     }
 
+    @Test
+    public void testAliasSameAsColumnName() throws Exception {
+        // test duplicate alias is same as column name
+        String sql = "select v1 v1, v2 + 1 v1, abs(v1) from t0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "1:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 4> : 2: v2 + 1\n" +
+                "  |  <slot 5> : abs(1: v1)");
+
+        Exception exception = Assert.assertThrows(SemanticException.class, () -> {
+            // test duplicate alias is different from column name
+            String duplicateAlias = "select v1 v4, v2 + 1 v4, abs(v4) from t0";
+            getFragmentPlan(duplicateAlias);
+        });
+        Assert.assertTrue(exception.getMessage(), exception.getMessage().contains("Column v4 is ambiguous"));
+    }
+
     private void testSqlRewrite(String sql, String expected) {
         testSqlRewrite(sql, expected, true);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectUsingAliasTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectUsingAliasTest.java
@@ -237,7 +237,20 @@ public class SelectUsingAliasTest extends PlanTestBase {
                 "  |  <slot 4> : 2: v2 + 1\n" +
                 "  |  <slot 5> : abs(1: v1)");
 
+        sql = "select v1 v1, v1 v1, abs(v1) from t0";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "1:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 4> : abs(1: v1)");
+
         Exception exception = Assert.assertThrows(SemanticException.class, () -> {
+            // test duplicate alias is different from column name
+            String duplicateAlias = "select v1 v1, v2 v1, abs(v1) from t0 order by v1";
+            getFragmentPlan(duplicateAlias);
+        });
+        Assert.assertTrue(exception.getMessage(), exception.getMessage().contains("Column 'v1' is ambiguous."));
+
+        exception = Assert.assertThrows(SemanticException.class, () -> {
             // test duplicate alias is different from column name
             String duplicateAlias = "select v1 v4, v2 + 1 v4, abs(v4) from t0";
             getFragmentPlan(duplicateAlias);


### PR DESCRIPTION
## Why I'm doing:
after https://github.com/StarRocks/starrocks/pull/43919, the sql in the image yields a wrong plan.
![img_v3_02eb_7acf65dd-21bd-4fd7-8fa6-1d3c849353bg](https://github.com/user-attachments/assets/eee2fd6e-f4fd-469e-b39d-207fa4368bc7)

## What I'm doing:
Even when alias name is same as the column name, we need add it into the `aliases` map then the next duplicate alias can be added into `aliasesMaybeAmbiguous` map.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
