### PR TITLE
[Enhancement] support query lake compaction profile in FE

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -100,6 +100,16 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
         _response->add_failed_tablets(context->tablet_id);
     }
 
+    // process compact stat
+    auto compact_stat = _response->add_compact_stats();
+    compact_stat->set_tablet_id(context->tablet_id);
+    compact_stat->set_read_time_remote(context->stats->io_ns_remote);
+    compact_stat->set_read_bytes_remote(context->stats->io_bytes_read_remote);
+    compact_stat->set_read_time_local(context->stats->io_ns_local_disk);
+    compact_stat->set_read_bytes_local(context->stats->io_bytes_read_local_disk);
+    compact_stat->set_in_queue_time_sec(context->stats->in_queue_time_sec);
+    compact_stat->set_sub_task_count(_request->tablet_ids_size());
+
     DCHECK(_request != nullptr);
     _status.update(context->status);
 
@@ -201,6 +211,9 @@ void CompactionScheduler::list_tasks(std::vector<CompactionTaskInfo>* infos) {
         // Load "finish_time" with memory_order_acquire and check its value before reading the "status" to avoid
         // the race condition between this thread and the `CompactionScheduler::thread_task` threads.
         info.finish_time = context->finish_time.load(std::memory_order_acquire);
+        if (info.runs > 0) {
+            info.profile = context->stats->to_json_stats();
+        }
         if (info.finish_time > 0) {
             info.status = context->status;
         }
@@ -337,6 +350,8 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     const auto txn_id = context->txn_id;
     const auto version = context->version;
 
+    int64_t in_queue_time_sec = start_time > context->enqueue_time_sec ? (start_time - context->enqueue_time_sec) : 0;
+    context->stats->in_queue_time_sec += in_queue_time_sec;
     context->start_time.store(start_time, std::memory_order_relaxed);
     context->runs.fetch_add(1, std::memory_order_relaxed);
 

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -23,16 +23,43 @@
 namespace starrocks::lake {
 
 static constexpr long TIME_UNIT_NS_PER_SECOND = 1000000000;
+static constexpr long BYTES_UNIT_MB = 1048576;
 
-void CompactionTaskStats::accumulate(const OlapReaderStatistics& reader_stats) {
-    io_ns += reader_stats.io_ns;
-    io_ns_remote += reader_stats.io_ns_remote;
-    io_ns_local_disk += reader_stats.io_ns_read_local_disk;
-    segment_init_ns += reader_stats.segment_init_ns;
-    column_iterator_init_ns += reader_stats.column_iterator_init_ns;
-    io_count_local_disk += reader_stats.io_count_local_disk;
-    io_count_remote += reader_stats.io_count_remote;
-    compressed_bytes_read += reader_stats.compressed_bytes_read;
+void CompactionTaskStats::collect(const OlapReaderStatistics& reader_stats) {
+    io_ns_remote = reader_stats.io_ns_remote;
+    io_ns_local_disk = reader_stats.io_ns_read_local_disk;
+    io_bytes_read_remote = reader_stats.compressed_bytes_read_remote;
+    io_bytes_read_local_disk = reader_stats.compressed_bytes_read_local_disk;
+    segment_init_ns = reader_stats.segment_init_ns;
+    column_iterator_init_ns = reader_stats.column_iterator_init_ns;
+    io_count_local_disk = reader_stats.io_count_local_disk;
+    io_count_remote = reader_stats.io_count_remote;
+}
+
+CompactionTaskStats CompactionTaskStats::operator+(const CompactionTaskStats& that) const {
+    CompactionTaskStats diff;
+    diff.io_ns_remote = io_ns_remote + that.io_ns_remote;
+    diff.io_ns_local_disk = io_ns_local_disk + that.io_ns_local_disk;
+    diff.io_bytes_read_remote = io_bytes_read_remote + that.io_bytes_read_remote;
+    diff.io_bytes_read_local_disk = io_bytes_read_local_disk + that.io_bytes_read_local_disk;
+    diff.segment_init_ns = segment_init_ns + that.segment_init_ns;
+    diff.column_iterator_init_ns = column_iterator_init_ns + that.column_iterator_init_ns;
+    diff.io_count_local_disk = io_count_local_disk + that.io_count_local_disk;
+    diff.io_count_remote = io_count_remote + that.io_count_remote;
+    return diff;
+}
+
+CompactionTaskStats CompactionTaskStats::operator-(const CompactionTaskStats& that) const {
+    CompactionTaskStats diff;
+    diff.io_ns_remote = io_ns_remote - that.io_ns_remote;
+    diff.io_ns_local_disk = io_ns_local_disk - that.io_ns_local_disk;
+    diff.io_bytes_read_remote = io_bytes_read_remote - that.io_bytes_read_remote;
+    diff.io_bytes_read_local_disk = io_bytes_read_local_disk - that.io_bytes_read_local_disk;
+    diff.segment_init_ns = segment_init_ns - that.segment_init_ns;
+    diff.column_iterator_init_ns = column_iterator_init_ns - that.column_iterator_init_ns;
+    diff.io_count_local_disk = io_count_local_disk - that.io_count_local_disk;
+    diff.io_count_remote = io_count_remote - that.io_count_remote;
+    return diff;
 }
 
 std::string CompactionTaskStats::to_json_stats() {
@@ -40,18 +67,16 @@ std::string CompactionTaskStats::to_json_stats() {
     root.SetObject();
     auto& allocator = root.GetAllocator();
     // add stats
-    root.AddMember("reader_total_time_second", rapidjson::Value(reader_time_ns / TIME_UNIT_NS_PER_SECOND), allocator);
-    root.AddMember("reader_io_second", rapidjson::Value(io_ns / TIME_UNIT_NS_PER_SECOND), allocator);
-    root.AddMember("reader_io_second_remote", rapidjson::Value(io_ns_remote / TIME_UNIT_NS_PER_SECOND), allocator);
-    root.AddMember("reader_io_second_local_disk", rapidjson::Value(io_ns_local_disk / TIME_UNIT_NS_PER_SECOND),
+    root.AddMember("read_local_sec", rapidjson::Value(io_ns_local_disk / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("read_local_mb", rapidjson::Value(io_bytes_read_local_disk / BYTES_UNIT_MB), allocator);
+    root.AddMember("read_remote_sec", rapidjson::Value(io_ns_remote / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("read_remote_mb", rapidjson::Value(io_bytes_read_remote / BYTES_UNIT_MB), allocator);
+    root.AddMember("read_remote_count", rapidjson::Value(io_count_remote), allocator);
+    root.AddMember("read_local_count", rapidjson::Value(io_count_local_disk), allocator);
+    root.AddMember("segment_init_sec", rapidjson::Value(segment_init_ns / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("column_iterator_init_sec", rapidjson::Value(column_iterator_init_ns / TIME_UNIT_NS_PER_SECOND),
                    allocator);
-    root.AddMember("reader_io_count_remote", rapidjson::Value(io_count_remote), allocator);
-    root.AddMember("reader_io_count_local_disk", rapidjson::Value(io_count_local_disk), allocator);
-    root.AddMember("compressed_bytes_read", rapidjson::Value(compressed_bytes_read), allocator);
-    root.AddMember("segment_init_second", rapidjson::Value(segment_init_ns / TIME_UNIT_NS_PER_SECOND), allocator);
-    root.AddMember("column_iterator_init_second", rapidjson::Value(column_iterator_init_ns / TIME_UNIT_NS_PER_SECOND),
-                   allocator);
-    root.AddMember("segment_write_second", rapidjson::Value(segment_write_ns / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("in_queue_sec", rapidjson::Value(in_queue_time_sec), allocator);
 
     rapidjson::StringBuffer strbuf;
     rapidjson::Writer<rapidjson::StringBuffer> writer(strbuf);

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -40,18 +40,19 @@ private:
 };
 
 struct CompactionTaskStats {
-    int64_t io_ns = 0;
     int64_t io_ns_remote = 0;
     int64_t io_ns_local_disk = 0;
+    int64_t io_bytes_read_remote = 0;
+    int64_t io_bytes_read_local_disk = 0;
     int64_t segment_init_ns = 0;
     int64_t column_iterator_init_ns = 0;
     int64_t io_count_local_disk = 0;
     int64_t io_count_remote = 0;
-    int64_t compressed_bytes_read = 0;
-    int64_t reader_time_ns = 0;
-    int64_t segment_write_ns = 0;
+    int64_t in_queue_time_sec = 0;
 
-    void accumulate(const OlapReaderStatistics& reader_stats);
+    void collect(const OlapReaderStatistics& reader_stats);
+    CompactionTaskStats operator+(const CompactionTaskStats& that) const;
+    CompactionTaskStats operator-(const CompactionTaskStats& that) const;
     std::string to_json_stats();
 };
 
@@ -82,6 +83,7 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     bool is_checker;
     Status status;
     Progress progress;
+    int64_t enqueue_time_sec; // time point when put into queue
     std::shared_ptr<CompactionTaskCallback> callback;
     std::unique_ptr<CompactionTaskStats> stats = std::make_unique<CompactionTaskStats>();
 };

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -44,7 +44,6 @@ Status HorizontalGeneralTabletWriter::open() {
 }
 
 Status HorizontalGeneralTabletWriter::write(const starrocks::Chunk& data, SegmentPB* segment) {
-    SCOPED_RAW_TIMER(&_stats.segment_write_ns);
     if (_seg_writer == nullptr || _seg_writer->estimate_segment_size() >= config::max_segment_file_size ||
         _seg_writer->num_rows_written() + data.num_rows() >= INT32_MAX /*TODO: configurable*/) {
         RETURN_IF_ERROR(flush_segment_writer(segment));
@@ -60,7 +59,6 @@ Status HorizontalGeneralTabletWriter::flush(SegmentPB* segment) {
 }
 
 Status HorizontalGeneralTabletWriter::finish(SegmentPB* segment) {
-    SCOPED_RAW_TIMER(&_stats.segment_write_ns);
     RETURN_IF_ERROR(flush_segment_writer(segment));
     _finished = true;
     return Status::OK();
@@ -145,7 +143,6 @@ Status VerticalGeneralTabletWriter::open() {
 
 Status VerticalGeneralTabletWriter::write_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes,
                                                   bool is_key) {
-    SCOPED_RAW_TIMER(&_stats.segment_write_ns);
     const size_t chunk_num_rows = data.num_rows();
     if (_segment_writers.empty()) {
         DCHECK(is_key);
@@ -217,7 +214,6 @@ Status VerticalGeneralTabletWriter::flush(SegmentPB* segment) {
 }
 
 Status VerticalGeneralTabletWriter::flush_columns() {
-    SCOPED_RAW_TIMER(&_stats.segment_write_ns);
     if (_segment_writers.empty()) {
         return Status::OK();
     }
@@ -233,7 +229,6 @@ Status VerticalGeneralTabletWriter::flush_columns() {
 }
 
 Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
-    SCOPED_RAW_TIMER(&_stats.segment_write_ns);
     for (auto& segment_writer : _segment_writers) {
         uint64_t segment_size = 0;
         uint64_t footer_position = 0;

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -65,7 +65,6 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     std::vector<uint64_t> rssid_rowids;
     rssid_rowids.reserve(chunk_size);
 
-    int64_t reader_time_ns = 0;
     const bool enable_light_pk_compaction_publish = StorageEngine::instance()->enable_light_pk_compaction_publish();
     while (true) {
         if (UNLIKELY(StorageEngine::instance()->bg_worker_stopped())) {
@@ -78,7 +77,6 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
         RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("Compaction"));
 #endif
         {
-            SCOPED_RAW_TIMER(&reader_time_ns);
             auto st = Status::OK();
             if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && enable_light_pk_compaction_publish) {
                 st = reader.get_next(chunk.get(), &rssid_rowids);
@@ -102,21 +100,16 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
         rssid_rowids.clear();
 
         _context->progress.update(100 * reader.stats().raw_rows_read / total_num_rows);
-        VLOG_EVERY_N(3, 1000) << "Tablet: " << _tablet.id() << ", compaction progress: " << _context->progress.value();
+        _context->stats->collect(reader.stats());
     }
+
+    RETURN_IF_ERROR(writer->finish());
 
     // Adjust the progress here for 2 reasons:
     // 1. For primary key, due to the existence of the delete vector, the rows read may be less than "total_num_rows"
     // 2. If the "total_num_rows" is 0, the progress will not be updated above
     _context->progress.update(100);
-    RETURN_IF_ERROR(writer->finish());
-
-    // add reader stats
-    _context->stats->reader_time_ns += reader_time_ns;
-    _context->stats->accumulate(reader.stats());
-
-    // update writer stats
-    _context->stats->segment_write_ns += writer->stats().segment_write_ns;
+    _context->stats->collect(reader.stats());
 
     auto txn_log = std::make_shared<TxnLog>();
     auto op_compaction = txn_log->mutable_op_compaction();

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -73,16 +73,14 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
         RETURN_IF_ERROR(compact_column_group(is_key, i, column_group_size, column_groups[i], writer, mask_buffer.get(),
                                              source_masks.get(), cancel_func));
     }
+
+    RETURN_IF_ERROR(writer->finish());
+
     // Adjust the progress here for 2 reasons:
     // 1. For primary key, due to the existence of the delete vector, the number of rows read may be less than the
     //    number of rows counted in the metadata.
     // 2. If the number of rows is 0, the progress will not be updated
     _context->progress.update(100);
-
-    RETURN_IF_ERROR(writer->finish());
-
-    // update writer stats
-    _context->stats->segment_write_ns += writer->stats().segment_write_ns;
 
     auto txn_log = std::make_shared<TxnLog>();
     auto op_compaction = txn_log->mutable_op_compaction();
@@ -164,6 +162,7 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
                                   config::lake_compaction_stream_buffer_size_bytes};
     RETURN_IF_ERROR(reader.open(reader_params));
 
+    CompactionTaskStats prev_stats;
     auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
     auto char_field_indexes = ChunkHelper::get_char_field_indexes(schema);
     std::vector<uint64_t> rssid_rowids;
@@ -172,7 +171,6 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
     VLOG(3) << "Compact column group. tablet: " << _tablet.id() << ", column group: " << column_group_index
             << ", reader chunk size: " << chunk_size;
 
-    int64 reader_time_ns = 0;
     const bool enable_light_pk_compaction_publish = StorageEngine::instance()->enable_light_pk_compaction_publish();
     while (true) {
         if (UNLIKELY(StorageEngine::instance()->bg_worker_stopped())) {
@@ -185,7 +183,6 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
         RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("Compaction"));
 #endif
         {
-            SCOPED_RAW_TIMER(&reader_time_ns);
             auto st = Status::OK();
             // Collect rssid & rowid only when compact primary key columns
             if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && is_key && enable_light_pk_compaction_publish) {
@@ -218,13 +215,18 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
 
         _context->progress.update((100 * column_group_index + 100 * reader.stats().raw_rows_read / _total_num_rows) /
                                   column_group_size);
-        VLOG_EVERY_N(3, 1000) << "Tablet: " << _tablet.id() << ", compaction progress: " << _context->progress.value();
+        CompactionTaskStats temp_stats;
+        temp_stats.collect(reader.stats());
+        CompactionTaskStats diff_stats = temp_stats - prev_stats;
+        *_context->stats = *_context->stats + diff_stats;
+        prev_stats = temp_stats;
     }
     RETURN_IF_ERROR(writer->flush_columns());
 
-    // add reader stats
-    _context->stats->reader_time_ns += reader_time_ns;
-    _context->stats->accumulate(reader.stats());
+    CompactionTaskStats temp_stats;
+    temp_stats.collect(reader.stats());
+    CompactionTaskStats diff_stats = temp_stats - prev_stats;
+    *_context->stats = *_context->stats + diff_stats;
 
     if (is_key) {
         RETURN_IF_ERROR(mask_buffer->flush());

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -54,6 +54,12 @@ TEST_F(LakeCompactionSchedulerTest, test_task_queue) {
     queue.set_target_size(5);
     ASSERT_EQ(5, queue.target_size());
     queue.put_by_txn_id(ctx->txn_id, ctx);
+
+    std::vector<std::unique_ptr<CompactionTaskContext>> v;
+    auto ctx2 = std::make_unique<CompactionTaskContext>(101 /* txn_id */, 102 /* tablet_id */, 1 /* version */,
+                                                        false /* is_checker */, nullptr);
+    v.push_back(std::move(ctx2));
+    queue.put_by_txn_id(101 /* txn_id */, v);
 }
 
 TEST_F(LakeCompactionSchedulerTest, test_list_tasks) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
@@ -38,6 +38,7 @@ public class BeCloudNativeCompactionsSystemTable {
                         .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("PROGRESS", ScalarType.createType(PrimitiveType.INT))
                         .column("STATUS", ScalarType.createType(PrimitiveType.VARCHAR))
+                        .column("PROFILE", ScalarType.createType(PrimitiveType.VARCHAR))
                         .build(), TSchemaTableType.SCH_BE_CLOUD_NATIVE_COMPACTIONS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CompactionsProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CompactionsProcNode.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 public class CompactionsProcNode implements ProcNodeInterface {
     private static final List<String> TITLES = Collections.unmodifiableList(Arrays.asList(
-            "Partition", "TxnID", "StartTime", "CommitTime", "FinishTime", "Error"));
+            "Partition", "TxnID", "StartTime", "CommitTime", "FinishTime", "Error", "Profile"));
 
     public CompactionsProcNode() {
     }
@@ -46,6 +46,7 @@ public class CompactionsProcNode implements ProcNodeInterface {
             row.add(record.getCommitTs().map(TimeUtils::longToTimeString).orElse(null));
             row.add(record.getFinishTs().map(TimeUtils::longToTimeString).orElse(null));
             row.add(record.getErrorMessage().orElse(null));
+            row.add(record.getExecutionProfile().orElse(null));
             result.addRow(row);
         }
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionProfile.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.compaction;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.proto.CompactStat;
+
+import javax.validation.constraints.NotNull;
+
+class CompactionProfile {
+    @SerializedName(value = "sub_task_count")
+    private int subTaskCount;
+    @SerializedName(value = "read_local_sec")
+    private long readLocalSec;
+    @SerializedName(value = "read_local_mb")
+    private long readLocalMb;
+    @SerializedName(value = "read_remote_sec")
+    private long readRemoteSec;
+    @SerializedName(value = "read_remote_mb")
+    private long readRemoteMb;
+    @SerializedName(value = "in_queue_sec")
+    private int inQueueSec;
+
+    public CompactionProfile(@NotNull CompactStat stat) {
+        subTaskCount = stat.subTaskCount;
+
+        readLocalSec = stat.readTimeLocal / 1000000000L;
+        readLocalMb = stat.readBytesLocal / 1048576;
+        readRemoteSec = stat.readTimeRemote / 1000000000L;
+        readRemoteMb = stat.readBytesRemote / 1048576;
+        inQueueSec = stat.inQueueTimeSec;
+    }
+
+    @Override
+    public String toString() {
+        return new Gson().toJson(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionRecord.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionRecord.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.lake.compaction;
 
+import com.google.common.base.Strings;
+
 import java.util.Objects;
 import java.util.Optional;
 
@@ -24,6 +26,7 @@ public class CompactionRecord {
     private final long finishTs;
     private final String partitionName;
     private final String errorMessage;
+    private final String executionProfile;
 
     private CompactionRecord(CompactionJob context, String errorMessage) {
         Objects.requireNonNull(context.getFullPartitionName());
@@ -33,6 +36,7 @@ public class CompactionRecord {
         this.finishTs = context.getFinishTs();
         this.partitionName = context.getFullPartitionName();
         this.errorMessage = errorMessage;
+        this.executionProfile = context.getExecutionProfile();
     }
 
     static CompactionRecord build(CompactionJob context) {
@@ -65,5 +69,9 @@ public class CompactionRecord {
 
     public Optional<String> getErrorMessage() {
         return errorMessage != null ? Optional.of(errorMessage) : Optional.empty();
+    }
+
+    public Optional<String> getExecutionProfile() {
+        return Strings.isNullOrEmpty(executionProfile) ? Optional.empty() : Optional.of(executionProfile);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
@@ -19,6 +19,7 @@ import com.starrocks.proto.AbortCompactionRequest;
 import com.starrocks.proto.AbortCompactionResponse;
 import com.starrocks.proto.CompactRequest;
 import com.starrocks.proto.CompactResponse;
+import com.starrocks.proto.CompactStat;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.transaction.TabletCommitInfo;
 import org.apache.commons.collections.CollectionUtils;
@@ -54,6 +55,7 @@ public class CompactionTask {
         this.nodeId = nodeId;
         this.rpcChannel = Objects.requireNonNull(rpcChannel, "rpcChannel is null");
         this.request = Objects.requireNonNull(request, "request is null");
+        this.responseFuture = null;
     }
 
     enum TaskResult {
@@ -135,5 +137,17 @@ public class CompactionTask {
 
     public int tabletCount() {
         return request.tabletIds.size();
+    }
+
+    public List<CompactStat> getCompactStats() {
+        if (!isDone()) {
+            return null;
+        }
+        try {
+            CompactResponse response = responseFuture.get();
+            return response.compactStats;
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.PhysicalPartitionImpl;
 import com.starrocks.catalog.Table;
+import com.starrocks.proto.CompactStat;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.Assert;
@@ -83,5 +84,38 @@ public class CompactionJobTest {
         assertDoesNotThrow(() -> {
             job.buildTabletCommitInfo();
         });
+    }
+
+    @Test
+    public void testGetExecutionProfile() {
+        Database db = new Database();
+        Table table = new Table(Table.TableType.CLOUD_NATIVE);
+        PhysicalPartition partition = new PhysicalPartitionImpl(0, "", 1, 2, null);
+        CompactionJob job = new CompactionJob(db, table, partition, 10010, true);
+
+        Assert.assertTrue(job.getExecutionProfile().isEmpty());
+
+        List<CompactionTask> list = new ArrayList<>();
+        list.add(new CompactionTask(100));
+        job.setTasks(list);
+        job.finish();
+        new MockUp<CompactionTask>() {
+            @Mock
+            public List<CompactStat> getCompactStats() {
+                List<CompactStat> list = new ArrayList<>();
+                CompactStat stat = new CompactStat();
+                stat.subTaskCount = 1;
+                stat.readTimeRemote = 2L;
+                stat.readBytesRemote = 3L;
+                stat.readTimeLocal = 4L;
+                stat.readBytesLocal = 5L;
+                stat.inQueueTimeSec = 6;
+                list.add(stat);
+                return list;
+            }
+        };
+
+        String s = job.getExecutionProfile();
+        Assert.assertFalse(s.isEmpty());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionProfileTest.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.compaction;
+
+import com.starrocks.proto.CompactStat;
+import org.junit.Assert;
+import org.junit.Test;
+
+class CompactionProfileTest {
+    @Test
+    public void testBasic() {
+        CompactStat stat = new CompactStat();
+        stat.subTaskCount = 1;
+        stat.readTimeRemote = 2L;
+        stat.readBytesRemote = 3L;
+        stat.readTimeLocal = 4L;
+        stat.readBytesLocal = 5L;
+        stat.inQueueTimeSec = 6;
+
+        CompactionProfile profile = new CompactionProfile(stat);
+
+        String s = profile.toString();
+        Assert.assertTrue(s.contains("sub_task_count"));
+        Assert.assertTrue(s.contains("read_local_sec"));
+        Assert.assertTrue(s.contains("read_local_mb"));
+        Assert.assertTrue(s.contains("read_remote_sec"));
+        Assert.assertTrue(s.contains("read_remote_mb"));
+        Assert.assertTrue(s.contains("in_queue_sec"));
+    }
+}

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -89,6 +89,24 @@ message CompactRequest {
     optional bytes encryption_meta = 6;
 }
 
+message CompactStat {
+    // basic
+    optional int64 tablet_id = 1;
+
+    // read
+    optional int64 read_time_remote = 11; // ns
+    optional int64 read_bytes_remote = 12;
+    optional int64 read_time_local = 13; // ns
+    optional int64 read_bytes_local = 14;
+
+    // write
+    // TODO
+
+    // other
+    optional int32 sub_task_count = 51; // tablet count in this compaction request
+    optional int32 in_queue_time_sec = 52;
+}
+
 message CompactResponse {
     repeated int64 failed_tablets = 1;
     // optional int64 execution_time = 2; // ms
@@ -97,6 +115,7 @@ message CompactResponse {
     // optional int64 num_output_bytes = 5;
     // optional int64 num_output_rows = 6;
     optional StatusPB status = 7;
+    repeated CompactStat compact_stats = 8;
 }
 
 message DropTableRequest {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
ADD `profile` field

```
show proc '/compactions';

| ssb.lineorder.40462              | 30366 | 2024-09-10 19:48:23 | 2024-09-10 19:48:52 | 2024-09-10 19:48:52 | NULL  | {"sub_task_count":1,"read_local_sec":0,"read_local_mb":214,"read_remote_sec":5,"read_remote_mb":240,"in_queue_sec":0} |
| ssb.lineorder.40461              | 30367 | 2024-09-10 19:48:23 | 2024-09-10 19:48:50 | 2024-09-10 19:48:52 | NULL  | {"sub_task_count":1,"read_local_sec":0,"read_local_mb":215,"read_remote_sec":4,"read_remote_mb":239,"in_queue_sec":0} |
| ssb.lineorder.40463              | 30365 | 2024-09-10 19:48:22 | 2024-09-10 19:48:51 | 2024-09-10 19:48:51 | NULL  | {"sub_task_count":1,"read_local_sec":0,"read_local_mb":215,"read_remote_sec":5,"read_remote_mb":239,"in_queue_sec":0} |
```

```
select * from information_schema.be_cloud_native_compactions;

| 10001 |  30365 |     40472 |      16 |       0 |    1 | 2024-09-10 19:48:22 | NULL        |      100 |        | {"read_local_sec":0,"read_local_mb":215,"read_remote_sec":5,"read_remote_mb":239,"read_remote_count":241,"read_local_count":10195,"segment_init_sec":0,"column_iterator_init_sec":0,"in_queue_sec":0} |
| 10001 |  30366 |     40471 |      16 |       0 |    1 | 2024-09-10 19:48:23 | NULL        |       91 |        | {"read_local_sec":0,"read_local_mb":212,"read_remote_sec":5,"read_remote_mb":236,"read_remote_count":236,"read_local_count":9822,"segment_init_sec":0,"column_iterator_init_sec":0,"in_queue_sec":0}  |
| 10001 |  30367 |     40470 |      16 |       0 |    1 | 2024-09-10 19:48:23 | NULL        |      100 |        | {"read_local_sec":0,"read_local_mb":215,"read_remote_sec":4,"read_remote_mb":239,"read_remote_count":241,"read_local_count":10229,"segment_init_sec":0,"column_iterator_init_sec":0,"in_queue_sec":0} |
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
