### PR TITLE
[BugFix] improve csv parser when handle empty enclose and escape

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2885,8 +2885,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             if (formatPropsContext.booleanValue() != null) {
                 trimspace = Boolean.parseBoolean(formatPropsContext.booleanValue().getText());
             }
-            csvFormat = new CsvFormat(enclose == null ? 0 : (byte) enclose.charAt(0),
-                    escape == null ? 0 : (byte) escape.charAt(0),
+            csvFormat = new CsvFormat((enclose == null || enclose.isEmpty()) ? 0 : (byte) enclose.charAt(0),
+                    (escape == null || escape.isEmpty()) ? 0 : (byte) escape.charAt(0),
                     skipheader, trimspace);
         } else {
             csvFormat = new CsvFormat((byte) 0, (byte) 0, 0, false);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/LoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/LoadStmtTest.java
@@ -103,6 +103,7 @@ public class LoadStmtTest {
         analyzeSuccess("LOAD LABEL test.testLabel (DATA INFILE(\"hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file\") INTO TABLE `t0`) WITH BROKER (\"username\"=\"sr\")");
         analyzeSuccess("LOAD LABEL test.testLabel (DATA INFILE(\"hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file\") INTO TABLE `t0` FORMAT AS CSV (SKIP_HEADER = 2 TRIM_SPACE = TRUE ENCLOSE = \"'\" ESCAPE = \"|\")) WITH BROKER (\"username\"=\"sr\")");
         analyzeSuccess("LOAD LABEL test.testLabel (DATA INFILE(\"hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file\") INTO TABLE `t0` FORMAT AS CSV (SKIP_HEADER = 2 TRIM_SPACE = TRUE ENCLOSE = \"'\" ESCAPE = \"|\")) WITH BROKER PROPERTIES (\"merge_condition\"=\"sr\")");
+        analyzeSuccess("LOAD LABEL test.testLabel (DATA INFILE(\"hdfs://hdfs_host:hdfs_port/user/starRocks/data/input/file\") INTO TABLE `t0` FORMAT AS CSV (SKIP_HEADER = 2 TRIM_SPACE = TRUE ENCLOSE = \"\" ESCAPE = \"\")) WITH BROKER (\"username\"=\"sr\")");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
String `enclose` and `escape` could be empty when use like: 
```
FORMAT AS "csv"
(
        enclose = ''
)
```
So enclose.charAt(0) could throws exceptions:
```
Unexpected exception: String index out of range: 0
```

## What I'm doing:
Fix it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
