### PR TITLE
[BugFix]kept_in_memory is false (backport #50530)

### DIFF
--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -51,7 +51,7 @@ Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
 
     IndexReadOptions index_opts;
     index_opts.use_page_cache = !opts.temporary_data && !config::disable_storage_page_cache;
-    index_opts.kept_in_memory = !opts.temporary_data;
+    index_opts.kept_in_memory = false;
     index_opts.skip_fill_data_cache = _skip_fill_data_cache();
     index_opts.read_file = _opts.read_file;
     index_opts.stats = _opts.stats;
@@ -310,7 +310,7 @@ Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const 
     if (_reader->has_zone_map()) {
         IndexReadOptions opts;
         opts.use_page_cache = !_opts.temporary_data && !config::disable_storage_page_cache;
-        opts.kept_in_memory = !_opts.temporary_data;
+        opts.kept_in_memory = false;
         opts.skip_fill_data_cache = _skip_fill_data_cache();
         opts.read_file = _opts.read_file;
         opts.stats = _opts.stats;


### PR DESCRIPTION
scalar_column_iterator.cpp: kept_in_memory is false

## Why I'm doing:
#50530 kept_in_memory is false
## What I'm doing:
fix: kept_in_memory -> false
Fixes #50530 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

