### PR TITLE
[BugFix] Avoid optimization time exceeding the limit in ApplyRuleTask

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/GroupExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/GroupExpression.java
@@ -30,7 +30,6 @@ import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
@@ -349,8 +348,7 @@ public class GroupExpression {
 
     public boolean hasAppliedMVRules() {
         if (!isAppliedMVRules.isPresent()) {
-            List<Rule> mvRules = RuleSet.getRewriteRulesByType(Arrays.asList(RuleSetType.MULTI_TABLE_MV_REWRITE,
-                    RuleSetType.SINGLE_TABLE_MV_REWRITE));
+            final List<Rule> mvRules = RuleSet.getRewriteRulesByType(RuleSetType.ALL_MV_REWRITE);
             isAppliedMVRules = Optional.of(mvRules.stream().anyMatch(rule -> hasRuleApplied(rule)));
         }
         return isAppliedMVRules.get();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Binder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Binder.java
@@ -241,7 +241,6 @@ public class Binder {
             // NOTE: To avoid iterating all children group expressions which may take a lot of time, only iterate
             // group expressions which are already rewritten by mv except the first iteration, so can be used for
             // nested mv rewritten.
-            // TODO: Introduce rule based join-reorder for mv rewrite, so can reduce this iteration time.
             int geSize = groupExpressions.size();
             while (++valueIndex < geSize) {
                 next = group.getLogicalExpressions().get(valueIndex);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/OptimizerTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/OptimizerTask.java
@@ -52,7 +52,6 @@ public abstract class OptimizerTask {
             if (groupExpression.hasRuleExplored(rule)) {
                 continue;
             }
-
             if (!rule.getPattern().matchWithoutChild(groupExpression)) {
                 continue;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewRewriteWithSSBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewRewriteWithSSBTest.java
@@ -72,7 +72,6 @@ public class MaterializedViewRewriteWithSSBTest extends MaterializedViewTestBase
                 "group by p_brand, LO_ORDERDATE";
 
         // This case must disable outer join to inner join in `JoinPredicatePushdown`
-        setTracLogModule("Optimizer");
         starRocksAssert.withMaterializedView(mv, () -> {
             String query = "select t1.p_brand as p_brand, t1.LO_ORDERDATE as LO_ORDERDATE,\n" +
                     "SUM(revenue_sum) + SUM(supplycost_sum) as revenue_and_supplycost_sum\n" +


### PR DESCRIPTION
## Why I'm doing:
- `MultiJoinBinder` will cause slow locks sometimes:
```
024 - 09 - 03 06 : 59 : 49.641Z WARN(starrocks - mysql - nio - pool - 3278 | 15273792)[LockManager.logSlowLockTrace() : 398] LockManager detects slow lock: {
	"owners": [{
		"id": 15246789,
		"name": "thrift-server-pool-14973570",
		"heldFor": 2133813,
		"waitTime": 0,
		"stack": ["app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.enumerate(Binder.java:202)", "app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.match(Binder.java:190)", "app//com.starrocks.sql.optimizer.rule.Binder.match(Binder.java:109)", "app//com.starrocks.sql.optimizer.rule.Binder.next(Binder.java:96)", "app//com.starrocks.sql.optimizer.task.ApplyRuleTask.execute(ApplyRuleTask.java:104)", "app//com.starrocks.sql.optimizer.task.SeriallyTaskScheduler.executeTasks(SeriallyTaskScheduler.java:65)", "app//com.starrocks.sql.optimizer.Optimizer.memoOptimize(Optimizer.java:803)", "app//com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:260)", "app//com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:184)", "app//com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:219)", "app//com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:130)", "app//com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:92)", "app//com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:533)", "app//com.starrocks.qe.ConnectProcessor.proxyExecute(ConnectProcessor.java:811)", "app//com.starrocks.service.FrontendServiceImpl.forward(FrontendServiceImpl.java:1207)", "app//com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:4481)", "app//com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:4461)", "app//org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40)", "app//org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40)", "app//com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311)"]
	},

2024 - 09 - 03 07 : 02 : 39.354Z WARN(thrift - server - pool - 15005392 | 15278893)[LockManager.logSlowLockTrace() : 398] LockManager detects slow lock: {
	"owners": [{
		"id": 15246789,
		"name": "thrift-server-pool-14973570",
		"heldFor": 2303527,
		"waitTime": 0,
		"stack": ["app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.enumerate(Binder.java:202)", "app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.match(Binder.java:190)", "app//com.starrocks.sql.optimizer.rule.Binder.match(Binder.java:109)", "app//com.starrocks.sql.optimizer.rule.Binder.next(Binder.java:96)", "app//com.starrocks.sql.optimizer.task.ApplyRuleTask.execute(ApplyRuleTask.java:104)", "app//com.starrocks.sql.optimizer.task.SeriallyTaskScheduler.executeTasks(SeriallyTaskScheduler.java:65)", "app//com.starrocks.sql.optimizer.Optimizer.memoOptimize(Optimizer.java:803)", "app//com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:260)", "app//com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:184)", "app//com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:219)", "app//com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:130)", "app//com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:92)", "app//com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:533)", "app//com.starrocks.qe.ConnectProcessor.proxyExecute(ConnectProcessor.java:811)", "app//com.starrocks.service.FrontendServiceImpl.forward(FrontendServiceImpl.java:1207)", "app//com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:4481)", "app//com.starrocks.thrift.FrontendService$Processor$forward.getResult(FrontendService.java:4461)", "app//org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40)", "app//org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40)", "app//com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311)"]
	},
```
## What I'm doing:
- Avoid optimization time exceeding the limit in ApplyRuleTask by using rule exhausting check.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
