### PR TITLE
[Enhancement] Show resource group in global and local current_queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -359,10 +359,10 @@ public class ResourceGroupMgr implements Writable {
 
                 if (exclusiveCpuCores != null && exclusiveCpuCores > 0) {
                     if (sumExclusiveCpuCores + exclusiveCpuCores - wg.getNormalizedExclusiveCpuCores() >=
-                            BackendResourceStat.getInstance().getAvgNumHardwareCoresOfBe()) {
+                            BackendResourceStat.getInstance().getMinNumHardwareCoresOfBe()) {
                         throw new DdlException(String.format(EXCEED_TOTAL_EXCLUSIVE_CPU_CORES_ERR_MSG,
                                 ResourceGroup.EXCLUSIVE_CPU_CORES,
-                                BackendResourceStat.getInstance().getAvgNumHardwareCoresOfBe() - 1));
+                                BackendResourceStat.getInstance().getMinNumHardwareCoresOfBe() - 1));
                     }
                     if (wg.getResourceGroupType() == TWorkGroupType.WG_SHORT_QUERY) {
                         throw new SemanticException(SHORT_QUERY_SET_EXCLUSIVE_CPU_CORES_ERR_MSG);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -148,6 +148,10 @@ public class ResourceGroupMgr implements Writable {
                 dropResourceGroupUnlocked(wg.getName());
             }
 
+            if (wg.getCpuWeight() == null) {
+                wg.setCpuWeight(0);
+            }
+
             if (ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME.equals(wg.getName())) {
                 wg.setId(ResourceGroup.DEFAULT_WG_ID);
             } else if (ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME.equals(wg.getName())) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
@@ -67,6 +67,7 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
             .add("ExecTime")
             .add("Warehouse")
             .add("CustomQueryId")
+            .add("ResourceGroup")
             .build();
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Sets;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.catalog.FsBroker;
+import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -1285,6 +1286,12 @@ public class DefaultCoordinator extends Coordinator {
             return "";
         }
         return connectContext.getSessionVariable().getWarehouseName();
+    }
+
+    @Override
+    public String getResourceGroupName() {
+        return jobSpec.getResourceGroup() == null ? ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME :
+                jobSpec.getResourceGroup().getName();
     }
 
     private void execShortCircuit() throws Exception {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -176,7 +176,9 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
                     .db(context.getDatabase())
                     .fragmentInstanceInfos(info.getCoord().getFragmentInstanceInfos())
                     .profile(info.getCoord().getQueryProfile())
-                    .warehouseName(info.coord.getWarehouseName()).build();
+                    .warehouseName(info.coord.getWarehouseName())
+                    .resourceGroupName(info.coord.getResourceGroupName())
+                    .build();
 
             querySet.put(queryIdStr, item);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -63,13 +63,14 @@ public class QueryStatisticsInfo {
     private long execTime;
     private String wareHouseName;
     private String customQueryId;
+    private String resourceGroupName;
 
     public QueryStatisticsInfo() {
     }
 
     public QueryStatisticsInfo(long queryStartTime, String feIp, String queryId, String connId, String db, String user,
                                long cpuCostNs, long scanBytes, long scanRows, long memUsageBytes, long spillBytes,
-                               long execTime, String wareHouseName, String customQueryId) {
+                               long execTime, String wareHouseName, String customQueryId, String resourceGroupName) {
         this.queryStartTime = queryStartTime;
         this.feIp = feIp;
         this.queryId = queryId;
@@ -84,6 +85,7 @@ public class QueryStatisticsInfo {
         this.execTime = execTime;
         this.wareHouseName = wareHouseName;
         this.customQueryId = customQueryId;
+        this.resourceGroupName = resourceGroupName;
     }
 
     public long getQueryStartTime() {
@@ -136,6 +138,10 @@ public class QueryStatisticsInfo {
 
     public String getWareHouseName() {
         return wareHouseName;
+    }
+
+    public String getResourceGroupName() {
+        return resourceGroupName;
     }
 
     public String getCustomQueryId() {
@@ -207,6 +213,11 @@ public class QueryStatisticsInfo {
         return this;
     }
 
+    public QueryStatisticsInfo withResourceGroupName(String resourceGroupName) {
+        this.resourceGroupName = resourceGroupName;
+        return this;
+    }
+
     public QueryStatisticsInfo withCustomQueryId(String customQueryId) {
         this.customQueryId = customQueryId;
         return this;
@@ -227,7 +238,8 @@ public class QueryStatisticsInfo {
                 .setSpillBytes(spillBytes)
                 .setExecTime(execTime)
                 .setWareHouseName(wareHouseName)
-                .setCustomQueryId(customQueryId);
+                .setCustomQueryId(customQueryId)
+                .setResourceGroupName(resourceGroupName);
     }
 
     public static QueryStatisticsInfo fromThrift(TQueryStatisticsInfo tinfo) {
@@ -245,7 +257,8 @@ public class QueryStatisticsInfo {
                 .withCpuCostNs(tinfo.getCpuCostNs())
                 .withExecTime(tinfo.getExecTime())
                 .withWareHouseName(tinfo.getWareHouseName())
-                .withCustomQueryId(tinfo.getCustomQueryId());
+                .withCustomQueryId(tinfo.getCustomQueryId())
+                .withResourceGroupName(tinfo.getResourceGroupName());
     }
 
     public List<String> formatToList() {
@@ -264,6 +277,7 @@ public class QueryStatisticsInfo {
         values.add(QueryStatisticsFormatter.getSecondsFromMilli(this.getExecTime()));
         values.add(this.getWareHouseName());
         values.add(this.getCustomQueryId());
+        values.add(this.getResourceGroupName());
         return values;
     }
 
@@ -281,13 +295,14 @@ public class QueryStatisticsInfo {
                 Objects.equals(db, that.db) && Objects.equals(user, that.user) && cpuCostNs == that.cpuCostNs &&
                 scanBytes == that.scanBytes && scanRows == that.scanRows && memUsageBytes == that.memUsageBytes &&
                 spillBytes == that.spillBytes && execTime == that.execTime &&
-                Objects.equals(wareHouseName, that.wareHouseName) && Objects.equals(customQueryId, that.customQueryId);
+                Objects.equals(wareHouseName, that.wareHouseName) && Objects.equals(customQueryId, that.customQueryId) &&
+                Objects.equals(resourceGroupName, that.resourceGroupName);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(queryStartTime, feIp, queryId, connId, db, user, cpuCostNs, scanBytes, scanRows, memUsageBytes,
-                spillBytes, execTime, wareHouseName, customQueryId);
+                spillBytes, execTime, wareHouseName, customQueryId, resourceGroupName);
     }
 
     @Override
@@ -306,6 +321,7 @@ public class QueryStatisticsInfo {
                 ", execTime=" + execTime +
                 ", wareHouseName=" + wareHouseName +
                 ", customQueryId=" + customQueryId +
+                ", resourceGroupName=" + resourceGroupName +
                 '}';
     }
 
@@ -341,7 +357,8 @@ public class QueryStatisticsInfo {
                     .withCpuCostNs(statistics.getCpuCostNs())
                     .withExecTime(item.getQueryExecTime())
                     .withWareHouseName(item.getWarehouseName())
-                    .withCustomQueryId(item.getCustomQueryId());
+                    .withCustomQueryId(item.getCustomQueryId())
+                    .withResourceGroupName(item.getResourceGroupName());
             sortedRowData.add(info);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
@@ -38,6 +38,7 @@ public final class QueryStatisticsItem {
     private final RuntimeProfile queryProfile;
     private final TUniqueId executionId;
     private final String warehouseName;
+    private final String resourceGroupName;
 
     private QueryStatisticsItem(Builder builder) {
         this.customQueryId = builder.customQueryId;
@@ -51,6 +52,7 @@ public final class QueryStatisticsItem {
         this.queryProfile = builder.queryProfile;
         this.executionId = builder.executionId;
         this.warehouseName = builder.warehouseName;
+        this.resourceGroupName = builder.resourceGroupName;
     }
 
     public String getDb() {
@@ -102,6 +104,10 @@ public final class QueryStatisticsItem {
         return warehouseName;
     }
 
+    public String getResourceGroupName() {
+        return resourceGroupName;
+    }
+
     public static final class Builder {
         private String customQueryId;
         private String queryId;
@@ -114,6 +120,7 @@ public final class QueryStatisticsItem {
         private RuntimeProfile queryProfile;
         private TUniqueId executionId;
         private String warehouseName;
+        private String resourceGroupName;
 
         public Builder() {
             fragmentInstanceInfos = Lists.newArrayList();
@@ -171,6 +178,11 @@ public final class QueryStatisticsItem {
 
         public Builder warehouseName(String warehouseName) {
             this.warehouseName = warehouseName;
+            return this;
+        }
+
+        public Builder resourceGroupName(String resourceGroupName) {
+            this.resourceGroupName = resourceGroupName;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -243,5 +243,7 @@ public abstract class Coordinator {
 
     public abstract String getWarehouseName();
 
+    public abstract String getResourceGroupName();
+
     public abstract boolean isShortCircuit();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
@@ -303,6 +303,11 @@ public class FeExecuteCoordinator extends Coordinator {
         return connectContext.getSessionVariable().getWarehouseName();
     }
 
+    @Override
+    public String getResourceGroupName() {
+        return "";
+    }
+
     public boolean isShortCircuit() {
         return false;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -1436,7 +1436,7 @@ public class ResourceGroupStmtTest {
         assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
                 "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
                 "rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
-                "rg2|null|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)\n" +
+                "rg2|0|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)\n" +
                 "rt_rg1|15|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rt_rg1_user)");
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
@@ -1554,7 +1554,7 @@ public class ResourceGroupStmtTest {
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
             assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
                     "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|null|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+                    "rg1|0|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
     }
@@ -1720,8 +1720,8 @@ public class ResourceGroupStmtTest {
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
             assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
                     "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|null|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
-                    "rg2|null|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
+                    "rg1|0|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
+                    "rg2|0|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
         }
 
         {
@@ -1745,8 +1745,8 @@ public class ResourceGroupStmtTest {
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
             assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
                     "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|null|14|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
-                    "rg2|null|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
+                    "rg1|0|14|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
+                    "rg2|0|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
         }
 
         {

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDirTest.java
@@ -48,7 +48,8 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withCpuCostNs(97323000)
             .withExecTime(3533000)
             .withWareHouseName("default_warehouse")
-            .withCustomQueryId("");
+            .withCustomQueryId("")
+            .withResourceGroupName("wg1");
 
 
     public static final QueryStatisticsInfo QUERY_TWO_LOCAL = new QueryStatisticsInfo()
@@ -65,7 +66,8 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withCpuCostNs(96576000)
             .withExecTime(2086000)
             .withWareHouseName("default_warehouse")
-            .withCustomQueryId("");
+            .withCustomQueryId("")
+            .withResourceGroupName("wg2");
 
     public static final QueryStatisticsInfo QUERY_ONE_REMOTE = new QueryStatisticsInfo()
             .withQueryStartTime(1721866428)
@@ -81,7 +83,8 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withCpuCostNs(97456000)
             .withExecTime(3687000)
             .withWareHouseName("default_warehouse")
-            .withCustomQueryId("");
+            .withCustomQueryId("")
+            .withResourceGroupName("wg3");
 
 
     public static final QueryStatisticsInfo QUERY_TWO_REMOTE = new QueryStatisticsInfo()
@@ -98,7 +101,8 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withCpuCostNs(96686000)
             .withExecTime(2196000)
             .withWareHouseName("default_warehouse")
-            .withCustomQueryId("");
+            .withCustomQueryId("")
+            .withResourceGroupName("wg");
 
     public static List<QueryStatisticsInfo> LOCAL_TEST_QUERIES =
             new ArrayList<>(List.of(QUERY_ONE_LOCAL, QUERY_TWO_LOCAL));

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDirTest.java
@@ -45,6 +45,7 @@ public class CurrentQueryStatisticsProcDirTest {
                 .customQueryId("abc1")
                 .queryId("queryId1")
                 .warehouseName("wh1")
+                .resourceGroupName("wg1")
                 .build()
         );
         statistic.put("queryId2", new QueryStatisticsItem.Builder()
@@ -52,6 +53,7 @@ public class CurrentQueryStatisticsProcDirTest {
                 .customQueryId("abc2")
                 .queryId("queryId2")
                 .warehouseName("wh1")
+                .resourceGroupName("wg2")
                 .build()
         );
         new MockUp<QeProcessorImpl>() {
@@ -80,6 +82,8 @@ public class CurrentQueryStatisticsProcDirTest {
         Assert.assertEquals("wh1", list1.get(12));
         // CustomQueryId
         Assert.assertEquals("abc1", list1.get(13));
+        // ResourceGroupName
+        Assert.assertEquals("wg1", list1.get(14));
 
         List<String> list2 = rows.get(1);
         Assert.assertEquals(list2.size(), CurrentQueryStatisticsProcDir.TITLE_NAMES.size());
@@ -89,6 +93,8 @@ public class CurrentQueryStatisticsProcDirTest {
         Assert.assertEquals("wh1", list2.get(12));
         // CustomQueryId
         Assert.assertEquals("abc2", list2.get(13));
+        // ResourceGroupName
+        Assert.assertEquals("wg2", list2.get(14));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
@@ -39,7 +39,8 @@ public class QueryStatisticsInfoTest {
                 firstQuery.getSpillBytes(),
                 firstQuery.getExecTime(),
                 firstQuery.getWareHouseName(),
-                firstQuery.getCustomQueryId()
+                firstQuery.getCustomQueryId(),
+                firstQuery.getResourceGroupName()
         );
         Assert.assertEquals(firstQuery, otherQuery);
         Assert.assertEquals(firstQuery.hashCode(), otherQuery.hashCode());

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1584,6 +1584,7 @@ struct TQueryStatisticsInfo {
     12: optional i64 execTime
     13: optional string wareHouseName
     14: optional string customQueryId
+    15: optional string resourceGroupName
 }
 
 struct TGetQueryStatisticsResponse {


### PR DESCRIPTION
## Why I'm doing:
Show `ResourceGroupName` in `show proc "/current_queries"` and `show proc "/global_current_queries"`.

```
show proc "/global_current_queries" \G
***************************[ 1. row ]***************************
StartTime     | 2024-09-05 19:34:16
feIp          | 127.0.0.1
QueryId       | c8942a3e-6b7a-11ef-b949-00163e02ada5
ConnectionId  | 0
Database      | d1
User          | root
ScanBytes     | 0.000 B
ScanRows      | 0 rows
MemoryUsage   | 184.188 KB
DiskSpillSize | 0.000 B
CPUTime       | 0.000 s
ExecTime      | 200.540 s
Warehouse     | default_warehouse
CustomQueryId |
ResourceGroup | default_wg
```

`show proc "/global_current_queries"` has some problems, when  the query is forwarded to leader:
1. `feIP` displays leader FE IP.
2. `ConnectionID` is always 0.

TODO
- We need fix these issues 
- and add a `information_schema.current_queries`.


## What I'm doing:


Relates to #49965.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
