### PR TITLE
[Enhancement] optimize show create routine load result(escape column name)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1194,7 +1194,7 @@ public class ShowExecutor {
                 List<ImportColumnDesc> descs = routineLoadJob.getColumnDescs();
                 for (int i = 0; i < descs.size(); i++) {
                     ImportColumnDesc desc = descs.get(i);
-                    createRoutineLoadSql.append(desc.toString());
+                    createRoutineLoadSql.append(desc.toSql());
                     if (descs.size() == 1 || i == descs.size() - 1) {
                         createRoutineLoadSql.append(")");
                     } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ImportColumnDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ImportColumnDesc.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.ParseNode;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.parser.NodePosition;
 
 public class ImportColumnDesc implements ParseNode {
@@ -70,6 +71,15 @@ public class ImportColumnDesc implements ParseNode {
         sb.append(columnName);
         if (expr != null) {
             sb.append("=").append(expr.toSql());
+        }
+        return sb.toString();
+    }
+
+    public String toSql() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("`").append(columnName).append("`");
+        if (expr != null) {
+            sb.append("=").append(AstToSQLBuilder.toSQL(expr));
         }
         return sb.toString();
     }


### PR DESCRIPTION
## Why I'm doing:

As #27638 described, show create routine load result COLUMNS doesn't quote column name, when column name is starrocks keyword, execute show result in console will failed.

```sql
mysql> CREATE ROUTINE LOAD hoffertest.sr_pulsar_08 on olap_tbl_02
    ->  COLUMNS TERMINATED BY '|',
    -> COLUMNS (rank, dteventtime, f_date, f_int, f_bigint, f_double, f_boolean, f_decimal,event_left=left(rank, 3))
    -> PROPERTIES
    -> (
    -> "desired_concurrent_number"="2",
    -> "max_error_number"="1000",
    -> "max_filter_ratio"="1.0",
    -> "max_batch_interval"="18",
    -> "max_batch_rows"="30000000",
    -> "format"="csv",
    -> "jsonpaths"="",
    -> "strip_outer_array"="false",
    -> "json_root"="",
    -> "strict_mode"="false",
    -> "timezone"="Asia/Shanghai",
    -> "partial_update"="false"
    -> )
    -> FROM PULSAR
    -> (
    ->   "pulsar_service_url"="pulsar://127.0.0.1:6650",
    ->   "pulsar_topic"="persistent://public/default/my-topic",
    ->   "pulsar_subscription"="sr_pulsar_01",
    ->   "property.pulsar_default_position"="POSITION_EARLIEST"
    -> );
No connection. Trying to reconnect...
Connection id:    0
Current database: hoffertest

ERROR 1064 (HY000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'rank' at line 3
```

## What I'm doing:

optimize show create routine load result by escape column name

```sql
mysql> show create routine load sr_pulsar_05 \G
*************************** 1. row ***************************
       Job: sr_pulsar_05
Create Job: CREATE ROUTINE LOAD hoffertest.sr_pulsar_05 on olap_tbl_02
COLUMNS TERMINATED BY '|',
COLUMNS (`rank`, `dteventtime`, `f_date`, `f_int`, `f_bigint`, `f_double`, `f_boolean`, `f_decimal`, `event_left`=left(`rank`, 3))
PROPERTIES
(
  "desired_concurrent_number"="2",
  "max_error_number"="1000",
  "max_filter_ratio"="1.0",
  "max_batch_interval"="18",
  "max_batch_rows"="30000000",
  "format"="csv",
  "jsonpaths"="",
  "strip_outer_array"="false",
  "json_root"="",
  "strict_mode"="false",
  "timezone"="Asia/Shanghai",
  "partial_update"="false"
)
FROM PULSAR
(
  "pulsar_service_url"="pulsar://127.0.0.1:6650",
  "pulsar_topic"="persistent://public/default/my-topic",
  "pulsar_subscription"="sr_pulsar_01",
  "property.pulsar_default_position"="POSITION_EARLIEST"
);
1 row in set (0.03 sec)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5