### PR TITLE
[Feature] Support IF EXISTS in the FUNCTION statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/GlobalFunctionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/GlobalFunctionMgr.java
@@ -78,6 +78,11 @@ public class GlobalFunctionMgr {
     private void addFunction(Function function, boolean isReplay, boolean allowExists, boolean createIfNotExists) throws UserException {
         String functionName = function.getFunctionName().getFunction();
         List<Function> existFuncs = name2Function.getOrDefault(functionName, ImmutableList.of());
+        if (allowExists && createIfNotExists) {
+            // In most DB system (like MySQL, Oracle, Snowflake etc.), these two conditions are now allowed to use together
+            throw new UserException(
+                    "\"IF NOT EXISTS\" and \"OR REPLACE\" cannot be used together in the same CREATE statement");
+        }
         if (!isReplay) {
             for (Function existFunc : existFuncs) {
                 if (function.compare(existFunc, Function.CompareMode.IS_IDENTICAL)) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -247,7 +247,7 @@ public class DDLStmtExecutor {
                     if (db == null) {
                         ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, name.getDb());
                     }
-                    db.addFunction(stmt.getFunction(), stmt.shouldReplaceIfExists());
+                    db.addFunction(stmt.getFunction(), stmt.shouldReplaceIfExists(), stmt.createIfNotExists());
                 }
             });
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -241,7 +241,7 @@ public class DDLStmtExecutor {
                 if (name.isGlobalFunction()) {
                     context.getGlobalStateMgr()
                             .getGlobalFunctionMgr()
-                            .userAddFunction(stmt.getFunction(), stmt.shouldReplaceIfExists());
+                            .userAddFunction(stmt.getFunction(), stmt.shouldReplaceIfExists(), stmt.createIfNotExists());
                 } else {
                     Database db = context.getGlobalStateMgr().getLocalMetastore().getDb(name.getDb());
                     if (db == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -258,13 +258,14 @@ public class DDLStmtExecutor {
             ErrorReport.wrapWithRuntimeException(() -> {
                 FunctionName name = stmt.getFunctionName();
                 if (name.isGlobalFunction()) {
-                    context.getGlobalStateMgr().getGlobalFunctionMgr().userDropFunction(stmt.getFunctionSearchDesc());
+                    context.getGlobalStateMgr().getGlobalFunctionMgr()
+                            .userDropFunction(stmt.getFunctionSearchDesc(), stmt.dropIfExists());
                 } else {
                     Database db = context.getGlobalStateMgr().getLocalMetastore().getDb(name.getDb());
                     if (db == null) {
                         ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, name.getDb());
                     }
-                    db.dropFunction(stmt.getFunctionSearchDesc());
+                    db.dropFunction(stmt.getFunctionSearchDesc(), stmt.dropIfExists());
                 }
             });
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -58,6 +58,7 @@ public class CreateFunctionStmt extends DdlStmt {
     private final Map<String, String> properties;
     private final String content;
     private final boolean shouldReplaceIfExists;
+    private final boolean createIfNotExists;
 
     // needed item set after analyzed
     private Function function;
@@ -81,7 +82,8 @@ public class CreateFunctionStmt extends DdlStmt {
                               TypeDef returnType,
                               Map<String, String> properties,
                               String content,
-                              boolean shouldReplaceIfExists) {
+                              boolean shouldReplaceIfExists,
+                              boolean createIfNotExists) {
         this(functionType,
                 functionName,
                 argsDef,
@@ -89,12 +91,13 @@ public class CreateFunctionStmt extends DdlStmt {
                 properties,
                 content,
                 shouldReplaceIfExists,
-                NodePosition.ZERO);
+                NodePosition.ZERO,
+                createIfNotExists);
     }
 
     public CreateFunctionStmt(String functionType, FunctionName functionName, FunctionArgsDef argsDef,
                               TypeDef returnType, Map<String, String> properties, String content,
-                              boolean shouldReplaceIfExists, NodePosition pos) {
+                              boolean shouldReplaceIfExists, NodePosition pos, boolean createIfNotExists) {
         super(pos);
         this.functionName = functionName;
         this.isAggregate = functionType.equalsIgnoreCase("AGGREGATE");
@@ -103,6 +106,7 @@ public class CreateFunctionStmt extends DdlStmt {
         this.returnType = returnType;
         this.content = content;
         this.shouldReplaceIfExists = shouldReplaceIfExists;
+        this.createIfNotExists = createIfNotExists;
         if (properties == null) {
             this.properties = ImmutableSortedMap.of();
         } else {
@@ -166,6 +170,10 @@ public class CreateFunctionStmt extends DdlStmt {
 
     public boolean shouldReplaceIfExists() {
         return shouldReplaceIfExists;
+    }
+
+    public boolean createIfNotExists() {
+        return createIfNotExists;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropFunctionStmt.java
@@ -32,14 +32,17 @@ public class DropFunctionStmt extends DdlStmt {
     // set after analyzed
     private FunctionSearchDesc functionSearchDesc;
 
-    public DropFunctionStmt(FunctionName functionName, FunctionArgsDef argsDef) {
-        this(functionName, argsDef, NodePosition.ZERO);
+    private final boolean dropIfExists;
+
+    public DropFunctionStmt(FunctionName functionName, FunctionArgsDef argsDef, boolean dropIfExists) {
+        this(functionName, argsDef, NodePosition.ZERO, dropIfExists);
     }
 
-    public DropFunctionStmt(FunctionName functionName, FunctionArgsDef argsDef, NodePosition pos) {
+    public DropFunctionStmt(FunctionName functionName, FunctionArgsDef argsDef, NodePosition pos, boolean dropIfExists) {
         super(pos);
         this.functionName = functionName;
         this.argsDef = argsDef;
+        this.dropIfExists = dropIfExists;
     }
 
     public FunctionName getFunctionName() {
@@ -52,6 +55,10 @@ public class DropFunctionStmt extends DdlStmt {
 
     public void setFunctionSearchDesc(FunctionSearchDesc functionSearchDesc) {
         this.functionSearchDesc = functionSearchDesc;
+    }
+
+    public boolean dropIfExists() {
+        return dropIfExists;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5444,6 +5444,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         String functionType = "SCALAR";
         boolean replaceIfExists = context.orReplace() != null && context.orReplace().OR() != null;
         boolean isGlobal = context.GLOBAL() != null;
+        boolean createIfNotExists = context.ifNotExists() != null;
         if (context.functionType != null) {
             functionType = context.functionType.getText();
         }
@@ -5483,7 +5484,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         }
 
         return new CreateFunctionStmt(functionType, fnName,
-                getFunctionArgsDef(context.typeList()), returnTypeDef, properties, inlineContent, replaceIfExists);
+                getFunctionArgsDef(context.typeList()), returnTypeDef, properties, inlineContent, replaceIfExists,
+                createIfNotExists);
     }
 
     // ------------------------------------------- Authz Statement -------------------------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5428,6 +5428,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
         String functionName = qualifiedName.toString();
         boolean isGlobal = context.GLOBAL() != null;
+        boolean dropIfExist = context.IF() != null && context.EXISTS() != null;
         FunctionName fnName = FunctionName.createFnName(functionName);
         if (isGlobal) {
             if (!Strings.isNullOrEmpty(fnName.getDb())) {
@@ -5436,7 +5437,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             fnName.setAsGlobalFunction();
         }
 
-        return new DropFunctionStmt(fnName, getFunctionArgsDef(context.typeList()), createPos(context));
+        return new DropFunctionStmt(fnName, getFunctionArgsDef(context.typeList()), createPos(context), dropIfExist);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1354,7 +1354,7 @@ dropFunctionStatement
     ;
 
 createFunctionStatement
-    : CREATE orReplace GLOBAL? functionType=(TABLE | AGGREGATE)? FUNCTION qualifiedName '(' typeList ')' RETURNS returnType=type (properties|inlineProperties)?? inlineFunction?
+    : CREATE orReplace GLOBAL? functionType=(TABLE | AGGREGATE)? FUNCTION ifNotExists qualifiedName '(' typeList ')' RETURNS returnType=type (properties|inlineProperties)?? inlineFunction?
     ;
 inlineFunction
     : AS ATTACHMENT

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1350,7 +1350,7 @@ showFunctionsStatement
     ;
 
 dropFunctionStatement
-    : DROP GLOBAL? FUNCTION qualifiedName '(' typeList ')'
+    : DROP GLOBAL? FUNCTION (IF EXISTS)?  qualifiedName '(' typeList ')'
     ;
 
 createFunctionStatement

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
@@ -196,9 +196,9 @@ public class DatabaseTest {
         Function f = new Function(name, argTypes, Type.INT, false);
 
         // Add the UDF for the first time
-        db.addFunction(f, true);
+        db.addFunction(f, true, false);
         // Attempt to add the same UDF again
-        db.addFunction(f, true);
+        db.addFunction(f, true, false);
 
         List<Function> functions = db.getFunctions();
         Assert.assertEquals(functions.size(), 1);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalFunctionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalFunctionMgrTest.java
@@ -66,13 +66,13 @@ public class GlobalFunctionMgrTest {
         name.setAsGlobalFunction();
         final Type[] argTypes = {Type.INT, Type.INT};
         Function f = new Function(name, argTypes, Type.INT, false);
-        globalFunctionMgr.userAddFunction(f, false);
+        globalFunctionMgr.userAddFunction(f, false, false);
         // User adds addDoubleDouble UDF
         FunctionName name2 = new FunctionName(null, "addDoubleDouble");
         name2.setAsGlobalFunction();
         final Type[] argTypes2 = {Type.DOUBLE, Type.DOUBLE};
         Function f2 = new Function(name2, argTypes2, Type.DOUBLE, false);
-        globalFunctionMgr.userAddFunction(f2, false);
+        globalFunctionMgr.userAddFunction(f2, false, false);
     }
 
     @Test
@@ -83,10 +83,10 @@ public class GlobalFunctionMgrTest {
         Function f = new Function(name, argTypes, Type.INT, false);
 
         // Add the UDF for the first time
-        globalFunctionMgr.userAddFunction(f, false);
+        globalFunctionMgr.userAddFunction(f, false, false);
 
         // Attempt to add the same UDF again, expecting an exception
-        Assert.assertThrows(UserException.class, () -> globalFunctionMgr.userAddFunction(f, false));
+        Assert.assertThrows(UserException.class, () -> globalFunctionMgr.userAddFunction(f, false, false));
     }
 
     @Test
@@ -97,9 +97,9 @@ public class GlobalFunctionMgrTest {
         Function f = new Function(name, argTypes, Type.INT, false);
 
         // Add the UDF for the first time
-        globalFunctionMgr.userAddFunction(f, true);
+        globalFunctionMgr.userAddFunction(f, true, false);
         // Attempt to add the same UDF again
-        globalFunctionMgr.userAddFunction(f, true);
+        globalFunctionMgr.userAddFunction(f, true, false);
 
         List<Function> functions = globalFunctionMgr.getFunctions();
         Assert.assertEquals(functions.size(), 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/CreateFunctionStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/CreateFunctionStmtTest.java
@@ -143,4 +143,36 @@ public class CreateFunctionStmtTest {
         Assert.assertEquals("my_udf_json_get", stmt.getFunctionName().getFunction());
         Assert.assertTrue(stmt.shouldReplaceIfExists());
     }
+
+    @Test
+    public void testCreateIfNotExistsUDF() throws Exception {
+        String createFunctionSql = "CREATE FUNCTION IF NOT EXISTS ABC.MY_UDF_JSON_GET(string, string) \n"
+                + "RETURNS string \n"
+                + "properties (\n"
+                + "    \"symbol\" = \"com.starrocks.udf.sample.UDFJsonGet\",\n"
+                + "    \"type\" = \"StarrocksJar\",\n"
+                + "    \"file\" = \"http://http_host:http_port/udf-1.0-SNAPSHOT-jar-with-dependencies.jar\"\n"
+                + ");";
+        CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                createFunctionSql, 32).get(0);
+
+        Assert.assertEquals("ABC", stmt.getFunctionName().getDb());
+        Assert.assertEquals("my_udf_json_get", stmt.getFunctionName().getFunction());
+        Assert.assertFalse(stmt.shouldReplaceIfExists());
+        Assert.assertTrue(stmt.createIfNotExists());
+
+        createFunctionSql = "CREATE OR REPLACE FUNCTION IF NOT EXISTS ABC.MY_UDF_JSON_GET(string, string) \n"
+                + "RETURNS string \n"
+                + "properties (\n"
+                + "    \"symbol\" = \"com.starrocks.udf.sample.UDFJsonGet\",\n"
+                + "    \"type\" = \"StarrocksJar\",\n"
+                + "    \"file\" = \"http://http_host:http_port/udf-1.0-SNAPSHOT-jar-with-dependencies.jar\"\n"
+                + ");";
+        try {
+            stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                    createFunctionSql, 32).get(0);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("\"IF NOT EXISTS\" and \"OR REPLACE\" cannot be used together"));
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/DropFunctionStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/DropFunctionStmtTest.java
@@ -32,4 +32,15 @@ public class DropFunctionStmtTest {
         Assert.assertEquals("ABC", stmt.getFunctionName().getDb());
         Assert.assertEquals("my_udf_json_get", stmt.getFunctionName().getFunction());
     }
+
+    @Test
+    public void testDropIfExists() throws Exception {
+        String dropFunctionSql = "DROP FUNCTION IF EXISTS ABC.MY_UDF_JSON_GET(string, string)";
+        DropFunctionStmt stmt = (DropFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                dropFunctionSql, 32).get(0);
+
+        Assert.assertEquals("ABC", stmt.getFunctionName().getDb());
+        Assert.assertEquals("my_udf_json_get", stmt.getFunctionName().getFunction());
+        Assert.assertTrue(stmt.dropIfExists());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
This PR addresses issue #42675  to implement support for the IF EXISTS for CREATE FUNC syntax in StarRocks. This feature allows users to conditionally create a function by:
- CREATE FUNCTION IF NOT EXISTS
- DROP FUNCTION IF EXISTS

## What I'm doing:

1. SQL Parser:
Modify the ANTLR grammar in `StarRocksParser.g4` to include IF EXISTS for CREATE FUNCTION. This will involve updating the createFunctionStatement rule to optionally accept IF EXISTS option.
2. AST Builder:
In `AstBuilder.java`, I’ll extend the visitCreate/DropFunctionStatement method to handle the new IF EXISTS logic and add corresponding params in Create/DropFunctionStmt
3. Query Executor:
In `DDLStmtExecutor.java`, get the ifNotExist from visitCreate/DropFunctionStatement context and pass it into catalog.
4. Catalog:
In `Database.java`, handle the conditional creation/drop of function.
6. Testing:
Add a new UT case in CreateFunctionStmtTest to verify the SQL query work as expected

Recommended review order:
StartRocks.g4 -> AstBuilder.java -> Create/DropFunctionStmt.java -> DDLStmtExecutor.java -> Database.java & GlobalFunctionMgr.java -> Testing

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
