### PR TITLE
[BugFix] Make create_directories compatible with symbolic links

### DIFF
--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -535,7 +535,7 @@ public:
         // all the other platforms.
         if (std::filesystem::is_symlink(dirname)) {
             char real_path[PATH_MAX];
-            char *result = realpath(dirname, real_path);
+            char* result = realpath(dirname, real_path);
             if (result == NULL) {
                 return io_error(fmt::format("create {} recursively", dirname), errno);
             }

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -10,11 +10,14 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <fmt/format.h>
+#include <limits.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <cstdio>
 #include <filesystem>
 #include <memory>
@@ -525,6 +528,24 @@ public:
     }
 
     Status create_dir_recursive(const std::string& dirname) override {
+        // Should be compatible with the scenario where `dirname` exists as a symbolic link
+        // and linked to an existing directory.
+        // On CentOS create_directories() will fail in this situation, but on Ubuntu, it won't.
+        // So we make a precheck here in order to have the same expected behavior on both and probably
+        // all the other platforms.
+        if (std::filesystem::is_symlink(dirname)) {
+            char real_path[PATH_MAX];
+            char *result = realpath(dirname, real_path);
+            if (result == NULL) {
+                return io_error(fmt::format("create {} recursively", dirname), errno);
+            }
+            if (std::filesystem::is_directory(real_path)) {
+                return Status::OK();
+            } else {
+                return io_error(fmt::format("create {} recursively", dirname), ENOTDIR);
+            }
+        }
+
         std::error_code ec;
         // If `dirname` already exist and is a directory, the return value would be false and ec.value() would be 0
         (void)std::filesystem::create_directories(dirname, ec);

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -10,15 +10,15 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <fmt/format.h>
-#include <limits.h>
-#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
 
 #include <cerrno>
+#include <climits>
 #include <cstdio>
+#include <cstdlib>
 #include <filesystem>
 #include <memory>
 
@@ -535,8 +535,8 @@ public:
         // all the other platforms.
         if (std::filesystem::is_symlink(dirname)) {
             char real_path[PATH_MAX];
-            char* result = realpath(dirname, real_path);
-            if (result == NULL) {
+            char* result = realpath(dirname.c_str(), real_path);
+            if (result == nullptr) {
                 return io_error(fmt::format("create {} recursively", dirname), errno);
             }
             if (std::filesystem::is_directory(real_path)) {

--- a/be/test/fs/fs_posix_test.cpp
+++ b/be/test/fs/fs_posix_test.cpp
@@ -321,6 +321,7 @@ TEST_F(PosixFileSystemTest, create_dir_recursive) {
     // Clean.
     ASSERT_OK(FileSystem::Default()->delete_dir_recursive(dir_path));
     ASSERT_TRUE(FileSystem::Default()->path_exists(dir_path).is_not_found());
+    ASSERT_TRUE(std::filesystem::remove("./ut_dir/fs_posix/soft_link_to_d"));
 }
 
 TEST_F(PosixFileSystemTest, iterate_dir2) {

--- a/be/test/fs/fs_posix_test.cpp
+++ b/be/test/fs/fs_posix_test.cpp
@@ -35,6 +35,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <filesystem>
 
 #include "common/logging.h"
 #include "fs/encrypt_file.h"
@@ -313,13 +314,13 @@ TEST_F(PosixFileSystemTest, create_dir_recursive) {
     ASSERT_TRUE(FileSystem::Default()->is_directory("./ut_dir/fs_posix/a/b/c/d").value());
 
     // Create soft link ./ut_dir/fs_posix/soft_link_to_d -> ./ut_dir/fs_posix/a/b/c/d.
-    FileSystem::Default()->create_directory_symlink("./ut_dir/fs_posix/a/b/c/d", "./ut_dir/fs_posix/soft_link_to_d");
+    std::filesystem::create_directory_symlink("./ut_dir/fs_posix/a/b/c/d", "./ut_dir/fs_posix/soft_link_to_d");
     ASSERT_OK(FileSystem::Default()->create_dir_recursive("./ut_dir/fs_posix/soft_link_to_d"));
 
     // Clean.
     ASSERT_OK(FileSystem::Default()->delete_dir_recursive(dir_path));
     ASSERT_TRUE(FileSystem::Default()->path_exists(dir_path).is_not_found());
-    ASSERT_TRUE(FileSystem::Default()->remove("./ut_dir/fs_posix/soft_link_to_d"));
+    ASSERT_TRUE(std::filesystem::remove("./ut_dir/fs_posix/soft_link_to_d"));
 }
 
 TEST_F(PosixFileSystemTest, iterate_dir2) {

--- a/be/test/fs/fs_posix_test.cpp
+++ b/be/test/fs/fs_posix_test.cpp
@@ -314,13 +314,13 @@ TEST_F(PosixFileSystemTest, create_dir_recursive) {
     ASSERT_TRUE(FileSystem::Default()->is_directory("./ut_dir/fs_posix/a/b/c/d").value());
 
     // Create soft link ./ut_dir/fs_posix/soft_link_to_d -> ./ut_dir/fs_posix/a/b/c/d.
-    std::filesystem::create_directory_symlink("./ut_dir/fs_posix/a/b/c/d", "./ut_dir/fs_posix/soft_link_to_d");
+    std::filesystem::create_directory_symlink(std::filesystem::absolute("./ut_dir/fs_posix/a/b/c/d"),
+                                              "./ut_dir/fs_posix/soft_link_to_d");
     ASSERT_OK(FileSystem::Default()->create_dir_recursive("./ut_dir/fs_posix/soft_link_to_d"));
 
     // Clean.
     ASSERT_OK(FileSystem::Default()->delete_dir_recursive(dir_path));
     ASSERT_TRUE(FileSystem::Default()->path_exists(dir_path).is_not_found());
-    ASSERT_TRUE(std::filesystem::remove("./ut_dir/fs_posix/soft_link_to_d"));
 }
 
 TEST_F(PosixFileSystemTest, iterate_dir2) {

--- a/be/test/fs/fs_posix_test.cpp
+++ b/be/test/fs/fs_posix_test.cpp
@@ -312,8 +312,14 @@ TEST_F(PosixFileSystemTest, create_dir_recursive) {
     ASSERT_TRUE(FileSystem::Default()->is_directory("./ut_dir/fs_posix/a/b/c").value());
     ASSERT_TRUE(FileSystem::Default()->is_directory("./ut_dir/fs_posix/a/b/c/d").value());
 
+    // Create soft link ./ut_dir/fs_posix/soft_link_to_d -> ./ut_dir/fs_posix/a/b/c/d.
+    FileSystem::Default()->create_directory_symlink("./ut_dir/fs_posix/a/b/c/d", "./ut_dir/fs_posix/soft_link_to_d");
+    ASSERT_OK(FileSystem::Default()->create_dir_recursive("./ut_dir/fs_posix/soft_link_to_d"));
+
+    // Clean.
     ASSERT_OK(FileSystem::Default()->delete_dir_recursive(dir_path));
     ASSERT_TRUE(FileSystem::Default()->path_exists(dir_path).is_not_found());
+    ASSERT_TRUE(FileSystem::Default()->remove("./ut_dir/fs_posix/soft_link_to_d"));
 }
 
 TEST_F(PosixFileSystemTest, iterate_dir2) {


### PR DESCRIPTION
## Why I'm doing:
```
E20240904 23:24:35.532979 140392654292800 starrocks_be.cpp:269] BE http server did not start correctly, exiting: create /opt/starrocks/app/be/log recursive: Not a directory
E20240904 23:24:35.532979 140392654292800 starrocks_be.cpp:269] BE http server did not start correctly, exiting: create /opt/starrocks/app/be/log recursive: Not a directory
E20240904 23:24:35.532979 140392654292800 starrocks_be.cpp:269] BE http server did not start correctly, exiting: create /opt/starrocks/app/be/log recursive: Not a directory
```

## What I'm doing:
create_directories() should be compatible with the scenario where `dirname` exists as a symbolic link
and linked to an existing directory. On CentOS create_directories() will fail in this situation,
but on Ubuntu, it won't. So we make a precheck here in order to have the same expected behavior
on both and probably all the other platforms.

Fixes #45518

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
