### PR TITLE
[Enhancement] support trino's show schemas function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -83,6 +83,7 @@ import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SetQualifier;
+import com.starrocks.sql.ast.ShowDbStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.TableFunctionRelation;
@@ -162,6 +163,7 @@ import io.trino.sql.tree.Row;
 import io.trino.sql.tree.RowDataType;
 import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.SetOperation;
+import io.trino.sql.tree.ShowSchemas;
 import io.trino.sql.tree.SimpleCaseExpression;
 import io.trino.sql.tree.SimpleGroupBy;
 import io.trino.sql.tree.SingleColumn;
@@ -737,6 +739,21 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         }
         return callExpr;
 
+    }
+
+    @Override
+    protected ParseNode visitShowSchemas(ShowSchemas node, ParseTreeContext context) {
+        String catalog = null;
+        if (!node.getCatalog().isEmpty()) {
+            catalog = node.getCatalog().map(Identifier::getValue).get();
+        }
+
+        if (!node.getLikePattern().isEmpty()) {
+            String likePattern = node.getLikePattern().get();
+            return new ShowDbStmt(likePattern, null, catalog, null);
+        } else {
+            return new ShowDbStmt(null, null, catalog, null);
+        }
     }
 
     private static AnalyticWindow.Type getFrameType(WindowFrame.Type type) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/TrinoParserUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/TrinoParserUtils.java
@@ -27,6 +27,7 @@ import io.trino.sql.tree.CreateTableAsSelect;
 import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.Query;
+import io.trino.sql.tree.ShowSchemas;
 import io.trino.sql.tree.Statement;
 
 import java.time.format.DateTimeParseException;
@@ -40,7 +41,7 @@ public class TrinoParserUtils {
         String trimmedQuery = query.trim();
         Statement statement = TrinoParser.parse(trimmedQuery);
         if (statement instanceof Query || statement instanceof Explain || statement instanceof ExplainAnalyze
-                || statement instanceof CreateTableAsSelect) {
+                || statement instanceof CreateTableAsSelect || statement instanceof ShowSchemas) {
             return (StatementBase) statement.accept(new AstBuilder(sqlMode), new ParseTreeContext());
         } else {
             throw trinoParserUnsupportedException("Unsupported statement type: " + statement.getClass().getName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -321,7 +321,7 @@ setCatalogStatement
 
 showDatabasesStatement
     : SHOW DATABASES ((FROM | IN) catalog=qualifiedName)? ((LIKE pattern=string) | (WHERE expression))?
-    | SHOW SCHEMAS ((LIKE pattern=string) | (WHERE expression))?
+    | SHOW SCHEMAS (FROM catalog=qualifiedName)? ((LIKE pattern=string) | (WHERE expression))?
     ;
 
 alterDbQuotaStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowDbStmtTest.java
@@ -111,4 +111,4 @@ public class ShowDbStmtTest {
         ShowDbStmt showDbStmt = (ShowDbStmt) UtFrameUtils.parseStmtWithNewParser(showSQL, ctx);
     }
 
-}
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -14,6 +14,9 @@
 
 package com.starrocks.connector.parser.trino;
 
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.sql.ast.ShowDbStmt;
+import com.starrocks.utframe.UtFrameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -1227,5 +1230,14 @@ public class TrinoQueryTest extends TrinoTestBase {
     public void testCastArrayDataType() throws Exception {
         String sql = "select cast(ARRAY[1] as array(int))";
         assertPlanContains(sql, "CAST([1] AS ARRAY<INT>)");
+    }
+
+    @Test
+    public void testShowSchemasFroCatalog() throws Exception {
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(UUIDUtil.genUUID()));
+        String showSQL = "show schemas from default_catalog";
+        ShowDbStmt showDbStmt = (ShowDbStmt) UtFrameUtils.parseStmtWithNewParser(showSQL, connectContext);
+        Assert.assertNotNull(showDbStmt);
+        Assert.assertEquals(1, showDbStmt.getMetaData().getColumnCount());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

mysql> set sql_dialect=trino;

mysql> show schemas;
+--------------------+
| Database           |
+--------------------+
| _statistics_       |
| information_schema |
| mydb               |
| sys                |
+--------------------+

mysql> show schemas from default_catalog;
+--------------------+
| Database           |
+--------------------+
| _statistics_       |
| information_schema |
| mydb               |
| sys                |
+--------------------+

mysql> show schemas from default_catalog like '__db';
+----------+
| Database |
+----------+
| mydb     |
+----------+

Fixes #40894 
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5