### PR TITLE
[Enhancement] Simplify date/datetime column predicate in certain cases

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.optimizer.rewrite.scalar.PruneTediousPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ReduceCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ScalarOperatorRewriteRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedCaseWhenRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedDateColumnPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedScanColumnRule;
 
@@ -48,6 +49,7 @@ public class ScalarOperatorRewriter {
             new NormalizePredicateRule(),
             new FoldConstantsRule(),
             new SimplifiedPredicateRule(),
+            new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE
@@ -70,6 +72,7 @@ public class ScalarOperatorRewriter {
             new FoldConstantsRule(),
             new SimplifiedScanColumnRule(),
             new SimplifiedPredicateRule(),
+            new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule(),
             ConsolidateLikesRule.INSTANCE

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedDateColumnPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedDateColumnPredicateRule.java
@@ -1,0 +1,214 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.analysis.BinaryType;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+
+/**
+ * if t is date
+ * date_format(t, '%Y%m%d') >= '20230327' -> `t` >= '20230327'
+ * date_format(t, '%Y-%m-%d') >= '2023-03-27' -> `t` >= '2023-03-27'
+ * substr(cast(t as varchar), 1, 10) >= '2023-03-27' -> `t` >= '2023-03-27'
+ * substring(cast(t as varchar), 1, 10) >= '2023-03-27' -> `t` >= '2023-03-27'
+ * replace(substring(cast(t as varchar), 1, 10), "-", "") >= '20230327' -> `t` >= '20230327'
+ *
+ * if it is datetime
+ * date_format(t, '%Y-%m-%d') >/>=/< '2023-03-27' -> t >/>=/< '2023-03-27'
+ * date_format(t, '%Y-%m-%d') <= '2023-03-27' -> t < days_add('2023-03-27', 1)
+ */
+public class SimplifiedDateColumnPredicateRule extends BottomUpScalarOperatorRewriteRule {
+
+    @Override
+    public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate,
+                                               ScalarOperatorRewriteContext context) {
+        ScalarOperator op = predicate.getChild(0);
+        if (!(op instanceof CallOperator)) {
+            return predicate;
+        }
+        ScalarOperator right = predicate.getChild(1);
+        if (!(right instanceof ConstantOperator)) {
+            return predicate;
+        }
+        ScalarOperator columnRef = null;
+        Extractor extractor = newExtractor((CallOperator) op, (ConstantOperator) right);
+        if (extractor != null && extractor.check()) {
+            columnRef = extractor.extractColumn();
+        }
+        if (columnRef == null) {
+            return predicate;
+        }
+        BinaryType binaryType = predicate.getBinaryType();
+        if (columnRef.getType().getPrimitiveType() == PrimitiveType.DATE) {
+            return new BinaryPredicateOperator(binaryType, columnRef, right);
+        }
+        // if t is datetime,
+        if (columnRef.getType().getPrimitiveType() == PrimitiveType.DATETIME) {
+            // date_format(t, '%Y-%m-%d') >/>=/< '2023-03-27' -> t >/>=/< '2023-03-27'
+            if (binaryType == BinaryType.GT || binaryType == BinaryType.GE || binaryType == BinaryType.LT) {
+                return new BinaryPredicateOperator(binaryType, columnRef, right);
+            }
+            // date_format(t, '%Y-%m-%d') <= '2023-03-27' -> t < days_add('2023-03-27', 1)
+            if (binaryType == BinaryType.LE) {
+                return new BinaryPredicateOperator(BinaryType.LT, columnRef, new CallOperator(
+                        FunctionSet.DAYS_SUB, Type.DATETIME,
+                        ImmutableList.of(right, ConstantOperator.createInt(1))));
+            }
+        }
+        return predicate;
+    }
+
+    private static boolean isSubstrFn(CallOperator call) {
+        return FunctionSet.SUBSTR.equalsIgnoreCase(call.getFnName())
+                || FunctionSet.SUBSTRING.equalsIgnoreCase(call.getFnName());
+    }
+
+    private Extractor newExtractor(CallOperator call, ConstantOperator value) {
+        if (FunctionSet.DATE_FORMAT.equalsIgnoreCase(call.getFnName())) {
+            return new DateFormatExtractor(call, value);
+        } else if (isSubstrFn(call)) {
+            return new SubstrExtractor(call, value, 10);
+        } else if (FunctionSet.REPLACE.equalsIgnoreCase(call.getFnName())) {
+            return new ReplaceAndSubstrExtractor(call, value);
+        }
+        return null;
+    }
+
+    private interface Extractor {
+        ScalarOperator extractColumn();
+
+        boolean check();
+    }
+
+    /**
+     * date_format(t, '%Y%m%d') -> t
+      */
+    private static class DateFormatExtractor implements Extractor {
+        private final CallOperator call;
+        private final ConstantOperator value;
+
+        public DateFormatExtractor(CallOperator call, ConstantOperator value) {
+            this.call = call;
+            this.value = value;
+        }
+
+        @Override
+        public boolean check() {
+            if (!call.getChild(1).isConstantRef()) {
+                return false;
+            }
+            ScalarOperator dateColumn = call.getChild(0);
+            return dateColumn.getType().getPrimitiveType() == PrimitiveType.DATE
+                    || dateColumn.getType().getPrimitiveType() == PrimitiveType.DATETIME;
+        }
+
+        @Override
+        public ScalarOperator extractColumn() {
+            ScalarOperator dateColumn = call.getChild(0);
+            ConstantOperator child = call.getChild(1).cast();
+            if ("%Y%m%d".equalsIgnoreCase(child.getVarchar()) || "%Y-%m-%d".equalsIgnoreCase(child.getVarchar())) {
+                // %Y%m%d(6) -> yyyyMMdd(8), %Y-%m-%d(8) -> yyyy-MM-dd(10), the length diff is 2
+                if (value.getVarchar().length() != child.getVarchar().length() + 2) {
+                    return null;
+                }
+                return dateColumn;
+            }
+            return null;
+        }
+    }
+
+    /**
+     * substr(cast(t as varchar), 1, 10) -> t
+      */
+    private static class SubstrExtractor implements Extractor {
+        private final CallOperator call;
+        private final ConstantOperator value;
+        private final int expectedLength;
+
+        public SubstrExtractor(CallOperator call, ConstantOperator value, int expectedLength) {
+            this.call = call;
+            this.value = value;
+            this.expectedLength = expectedLength;
+        }
+
+        @Override
+        public boolean check() {
+            if (!(call.getChild(1).isConstantRef() && ((ConstantOperator) call.getChild(1)).getInt() == 1)
+                    || !(call.getChild(2).isConstantRef() && ((ConstantOperator) call.getChild(2)).getInt() == 10)) {
+                return false;
+            }
+            if (!(call.getChild(0) instanceof CastOperator)) {
+                return false;
+            }
+            CastOperator op = call.getChild(0).cast();
+            return op.getChild(0).getType().getPrimitiveType() == PrimitiveType.DATE
+                    || op.getChild(0).getType().getPrimitiveType() == PrimitiveType.DATETIME;
+        }
+
+        @Override
+        public ScalarOperator extractColumn() {
+            CastOperator op = call.getChild(0).cast();
+            if (value.getVarchar().length() != expectedLength) {
+                return null;
+            }
+            return op.getChild(0);
+        }
+    }
+
+    /**
+     * replace(substring(cast(t as varchar), 1, 10), "-", "") -> t
+     */
+    private static class ReplaceAndSubstrExtractor implements Extractor {
+        private final CallOperator call;
+        private final ConstantOperator value;
+
+        public ReplaceAndSubstrExtractor(CallOperator call, ConstantOperator value) {
+            this.call = call;
+            this.value = value;
+        }
+
+        @Override
+        public boolean check() {
+            if (!(call.getChild(0) instanceof CallOperator && isSubstrFn((CallOperator) call.getChild(0)))) {
+                return false;
+            }
+            if (!call.getChild(1).isConstantRef() || !((ConstantOperator) call.getChild(1)).getVarchar().equals("-")) {
+                return false;
+            }
+            if (!call.getChild(2).isConstantRef() || !((ConstantOperator) call.getChild(2)).getVarchar().isEmpty()) {
+                return false;
+            }
+            // yyyyMMdd
+            if (value.getVarchar().length() != 8) {
+                return false;
+            }
+            return new SubstrExtractor((CallOperator) call.getChild(0), value, 8).check();
+        }
+
+        @Override
+        public ScalarOperator extractColumn() {
+            return new SubstrExtractor((CallOperator) call.getChild(0), value, 8).extractColumn();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedDateColumnPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedDateColumnPredicateRule.java
@@ -200,12 +200,10 @@ public class SimplifiedDateColumnPredicateRule extends BottomUpScalarOperatorRew
     private static class ReplaceAndSubstrExtractor implements Extractor {
         private final CallOperator call;
         private final ConstantOperator value;
-        private final SubstrExtractor substrExtractor;
 
         public ReplaceAndSubstrExtractor(CallOperator call, ConstantOperator value) {
             this.call = call;
             this.value = value;
-            this.substrExtractor = new SubstrExtractor((CallOperator) call.getChild(0), value, 8);
         }
 
         @Override
@@ -223,12 +221,12 @@ public class SimplifiedDateColumnPredicateRule extends BottomUpScalarOperatorRew
             if (value.getVarchar().length() != 8) {
                 return false;
             }
-            return substrExtractor.check();
+            return new SubstrExtractor((CallOperator) call.getChild(0), value, 8).check();
         }
 
         @Override
         public ScalarOperator extractColumn() {
-            return substrExtractor.extractColumn();
+            return new SubstrExtractor((CallOperator) call.getChild(0), value, 8).extractColumn();
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -517,7 +517,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
         sql("select c3, sum(c4) from test_base_part3 where date_format(c3,'%Y%m%d')='20240602' group by c3")
                 .contains("TABLE: partial_mv_14\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: '%Y%m%d') = '20240602', date_format(col$: c3\n" +
+                        "     PREDICATES: col$: c3 = '2024-06-02'\n" +
                         "     partitions=1/5");
         starRocksAssert.dropMaterializedView("partial_mv_14");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedDateColumnPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedDateColumnPredicateRuleTest.java
@@ -49,6 +49,10 @@ public class SimplifiedDateColumnPredicateRuleTest {
             verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN2));
             verifyNotDate(
                     new BinaryPredicateOperator(BinaryType.GT, call, ConstantOperator.createVarchar("2024050600")));
+            verifyNotDate(
+                    new BinaryPredicateOperator(BinaryType.GT, call, ConstantOperator.createVarchar("20240500")));
+            verifyNotDate(
+                    new BinaryPredicateOperator(BinaryType.GT, call, ConstantOperator.createVarchar(" 20240506 ")));
         }
         {
             // dt is date

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedDateColumnPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedDateColumnPredicateRuleTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertSame;
 public class SimplifiedDateColumnPredicateRuleTest {
     private static final ConstantOperator DATE_BEGIN = ConstantOperator.createVarchar("20240506");
     private static final ConstantOperator DATE_BEGIN2 = ConstantOperator.createVarchar("2024-05-06");
-    private static final ConstantOperator DATE_END = ConstantOperator.createVarchar("20240606");
 
     private final SimplifiedDateColumnPredicateRule rule = new SimplifiedDateColumnPredicateRule();
 
@@ -48,6 +47,8 @@ public class SimplifiedDateColumnPredicateRuleTest {
             verifyDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN));
             verifyDate(new BinaryPredicateOperator(BinaryType.GE, call, DATE_BEGIN));
             verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN2));
+            verifyNotDate(
+                    new BinaryPredicateOperator(BinaryType.GT, call, ConstantOperator.createVarchar("2024050600")));
         }
         {
             // dt is date
@@ -58,6 +59,8 @@ public class SimplifiedDateColumnPredicateRuleTest {
             verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN));
             verifyDate(new BinaryPredicateOperator(BinaryType.GE, call, DATE_BEGIN2));
             verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN));
+            verifyNotDate(
+                    new BinaryPredicateOperator(BinaryType.EQ, call, ConstantOperator.createVarchar("2024050600")));
         }
         {
             // dt is datetime

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedDateColumnPredicateRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedDateColumnPredicateRuleTest.java
@@ -1,0 +1,237 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.analysis.BinaryType;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class SimplifiedDateColumnPredicateRuleTest {
+    private static final ConstantOperator DATE_BEGIN = ConstantOperator.createVarchar("20240506");
+    private static final ConstantOperator DATE_BEGIN2 = ConstantOperator.createVarchar("2024-05-06");
+    private static final ConstantOperator DATE_END = ConstantOperator.createVarchar("20240606");
+
+    private final SimplifiedDateColumnPredicateRule rule = new SimplifiedDateColumnPredicateRule();
+
+    @Test
+    public void testDateFormat() {
+        {
+            // dt is date
+            ScalarOperator call = new CallOperator("date_format", Type.VARCHAR, ImmutableList.of(
+                    new ColumnRefOperator(1, Type.DATE, "dt", true),
+                    ConstantOperator.createVarchar("%Y%m%d")
+            ));
+            verifyDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN));
+            verifyDate(new BinaryPredicateOperator(BinaryType.GE, call, DATE_BEGIN));
+            verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN2));
+        }
+        {
+            // dt is date
+            ScalarOperator call = new CallOperator("date_format", Type.VARCHAR, ImmutableList.of(
+                    new ColumnRefOperator(1, Type.DATE, "dt", true),
+                    ConstantOperator.createVarchar("%Y-%m-%d")
+            ));
+            verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN));
+            verifyDate(new BinaryPredicateOperator(BinaryType.GE, call, DATE_BEGIN2));
+            verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN));
+        }
+        {
+            // dt is datetime
+            ScalarOperator datetimeColumn = new ColumnRefOperator(1, Type.DATETIME, "dt", true);
+            ScalarOperator call = new CallOperator("date_format", Type.VARCHAR, ImmutableList.of(
+                    datetimeColumn,
+                    ConstantOperator.createVarchar("%Y%m%d")
+            ));
+            verifyNotDateTime(new BinaryPredicateOperator(BinaryType.GT, call, DATE_BEGIN2));
+            verifyDateTime(new BinaryPredicateOperator(BinaryType.GT, call, DATE_BEGIN));
+            verifyDateTime(new BinaryPredicateOperator(BinaryType.GE, call, DATE_BEGIN));
+            verifyDateTime(new BinaryPredicateOperator(BinaryType.LT, call, DATE_BEGIN));
+            verifyDateTime(new BinaryPredicateOperator(BinaryType.LE, call, DATE_BEGIN));
+            verifyNotDateTime(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN));
+        }
+        // dt is varchar
+        ScalarOperator varcharCall = new CallOperator("date_format", Type.VARCHAR, ImmutableList.of(
+                new ColumnRefOperator(1, Type.VARCHAR, "dt", true),
+                ConstantOperator.createVarchar("%Y%m%d")
+        ));
+        verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, varcharCall, DATE_BEGIN2));
+        verifyNotDate(new BinaryPredicateOperator(BinaryType.GE, varcharCall, DATE_BEGIN2));
+    }
+
+    @Test
+    public void testSubstr() {
+        for (String fn : new String[] {"substr", "substring"}) {
+            {
+                // dt is date
+                ScalarOperator call = new CallOperator(fn, Type.VARCHAR, ImmutableList.of(
+                        new CastOperator(Type.VARCHAR, new ColumnRefOperator(1, Type.DATE, "dt", true)),
+                        ConstantOperator.createInt(1),
+                        ConstantOperator.createInt(10)
+                ));
+                verifyDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN2));
+                verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN));
+                verifyDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN2));
+            }
+            {
+                // dt is datetime
+                ScalarOperator datetimeColumn = new ColumnRefOperator(1, Type.DATETIME, "dt", true);
+                ScalarOperator call = new CallOperator(fn, Type.VARCHAR, ImmutableList.of(
+                        new CastOperator(Type.VARCHAR, datetimeColumn),
+                        ConstantOperator.createInt(1),
+                        ConstantOperator.createInt(10)
+                ));
+                verifyNotDateTime(new BinaryPredicateOperator(BinaryType.GT, call, DATE_BEGIN));
+                verifyDateTime(new BinaryPredicateOperator(BinaryType.GT, call, DATE_BEGIN2));
+                verifyDateTime(new BinaryPredicateOperator(BinaryType.GE, call, DATE_BEGIN2));
+                verifyDateTime(new BinaryPredicateOperator(BinaryType.LT, call, DATE_BEGIN2));
+                verifyDateTime(new BinaryPredicateOperator(BinaryType.LE, call, DATE_BEGIN2));
+            }
+            {
+                // dt is varchar
+                ScalarOperator varcharCall = new CallOperator(fn, Type.VARCHAR, ImmutableList.of(
+                        new ColumnRefOperator(1, Type.VARCHAR, "dt", true),
+                        ConstantOperator.createInt(1),
+                        ConstantOperator.createInt(10)
+                ));
+                verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, varcharCall, DATE_BEGIN2));
+                verifyNotDate(new BinaryPredicateOperator(BinaryType.GE, varcharCall, DATE_BEGIN2));
+                // dt is date, but substr end offset is not 10
+                ScalarOperator call = new CallOperator(fn, Type.VARCHAR, ImmutableList.of(
+                        new ColumnRefOperator(1, Type.DATE, "dt", true),
+                        ConstantOperator.createInt(1),
+                        ConstantOperator.createInt(9)
+                ));
+                verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, call, DATE_BEGIN2));
+                verifyNotDate(new BinaryPredicateOperator(BinaryType.GE, call, DATE_BEGIN2));
+            }
+        }
+    }
+
+    @Test
+    public void testReplaceAndSubstr() {
+        {
+            // dt is date
+            ScalarOperator call = new CallOperator(FunctionSet.SUBSTR, Type.VARCHAR, ImmutableList.of(
+                    new CastOperator(Type.VARCHAR, new ColumnRefOperator(1, Type.DATE, "dt", true)),
+                    ConstantOperator.createInt(1),
+                    ConstantOperator.createInt(10)
+            ));
+            ScalarOperator replaceCall = new CallOperator(FunctionSet.REPLACE, Type.VARCHAR, ImmutableList.of(
+                    call,
+                    ConstantOperator.createVarchar("-"),
+                    ConstantOperator.createVarchar("")
+            ));
+            verifyDate(new BinaryPredicateOperator(BinaryType.EQ, replaceCall, DATE_BEGIN));
+            verifyNotDate(new BinaryPredicateOperator(BinaryType.GE, replaceCall, DATE_BEGIN2));
+        }
+        {
+            // dt is varchar
+            ScalarOperator varcharCall = new CallOperator(FunctionSet.SUBSTR, Type.VARCHAR, ImmutableList.of(
+                    new ColumnRefOperator(1, Type.VARCHAR, "dt", true),
+                    ConstantOperator.createInt(1),
+                    ConstantOperator.createInt(10)
+            ));
+            CallOperator replaceCall = new CallOperator(FunctionSet.REPLACE, Type.VARCHAR, ImmutableList.of(
+                    varcharCall,
+                    ConstantOperator.createVarchar("-"),
+                    ConstantOperator.createVarchar("")
+            ));
+            verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, replaceCall, DATE_BEGIN2));
+            verifyNotDate(new BinaryPredicateOperator(BinaryType.GE, replaceCall, DATE_BEGIN2));
+        }
+        {
+            // dt is date
+            ScalarOperator call = new CallOperator(FunctionSet.SUBSTR, Type.VARCHAR, ImmutableList.of(
+                    new CastOperator(Type.VARCHAR, new ColumnRefOperator(1, Type.DATE, "dt", true)),
+                    ConstantOperator.createInt(1),
+                    ConstantOperator.createInt(10)
+            ));
+            // not replace '-' to ''
+            CallOperator replaceCall = new CallOperator(FunctionSet.REPLACE, Type.VARCHAR, ImmutableList.of(
+                    call,
+                    ConstantOperator.createVarchar("-"),
+                    ConstantOperator.createVarchar("a")
+            ));
+            verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, replaceCall, DATE_BEGIN2));
+            verifyNotDate(new BinaryPredicateOperator(BinaryType.GE, replaceCall, DATE_BEGIN2));
+        }
+        {
+            // dt is date, but substr end offset is not 10
+            ScalarOperator call = new CallOperator(FunctionSet.SUBSTR, Type.VARCHAR, ImmutableList.of(
+                    new ColumnRefOperator(1, Type.DATE, "dt", true),
+                    ConstantOperator.createInt(1),
+                    ConstantOperator.createInt(9)
+            ));
+            CallOperator replaceCall = new CallOperator(FunctionSet.REPLACE, Type.VARCHAR, ImmutableList.of(
+                    call,
+                    ConstantOperator.createVarchar("-"),
+                    ConstantOperator.createVarchar("")
+            ));
+            verifyNotDate(new BinaryPredicateOperator(BinaryType.EQ, replaceCall, DATE_BEGIN2));
+            verifyNotDate(new BinaryPredicateOperator(BinaryType.GE, replaceCall, DATE_BEGIN2));
+        }
+        {
+            // dt is datetime
+            ScalarOperator datetimeColumn = new ColumnRefOperator(1, Type.DATETIME, "dt", true);
+            ScalarOperator call = new CallOperator(FunctionSet.SUBSTR, Type.VARCHAR, ImmutableList.of(
+                    new CastOperator(Type.VARCHAR, datetimeColumn),
+                    ConstantOperator.createInt(1),
+                    ConstantOperator.createInt(10)
+            ));
+            CallOperator replaceCall = new CallOperator(FunctionSet.REPLACE, Type.VARCHAR, ImmutableList.of(
+                    call,
+                    ConstantOperator.createVarchar("-"),
+                    ConstantOperator.createVarchar("")
+            ));
+            verifyNotDateTime(new BinaryPredicateOperator(BinaryType.GT, replaceCall, DATE_BEGIN2));
+            verifyDateTime(new BinaryPredicateOperator(BinaryType.GT, replaceCall, DATE_BEGIN));
+            verifyDateTime(new BinaryPredicateOperator(BinaryType.GE, replaceCall, DATE_BEGIN));
+            verifyDateTime(new BinaryPredicateOperator(BinaryType.LT, replaceCall, DATE_BEGIN));
+            verifyDateTime(new BinaryPredicateOperator(BinaryType.LE, replaceCall, DATE_BEGIN));
+        }
+    }
+
+    private void verifyDate(ScalarOperator operator) {
+        ScalarOperator result = rule.apply(operator, null);
+        assertSame(PrimitiveType.DATE, result.getChild(0).getType().getPrimitiveType());
+    }
+
+    private void verifyNotDate(ScalarOperator operator) {
+        ScalarOperator result = rule.apply(operator, null);
+        assertNotSame(PrimitiveType.DATE, result.getChild(0).getType().getPrimitiveType());
+    }
+
+    private void verifyDateTime(ScalarOperator operator) {
+        ScalarOperator result = rule.apply(operator, null);
+        assertSame(PrimitiveType.DATETIME, result.getChild(0).getType().getPrimitiveType());
+    }
+
+    private void verifyNotDateTime(ScalarOperator operator) {
+        ScalarOperator result = rule.apply(operator, null);
+        assertNotSame(PrimitiveType.DATETIME, result.getChild(0).getType().getPrimitiveType());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Some user use `date/datetime` column as string, in this case sparse index is not used.
This pr will do these rewrite
```sql
 --if t is date
 date_format(t, '%Y%m%d') >= '20230327' -> `t` >= '20230327'
 date_format(t, '%Y-%m-%d') >= '2023-03-27' -> `t` >= '2023-03-27'
 substr(t, 1, 10) >= '2023-03-27' -> `t` >= '2023-03-27'
 substring(t, 1, 10) >= '2023-03-27' -> `t` >= '2023-03-27'
 replace(substring(t, 1, 10), "-", "") >= '20230327' -> `t` >= '20230327'
 
 --if t is datetime
 date_format(t, '%Y-%m-%d') >/>=/< '2023-03-27' -> `t` >/>=/< '2023-03-27'
 date_format(t, '%Y-%m-%d') <= '2023-03-27' -> `t` < days_add('2023-03-27', 1)
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
