### PR TITLE
[BugFix] RangePredicateExtractor discard predicates mistakenly

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
@@ -14,12 +14,17 @@
 
 package com.starrocks.sql.optimizer.rewrite;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.BinaryType;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.BetweenPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
@@ -34,6 +39,10 @@ import com.starrocks.sql.optimizer.rewrite.scalar.ReduceCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -162,5 +171,33 @@ public class ScalarOperatorRewriterTest {
         ScalarOperator rewritten2 = new ScalarOperatorRewriter()
                 .rewrite(isnotNull, ScalarOperatorRewriter.DEFAULT_REWRITE_SCAN_PREDICATE_RULES);
         Assert.assertEquals(ConstantOperator.TRUE, rewritten2);
+    }
+
+    @Test
+    public void testRangeExtract() {
+        Supplier<ScalarOperator> predicate1Maker = () -> {
+            ColumnRefOperator col1 = new ColumnRefOperator(1, Type.DATE, "dt", false);
+            CallOperator call = new CallOperator(FunctionSet.DATE_TRUNC, Type.DATE,
+                    Arrays.asList(ConstantOperator.createVarchar("YEAR"), col1));
+            return new BinaryPredicateOperator(BinaryType.EQ, call, ConstantOperator.createDate(
+                    LocalDateTime.of(2024, 1, 1, 0, 0, 0)));
+        };
+
+        Supplier<ScalarOperator> predicate2Maker = () -> {
+            ColumnRefOperator col2 = new ColumnRefOperator(2, Type.VARCHAR, "mode", false);
+            return new BinaryPredicateOperator(BinaryType.EQ, col2, ConstantOperator.createVarchar("Buzz"));
+        };
+
+        ScalarOperator predicate1 = Utils.compoundAnd(predicate1Maker.get(), predicate2Maker.get());
+        ScalarOperator predicate2 = Utils.compoundAnd(predicate1Maker.get(), predicate2Maker.get());
+        ScalarOperator predicates = Utils.compoundAnd(predicate1, predicate2);
+
+        ScalarRangePredicateExtractor rangeExtractor = new ScalarRangePredicateExtractor();
+        ScalarOperator result = rangeExtractor.rewriteOnlyColumn(Utils.compoundAnd(Utils.extractConjuncts(predicates)
+                .stream().map(rangeExtractor::rewriteOnlyColumn).collect(Collectors.toList())));
+        Preconditions.checkState(result != null);
+        String expect = "date_trunc(YEAR, 1: dt) = 2024-01-01 AND 2: mode = Buzz";
+        String actual = result.toString();
+        Assert.assertEquals(actual, expect, actual);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneUKFKJoinRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneUKFKJoinRuleTest.java
@@ -137,7 +137,7 @@ public class PruneUKFKJoinRuleTest extends TPCDSPlanTestBase {
                     "t_uk join t_fk on t_uk.v1 = t_fk.v1 and t_fk.v1 = 5";
             String plan = getFragmentPlan(sql);
             assertNotContains(plan, "HASH JOIN");
-            assertNotContains(plan, "v1 IS NOT NULL");
+            assertContains(plan, "v1 IS NOT NULL");
             assertContains(plan, "4: v1 = 5");
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -1799,10 +1799,10 @@ public class SubqueryTest extends PlanTestBase {
 
         String sql = "select v1 from t0 where v1 = 1 or v2 in (select v4 from t1 where v2 = v4 and v5 = 1)";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "15:AGGREGATE (merge finalize)\n" +
-                "  |  group by: 8: v4\n" +
-                "  |  \n" +
-                "  14:EXCHANGE");
+        assertContains(plan, "  |----15:AGGREGATE (merge finalize)\n" +
+                "  |    |  group by: 8: v4\n" +
+                "  |    |  \n" +
+                "  |    14:EXCHANGE");
         assertContains(plan, "9:HASH JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN (BUCKET_SHUFFLE(S))\n" +
                 "  |  colocate: false, reason: \n" +
@@ -1823,16 +1823,23 @@ public class SubqueryTest extends PlanTestBase {
                 "or v2 in (select v4 from t1 where v2 = v4 and v5 = 1)";
 
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "33:AGGREGATE (merge finalize)\n" +
-                "  |  group by: 12: v4\n" +
+        assertContains(plan, "  |----32:AGGREGATE (merge finalize)\n" +
+                "  |    |  group by: 12: v4\n" +
+                "  |    |  \n" +
+                "  |    31:EXCHANGE");
+        assertContains(plan, "  27:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 7> : 7: expr\n" +
+                "  |  <slot 15> : 15: countRows\n" +
+                "  |  <slot 16> : 16: countNotNulls\n" +
                 "  |  \n" +
-                "  32:EXCHANGE");
-        assertContains(plan, "27:HASH JOIN\n" +
+                "  26:HASH JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN (BUCKET_SHUFFLE(S))\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 14: v4 = 2: v2\n" +
                 "  |  \n" +
-                "  |----26:EXCHANGE\n" +
+                "  |----25:EXCHANGE\n" +
                 "  |    \n" +
                 "  6:AGGREGATE (merge finalize)\n" +
                 "  |  output: count(15: countRows), count(16: countNotNulls)\n" +


### PR DESCRIPTION
## Why I'm doing:
Fix bug: https://github.com/StarRocks/starrocks/issues/50311
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
