### PR TITLE
[BugFix] Fix decimal literal equals uncheck type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
@@ -526,7 +526,7 @@ public class DecimalLiteral extends LiteralExpr {
 
     @Override
     public boolean equals(Object obj) {
-        return super.equals(obj);
+        return super.equals(obj) && (type.matchesType(((LiteralExpr) obj).getType()));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -275,4 +275,15 @@ public class DecimalTypeTest extends PlanTestBase {
         assertContains(plan, "1:Project\n" +
                 "  |  <slot 16> : CAST(1: c_0_0 AS DOUBLE) < CAST('1969-12-10 23:46:53' AS DOUBLE)");
     }
+
+    @Test
+    public void testSameValueDiffTypeDecimal() throws Exception {
+        String sql = "SELECT t1a,\n" +
+                "    sum(t1f * 1.00000000000) / NULLIF(sum(t1c), 0) AS aaaa,\n" +
+                "    sum(t1f * 1.000) / NULLIF(sum(t1d * 1.000), 0) * 1000 AS bbbb\n" +
+                " FROM test_all_type \n" +
+                " GROUP BY t1a;\n ";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "<slot 11> : 6: t1f * 1.0\n");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
![image](https://github.com/user-attachments/assets/f19909f9-8570-4dd1-8759-289ea6a56308)

`sum(gmv * 1.00000000000)`: `1.00000000000` is `DECIMAL64(12, 11)` Literal
`sum(gmv * 1.000)` : `1.000` is `DECIMAL32(4, 3)` Literal

equals method check `1.00000000000` is same as `1.000`, but the results of hashcode method is different.
In analyze, will check duplicate expression by list.contains, only use equals method, then two expression will be reduce to one, but in QueryTransform, use HashMap to find expression, it's will take can't find expression because hashcode is different.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
