### PR TITLE
[BugFix] MV rewrite may generate wrong plans if query only contains constant call operators

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
@@ -161,7 +161,14 @@ public class EquationRewriter {
                     return rewritten;
                 }
             }
-
+            // If count(1)/sum(1) cannot be rewritten by mv's defined equivalents, return null directly,
+            // otherwise it may cause a wrong plan.
+            // mv       : SELECT 1, count(distinct k1) from tbl1;
+            // query    : SELECT count(1) from tbl1;
+            // MV should not rewrite the query.
+            if (call.isAggregate() && call.isConstant()) {
+                return null;
+            }
             return super.visitCall(call, context);
         }
 


### PR DESCRIPTION
## Why I'm doing:
```
CREATE MATERIALIZED VIEW `test_mv1` (`1`, `count(DISTINCT k2)`)
DISTRIBUTED BY RANDOM
REFRESH MANUAL
PROPERTIES (
"replicated_storage" = "true",
"replication_num" = "1",
"storage_medium" = "HDD"
)
AS SELECT 1 AS `1`, count(DISTINCT `s1`.`k2`) AS `count(DISTINCT k2)`
FROM `test`.`s1`;

mysql> explain select count(1) from s1;
+-----------------------------+
| Explain String              |
+-----------------------------+
| PLAN FRAGMENT 0             |
|  OUTPUT EXPRS:4: count      |
|   PARTITION: UNPARTITIONED  |
|                             |
|   RESULT SINK               |
|                             |
|   2:EXCHANGE                |
|                             |
| PLAN FRAGMENT 1             |
|  OUTPUT EXPRS:              |
|   PARTITION: RANDOM         |
|                             |
|   STREAM DATA SINK          |
|     EXCHANGE ID: 02         |
|     UNPARTITIONED           |
|                             |
|   1:Project                 |
|   |  <slot 4> : count(5: 1) |
|   |                         |
|   0:OlapScanNode            |
|      TABLE: test_mv1        |
|      PREAGGREGATION: ON     |
|      partitions=1/1         |
|      rollup: test_mv1       |
|      tabletRatio=2/2        |
|      tabletList=30937,30939 |
|      cardinality=1          |
|      avgRowSize=8.0         |
|      MaterializedView: true |
+-----------------------------+
29 rows in set (0.00 sec)
```

Query will face this error:
```
mysql> select count(1) from s1; 

ERROR 1064 (HY000): Vectorized engine does not support the operator, node_type: 0 backend [id=10001] [host=172.26.92.227]
```

## What I'm doing:
- Fix mv rewrite wrong plans if query only contains constant call operators 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
