### PR TITLE
[Enhancement] remove partition predicate from cardinality estimation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -222,12 +222,13 @@ public class ListPartitionPruner implements PartitionPruner {
     }
 
     /**
+     * TODO: support more cases
      * Only some simple conjuncts can be pruned
      */
     public static boolean canPruneWithConjunct(ScalarOperator conjunct) {
         if (conjunct instanceof BinaryPredicateOperator) {
             BinaryPredicateOperator bop = conjunct.cast();
-            return bop.getBinaryType().isEqualOrRange() && bop.getChild(1).isConstantRef();
+            return bop.getBinaryType().isEqualOrRange() && evaluateConstant(bop.getChild(1)) != null;
         } else if (conjunct instanceof InPredicateOperator) {
             InPredicateOperator inOp = conjunct.cast();
             return !inOp.isNotIn() && inOp.getChildren().stream().skip(1).allMatch(ScalarOperator::isConstant);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -242,7 +242,7 @@ public class ListPartitionPruner implements PartitionPruner {
      * - conjunct: dt >= '2024-01-01'
      * - generate-expr: month=date_trunc('MONTH', dt)
      */
-    public static List<String> deduceColumns(LogicalScanOperator scanOperator) {
+    public static List<String> deduceGenerateColumns(LogicalScanOperator scanOperator) {
         List<String> partitionColumnNames = scanOperator.getTable().getPartitionColumnNames();
         if (CollectionUtils.isEmpty(partitionColumnNames)) {
             return Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -49,6 +49,7 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorEvaluator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.plan.ScalarOperatorToExpr;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -218,6 +219,61 @@ public class ListPartitionPruner implements PartitionPruner {
                 return new ArrayList<>(matches);
             }
         }
+    }
+
+    /**
+     * Only some simple conjuncts can be pruned
+     */
+    public static boolean canPruneWithConjunct(ScalarOperator conjunct) {
+        if (conjunct instanceof BinaryPredicateOperator) {
+            BinaryPredicateOperator bop = conjunct.cast();
+            return bop.getBinaryType().isEqualOrRange() && bop.getChild(1).isConstantRef();
+        } else if (conjunct instanceof InPredicateOperator) {
+            InPredicateOperator inOp = conjunct.cast();
+            return !inOp.isNotIn() && inOp.getChildren().stream().skip(1).allMatch(ScalarOperator::isConstant);
+        }
+        return false;
+    }
+
+    /**
+     * Can we use this conjunct to deduce extract pruneable-conjuncts
+     * Example:
+     * - conjunct: dt >= '2024-01-01'
+     * - generate-expr: month=date_trunc('MONTH', dt)
+     */
+    public static List<String> deduceColumns(LogicalScanOperator scanOperator) {
+        List<String> partitionColumnNames = scanOperator.getTable().getPartitionColumnNames();
+        if (CollectionUtils.isEmpty(partitionColumnNames)) {
+            return Lists.newArrayList();
+        }
+        List<String> result = Lists.newArrayList(partitionColumnNames);
+
+        java.util.function.Function<SlotRef, ColumnRefOperator> slotRefResolver = (slot) -> {
+            return scanOperator.getColumnNameToColRefMap().get(slot.getColumnName());
+        };
+        Consumer<SlotRef> slotRefConsumer = (slot) -> {
+            ColumnRefOperator ref = scanOperator.getColumnNameToColRefMap().get(slot.getColumnName());
+            slot.setType(ref.getType());
+        };
+        for (String partitionColumn : partitionColumnNames) {
+            Column column = scanOperator.getTable().getColumn(partitionColumn);
+            if (column != null && column.isGeneratedColumn()) {
+                Expr generatedExpr = column.getGeneratedColumnExpr(scanOperator.getTable().getBaseSchema());
+                ExpressionAnalyzer.analyzeExpressionResolveSlot(generatedExpr, ConnectContext.get(), slotRefConsumer);
+                ScalarOperator call =
+                        SqlToScalarOperatorTranslator.translateWithSlotRef(generatedExpr, slotRefResolver);
+
+                if (call instanceof CallOperator &&
+                        ScalarOperatorEvaluator.INSTANCE.isMonotonicFunction((CallOperator) call)) {
+                    List<ColumnRefOperator> columnRefOperatorList = Utils.extractColumnRef(call);
+                    for (ColumnRefOperator ref : columnRefOperatorList) {
+                        result.add(ref.getName());
+                    }
+                }
+            }
+        }
+
+        return result;
     }
 
     public void prepareDeduceExtraConjuncts(LogicalScanOperator scanOperator) {
@@ -393,6 +449,11 @@ public class ListPartitionPruner implements PartitionPruner {
     }
 
     private boolean isSinglePartitionColumn(ScalarOperator predicate) {
+        return isSinglePartitionColumn(predicate, partitionColumnRefs);
+    }
+
+    private static boolean isSinglePartitionColumn(ScalarOperator predicate,
+                                                   List<ColumnRefOperator> partitionColumnRefs) {
         List<ColumnRefOperator> columnRefOperatorList = Utils.extractColumnRef(predicate);
         if (columnRefOperatorList.size() == 1 && partitionColumnRefs.contains(columnRefOperatorList.get(0))) {
             // such int_part_column + 1 = 11 can't prune partition
@@ -405,7 +466,7 @@ public class ListPartitionPruner implements PartitionPruner {
         return false;
     }
 
-    private LiteralExpr castLiteralExpr(LiteralExpr literalExpr, Type type) {
+    private static LiteralExpr castLiteralExpr(LiteralExpr literalExpr, Type type) {
         LiteralExpr result = null;
         String value = literalExpr.getStringValue();
         if (literalExpr.getType() == Type.DATE && type.isNumericType()) {
@@ -441,7 +502,7 @@ public class ListPartitionPruner implements PartitionPruner {
         return newPartitionValueMap;
     }
 
-    private ConstantOperator evaluateConstant(ScalarOperator operator) {
+    private static ConstantOperator evaluateConstant(ScalarOperator operator) {
         if (operator.isConstantRef()) {
             return (ConstantOperator) operator;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1695,7 +1695,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         if (isTableTypeSupported && !optimizerContext.isObtainedFromInternalStatistics()) {
             LogicalScanOperator scanOperator = operator.cast();
             List<String> partitionColNames = scanOperator.getTable().getPartitionColumnNames();
-            partitionColNames.addAll(ListPartitionPruner.deduceColumns(scanOperator));
+            partitionColNames.addAll(ListPartitionPruner.deduceGenerateColumns(scanOperator));
 
             List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
             List<ScalarOperator> newPredicates = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.statistics;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -189,6 +190,13 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         this.expressionContext = expressionContext;
         this.columnRefFactory = columnRefFactory;
         this.optimizerContext = optimizerContext;
+    }
+
+    @VisibleForTesting
+    public StatisticsCalculator() {
+        this.expressionContext = null;
+        this.columnRefFactory = null;
+        this.optimizerContext = null;
     }
 
     public void estimatorStats() {
@@ -1679,10 +1687,10 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     }
 
     // avoid use partition cols filter rows twice
-    private ScalarOperator removePartitionPredicate(ScalarOperator predicate, Operator operator,
+    @VisibleForTesting
+    public ScalarOperator removePartitionPredicate(ScalarOperator predicate, Operator operator,
                                                     OptimizerContext optimizerContext) {
-        boolean isTableTypeSupported =
-                operator instanceof LogicalIcebergScanOperator ||
+        boolean isTableTypeSupported = operator instanceof LogicalIcebergScanOperator ||
                         isOlapScanListPartitionTable(operator);
         if (isTableTypeSupported && !optimizerContext.isObtainedFromInternalStatistics()) {
             LogicalScanOperator scanOperator = operator.cast();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -16,7 +16,15 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.optimizer.Memo;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -200,6 +208,39 @@ public class PartitionPruneTest extends PlanTestBase {
         String sql = "select * from ptest partition(p202007) where d2 is null";
         String plan = getFragmentPlan(sql);
         assertCContains(plan, "partitions=0/4");
+    }
+
+    private static Pair<ScalarOperator, LogicalScanOperator> buildConjunctAndScan(String sql) throws Exception {
+        Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        ExecPlan execPlan = pair.second;
+        LogicalScanOperator scanOperator =
+                (LogicalScanOperator) execPlan.getLogicalPlan().getRoot().inputAt(0).inputAt(0).inputAt(0).getOp();
+        ScalarOperator predicate = execPlan.getPhysicalPlan().getOp().getPredicate();
+        return Pair.create(predicate, scanOperator);
+    }
+
+    private void testRemovePredicate(String sql, String expected) throws Exception {
+        Pair<ScalarOperator, LogicalScanOperator> pair = buildConjunctAndScan(sql);
+        StatisticsCalculator calculator = new StatisticsCalculator();
+        OptimizerContext context = new OptimizerContext(new Memo(), new ColumnRefFactory());
+        ScalarOperator newPredicate = calculator.removePartitionPredicate(pair.first, pair.second, context);
+        Assert.assertEquals(expected, newPredicate.toString());
+    }
+
+    @Test
+    public void testGeneratedColumnPrune_RemovePredicate() throws Exception {
+        testRemovePredicate("select * from t_gen_col where c1 = '2024-01-01' ", "true");
+        testRemovePredicate("select * from t_gen_col where c1 = '2024-01-01' and c2 > 100", "true");
+        testRemovePredicate("select * from t_gen_col where c1 >= '2024-01-01'  and c1 <= '2024-01-03' " +
+                "and c2 > 100", "true");
+        testRemovePredicate("select * from t_gen_col where c2 in (1, 2,3)", "true");
+        testRemovePredicate("select * from t_gen_col where c2 = cast('123' as int)", "true");
+
+        // can not be removed
+        testRemovePredicate("select * from t_gen_col where c1 = random() and c2 > 100",
+                "cast(1: c1 as double) = random(1)");
+        testRemovePredicate("select * from t_gen_col where c2 + 100 > c1 + 1",
+                "cast(add(2: c2, 100) as double) > add(cast(1: c1 as double), 1)");
     }
 
     @Test

--- a/test/sql/test_list_partition/R/test_list_partition_cardinality
+++ b/test/sql/test_list_partition/R/test_list_partition_cardinality
@@ -43,7 +43,7 @@ function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi
 -- result:
 None
 -- !result
-function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1', 'cardinality: 2')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1', 'cardinality: 4')
 -- result:
 None
 -- !result
@@ -55,7 +55,7 @@ function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi
 -- result:
 None
 -- !result
-function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=4', 'cardinality: 500')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=4', 'cardinality: 1000')
 -- result:
 None
 -- !result
@@ -67,7 +67,7 @@ function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi
 -- result:
 None
 -- !result
-function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=2', 'cardinality: 2')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=2', 'cardinality: 3')
 -- result:
 None
 -- !result
@@ -75,7 +75,7 @@ function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi
 -- result:
 None
 -- !result
-function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=7', 'cardinality: 500')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=7', 'cardinality: 1000')
 -- result:
 None
 -- !result

--- a/test/sql/test_list_partition/T/test_list_partition_cardinality
+++ b/test/sql/test_list_partition/T/test_list_partition_cardinality
@@ -29,13 +29,13 @@ ANALYZE FULL TABLE partitions_multi_column_1 WITH SYNC MODE;
 SELECT count(*) FROM partitions_multi_column_1;
 
 function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=0', 'EMPTYSET')
-function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1', 'cardinality: 2')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1', 'cardinality: 4')
 function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=2', 'cardinality: 1')
 function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=3', 'cardinality: 1')
-function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=4', 'cardinality: 500')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=4', 'cardinality: 1000')
 
 function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=0', 'EMPTYSET')
 function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=1', 'cardinality: 1')
-function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=2', 'cardinality: 2')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=2', 'cardinality: 3')
 function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=3', 'cardinality: 1')
-function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=7', 'cardinality: 500')
+function: assert_explain_verbose_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c2=7', 'cardinality: 1000')


### PR DESCRIPTION
## Why I'm doing:



## What I'm doing:

Partition predicate has been applied to partition prune, which already contributed to the cardinality of scan node, so it should not be considered as predicate to estimate cardinality again, otherwise the estimation will be incorrect.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
