### PR TITLE
[Enhancement] allow to run user defined analyze job simultaneously

### DIFF
--- a/docs/en/sql-reference/sql-statements/cbo_stats/CREATE_ANALYZE.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/CREATE_ANALYZE.md
@@ -10,7 +10,9 @@ Customizes an automatic collection task for collecting CBO statistics.
 
 By default, StarRocks automatically collects full statistics of a table. It checks for any data updates every 5 minutes. If data change is detected, data collection will be automatically triggered. If you do not want to use automatic full collection, you can set the FE configuration item `enable_collect_full_statistic` to `false` and customize a collection task.
 
-Before creating a custom automatic collection task, you must disable automatic full collection (`enable_collect_full_statistic = false`). Otherwise, custom tasks cannot take effect.
+Behaviour difference:
+- Before 3.2.12 and 3.3.4, to create a custom automatic collection task, you must disable automatic full collection (`enable_collect_full_statistic = false`). Otherwise, custom tasks cannot take effect.
+- Since these version, you can create analyze job and keep system tasks. The user-created tasks would overwrite the system tasks if they have conflicts.
 
 This statement is supported from v2.4.
 

--- a/docs/en/using_starrocks/Cost_based_optimizer.md
+++ b/docs/en/using_starrocks/Cost_based_optimizer.md
@@ -81,7 +81,7 @@ update_time: 2023-12-01 15:17:10.274000
 
 Data size and data distribution constantly change in a table. Statistics must be updated regularly to represent that data change. Before creating a statistics collection task, you must choose a collection type and method that best suit your business requirements.
 
-StarRocks supports full and sampled collection, both can be performed automatically and manually. By default, StarRocks automatically collects full statistics of a table. It checks for any data updates every 5 minutes. If data change is detected, data collection will be automatically triggered. If you do not want to use automatic full collection, you can set the FE configuration item `enable_collect_full_statistic` to `false` and customize a collection task.
+StarRocks supports full and sampled collection, both can be performed automatically and manually. By default, StarRocks automatically collects full statistics of a table. It checks for any data updates every 5 minutes. If data change is detected, data collection will be automatically triggered. If you do not want to use automatic full collection, you can customize a collection task.
 
 | **Collection type** | **Collection method** | **Description**                                              | **Advantage and disadvantage**                               |
 | ------------------- | --------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
@@ -264,7 +264,6 @@ PROPERTIES(
 
 You can use the CREATE ANALYZE statement to customize an automatic collection task. You must have the INSERT and SELECT privileges on the coreesponding table to perform the ANALYZE TABLE operation.
 
-Before creating a custom automatic collection task, you must disable automatic full collection (`enable_collect_full_statistic = false`). Otherwise, custom tasks cannot take effect.
 
 ```SQL
 -- Automatically collect stats of all databases.

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeJob.java
@@ -61,5 +61,13 @@ public interface AnalyzeJob {
 
     boolean isAnalyzeAllTable();
 
-    void run(ConnectContext statsConnectContext, StatisticExecutor statisticExecutor);
+    List<StatisticsCollectJob> instantiateJobs();
+
+    default void run(ConnectContext statsConnectContext, StatisticExecutor statisticExecutor) {
+        run(statsConnectContext, statisticExecutor, instantiateJobs());
+    }
+
+    void run(ConnectContext statsConnectContext,
+             StatisticExecutor statisticExecutor,
+             List<StatisticsCollectJob> jobs);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeJob.java
@@ -184,14 +184,18 @@ public class ExternalAnalyzeJob implements AnalyzeJob, Writable {
     }
 
     @Override
-    public void run(ConnectContext statsConnectContext, StatisticExecutor statisticExecutor) {
+    public List<StatisticsCollectJob> instantiateJobs() {
+        return StatisticsCollectJobFactory.buildExternalStatisticsCollectJob(this);
+    }
+
+    @Override
+    public void run(ConnectContext statsConnectContext, StatisticExecutor statisticExecutor,
+                    List<StatisticsCollectJob> jobs) {
         setStatus(StatsConstants.ScheduleStatus.RUNNING);
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().updateAnalyzeJobWithoutLog(this);
-        List<StatisticsCollectJob> statisticsCollectJobList =
-                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob(this);
 
         boolean hasFailedCollectJob = false;
-        for (StatisticsCollectJob statsJob : statisticsCollectJobList) {
+        for (StatisticsCollectJob statsJob : jobs) {
             AnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
                     statsJob.getCatalogName(), statsJob.getDb().getFullName(), statsJob.getTable().getName(),
                     statsJob.getTable().getUUID(), statsJob.getColumnNames(), statsJob.getType(), statsJob.getScheduleType(),

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -35,6 +35,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -123,6 +124,10 @@ public abstract class StatisticsCollectJob {
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public boolean isAnalyzeTable() {
+        return CollectionUtils.isEmpty(columnNames);
     }
 
     protected void setDefaultSessionVariable(ConnectContext context) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -59,6 +59,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
@@ -512,6 +513,53 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         nativeAnalyzeJob.run(statsConnectCtx, statisticExecutor);
         Assert.assertEquals(StatsConstants.ScheduleStatus.FAILED, nativeAnalyzeJob.getStatus());
         Assert.assertEquals("mock exception", nativeAnalyzeJob.getReason());
+    }
+
+    @Test
+    public void createAnalyzeJobSimultaneously() throws Exception {
+        new MockUp<StatisticsCollectJob>() {
+            @Mock
+            public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
+            }
+        };
+
+        // case: sample table
+        {
+            starRocksAssert.ddl("create analyze sample table test.t0_stats");
+            StatisticAutoCollector collector = new StatisticAutoCollector();
+            List<StatisticsCollectJob> jobs = collector.runJobs();
+            Optional<StatisticsCollectJob> tableJob = jobs.stream()
+                    .filter(x -> x.getTable().getName().equalsIgnoreCase("t0_stats")).findFirst();
+            Assert.assertTrue(tableJob.isPresent());
+            Assert.assertEquals(StatsConstants.AnalyzeType.SAMPLE, tableJob.get().getType());
+            starRocksAssert.dropAnalyzeForTable("t0_stats");
+        }
+
+        // case: column
+        {
+            starRocksAssert.ddl("create analyze full table test.t0_stats(v2)");
+            StatisticAutoCollector collector = new StatisticAutoCollector();
+            List<StatisticsCollectJob> jobs = collector.runJobs();
+            long count = jobs.stream()
+                    .filter(x -> x.getTable().getName().equalsIgnoreCase("t0_stats"))
+                    .count();
+            Assert.assertEquals(2, count);
+            starRocksAssert.dropAnalyzeForTable("t0_stats");
+        }
+
+        // case: overlapped columns
+        {
+            starRocksAssert.ddl("create analyze full table test.t0_stats(v2)");
+            starRocksAssert.ddl("create analyze full table test.t0_stats(v3)");
+            starRocksAssert.ddl("create analyze full table test.t0_stats(v2, v3)");
+            StatisticAutoCollector collector = new StatisticAutoCollector();
+            List<StatisticsCollectJob> jobs = collector.runJobs();
+            long count = jobs.stream()
+                    .filter(x -> x.getTable().getName().equalsIgnoreCase("t0_stats"))
+                    .count();
+            Assert.assertEquals(4, count);
+            starRocksAssert.dropAnalyzeForTable("t0_stats");
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -1078,6 +1078,15 @@ public class StarRocksAssert {
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, ctx), ctx);
     }
 
+    public void dropAnalyzeForTable(String tableName) throws Exception {
+        List<String> showJob = show(String.format("show analyze job where `table` = '%s' ", tableName)).get(0);
+        if (showJob.isEmpty()) {
+            return;
+        }
+        long jobId = Long.parseLong(showJob.get(0));
+        ddl("drop analyze " + jobId);
+    }
+
     private void checkAlterJob() throws InterruptedException {
         // check alter job
         Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();


### PR DESCRIPTION
## Why I'm doing:

Previously we don't allow for running system analyze jobs and user-created jobs simultaneously, it doesn't make sense at all.


## What I'm doing:

- Allow for running for these two kinds of jobs simultaneously 
- User-created jobs has high-priority, it would overwrite the system jobs
- Analyze table conflicts another analyze table, but analyze table doesn't conflict with analyze column


Depends on https://github.com/StarRocks/starrocks/pull/50683
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
