### PR TITLE
[BugFix] fix storage volume validation rule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/SharedDataStorageVolumeMgr.java
@@ -359,8 +359,12 @@ public class SharedDataStorageVolumeMgr extends StorageVolumeMgr {
             if (!uri.isAbsolute()) {
                 uri = new URI(defaultScheme + "://" + uriStr);
             }
-            if (Strings.isNullOrEmpty(uri.getAuthority()) || uri.getPort() != -1) {
-                // no bucket or bucket name contains ':'
+            if (Strings.isNullOrEmpty(uri.getAuthority())) {
+                throw new InvalidConfException("");
+            }
+            if (uri.getPort() != -1 && "s3".equals(defaultScheme)) {
+                // s3 uri, not allow `:` in authority, e.g. the following url is invalid
+                // - s3://{bucket}:3020/b/c
                 throw new InvalidConfException("");
             }
             if (matchScheme && !uri.getScheme().equals(defaultScheme)) {

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -387,6 +387,9 @@ public class SharedDataStorageVolumeMgrTest {
         Config.aws_s3_path = "bucketname:30/b";
         Assert.assertThrows(InvalidConfException.class, SharedDataStorageVolumeMgr::parseLocationsFromConfig);
 
+        Config.aws_s3_path = "s3://bucketname:9030/b";
+        Assert.assertThrows(InvalidConfException.class, SharedDataStorageVolumeMgr::parseLocationsFromConfig);
+
         Config.aws_s3_path = "/";
         Assert.assertThrows(InvalidConfException.class, SharedDataStorageVolumeMgr::parseLocationsFromConfig);
 
@@ -399,6 +402,12 @@ public class SharedDataStorageVolumeMgrTest {
             List<String> locations = SharedDataStorageVolumeMgr.parseLocationsFromConfig();
             Assert.assertEquals(1, locations.size());
             Assert.assertEquals("hdfs://url", locations.get(0));
+        }
+        Config.cloud_native_hdfs_url = "viewfs://host:9030/a/b/c";
+        {
+            List<String> locations = SharedDataStorageVolumeMgr.parseLocationsFromConfig();
+            Assert.assertEquals(1, locations.size());
+            Assert.assertEquals("viewfs://host:9030/a/b/c", locations.get(0));
         }
     }
 


### PR DESCRIPTION
* allow port in url for non-s3 storage volume type

## Why I'm doing:

## What I'm doing:

Fixes #50769

Introduced in #47088

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
