### PR TITLE
[Enhancement] reduce mem alloc failed because unfair memory sharing

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -127,7 +127,7 @@ class DataSourceProvider {
 public:
     static constexpr int64_t MIN_DATA_SOURCE_MEM_BYTES = 16 * 1024 * 1024;  // 16MB
     static constexpr int64_t MAX_DATA_SOURCE_MEM_BYTES = 256 * 1024 * 1024; // 256MB
-    static constexpr int64_t PER_FIELD_MEM_BYTES = 4 * 1024 * 1024;         // 4MB
+    static constexpr int64_t PER_FIELD_MEM_BYTES = 1 * 1024 * 1024;         // 1MB
 
     virtual ~DataSourceProvider() = default;
 

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "connector_chunk_sink.h"
+#include "connector/connector_chunk_sink.h"
 #include "exec/pipeline/scan/morsel.h"
 #include "exprs/runtime_filter_bank.h"
 #include "gen_cpp/InternalService_types.h"

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -232,8 +232,13 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const Unified
             spill_mem_limit_ratio = query_options.spill_mem_limit_threshold;
         }
     }
+
+    int scan_node_number = 1;
+    if (query_globals.__isset.scan_node_number) {
+        scan_node_number = query_globals.scan_node_number;
+    }
     _query_ctx->init_mem_tracker(option_query_mem_limit, parent_mem_tracker, big_query_mem_limit, spill_mem_limit_ratio,
-                                 wg.get(), runtime_state);
+                                 wg.get(), runtime_state, scan_node_number);
 
     auto query_mem_tracker = _query_ctx->mem_tracker();
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(query_mem_tracker.get());

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -106,7 +106,7 @@ void QueryContext::cancel(const Status& status) {
 
 void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent, int64_t big_query_mem_limit,
                                     std::optional<double> spill_mem_reserve_ratio, workgroup::WorkGroup* wg,
-                                    RuntimeState* runtime_state) {
+                                    RuntimeState* runtime_state, int scan_node_number) {
     std::call_once(_init_mem_tracker_once, [=]() {
         _profile = std::make_shared<RuntimeProfile>("Query" + print_id(_query_id));
         auto* mem_tracker_counter =
@@ -138,7 +138,7 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
             _static_query_mem_limit = std::min(big_query_mem_limit, _static_query_mem_limit);
         }
         _connector_scan_operator_mem_share_arbitrator =
-                _object_pool.add(new ConnectorScanOperatorMemShareArbitrator(_static_query_mem_limit));
+                _object_pool.add(new ConnectorScanOperatorMemShareArbitrator(_static_query_mem_limit, scan_node_number));
 
         {
             MemTracker* connector_scan_parent = GlobalEnv::GetInstance()->connector_scan_pool_mem_tracker();

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -137,8 +137,8 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
         if (big_query_mem_limit > 0) {
             _static_query_mem_limit = std::min(big_query_mem_limit, _static_query_mem_limit);
         }
-        _connector_scan_operator_mem_share_arbitrator =
-                _object_pool.add(new ConnectorScanOperatorMemShareArbitrator(_static_query_mem_limit, scan_node_number));
+        _connector_scan_operator_mem_share_arbitrator = _object_pool.add(
+                new ConnectorScanOperatorMemShareArbitrator(_static_query_mem_limit, scan_node_number));
 
         {
             MemTracker* connector_scan_parent = GlobalEnv::GetInstance()->connector_scan_pool_mem_tracker();

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -163,7 +163,7 @@ public:
     /// that there is a big query memory limit of this resource group.
     void init_mem_tracker(int64_t query_mem_limit, MemTracker* parent, int64_t big_query_mem_limit = -1,
                           std::optional<double> spill_mem_limit = std::nullopt, workgroup::WorkGroup* wg = nullptr,
-                          RuntimeState* state = nullptr);
+                          RuntimeState* state = nullptr, int scan_node_number = 1);
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
     MemTracker* connector_scan_mem_tracker() { return _connector_scan_mem_tracker.get(); }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -24,6 +24,11 @@
 namespace starrocks::pipeline {
 
 // ==================== ConnectorScanOperatorFactory ====================
+ConnectorScanOperatorMemShareArbitrator::ConnectorScanOperatorMemShareArbitrator(int64_t query_mem_limit)
+        : query_mem_limit(query_mem_limit),
+          scan_mem_limit(query_mem_limit),
+          total_chunk_source_mem_bytes(6 * 256 * 1024 * 1024) {}
+
 int64_t ConnectorScanOperatorMemShareArbitrator::update_chunk_source_mem_bytes(int64_t old_value, int64_t new_value) {
     int64_t diff = new_value - old_value;
     int64_t total = total_chunk_source_mem_bytes.fetch_add(diff) + diff;
@@ -291,7 +296,7 @@ ChunkSourcePtr ConnectorScanOperator::create_chunk_source(MorselPtr morsel, int3
         _adaptive_processor->started_running = true;
         int64_t c = L->update_active_scan_operator_count(1);
         if (c == 0) {
-            _adjust_scan_mem_limit(0, L->get_arb_chunk_source_mem_bytes());
+            _adjust_scan_mem_limit(256 * 1024 * 1024, L->get_arb_chunk_source_mem_bytes());
         }
     }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -24,10 +24,11 @@
 namespace starrocks::pipeline {
 
 // ==================== ConnectorScanOperatorFactory ====================
-ConnectorScanOperatorMemShareArbitrator::ConnectorScanOperatorMemShareArbitrator(int64_t query_mem_limit)
+ConnectorScanOperatorMemShareArbitrator::ConnectorScanOperatorMemShareArbitrator(int64_t query_mem_limit,
+                                                                                 int scan_node_number)
         : query_mem_limit(query_mem_limit),
           scan_mem_limit(query_mem_limit),
-          total_chunk_source_mem_bytes(6 * 256 * 1024 * 1024) {}
+          total_chunk_source_mem_bytes(scan_node_number * connector::DataSourceProvider::MAX_DATA_SOURCE_MEM_BYTES) {}
 
 int64_t ConnectorScanOperatorMemShareArbitrator::update_chunk_source_mem_bytes(int64_t old_value, int64_t new_value) {
     int64_t diff = new_value - old_value;
@@ -296,7 +297,8 @@ ChunkSourcePtr ConnectorScanOperator::create_chunk_source(MorselPtr morsel, int3
         _adaptive_processor->started_running = true;
         int64_t c = L->update_active_scan_operator_count(1);
         if (c == 0) {
-            _adjust_scan_mem_limit(256 * 1024 * 1024, L->get_arb_chunk_source_mem_bytes());
+            _adjust_scan_mem_limit(connector::DataSourceProvider::MAX_DATA_SOURCE_MEM_BYTES,
+                                   L->get_arb_chunk_source_mem_bytes());
         }
     }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -35,7 +35,7 @@ struct ConnectorScanOperatorMemShareArbitrator {
     int64_t scan_mem_limit = 0;
     std::atomic<int64_t> total_chunk_source_mem_bytes = 0;
 
-    ConnectorScanOperatorMemShareArbitrator(int64_t query_mem_limit);
+    ConnectorScanOperatorMemShareArbitrator(int64_t query_mem_limit, int scan_node_number);
 
     int64_t set_scan_mem_ratio(double mem_ratio) {
         scan_mem_limit = std::max<int64_t>(1, query_mem_limit * mem_ratio);

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -35,8 +35,7 @@ struct ConnectorScanOperatorMemShareArbitrator {
     int64_t scan_mem_limit = 0;
     std::atomic<int64_t> total_chunk_source_mem_bytes = 0;
 
-    ConnectorScanOperatorMemShareArbitrator(int64_t query_mem_limit)
-            : query_mem_limit(query_mem_limit), scan_mem_limit(query_mem_limit) {}
+    ConnectorScanOperatorMemShareArbitrator(int64_t query_mem_limit);
 
     int64_t set_scan_mem_ratio(double mem_ratio) {
         scan_mem_limit = std::max<int64_t>(1, query_mem_limit * mem_ratio);

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -188,9 +188,9 @@ void WorkGroup::init() {
     _scan_sched_entity.set_queue(workgroup::create_scan_task_queue());
     _connector_scan_sched_entity.set_queue(workgroup::create_scan_task_queue());
 
-    _connector_scan_mem_tracker = std::make_shared<MemTracker>(
-            MemTracker::RESOURCE_GROUP, _memory_limit_bytes * config::connector_scan_use_query_mem_ratio,
-            _name + "/connector_scan", GlobalEnv::GetInstance()->connector_scan_pool_mem_tracker());
+    _connector_scan_mem_tracker =
+            std::make_shared<MemTracker>(MemTracker::RESOURCE_GROUP, _memory_limit_bytes, _name + "/connector_scan",
+                                         GlobalEnv::GetInstance()->connector_scan_pool_mem_tracker());
 }
 
 std::string WorkGroup::to_string() const {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -206,8 +206,7 @@ Status GlobalEnv::_init_mem_tracker() {
     int64_t query_pool_spill_limit = query_pool_mem_limit * config::query_pool_spill_mem_limit_threshold;
     _query_pool_mem_tracker->set_reserve_limit(query_pool_spill_limit);
     _connector_scan_pool_mem_tracker =
-            regist_tracker(MemTracker::QUERY_POOL, query_pool_mem_limit * config::connector_scan_use_query_mem_ratio,
-                           "query_pool/connector_scan", nullptr);
+            regist_tracker(MemTracker::QUERY_POOL, query_pool_mem_limit, "query_pool/connector_scan", nullptr);
 
     int64_t load_mem_limit = calc_max_load_memory(_process_mem_tracker->limit());
     _load_mem_tracker = regist_tracker(MemTracker::LOAD, load_mem_limit, "load", process_mem_tracker());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -112,6 +112,7 @@ public class JobSpec {
             if (context.getLastQueryId() != null) {
                 queryGlobals.setLast_query_id(context.getLastQueryId().toString());
             }
+            queryGlobals.setScan_node_number(scanNodes.size());
 
             return new Builder()
                     .queryId(context.getExecutionId())
@@ -141,6 +142,7 @@ public class JobSpec {
             if (context.getLastQueryId() != null) {
                 queryGlobals.setLast_query_id(context.getLastQueryId().toString());
             }
+            queryGlobals.setScan_node_number(scanNodes.size());
 
             return new Builder()
                     .queryId(context.getExecutionId())

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -175,7 +175,7 @@ struct TSpillOptions {
 struct TQueryOptions {
   2: optional i32 max_errors = 0
   4: optional i32 batch_size = 0
-  
+
   12: optional i64 mem_limit = 2147483648
   13: optional bool abort_on_default_limit_exceeded = 0
   14: optional i32 query_timeout = 3600
@@ -215,7 +215,7 @@ struct TQueryOptions {
   59: optional bool enable_tablet_internal_parallel;
 
   60: optional i32 query_delivery_timeout;
-  
+
   61: optional bool enable_query_debug_trace;
 
   62: optional Types.TCompressionType load_transmission_compression_type;
@@ -229,7 +229,7 @@ struct TQueryOptions {
   67: optional bool enable_pipeline_query_statistic = false;
 
   68: optional i32 transmission_encode_level;
-  
+
   69: optional bool enable_populate_datacache;
 
   70: optional bool allow_throw_exception = 0;
@@ -253,7 +253,7 @@ struct TQueryOptions {
   85: optional TSpillMode spill_mode;
 
   82: optional TSpillOptions spill_options;
-  
+
   86: optional i32 io_tasks_per_scan_operator = 4;
   87: optional i32 connector_io_tasks_per_scan_operator = 16;
   88: optional double runtime_filter_early_return_selectivity = 0.05;
@@ -399,6 +399,8 @@ struct TQueryGlobals {
   30: optional string last_query_id
 
   31: optional i64 timestamp_us
+
+  32: optional i64 scan_node_number
 }
 
 
@@ -469,7 +471,7 @@ struct TExecPlanFragmentParams {
   53: optional WorkGroup.TWorkGroup workgroup
   54: optional bool enable_resource_group
   55: optional i32 func_version
-  
+
   // Sharing data between drivers of same scan operator
   56: optional bool enable_shared_scan
 


### PR DESCRIPTION
## Why I'm doing:

One problem with tpch sf100 Q21 is that the performance is very unstable, if you look at the logs you can see that there are a lot of mem alloc failed cases inside scan node 8

```
python run-bench.py --endpoint 127.0.0.1 --port 41003 --user root --mysql --db hive.zz_tpch_sf100_hive_parquet_lz4 --sql-file tpch --times 3 --warmup 1 --include Q21

running Q21 on mysql
>>> warmup begin
--> 20130. avg = 20130.
<<< warmup end
--> 12773. avg = 12773.
--> 12996. avg = 12884.
--> 17706. avg = 14491.
```

If you analyze the logs,  you can observe that most of the memory is allocated by nodes 0,2,5. This leads to a problem that node 8 has almost no way to get memory: (my memory is 64G, scan_mem_ratio=0.3, then at most 15G memory is allocated to connector scan ndoe)
- 0: mem = 6206458665(6G), io task = 24
- 2: mem = 5338887537(5G), io task = 20
- 5: mem = 4438315236(4G), io task = 17

The root cause of this problem is the connector mem arbitrator implementation. The original intent of this implementation was to be able to average memory between each node. The algorithm is as follows:

```
int64_t ConnectorScanOperatorMemShareArbitrator::update_chunk_source_mem_bytes(int64_t old_value, int64_t new_value) {
    int64_t diff = new_value - old_value;
    int64_t total = total_chunk_source_mem_bytes.fetch_add(diff) + diff;
    if (new_value == 0) return 0;
    if (total <= 0) return scan_mem_limit;
    return scan_mem_limit * (new_value * 1.0 / std::max(total, new_value));
}
```

Each node starts with` update_chunk_source_mem_bytes(0, mem)`. But the problem with this is that for the very first node, it uses up all the memory. And it causes all the following nodes to not get any memory.

## What I'm doing:

So the fix here is to 
- count exactly how many connector scan node nodes exist on the FE 
- and preset each node to initially use 256MB of memory. 
- then each node makes adjustments from `update_chunk_source_mem_bytes(256M, mem)`

## benchmark

After the modification, the execution time can be stabilized at 9s

```
running Q21 on mysql
>>> warmup begin
--> 9795. avg = 9795.
<<< warmup end
--> 9445. avg = 9445.
--> 10411. avg = 9928. --> 9068. avg = 9928.
--> 9068. avg = 9641.
```

If more memory is given, then the time can be reduced even further

```
running Q21 on mysql
>>> warmup begin
--> 6679. avg = 6679.
<<< warmup end
avg = 7262. avg = 7262. --> 7958. avg = 7958. avg = 7262.
--> 7958. avg = 7610. --> 6572. avg = 6572. avg = 7610.
--> 6572. avg = 7264.
```

Here you can compare the effect of turning off the adaptive effect, the time difference is not much.

```
>>> warmup begin
--> 9423. avg = 9423.
<<< warmup end
--> 7516. avg = 7516. avg = 7288. avg = 7288.
--> 7288. avg = 7402.
--> 7293. avg = 7365.
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
