### PR TITLE
[Enhancement] add memory statistic for cloud native persistent index's sstable

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -739,6 +739,11 @@ size_t LakePersistentIndex::memory_usage() const {
     if (_immutable_memtable != nullptr) {
         mem_usage += _immutable_memtable->memory_usage();
     }
+    for (const auto& sst_ptr : _sstables) {
+        if (sst_ptr != nullptr) {
+            mem_usage += sst_ptr->memory_usage();
+        }
+    }
     return mem_usage;
 }
 

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -105,4 +105,8 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
     return Status::OK();
 }
 
+size_t PersistentIndexSstable::memory_usage() const {
+    return (_sst != nullptr) ? _sst->memory_usage() : 0;
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/persistent_index_sstable.h
+++ b/be/src/storage/lake/persistent_index_sstable.h
@@ -58,6 +58,8 @@ public:
 
     const PersistentIndexSstablePB& sstable_pb() const { return _sstable_pb; }
 
+    size_t memory_usage() const;
+
 private:
     std::unique_ptr<sstable::Table> _sst{nullptr};
     std::unique_ptr<sstable::FilterPolicy> _filter_policy{nullptr};

--- a/be/src/storage/sstable/table.h
+++ b/be/src/storage/sstable/table.h
@@ -51,6 +51,8 @@ public:
     Status MultiGet(const ReadOptions&, const Slice* keys, ForwardIt begin, ForwardIt end,
                     std::vector<std::string>* values);
 
+    size_t memory_usage() const;
+
 private:
     struct Rep;
 

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -91,8 +91,7 @@ TEST_F(LakePersistentIndexTest, test_basic_api) {
     auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
     ASSERT_OK(index->init(_tablet_metadata->sstable_meta()));
     ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
-    // insert duplicate should return error
-    // ASSERT_FALSE(index->insert(N, key_slices.data(), values.data(), 0).ok());
+    ASSERT_TRUE(index->memory_usage() > 0);
 
     // test get
     vector<IndexValue> get_values(keys.size());
@@ -233,6 +232,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
         // generate sst files.
         index->minor_compact();
     }
+    ASSERT_TRUE(index->memory_usage() > 0);
 
     Tablet tablet(_tablet_mgr.get(), tablet_id);
     auto tablet_metadata_ptr = std::make_shared<TabletMetadata>();

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -229,6 +229,8 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
     sstable_pb.set_filename(filename);
     sstable_pb.set_filesize(filesize);
     ASSERT_OK(sst->init(std::move(read_file), sstable_pb, cache_ptr.get()));
+    // check memory usage
+    ASSERT_TRUE(sst->memory_usage() > 0);
 
     {
         // 3. multi get with version (all keys included)


### PR DESCRIPTION
## Why I'm doing:
In current implementation, memory usage of cloud native index only included memtable, lack of sstable.

## What I'm doing:
I Include sstable's memory in cloud native index's memory usage statistic.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
