### PR TITLE
[Enhancement] Delete the calculation memory size of Iceberg Table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -438,12 +438,6 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                 .collect(Collectors.toList()),
                 databases.size());
 
-        Pair<List<Object>, Long> tableSamples = Pair.create(tables.asMap().values()
-                .stream()
-                .limit(MEMORY_META_SAMPLES)
-                .collect(Collectors.toList()),
-                tables.size());
-
         List<Object> partitions = partitionNames.asMap().values()
                 .stream()
                 .flatMap(List::stream)
@@ -475,7 +469,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                 .sum();
         Pair<List<Object>, Long> deleteFileSamples = Pair.create(deleteFiles, deleteFilesTotal);
 
-        return Lists.newArrayList(dbSamples, tableSamples, partitionSamples, dataFileSamples, deleteFileSamples);
+        return Lists.newArrayList(dbSamples, partitionSamples, dataFileSamples, deleteFileSamples);
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:
The memory of dataFile will be counted twice because dataFile is also referenced by Iceberg Table.

## What I'm doing:
Delete the calculation memory size of Iceberg Table.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
