### PR TITLE
[BugFix] fix npe of remove partition predicte

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1689,9 +1689,9 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     // avoid use partition cols filter rows twice
     @VisibleForTesting
     public ScalarOperator removePartitionPredicate(ScalarOperator predicate, Operator operator,
-                                                    OptimizerContext optimizerContext) {
+                                                   OptimizerContext optimizerContext) {
         boolean isTableTypeSupported = operator instanceof LogicalIcebergScanOperator ||
-                        isOlapScanListPartitionTable(operator);
+                isOlapScanListPartitionTable(operator);
         if (isTableTypeSupported && !optimizerContext.isObtainedFromInternalStatistics()) {
             LogicalScanOperator scanOperator = operator.cast();
             List<String> partitionColNames = scanOperator.getTable().getPartitionColumnNames();
@@ -1700,8 +1700,8 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
             List<ScalarOperator> newPredicates = Lists.newArrayList();
             for (ScalarOperator scalarOperator : conjuncts) {
-                boolean isPartitionCol = isPartitionCol(scalarOperator.getChild(0), partitionColNames);
-                if (isPartitionCol && ListPartitionPruner.canPruneWithConjunct(scalarOperator)) {
+                if (ListPartitionPruner.canPruneWithConjunct(scalarOperator) &&
+                        isPartitionCol(scalarOperator.getChild(0), partitionColNames)) {
                     // drop this predicate
                 } else {
                     newPredicates.add(scalarOperator);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -71,6 +71,13 @@ public class PartitionPruneTest extends PlanTestBase {
         starRocksAssert.ddl("ALTER TABLE t_gen_col ADD PARTITION p2_202402 VALUES IN (('2', '2024-02-01'))");
         starRocksAssert.ddl("ALTER TABLE t_gen_col ADD PARTITION p2_202403 VALUES IN (('2', '2024-03-01'))");
 
+        starRocksAssert.withTable("CREATE TABLE t_bool_partition (" +
+                " c1 datetime NOT NULL, " +
+                " c2 boolean" +
+                " ) " +
+                " PARTITION BY (c1, c2) " +
+                " PROPERTIES('replication_num'='1')");
+
         // year(c1)
         starRocksAssert.withTable("CREATE TABLE t_gen_col_1 (" +
                 " c1 datetime NOT NULL," +
@@ -235,6 +242,10 @@ public class PartitionPruneTest extends PlanTestBase {
                 "and c2 > 100", "true");
         testRemovePredicate("select * from t_gen_col where c2 in (1, 2,3)", "true");
         testRemovePredicate("select * from t_gen_col where c2 = cast('123' as int)", "true");
+
+        // bool partition column
+        testRemovePredicate("select * from t_bool_partition where c2=true", "2: c2");
+        testRemovePredicate("select * from t_bool_partition where c2=false", "true");
 
         // can not be removed
         testRemovePredicate("select * from t_gen_col where c1 = random() and c2 > 100",


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`where c_bool=true` => `ColumnRef(c_bool)`, which has no children
so we should check operator type before call `getChild`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
