### PR TITLE
[BugFix] Fix link error on libsframe after static linking bfd

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -969,7 +969,7 @@ if (NOT ("${MAKE_TEST}" STREQUAL "ON" AND "${BUILD_FOR_SANITIZE}" STREQUAL "ON")
 endif()
 
 set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS}
-    ${WL_LINK_STATIC} -lbfd
+    ${WL_LINK_STATIC} -lbfd -lsframe
     ${WL_LINK_DYNAMIC} -lresolv -liberty -lc -lm -ldl -rdynamic -pthread -Wl,-wrap=__cxa_throw
 )
 


### PR DESCRIPTION
## Why I'm doing:

After static linking libbfd(https://github.com/StarRocks/starrocks/pull/50515), my ubuntu22 build throw link error like this, looks like need to explictly link sframe lib (as libbfd's dependence) too.
```
[100%] Linking CXX executable /home/decster/projects/starrocks/be/output/lib/starrocks_be
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libbfd.a(elfxx-x86.o): in function `_bfd_x86_elf_write_sframe_plt':
./builddir-single/bfd/../../bfd/elfxx-x86.c:1991:(.text+0xae9): undefined reference to `sframe_encoder_write'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1997:(.text+0xb1e): undefined reference to `sframe_encoder_free'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libbfd.a(elfxx-x86.o): in function `_bfd_x86_elf_create_sframe_plt':
./builddir-single/bfd/../../bfd/elfxx-x86.c:1886:(.text+0xc26): undefined reference to `sframe_encode'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1894:(.text+0xc36): undefined reference to `sframe_calc_fre_type'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1895:(.text+0xc41): undefined reference to `sframe_fde_create_func_info'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1903:(.text+0xc5b): undefined reference to `sframe_encoder_add_funcdesc_v2'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1914:(.text+0xca8): undefined reference to `sframe_encoder_add_fre'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1886:(.text+0xd0e): undefined reference to `sframe_encode'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1894:(.text+0xd1e): undefined reference to `sframe_calc_fre_type'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1895:(.text+0xd29): undefined reference to `sframe_fde_create_func_info'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1886:(.text+0xd97): undefined reference to `sframe_encode'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1894:(.text+0xda7): undefined reference to `sframe_calc_fre_type'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1895:(.text+0xdb2): undefined reference to `sframe_fde_create_func_info'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1926:(.text+0xdd0): undefined reference to `sframe_fde_create_func_info'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1932:(.text+0xdef): undefined reference to `sframe_encoder_add_funcdesc_v2'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1945:(.text+0xe36): undefined reference to `sframe_encoder_add_fre'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elfxx-x86.c:1886:(.text+0xe8e): undefined reference to `sframe_encode'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libbfd.a(elf-sframe.o): in function `_bfd_elf_parse_sframe':
./builddir-single/bfd/../../bfd/elf-sframe.c:220:(.text+0x105): undefined reference to `sframe_decode'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libbfd.a(elf-sframe.o): in function `sframe_decoder_init_func_bfdinfo':
./builddir-single/bfd/../../bfd/elf-sframe.c:107:(.text+0x11e): undefined reference to `sframe_decoder_get_num_fidx'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libbfd.a(elf-sframe.o): in function `_bfd_elf_parse_sframe':
./builddir-single/bfd/../../bfd/elf-sframe.c:229:(.text+0x20e): undefined reference to `sframe_decoder_free'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libbfd.a(elf-sframe.o): in function `_bfd_elf_discard_section_sframe':
./builddir-single/bfd/../../bfd/elf-sframe.c:278:(.text+0x2ec): undefined reference to `sframe_decoder_get_num_fidx'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libbfd.a(elf-sframe.o): in function `_bfd_elf_merge_section_sframe':
./builddir-single/bfd/../../bfd/elf-sframe.c:396:(.text+0x524): undefined reference to `sframe_decoder_get_abi_arch'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:397:(.text+0x52e): undefined reference to `sframe_encoder_get_abi_arch'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:406:(.text+0x54f): undefined reference to `sframe_decoder_get_version'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:407:(.text+0x559): undefined reference to `sframe_encoder_get_version'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:422:(.text+0x57b): undefined reference to `sframe_decoder_get_num_fidx'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:423:(.text+0x589): undefined reference to `sframe_encoder_get_num_fidx'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:437:(.text+0x644): undefined reference to `sframe_decoder_get_funcdesc_v2'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:468:(.text+0x68e): undefined reference to `sframe_decoder_get_hdr_size'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:494:(.text+0x718): undefined reference to `sframe_encoder_add_funcdesc_v2'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:504:(.text+0x754): undefined reference to `sframe_decoder_get_fre'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:506:(.text+0x76d): undefined reference to `sframe_encoder_add_fre'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:514:(.text+0x7b4): undefined reference to `sframe_decoder_free'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:358:(.text+0x985): undefined reference to `sframe_decoder_get_abi_arch'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:359:(.text+0x995): undefined reference to `sframe_decoder_get_fixed_fp_offset'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:360:(.text+0x9a4): undefined reference to `sframe_decoder_get_fixed_ra_offset'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:366:(.text+0x9c9): undefined reference to `sframe_encode'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/libbfd.a(elf-sframe.o): in function `_bfd_elf_write_section_sframe':
./builddir-single/bfd/../../bfd/elf-sframe.c:544:(.text+0xa98): undefined reference to `sframe_encoder_write'
/usr/bin/ld: ./builddir-single/bfd/../../bfd/elf-sframe.c:559:(.text+0xac4): undefined reference to `sframe_encoder_free'
collect2: error: ld returned 1 exit status
make[3]: *** [src/service/CMakeFiles/starrocks_be.dir/build.make:341: /home/decster/projects/starrocks/be/output/lib/starrocks_be] Error 1
make[2]: *** [CMakeFiles/Makefile2:1164: src/service/CMakeFiles/starrocks_be.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:1171: src/service/CMakeFiles/starrocks_be.dir/rule] Error 2
make: *** [Makefile:449: starrocks_be] Error 2

```
## What I'm doing:

Add libsframe in static link

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
