### PR TITLE
[Feature] routine load csv data support discard unknow fields

### DIFF
--- a/be/src/exec/csv_scanner.h
+++ b/be/src/exec/csv_scanner.h
@@ -97,6 +97,7 @@ private:
     bool _use_v2;
     CSVReader::Fields fields;
     CSVRow row;
+    bool _discard_unknown_fields = false;
 };
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -372,6 +372,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
             jobProperties.put(CreateRoutineLoadStmt.TRIMSPACE, stmt.isTrimspace() ? "true" : "false");
             jobProperties.put(CreateRoutineLoadStmt.ENCLOSE, Byte.toString(stmt.getEnclose()));
             jobProperties.put(CreateRoutineLoadStmt.ESCAPE, Byte.toString(stmt.getEscape()));
+            jobProperties.put(CreateRoutineLoadStmt.DISCARD_UNKNOWN_FIELDS, String.valueOf(stmt.isDiscardUnknownFields()));
         } else if (stmt.getFormat().equals("json")) {
             jobProperties.put(CreateRoutineLoadStmt.FORMAT, "json");
             if (!Strings.isNullOrEmpty(stmt.getJsonPaths())) {
@@ -2081,5 +2082,13 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         if (streamLoadTask != null) {
             streamLoadTask.replayOnVisible(txnState);
         }
+    }
+
+    public boolean isDiscardUnknownFields() {
+        String value = jobProperties.get(CreateRoutineLoadStmt.DISCARD_UNKNOWN_FIELDS);
+        if (value == null) {
+            return false;
+        }
+        return Boolean.valueOf(value);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -86,6 +86,7 @@ public class StreamLoadInfo {
     private long logRejectedRecordNum = 0;
     private TPartialUpdateMode partialUpdateMode = TPartialUpdateMode.ROW_MODE;
     private long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+    private boolean discardUnknownFields = false;
 
     private TCompressionType payloadCompressionType = TCompressionType.NO_COMPRESSION;
 
@@ -522,6 +523,7 @@ public class StreamLoadInfo {
         enclose = routineLoadJob.getEnclose();
         escape = routineLoadJob.getEscape();
         warehouseId = routineLoadJob.getWarehouseId();
+        discardUnknownFields = routineLoadJob.isDiscardUnknownFields();
     }
 
     // used for stream load
@@ -569,5 +571,9 @@ public class StreamLoadInfo {
 
     public long getExecMemLimit() {
         return execMemLimit;
+    }
+
+    public boolean isDiscardUnknownFields() {
+        return discardUnknownFields;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -394,6 +394,7 @@ public class StreamLoadScanNode extends LoadScanNode {
             rangeDesc.setSize(-1);
             rangeDesc.setNum_of_columns_from_file(paramCreateContext.tupleDescriptor.getSlots().size());
             rangeDesc.setCompression_type(streamLoadInfo.getPayloadCompressionType());
+            rangeDesc.setDiscard_unknown_fields(streamLoadInfo.isDiscardUnknownFields());
             brokerScanRange.addToRanges(rangeDesc);
             brokerScanRange.setBroker_addresses(Lists.newArrayList());
             if (needAssignBE) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterRoutineLoadStmt.java
@@ -56,6 +56,7 @@ public class AlterRoutineLoadStmt extends DdlStmt {
             .add(CreateRoutineLoadStmt.STRIP_OUTER_ARRAY)
             .add(CreateRoutineLoadStmt.TASK_TIMEOUT_SECOND)
             .add(CreateRoutineLoadStmt.TASK_CONSUME_SECOND)
+            .add(CreateRoutineLoadStmt.DISCARD_UNKNOWN_FIELDS)
             .add(LoadStmt.STRICT_MODE)
             .add(LoadStmt.TIMEZONE)
             .build();
@@ -280,6 +281,11 @@ public class AlterRoutineLoadStmt extends DdlStmt {
         if (jobProperties.containsKey(CreateRoutineLoadStmt.STRIP_OUTER_ARRAY)) {
             boolean stripOuterArray = Boolean.valueOf(jobProperties.get(CreateRoutineLoadStmt.STRIP_OUTER_ARRAY));
             analyzedJobProperties.put(CreateRoutineLoadStmt.STRIP_OUTER_ARRAY, String.valueOf(stripOuterArray));
+        }
+
+        if (jobProperties.containsKey(CreateRoutineLoadStmt.DISCARD_UNKNOWN_FIELDS)) {
+            boolean discardUnknownFields = Boolean.valueOf(jobProperties.get(CreateRoutineLoadStmt.DISCARD_UNKNOWN_FIELDS));
+            analyzedJobProperties.put(CreateRoutineLoadStmt.DISCARD_UNKNOWN_FIELDS, String.valueOf(discardUnknownFields));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -118,6 +118,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String TRIMSPACE = "trim_space";
     public static final String ENCLOSE = "enclose";
     public static final String ESCAPE = "escape";
+    public static final String DISCARD_UNKNOWN_FIELDS = "discard_unknown_fields";
 
     // kafka type properties
     public static final String KAFKA_BROKER_LIST_PROPERTY = "kafka_broker_list";
@@ -164,6 +165,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(TASK_CONSUME_SECOND)
             .add(TASK_TIMEOUT_SECOND)
             .add(PropertyAnalyzer.PROPERTIES_WAREHOUSE)
+            .add(DISCARD_UNKNOWN_FIELDS)
             .build();
 
     private static final ImmutableSet<String> KAFKA_PROPERTIES_SET = new ImmutableSet.Builder<String>()
@@ -223,6 +225,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     private boolean trimspace = false;
     private byte enclose = 0;
     private byte escape = 0;
+    private boolean discardUnknownFields = false;
 
     // kafka related properties
     private String kafkaBrokerList;
@@ -566,6 +569,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
         strictMode = Util.getBooleanPropertyOrDefault(jobProperties.get(LoadStmt.STRICT_MODE),
                 RoutineLoadJob.DEFAULT_STRICT_MODE,
                 LoadStmt.STRICT_MODE + " should be a boolean");
+
+        discardUnknownFields = Util.getBooleanPropertyOrDefault(jobProperties.get(DISCARD_UNKNOWN_FIELDS),
+                false, DISCARD_UNKNOWN_FIELDS + " should be a boolean");
 
         partialUpdate = Util.getBooleanPropertyOrDefault(jobProperties.get(LoadStmt.PARTIAL_UPDATE),
                 false,
@@ -995,5 +1001,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) throws RuntimeException {
         return visitor.visitCreateRoutineLoadStatement(this, context);
+    }
+
+    public boolean isDiscardUnknownFields() {
+        return discardUnknownFields;
     }
 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -176,6 +176,7 @@ struct TBrokerRangeDesc {
     12: optional string jsonpaths
     13: optional string json_root
     14: optional Types.TCompressionType compression_type
+    15: optional bool discard_unknown_fields;
 }
 
 enum TObjectStoreType {


### PR DESCRIPTION
## Why I'm doing:

When routine load job load csv data into starrocks, we frequently found load job changed to `PAUSED` state with reason `Value count does not match column count`, this is becasue csv datasource has add more field into log data(more csv fields).  We expect routine load continue run until user need to write new added field to olap table, then changed to `PAUSED` once csv data has more fields.


## What I'm doing:

Add a job property named `discard_unknown_fields` to allow routine load job discard new added fields and just receive fields in routine load jobs columns, which can be spec in create and alter routine load job sql.

- in create sql(default is false)

```
CREATE ROUTINE LOAD rl_test_01 ON tbl_01
COLUMNS TERMINATED BY ",",
COLUMNS (field_a, field_b, field_c)
PROPERTIES
(
    "desired_concurrent_number" = "1",
    "discard_unknown_fields" = "true"
)
```

- alter after create

```
pause routine load for rl_test_01;
alter routine load for rl_test_01 properties ("discard_unknown_fields" = "true");
resume routine load for rl_test_01;
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
