### PR TITLE
[Enhancement] List Partition For AMV(Part 4): Support more patterns for list partition materialized views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -91,7 +91,7 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
         });
 
         ListPartitionDiffResult result = ListPartitionDiffer.computeListPartitionDiff(mv, refBaseTablePartitionMap,
-                allBasePartitionItems, tableRefIdxes);
+                allBasePartitionItems, tableRefIdxes, isQueryRewrite);
         if (result == null) {
             logMVPrepare(mv, "Partitioned mv compute list diff failed");
             return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
@@ -131,7 +131,7 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
                 TableProperty.QueryRewriteConsistencyMode.LOOSE);
         ListPartitionDiff listPartitionDiff = null;
         try {
-            ListPartitionDiffResult result = ListPartitionDiffer.computeListPartitionDiff(mv);
+            ListPartitionDiffResult result = ListPartitionDiffer.computeListPartitionDiff(mv, isQueryRewrite);
             if (result == null) {
                 logMVPrepare(mv, "Partitioned mv compute list diff failed");
                 return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -15,7 +15,6 @@
 package com.starrocks.catalog.mv;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
@@ -83,9 +82,8 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
                 mvTimelinessInfo);
 
         // collect all ref base table's partition range map
-        Map<Table, Map<String, Set<String>>> extBaseToMVPartitionNameMap = Maps.newHashMap();
         Map<Table, Map<String, Range<PartitionKey>>> basePartitionNameToRangeMap =
-                RangePartitionDiffer.syncBaseTablePartitionInfos(mv, partitionExpr, extBaseToMVPartitionNameMap);
+                RangePartitionDiffer.syncBaseTablePartitionInfos(mv, partitionExpr);
 
         // If base table is materialized view, add partition name to cell mapping into base table partition mapping,
         // otherwise base table(mv) may lose partition names of the real base table changed partitions.
@@ -100,7 +98,7 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
 
         // There may be a performance issue here, because it will fetch all partitions of base tables and mv partitions.
         RangePartitionDiffResult differ = RangePartitionDiffer.computeRangePartitionDiff(mv, null,
-                extBaseToMVPartitionNameMap, basePartitionNameToRangeMap, isQueryRewrite);
+                basePartitionNameToRangeMap, isQueryRewrite);
         if (differ == null) {
             throw new AnalysisException(String.format("Compute partition difference of mv %s with base table failed.",
                     mv.getName()));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -80,7 +80,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
 
         ListPartitionDiffResult result;
         try {
-            result = ListPartitionDiffer.computeListPartitionDiff(mv);
+            result = ListPartitionDiffer.computeListPartitionDiff(mv, false);
             if (result == null) {
                 LOG.warn("compute list partition diff failed: mv: {}", mv.getName());
                 return false;
@@ -128,6 +128,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             mvContext.setRefBaseTableMVIntersectedPartitions(baseToMvNameRef);
             mvContext.setMvRefBaseTableIntersectedPartitions(mvToBaseNameRef);
             mvContext.setRefBaseTableListPartitionMap(refBaseTablePartitionMap);
+            mvContext.setExternalRefBaseTableMVPartitionMap(result.getRefBaseTableMVPartitionMap());
         }
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -130,7 +130,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         mvContext.setRefBaseTableMVIntersectedPartitions(baseToMvNameRef);
         mvContext.setMvRefBaseTableIntersectedPartitions(mvToBaseNameRef);
         mvContext.setRefBaseTableRangePartitionMap(result.refBaseTablePartitionMap);
-        mvContext.setExternalRefBaseTableMVPartitionMap(result.refBaseTableMVPartitionMap);
+        mvContext.setExternalRefBaseTableMVPartitionMap(result.getRefBaseTableMVPartitionMap());
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3060,9 +3060,6 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 }
                 return new ListPartitionInfo(PartitionType.LIST, Collections.singletonList(stmt.getPartitionColumn()));
             } else {
-                if (partitionType != PartitionType.RANGE) {
-                    throw new DdlException("Unsupported partition type: " + partitionType);
-                }
                 ExpressionPartitionDesc expressionPartitionDesc = new ExpressionPartitionDesc(partitionByExpr);
                 if ((partitionByExpr instanceof FunctionCallExpr)) {
                     FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionByExpr;

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -86,7 +86,6 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.PhysicalPartitionImpl;
-import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
@@ -3007,7 +3006,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         materializedView.getWarehouseId());
                 materializedView.addPartition(partition);
             } else {
-                Expr partitionExpr = stmt.getPartitionExpDesc().getExpr();
+                Expr partitionExpr = stmt.getPartitionByExpr();
                 Map<Expr, SlotRef> partitionExprMaps = MVPartitionExprResolver.getMVPartitionExprsChecked(partitionExpr,
                         stmt.getQueryStatement(), stmt.getBaseTableInfos());
                 LOG.info("Generate mv {} partition exprs: {}", mvName, partitionExprMaps);
@@ -3051,30 +3050,38 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     public static PartitionInfo buildPartitionInfo(CreateMaterializedViewStatement stmt) throws DdlException {
-        ExpressionPartitionDesc expressionPartitionDesc = stmt.getPartitionExpDesc();
-        if (expressionPartitionDesc != null) {
-            Expr expr = expressionPartitionDesc.getExpr();
-            if (expr instanceof SlotRef) {
-                SlotRef slotRef = (SlotRef) expr;
-                if (slotRef.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
-                    return new ListPartitionInfo(PartitionType.LIST,
-                            Collections.singletonList(stmt.getPartitionColumn()));
+        Expr partitionByExpr = stmt.getPartitionByExpr();
+        PartitionType partitionType = stmt.getPartitionType();
+        if (partitionByExpr != null) {
+            if (partitionType == PartitionType.LIST) {
+                if (!(partitionByExpr instanceof SlotRef)) {
+                    throw new DdlException("List partition only support partition by slot ref column:"
+                            + partitionByExpr.toSql());
                 }
-            }
-            if ((expr instanceof FunctionCallExpr)) {
-                FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
-                if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)) {
-                    Column partitionColumn = new Column(stmt.getPartitionColumn());
-                    partitionColumn.setType(com.starrocks.catalog.Type.DATE);
-                    return expressionPartitionDesc.toPartitionInfo(
-                            Collections.singletonList(partitionColumn),
-                            Maps.newHashMap(), false);
+                return new ListPartitionInfo(PartitionType.LIST, Collections.singletonList(stmt.getPartitionColumn()));
+            } else {
+                if (partitionType != PartitionType.RANGE) {
+                    throw new DdlException("Unsupported partition type: " + partitionType);
                 }
+                ExpressionPartitionDesc expressionPartitionDesc = new ExpressionPartitionDesc(partitionByExpr);
+                if ((partitionByExpr instanceof FunctionCallExpr)) {
+                    FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionByExpr;
+                    if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)) {
+                        Column partitionColumn = new Column(stmt.getPartitionColumn());
+                        partitionColumn.setType(com.starrocks.catalog.Type.DATE);
+                        return expressionPartitionDesc.toPartitionInfo(
+                                Collections.singletonList(partitionColumn),
+                                Maps.newHashMap(), false);
+                    }
+                }
+                return expressionPartitionDesc.toPartitionInfo(
+                        Collections.singletonList(stmt.getPartitionColumn()),
+                        Maps.newHashMap(), false);
             }
-            return expressionPartitionDesc.toPartitionInfo(
-                    Collections.singletonList(stmt.getPartitionColumn()),
-                    Maps.newHashMap(), false);
         } else {
+            if (partitionType != PartitionType.UNPARTITIONED && partitionType != null) {
+                throw new DdlException("Partition type is " + stmt.getPartitionType() + ", but partition by expr is null");
+            }
             return new SinglePartitionInfo();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -47,6 +47,7 @@ import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
@@ -68,7 +69,6 @@ import com.starrocks.sql.ast.ColWithComment;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
-import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.IndexDef;
 import com.starrocks.sql.ast.PartitionRangeDesc;
@@ -336,7 +336,7 @@ public class MaterializedViewAnalyzer {
                 columnExprMap.put(pair.first, outputExpressions.get(pair.second));
             }
             // some check if partition exp exists
-            if (statement.getPartitionExpDesc() != null) {
+            if (statement.getPartitionByExpr() != null) {
                 // check partition expression all in column list and
                 // write the expr into partitionExpDesc if partition expression exists
                 checkExpInColumn(statement);
@@ -346,7 +346,10 @@ public class MaterializedViewAnalyzer {
                 checkPartitionExpPatterns(statement);
                 // check partition column must be base table's partition column
                 checkPartitionColumnWithBaseTable(statement, aliasTableMap);
+                // check window function can be used in partitioned mv
                 checkWindowFunctions(statement, columnExprMap);
+                // determine mv partition 's type: list or range
+                determinePartitionType(statement, aliasTableMap);
             }
             // check and analyze distribution
             checkDistribution(statement, aliasTableMap);
@@ -634,12 +637,12 @@ public class MaterializedViewAnalyzer {
         }
 
         private void checkExpInColumn(CreateMaterializedViewStatement statement) {
-            ExpressionPartitionDesc expressionPartitionDesc = statement.getPartitionExpDesc();
+            Expr partitionByExpr = statement.getPartitionByExpr();
             List<Column> columns = statement.getMvColumnItems();
-            SlotRef slotRef = getSlotRef(expressionPartitionDesc.getExpr());
+            SlotRef slotRef = getSlotRef(partitionByExpr);
             if (slotRef.getTblNameWithoutAnalyzed() != null) {
                 throw new SemanticException("Materialized view partition exp: "
-                        + slotRef.toSql() + " must related to column", expressionPartitionDesc.getExpr().getPos());
+                        + slotRef.toSql() + " must related to column", partitionByExpr.getPos());
             }
             int columnId = 0;
             for (Column column : columns) {
@@ -674,8 +677,11 @@ public class MaterializedViewAnalyzer {
         private void checkPartitionColumnExprs(CreateMaterializedViewStatement statement,
                                                Map<Column, Expr> columnExprMap,
                                                ConnectContext connectContext) throws SemanticException {
-            ExpressionPartitionDesc expressionPartitionDesc = statement.getPartitionExpDesc();
+            Expr partitionByExpr = statement.getPartitionByExpr();
             Column partitionColumn = statement.getPartitionColumn();
+            if (partitionByExpr == null) {
+                return;
+            }
 
             // partition column expr from input query
             Expr partitionColumnExpr = columnExprMap.get(partitionColumn);
@@ -684,13 +690,13 @@ public class MaterializedViewAnalyzer {
             } catch (Exception e) {
                 LOG.warn("resolve partition column failed", e);
                 throw new SemanticException("Resolve partition column failed:" + e.getMessage(),
-                        statement.getPartitionExpDesc().getPos());
+                        statement.getPartitionByExpr().getPos());
             }
 
             // set partition-ref into statement
-            if (expressionPartitionDesc.isFunction()) {
+            if (partitionByExpr instanceof FunctionCallExpr) {
                 // e.g. partition by date_trunc('month', dt)
-                FunctionCallExpr functionCallExpr = (FunctionCallExpr) expressionPartitionDesc.getExpr();
+                FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionByExpr;
                 String functionName = functionCallExpr.getFnName().getFunction();
                 if (!PartitionFunctionChecker.FN_NAME_TO_PATTERN.containsKey(functionName)) {
                     throw new SemanticException("Materialized view partition function " +
@@ -718,7 +724,7 @@ public class MaterializedViewAnalyzer {
                     statement.setPartitionRefTableExpr(partitionColumnExpr);
                 } else {
                     throw new SemanticException("Materialized view partition function must related with column",
-                            expressionPartitionDesc.getPos());
+                            partitionByExpr.getPos());
                 }
             }
         }
@@ -807,6 +813,59 @@ public class MaterializedViewAnalyzer {
                         table.getType());
             }
             replaceTableAlias(slotRef, statement, tableNameTableMap);
+        }
+
+        private void determinePartitionType(CreateMaterializedViewStatement statement,
+                                            Map<TableName, Table> tableNameTableMap) {
+            Expr partitionRefTableExpr = statement.getPartitionRefTableExpr();
+            if (partitionRefTableExpr == null) {
+                statement.setPartitionType(PartitionType.UNPARTITIONED);
+                return;
+            }
+
+            SlotRef slotRef = getSlotRef(partitionRefTableExpr);
+            Table refBaseTable = tableNameTableMap.get(slotRef.getTblNameWithoutAnalyzed());
+            if (refBaseTable == null) {
+                throw new SemanticException("Materialized view partition expression %s could only ref to base table",
+                        slotRef.toSql());
+            }
+
+            if (refBaseTable.isNativeTableOrMaterializedView()) {
+                // To olap table, determine mv's partition by its ref base table's partition type.
+                OlapTable olapTable = (OlapTable) refBaseTable;
+                PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+                if (partitionInfo.isRangePartition()) {
+                    // set the partition type
+                    statement.setPartitionType(PartitionType.RANGE);
+                } else if (partitionInfo.isListPartition()) {
+                    // set the partition type
+                    statement.setPartitionType(PartitionType.LIST);
+                }
+            } else {
+                List<Column> refPartitionCols = refBaseTable.getPartitionColumns();
+                Optional<Column> refPartitionColOpt = refPartitionCols.stream()
+                        .filter(col -> col.getName().equals(slotRef.getColumnName()))
+                        .findFirst();
+                if (refPartitionColOpt.isEmpty()) {
+                    throw new SemanticException("Materialized view partition column in partition exp " +
+                            "must be base table partition column", partitionRefTableExpr.getPos());
+                }
+                Column refPartitionCol = refPartitionColOpt.get();
+                Type partitionExprType = refPartitionCol.getType();
+                Expr partitionByExpr = statement.getPartitionByExpr();
+                // To olap table, determine mv's partition by its ref base table's partition column type:
+                // - if the partition column is string type && no use `str2date`, use list partition.
+                // - otherwise use range partition as before.
+                // To be compatible with old implementations, if the partition column is not a string type,
+                // still use range partition.
+                // TODO: remove this compatibility code in the future, use list partition directly later.
+                if (partitionExprType.isStringType() && (partitionByExpr instanceof SlotRef) &&
+                        !MvUtils.isStr2Date(partitionRefTableExpr)) {
+                    statement.setPartitionType(PartitionType.LIST);
+                } else {
+                    statement.setPartitionType(PartitionType.RANGE);
+                }
+            }
         }
 
         private void checkPartitionColumnWithBaseOlapTable(SlotRef slotRef, OlapTable table) {
@@ -1007,7 +1066,7 @@ public class MaterializedViewAnalyzer {
 
         private void checkPartitionColumnType(Column partitionColumn) {
             PrimitiveType type = partitionColumn.getPrimitiveType();
-            if (!type.isFixedPointType() && !type.isDateType() && type != PrimitiveType.CHAR && type != PrimitiveType.VARCHAR) {
+            if (!type.isFixedPointType() && !type.isDateType() && !type.isStringType()) {
                 throw new SemanticException("Materialized view partition exp column:"
                         + partitionColumn.getName() + " with type " + type + " not supported");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -862,7 +862,7 @@ public class MaterializedViewAnalyzer {
                 // still use range partition.
                 // TODO: remove this compatibility code in the future, use list partition directly later.
                 if (partitionExprType.isStringType() && (partitionByExpr instanceof SlotRef) &&
-                        !MvUtils.isStr2Date(partitionRefTableExpr)) {
+                        !(partitionRefTableExpr instanceof FunctionCallExpr)) {
                     statement.setPartitionType(PartitionType.LIST);
                 } else {
                     statement.setPartitionType(PartitionType.RANGE);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.PartitionType;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.plan.ExecPlan;
@@ -49,7 +50,12 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private boolean ifNotExists;
     private String comment;
     private RefreshSchemeClause refreshSchemeDesc;
-    private ExpressionPartitionDesc expressionPartitionDesc;
+
+    // partition by clause which may be list or range partition expr.
+    private final Expr partitionByExpr;
+    // partition type of the mv which is deduced by its referred base table.
+    private PartitionType partitionType;
+
     private Map<String, String> properties;
     private QueryStatement queryStatement;
     private DistributionDesc distributionDesc;
@@ -88,7 +94,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
                                            List<IndexDef> indexDefs,
                                            String comment,
                                            RefreshSchemeClause refreshSchemeDesc,
-                                           ExpressionPartitionDesc expressionPartitionDesc,
+                                           Expr partitionByExpr,
                                            DistributionDesc distributionDesc, List<String> sortKeys,
                                            Map<String, String> properties,
                                            QueryStatement queryStatement,
@@ -101,7 +107,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.ifNotExists = ifNotExists;
         this.comment = comment;
         this.refreshSchemeDesc = refreshSchemeDesc;
-        this.expressionPartitionDesc = expressionPartitionDesc;
+        this.partitionByExpr = partitionByExpr;
         this.distributionDesc = distributionDesc;
         this.sortKeys = sortKeys;
         this.properties = properties;
@@ -149,12 +155,23 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.refreshSchemeDesc = refreshSchemeDesc;
     }
 
-    public ExpressionPartitionDesc getPartitionExpDesc() {
-        return expressionPartitionDesc;
+    /**
+     * Get partition by expr of the mv
+     */
+    public Expr getPartitionByExpr() {
+        return partitionByExpr;
     }
 
-    public void setPartitionExpDesc(ExpressionPartitionDesc expressionPartitionDesc) {
-        this.expressionPartitionDesc = expressionPartitionDesc;
+    /**
+     * Get partition type of the mv
+     * @return
+     */
+    public PartitionType getPartitionType() {
+        return partitionType;
+    }
+
+    public void setPartitionType(PartitionType partitionType) {
+        this.partitionType = partitionType;
     }
 
     public void setKeysType(KeysType keysType) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffResult.java
@@ -18,11 +18,12 @@ import com.starrocks.catalog.Table;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The result of diffing between materialized view and the base tables.
  */
-public class ListPartitionDiffResult {
+public class ListPartitionDiffResult extends PartitionDiffResult {
     // The partition range of the materialized view: <mv partition name, mv partition range>
     public final Map<String, PListCell> mvListPartitionMap;
     // The partition range of the base tables: <base table, <base table partition name, base table partition range>>
@@ -36,7 +37,9 @@ public class ListPartitionDiffResult {
     public ListPartitionDiffResult(Map<String, PListCell> mvListPartitionMap,
                                    Map<Table, Map<String, PListCell>> refBaseTablePartitionMap,
                                    ListPartitionDiff listPartitionDiff,
-                                   Map<Table, List<Integer>> refBaseTableRefIdxMap) {
+                                   Map<Table, List<Integer>> refBaseTableRefIdxMap,
+                                   Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap) {
+        super(refBaseTableMVPartitionMap);
         this.mvListPartitionMap = mvListPartitionMap;
         this.refBaseTablePartitionMap = refBaseTablePartitionMap;
         this.listPartitionDiff = listPartitionDiff;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffResult.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.starrocks.catalog.Table;
+
+import java.util.Map;
+import java.util.Set;
+
+public abstract class PartitionDiffResult {
+    // For external table, the mapping of base table partition to mv partition:
+    // <base table, <base table partition name, mv partition name>>
+    public final Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap;
+
+    public PartitionDiffResult(Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap) {
+        this.refBaseTableMVPartitionMap = refBaseTableMVPartitionMap;
+    }
+
+    public Map<Table, Map<String, Set<String>>> getRefBaseTableMVPartitionMap() {
+        return refBaseTableMVPartitionMap;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -14,9 +14,50 @@
 
 package com.starrocks.sql.common;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.PartitionUtil;
+
+import java.util.Map;
+import java.util.Set;
+
 /**
  * {@link PartitionDiffer} is used to compare the difference between two partitions which can be range
  * partition or list partition.
  */
 public abstract class PartitionDiffer {
+    /**
+     * To solve multi partition columns' problem of external table, record the mv partition name to all the same
+     * partition names map here.
+     * @param partitionTableAndColumns the partition table and its partition column
+     * @param result the result map
+     */
+    public static void collectExternalPartitionNameMapping(Map<Table, Column> partitionTableAndColumns,
+                                                           Map<Table, Map<String, Set<String>>> result) throws AnalysisException {
+        for (Map.Entry<Table, Column> e1 : partitionTableAndColumns.entrySet()) {
+            Table refBaseTable = e1.getKey();
+            Column refPartitionColumn = e1.getValue();
+            collectExternalBaseTablePartitionMapping(refBaseTable, refPartitionColumn, result);
+        }
+    }
+
+    /**
+     * Collect the external base table's partition name to its intersected materialized view names.
+     * @param refBaseTable the base table
+     * @param refTablePartitionColumn the partition column of the base table
+     * @param result the result map
+     * @throws AnalysisException
+     */
+    private static void collectExternalBaseTablePartitionMapping(
+            Table refBaseTable,
+            Column refTablePartitionColumn,
+            Map<Table, Map<String, Set<String>>> result) throws AnalysisException {
+        if (refBaseTable.isNativeTableOrMaterializedView()) {
+            return;
+        }
+        Map<String, Set<String>> mvPartitionNameMap = PartitionUtil.getMVPartitionNameMapOfExternalTable(refBaseTable,
+                refTablePartitionColumn, PartitionUtil.getPartitionNames(refBaseTable));
+        result.put(refBaseTable, mvPartitionNameMap);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffResult.java
@@ -24,14 +24,11 @@ import java.util.Set;
 /**
  * The result of diffing between materialized view and the base tables.
  */
-public class RangePartitionDiffResult {
+public class RangePartitionDiffResult extends PartitionDiffResult {
     // The partition range of the materialized view: <mv partition name, mv partition range>
     public final Map<String, Range<PartitionKey>> mvRangePartitionMap;
     // The partition range of the base tables: <base table, <base table partition name, base table partition range>>
     public final Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap;
-    // For external table, the mapping of base table partition to mv partition:
-    // <base table, <base table partition name, mv partition name>>
-    public final Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap;
     // The diff result of partition range between materialized view and base tables
     public final RangePartitionDiff rangePartitionDiff;
 
@@ -39,9 +36,9 @@ public class RangePartitionDiffResult {
                                     Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap,
                                     Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap,
                                     RangePartitionDiff rangePartitionDiff) {
+        super(refBaseTableMVPartitionMap);
         this.mvRangePartitionMap = mvRangePartitionMap;
         this.refBaseTablePartitionMap = refBaseTablePartitionMap;
-        this.refBaseTableMVPartitionMap = refBaseTableMVPartitionMap;
         this.rangePartitionDiff = rangePartitionDiff;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -58,7 +58,6 @@ import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.DmlStmt;
-import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.RefreshSchemeClause;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.MvRewritePreprocessor;
@@ -854,10 +853,10 @@ public class CreateMaterializedViewTest {
         try {
             CreateMaterializedViewStatement createMaterializedViewStatement =
                     (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            ExpressionPartitionDesc partitionExpDesc = createMaterializedViewStatement.getPartitionExpDesc();
-            Assert.assertFalse(partitionExpDesc.isFunction());
-            Assert.assertTrue(partitionExpDesc.getExpr() instanceof SlotRef);
-            Assert.assertEquals("ss", partitionExpDesc.getSlotRef().getColumnName());
+            Expr partitionByExpr = createMaterializedViewStatement.getPartitionByExpr();
+            Assert.assertTrue(partitionByExpr instanceof SlotRef);
+            SlotRef slotRef = (SlotRef) partitionByExpr;
+            Assert.assertEquals("ss", slotRef.getColumnName());
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -876,10 +875,10 @@ public class CreateMaterializedViewTest {
         try {
             CreateMaterializedViewStatement createMaterializedViewStatement =
                     (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            ExpressionPartitionDesc partitionExpDesc = createMaterializedViewStatement.getPartitionExpDesc();
-            Assert.assertFalse(partitionExpDesc.isFunction());
-            Assert.assertTrue(partitionExpDesc.getExpr() instanceof SlotRef);
-            Assert.assertEquals("ss", partitionExpDesc.getSlotRef().getColumnName());
+            Expr partitionByExpr = createMaterializedViewStatement.getPartitionByExpr();
+            Assert.assertTrue(partitionByExpr instanceof SlotRef);
+            SlotRef slotRef = (SlotRef) partitionByExpr;
+            Assert.assertEquals("ss", slotRef.getColumnName());
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -915,11 +914,12 @@ public class CreateMaterializedViewTest {
         try {
             CreateMaterializedViewStatement createMaterializedViewStatement =
                     (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            ExpressionPartitionDesc partitionExpDesc = createMaterializedViewStatement.getPartitionExpDesc();
-            Assert.assertTrue(partitionExpDesc.isFunction());
-            Assert.assertTrue(partitionExpDesc.getExpr() instanceof FunctionCallExpr);
-            Assert.assertEquals(partitionExpDesc.getExpr().getChild(1), partitionExpDesc.getSlotRef());
-            Assert.assertEquals("ss", partitionExpDesc.getSlotRef().getColumnName());
+            Expr partitionByExpr = createMaterializedViewStatement.getPartitionByExpr();
+            Assert.assertTrue(partitionByExpr instanceof FunctionCallExpr);
+            List<SlotRef> slotRefs = Lists.newArrayList();
+            partitionByExpr.collect(SlotRef.class, slotRefs);
+            Assert.assertEquals(partitionByExpr.getChild(1), slotRefs.get(0));
+            Assert.assertEquals("ss", slotRefs.get(0).getColumnName());
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -939,11 +939,12 @@ public class CreateMaterializedViewTest {
                     "as select a, b, c, d from jdbc0.partitioned_db0.tbl1;";
             CreateMaterializedViewStatement createMaterializedViewStatement =
                     (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            ExpressionPartitionDesc partitionExpDesc = createMaterializedViewStatement.getPartitionExpDesc();
-            Assert.assertTrue(partitionExpDesc.isFunction());
-            Assert.assertTrue(partitionExpDesc.getExpr() instanceof FunctionCallExpr);
-            Assert.assertEquals(partitionExpDesc.getExpr().getChild(0), partitionExpDesc.getSlotRef());
-            Assert.assertEquals("d", partitionExpDesc.getSlotRef().getColumnName());
+            Expr partitionByExpr = createMaterializedViewStatement.getPartitionByExpr();
+            Assert.assertTrue(partitionByExpr instanceof FunctionCallExpr);
+            List<SlotRef> slotRefs = Lists.newArrayList();
+            partitionByExpr.collect(SlotRef.class, slotRefs);
+            Assert.assertEquals(partitionByExpr.getChild(0), slotRefs.get(0));
+            Assert.assertEquals("d", slotRefs.get(0).getColumnName());
         }
 
         // slot
@@ -986,11 +987,12 @@ public class CreateMaterializedViewTest {
         try {
             CreateMaterializedViewStatement createMaterializedViewStatement =
                     (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            ExpressionPartitionDesc partitionExpDesc = createMaterializedViewStatement.getPartitionExpDesc();
-            Assert.assertTrue(partitionExpDesc.isFunction());
-            Assert.assertTrue(partitionExpDesc.getExpr() instanceof FunctionCallExpr);
-            Assert.assertEquals(partitionExpDesc.getExpr().getChild(1), partitionExpDesc.getSlotRef());
-            Assert.assertEquals("k1", partitionExpDesc.getSlotRef().getColumnName());
+            Expr partitionByExpr = createMaterializedViewStatement.getPartitionByExpr();
+            Assert.assertTrue(partitionByExpr instanceof FunctionCallExpr);
+            List<SlotRef> slotRefs = Lists.newArrayList();
+            partitionByExpr.collect(SlotRef.class, slotRefs);
+            Assert.assertEquals(partitionByExpr.getChild(1), slotRefs.get(0));
+            Assert.assertEquals("k1", slotRefs.get(0).getColumnName());
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -1009,11 +1011,12 @@ public class CreateMaterializedViewTest {
         try {
             CreateMaterializedViewStatement createMaterializedViewStatement =
                     (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            ExpressionPartitionDesc partitionExpDesc = createMaterializedViewStatement.getPartitionExpDesc();
-            Assert.assertFalse(partitionExpDesc.isFunction());
-            Assert.assertTrue(partitionExpDesc.getExpr() instanceof SlotRef);
-            Assert.assertEquals(partitionExpDesc.getExpr(), partitionExpDesc.getSlotRef());
-            Assert.assertEquals("k1", partitionExpDesc.getSlotRef().getColumnName());
+            Expr partitionByExpr = createMaterializedViewStatement.getPartitionByExpr();
+            Assert.assertTrue(partitionByExpr instanceof SlotRef);
+            List<SlotRef> slotRefs = Lists.newArrayList();
+            partitionByExpr.collect(SlotRef.class, slotRefs);
+            Assert.assertEquals(partitionByExpr, slotRefs.get(0));
+            Assert.assertEquals("k1", slotRefs.get(0).getColumnName());
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -4775,5 +4778,59 @@ public class CreateMaterializedViewTest {
                 connectContext);
         backend = systemInfoService.getBackend(12011);
         systemInfoService.dropBackend(backend);
+    }
+
+    @Test
+    public void testCreateListPartitionedMVOfOlap() throws Exception {
+        String sql = "CREATE TABLE `s1` (\n" +
+                "   `id` varchar(36),\n" +
+                "   `location_id` varchar(36),\n" +
+                "   `location_id_hash` int,\n" +
+                "   `source_id` varchar(36),\n" +
+                "   `person_id` varchar(36)\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY(`id`,`location_id`,`location_id_hash`)\n" +
+                "PARTITION BY (`location_id_hash`)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "   \"replication_num\" = \"1\"\n" +
+                ");";
+        starRocksAssert.withTable(sql);
+        String mvSql = "create materialized view test_mv1\n" +
+                "PARTITION BY `location_id_hash`\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ") \n" +
+                "as select `id`, `location_id`, `location_id_hash` from `s1`;";
+        starRocksAssert.withMaterializedView(mvSql, () -> {
+            MaterializedView mv = starRocksAssert.getMv("test", "test_mv1");
+            Assert.assertTrue(mv.getPartitionInfo().isListPartition());
+        });
+        starRocksAssert.dropTable("s1");
+    }
+
+    @Test
+    public void testCreateListPartitionedMVOfExternal() throws Exception {
+        String sql = "create materialized view mv1 " +
+                "partition by (d)" +
+                "distributed by hash(a) buckets 10 " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") " +
+                "as select a, b, c, d from jdbc0.partitioned_db0.tbl1;";
+        CreateMaterializedViewStatement stmt =
+                (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        Expr partitionByExpr = stmt.getPartitionByExpr();
+        Assert.assertTrue(partitionByExpr instanceof SlotRef);
+        List<SlotRef> slotRefs = Lists.newArrayList();
+        partitionByExpr.collect(SlotRef.class, slotRefs);
+        Assert.assertEquals(partitionByExpr, slotRefs.get(0));
+        Assert.assertEquals("d", slotRefs.get(0).getColumnName());
+        starRocksAssert.withMaterializedView(sql, () -> {
+            MaterializedView mv = starRocksAssert.getMv("test", "mv1");
+            Assert.assertTrue(mv.getPartitionInfo().isListPartition());
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -429,7 +429,6 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
                 connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(1);
                 validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
                 Assert.assertEquals(1, validMVs.size());
-                Assert.assertTrue(containsMV(validMVs, "mv_3"));
                 connectContext.getSessionVariable().setEnableMaterializedViewPlanCache(true);
 
                 // if mv_3 is in the plan cache

--- a/test/sql/test_materialized_view_refresh/R/test_mv_with_list_partitions_hive
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_with_list_partitions_hive
@@ -1,0 +1,128 @@
+-- name: test_mv_with_list_partitions_hive
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_hive_${uuid0};
+-- result:
+-- !result
+create database mv_hive_db_${uuid0};
+-- result:
+-- !result
+use mv_hive_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+   `id` varchar(36),
+   `location_id` varchar(36),
+   `location_id_hash` int,
+   `source_id` varchar(36),
+   `person_id` varchar(36)
+)
+PARTITION BY (person_id);
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1, 'beijing', 20, 'a', 'a1'), (2, 'guangdong', 30, 'b', 'b1'), (3, 'guangdong', 20, 'c', 'c1');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create materialized view test_mv1
+PARTITION BY `person_id`
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+) 
+as select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2, 3;
+-- result:
+1	beijing	a1
+2	guangdong	b1
+3	guangdong	c1
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='guangdong'", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='beijing'", "test_mv1")
+-- result:
+True
+-- !result
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2, 3;
+-- result:
+1	beijing	a1
+2	guangdong	b1
+3	guangdong	c1
+-- !result
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='guangdong' order by 1, 2, 3;
+-- result:
+2	guangdong	b1
+3	guangdong	c1
+-- !result
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='beijing' order by 1, 2, 3;
+-- result:
+1	beijing	a1
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (3, 'guangdong', 30, 'c', 'c1');
+-- result:
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='guangdong'", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='beijing'", "test_mv1")
+-- result:
+True
+-- !result
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2, 3;
+-- result:
+1	beijing	a1
+2	guangdong	b1
+3	guangdong	c1
+3	guangdong	c1
+-- !result
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='guangdong' order by 1, 2, 3;
+-- result:
+2	guangdong	b1
+3	guangdong	c1
+3	guangdong	c1
+-- !result
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='beijing' order by 1, 2, 3;
+-- result:
+1	beijing	a1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop database default_catalog.db_${uuid0} force;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_with_list_partitions_iceberg
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_with_list_partitions_iceberg
@@ -1,0 +1,128 @@
+-- name: test_mv_with_list_partitions_iceberg
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+use mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+   `id` varchar(36),
+   `location_id` varchar(36),
+   `location_id_hash` int,
+   `source_id` varchar(36),
+   `person_id` varchar(36)
+)
+PARTITION BY (person_id);
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1, 'beijing', 20, 'a', 'a1'), (2, 'guangdong', 30, 'b', 'b1'), (3, 'guangdong', 20, 'c', 'c1');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create materialized view test_mv1
+PARTITION BY `person_id`
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+) 
+as select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2, 3;
+-- result:
+1	beijing	a1
+2	guangdong	b1
+3	guangdong	c1
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='guangdong'", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='beijing'", "test_mv1")
+-- result:
+True
+-- !result
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 order by 1, 2, 3;
+-- result:
+1	beijing	a1
+2	guangdong	b1
+3	guangdong	c1
+-- !result
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='guangdong' order by 1, 2, 3;
+-- result:
+2	guangdong	b1
+3	guangdong	c1
+-- !result
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='beijing' order by 1, 2, 3;
+-- result:
+1	beijing	a1
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES (3, 'guangdong', 30, 'c', 'c1');
+-- result:
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='guangdong'", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='beijing'", "test_mv1")
+-- result:
+True
+-- !result
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 order by 1, 2, 3;
+-- result:
+1	beijing	a1
+2	guangdong	b1
+3	guangdong	c1
+3	guangdong	c1
+-- !result
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='guangdong' order by 1, 2, 3;
+-- result:
+2	guangdong	b1
+3	guangdong	c1
+3	guangdong	c1
+-- !result
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='beijing' order by 1, 2, 3;
+-- result:
+1	beijing	a1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop database default_catalog.db_${uuid0} force;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_with_list_partitions_olap
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_with_list_partitions_olap
@@ -1,0 +1,94 @@
+-- name: test_mv_with_list_partitions_olap
+CREATE TABLE `t1` (
+   `id` varchar(36),
+   `location_id` varchar(36),
+   `location_id_hash` int,
+   `source_id` varchar(36),
+   `person_id` varchar(36)
+) ENGINE=OLAP
+PRIMARY KEY(`id`,`location_id`,`location_id_hash`)
+PARTITION BY (`location_id_hash`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+   "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1, 'beijing', 20, 'a', 'a1'), (2, 'guangdong', 30, 'b', 'b1'), (3, 'guangdong', 20, 'c', 'c1');
+-- result:
+-- !result
+create materialized view test_mv1
+PARTITION BY `location_id_hash`
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+) 
+as select `id`, `location_id`, `location_id_hash` from `t1`;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select * from test_mv1 order by 1, 2, 3;
+-- result:
+1	beijing	20
+2	guangdong	30
+3	guangdong	20
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1`", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1` where location_id='guangdong'", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1` where location_id='beijing'", "test_mv1")
+-- result:
+True
+-- !result
+select `id`, `location_id`, `location_id_hash` from `t1` order by 1, 2, 3;
+-- result:
+1	beijing	20
+2	guangdong	30
+3	guangdong	20
+-- !result
+select `id`, `location_id`, `location_id_hash` from `t1` where location_id='guangdong' order by 1, 2, 3;
+-- result:
+2	guangdong	30
+3	guangdong	20
+-- !result
+select `id`, `location_id`, `location_id_hash` from `t1` where location_id='beijing' order by 1, 2, 3;
+-- result:
+1	beijing	20
+-- !result
+INSERT INTO t1 VALUES (3, 'guangdong', 30, 'c', 'c1');
+-- result:
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1`", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1` where location_id='guangdong'", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1` where location_id='beijing'", "test_mv1")
+-- result:
+True
+-- !result
+select `id`, `location_id`, `location_id_hash` from `t1` order by 1, 2, 3;
+-- result:
+1	beijing	20
+2	guangdong	30
+3	guangdong	20
+3	guangdong	30
+-- !result
+select `id`, `location_id`, `location_id_hash` from `t1` where location_id='guangdong' order by 1, 2, 3;
+-- result:
+2	guangdong	30
+3	guangdong	20
+3	guangdong	30
+-- !result
+select `id`, `location_id`, `location_id_hash` from `t1` where location_id='beijing' order by 1, 2, 3;
+-- result:
+1	beijing	20
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_with_list_partitions_hive
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_with_list_partitions_hive
@@ -1,0 +1,62 @@
+-- name: test_mv_with_list_partitions_hive
+
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+
+
+-- create hive table
+set catalog mv_hive_${uuid0};
+create database mv_hive_db_${uuid0};
+use mv_hive_db_${uuid0};
+
+CREATE TABLE t1 (
+   `id` varchar(36),
+   `location_id` varchar(36),
+   `location_id_hash` int,
+   `source_id` varchar(36),
+   `person_id` varchar(36)
+)
+PARTITION BY (person_id);
+INSERT INTO t1 VALUES (1, 'beijing', 20, 'a', 'a1'), (2, 'guangdong', 30, 'b', 'b1'), (3, 'guangdong', 20, 'c', 'c1');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+create materialized view test_mv1
+PARTITION BY `person_id`
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+) 
+as select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1;
+
+refresh materialized view  test_mv1 with sync mode;
+
+select * from test_mv1 order by 1, 2, 3;
+
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='guangdong'", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='beijing'", "test_mv1")
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2, 3;
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='guangdong' order by 1, 2, 3;
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='beijing' order by 1, 2, 3;
+
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (3, 'guangdong', 30, 'c', 'c1');
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='guangdong'", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='beijing'", "test_mv1")
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2, 3;
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='guangdong' order by 1, 2, 3;
+select `id`, `location_id`, `person_id` from mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where location_id='beijing' order by 1, 2, 3;
+
+
+drop materialized view test_mv1;
+drop database default_catalog.db_${uuid0} force;
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
+drop database mv_hive_${uuid0}.mv_hive_db_${uuid0} force;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_with_list_partitions_iceberg
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_with_list_partitions_iceberg
@@ -1,0 +1,61 @@
+-- name: test_mv_with_list_partitions_iceberg
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+-- create iceberg table
+set catalog mv_iceberg_${uuid0};
+create database mv_iceberg_db_${uuid0};
+use mv_iceberg_db_${uuid0};
+
+CREATE TABLE t1 (
+   `id` varchar(36),
+   `location_id` varchar(36),
+   `location_id_hash` int,
+   `source_id` varchar(36),
+   `person_id` varchar(36)
+)
+PARTITION BY (person_id);
+INSERT INTO t1 VALUES (1, 'beijing', 20, 'a', 'a1'), (2, 'guangdong', 30, 'b', 'b1'), (3, 'guangdong', 20, 'c', 'c1');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+create materialized view test_mv1
+PARTITION BY `person_id`
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+) 
+as select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1;
+
+refresh materialized view  test_mv1 with sync mode;
+
+select * from test_mv1 order by 1, 2, 3;
+
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='guangdong'", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='beijing'", "test_mv1")
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 order by 1, 2, 3;
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='guangdong' order by 1, 2, 3;
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='beijing' order by 1, 2, 3;
+
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES (3, 'guangdong', 30, 'c', 'c1');
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='guangdong'", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='beijing'", "test_mv1")
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 order by 1, 2, 3;
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='guangdong' order by 1, 2, 3;
+select `id`, `location_id`, `person_id` from mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 where location_id='beijing' order by 1, 2, 3;
+
+
+drop materialized view test_mv1;
+drop database default_catalog.db_${uuid0} force;
+drop table mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0} force;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_with_list_partitions_olap
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_with_list_partitions_olap
@@ -1,0 +1,44 @@
+-- name: test_mv_with_list_partitions_olap
+
+CREATE TABLE `t1` (
+   `id` varchar(36),
+   `location_id` varchar(36),
+   `location_id_hash` int,
+   `source_id` varchar(36),
+   `person_id` varchar(36)
+) ENGINE=OLAP
+PRIMARY KEY(`id`,`location_id`,`location_id_hash`)
+PARTITION BY (`location_id_hash`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+   "replication_num" = "1"
+);
+INSERT INTO t1 VALUES (1, 'beijing', 20, 'a', 'a1'), (2, 'guangdong', 30, 'b', 'b1'), (3, 'guangdong', 20, 'c', 'c1');
+
+create materialized view test_mv1
+PARTITION BY `location_id_hash`
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+    "replication_num" = "1"
+) 
+as select `id`, `location_id`, `location_id_hash` from `t1`;
+
+refresh materialized view  test_mv1 with sync mode;
+
+select * from test_mv1 order by 1, 2, 3;
+
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1`", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1` where location_id='guangdong'", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1` where location_id='beijing'", "test_mv1")
+select `id`, `location_id`, `location_id_hash` from `t1` order by 1, 2, 3;
+select `id`, `location_id`, `location_id_hash` from `t1` where location_id='guangdong' order by 1, 2, 3;
+select `id`, `location_id`, `location_id_hash` from `t1` where location_id='beijing' order by 1, 2, 3;
+
+INSERT INTO t1 VALUES (3, 'guangdong', 30, 'c', 'c1');
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1`", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1` where location_id='guangdong'", "test_mv1")
+function: print_hit_materialized_view("select `id`, `location_id`, `location_id_hash` from `t1` where location_id='beijing'", "test_mv1")
+select `id`, `location_id`, `location_id_hash` from `t1` order by 1, 2, 3;
+select `id`, `location_id`, `location_id_hash` from `t1` where location_id='guangdong' order by 1, 2, 3;
+select `id`, `location_id`, `location_id_hash` from `t1` where location_id='beijing' order by 1, 2, 3;
+


### PR DESCRIPTION
## Why I'm doing:
- Even though list partition for mv has been supported, but this case will still fail:
```
CREATE TABLE `t1` (
   `id` varchar(36),
   `location_id` varchar(36),
   `location_id_hash` int,
   `source_id` varchar(36),
   `person_id` varchar(36)
) ENGINE=OLAP
PRIMARY KEY(`id`,`location_id`,`location_id_hash`)
PARTITION BY (`location_id_hash`)
DISTRIBUTED BY HASH(`id`) BUCKETS 3
PROPERTIES (
   "replication_num" = "1"
);

create materialized view test_mv1
PARTITION BY `location_id_hash`
DISTRIBUTED BY HASH(`id`) BUCKETS 3
PROPERTIES (
    "replication_num" = "1"
) 
as select `id`, `location_id`, `location_id_hash` from `t1`;
```

This is because StarRocks only supports list partition mv for olap table with string table, we can support more patterns for list partition mvs.

## What I'm doing:
1. Support more patterns for list partition mvs:
  -  ref base table is OlapTable with non-string partition column types;
  - ref base table is hive/iceberg table with string column types and without `str2date` function exprs.
2. Add more list partition mv test cases:
  - ref base table is OlapTable with non-string partition column types;
  - ref base table is hive/iceberg table with string column types.

TODO:
- we can support more partition patterns for list mv later.

Fixes https://github.com/StarRocks/starrocks/issues/46087

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
