### PR TITLE
[BugFix] Fix null exception when insert overwrite job run concurrecy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJob.java
@@ -42,6 +42,9 @@ public class InsertOverwriteJob {
     @SerializedName(value = "warehouseId")
     private long warehouseId;
 
+    @SerializedName(value = "sourcePartitionNames")
+    private List<String> sourcePartitionNames;
+
 
     private transient InsertStmt insertStmt;
 
@@ -87,6 +90,14 @@ public class InsertOverwriteJob {
 
     public void setSourcePartitionIds(List<Long> sourcePartitionIds) {
         this.sourcePartitionIds = sourcePartitionIds;
+    }
+
+    public List<String> getSourcePartitionNames() {
+        return sourcePartitionNames;
+    }
+
+    public void setSourcePartitionNames(List<String> sourcePartitionNames) {
+        this.sourcePartitionNames = sourcePartitionNames;
     }
 
     public List<Long> getTmpPartitionIds() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -183,6 +183,7 @@ public class InsertOverwriteJobRunner {
             case OVERWRITE_RUNNING:
                 job.setSourcePartitionIds(info.getSourcePartitionIds());
                 job.setTmpPartitionIds(info.getTmpPartitionIds());
+                job.setSourcePartitionNames(info.getSourcePartitionNames());
                 job.setJobState(InsertOverwriteJobState.OVERWRITE_RUNNING);
                 break;
             case OVERWRITE_SUCCESS:
@@ -225,8 +226,21 @@ public class InsertOverwriteJobRunner {
         }
 
         try {
+            OlapTable targetTable;
+            targetTable = checkAndGetTable(db, tableId);
+            List<String> sourcePartitionNames = Lists.newArrayList();
+            for (Long id : job.getSourcePartitionIds()) {
+                Partition partition = targetTable.getPartition(partitionId);
+                if (partition == null) {
+                    throw new DmlException("partition id:%s does not exist in table id:%s", partitionId, tableId);
+                }
+                sourcePartitionNames.add(partition.getName());
+            }
+            job.setSourcePartitionNames(sourcePartitionNames);
+
             InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
-                    InsertOverwriteJobState.OVERWRITE_RUNNING, job.getSourcePartitionIds(), job.getTmpPartitionIds());
+                    InsertOverwriteJobState.OVERWRITE_RUNNING, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
+                    job.getTmpPartitionIds());
             GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
         } finally {
             locker.unLockDatabase(db, tableId, LockType.WRITE);
@@ -405,7 +419,8 @@ public class InsertOverwriteJobRunner {
                 sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
 
                 InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
-                        OVERWRITE_FAILED, job.getSourcePartitionIds(), job.getTmpPartitionIds());
+                        OVERWRITE_FAILED, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
+                        job.getTmpPartitionIds());
                 GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
             }
         } catch (Exception e) {
@@ -429,6 +444,19 @@ public class InsertOverwriteJobRunner {
             // try exception to release write lock finally
             final OlapTable targetTable = checkAndGetTable(db, tableId);
             tmpTargetTable = targetTable;
+            List<String> sourcePartitionNames = job.getSourcePartitionNames();
+            if (sourcePartitionNames == null || sourcePartitionNames.isEmpty()) {
+                sourcePartitionNames = job.getSourcePartitionIds().stream()
+                        .map(partitionId -> {
+                            Partition partition = targetTable.getPartition(partitionId);
+                            if (partition == null) {
+                                throw new DmlException("Partition id:%s does not exist in table id:%s", partitionId, tableId);
+                            }
+                            return partition.getName();
+                        })
+                        .collect(Collectors.toList());
+            }
+
             List<String> sourcePartitionNames = job.getSourcePartitionIds().stream()
                     .map(partitionId -> targetTable.getPartition(partitionId).getName())
                     .collect(Collectors.toList());
@@ -457,7 +485,8 @@ public class InsertOverwriteJobRunner {
                 sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
 
                 InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
-                        InsertOverwriteJobState.OVERWRITE_SUCCESS, job.getSourcePartitionIds(), job.getTmpPartitionIds());
+                        InsertOverwriteJobState.OVERWRITE_SUCCESS, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
+                        job.getTmpPartitionIds());
                 GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
 
                 try {

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -556,7 +556,7 @@ public class InsertOverwriteJobRunner {
         return (OlapTable) table;
     }
 
-    public void testDoCommit(boolean isReplay) {
+    protected void testDoCommit(boolean isReplay) {
         doCommit(isReplay);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/InsertOverwriteStateChangeInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/InsertOverwriteStateChangeInfo.java
@@ -42,13 +42,19 @@ public class InsertOverwriteStateChangeInfo implements Writable {
     @SerializedName(value = "tmpPartitionIds")
     private List<Long> tmpPartitionIds;
 
+    @SerializedName(value = "sourcePartitionNames")
+    private List<String> sourcePartitionNames = null;
+
     public InsertOverwriteStateChangeInfo(long jobId, InsertOverwriteJobState fromState,
                                           InsertOverwriteJobState toState,
-                                          List<Long> sourcePartitionIds, List<Long> tmpPartitionIds) {
+                                          List<Long> sourcePartitionIds, 
+                                          List<String> sourcePartitionNames,
+                                          List<Long> tmpPartitionIds) {
         this.jobId = jobId;
         this.fromState = fromState;
         this.toState = toState;
         this.sourcePartitionIds = sourcePartitionIds;
+        this.sourcePartitionNames = sourcePartitionNames;
         this.tmpPartitionIds = tmpPartitionIds;
     }
 
@@ -70,6 +76,10 @@ public class InsertOverwriteStateChangeInfo implements Writable {
 
     public List<Long> getTmpPartitionIds() {
         return tmpPartitionIds;
+    }
+
+    public List<String> getSourcePartitionNames() {
+        return sourcePartitionNames;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobManagerTest.java
@@ -132,12 +132,12 @@ public class InsertOverwriteJobManagerTest {
         List<Long> newPartitionNames = Lists.newArrayList(10001L);
         InsertOverwriteStateChangeInfo stateChangeInfo = new InsertOverwriteStateChangeInfo(1100L,
                 InsertOverwriteJobState.OVERWRITE_PENDING, InsertOverwriteJobState.OVERWRITE_RUNNING,
-                sourcePartitionNames, newPartitionNames);
+                sourcePartitionNames, null, newPartitionNames);
         insertOverwriteJobManager.replayInsertOverwriteStateChange(stateChangeInfo);
 
         InsertOverwriteStateChangeInfo stateChangeInfo2 = new InsertOverwriteStateChangeInfo(1100L,
                 InsertOverwriteJobState.OVERWRITE_RUNNING, InsertOverwriteJobState.OVERWRITE_SUCCESS,
-                sourcePartitionNames, newPartitionNames);
+                sourcePartitionNames, null, newPartitionNames);
         insertOverwriteJobManager.replayInsertOverwriteStateChange(stateChangeInfo2);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -28,11 +28,13 @@ import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.InsertStmt;
+//import com.starrocks.sql.common.DmlException;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+//import org.junit.jupiter.api.Assertions;
 
 import java.sql.SQLException;
 
@@ -138,5 +140,24 @@ public class InsertOverwriteJobRunnerTest {
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000000);
         String sql = "insert overwrite t3 partitions(p1, p1) select * from t4";
         cluster.runSql("insert_overwrite_test", sql);
+    }
+
+    @Test
+    public void testInsertOverwriteConcurrencyWithSamePartitions() throws Exception {
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("insert_overwrite_test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "t1");
+        Assert.assertTrue(table instanceof OlapTable);
+        OlapTable olapTable = (OlapTable) table;
+        InsertOverwriteJob insertOverwriteJob = new InsertOverwriteJob(100L, database.getId(), olapTable.getId(),
+                Lists.newArrayList(olapTable.getPartition("t1").getId()));
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(insertOverwriteJob);
+
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000000);
+        String sql = "insert overwrite t1 partitions(t1) select * from t2";
+        cluster.runSql("insert_overwrite_test", sql);
+        
+        Assertions.assertThrows(DmlException.class, () -> runner.testDoCommit(false));
+        insertOverwriteJob.setSourcePartitionNames(Lists.newArrayList("t1"));
+        Assertions.assertThrows(DmlException.class, () -> runner.testDoCommit(false));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -28,13 +28,13 @@ import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.InsertStmt;
-//import com.starrocks.sql.common.DmlException;
+import com.starrocks.sql.common.DmlException;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-//import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assertions;
 
 import java.sql.SQLException;
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -97,7 +97,7 @@ public class InsertOverwriteJobRunnerTest {
                 Lists.newArrayList(olapTable.getPartition("t1").getId()));
         InsertOverwriteStateChangeInfo stateChangeInfo = new InsertOverwriteStateChangeInfo(100L,
                 InsertOverwriteJobState.OVERWRITE_PENDING, InsertOverwriteJobState.OVERWRITE_RUNNING,
-                Lists.newArrayList(2000L), Lists.newArrayList(2001L));
+                Lists.newArrayList(2000L), null, Lists.newArrayList(2001L));
         Assert.assertEquals(100L, stateChangeInfo.getJobId());
         Assert.assertEquals(InsertOverwriteJobState.OVERWRITE_PENDING, stateChangeInfo.getFromState());
         Assert.assertEquals(InsertOverwriteJobState.OVERWRITE_RUNNING, stateChangeInfo.getToState());

--- a/fe/fe-core/src/test/java/com/starrocks/persist/InsertOverwriteStateChangeInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/InsertOverwriteStateChangeInfoTest.java
@@ -35,7 +35,7 @@ public class InsertOverwriteStateChangeInfoTest {
         List<Long> newPartitionNames = Lists.newArrayList(1000L, 1001L);
         InsertOverwriteStateChangeInfo stateChangeInfo = new InsertOverwriteStateChangeInfo(100L,
                 InsertOverwriteJobState.OVERWRITE_PENDING, InsertOverwriteJobState.OVERWRITE_RUNNING,
-                sourcePartitionNames, newPartitionNames);
+                sourcePartitionNames, null, newPartitionNames);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
         stateChangeInfo.write(dataOutputStream);


### PR DESCRIPTION
## Why I'm doing:
If we run multiple insert overwrite jobs concurrency with the same partition, we will first record the partition ids and replace partition at last. However, we will create a new partition with a new partition id and replace the old partition. So only the first insert overwrite job can run success because the following jobs can not find the partition according to the partition id and they will throw null exception.

## What I'm doing:
Save the source partition name and try to find the partition according to the partition name.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
