### PR TITLE
[BugFix] add return type check in Java UDTF

### DIFF
--- a/be/src/udf/java/java_data_converter.h
+++ b/be/src/udf/java/java_data_converter.h
@@ -63,4 +63,5 @@ template <bool handle_null>
 jvalue cast_to_jvalue(LogicalType type, bool is_boxed, const Column* col, int row_num);
 void release_jvalue(bool is_boxed, jvalue val);
 void append_jvalue(MethodTypeDescriptor method_type_desc, Column* col, jvalue val);
+Status check_type_matched(MethodTypeDescriptor method_type_desc, jobject val);
 } // namespace starrocks

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -102,6 +102,8 @@ void JVMFunctionHelper::_init() {
     CHECK(_list_class);
     CHECK(_exception_util_class);
 
+    _equals = _env->GetMethodID(_object_class, "equals", "(Ljava/lang/Object;)Z");
+
     ADD_NUMBERIC_CLASS(boolean, Boolean, Z);
     ADD_NUMBERIC_CLASS(byte, Byte, B);
     ADD_NUMBERIC_CLASS(short, Short, S);
@@ -218,6 +220,19 @@ std::string JVMFunctionHelper::array_to_string(jobject object) {
     CHECK_FUNCTION_EXCEPTION(_env, "array_to_string")
     value = to_cxx_string((jstring)jstr);
     return value;
+}
+
+bool JVMFunctionHelper::equals(jobject obj1, jobject obj2) {
+    if (obj1 == obj2) {
+        return true;
+    }
+    if (obj1 == nullptr) {
+        return false;
+    }
+    _env->ExceptionClear();
+    bool res = _env->CallBooleanMethod(obj1, _equals, obj2);
+    CHECK_FUNCTION_EXCEPTION(_env, "equals")
+    return res;
 }
 
 std::string JVMFunctionHelper::to_string(jobject obj) {
@@ -415,10 +430,6 @@ Slice JVMFunctionHelper::sliceVal(jstring jstr, std::string* buffer) {
     buffer->resize(length);
     _env->GetStringUTFRegion(jstr, 0, length, buffer->data());
     return {buffer->data(), buffer->length()};
-}
-
-Slice JVMFunctionHelper::sliceVal(jstring jstr) {
-    return {_env->GetStringUTFChars(jstr, nullptr)};
 }
 
 std::string JVMFunctionHelper::to_jni_class_name(const std::string& name) {

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -102,8 +102,6 @@ void JVMFunctionHelper::_init() {
     CHECK(_list_class);
     CHECK(_exception_util_class);
 
-    _equals = _env->GetMethodID(_object_class, "equals", "(Ljava/lang/Object;)Z");
-
     ADD_NUMBERIC_CLASS(boolean, Boolean, Z);
     ADD_NUMBERIC_CLASS(byte, Byte, B);
     ADD_NUMBERIC_CLASS(short, Short, S);
@@ -220,19 +218,6 @@ std::string JVMFunctionHelper::array_to_string(jobject object) {
     CHECK_FUNCTION_EXCEPTION(_env, "array_to_string")
     value = to_cxx_string((jstring)jstr);
     return value;
-}
-
-bool JVMFunctionHelper::equals(jobject obj1, jobject obj2) {
-    if (obj1 == obj2) {
-        return true;
-    }
-    if (obj1 == nullptr) {
-        return false;
-    }
-    _env->ExceptionClear();
-    bool res = _env->CallBooleanMethod(obj1, _equals, obj2);
-    CHECK_FUNCTION_EXCEPTION(_env, "equals")
-    return res;
 }
 
 std::string JVMFunctionHelper::to_string(jobject obj) {

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -37,9 +37,10 @@ extern "C" JNIEnv* getJNIEnv(void);
     jmethodID _value_of_##TYPE;     \
     jmethodID _val_##TYPE;
 
-#define DECLARE_NEW_BOX(TYPE, CLAZZ) \
-    jobject new##CLAZZ(TYPE value);  \
-    TYPE val##TYPE(jobject obj);
+#define DECLARE_NEW_BOX(PRIM_CLAZZ, TYPE, CLAZZ) \
+    jobject new##CLAZZ(TYPE value);              \
+    TYPE val##TYPE(jobject obj);                 \
+    jclass TYPE##_class() { return _class_##PRIM_CLAZZ; }
 
 namespace starrocks {
 class DirectByteBuffer;
@@ -59,6 +60,7 @@ public:
     // Arrays.toString()
     std::string array_to_string(jobject object);
     // Object::toString()
+    bool equals(jobject obj1, jobject obj2);
     std::string to_string(jobject obj);
     std::string to_cxx_string(jstring str);
     std::string dumpExceptionString(jthrowable throwable);
@@ -117,19 +119,19 @@ public:
     jobject list_get(jobject obj, int idx);
     int list_size(jobject obj);
 
-    DECLARE_NEW_BOX(uint8_t, Boolean)
-    DECLARE_NEW_BOX(int8_t, Byte)
-    DECLARE_NEW_BOX(int16_t, Short)
-    DECLARE_NEW_BOX(int32_t, Integer)
-    DECLARE_NEW_BOX(int64_t, Long)
-    DECLARE_NEW_BOX(float, Float)
-    DECLARE_NEW_BOX(double, Double)
+    DECLARE_NEW_BOX(boolean, uint8_t, Boolean)
+    DECLARE_NEW_BOX(byte, int8_t, Byte)
+    DECLARE_NEW_BOX(short, int16_t, Short)
+    DECLARE_NEW_BOX(int, int32_t, Integer)
+    DECLARE_NEW_BOX(long, int64_t, Long)
+    DECLARE_NEW_BOX(float, float, Float)
+    DECLARE_NEW_BOX(double, double, Double)
 
     jobject newString(const char* data, size_t size);
-
-    Slice sliceVal(jstring jstr);
     size_t string_length(jstring jstr);
+
     Slice sliceVal(jstring jstr, std::string* buffer);
+    jclass string_clazz() { return _string_class; }
     // replace '.' as '/'
     // eg: java.lang.Integer -> java/lang/Integer
     static std::string to_jni_class_name(const std::string& name);
@@ -174,6 +176,7 @@ private:
     jobject _utf8_charsets;
 
     jclass _udf_helper_class;
+    jmethodID _equals;
     jmethodID _create_boxed_array;
     jmethodID _batch_update;
     jmethodID _batch_update_if_not_null;

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -176,7 +176,6 @@ private:
     jobject _utf8_charsets;
 
     jclass _udf_helper_class;
-    jmethodID _equals;
     jmethodID _create_boxed_array;
     jmethodID _batch_update;
     jmethodID _batch_update_if_not_null;

--- a/test/sql/test_udf/R/test_jvm_udf
+++ b/test/sql/test_udf/R/test_jvm_udf
@@ -9,6 +9,48 @@ type = "StarrocksJar"
 file = "${udf_url}/starrocks-jdbc%2FSumbigint.jar";
 -- result:
 -- !result
+CREATE TABLE FUNCTION udtfstring(string)
+RETURNS string
+symbol = "UDTFstring"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFstring.jar";
+-- result:
+-- !result
+CREATE TABLE FUNCTION udtfstring_wrong_match(string)
+RETURNS int
+symbol = "UDTFstring"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFstring.jar";
+-- result:
+-- !result
+CREATE TABLE FUNCTION udtfint(int)
+RETURNS int
+symbol = "UDTFint"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFint.jar";
+-- result:
+-- !result
+CREATE TABLE FUNCTION udtfbigint(bigint)
+RETURNS bigint
+symbol = "UDTFbigint"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFbigint.jar";
+-- result:
+-- !result
+CREATE TABLE FUNCTION udtffloat(float)
+RETURNS float
+symbol = "UDTFfloat"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFfloat.jar";
+-- result:
+-- !result
+CREATE TABLE FUNCTION udtfdouble(double)
+RETURNS double
+symbol = "UDTFdouble"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFdouble.jar";
+-- result:
+-- !result
 CREATE TABLE `t0` (
   `c0` int(11) NULL COMMENT "",
   `c1` varchar(20) NULL COMMENT "",
@@ -24,6 +66,30 @@ PROPERTIES (
 -- !result
 insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
 -- result:
+-- !result
+select count(udtfstring) from t0, udtfstring(c1);
+-- result:
+81920
+-- !result
+select count(udtfstring_wrong_match) from t0, udtfstring_wrong_match(c1);
+-- result:
+E: (1064, 'Type not matched')
+-- !result
+select count(udtfint) from t0, udtfint(c1);
+-- result:
+81920
+-- !result
+select count(udtfbigint) from t0, udtfbigint(c1);
+-- result:
+81920
+-- !result
+select count(udtffloat) from t0, udtffloat(c1);
+-- result:
+81920
+-- !result
+select count(udtfdouble) from t0, udtfdouble(c1);
+-- result:
+81920
 -- !result
 set streaming_preaggregation_mode="force_streaming";
 -- result:

--- a/test/sql/test_udf/R/test_jvm_udf
+++ b/test/sql/test_udf/R/test_jvm_udf
@@ -73,7 +73,7 @@ select count(udtfstring) from t0, udtfstring(c1);
 -- !result
 select count(udtfstring_wrong_match) from t0, udtfstring_wrong_match(c1);
 -- result:
-E: (1064, 'Type not matched')
+E: (1064, 'Type not matched, expect class java.lang.Integer, but got class java.lang.String')
 -- !result
 select count(udtfint) from t0, udtfint(c1);
 -- result:

--- a/test/sql/test_udf/T/test_jvm_udf
+++ b/test/sql/test_udf/T/test_jvm_udf
@@ -8,6 +8,43 @@ symbol = "Sumbigint"
 type = "StarrocksJar"
 file = "${udf_url}/starrocks-jdbc%2FSumbigint.jar";
 
+CREATE TABLE FUNCTION udtfstring(string)
+RETURNS string
+symbol = "UDTFstring"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFstring.jar";
+
+CREATE TABLE FUNCTION udtfstring_wrong_match(string)
+RETURNS int
+symbol = "UDTFstring"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFstring.jar";
+
+CREATE TABLE FUNCTION udtfint(int)
+RETURNS int
+symbol = "UDTFint"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFint.jar";
+
+CREATE TABLE FUNCTION udtfbigint(bigint)
+RETURNS bigint
+symbol = "UDTFbigint"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFbigint.jar";
+
+CREATE TABLE FUNCTION udtffloat(float)
+RETURNS float
+symbol = "UDTFfloat"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFfloat.jar";
+
+CREATE TABLE FUNCTION udtfdouble(double)
+RETURNS double
+symbol = "UDTFdouble"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc%2FUDTFdouble.jar";
+
+
 CREATE TABLE `t0` (
   `c0` int(11) NULL COMMENT "",
   `c1` varchar(20) NULL COMMENT "",
@@ -21,6 +58,14 @@ PROPERTIES (
 );
 
 insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+
+-- test udtf cases
+select count(udtfstring) from t0, udtfstring(c1);
+select count(udtfstring_wrong_match) from t0, udtfstring_wrong_match(c1);
+select count(udtfint) from t0, udtfint(c1);
+select count(udtfbigint) from t0, udtfbigint(c1);
+select count(udtffloat) from t0, udtffloat(c1);
+select count(udtfdouble) from t0, udtfdouble(c1);
 
 -- test group by limit case:
 set streaming_preaggregation_mode="force_streaming";


### PR DESCRIPTION
## Why I'm doing:

```
*** SIGSEGV (@0x228) received by PID 1463834 (TID 0x7f75201bc640) from PID 552; stack trace: ***
    @     0x7f767c211ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xc55e3a9 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f767cee101d os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x7f767cee5d49 JVM_handle_linux_signal
    @     0x7f767ced91f8 signalHandler(int, siginfo_t*, void*)
    @     0x7f767c1ba520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f767ccb7924 jni_invoke_nonstatic(JNIEnv_*, JavaValue*, _jobject*, JNICallType, _jmethodID*, JNI_ArgumentPusher*, Thread*) [clone .constprop.233]
    @     0x7f767ccc1579 jni_CallLongMethodV
    @          0x56d9f6f JNIEnv_::CallLongMethod(_jobject*, _jmethodID*, ...)
    @          0x8a30313 starrocks::append_jvalue(starrocks::MethodTypeDescriptor, starrocks::Column*, jvalue)
    @          0x78c5cbd starrocks::JavaUDTFFunction::process(starrocks::RuntimeState*, starrocks::TableFunctionState*) const
    @          0x5b2514e starrocks::pipeline::TableFunctionOperator::_process_table_function(starrocks::RuntimeState*)
    @          0x5b266ea starrocks::pipeline::TableFunctionOperator::pull_chunk(starrocks::RuntimeState*)
    @          0x5abff76 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x5aad0db starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x8b62fd4 starrocks::ThreadPool::dispatch_thread()
    @          0x8b5c0f9 starrocks::Thread::supervise_thread(void*)
    @     0x7f767c20cac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f767c29e850 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
