### PR TITLE
[Feature] Support trigger analyze when query connector table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2091,6 +2091,24 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long histogram_max_sample_row_count = 10000000;
 
+    @ConfField(mutable = true)
+    public static long connector_table_query_trigger_analyze_small_table_rows = 10000000; // 10M
+
+    @ConfField(mutable = true)
+    public static long connector_table_query_trigger_analyze_small_table_interval = 6 * 60 * 60; // unit: second, default 6h
+
+    @ConfField(mutable = true)
+    public static long connector_table_query_trigger_analyze_large_table_interval = 24 * 60 * 60; // unit: second, default 24h
+
+    @ConfField(mutable = true)
+    public static int connector_table_query_trigger_analyze_max_running_task_num = 2;
+
+    @ConfField(mutable = true)
+    public static long connector_table_query_trigger_analyze_max_pending_task_num = 100;
+
+    @ConfField(mutable = true)
+    public static long connector_table_query_trigger_analyze_schedule_interval = 30; // unit: second, default 30s
+
     /**
      * If set to true, Planner will try to select replica of tablet on same host as this Frontend.
      * This may reduce network transmission in following case:

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTask.java
@@ -140,7 +140,7 @@ public class ConnectorAnalyzeTask {
         }
     }
 
-    private AnalyzeStatus executeAnalyze(ConnectContext statsConnectCtx, AnalyzeStatus analyzeStatus) {
+    public AnalyzeStatus executeAnalyze(ConnectContext statsConnectCtx, AnalyzeStatus analyzeStatus) {
         List<String> columnNames = Lists.newArrayList(columns);
         List<Type> columnTypes = columnNames.stream().map(col -> {
             Column column = table.getColumn(col);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTask.java
@@ -1,0 +1,160 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.statistics;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.Config;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.statistic.AnalyzeStatus;
+import com.starrocks.statistic.ExternalAnalyzeStatus;
+import com.starrocks.statistic.StatisticExecutor;
+import com.starrocks.statistic.StatisticUtils;
+import com.starrocks.statistic.StatisticsCollectJobFactory;
+import com.starrocks.statistic.StatsConstants;
+import io.trino.hive.$internal.org.apache.commons.lang3.tuple.Triple;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ConnectorAnalyzeTask {
+    private static final Logger LOG = LogManager.getLogger(ConnectorAnalyzeTask.class);
+
+    private final String catalogName;
+    private final Database db;
+    private final Table table;
+    private final Set<String> columns;
+
+    public ConnectorAnalyzeTask(Triple<String, Database, Table> tableTriple, Set<String> columns) {
+        this.catalogName = Preconditions.checkNotNull(tableTriple.getLeft());
+        this.db = Preconditions.checkNotNull(tableTriple.getMiddle());
+        this.table = Preconditions.checkNotNull(tableTriple.getRight());
+        this.columns = columns;
+    }
+
+    public Set<String> getColumns() {
+        return columns;
+    }
+
+    public void mergeTask(ConnectorAnalyzeTask other) {
+        this.columns.addAll(other.columns);
+    }
+
+    public void removeColumns(Set<String> columns) {
+        this.columns.removeAll(columns);
+    }
+
+    private boolean skipAnalyzeUseLastUpdateTime(LocalDateTime lastUpdateTime) {
+        // do not know the table row count, use small table analyze interval
+        if (lastUpdateTime.plusSeconds(Config.connector_table_query_trigger_analyze_small_table_interval).
+                isAfter(LocalDateTime.now())) {
+            LOG.info("Table {}.{}.{} is already analyzed at {}, skip it", catalogName, db.getFullName(),
+                    table.getName(), lastUpdateTime);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public Optional<AnalyzeStatus> run() {
+        // check analyze status first, if the table is analyzing, skip it
+        Optional<ExternalAnalyzeStatus> lastAnalyzedStatus = GlobalStateMgr.getCurrentState().getAnalyzeMgr()
+                .getAnalyzeStatusMap().values().stream()
+                .filter(status -> status instanceof ExternalAnalyzeStatus)
+                .map(status -> (ExternalAnalyzeStatus) status)
+                .filter(status -> status.getTableUUID().equals(table.getUUID()))
+                .filter(status -> !status.getStatus().equals(StatsConstants.ScheduleStatus.FAILED))
+                .max(Comparator.comparing(ExternalAnalyzeStatus::getStartTime));
+        if (lastAnalyzedStatus.isPresent()) {
+            StatsConstants.ScheduleStatus lastScheduleStatus = lastAnalyzedStatus.get().getStatus();
+            if (lastScheduleStatus == StatsConstants.ScheduleStatus.PENDING ||
+                    lastScheduleStatus == StatsConstants.ScheduleStatus.RUNNING) {
+                LOG.info("Table {}.{}.{} analyze status is {}, skip it", catalogName, db.getFullName(),
+                        table.getName(), lastScheduleStatus);
+                return Optional.empty();
+            } else {
+                // analyze status is Finished
+                // check the analyzed columns
+                List<String> analyzedColumns = lastAnalyzedStatus.get().getColumns();
+                if (analyzedColumns == null || analyzedColumns.isEmpty()) {
+                    // analyzed all columns in last analyzed time, check the update time
+                    if (skipAnalyzeUseLastUpdateTime(lastAnalyzedStatus.get().getStartTime())) {
+                        return Optional.empty();
+                    }
+                } else {
+                    Set<String> lastAnalyzedColumnsSet = new HashSet<>(analyzedColumns);
+                    if (lastAnalyzedColumnsSet.containsAll(columns)) {
+                        if (skipAnalyzeUseLastUpdateTime(lastAnalyzedStatus.get().getStartTime())) {
+                            return Optional.empty();
+                        }
+                    } else {
+                        if (skipAnalyzeUseLastUpdateTime(lastAnalyzedStatus.get().getStartTime())) {
+                            columns.removeAll(lastAnalyzedColumnsSet);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Init new analyze status
+        AnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
+                catalogName, db.getOriginName(), table.getName(),
+                table.getUUID(),
+                Lists.newArrayList(columns), StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.ONCE,
+                Maps.newHashMap(), LocalDateTime.now());
+
+        analyzeStatus.setStatus(StatsConstants.ScheduleStatus.PENDING);
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
+
+        ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+        statsConnectCtx.setThreadLocalInfo();
+        try {
+            return Optional.of(executeAnalyze(statsConnectCtx, analyzeStatus));
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    private AnalyzeStatus executeAnalyze(ConnectContext statsConnectCtx, AnalyzeStatus analyzeStatus) {
+        List<String> columnNames = Lists.newArrayList(columns);
+        List<Type> columnTypes = columnNames.stream().map(col -> {
+            Column column = table.getColumn(col);
+            Preconditions.checkNotNull(column, "Column " + col + " does not exist in table " + table.getName());
+            return column.getType();
+        }).collect(Collectors.toList());
+        StatisticExecutor statisticExecutor = new StatisticExecutor();
+        return statisticExecutor.collectStatistics(statsConnectCtx,
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob(
+                        catalogName, db, table, null,
+                        columnNames, columnTypes,
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE, Maps.newHashMap()),
+                analyzeStatus,
+                false);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueue.java
@@ -1,0 +1,124 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.statistics;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.common.Config;
+import com.starrocks.common.ThreadPoolManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class ConnectorAnalyzeTaskQueue {
+    private static final Logger LOG = LogManager.getLogger(ConnectorAnalyzeTaskQueue.class);
+    // rwLock is used to protect pendingTasks
+    private final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock.WriteLock wLock = rwLock.writeLock();
+    private final ReentrantReadWriteLock.ReadLock rLock = rwLock.readLock();
+
+    // use LinkedHashMap to keep the order of pending tasks
+    private final Map<String, ConnectorAnalyzeTask> pendingTasks = Maps.newLinkedHashMap();
+    private final Map<String, ConnectorAnalyzeTask> runningTasks = Maps.newConcurrentMap();
+
+    private final ExecutorService taskRunPool = ThreadPoolManager.newDaemonFixedThreadPool(
+            Config.connector_table_query_trigger_analyze_max_running_task_num,
+            Config.connector_table_query_trigger_analyze_max_running_task_num,
+            "connector-trigger-analyze-pool", true);
+
+    public boolean addPendingTask(String tableUUID, ConnectorAnalyzeTask task) {
+        if (task == null) {
+            return false;
+        }
+
+        wLock.lock();
+        try {
+            if (pendingTasks.size() >= Config.connector_table_query_trigger_analyze_max_pending_task_num) {
+                LOG.warn("Connector Analyze TaskQueue pending task num reach limit: {}, current: {}",
+                        Config.connector_table_query_trigger_analyze_max_pending_task_num, pendingTasks.size());
+                return false;
+            }
+
+            ConnectorAnalyzeTask runningTask = runningTasks.get(tableUUID);
+            if (runningTask != null) {
+                // there is a running task for this table, remove columns which are already in running task
+                task.removeColumns(runningTask.getColumns());
+            }
+
+            if (!pendingTasks.containsKey(tableUUID)) {
+                pendingTasks.put(tableUUID, task);
+            } else {
+                pendingTasks.get(tableUUID).mergeTask(task);
+            }
+        } finally {
+            wLock.unlock();
+        }
+
+        return true;
+    }
+
+    public int getPendingTaskSize() {
+        rLock.lock();
+        try {
+            return pendingTasks.size();
+        } finally {
+            rLock.unlock();
+        }
+    }
+
+    public boolean isMaxRunningConcurrencyReached() {
+        return runningTasks.size() >= Config.connector_table_query_trigger_analyze_max_running_task_num;
+    }
+
+    public void scheduledPendingTask() {
+        // do not dispatch task if max running concurrency reached or no pending task
+        if (isMaxRunningConcurrencyReached()) {
+            LOG.info("Connector Analyze TaskQueue running task num reach limit: {}, current: {}",
+                    Config.connector_table_query_trigger_analyze_max_running_task_num, runningTasks.size());
+            return;
+        }
+
+        wLock.lock();
+        try {
+            if (pendingTasks.isEmpty()) {
+                return;
+            }
+            List<String> removePendingTasks = Lists.newArrayList();
+            for (Map.Entry<String, ConnectorAnalyzeTask> entry : pendingTasks.entrySet()) {
+                ConnectorAnalyzeTask task = entry.getValue();
+                removePendingTasks.add(entry.getKey());
+                runningTasks.put(entry.getKey(), task);
+                CompletableFuture.supplyAsync(task::run, taskRunPool).whenComplete((result, e) -> {
+                    if (e != null) {
+                        LOG.warn("Table {} analyze task failed", entry.getKey(), e);
+                    }
+                    runningTasks.remove(entry.getKey());
+                });
+                if (isMaxRunningConcurrencyReached()) {
+                    break;
+                }
+            }
+            removePendingTasks.forEach(pendingTasks::remove);
+        } finally {
+            wLock.unlock();
+        }
+
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueue.java
@@ -60,6 +60,10 @@ public class ConnectorAnalyzeTaskQueue {
             if (runningTask != null) {
                 // there is a running task for this table, remove columns which are already in running task
                 task.removeColumns(runningTask.getColumns());
+                if (task.getColumns().isEmpty()) {
+                    LOG.info("Table {} has a running task, skip this task", tableUUID);
+                    return true;
+                }
             }
 
             if (!pendingTasks.containsKey(tableUUID)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorTableTriggerAnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorTableTriggerAnalyzeMgr.java
@@ -1,0 +1,105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.statistics;
+
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.DateUtils;
+import io.trino.hive.$internal.org.apache.commons.lang3.tuple.Triple;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ConnectorTableTriggerAnalyzeMgr {
+    private static final Logger LOG = LogManager.getLogger(ConnectorTableTriggerAnalyzeMgr.class);
+
+    private final ConnectorAnalyzeTaskQueue connectorAnalyzeTaskQueue = new ConnectorAnalyzeTaskQueue();
+    private final ScheduledExecutorService dispatchScheduler = Executors.newScheduledThreadPool(1);
+    private final AtomicBoolean isStart = new AtomicBoolean(false);
+
+    public void start() {
+        if (isStart.compareAndSet(false, true)) {
+            dispatchScheduler.scheduleAtFixedRate(connectorAnalyzeTaskQueue::scheduledPendingTask, 0,
+                    Config.connector_table_query_trigger_analyze_schedule_interval, TimeUnit.SECONDS);
+        }
+    }
+
+    public void checkAndUpdateTableStats(Map<ConnectorTableColumnKey, Optional<ConnectorTableColumnStats>> columnStats) {
+        if (columnStats == null || columnStats.isEmpty()) {
+            return;
+        }
+
+        Set<String> analyzeColumns = Sets.newHashSet();
+        Triple<String, Database, Table> tableTriple = null;
+        boolean tableExist = false;
+        String tableUUID = null;
+        for (Map.Entry<ConnectorTableColumnKey, Optional<ConnectorTableColumnStats>> entry : columnStats.entrySet()) {
+            ConnectorTableColumnKey columnKey = entry.getKey();
+            // first check table exist
+            if (!tableExist) {
+                try {
+                    tableTriple = StatisticsUtils.getTableTripleByUUID(columnKey.tableUUID);
+                    // check table could run analyze
+                    if (!tableTriple.getRight().isAnalyzableExternalTable()) {
+                        return;
+                    }
+                    tableExist = true;
+                    tableUUID = columnKey.tableUUID;
+                } catch (Exception e) {
+                    LOG.warn("Table {} is not existed", columnKey.tableUUID);
+                    return;
+                }
+            }
+
+            // check column stats exist
+            Optional<ConnectorTableColumnStats> columnStatsOptional = entry.getValue();
+            if (columnStatsOptional.isEmpty()) {
+                analyzeColumns.add(columnKey.column);
+            } else {
+                // check column stats last update time
+                ConnectorTableColumnStats columnStatsValue = columnStatsOptional.get();
+                if (columnStatsValue.getUpdateTime() == null) {
+                    analyzeColumns.add(columnKey.column);
+                }
+                LocalDateTime lastUpdateTime = DateUtils.parseStrictDateTime(columnStatsValue.getUpdateTime());
+                long rowCount = columnStatsValue.getRowCount();
+                long timeInterval = rowCount < Config.connector_table_query_trigger_analyze_small_table_rows ?
+                        Config.connector_table_query_trigger_analyze_small_table_interval :
+                        Config.connector_table_query_trigger_analyze_large_table_interval;
+                if (!lastUpdateTime.plusSeconds(timeInterval).isAfter(LocalDateTime.now())) {
+                    analyzeColumns.add(columnKey.column);
+                }
+            }
+        }
+
+        if (!analyzeColumns.isEmpty()) {
+            // need to execute analyze
+            if (!this.connectorAnalyzeTaskQueue.
+                    addPendingTask(tableUUID, new ConnectorAnalyzeTask(tableTriple, analyzeColumns))) {
+                LOG.warn("Add analyze pending task {} failed.", tableUUID);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -418,6 +418,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_ICEBERG_COLUMN_STATISTICS = "enable_iceberg_column_statistics";
     public static final String ENABLE_DELTA_LAKE_COLUMN_STATISTICS = "enable_delta_lake_column_statistics";
+    public static final String ENABLE_QUERY_TRIGGER_ANALYZE = "enable_query_trigger_analyze";
+
     public static final String PLAN_MODE = "plan_mode";
 
     public static final String ENABLE_HIVE_COLUMN_STATS = "enable_hive_column_stats";
@@ -2089,6 +2091,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_DELTA_LAKE_COLUMN_STATISTICS)
     private boolean enableDeltaLakeColumnStatistics = false;
 
+    @VarAttr(name = ENABLE_QUERY_TRIGGER_ANALYZE)
+    private boolean enableQueryTriggerAnalyze = true;
+
     @VarAttr(name = PLAN_MODE)
     private String planMode = PlanMode.AUTO.modeName();
 
@@ -2201,6 +2206,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableIcebergColumnStatistics(boolean enableIcebergColumnStatistics) {
         this.enableIcebergColumnStatistics = enableIcebergColumnStatistics;
+    }
+
+    public boolean isEnableQueryTriggerAnalyze() {
+        return enableQueryTriggerAnalyze;
     }
 
     public String getPlanMode() {
@@ -2415,6 +2424,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableCacheSelect(boolean enableCacheSelect) {
         this.enableCacheSelect = enableCacheSelect;
+    }
+
+    public void setConnectorIoTasksPerScanOperator(int connectorIoTasksPerScanOperator) {
+        this.connectorIoTasksPerScanOperator = connectorIoTasksPerScanOperator;
     }
 
     public boolean isCboUseDBLock() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -108,6 +108,7 @@ import com.starrocks.connector.elasticsearch.EsRepository;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.ConnectorTableMetadataProcessor;
 import com.starrocks.connector.hive.events.MetastoreEventsProcessor;
+import com.starrocks.connector.statistics.ConnectorTableTriggerAnalyzeMgr;
 import com.starrocks.consistency.ConsistencyChecker;
 import com.starrocks.consistency.LockChecker;
 import com.starrocks.consistency.MetaRecoveryDaemon;
@@ -432,6 +433,7 @@ public class GlobalStateMgr {
     private final CatalogMgr catalogMgr;
     private final ConnectorMgr connectorMgr;
     private final ConnectorTblMetaInfoMgr connectorTblMetaInfoMgr;
+    private ConnectorTableTriggerAnalyzeMgr connectorTableTriggerAnalyzeMgr;
 
     private final TaskManager taskManager;
     private final InsertOverwriteJobMgr insertOverwriteJobMgr;
@@ -709,6 +711,7 @@ public class GlobalStateMgr {
         this.connectorTblMetaInfoMgr = new ConnectorTblMetaInfoMgr();
         this.metadataMgr = new MetadataMgr(localMetastore, temporaryTableMgr, connectorMgr, connectorTblMetaInfoMgr);
         this.catalogMgr = new CatalogMgr(connectorMgr);
+        this.connectorTableTriggerAnalyzeMgr = new ConnectorTableTriggerAnalyzeMgr();
 
         this.taskManager = new TaskManager();
         this.insertOverwriteJobMgr = new InsertOverwriteJobMgr();
@@ -919,6 +922,10 @@ public class GlobalStateMgr {
 
     public MetadataMgr getMetadataMgr() {
         return metadataMgr;
+    }
+
+    public ConnectorTableTriggerAnalyzeMgr getConnectorTableTriggerAnalyzeMgr() {
+        return connectorTableTriggerAnalyzeMgr;
     }
 
     @VisibleForTesting
@@ -1427,6 +1434,8 @@ public class GlobalStateMgr {
 
         // The memory tracker should be placed at the end
         memoryUsageTracker.start();
+
+        connectorTableTriggerAnalyzeMgr.start();
     }
 
     private void transferToNonLeader(FrontendNodeType newType) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1400,6 +1400,7 @@ public class GlobalStateMgr {
         }
         temporaryTableCleaner.start();
 
+        connectorTableTriggerAnalyzeMgr.start();
     }
 
     // start threads that should run on all FE
@@ -1434,8 +1435,6 @@ public class GlobalStateMgr {
 
         // The memory tracker should be placed at the end
         memoryUsageTracker.start();
-
-        connectorTableTriggerAnalyzeMgr.start();
     }
 
     private void transferToNonLeader(FrontendNodeType newType) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -176,7 +176,7 @@ public class CachedStatisticStorage implements StatisticStorage {
                     LOG.warn("Get connector table column statistics filed, exception: ", e);
                     return;
                 }
-                if (sessionVariable.isEnableQueryTriggerAnalyze()) {
+                if (sessionVariable.isEnableQueryTriggerAnalyze() && GlobalStateMgr.getCurrentState().isLeader()) {
                     GlobalStateMgr.getCurrentState().getConnectorTableTriggerAnalyzeMgr().checkAndUpdateTableStats(res);
                 }
             }, statsCacheRefresherExecutor);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -29,6 +29,9 @@ import com.starrocks.connector.statistics.ConnectorColumnStatsCacheLoader;
 import com.starrocks.connector.statistics.ConnectorHistogramColumnStatsCacheLoader;
 import com.starrocks.connector.statistics.ConnectorTableColumnKey;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatisticUtils;
 import org.apache.logging.log4j.LogManager;
@@ -165,6 +168,18 @@ public class CachedStatisticStorage implements StatisticStorage {
         try {
             CompletableFuture<Map<ConnectorTableColumnKey, Optional<ConnectorTableColumnStats>>> result =
                     connectorTableCachedStatistics.getAll(cacheKeys);
+
+            SessionVariable sessionVariable = ConnectContext.get() == null ? VariableMgr.newSessionVariable() :
+                    ConnectContext.get().getSessionVariable();
+            result.whenCompleteAsync((res, e) -> {
+                if (e != null) {
+                    LOG.warn("Get connector table column statistics filed, exception: ", e);
+                    return;
+                }
+                if (sessionVariable.isEnableQueryTriggerAnalyze()) {
+                    GlobalStateMgr.getCurrentState().getConnectorTableTriggerAnalyzeMgr().checkAndUpdateTableStats(res);
+                }
+            }, statsCacheRefresherExecutor);
             if (result.isDone()) {
                 List<ConnectorTableColumnStats> columnStatistics = new ArrayList<>();
                 Map<ConnectorTableColumnKey, Optional<ConnectorTableColumnStats>> realResult;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -132,6 +132,9 @@ public abstract class StatisticsCollectJob {
         // acceleration, then page cache is better filled with the user's data.
         sessionVariable.setUsePageCache(false);
         sessionVariable.setEnableMaterializedViewRewrite(false);
+        // set the max task num of connector io tasks per scan operator to 4, default is 16,
+        // to avoid generate too many chunk source for collect stats in BE
+        sessionVariable.setConnectorIoTasksPerScanOperator(4);
     }
 
     protected void collectStatisticSync(String sql, ConnectContext context) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueueTest.java
@@ -1,0 +1,101 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.statistics;
+
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import io.trino.hive.$internal.org.apache.commons.lang3.tuple.Triple;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ConnectorAnalyzeTaskQueueTest {
+    private static ConnectContext ctx;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        ConnectorPlanTestBase.mockHiveCatalog(ctx);
+    }
+
+    @Test
+    public void testAddPendingTaskWithMerge() {
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+                "partitioned_db", "orders");
+        String tableUUID = table.getUUID();
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
+
+        ConnectorAnalyzeTaskQueue queue = new ConnectorAnalyzeTaskQueue();
+        queue.addPendingTask(tableUUID, task1);
+        Assert.assertEquals(1, queue.getPendingTaskSize());
+        // merge task
+        ConnectorAnalyzeTask task2 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderstatus"));
+        queue.addPendingTask(tableUUID, task2);
+        Assert.assertEquals(1, queue.getPendingTaskSize());
+    }
+
+
+    @Test
+    public void testAddPendingTaskExceedLimit() {
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+                "partitioned_db", "orders");
+        String tableUUID = table.getUUID();
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
+
+        Config.connector_table_query_trigger_analyze_max_pending_task_num = 1;
+        ConnectorAnalyzeTaskQueue queue = new ConnectorAnalyzeTaskQueue();
+        queue.addPendingTask(tableUUID, task1);
+        Assert.assertEquals(1, queue.getPendingTaskSize());
+        // add task exceed limit
+        ConnectorAnalyzeTask task2 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderstatus"));
+        Assert.assertFalse(queue.addPendingTask(tableUUID, task2));
+        Config.connector_table_query_trigger_analyze_max_pending_task_num = 100;
+    }
+
+    @Test
+    public void testScheduledPendingTask() {
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+                "partitioned_db", "orders");
+        String tableUUID = table.getUUID();
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
+
+        ConnectorAnalyzeTaskQueue queue = new ConnectorAnalyzeTaskQueue();
+        queue.addPendingTask(tableUUID, task1);
+        Assert.assertEquals(1, queue.getPendingTaskSize());
+
+        queue.scheduledPendingTask();
+        Assert.assertEquals(0, queue.getPendingTaskSize());
+
+        ConnectorAnalyzeTask task2 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_custkey", "o_orderstatus"));
+        queue.addPendingTask(tableUUID, task2);
+
+        Config.connector_table_query_trigger_analyze_max_running_task_num = 0;
+        queue.scheduledPendingTask();
+        Assert.assertEquals(1, queue.getPendingTaskSize());
+        Config.connector_table_query_trigger_analyze_max_running_task_num = 2;
+        queue.scheduledPendingTask();
+        Assert.assertEquals(0, queue.getPendingTaskSize());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskTest.java
@@ -1,0 +1,92 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.statistics;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.statistic.AnalyzeStatus;
+import com.starrocks.statistic.ExternalAnalyzeStatus;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.utframe.UtFrameUtils;
+import io.trino.hive.$internal.org.apache.commons.lang3.tuple.Triple;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public class ConnectorAnalyzeTaskTest {
+    private static ConnectContext ctx;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        ConnectorPlanTestBase.mockHiveCatalog(ctx);
+    }
+
+    @Test
+    public void testMergeTask() {
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+                "partitioned_db", "orders");
+        String tableUUID = table.getUUID();
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
+
+        ConnectorAnalyzeTask task2 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_custkey", "o_orderstatus"));
+        task1.mergeTask(task2);
+        Assert.assertEquals(3, task1.getColumns().size());
+    }
+
+    @Test
+    public void testTaskRun() {
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+                "partitioned_db", "orders");
+        String tableUUID = table.getUUID();
+        ExternalAnalyzeStatus externalAnalyzeStatus = new ExternalAnalyzeStatus(1, "hive0", "partitioned_db", "orders",
+                tableUUID, List.of("o_custkey", "o_orderstatus"), StatsConstants.AnalyzeType.FULL,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now());
+        externalAnalyzeStatus.setStatus(StatsConstants.ScheduleStatus.RUNNING);
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeStatus(externalAnalyzeStatus);
+
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
+        Optional<AnalyzeStatus> result = task1.run();
+        Assert.assertTrue(result.isEmpty());
+
+        new MockUp<ConnectorAnalyzeTask>() {
+            @Mock
+            private AnalyzeStatus executeAnalyze(ConnectContext statsConnectCtx, AnalyzeStatus analyzeStatus) {
+                return analyzeStatus;
+            }
+        };
+        // execute analyze when last analyze status is finish
+        externalAnalyzeStatus.setStatus(StatsConstants.ScheduleStatus.FINISH);
+        result = task1.run();
+        Assert.assertTrue(result.isPresent());
+        Assert.assertTrue(result.get() instanceof ExternalAnalyzeStatus);
+        ExternalAnalyzeStatus externalAnalyzeStatusResult = (ExternalAnalyzeStatus) result.get();
+        Assert.assertEquals(List.of("o_orderkey"), externalAnalyzeStatusResult.getColumns());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Support trigger analyze when query connector table

![image](https://github.com/user-attachments/assets/8b6ca5c6-d4e0-4dc3-a862-70270126b1bd)
Collecting statistical information can help the optimizer choose a better plan and improve performance. By only collecting statistics for queried tables, we can avoid collecting useless statistical information.

Fixes #50870
## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
