### PR TITLE
[Enhancement] Show resource group in global and local current_queries and fix check bind_cpu (backport #50763)

### DIFF
--- a/be/src/exec/workgroup/pipeline_executor_set.h
+++ b/be/src/exec/workgroup/pipeline_executor_set.h
@@ -33,9 +33,9 @@ struct PipelineExecutorSetConfig {
     const uint32_t num_total_scan_threads;
     uint32_t num_total_connector_scan_threads;
 
-    CpuUtil::CpuIds total_cpuids;
+    const CpuUtil::CpuIds total_cpuids;
 
-    bool enable_bind_cpus;
+    const bool enable_bind_cpus;
     bool enable_cpu_borrowing;
 };
 

--- a/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
+++ b/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
@@ -147,10 +147,11 @@ void ExecutorsManager::change_num_connector_scan_threads(uint32_t num_connector_
 }
 
 void ExecutorsManager::change_enable_resource_group_cpu_borrowing(bool val) {
-    if (_conf.enable_cpu_borrowing == val) {
+    const bool new_val = val && _conf.enable_bind_cpus;
+    if (_conf.enable_cpu_borrowing == new_val) {
         return;
     }
-    _conf.enable_cpu_borrowing = val;
+    _conf.enable_cpu_borrowing = new_val;
 
     update_shared_executors();
 }

--- a/be/src/http/action/pipeline_blocking_drivers_action.cpp
+++ b/be/src/http/action/pipeline_blocking_drivers_action.cpp
@@ -161,11 +161,8 @@ void PipelineBlockingDriversAction::_handle_stat(HttpRequest* req) {
         };
 
         QueryMap query_map_in_wg;
-        _exec_env->workgroup_manager()->for_each_workgroup([&](const workgroup::WorkGroup& wg) {
-            if (wg.exclusive_executors() != nullptr) {
-                wg.exclusive_executors()->driver_executor()->iterate_immutable_blocking_driver(
-                        iterate_func_generator(query_map_in_wg));
-            }
+        _exec_env->workgroup_manager()->for_each_executors([&](const workgroup::PipelineExecutorSet& executor) {
+            executor.driver_executor()->iterate_immutable_blocking_driver(iterate_func_generator(query_map_in_wg));
         });
         rapidjson::Document queries_in_wg_obj = query_map_to_doc_func(query_map_in_wg);
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -435,6 +435,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     // Disable bind cpus when cgroup has cpu quota but no cpuset.
     const bool enable_bind_cpus = config::enable_resource_group_bind_cpus &&
                                   (!CpuInfo::is_cgroup_with_cpu_quota() || CpuInfo::is_cgroup_with_cpuset());
+    config::enable_resource_group_bind_cpus = enable_bind_cpus;
     workgroup::PipelineExecutorSetConfig executors_manager_opts(
             CpuInfo::num_cores(), _max_executor_threads, num_io_threads, connector_num_io_threads,
             CpuInfo::get_core_ids(), enable_bind_cpus, config::enable_resource_group_cpu_borrowing);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -150,6 +150,10 @@ public class ResourceGroupMgr implements Writable {
                 dropResourceGroupUnlocked(wg.getName());
             }
 
+            if (wg.getCpuWeight() == null) {
+                wg.setCpuWeight(0);
+            }
+
             if (ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME.equals(wg.getName())) {
                 wg.setId(ResourceGroup.DEFAULT_WG_ID);
             } else if (ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME.equals(wg.getName())) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
@@ -66,6 +66,7 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
             .add("CPUTime")
             .add("ExecTime")
             .add("Warehouse")
+            .add("ResourceGroup")
             .build();
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Sets;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.catalog.FsBroker;
+import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -1171,6 +1172,12 @@ public class DefaultCoordinator extends Coordinator {
             return "";
         }
         return connectContext.getSessionVariable().getWarehouseName();
+    }
+
+    @Override
+    public String getResourceGroupName() {
+        return jobSpec.getResourceGroup() == null ? ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME :
+                jobSpec.getResourceGroup().getName();
     }
 
     private void execShortCircuit() throws Exception {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -172,7 +172,9 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
                     .db(context.getDatabase())
                     .fragmentInstanceInfos(info.getCoord().getFragmentInstanceInfos())
                     .profile(info.getCoord().getQueryProfile())
-                    .warehouseName(info.coord.getWarehouseName()).build();
+                    .warehouseName(info.coord.getWarehouseName())
+                    .resourceGroupName(info.coord.getResourceGroupName())
+                    .build();
 
             querySet.put(queryIdStr, item);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsInfo.java
@@ -62,13 +62,14 @@ public class QueryStatisticsInfo {
     private long spillBytes;
     private long execTime;
     private String wareHouseName;
+    private String resourceGroupName;
 
     public QueryStatisticsInfo() {
     }
 
     public QueryStatisticsInfo(long queryStartTime, String feIp, String queryId, String connId, String db, String user,
                                long cpuCostNs, long scanBytes, long scanRows, long memUsageBytes, long spillBytes,
-                               long execTime, String wareHouseName) {
+                               long execTime, String wareHouseName, String resourceGroupName) {
         this.queryStartTime = queryStartTime;
         this.feIp = feIp;
         this.queryId = queryId;
@@ -82,6 +83,7 @@ public class QueryStatisticsInfo {
         this.spillBytes = spillBytes;
         this.execTime = execTime;
         this.wareHouseName = wareHouseName;
+        this.resourceGroupName = resourceGroupName;
     }
 
     public long getQueryStartTime() {
@@ -136,6 +138,9 @@ public class QueryStatisticsInfo {
         return wareHouseName;
     }
 
+    public String getResourceGroupName() {
+        return resourceGroupName;
+    }
     public QueryStatisticsInfo withQueryStartTime(long queryStartTime) {
         this.queryStartTime = queryStartTime;
         return this;
@@ -201,6 +206,11 @@ public class QueryStatisticsInfo {
         return this;
     }
 
+    public QueryStatisticsInfo withResourceGroupName(String resourceGroupName) {
+        this.resourceGroupName = resourceGroupName;
+        return this;
+    }
+
     public TQueryStatisticsInfo toThrift() {
         return new TQueryStatisticsInfo()
                 .setQueryStartTime(queryStartTime)
@@ -215,7 +225,8 @@ public class QueryStatisticsInfo {
                 .setMemUsageBytes(memUsageBytes)
                 .setSpillBytes(spillBytes)
                 .setExecTime(execTime)
-                .setWareHouseName(wareHouseName);
+                .setWareHouseName(wareHouseName)
+                .setResourceGroupName(resourceGroupName);
     }
 
     public static QueryStatisticsInfo fromThrift(TQueryStatisticsInfo tinfo) {
@@ -232,7 +243,8 @@ public class QueryStatisticsInfo {
                 .withSpillBytes(tinfo.getSpillBytes())
                 .withCpuCostNs(tinfo.getCpuCostNs())
                 .withExecTime(tinfo.getExecTime())
-                .withWareHouseName(tinfo.getWareHouseName());
+                .withWareHouseName(tinfo.getWareHouseName())
+                .withResourceGroupName(tinfo.getResourceGroupName());
     }
 
     public List<String> formatToList() {
@@ -250,6 +262,7 @@ public class QueryStatisticsInfo {
         values.add(QueryStatisticsFormatter.getSecondsFromNano(this.getCpuCostNs()));
         values.add(QueryStatisticsFormatter.getSecondsFromMilli(this.getExecTime()));
         values.add(this.getWareHouseName());
+        values.add(this.getResourceGroupName());
         return values;
     }
 
@@ -267,13 +280,14 @@ public class QueryStatisticsInfo {
                 Objects.equals(db, that.db) && Objects.equals(user, that.user) && cpuCostNs == that.cpuCostNs &&
                 scanBytes == that.scanBytes && scanRows == that.scanRows && memUsageBytes == that.memUsageBytes &&
                 spillBytes == that.spillBytes && execTime == that.execTime &&
-                Objects.equals(wareHouseName, that.wareHouseName);
+                Objects.equals(wareHouseName, that.wareHouseName) &&
+                        Objects.equals(resourceGroupName, that.resourceGroupName);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(queryStartTime, feIp, queryId, connId, db, user, cpuCostNs, scanBytes, scanRows, memUsageBytes,
-                spillBytes, execTime, wareHouseName);
+                spillBytes, execTime, wareHouseName, resourceGroupName);
     }
 
     @Override
@@ -291,6 +305,7 @@ public class QueryStatisticsInfo {
                 ", spillBytes=" + spillBytes +
                 ", execTime=" + execTime +
                 ", wareHouseName=" + wareHouseName +
+                ", resourceGroupName=" + resourceGroupName +
                 '}';
     }
 
@@ -325,7 +340,8 @@ public class QueryStatisticsInfo {
                     .withSpillBytes(statistics.getSpillBytes())
                     .withCpuCostNs(statistics.getCpuCostNs())
                     .withExecTime(item.getQueryExecTime())
-                    .withWareHouseName(item.getWarehouseName());
+                    .withWareHouseName(item.getWarehouseName())
+                    .withResourceGroupName(item.getResourceGroupName());
             sortedRowData.add(info);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
@@ -37,6 +37,7 @@ public final class QueryStatisticsItem {
     private final RuntimeProfile queryProfile;
     private final TUniqueId executionId;
     private final String warehouseName;
+    private final String resourceGroupName;
 
     private QueryStatisticsItem(Builder builder) {
         this.queryId = builder.queryId;
@@ -49,6 +50,7 @@ public final class QueryStatisticsItem {
         this.queryProfile = builder.queryProfile;
         this.executionId = builder.executionId;
         this.warehouseName = builder.warehouseName;
+        this.resourceGroupName = builder.resourceGroupName;
     }
 
     public String getDb() {
@@ -96,6 +98,10 @@ public final class QueryStatisticsItem {
         return warehouseName;
     }
 
+    public String getResourceGroupName() {
+        return resourceGroupName;
+    }
+
     public static final class Builder {
         private String queryId;
         private String db;
@@ -107,6 +113,7 @@ public final class QueryStatisticsItem {
         private RuntimeProfile queryProfile;
         private TUniqueId executionId;
         private String warehouseName;
+        private String resourceGroupName;
 
         public Builder() {
             fragmentInstanceInfos = Lists.newArrayList();
@@ -159,6 +166,11 @@ public final class QueryStatisticsItem {
 
         public Builder warehouseName(String warehouseName) {
             this.warehouseName = warehouseName;
+            return this;
+        }
+
+        public Builder resourceGroupName(String resourceGroupName) {
+            this.resourceGroupName = resourceGroupName;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -232,5 +232,7 @@ public abstract class Coordinator {
 
     public abstract String getWarehouseName();
 
+    public abstract String getResourceGroupName();
+
     public abstract boolean isShortCircuit();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
@@ -303,6 +303,11 @@ public class FeExecuteCoordinator extends Coordinator {
         return connectContext.getSessionVariable().getWarehouseName();
     }
 
+    @Override
+    public String getResourceGroupName() {
+        return "";
+    }
+
     public boolean isShortCircuit() {
         return false;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -1436,7 +1436,7 @@ public class ResourceGroupStmtTest {
         assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
                 "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
                 "rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
-                "rg2|null|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)\n" +
+                "rg2|0|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)\n" +
                 "rt_rg1|15|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rt_rg1_user)");
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
@@ -1554,7 +1554,7 @@ public class ResourceGroupStmtTest {
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
             assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
                     "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|null|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+                    "rg1|0|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
     }
@@ -1720,8 +1720,8 @@ public class ResourceGroupStmtTest {
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
             assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
                     "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|null|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
-                    "rg2|null|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
+                    "rg1|0|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
+                    "rg2|0|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
         }
 
         {
@@ -1745,8 +1745,8 @@ public class ResourceGroupStmtTest {
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
             assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
                     "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|null|14|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
-                    "rg2|null|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
+                    "rg1|0|14|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
+                    "rg2|0|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
         }
 
         {

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentGlobalQueryStatisticsProcDirTest.java
@@ -47,7 +47,8 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withSpillBytes(0)
             .withCpuCostNs(97323000)
             .withExecTime(3533000)
-            .withWareHouseName("default_warehouse");
+            .withWareHouseName("default_warehouse")
+            .withResourceGroupName("wg1");
 
 
     public static final QueryStatisticsInfo QUERY_TWO_LOCAL = new QueryStatisticsInfo()
@@ -63,7 +64,8 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withSpillBytes(0)
             .withCpuCostNs(96576000)
             .withExecTime(2086000)
-            .withWareHouseName("default_warehouse");
+            .withWareHouseName("default_warehouse")
+            .withResourceGroupName("wg2");
 
     public static final QueryStatisticsInfo QUERY_ONE_REMOTE = new QueryStatisticsInfo()
             .withQueryStartTime(1721866428)
@@ -78,7 +80,8 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withSpillBytes(0)
             .withCpuCostNs(97456000)
             .withExecTime(3687000)
-            .withWareHouseName("default_warehouse");
+            .withWareHouseName("default_warehouse")
+            .withResourceGroupName("wg3");
 
 
     public static final QueryStatisticsInfo QUERY_TWO_REMOTE = new QueryStatisticsInfo()
@@ -94,7 +97,8 @@ public class CurrentGlobalQueryStatisticsProcDirTest {
             .withSpillBytes(0)
             .withCpuCostNs(96686000)
             .withExecTime(2196000)
-            .withWareHouseName("default_warehouse");
+            .withWareHouseName("default_warehouse")
+            .withResourceGroupName("wg");
 
     public static List<QueryStatisticsInfo> LOCAL_TEST_QUERIES =
             new ArrayList<>(List.of(QUERY_ONE_LOCAL, QUERY_TWO_LOCAL));

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDirTest.java
@@ -44,12 +44,14 @@ public class CurrentQueryStatisticsProcDirTest {
                 .queryStartTime(1)
                 .queryId("queryId1")
                 .warehouseName("wh1")
+                .resourceGroupName("wg1")
                 .build()
         );
         statistic.put("queryId2", new QueryStatisticsItem.Builder()
                 .queryStartTime(2)
                 .queryId("queryId2")
                 .warehouseName("wh1")
+                .resourceGroupName("wg2")
                 .build()
         );
         new MockUp<QeProcessorImpl>() {
@@ -76,6 +78,8 @@ public class CurrentQueryStatisticsProcDirTest {
         Assert.assertEquals("queryId1", list1.get(2));
         // Warehouse
         Assert.assertEquals("wh1", list1.get(12));
+        // ResourceGroupName
+        Assert.assertEquals("wg1", list1.get(13));
 
         List<String> list2 = rows.get(1);
         Assert.assertEquals(list2.size(), CurrentQueryStatisticsProcDir.TITLE_NAMES.size());
@@ -83,6 +87,8 @@ public class CurrentQueryStatisticsProcDirTest {
         Assert.assertEquals("queryId2", list2.get(2));
         // Warehouse
         Assert.assertEquals("wh1", list2.get(12));
+        // ResourceGroupName
+        Assert.assertEquals("wg2", list2.get(13));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryStatisticsInfoTest.java
@@ -38,7 +38,8 @@ public class QueryStatisticsInfoTest {
                 firstQuery.getMemUsageBytes(),
                 firstQuery.getSpillBytes(),
                 firstQuery.getExecTime(),
-                firstQuery.getWareHouseName()
+                firstQuery.getWareHouseName(),
+                firstQuery.getResourceGroupName()
         );
         Assert.assertEquals(firstQuery, otherQuery);
         Assert.assertEquals(firstQuery.hashCode(), otherQuery.hashCode());

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1534,6 +1534,7 @@ struct TQueryStatisticsInfo {
     11: optional i64 spillBytes
     12: optional i64 execTime
     13: optional string wareHouseName
+    15: optional string resourceGroupName
 }
 
 struct TGetQueryStatisticsResponse {


### PR DESCRIPTION
CP from #50763 #50809.

## Why I'm doing:
Show `ResourceGroupName` in `show proc "/current_queries"` and `show proc "/global_current_queries"`.

```
show proc "/global_current_queries" \G
***************************[ 1. row ]***************************
StartTime     | 2024-09-05 19:34:16
feIp          | 127.0.0.1
QueryId       | c8942a3e-6b7a-11ef-b949-00163e02ada5
ConnectionId  | 0
Database      | d1
User          | root
ScanBytes     | 0.000 B
ScanRows      | 0 rows
MemoryUsage   | 184.188 KB
DiskSpillSize | 0.000 B
CPUTime       | 0.000 s
ExecTime      | 200.540 s
Warehouse     | default_warehouse
CustomQueryId |
ResourceGroup | default_wg
```

`show proc "/global_current_queries"` has some problems, when  the query is forwarded to leader:
1. `feIP` displays leader FE IP.
2. `ConnectionID` is always 0.

TODO
- We need fix these issues 
- and add a `information_schema.current_queries`.


## What I'm doing:


Relates to #49965.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

