### PR TITLE
[BugFix] fix analyzing error in prepare stmt with HAVING clause

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -38,6 +38,7 @@ import com.starrocks.analysis.LikePredicate;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.MatchExpr;
 import com.starrocks.analysis.OrderByElement;
+import com.starrocks.analysis.Parameter;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.Subquery;
@@ -128,6 +129,9 @@ public class AggregationAnalyzer {
 
         @Override
         public Boolean visitExpression(Expr node, Void context) {
+            if (node instanceof Parameter) {
+                return true;
+            }
             throw new SemanticException(node.toSql() + " must appear in the GROUP BY clause or be used in an aggregate function",
                     node.getPos());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
@@ -106,6 +106,23 @@ public class PreparedStmtTest{
     }
 
     @Test
+    public void testPrepareStatementParserWithHavingClause() {
+        String sql = "PREPARE stmt1 FROM SELECT prepare_stmt.c0 from prepare_stmt GROUP BY prepare_stmt.c0 HAVING COUNT(*) = ?";
+        try {
+            PrepareStmt stmt = (PrepareStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        } catch (Exception e) {
+            Assert.fail("should not reach here");
+        }
+
+        sql = "PREPARE stmt1 FROM SELECT prepare_stmt.c0 from prepare_stmt GROUP BY prepare_stmt.c0 HAVING c0 > ?";
+        try {
+            PrepareStmt stmt = (PrepareStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        } catch (Exception e) {
+            Assert.fail("should not reach here");
+        }
+    }
+
+    @Test
     public void testPrepareStmtWithCte() throws Exception {
         String sql = "PREPARE stmt FROM with cte as (select * from prepare_stmt where c0 = ?) select * from cte where c1 = ?";
         PrepareStmt stmt = (PrepareStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);


### PR DESCRIPTION
## Why I'm doing:
The following prepare statement fails to be executed :
```
starrocks> show variables like 'sql_mode';
+---------------+-------+
| Variable_name | Value |
+---------------+-------+
| sql_mode      |       |
+---------------+-------+
1 row in set (0.00 sec)

starrocks> prepare stmt1 from select a from t group by a having count(*) = ?;
ERROR 1064 (HY000): Getting analyzing error. Detail message: ? must appear in the GROUP BY clause or be used in an aggregate function.

starrocks> prepare pp from select a, b from t group by a, b having a > ?;
ERROR 1064 (HY000): Getting analyzing error. Detail message: ? must appear in the GROUP BY clause or be used in an aggregate function.
```

## What I'm doing:
the aggregation type will not be verified when the expression is a parameter, 
```
starrocks> prepare stmt1 from select a from t group by a having count(*) = ?;
Query OK, 0 rows affected (0.00 sec)

starrocks> set @p1 = 1;
Query OK, 0 rows affected (0.01 sec)

starrocks> execute stmt1 using @p1 ;
+------+
| a    |
+------+
|    2 |
|    1 |
+------+
2 rows in set (0.02 sec)
```

```
starrocks> prepare pp from select a from t group by a having a > ?;
Query OK, 0 rows affected (0.00 sec)

starrocks> set @p1 = 1;
Query OK, 0 rows affected (0.01 sec)

starrocks> execute pp using @p1;
+------+
| a    |
+------+
|    2 |
+------+
1 row in set (0.03 sec)
```
Fixes #50584

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
