### PR TITLE
[Enhancement] reduce lock granular of TabletStatMgr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -115,8 +115,7 @@ public class TabletStatMgr extends FrontendDaemon {
                 }
 
                 // NOTE: calculate the row first with read lock, then update the stats with write lock
-                // TODO: lock the table instead of database
-                locker.lockDatabase(db, LockType.READ);
+                locker.lockTableWithIntensiveDbLock(db, table.getId(), LockType.READ);
                 Map<Long, Long> indexRowCountMap = Maps.newHashMap();
                 try {
                     OlapTable olapTable = (OlapTable) table;
@@ -140,11 +139,11 @@ public class TabletStatMgr extends FrontendDaemon {
                     LOG.debug("finished to set row num for table: {} in database: {}",
                             table.getName(), db.getFullName());
                 } finally {
-                    locker.unLockDatabase(db, LockType.READ);
+                    locker.unLockTableWithIntensiveDbLock(db, table, LockType.READ);
                 }
 
                 // update
-                locker.lockDatabase(db, LockType.WRITE);
+                locker.lockTableWithIntensiveDbLock(db, table.getId(), LockType.WRITE);
                 try {
                     OlapTable olapTable = (OlapTable) table;
                     for (Partition partition : olapTable.getAllPartitions()) {
@@ -160,7 +159,7 @@ public class TabletStatMgr extends FrontendDaemon {
                     }
                     adjustStatUpdateRows(table.getId(), totalRowCount);
                 } finally {
-                    locker.unLockDatabase(db, LockType.WRITE);
+                    locker.unLockTableWithIntensiveDbLock(db, table, LockType.WRITE);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -36,6 +36,7 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.FrontendDaemon;
@@ -107,14 +108,17 @@ public class TabletStatMgr extends FrontendDaemon {
                 continue;
             }
             Locker locker = new Locker();
-            locker.lockDatabase(db, LockType.WRITE);
-            try {
-                for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
-                    long totalRowCount = 0L;
-                    if (!table.isNativeTableOrMaterializedView()) {
-                        continue;
-                    }
+            for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId())) {
+                long totalRowCount = 0L;
+                if (!table.isNativeTableOrMaterializedView()) {
+                    continue;
+                }
 
+                // NOTE: calculate the row first with read lock, then update the stats with write lock
+                // TODO: lock the table instead of database
+                locker.lockDatabase(db, LockType.READ);
+                Map<Long, Long> indexRowCountMap = Maps.newHashMap();
+                try {
                     OlapTable olapTable = (OlapTable) table;
                     for (Partition partition : olapTable.getAllPartitions()) {
                         for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
@@ -122,10 +126,11 @@ public class TabletStatMgr extends FrontendDaemon {
                             for (MaterializedIndex index : physicalPartition.getMaterializedIndices(
                                     IndexExtState.VISIBLE)) {
                                 long indexRowCount = 0L;
+                                // NOTE: can take a rather long time to iterate lots of tablets
                                 for (Tablet tablet : index.getTablets()) {
                                     indexRowCount += tablet.getRowCount(version);
                                 } // end for tablets
-                                index.setRowCount(indexRowCount);
+                                indexRowCountMap.put(index.getId(), indexRowCount);
                                 if (!olapTable.isTempPartition(partition.getId())) {
                                     totalRowCount += indexRowCount;
                                 }
@@ -134,10 +139,29 @@ public class TabletStatMgr extends FrontendDaemon {
                     } // end for partitions
                     LOG.debug("finished to set row num for table: {} in database: {}",
                             table.getName(), db.getFullName());
-                    adjustStatUpdateRows(table.getId(), totalRowCount);
+                } finally {
+                    locker.unLockDatabase(db, LockType.READ);
                 }
-            } finally {
-                locker.unLockDatabase(db, LockType.WRITE);
+
+                // update
+                locker.lockDatabase(db, LockType.WRITE);
+                try {
+                    OlapTable olapTable = (OlapTable) table;
+                    for (Partition partition : olapTable.getAllPartitions()) {
+                        for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                            for (MaterializedIndex index :
+                                    physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                                Long indexRowCount = indexRowCountMap.get(index.getId());
+                                if (indexRowCount != null) {
+                                    index.setRowCount(indexRowCount);
+                                }
+                            }
+                        }
+                    }
+                    adjustStatUpdateRows(table.getId(), totalRowCount);
+                } finally {
+                    locker.unLockDatabase(db, LockType.WRITE);
+                }
             }
         }
         LOG.info("finished to update index row num of all databases. cost: {} ms",
@@ -149,7 +173,8 @@ public class TabletStatMgr extends FrontendDaemon {
         if (!RunMode.isSharedNothingMode()) {
             return;
         }
-        ImmutableMap<Long, Backend> backends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend();
+        ImmutableMap<Long, Backend> backends =
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend();
 
         long start = System.currentTimeMillis();
         for (Backend backend : backends.values()) {
@@ -354,10 +379,13 @@ public class TabletStatMgr extends FrontendDaemon {
                     LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
                     Future<TabletStatResponse> responseFuture = lakeService.getTabletStats(request);
                     responseList.add(responseFuture);
-                    LOG.debug("Sent tablet stat collection task to node {} for partition {} of version {}. tablet count={}",
+                    LOG.debug(
+                            "Sent tablet stat collection task to node {} for partition {} of version {}. tablet " +
+                                    "count={}",
                             node.getHost(), debugName(), version, entry.getValue().size());
                 } catch (Throwable e) {
-                    LOG.warn("Fail to send tablet stat task to host {} for partition {}: {}", node.getHost(), debugName(),
+                    LOG.warn("Fail to send tablet stat task to host {} for partition {}: {}", node.getHost(),
+                            debugName(),
                             e.getMessage());
                 }
             }


### PR DESCRIPTION
## Why I'm doing:
This lock can be held for nearly 1 second in cases of millions of tablets.

## What I'm doing:
- Hold the read lock when iterating all tablets

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
