### PR TITLE
[BugFix] Clear probe RF whose probe expr contains dict mapping expr (backport #50690)

### DIFF
--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -18,6 +18,7 @@
 
 #include "column/column.h"
 #include "exec/pipeline/runtime_filter_types.h"
+#include "exprs/dictmapping_expr.h"
 #include "exprs/in_const_predicate.hpp"
 #include "exprs/literal.h"
 #include "exprs/runtime_filter.h"
@@ -630,6 +631,23 @@ void RuntimeFilterProbeCollector::update_selectivity(Chunk* chunk, RuntimeBloomF
     }
 }
 
+static bool contains_dict_mapping_expr(Expr* expr) {
+    if (typeid(*expr) == typeid(DictMappingExpr)) {
+        return true;
+    }
+
+    return std::any_of(expr->children().begin(), expr->children().end(),
+                       [](Expr* child) { return contains_dict_mapping_expr(child); });
+}
+
+static bool contains_dict_mapping_expr(RuntimeFilterProbeDescriptor* probe_desc) {
+    auto* probe_expr_ctx = probe_desc->probe_expr_ctx();
+    if (probe_expr_ctx == nullptr) {
+        return false;
+    }
+    return contains_dict_mapping_expr(probe_expr_ctx->root());
+}
+
 void RuntimeFilterProbeCollector::push_down(const RuntimeState* state, TPlanNodeId target_plan_node_id,
                                             RuntimeFilterProbeCollector* parent, const std::vector<TupleId>& tuple_ids,
                                             std::set<TPlanNodeId>& local_rf_waiting_set) {
@@ -641,8 +659,10 @@ void RuntimeFilterProbeCollector::push_down(const RuntimeState* state, TPlanNode
             ++iter;
             continue;
         }
-        if (desc->is_bound(tuple_ids) && !(state->broadcast_join_right_offsprings().contains(target_plan_node_id) &&
-                                           state->non_broadcast_rf_ids().contains(desc->filter_id()))) {
+        if (desc->is_bound(tuple_ids) &&
+            !(state->broadcast_join_right_offsprings().contains(target_plan_node_id) &&
+              state->non_broadcast_rf_ids().contains(desc->filter_id())) &&
+            !contains_dict_mapping_expr(desc)) {
             add_descriptor(desc);
             if (desc->is_local()) {
                 local_rf_waiting_set.insert(desc->build_plan_node_id());

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -1502,4 +1502,15 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return hints;
     }
 
+    public boolean containsDictMappingExpr() {
+        return containsDictMappingExpr(this);
+    }
+
+    private static boolean containsDictMappingExpr(Expr expr) {
+        if (expr instanceof DictMappingExpr) {
+            return true;
+        }
+        return expr.getChildren().stream().anyMatch(child -> containsDictMappingExpr(child));
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -886,4 +886,22 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
         removeRfOfRightOffspring(getPlanRoot(), localRightOffsprings, filterIds);
     }
+
+    public void removeDictMappingProbeRuntimeFilters() {
+        removeDictMappingProbeRuntimeFilters(getPlanRoot());
+    }
+
+    private void removeDictMappingProbeRuntimeFilters(PlanNode root) {
+        root.getProbeRuntimeFilters().removeIf(filter -> {
+            Expr probExpr = filter.getNodeIdToProbeExpr().get(root.getId().asInt());
+            return probExpr.containsDictMappingExpr();
+        });
+
+        for (PlanNode child : root.getChildren()) {
+            if (child.getFragmentId().equals(root.getFragmentId())) {
+                removeDictMappingProbeRuntimeFilters(child);
+            }
+        }
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -181,7 +181,11 @@ public class ProjectNode extends PlanNode {
             return false;
         }
 
-        return pushdownRuntimeFilterForChildOrAccept(descTbl, description, probeExpr, candidatesOfSlotExpr(probeExpr, couldBound(description, descTbl)),
+        Optional<List<Expr>> optProbeExprCandidates = candidatesOfSlotExpr(probeExpr, couldBound(description, descTbl));
+        optProbeExprCandidates.ifPresent(
+                exprs -> exprs.removeIf(probeExprCandidate -> probeExprCandidate.containsDictMappingExpr()));
+
+        return pushdownRuntimeFilterForChildOrAccept(descTbl, description, probeExpr, optProbeExprCandidates,
                 partitionByExprs, candidatesOfSlotExprs(partitionByExprs, couldBoundForPartitionExpr()), 0, true);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -366,6 +366,8 @@ public class PlanFragmentBuilder {
             fragment.computeLocalRfWaitingSet(fragment.getPlanRoot(), shouldClearRuntimeFilters);
         }
 
+        fragments.forEach(PlanFragment::removeDictMappingProbeRuntimeFilters);
+
         if (useQueryCache(execPlan)) {
             for (PlanFragment fragment : execPlan.getFragments()) {
                 FragmentNormalizer normalizer = new FragmentNormalizer(execPlan, fragment);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1950,7 +1950,8 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  \n" +
                 "  2:Project\n" +
                 "  |  output columns:\n" +
-                "  |  12 <-> CASE WHEN DictExpr(38: P_NAME,[<place-holder> = 'a']) THEN 'a1' WHEN DictExpr(39: P_BRAND,[<place-holder> = 'b']) THEN 'b1' ELSE 'c1' END\n" +
+                "  |  12 <-> CASE WHEN DictExpr(38: P_NAME,[<place-holder> = 'a']) THEN 'a1' WHEN " +
+                "DictExpr(39: P_BRAND,[<place-holder> = 'b']) THEN 'b1' ELSE 'c1' END\n" +
                 "  |  38 <-> [38: P_NAME, INT, false]\n" +
                 "  |  cardinality: 1\n" +
                 "  |  probe runtime filters:\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1921,4 +1921,49 @@ public class LowCardinalityTest extends PlanTestBase {
                 "substr(md5(DictExpr(10: S_ADDRESS,[<place-holder>])), 1, 3))");
     }
 
+    @Test
+    public void testRuntimeFilterOnProjectWithDictExpr() throws Exception {
+        String sql = "WITH \n" +
+                "   w1 AS (\n" +
+                "     SELECT CASE\n" +
+                "         WHEN P_NAME = 'a' THEN 'a1'\n" +
+                "         WHEN P_BRAND = 'b' THEN 'b1'\n" +
+                "         ELSE 'c1'\n" +
+                "      END as P_NAME2, P_NAME from part_v2\n" +
+                "      UNION ALL\n" +
+                "      SELECT P_NAME, P_NAME from part_v2\n" +
+                ")\n" +
+                "SELECT count(1) \n" +
+                "FROM  \n" +
+                "   w1 t1 \n" +
+                "   JOIN [broadcast] part_v2 t2 ON t1.P_NAME2 = t2.P_NAME AND t1.P_NAME = t2.P_NAME;";
+        String plan = getCostExplain(sql);
+        assertContains(plan, "  3:Decode\n" +
+                "  |  <dict id 38> : <string id 2>\n" +
+                "  |  cardinality: 1\n" +
+                "  |  probe runtime filters:\n" +
+                "  |  - filter_id = 1, probe_expr = (2: P_NAME)\n" +
+                "  |  column statistics: \n" +
+                "  |  * P_NAME-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                "  |  * P_BRAND-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                "  |  * cast-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE\n" +
+                "  |  \n" +
+                "  2:Project\n" +
+                "  |  output columns:\n" +
+                "  |  12 <-> CASE WHEN DictDecode(38: P_NAME, [<place-holder> = 'a']) THEN 'a1' " +
+                "WHEN DictDecode(39: P_BRAND, [<place-holder> = 'b']) THEN 'b1' ELSE 'c1' END\n" +
+                "  |  38 <-> [38: P_NAME, INT, false]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  probe runtime filters:\n" +
+                "  |  - filter_id = 0, probe_expr = (<slot 12>)\n" +
+                "  |  column statistics: \n" +
+                "  |  * cast-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE\n" +
+                "  |  \n" +
+                "  1:OlapScanNode\n" +
+                "     table: part_v2, rollup: part_v2\n" +
+                "     preAggregation: on\n" +
+                "     dict_col=P_NAME,P_BRAND");
+        System.out.println(plan);
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1942,7 +1942,7 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  <dict id 38> : <string id 2>\n" +
                 "  |  cardinality: 1\n" +
                 "  |  probe runtime filters:\n" +
-                "  |  - filter_id = 1, probe_expr = (2: P_NAME)\n" +
+                "  |  - filter_id = 1, probe_expr = (2)\n" +
                 "  |  column statistics: \n" +
                 "  |  * P_NAME-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
                 "  |  * P_BRAND-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
@@ -1950,8 +1950,7 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  \n" +
                 "  2:Project\n" +
                 "  |  output columns:\n" +
-                "  |  12 <-> CASE WHEN DictDecode(38: P_NAME, [<place-holder> = 'a']) THEN 'a1' " +
-                "WHEN DictDecode(39: P_BRAND, [<place-holder> = 'b']) THEN 'b1' ELSE 'c1' END\n" +
+                "  |  12 <-> CASE WHEN DictExpr(38: P_NAME,[<place-holder> = 'a']) THEN 'a1' WHEN DictExpr(39: P_BRAND,[<place-holder> = 'b']) THEN 'b1' ELSE 'c1' END\n" +
                 "  |  38 <-> [38: P_NAME, INT, false]\n" +
                 "  |  cardinality: 1\n" +
                 "  |  probe runtime filters:\n" +


### PR DESCRIPTION
CP from #50690.

## Why I'm doing:

If the equi-join predicate is derived from an expression evaluated on a column with low cardinality, a corresponding runtime filter will be generated on the `OlapScanNode.` The probe expression for this filter is a `DictMappingExpr`.

Except for the main branch, this `DictMappingExpr` in the probe expression is not rewritten, leading to a crash when evaluated using a DictID column.

```
*** Aborted at 1725338148 (unix time) try "date -d @1725338148" if you are using GNU date ***
PC: @          0x2dc0ce0 starrocks::memequal()
*** SIGSEGV (@0x7) received by PID 167210 (TID 0x7f57b5d00700) from PID 7; stack trace: ***
    @          0x5c32442 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f58f08c7630 (unknown)
    @          0x2dc0ce0 starrocks::memequal()
    @          0x3a6b20a starrocks::vectorized::UnpackConstColumnBinaryFunction<>::evaluate<>()
    @          0x3a6b61c starrocks::vectorized::VectorizedBinaryPredicate<>::evaluate_checked()
    @          0x4045b19 starrocks::vectorized::DictMappingExpr::evaluate_checked()
    @          0x3b7df24 starrocks::vectorized::VectorizedCaseExpr<>::evaluate_no_case()
    @          0x3b84e0d starrocks::vectorized::VectorizedCaseExpr<>::evaluate_checked()
    @          0x394a3b3 starrocks::ExprContext::evaluate()
    @          0x4133af0 starrocks::vectorized::RuntimeFilterProbeCollector::update_selectivity()
    @          0x4134caf starrocks::vectorized::RuntimeFilterProbeCollector::evaluate()
    @          0x2dd4506 starrocks::pipeline::Operator::eval_runtime_bloom_filters()
    @          0x2ddab55 starrocks::pipeline::ScanOperator::pull_chunk()
    @          0x2db7ed0 starrocks::pipeline::PipelineDriver::process()
    @          0x5207fca starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x4bea3a2 starrocks::ThreadPool::dispatch_thread()
    @          0x4be4e3a starrocks::Thread::supervise_thread()
    @     0x7f58f08bfea5 start_thread
    @     0x7f58efedab0d __clone
    @                0x0 (unknown)
```

Plan:


```
  3:Decode
  |  <dict id 38> : <string id 2>
  |  cardinality: 1
  |  probe runtime filters:
  |  - filter_id = 1, probe_expr = (2: P_NAME)
  |  column statistics: 
  |  * P_NAME-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN
  |  * P_BRAND-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN
  |  * cast-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE
  |  
  2:Project
  |  output columns:
  |  12 <-> CASE WHEN DictDecode(38: P_NAME, [<place-holder> = 'a']) THEN 'a1' WHEN DictDecode(39: P_BRAND, [<place-holder> = 'b']) THEN 'b1' ELSE 'c1' END
  |  38 <-> [38: P_NAME, INT, false]
  |  cardinality: 1
  |  column statistics: 
  |  * cast-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE
  |  
  1:OlapScanNode
     table: part_v2, rollup: part_v2
     preAggregation: on
     dict_col=P_NAME,P_BRAND
     partitionsRatio=1/1, tabletsRatio=10/10
     tabletList=14325,14327,14329,14331,14333,14335,14337,14339,14341,14343
     actualRows=0, avgRowSize=18.0
     cardinality: 1
     probe runtime filters:
     - filter_id = 0, probe_expr = (CASE WHEN DictDecode(38: P_NAME, [<place-holder> = 'a']) THEN 'a1' WHEN DictDecode(39: P_BRAND, [<place-holder> = 'b']) THEN 'b1' ELSE 'c1' END)
```

## What I'm doing:

To address this case, a check is performed in the `ProjectNode`. If an expression contains a `DictMappingExpr`, the RF will be no longer pushed down to its children.

Additionally, both FE and BE have implemented a fallback strategy to remove all probe runtime filters that include a `DictMappingExpr` in the probe expression.

Plan after this PR:

```
  3:Decode
  |  <dict id 38> : <string id 2>
  |  cardinality: 1
  |  probe runtime filters:
  |  - filter_id = 1, probe_expr = (2: P_NAME)
  |  column statistics: 
  |  * P_NAME-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN
  |  * P_BRAND-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN
  |  * cast-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE
  |  
  2:Project
  |  output columns:
  |  12 <-> CASE WHEN DictDecode(38: P_NAME, [<place-holder> = 'a']) THEN 'a1' WHEN DictDecode(39: P_BRAND, [<place-holder> = 'b']) THEN 'b1' ELSE 'c1' END
  |  38 <-> [38: P_NAME, INT, false]
  |  cardinality: 1
  |  probe runtime filters:
  |  - filter_id = 0, probe_expr = (<slot 12>)
  |  column statistics: 
  |  * cast-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE
  |  
  1:OlapScanNode
     table: part_v2, rollup: part_v2
     preAggregation: on
     dict_col=P_NAME,P_BRAND
     partitionsRatio=0/1, tabletsRatio=0/0
     tabletList=
     actualRows=0, avgRowSize=18.0
     cardinality: 1
     column statistics: 
     * P_NAME-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN
     * P_BRAND-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN
     * cast-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE
     * 
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5


