### PR TITLE
[BugFix] fix alloc-dealloc-mismatch in raw container

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -33,7 +33,7 @@ public:
     using Offset = T;
     using Offsets = Buffer<T>;
 
-    using Bytes = starrocks::raw::RawVectorPad16<uint8_t>;
+    using Bytes = starrocks::raw::RawVectorPad16<uint8_t, ColumnAllocator<uint8_t>>;
 
     struct BinaryDataProxyContainer {
         BinaryDataProxyContainer(const BinaryColumnBase& column) : _column(column) {}

--- a/be/src/util/raw_container.h
+++ b/be/src/util/raw_container.h
@@ -150,18 +150,18 @@ using RawStringPad16 = std::string;
 // starrocks::raw::RawVectorPad16<int8_t> a;
 // a.resize(100);
 // std::vector<uint8_t> b = std::move(reinterpret_cast<std::vector<uint8_t>&>(a));
-template <class T>
-using RawVector = std::vector<T, RawAllocator<T, 0>>;
+template <class T, class Alloc = std::allocator<T>>
+using RawVector = std::vector<T, RawAllocator<T, 0, Alloc>>;
 
-template <class T>
-using RawVectorPad16 = std::vector<T, RawAllocator<T, 16>>;
+template <class T, class Alloc = std::allocator<T>>
+using RawVectorPad16 = std::vector<T, RawAllocator<T, 16, Alloc>>;
 
 template <typename Container, typename T = typename Container::value_type>
 inline typename std::enable_if<
         std::is_same<Container, std::vector<typename Container::value_type, typename Container::allocator_type>>::value,
         void>::type
 make_room(Container* v, size_t n) {
-    RawVector<T> rv;
+    RawVector<T, typename Container::allocator_type> rv;
     rv.resize(n);
     v->swap(reinterpret_cast<Container&>(rv));
 }
@@ -177,7 +177,7 @@ inline typename std::enable_if<
         std::is_same<Container, std::vector<typename Container::value_type, typename Container::allocator_type>>::value,
         void>::type
 stl_vector_resize_uninitialized(Container* vec, size_t new_size) {
-    ((RawVector<T>*)vec)->resize(new_size);
+    ((RawVector<T, typename Container::allocator_type>*)vec)->resize(new_size);
 }
 
 inline void stl_string_resize_uninitialized(std::string* str, size_t new_size) {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -436,6 +436,7 @@ set(EXEC_FILES
         ./util/priority_queue_test.cpp
         ./util/rle_encoding_test.cpp
         ./util/runtime_profile_test.cpp
+        ./util/raw_container_test.cpp
         ./util/scoped_cleanup_test.cpp
         ./util/string_parser_test.cpp
         ./util/string_util_test.cpp

--- a/be/test/util/raw_container_test.cpp
+++ b/be/test/util/raw_container_test.cpp
@@ -12,18 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+#include "util/raw_container.h"
 
-#include <cstdint>
-#include <vector>
+#include <gtest/gtest.h>
 
 #include "runtime/memory/column_allocator.h"
-#include "util/raw_container.h"
 
 namespace starrocks {
 
-// Bytes is a special vector<uint8_t> in which the internal memory is always allocated with an additional 16 bytes,
-// to make life easier with 128 bit instructions.
-typedef starrocks::raw::RawVectorPad16<uint8_t, ColumnAllocator<uint8_t>> Bytes;
+TEST(TestRawContainer, testResizeWithStdAllocator) {
+    std::vector<int> v;
+    raw::make_room(&v, 5);
+    ASSERT_EQ(v.size(), 5);
+    raw::stl_vector_resize_uninitialized(&v, 10);
+    ASSERT_EQ(v.size(), 10);
+}
 
+TEST(TestRawContainer, testResizeWithColumnAllocator) {
+    std::vector<int, ColumnAllocator<int>> v;
+    raw::make_room(&v, 5);
+    ASSERT_EQ(v.size(), 5);
+    raw::stl_vector_resize_uninitialized(&v, 10);
+    ASSERT_EQ(v.size(), 10);
+}
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix #50714
introduced by #50408
We need to ensure that the allocator type of RawVector is consistent with the Container



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
