### PR TITLE
[Enhancement] support constant folding in translating scalarOperator phase

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -396,17 +396,14 @@ public class FunctionAnalyzer {
                 throw new SemanticException(
                         "percentile_approx requires the first parameter's type is numeric type");
             }
-            if (!functionCallExpr.getChild(1).getType().isNumericType() ||
-                    !functionCallExpr.getChild(1).isConstant()) {
-                throw new SemanticException(
-                        "percentile_approx requires the second parameter's type is numeric constant type");
+            if (!functionCallExpr.getChild(1).getType().isNumericType()) {
+                throw new SemanticException("percentile_approx requires the second parameter's type is numeric type");
             }
 
             if (functionCallExpr.getChildren().size() == 3) {
-                if (!functionCallExpr.getChild(2).getType().isNumericType() ||
-                        !functionCallExpr.getChild(2).isConstant()) {
+                if (!functionCallExpr.getChild(2).getType().isNumericType()) {
                     throw new SemanticException(
-                            "percentile_approx requires the third parameter's type is numeric constant type");
+                            "percentile_approx requires the third parameter's type is numeric type");
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -298,7 +298,8 @@ public final class SqlToScalarOperatorTranslator {
                     !expr.isConstant()) {
                 ScalarOperator res = Utils.getValueIfExists(expressionMapping.getExpressionToColumns(), expr);
                 if (res != null) {
-                    return res;
+                    ScalarOperator constantOperator = expressionMapping.getColumnRefToConstOperators().get(res);
+                    return constantOperator == null ? res : constantOperator;
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
@@ -40,7 +40,6 @@ import static com.starrocks.catalog.FunctionSet.ANY_VALUE;
 import static com.starrocks.catalog.FunctionSet.APPROX_COUNT_DISTINCT;
 import static com.starrocks.catalog.FunctionSet.AVG;
 import static com.starrocks.catalog.FunctionSet.BITMAP_UNION_INT;
-import static com.starrocks.catalog.FunctionSet.COUNT;
 import static com.starrocks.catalog.FunctionSet.HLL_RAW;
 import static com.starrocks.catalog.FunctionSet.INTERSECT_COUNT;
 import static com.starrocks.catalog.FunctionSet.MAX;
@@ -51,7 +50,6 @@ import static com.starrocks.catalog.FunctionSet.NDV;
 import static com.starrocks.catalog.FunctionSet.PERCENTILE_APPROX;
 import static com.starrocks.catalog.FunctionSet.PERCENTILE_CONT;
 import static com.starrocks.catalog.FunctionSet.PERCENTILE_UNION;
-import static com.starrocks.catalog.FunctionSet.STDDEV;
 import static com.starrocks.catalog.FunctionSet.SUM;
 
 public class TypeChecker implements PlanValidator.Checker {
@@ -204,6 +202,12 @@ public class TypeChecker implements PlanValidator.Checker {
                 throw new IllegalArgumentException("percentile_approx " +
                         "requires the second parameter's type is numeric constant type");
             }
+
+            if (arguments.size() == 3 && !(arguments.get(2) instanceof ConstantOperator)) {
+                throw new IllegalArgumentException("percentile_approx " +
+                        "requires the third parameter's type is numeric constant type");
+            }
+
             ConstantOperator rate = (ConstantOperator) arg1;
             if (rate.getDouble() < 0 || rate.getDouble() > 1) {
                 throw new SemanticException("percentile_approx second parameter'value must be between 0 and 1");
@@ -216,9 +220,6 @@ public class TypeChecker implements PlanValidator.Checker {
             Type[] definedTypes = aggCall.getFunction().getArgs();
             List<Type> argTypes = arguments.stream().map(ScalarOperator::getType).collect(Collectors.toList());
             switch (functionName) {
-                case COUNT:
-                case STDDEV:
-                    break;
                 case MIN:
                 case MAX:
                 case ANY_VALUE:

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -371,40 +371,6 @@ public class SelectStmtTest {
     }
 
     @Test
-    void testGroupByCountDistinctArrayWithSkewHint() throws Exception {
-        FeConstants.runningUnitTest = true;
-        // array is not supported now
-        String sql =
-                "select b1, count(distinct [skew] a1) as cnt from (select split('a,b,c', ',') as a1, 'aaa' as b1) t1 group by b1";
-        String s = starRocksAssert.query(sql).explainQuery();
-        Assert.assertTrue(s, s.contains("OUTPUT EXPRS:4: b1 | 6: count\n" +
-                "  PARTITION: UNPARTITIONED\n" +
-                "\n" +
-                "  RESULT SINK\n" +
-                "\n" +
-                "  4:AGGREGATE (merge finalize)\n" +
-                "  |  output: count(6: count)\n" +
-                "  |  group by: 4: b1\n" +
-                "  |  \n" +
-                "  3:AGGREGATE (update serialize)\n" +
-                "  |  STREAMING\n" +
-                "  |  output: count(5: a1)\n" +
-                "  |  group by: 4: b1\n" +
-                "  |  \n" +
-                "  2:AGGREGATE (update serialize)\n" +
-                "  |  group by: 4: b1, 5: a1\n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 4> : 'aaa'\n" +
-                "  |  <slot 5> : split('a,b,c', ',')\n" +
-                "  |  \n" +
-                "  0:UNION\n" +
-                "     constant exprs: \n" +
-                "         NULL"));
-        FeConstants.runningUnitTest = false;
-    }
-
-    @Test
     void testGroupByMultiColumnCountDistinctWithSkewHint() throws Exception {
         FeConstants.runningUnitTest = true;
         String sql =

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -266,8 +266,8 @@ public class AnalyzeAggregateTest {
         analyzeFail("select percentile_approx('c',0.5) from tall group by tb");
         analyzeFail("select percentile_approx(1,'c') from tall group by tb");
         analyzeFail("select percentile_approx(1,1,'c') from tall group by tb");
-        analyzeFail("select percentile_approx(1,1,tc) from tall group by tb");
         analyzeFail("select percentile_approx(1,1,0.5,tc) from tall group by tb");
+        analyzeSuccess("select percentile_approx(1,1,tc) from tall group by tb");
         analyzeSuccess("select percentile_approx(1,5) from tall group by tb");
         analyzeSuccess("select percentile_approx(1,0.5,1047) from tall group by tb");
         analyzeSuccess("select percentile_disc(tj,0.5) from tall group by tb");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -20,6 +20,7 @@ import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.UtFrameUtils;
@@ -2393,12 +2394,22 @@ public class AggregateTest extends PlanTestBase {
         String plan = getCostExplain(sql);
         assertContains(plan, "percentile_approx[(1.0, 0.4); args: DOUBLE,DOUBLE");
 
+        sql = "with cc as (select 1 as a) select percentile_approx(1, cc.a) from cc;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "2:AGGREGATE (update finalize)\n" +
+                "  |  output: percentile_approx(1.0, 1.0)\n" +
+                "  |  group by: ");
+        Exception exception = Assert.assertThrows(StarRocksPlannerException.class, () -> {
+            String testSql = "with cc as (select 1 as a, v1 from t0) select percentile_approx(1, cc.a, cc.v1) from cc;";
+            getFragmentPlan(testSql);
+        });
+        Assert.assertTrue(exception.getMessage().contains("the third parameter's type is numeric constant type"));
+
         sql = "select percentile_approx(1, cast(1.3 as DOUBLE));";
         expectedException.expect(SemanticException.class);
         expectedException.expectMessage("Getting analyzing error. " +
                 "Detail message: percentile_approx second parameter'value must be between 0 and 1.");
         getCostExplain(sql);
-        plan = getCostExplain(sql);
 
         sql = "select percentile_cont(1, cast(0.4 as DOUBLE));";
         expectedException.expect(SemanticException.class);
@@ -2891,14 +2902,5 @@ public class AggregateTest extends PlanTestBase {
                 "  |  output: sum(1: v1)\n" +
                 "  |  group by: 2: v2, 3: v3\n" +
                 "  |  having: 2: v2 + 2 + 5: sum > 0");
-    }
-
-    @Test
-    public void testPercentileFunction() throws Exception {
-        String sql = "with cc as (select 1 as a) select percentile_approx(1, cc.a) from cc;";
-        String plan = getFragmentPlan(sql);
-        assertContains(plan, "2:AGGREGATE (update finalize)\n" +
-                "  |  output: percentile_approx(1.0, 1.0)\n" +
-                "  |  group by: ");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2892,4 +2892,13 @@ public class AggregateTest extends PlanTestBase {
                 "  |  group by: 2: v2, 3: v3\n" +
                 "  |  having: 2: v2 + 2 + 5: sum > 0");
     }
+
+    @Test
+    public void testPercentileFunction() throws Exception {
+        String sql = "with cc as (select 1 as a) select percentile_approx(1, cc.a) from cc;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "2:AGGREGATE (update finalize)\n" +
+                "  |  output: percentile_approx(1.0, 1.0)\n" +
+                "  |  group by: ");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -3283,10 +3283,10 @@ public class JoinTest extends PlanTestBase {
                 "    );";
         String plan = getFragmentPlan(query);
         //outer join can not use const expr replacement optimization because it may generate null values
-        assertContains(plan, "10:Project\n" +
+        assertContains(plan, "12:Project\n" +
                 "  |  <slot 29> : 29: expr\n" +
                 "  |  \n" +
-                "  9:NESTLOOP JOIN\n" +
+                "  11:NESTLOOP JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN\n" +
                 "  |  colocate: false, reason:");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -29,13 +29,16 @@ public class SetTest extends PlanTestBase {
     public void testValuesNodePredicate() throws Exception {
         String queryStr = "SELECT 1 AS z, MIN(a.x) FROM (select 1 as x) a WHERE abs(1) = 2";
         String explainString = getFragmentPlan(queryStr);
-        Assert.assertTrue(explainString.contains("3:Project\n" +
+        Assert.assertTrue(explainString.contains("4:Project\n" +
                 "  |  <slot 4> : 4: min\n" +
                 "  |  <slot 5> : 1\n" +
                 "  |  \n" +
-                "  2:AGGREGATE (update finalize)\n" +
+                "  3:AGGREGATE (update finalize)\n" +
                 "  |  output: min(1)\n" +
                 "  |  group by: \n" +
+                "  |  \n" +
+                "  2:Project\n" +
+                "  |  <slot 7> : 1\n" +
                 "  |  \n" +
                 "  1:SELECT\n" +
                 "  |  predicates: abs(1) = 2\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -1382,4 +1382,14 @@ public class WindowTest extends PlanTestBase {
                 "  |  <slot 2> : 2: v2\n" +
                 "  |  <slot 6> : array_length(3: v3)");
     }
+
+    @Test
+    public void testOrderByConstant() throws Exception {
+        String sql = "with cc as (select *, 1 as a from t0) select v1, row_number() over (order by a) from cc";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "4:ANALYTIC\n" +
+                "  |  functions: [, row_number(), ]\n" +
+                "  |  order by: 9: a ASC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+    }
 }

--- a/test/sql/test_agg_function/R/test_percentile_approx
+++ b/test/sql/test_agg_function/R/test_percentile_approx
@@ -19,3 +19,11 @@ select percentile_approx(c2, 0.5) from t1;
 -- result:
 500.5
 -- !result
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx(c2, v1) from tt;
+-- result:
+500.5
+-- !result
+with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx(c2, v1, v2 + 1) from tt;
+-- result:
+500.5
+-- !result

--- a/test/sql/test_agg_function/T/test_percentile_approx
+++ b/test/sql/test_agg_function/T/test_percentile_approx
@@ -11,3 +11,5 @@ insert into t1 select generate_series, generate_series from table(generate_serie
 set pipeline_dop=1;
 
 select percentile_approx(c2, 0.5) from t1;
+with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ percentile_approx(c2, v1) from tt;
+with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ percentile_approx(c2, v1, v2 + 1) from tt;


### PR DESCRIPTION
## Why I'm doing:
Failed to execute query like
```
with cc as (select 1 as a) select percentile_approx(1, cc.a) from cc;
```
Because of 
```
if (!functionCallExpr.getChild(1).getType().isNumericType() ||
                    !functionCallExpr.getChild(1).isConstant()) {
                throw new SemanticException(
                        "percentile_approx requires the second parameter's type is numeric constant type");
            }
```

## What I'm doing:
After https://github.com/StarRocks/starrocks/pull/49724, we will replace columnRef to constant if it's possible, but sometimes the translator may directly invoke visit() method instead of visitSlot() method.
So return constant if it's possible in visit() method.

Actually, this pr still can't resolve the constant folding totally.  The below method can still return a columnRef even when it can be replaced by a constant. 
```
public static ScalarOperator translate(Expr expression, ExpressionMapping expressionMapping,
                                           List<ColumnRefOperator> correlation, ColumnRefFactory columnRefFactory,
                                           ConnectContext session, CTETransformerContext cteContext,
                                           OptExprBuilder builder,
                                           Map<ScalarOperator, SubqueryOperator> subqueryPlaceholders,
                                           boolean useSemiAnti) {
        ColumnRefOperator columnRefOperator = expressionMapping.get(expression);
        if (columnRefOperator != null) {
            return columnRefOperator;
        }
}
```
SQL like 
```
with cc as (select *, 1 as a from t0) select v1, row_number() over (order by a) from cc
```
didn't replace the `a` to 1.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
