### PR TITLE
[Enhancement] improve return filename from delta column group by index

### DIFF
--- a/be/src/storage/delta_column_group.h
+++ b/be/src/storage/delta_column_group.h
@@ -67,6 +67,14 @@ public:
         return column_files;
     }
 
+    StatusOr<std::string> column_file_by_idx(const std::string& dir_path, uint32_t idx) const {
+        if (idx >= _column_files.size()) {
+            return Status::InvalidArgument(fmt::format("column_file_by_idx fail, path: {} column file cnt: {} idx: {}",
+                                                       dir_path, _column_files.size(), idx));
+        }
+        return dir_path + "/" + _column_files[idx];
+    }
+
     // TODO: rename
     std::vector<std::vector<ColumnUID>>& column_ids() { return _column_uids; }
     // TODO: rename

--- a/be/src/storage/delta_column_group.h
+++ b/be/src/storage/delta_column_group.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include "common/status.h"
+#include "common/statusor.h"
+#include "fmt/format.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "gen_cpp/olap_common.pb.h"
 #include "storage/olap_common.h"

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -484,7 +484,8 @@ StatusOr<std::shared_ptr<Segment>> Segment::new_dcg_segment(const DeltaColumnGro
     } else {
         tablet_schema = TabletSchema::create_with_uid(_tablet_schema.schema(), dcg.column_ids()[idx]);
     }
-    FileInfo info{.path = dcg.column_file_by_idx(parent_name(_segment_file_info.path), idx)};
+    ASSIGN_OR_RETURN(auto filepath, dcg.column_file_by_idx(parent_name(_segment_file_info.path), idx));
+    FileInfo info{.path = filepath};
     if (idx < dcg.encryption_metas().size()) {
         info.encryption_meta = dcg.encryption_metas()[idx];
     }

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -484,7 +484,7 @@ StatusOr<std::shared_ptr<Segment>> Segment::new_dcg_segment(const DeltaColumnGro
     } else {
         tablet_schema = TabletSchema::create_with_uid(_tablet_schema.schema(), dcg.column_ids()[idx]);
     }
-    FileInfo info{.path = dcg.column_files(parent_name(_segment_file_info.path))[idx]};
+    FileInfo info{.path = dcg.column_file_by_idx(parent_name(_segment_file_info.path), idx)};
     if (idx < dcg.encryption_metas().size()) {
         info.encryption_meta = dcg.encryption_metas()[idx];
     }

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -498,7 +498,7 @@ StatusOr<std::shared_ptr<Segment>> SegmentIterator::_get_dcg_segment(uint32_t uc
         // cols file index -> column index in corresponding file
         std::pair<int32_t, int32_t> idx = dcg->get_column_idx(ucid);
         if (idx.first >= 0) {
-            auto column_file = dcg->column_files(parent_name(_segment->file_name()))[idx.first];
+            auto column_file = dcg->column_file_by_idx(parent_name(_segment->file_name(), idx.first));
             if (_dcg_segments.count(column_file) == 0) {
                 ASSIGN_OR_RETURN(auto dcg_segment, _segment->new_dcg_segment(*dcg, idx.first, _opts.tablet_schema));
                 _dcg_segments[column_file] = dcg_segment;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -498,7 +498,7 @@ StatusOr<std::shared_ptr<Segment>> SegmentIterator::_get_dcg_segment(uint32_t uc
         // cols file index -> column index in corresponding file
         std::pair<int32_t, int32_t> idx = dcg->get_column_idx(ucid);
         if (idx.first >= 0) {
-            auto column_file = dcg->column_file_by_idx(parent_name(_segment->file_name(), idx.first));
+            ASSIGN_OR_RETURN(auto column_file, dcg->column_file_by_idx(parent_name(_segment->file_name(), idx.first)));
             if (_dcg_segments.count(column_file) == 0) {
                 ASSIGN_OR_RETURN(auto dcg_segment, _segment->new_dcg_segment(*dcg, idx.first, _opts.tablet_schema));
                 _dcg_segments[column_file] = dcg_segment;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -498,7 +498,7 @@ StatusOr<std::shared_ptr<Segment>> SegmentIterator::_get_dcg_segment(uint32_t uc
         // cols file index -> column index in corresponding file
         std::pair<int32_t, int32_t> idx = dcg->get_column_idx(ucid);
         if (idx.first >= 0) {
-            ASSIGN_OR_RETURN(auto column_file, dcg->column_file_by_idx(parent_name(_segment->file_name(), idx.first)));
+            ASSIGN_OR_RETURN(auto column_file, dcg->column_file_by_idx(parent_name(_segment->file_name()), idx.first));
             if (_dcg_segments.count(column_file) == 0) {
                 ASSIGN_OR_RETURN(auto dcg_segment, _segment->new_dcg_segment(*dcg, idx.first, _opts.tablet_schema));
                 _dcg_segments[column_file] = dcg_segment;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5109,7 +5109,7 @@ static StatusOr<std::shared_ptr<Segment>> get_dcg_segment(GetDeltaColumnContext&
     for (const auto& dcg : ctx.dcgs) {
         std::pair<int32_t, int32_t> idx = dcg->get_column_idx(ucid);
         if (idx.first >= 0) {
-            std::string column_file = dcg->column_files(parent_name(ctx.segment->file_name()))[idx.first];
+            std::string column_file = dcg->column_file_by_idx(parent_name(ctx.segment->file_name(), idx.first));
             if (ctx.dcg_segments.count(column_file) == 0) {
                 ASSIGN_OR_RETURN(auto dcg_segment, ctx.segment->new_dcg_segment(*dcg, idx.first, read_tablet_schema));
                 ctx.dcg_segments[column_file] = dcg_segment;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5109,7 +5109,8 @@ static StatusOr<std::shared_ptr<Segment>> get_dcg_segment(GetDeltaColumnContext&
     for (const auto& dcg : ctx.dcgs) {
         std::pair<int32_t, int32_t> idx = dcg->get_column_idx(ucid);
         if (idx.first >= 0) {
-            std::string column_file = dcg->column_file_by_idx(parent_name(ctx.segment->file_name(), idx.first));
+            ASSIGN_OR_RETURN(std::string column_file,
+                             dcg->column_file_by_idx(parent_name(ctx.segment->file_name(), idx.first)));
             if (ctx.dcg_segments.count(column_file) == 0) {
                 ASSIGN_OR_RETURN(auto dcg_segment, ctx.segment->new_dcg_segment(*dcg, idx.first, read_tablet_schema));
                 ctx.dcg_segments[column_file] = dcg_segment;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5110,7 +5110,7 @@ static StatusOr<std::shared_ptr<Segment>> get_dcg_segment(GetDeltaColumnContext&
         std::pair<int32_t, int32_t> idx = dcg->get_column_idx(ucid);
         if (idx.first >= 0) {
             ASSIGN_OR_RETURN(std::string column_file,
-                             dcg->column_file_by_idx(parent_name(ctx.segment->file_name(), idx.first)));
+                             dcg->column_file_by_idx(parent_name(ctx.segment->file_name()), idx.first));
             if (ctx.dcg_segments.count(column_file) == 0) {
                 ASSIGN_OR_RETURN(auto dcg_segment, ctx.segment->new_dcg_segment(*dcg, idx.first, read_tablet_schema));
                 ctx.dcg_segments[column_file] = dcg_segment;

--- a/be/test/storage/delta_column_group_test.cpp
+++ b/be/test/storage/delta_column_group_test.cpp
@@ -215,17 +215,17 @@ TEST(TestDeltaColumnGroup, testDeltaColumnGroupVerPBLoad) {
     ASSERT_TRUE(idx.first == 0);
     ASSERT_TRUE(idx.second == 1);
     ASSERT_TRUE("tmp/aaa.cols" == dcg.column_files("tmp")[idx.first]);
-    ASSERT_TRUE("tmp/aaa.cols" == dcg.column_file_by_idx("tmp", idx.first));
+    ASSERT_TRUE("tmp/aaa.cols" == dcg.column_file_by_idx("tmp", idx.first).value());
     idx = dcg.get_column_idx(5);
     ASSERT_TRUE(idx.first == 1);
     ASSERT_TRUE(idx.second == 0);
     ASSERT_TRUE("tmp/bbb.cols" == dcg.column_files("tmp")[idx.first]);
-    ASSERT_TRUE("tmp/bbb.cols" == dcg.column_file_by_idx("tmp", idx.first));
+    ASSERT_TRUE("tmp/bbb.cols" == dcg.column_file_by_idx("tmp", idx.first).value());
     idx = dcg.get_column_idx(8);
     ASSERT_TRUE(idx.first == 2);
     ASSERT_TRUE(idx.second == 1);
     ASSERT_TRUE("tmp/ccc.cols" == dcg.column_files("tmp")[idx.first]);
-    ASSERT_TRUE("tmp/ccc.cols" == dcg.column_file_by_idx("tmp", idx.first));
+    ASSERT_TRUE("tmp/ccc.cols" == dcg.column_file_by_idx("tmp", idx.first).value());
 
     // overflow
     ASSERT_FALSE(dcg.column_file_by_idx("tmp", 100).ok());

--- a/be/test/storage/delta_column_group_test.cpp
+++ b/be/test/storage/delta_column_group_test.cpp
@@ -215,14 +215,20 @@ TEST(TestDeltaColumnGroup, testDeltaColumnGroupVerPBLoad) {
     ASSERT_TRUE(idx.first == 0);
     ASSERT_TRUE(idx.second == 1);
     ASSERT_TRUE("tmp/aaa.cols" == dcg.column_files("tmp")[idx.first]);
+    ASSERT_TRUE("tmp/aaa.cols" == dcg.column_file_by_idx("tmp", idx.first));
     idx = dcg.get_column_idx(5);
     ASSERT_TRUE(idx.first == 1);
     ASSERT_TRUE(idx.second == 0);
     ASSERT_TRUE("tmp/bbb.cols" == dcg.column_files("tmp")[idx.first]);
+    ASSERT_TRUE("tmp/bbb.cols" == dcg.column_file_by_idx("tmp", idx.first));
     idx = dcg.get_column_idx(8);
     ASSERT_TRUE(idx.first == 2);
     ASSERT_TRUE(idx.second == 1);
     ASSERT_TRUE("tmp/ccc.cols" == dcg.column_files("tmp")[idx.first]);
+    ASSERT_TRUE("tmp/ccc.cols" == dcg.column_file_by_idx("tmp", idx.first));
+
+    // overflow
+    ASSERT_FALSE(dcg.column_file_by_idx("tmp", 100).ok());
 }
 
 } // namespace starrocks

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -340,16 +340,22 @@ TEST_F(MetaFileTest, test_dcg) {
         EXPECT_TRUE(pdcgs.size() == 1);
         auto idx = pdcgs[0]->get_column_idx(3);
         EXPECT_TRUE("tmp/ddd.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
+        EXPECT_TRUE("tmp/ddd.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first));
         idx = pdcgs[0]->get_column_idx(4);
         EXPECT_TRUE("tmp/ccc.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
+        EXPECT_TRUE("tmp/ccc.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first));
         idx = pdcgs[0]->get_column_idx(5);
         EXPECT_TRUE("tmp/ddd.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
+        EXPECT_TRUE("tmp/ddd.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first));
         idx = pdcgs[0]->get_column_idx(6);
         EXPECT_TRUE("tmp/bbb.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
+        EXPECT_TRUE("tmp/bbb.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first));
         idx = pdcgs[0]->get_column_idx(7);
         EXPECT_TRUE("tmp/ccc.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
+        EXPECT_TRUE("tmp/ccc.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first));
         idx = pdcgs[0]->get_column_idx(8);
         EXPECT_TRUE("tmp/bbb.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
+        EXPECT_TRUE("tmp/bbb.cols" == pdcgs[0]->column_files("tmp", idx.first));
     }
     // 4. compact (conflict)
     {

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -340,22 +340,22 @@ TEST_F(MetaFileTest, test_dcg) {
         EXPECT_TRUE(pdcgs.size() == 1);
         auto idx = pdcgs[0]->get_column_idx(3);
         EXPECT_TRUE("tmp/ddd.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
-        EXPECT_TRUE("tmp/ddd.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first));
+        EXPECT_TRUE("tmp/ddd.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first).value());
         idx = pdcgs[0]->get_column_idx(4);
         EXPECT_TRUE("tmp/ccc.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
-        EXPECT_TRUE("tmp/ccc.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first));
+        EXPECT_TRUE("tmp/ccc.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first).value());
         idx = pdcgs[0]->get_column_idx(5);
         EXPECT_TRUE("tmp/ddd.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
-        EXPECT_TRUE("tmp/ddd.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first));
+        EXPECT_TRUE("tmp/ddd.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first).value());
         idx = pdcgs[0]->get_column_idx(6);
         EXPECT_TRUE("tmp/bbb.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
-        EXPECT_TRUE("tmp/bbb.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first));
+        EXPECT_TRUE("tmp/bbb.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first).value());
         idx = pdcgs[0]->get_column_idx(7);
         EXPECT_TRUE("tmp/ccc.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
-        EXPECT_TRUE("tmp/ccc.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first));
+        EXPECT_TRUE("tmp/ccc.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first).value());
         idx = pdcgs[0]->get_column_idx(8);
         EXPECT_TRUE("tmp/bbb.cols" == pdcgs[0]->column_files("tmp")[idx.first]);
-        EXPECT_TRUE("tmp/bbb.cols" == pdcgs[0]->column_files("tmp", idx.first));
+        EXPECT_TRUE("tmp/bbb.cols" == pdcgs[0]->column_file_by_idx("tmp", idx.first).value());
     }
     // 4. compact (conflict)
     {

--- a/be/test/storage/tablet_meta_manager_test.cpp
+++ b/be/test/storage/tablet_meta_manager_test.cpp
@@ -412,6 +412,7 @@ TEST_F(TabletMetaManagerTest, delta_column_group_operations) {
         CHECK(TabletMetaManager::get_delta_column_group(meta, tablet_id, segid, i, &dcgs).ok());
         ASSERT_EQ(dcgs.size(), i);
         ASSERT_EQ(dcgs[0]->column_files("111").front(), "111/1110.cols");
+        ASSERT_EQ(dcgs[0]->column_file_by_idx("111", 0), "111/1110.cols");
         ASSERT_EQ(dcgs[0]->get_column_idx(10).first, 0);
         ASSERT_EQ(dcgs[0]->get_column_idx(10).second, 1);
         ASSERT_EQ(dcgs[0]->get_column_idx(11).first, -1);
@@ -425,7 +426,7 @@ TEST_F(TabletMetaManagerTest, delta_column_group_operations) {
         int segid = (rand() % 20) + 1;
         CHECK(TabletMetaManager::scan_delta_column_group(meta, tablet_id, segid, i, i + len, &dcgs).ok());
         ASSERT_EQ(dcgs.size(), len);
-        ASSERT_EQ(dcgs[0]->column_files("111").front(), "111/1110.cols");
+        ASSERT_EQ(dcgs[0]->column_file_by_idx("111", 0), "111/1110.cols");
         ASSERT_EQ(dcgs[0]->get_column_idx(10).first, 0);
         ASSERT_EQ(dcgs[0]->get_column_idx(10).second, 1);
         ASSERT_EQ(dcgs[0]->get_column_idx(11).first, -1);

--- a/be/test/storage/tablet_meta_manager_test.cpp
+++ b/be/test/storage/tablet_meta_manager_test.cpp
@@ -412,7 +412,7 @@ TEST_F(TabletMetaManagerTest, delta_column_group_operations) {
         CHECK(TabletMetaManager::get_delta_column_group(meta, tablet_id, segid, i, &dcgs).ok());
         ASSERT_EQ(dcgs.size(), i);
         ASSERT_EQ(dcgs[0]->column_files("111").front(), "111/1110.cols");
-        ASSERT_EQ(dcgs[0]->column_file_by_idx("111", 0), "111/1110.cols");
+        ASSERT_EQ(dcgs[0]->column_file_by_idx("111", 0).value(), "111/1110.cols");
         ASSERT_EQ(dcgs[0]->get_column_idx(10).first, 0);
         ASSERT_EQ(dcgs[0]->get_column_idx(10).second, 1);
         ASSERT_EQ(dcgs[0]->get_column_idx(11).first, -1);
@@ -426,7 +426,7 @@ TEST_F(TabletMetaManagerTest, delta_column_group_operations) {
         int segid = (rand() % 20) + 1;
         CHECK(TabletMetaManager::scan_delta_column_group(meta, tablet_id, segid, i, i + len, &dcgs).ok());
         ASSERT_EQ(dcgs.size(), len);
-        ASSERT_EQ(dcgs[0]->column_file_by_idx("111", 0), "111/1110.cols");
+        ASSERT_EQ(dcgs[0]->column_file_by_idx("111", 0).value(), "111/1110.cols");
         ASSERT_EQ(dcgs[0]->get_column_idx(10).first, 0);
         ASSERT_EQ(dcgs[0]->get_column_idx(10).second, 1);
         ASSERT_EQ(dcgs[0]->get_column_idx(11).first, -1);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
I introduce `column_file_by_idx` to return filename delta column group by index, it will be more efficient than use `column_files` to return filename array.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
