### PR TITLE
[BugFix] Fix REPLACE constant fold (backport #50828)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -1303,7 +1303,8 @@ public class ScalarOperatorFunctions {
     @ConstantFunction(name = "replace", argTypes = {VARCHAR, VARCHAR, VARCHAR}, returnType = VARCHAR)
     public static ConstantOperator replace(ConstantOperator value, ConstantOperator target,
                                            ConstantOperator replacement) {
-        return ConstantOperator.createVarchar(value.getVarchar().replace(target.getVarchar(), replacement.getVarchar()));
+        return ConstantOperator.createVarchar(
+                StringUtils.replace(value.getVarchar(), target.getVarchar(), replacement.getVarchar()));
     }
 
     private static ConstantOperator createDecimalConstant(BigDecimal result) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -1431,11 +1431,21 @@ public class ScalarOperatorFunctionsTest {
 
     @Test
     public void testReplace() {
-        assertEquals("20240806", ScalarOperatorFunctions.replace(
-                new ConstantOperator("2024-08-06", Type.VARCHAR),
-                new ConstantOperator("-", Type.VARCHAR),
-                new ConstantOperator("", Type.VARCHAR)
-        ).getVarchar());
+        // arg0, arg1, arg2, expected_result
+        String[][] testCases = {
+                {"2024-08-06", "-", "", "20240806"},
+                {"abc def ghi", "", "1234", "abc def ghi"},
+                {"abc def ghi abc", "abc", "1234", "1234 def ghi 1234"},
+                {"", "abc", "1234", ""}
+        };
+
+        for (String[] tc : testCases) {
+            assertEquals("Test case: " + Arrays.toString(tc), tc[3], ScalarOperatorFunctions.replace(
+                    new ConstantOperator(tc[0], Type.VARCHAR),
+                    new ConstantOperator(tc[1], Type.VARCHAR),
+                    new ConstantOperator(tc[2], Type.VARCHAR)
+            ).getVarchar());
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -455,4 +455,37 @@ public class ConstantExpressionTest extends PlanTestBase {
         }
     }
 
+    @Test
+    public void testReplace() throws Exception {
+        {
+            String plan = getFragmentPlan("SELECT REPLACE('abc def ghi abc', '', '1234')");
+            assertContains(plan, "<slot 2> : 'abc def ghi abc'");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT REPLACE('abc def ghi abc', 'abc', '1234')");
+            assertContains(plan, "<slot 2> : '1234 def ghi 1234'");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT REPLACE('', 'abc', '1234')");
+            assertContains(plan, "<slot 2> : ''");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT REPLACE(NULL, 'abc', '1234')");
+            assertContains(plan, "<slot 2> : NULL");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT REPLACE('abc def ghi abc', NULL, '1234')");
+            assertContains(plan, "<slot 2> : NULL");
+        }
+
+        {
+            String plan = getFragmentPlan("SELECT REPLACE('abc def ghi abc', 'abc', NULL)");
+            assertContains(plan, "<slot 2> : NULL");
+        }
+
+    }
 }


### PR DESCRIPTION
CP from #50828.


## Why I'm doing:
The behaviour of the Java native method `String::replace(target, replacement)` is different from that of BE.

It considers the empty target string `""` as a valid character sequence and inserts the `replacement` string to each gap between chars.

```
select REPLACE( "foo bar bar" ,  "" ,  "123" );
+-------------------------------------------------+
| replace('foo bar bar', '', '123')               |
+-------------------------------------------------+
| 123f123o123o123 123b123a123r123 123b123a123r123 |
+-------------------------------------------------+

explain select REPLACE( "foo bar bar" ,  "" ,  "123" );
+-------------------------------------------------------------------+
| Explain String                                                    |
+-------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                   |
|  OUTPUT EXPRS:2: replace                                          |
|   PARTITION: UNPARTITIONED                                        |
|                                                                   |
|   RESULT SINK                                                     |
|                                                                   |
|   1:Project                                                       |
|   |  <slot 2> : '123f123o123o123 123b123a123r123 123b123a123r123' |
|   |                                                               |
|   0:UNION                                                         |
|      constant exprs:                                              |
|          NULL                                                     |
+-------------------------------------------------------------------+
```

## What I'm doing:
Use `org.apache.commons.lang.String::replace` instead of Java native version.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

