### PR TITLE
[Enhancement] Store default resource group in FE

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1273,10 +1273,10 @@ CONF_mInt64(load_tablet_timeout_seconds, "60");
 CONF_mBool(enable_pk_value_column_zonemap, "true");
 
 // Used by default mv resource group
-CONF_mDouble(default_mv_resource_group_memory_limit, "0.8");
-CONF_mInt32(default_mv_resource_group_cpu_limit, "1");
-CONF_mInt32(default_mv_resource_group_concurrency_limit, "0");
-CONF_mDouble(default_mv_resource_group_spill_mem_limit_threshold, "0.8");
+CONF_Double(default_mv_resource_group_memory_limit, "0.8");
+CONF_Int32(default_mv_resource_group_cpu_limit, "1");
+CONF_Int32(default_mv_resource_group_concurrency_limit, "0");
+CONF_Double(default_mv_resource_group_spill_mem_limit_threshold, "0.8");
 
 // Max size of key columns size of primary key table, default value is 128 bytes
 CONF_mInt32(primary_key_limit_size, "128");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1272,7 +1272,8 @@ CONF_mInt64(load_tablet_timeout_seconds, "60");
 
 CONF_mBool(enable_pk_value_column_zonemap, "true");
 
-// Used by default mv resource group
+// Used by default mv resource group.
+// These parameters are deprecated because now FE store and persist default_mv_wg.
 CONF_Double(default_mv_resource_group_memory_limit, "0.8");
 CONF_Int32(default_mv_resource_group_cpu_limit, "1");
 CONF_Int32(default_mv_resource_group_concurrency_limit, "0");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -245,34 +245,6 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             }
         });
 
-        _config_callback.emplace("default_mv_resource_group_memory_limit", [&]() {
-            LOG(INFO) << "set default_mv_resource_group_memory_limit:"
-                      << config::default_mv_resource_group_memory_limit;
-            workgroup::DefaultWorkGroupInitialization default_wg_initializer;
-            auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
-            workgroup::WorkGroupManager::instance()->add_workgroup(default_mv_wg);
-        });
-        _config_callback.emplace("default_mv_resource_group_cpu_limit", [&]() {
-            LOG(INFO) << "set default_mv_resource_group_cpu_limit:" << config::default_mv_resource_group_cpu_limit;
-            workgroup::DefaultWorkGroupInitialization default_wg_initializer;
-            auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
-            workgroup::WorkGroupManager::instance()->add_workgroup(default_mv_wg);
-        });
-        _config_callback.emplace("default_mv_resource_group_concurrency_limit", [&]() {
-            LOG(INFO) << "set default_mv_resource_group_concurrency_limit:"
-                      << config::default_mv_resource_group_concurrency_limit;
-            workgroup::DefaultWorkGroupInitialization default_wg_initializer;
-            auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
-            workgroup::WorkGroupManager::instance()->add_workgroup(default_mv_wg);
-        });
-        _config_callback.emplace("default_mv_resource_group_spill_mem_limit_threshold", [&]() {
-            LOG(INFO) << "set default_mv_resource_group_spill_mem_limit_threshold:"
-                      << config::default_mv_resource_group_spill_mem_limit_threshold;
-            workgroup::DefaultWorkGroupInitialization default_wg_initializer;
-            auto default_mv_wg = default_wg_initializer.create_default_mv_workgroup();
-            workgroup::WorkGroupManager::instance()->add_workgroup(default_mv_wg);
-        });
-
 #ifdef USE_STAROS
         _config_callback.emplace("starlet_cache_thread_num", [&]() {
             if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_threadpool_size", value).empty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -25,6 +26,7 @@ import java.text.DecimalFormat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -51,20 +53,15 @@ public class ResourceGroup {
     public static final String DEFAULT_MV_RESOURCE_GROUP_NAME = "default_mv_wg";
     public static final String SPILL_MEM_LIMIT_THRESHOLD = "spill_mem_limit_threshold";
 
-    public static final long DEFAULT_WG_ID = 0;
-    public static final long DEFAULT_MV_WG_ID = 1;
-    public static final long DEFAULT_MV_VERSION = 1;
+    /**
+     * EN: In the old version, DEFAULT_WG and DEFAULT_MV_WG are not saved and persisted in the FE, but are only created in each
+     * BE. Its ID is 0 and 1. To distinguish it from the old version, a new ID 2 and 3 is used here.
+     */
+    public static final long DEFAULT_WG_ID = 2;
+    public static final long DEFAULT_MV_WG_ID = 3;
 
-    public static final ResourceGroup DEFAULT_WG = new ResourceGroup();
-    public static final ResourceGroup DEFAULT_MV_WG = new ResourceGroup();
-
-    static {
-        DEFAULT_WG.setId(DEFAULT_WG_ID);
-        DEFAULT_WG.setName(DEFAULT_RESOURCE_GROUP_NAME);
-
-        DEFAULT_MV_WG.setId(DEFAULT_MV_WG_ID);
-        DEFAULT_MV_WG.setName(DEFAULT_MV_RESOURCE_GROUP_NAME);
-    }
+    public static final Set<String> BUILTIN_WG_NAMES =
+            ImmutableSet.of(DEFAULT_RESOURCE_GROUP_NAME, DEFAULT_MV_RESOURCE_GROUP_NAME);
 
     private static class ColumnMeta {
         public ColumnMeta(Column column, BiFunction<ResourceGroup, ResourceGroupClassifier, String> valueSupplier) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -54,7 +54,7 @@ public class ResourceGroup {
     public static final String SPILL_MEM_LIMIT_THRESHOLD = "spill_mem_limit_threshold";
 
     /**
-     * EN: In the old version, DEFAULT_WG and DEFAULT_MV_WG are not saved and persisted in the FE, but are only created in each
+     * In the old version, DEFAULT_WG and DEFAULT_MV_WG are not saved and persisted in the FE, but are only created in each
      * BE. Its ID is 0 and 1. To distinguish it from the old version, a new ID 2 and 3 is used here.
      */
     public static final long DEFAULT_WG_ID = 2;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -641,7 +641,6 @@ public class ResourceGroupMgr implements Writable {
             CreateResourceGroupStmt defaultWgStmt = new CreateResourceGroupStmt(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME,
                     true, false, Collections.emptyList(), defaultWgProperties);
             defaultWgStmt.analyze();
-            defaultWgStmt.getResourceGroup().setId(ResourceGroup.DEFAULT_WG_ID);
             createResourceGroup(defaultWgStmt);
 
             Map<String, String> defaultMvWgProperties = ImmutableMap.of(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
@@ -56,7 +57,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -107,10 +108,10 @@ public class ResourceGroupMgr implements Writable {
         writeLock();
         try {
             ResourceGroup wg = stmt.getResourceGroup();
+            boolean needReplace = false;
             if (resourceGroupMap.containsKey(wg.getName())) {
-                // create resource_group or replace <name> ...
                 if (stmt.isReplaceIfExists()) {
-                    dropResourceGroupUnlocked(wg.getName());
+                    needReplace = true;
                 } else if (!stmt.isIfNotExists()) {
                     throw new DdlException(String.format("RESOURCE_GROUP(%s) already exists", wg.getName()));
                 } else {
@@ -129,7 +130,8 @@ public class ResourceGroupMgr implements Writable {
                 throw new DdlException("MV Resource Group not support classifiers.");
             }
 
-            if (wg.getClassifiers() == null || wg.getClassifiers().isEmpty() &&
+            if ((wg.getClassifiers() == null || wg.getClassifiers().isEmpty()) &&
+                    !ResourceGroup.BUILTIN_WG_NAMES.contains(wg.getName()) &&
                     !wg.getResourceGroupType().equals(TWorkGroupType.WG_MV)) {
                 throw new DdlException("This type Resource Group need define classifiers.");
             }
@@ -141,7 +143,18 @@ public class ResourceGroupMgr implements Writable {
                         BackendResourceStat.getInstance().getAvgNumHardwareCoresOfBe() - 1));
             }
 
-            wg.setId(GlobalStateMgr.getCurrentState().getNextId());
+            if (needReplace) {
+                dropResourceGroupUnlocked(wg.getName());
+            }
+
+            if (ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME.equals(wg.getName())) {
+                wg.setId(ResourceGroup.DEFAULT_WG_ID);
+            } else if (ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME.equals(wg.getName())) {
+                wg.setId(ResourceGroup.DEFAULT_MV_WG_ID);
+            } else {
+                wg.setId(GlobalStateMgr.getCurrentState().getNextId());
+            }
+
             wg.setVersion(wg.getId());
             for (ResourceGroupClassifier classifier : wg.getClassifiers()) {
                 classifier.setResourceGroupId(wg.getId());
@@ -164,11 +177,9 @@ public class ResourceGroupMgr implements Writable {
 
         List<List<String>> rows;
         if (stmt.getName() != null) {
-            rows = GlobalStateMgr.getCurrentState().getResourceGroupMgr().showOneResourceGroup(
-                    stmt.getName(), stmt.isVerbose());
+            rows = showOneResourceGroup(stmt.getName(), stmt.isVerbose());
         } else {
-            rows = GlobalStateMgr.getCurrentState().getResourceGroupMgr()
-                    .showAllResourceGroups(ConnectContext.get(), stmt.isVerbose(), stmt.isListAll());
+            rows = showAllResourceGroups(ConnectContext.get(), stmt.isVerbose(), stmt.isListAll());
         }
         return rows;
     }
@@ -309,23 +320,6 @@ public class ResourceGroupMgr implements Writable {
         }
     }
 
-    public ResourceGroup getResourceGroupIncludingDefault(long id) {
-        ResourceGroup group = getResourceGroup(id);
-        if (group != null) {
-            return group;
-        }
-
-        if (id == ResourceGroup.DEFAULT_WG_ID) {
-            return ResourceGroup.DEFAULT_WG;
-        }
-
-        if (id == ResourceGroup.DEFAULT_MV_WG_ID) {
-            return ResourceGroup.DEFAULT_MV_WG;
-        }
-
-        return null;
-    }
-
     public void alterResourceGroup(AlterResourceGroupStmt stmt) throws DdlException {
         writeLock();
         try {
@@ -339,6 +333,7 @@ public class ResourceGroupMgr implements Writable {
                     !(cmd instanceof AlterResourceGroupStmt.AlterProperties)) {
                 throw new DdlException("MV Resource Group not support classifiers.");
             }
+
             if (cmd instanceof AlterResourceGroupStmt.AddClassifiers) {
                 List<ResourceGroupClassifier> newAddedClassifiers = stmt.getNewAddedClassifiers();
                 for (ResourceGroupClassifier classifier : newAddedClassifiers) {
@@ -422,13 +417,8 @@ public class ResourceGroupMgr implements Writable {
                 TWorkGroupType workGroupType = changedProperties.getResourceGroupType();
                 Preconditions.checkState(workGroupType == null);
             } else if (cmd instanceof AlterResourceGroupStmt.DropClassifiers) {
-                Set<Long> classifierToDrop = stmt.getClassifiersToDrop().stream().collect(Collectors.toSet());
-                Iterator<ResourceGroupClassifier> classifierIterator = wg.getClassifiers().iterator();
-                while (classifierIterator.hasNext()) {
-                    if (classifierToDrop.contains(classifierIterator.next().getId())) {
-                        classifierIterator.remove();
-                    }
-                }
+                Set<Long> classifierToDrop = new HashSet<>(stmt.getClassifiersToDrop());
+                wg.getClassifiers().removeIf(classifier -> classifierToDrop.contains(classifier.getId()));
                 for (Long classifierId : classifierToDrop) {
                     classifierMap.remove(classifierId);
                 }
@@ -439,6 +429,7 @@ public class ResourceGroupMgr implements Writable {
                 }
                 classifierList.clear();
             }
+
             // only when changing properties, version is required to update. because changing classifiers needs not
             // propagate to BE.
             if (cmd instanceof AlterResourceGroupStmt.AlterProperties) {
@@ -631,6 +622,39 @@ public class ResourceGroupMgr implements Writable {
             }
         } finally {
             readUnlock();
+        }
+    }
+
+    public void createBuiltinResourceGroupsIfNotExist() {
+        try {
+            ResourceGroup defaultWg = getResourceGroup(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME);
+            if (defaultWg != null) {
+                return;
+            }
+
+            final int avgCpuCores = BackendResourceStat.getInstance().getAvgNumHardwareCoresOfBe();
+
+            Map<String, String> defaultWgProperties = ImmutableMap.of(
+                    ResourceGroup.CPU_WEIGHT, Integer.toString(avgCpuCores),
+                    ResourceGroup.MEM_LIMIT, "1.0"
+            );
+            CreateResourceGroupStmt defaultWgStmt = new CreateResourceGroupStmt(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME,
+                    true, false, Collections.emptyList(), defaultWgProperties);
+            defaultWgStmt.analyze();
+            defaultWgStmt.getResourceGroup().setId(ResourceGroup.DEFAULT_WG_ID);
+            createResourceGroup(defaultWgStmt);
+
+            Map<String, String> defaultMvWgProperties = ImmutableMap.of(
+                    ResourceGroup.CPU_WEIGHT, "1",
+                    ResourceGroup.MEM_LIMIT, "0.8",
+                    ResourceGroup.SPILL_MEM_LIMIT_THRESHOLD, "0.8"
+            );
+            CreateResourceGroupStmt defaultMvWgStmt = new CreateResourceGroupStmt(ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME,
+                    true, false, Collections.emptyList(), defaultMvWgProperties);
+            defaultMvWgStmt.analyze();
+            createResourceGroup(defaultMvWgStmt);
+        } catch (Exception e) {
+            LOG.warn("failed to create builtin resource groups", e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.ResourceGroupClassifier;
+import com.starrocks.catalog.ResourceGroupMgr;
 import com.starrocks.common.Config;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
@@ -305,33 +306,31 @@ public class CoordinatorPreprocessor {
         if (connect == null || !connect.getSessionVariable().isEnableResourceGroup()) {
             return null;
         }
-        SessionVariable sessionVariable = connect.getSessionVariable();
+
+        final ResourceGroupMgr resourceGroupMgr = GlobalStateMgr.getCurrentState().getResourceGroupMgr();
+        final SessionVariable sessionVariable = connect.getSessionVariable();
         TWorkGroup resourceGroup = null;
 
         // 1. try to use the resource group specified by the variable
         if (StringUtils.isNotEmpty(sessionVariable.getResourceGroup())) {
             String rgName = sessionVariable.getResourceGroup();
-            resourceGroup = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByName(rgName);
-            if (rgName.equalsIgnoreCase(ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME)) {
-                ResourceGroup defaultMVResourceGroup = new ResourceGroup();
-                defaultMVResourceGroup.setId(ResourceGroup.DEFAULT_MV_WG_ID);
-                defaultMVResourceGroup.setName(ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME);
-                defaultMVResourceGroup.setVersion(ResourceGroup.DEFAULT_MV_VERSION);
-                resourceGroup = defaultMVResourceGroup.toThrift();
-            }
+            resourceGroup = resourceGroupMgr.chooseResourceGroupByName(rgName);
         }
 
         // 2. try to use the resource group specified by workgroup_id
         long workgroupId = connect.getSessionVariable().getResourceGroupId();
         if (resourceGroup == null && workgroupId > 0) {
-            resourceGroup = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroupByID(workgroupId);
+            resourceGroup = resourceGroupMgr.chooseResourceGroupByID(workgroupId);
         }
 
         // 3. if the specified resource group not exist try to use the default one
         if (resourceGroup == null) {
             Set<Long> dbIds = connect.getCurrentSqlDbIds();
-            resourceGroup = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
-                    connect, queryType, dbIds);
+            resourceGroup = resourceGroupMgr.chooseResourceGroup(connect, queryType, dbIds);
+        }
+
+        if (resourceGroup == null) {
+            resourceGroup = resourceGroupMgr.chooseResourceGroupByName(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME);
         }
 
         if (resourceGroup != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1288,6 +1288,7 @@ public class GlobalStateMgr {
         }
 
         createBuiltinStorageVolume();
+        resourceGroupMgr.createBuiltinResourceGroupsIfNotExist();
         keyMgr.initDefaultMasterKey();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -86,6 +86,7 @@ import com.starrocks.sql.ast.DropFunctionStmt;
 import com.starrocks.sql.ast.DropHistogramStmt;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.DropRepositoryStmt;
+import com.starrocks.sql.ast.DropResourceGroupStmt;
 import com.starrocks.sql.ast.DropResourceStmt;
 import com.starrocks.sql.ast.DropRoleStmt;
 import com.starrocks.sql.ast.DropStatsStmt;
@@ -230,6 +231,12 @@ public class Analyzer {
 
         @Override
         public Void visitAlterResourceGroupStatement(AlterResourceGroupStmt statement, ConnectContext session) {
+            statement.analyze();
+            return null;
+        }
+
+        @Override
+        public Void visitDropResourceGroupStatement(DropResourceGroupStmt statement, ConnectContext session) {
             statement.analyze();
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
@@ -193,8 +193,8 @@ public class ResourceGroupAnalyzer {
                 } else {
                     memLimit = Double.parseDouble(value);
                 }
-                if (memLimit <= 0.0 || memLimit >= 1.0) {
-                    throw new SemanticException("mem_limit should range from 0.00(exclude) to 1.00(exclude)");
+                if (memLimit <= 0.0 || memLimit > 1.0) {
+                    throw new SemanticException("mem_limit should range from 0.00(exclude) to 1.00(include)");
                 }
                 resourceGroup.setMemLimit(memLimit);
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterResourceGroupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterResourceGroupStmt.java
@@ -92,6 +92,10 @@ public class AlterResourceGroupStmt extends DdlStmt {
                         "should be specified");
             }
         }
+
+        if (ResourceGroup.BUILTIN_WG_NAMES.contains(name) && !(cmd instanceof AlterProperties)) {
+            throw new SemanticException(String.format("cannot alter classifiers of builtin resource group [%s]", name));
+        }
     }
 
     public List<ResourceGroupClassifier> getNewAddedClassifiers() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateResourceGroupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateResourceGroupStmt.java
@@ -36,27 +36,27 @@ import static com.starrocks.catalog.ResourceGroupMgr.SHORT_QUERY_SET_DEDICATED_C
 // with ('cpu_core_limit'='n', 'mem_limit'='m%', 'concurrency_limit'='n', 'type' = 'normal');
 //
 public class CreateResourceGroupStmt extends DdlStmt {
-    private String name;
+    private final String name;
     private boolean ifNotExists;
     private boolean replaceIfExists;
-    private List<List<Predicate>> classifiers;
-    private Map<String, String> properties;
+    private final List<List<Predicate>> classifiers;
+    private final Map<String, String> properties;
     private ResourceGroup resourceGroup;
 
     public CreateResourceGroupStmt(String name, boolean ifNotExists, boolean replaceIfExists,
-                                   List<List<Predicate>> classifiers, Map<String, String> proeprties) {
-        this(name, ifNotExists, replaceIfExists, classifiers, proeprties, NodePosition.ZERO);
+                                   List<List<Predicate>> classifiers, Map<String, String> properties) {
+        this(name, ifNotExists, replaceIfExists, classifiers, properties, NodePosition.ZERO);
     }
 
     public CreateResourceGroupStmt(String name, boolean ifNotExists, boolean replaceIfExists,
-                                   List<List<Predicate>> classifiers, Map<String, String> proeprties,
+                                   List<List<Predicate>> classifiers, Map<String, String> properties,
                                    NodePosition pos) {
         super(pos);
         this.name = name;
         this.ifNotExists = ifNotExists;
         this.replaceIfExists = replaceIfExists;
         this.classifiers = classifiers;
-        this.properties = proeprties;
+        this.properties = properties;
     }
 
     public boolean isIfNotExists() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropResourceGroupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropResourceGroupStmt.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.ast;
 
+import com.starrocks.catalog.ResourceGroup;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.parser.NodePosition;
 
 // Drop ResourceGroup specified by name
@@ -32,6 +34,12 @@ public class DropResourceGroupStmt extends DdlStmt {
 
     public String getName() {
         return name;
+    }
+
+    public void analyze() {
+        if (ResourceGroup.BUILTIN_WG_NAMES.contains(name)) {
+            throw new SemanticException(String.format("cannot drop builtin resource group [%s]", name));
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -673,7 +673,7 @@ public class SystemInfoService implements GsonPostProcessable {
             List<Pair<ResourceGroup, TResourceGroupUsage>> groupAndUsages = new ArrayList<>(groupUsages.size());
             for (TResourceGroupUsage usage : groupUsages) {
                 ResourceGroup group = GlobalStateMgr.getCurrentState().getResourceGroupMgr()
-                        .getResourceGroupIncludingDefault(usage.getGroup_id());
+                        .getResourceGroup(usage.getGroup_id());
                 if (group == null) {
                     continue;
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -13,6 +13,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.ResourceGroupAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.thrift.TWorkGroupOpType;
 import com.starrocks.utframe.StarRocksAssert;
@@ -174,6 +175,8 @@ public class ResourceGroupStmtTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        BackendResourceStat.getInstance().setNumHardwareCoresOfBe(1, 32);
+
         UtFrameUtils.createMinStarRocksCluster();
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         Config.alter_scheduler_interval_millisecond = 1;
@@ -219,7 +222,7 @@ public class ResourceGroupStmtTest {
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP " + name);
         }
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
-        Assert.assertTrue(rows.toString(), rows.isEmpty());
+        assertThat(rows.size()).isEqualTo(2);
     }
 
     private void assertResourceGroupNotExist(String wg) {
@@ -232,7 +235,8 @@ public class ResourceGroupStmtTest {
         createResourceGroups();
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String result = rowsToString(rows);
-        String expect = "" +
+        String expect = "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|NORMAL|(weight=0.0)\n" +
+                "default_wg|32|0|100.0%|null|0|0|0|null|100%|NORMAL|(weight=0.0)\n" +
                 "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
                 "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
                 "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
@@ -366,7 +370,7 @@ public class ResourceGroupStmtTest {
     public void testAlterResourceGroupDropManyClassifiers() throws Exception {
         createResourceGroups();
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
-        String rgName = rows.get(0).get(0);
+        String rgName = rows.get(2).get(0);
         List<String> classifierIds = rows.stream().filter(row -> row.get(0).equals(rgName))
                 .map(row -> getClassifierId(row.get(row.size() - 1))).collect(Collectors.toList());
         rows = rows.stream().peek(row -> {
@@ -399,6 +403,9 @@ public class ResourceGroupStmtTest {
                 continue;
             }
             String rgName = row.get(0);
+            if (ResourceGroup.BUILTIN_WG_NAMES.contains(rgName)) {
+                continue;
+            }
             String classifier = row.get(row.size() - 1);
             String id = getClassifierId(classifier);
             Integer count = classifierCount.computeIfPresent(rgName, (rg, countClassifier) -> countClassifier - 1);
@@ -631,7 +638,8 @@ public class ResourceGroupStmtTest {
         }
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String result = rowsToString(rows);
-        String expect = "" +
+        String expect = "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|NORMAL|(weight=0.0)\n" +
+                "default_wg|32|0|100.0%|null|0|0|0|null|100%|NORMAL|(weight=0.0)\n" +
                 "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
                 "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
                 "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
@@ -1264,9 +1272,10 @@ public class ResourceGroupStmtTest {
                 "   'concurrency_limit' = '31'," +
                 "   'type' = 'normal'" +
                 "   );";
-        String showResult =
+        String showResult = "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|NORMAL|(weight=0.0)\n" +
+                "default_wg|32|0|100.0%|null|0|0|0|null|100%|NORMAL|(weight=0.0)\n" +
                 "rg1|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.0, 2.0), plan_mem_cost_range=[-100.0, 1000.0))\n" +
-                        "rg2|32|0|30.0%|null|0|0|0|31|100%|NORMAL|(weight=2.0, user=rg1_user, plan_mem_cost_range=[0.0, 2000.0))";
+                "rg2|32|0|30.0%|null|0|0|0|31|100%|NORMAL|(weight=2.0, user=rg1_user, plan_mem_cost_range=[0.0, 2000.0))";
 
         starRocksAssert.executeResourceGroupDdlSql(createSQL1);
         starRocksAssert.executeResourceGroupDdlSql(createSQL2);
@@ -1285,7 +1294,7 @@ public class ResourceGroupStmtTest {
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg2");
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
-            Assert.assertTrue(rows.isEmpty());
+            assertThat(rows.size()).isEqualTo(2);
 
             try (ByteArrayInputStream bufferInput = new ByteArrayInputStream(bufferOutput.toByteArray());
                     DataInputStream inputStream = new DataInputStream(bufferInput)) {
@@ -1362,7 +1371,9 @@ public class ResourceGroupStmtTest {
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String actual = rowsToString(rows);
         String expected =
-                "rg1|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=2.0, plan_cpu_cost_range=[11.0, 12.0), plan_mem_cost_range=[-100.0, 11000.0))\n" +
+                "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|NORMAL|(weight=0.0)\n" +
+                        "default_wg|32|0|100.0%|null|0|0|0|null|100%|NORMAL|(weight=0.0)\n" +
+                        "rg1|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=2.0, plan_cpu_cost_range=[11.0, 12.0), plan_mem_cost_range=[-100.0, 11000.0))\n" +
                         "rg2|16|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_cpu_cost_range=[21.0, 22.0))\n" +
                         "rg3|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_mem_cost_range=[-100.0, 31000.0))";
         Assert.assertEquals(expected, actual);
@@ -1392,7 +1403,8 @@ public class ResourceGroupStmtTest {
                 ");";
         starRocksAssert.executeResourceGroupDdlSql(createSQL);
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
-        assertThat(rowsToString(rows)).isEqualTo(
+        assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|NORMAL|(weight=0.0)\n" +
+                "default_wg|32|0|100.0%|null|0|0|0|null|100%|NORMAL|(weight=0.0)\n" +
                 "rg1|10|0|20.0%|8|0|0|0|null|100%|NORMAL|(weight=1.5, source_ip=192.168.2.1/32)");
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
@@ -1421,7 +1433,9 @@ public class ResourceGroupStmtTest {
                 ");");
 
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-        assertThat(rowsToString(rows)).isEqualTo("rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
+        assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                "rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
                 "rg2|null|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)\n" +
                 "rt_rg1|15|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rt_rg1_user)");
 
@@ -1491,7 +1505,9 @@ public class ResourceGroupStmtTest {
                     ");";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                    "rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
 
@@ -1504,7 +1520,9 @@ public class ResourceGroupStmtTest {
                     ");";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                    "rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
 
@@ -1518,7 +1536,9 @@ public class ResourceGroupStmtTest {
                     ");";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("rg1|0|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                    "rg1|0|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
 
@@ -1531,7 +1551,9 @@ public class ResourceGroupStmtTest {
                     ");";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("rg1|null|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                    "rg1|null|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
     }
@@ -1547,7 +1569,9 @@ public class ResourceGroupStmtTest {
                     ");";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                    "rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
         }
 
         {
@@ -1613,7 +1637,9 @@ public class ResourceGroupStmtTest {
                     ")";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("rg1|0|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                    "rg1|0|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
         }
 
         {
@@ -1624,7 +1650,9 @@ public class ResourceGroupStmtTest {
                     ")";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("rg1|15|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                    "rg1|15|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
         }
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
@@ -1655,7 +1683,9 @@ public class ResourceGroupStmtTest {
                     "   'type' = 'short_query'" +
                     ");");
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("rg1|17|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                    "rg1|17|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
 
             String sql = "ALTER resource group rg1 \n" +
                     "WITH (\n" +
@@ -1669,7 +1699,6 @@ public class ResourceGroupStmtTest {
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
     }
-
 
     @Test
     public void testValidateSumDedicatedCpuCores() throws Exception {
@@ -1687,7 +1716,9 @@ public class ResourceGroupStmtTest {
                     "   'dedicated_cpu_cores' = '15'" +
                     ");");
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("rg1|null|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                    "rg1|null|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
                     "rg2|null|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
         }
 
@@ -1709,7 +1740,9 @@ public class ResourceGroupStmtTest {
                     ")";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("rg1|null|14|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
+                    "rg1|null|14|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
                     "rg2|null|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
         }
 
@@ -1728,6 +1761,59 @@ public class ResourceGroupStmtTest {
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg2");
+    }
+
+    @Test
+    public void testDropBuiltinGroup() {
+        Assert.assertThrows("cannot drop builtin resource group [default_wg]",
+                SemanticException.class, () -> starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP default_wg"));
+        Assert.assertThrows("cannot drop builtin resource group [default_mv_wg]",
+                SemanticException.class, () -> starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP default_mv_wg"));
+    }
+
+    @Test
+    public void testAlterClassifierBuiltinGroup() {
+        Assert.assertThrows("cannot alter classifiers of builtin resource group [default_wg]",
+                SemanticException.class,
+                () -> starRocksAssert.executeResourceGroupDdlSql("ALTER RESOURCE GROUP default_wg ADD (user='rg1')"));
+        Assert.assertThrows("cannot alter classifiers of builtin resource group [default_mv_wg]",
+                SemanticException.class,
+                () -> starRocksAssert.executeResourceGroupDdlSql("ALTER RESOURCE GROUP default_mv_wg ADD (user='rg1')"));
+    }
+
+    @Test
+    public void testAlterPropertyBuiltinGroup() throws Exception {
+        {
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)");
+        }
+
+        {
+            String sql1 = "ALTER resource group default_wg \n" +
+                    "WITH ( 'cpu_weight' = '14' )";
+            String sql2 = "ALTER resource group default_mv_wg \n" +
+                    "WITH ( 'cpu_weight' = '12' )";
+            starRocksAssert.executeResourceGroupDdlSql(sql1);
+            starRocksAssert.executeResourceGroupDdlSql(sql2);
+
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|12|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|14|0|100.0%|0|0|0|null|100%|(weight=0.0)");
+        }
+
+        {
+            String sql1 = "ALTER resource group default_wg \n" +
+                    "WITH ( 'cpu_weight' = '32' )";
+            String sql2 = "ALTER resource group default_mv_wg \n" +
+                    "WITH ( 'cpu_weight' = '1' )";
+            starRocksAssert.executeResourceGroupDdlSql(sql1);
+            starRocksAssert.executeResourceGroupDdlSql(sql2);
+
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)");
+        }
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -1764,6 +1764,16 @@ public class ResourceGroupStmtTest {
     }
 
     @Test
+    public void testCreateBuiltinGroup() throws Exception {
+        Assert.assertThrows("RESOURCE_GROUP(default_wg) already exists",
+                DdlException.class, () -> starRocksAssert.executeResourceGroupDdlSql(
+                        "CREATE RESOURCE GROUP default_wg WITH ( 'cpu_weight' = '14', 'mem_limit' = '0.1' )"));
+        Assert.assertThrows("RESOURCE_GROUP(default_mv_wg) already exists",
+                DdlException.class, () -> starRocksAssert.executeResourceGroupDdlSql(
+                        "CREATE RESOURCE GROUP default_mv_wg WITH ( 'cpu_weight' = '14', 'mem_limit' = '0.1' )"));
+    }
+
+    @Test
     public void testDropBuiltinGroup() {
         Assert.assertThrows("cannot drop builtin resource group [default_wg]",
                 SemanticException.class, () -> starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP default_wg"));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -1459,12 +1459,16 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
 
     @Test
     public void testShowResourceGroupUsage() throws Exception {
+        TWorkGroup defaultGroup =
+                new TWorkGroup().setId(ResourceGroup.DEFAULT_WG_ID).setName(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME);
+        TWorkGroup defaultMvGroup =
+                new TWorkGroup().setId(ResourceGroup.DEFAULT_MV_WG_ID).setName(ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME);
         TWorkGroup group0 = new TWorkGroup().setId(10L).setName("wg0");
         TWorkGroup group1 = new TWorkGroup().setId(11L).setName("wg1");
         TWorkGroup group2 = new TWorkGroup().setId(12L).setName("wg2");
         TWorkGroup group3 = new TWorkGroup().setId(13L).setName("wg3");
         TWorkGroup nonGroup = new TWorkGroup().setId(LogicalSlot.ABSENT_GROUP_ID);
-        List<TWorkGroup> groups = ImmutableList.of(group0, group1, group2, group3, nonGroup);
+        List<TWorkGroup> groups = ImmutableList.of(defaultGroup, defaultMvGroup, group0, group1, group2, group3, nonGroup);
         groups.forEach(this::mockResourceGroup);
 
         List<Backend> backends = ImmutableList.of(
@@ -1505,8 +1509,8 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
         {
             String res = starRocksAssert.executeShowResourceUsageSql("SHOW USAGE RESOURCE GROUPS;");
             assertThat(res).isEqualTo("Name|Id|Backend|BEInUseCpuCores|BEInUseMemBytes|BERunningQueries\n" +
-                    "default_wg|0|be0-host|3.112|39|38\n" +
-                    "default_mv_wg|1|be1-host|4.11|49|48\n" +
+                    "default_wg|2|be0-host|3.112|39|38\n" +
+                    "default_mv_wg|3|be1-host|4.11|49|48\n" +
                     "wg0|10|be0-host|0.112|9|8\n" +
                     "wg0|10|be1-host|1.11|19|18\n" +
                     "wg1|11|be0-host|0.1|0|0\n" +


### PR DESCRIPTION
## Why I'm doing:

Currently, when a query does not match any user-created resource groups, it will use either `default_wg` or `default_mv_wg`. However, these two builtin resource groups are not saved or persisted in FE; they are only created in each BE. This leads to two issues:
1. `show resource group` does not display these resource groups.
2. It is not possible to modify the properties of these resource groups.

## What I'm doing:

1. After the **Leader** has loaded the image and editlog, it checks whether there is a need to create builtin resource groups. If they are currently absent, they will be created; otherwise, no action will be taken.
2. The IDs for the newly created `default_wg` and `default_mv_wg` will be 2 and 3, instead of the current 0 and 1. This is because we still retain the original 0 and 1 for `default_wg` and `default_mv_wg` in BE as a fallback and compatibility strategy (e.g., in cases where only the BE has been upgraded and not the FE).
3. During ALTER classifier and DROP Resource Group operations, it checks if the resource group is a builtin one. If it is, an error will be returned.
4. Additionally, fix the bug in `REPLACE RESOURCE GROUP` by performing all validations before dropping the original resource group. Otherwise, if the original resource group is dropped and then the validation finds issues with the new resource group leading to an error, the resource group would cease to exist.

Relates to #49965.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
