### PR TITLE
[Enhancement]  Implement trino to_unixtime funtion in timestamp with timezone case

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -93,7 +93,7 @@ public class TimeUtils {
     // A regular expressions that will support the pattern like ('Date/DateTime TimeZone').
     // For example ('2024-09-09 11:40:40.123 Asia/Shanghai'), ('2024-09-09 Asia/Shanghai').
     public static final Pattern DATETIME_WITH_TIME_ZONE_PATTERN =
-            Pattern.compile( "(?<year>[-+]?\\d{4,})-(?<month>\\d{1,2})-(?<day>\\d{1,2})"
+            Pattern.compile("(?<year>[-+]?\\d{4,})-(?<month>\\d{1,2})-(?<day>\\d{1,2})"
                     + "( (?:(?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?"
                     + "\\s*(?<timezone>.+)?)?");
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -89,6 +89,13 @@ public class TimeUtils {
                     + "[\\-\\/\\s]?((0?[1-9])|([1-2][0-9])|(3[01])))|(((0?[469])|(11))[\\-\\/\\s]?"
                     + "((0?[1-9])|([1-2][0-9])|(30)))|(0?2[\\-\\/\\s]?((0?[1-9])|(1[0-9])|(2[0-8]))))))"
                     + "(\\s(((0?[0-9])|([1][0-9])|([2][0-3]))\\:([0-5]?[0-9])((\\s)|(\\:([0-5]?[0-9])))))?$");
+    
+    // A regular expressions that will support the pattern like ('Date/DateTime TimeZone').
+    // For example ('2024-09-09 11:40:40.123 Asia/Shanghai'), ('2024-09-09 Asia/Shanghai').
+    public static final Pattern DATETIME_WITH_TIME_ZONE_PATTERN =
+            Pattern.compile( "(?<year>[-+]?\\d{4,})-(?<month>\\d{1,2})-(?<day>\\d{1,2})"
+                    + "( (?:(?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?"
+                    + "\\s*(?<timezone>.+)?)?");
 
     private static final Pattern TIMEZONE_OFFSET_FORMAT_REG = Pattern.compile("^[+-]{0,1}\\d{1,2}\\:\\d{2}$");
 
@@ -356,5 +363,40 @@ public class TimeUtils {
             timezone = VariableMgr.getDefaultSessionVariable().getTimeZone();
         }
         return timezone;
+    }
+    
+    /**
+     * Parse the time zone of the given timestampLiteral
+     * using DATETIME_WITH_TIME_ZONE_PATTERN regular expressions
+     *
+     * @param value the value of the timestampLiteral
+     * @return `null` or zone id of the parsed timezone
+     */
+    public static ZoneId parseTimeZoneFromString(String value) {
+        Matcher matcher = DATETIME_WITH_TIME_ZONE_PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid TIMESTAMP:" + value);
+        }
+        String timeZone = matcher.group("timezone");
+        return timeZone == null ? null : ZoneId.of(timeZone);
+    }
+    
+    /**
+     * Parse the date or dateTime string of the given timestampLiteral
+     * using DATETIME_WITH_TIME_ZONE_PATTERN regular expressions
+     *
+     * @param value the value of the timestampLiteral
+     * @return the date or dateTime string
+     */
+    public static String parseDateTimeFromString(String value) {
+        Matcher matcher = DATETIME_WITH_TIME_ZONE_PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid TIMESTAMP:" + value);
+        }
+        int timezoneStart = matcher.start("timezone");
+        if (timezoneStart != -1) {
+            return value.substring(0, timezoneStart).trim();
+        }
+        return value;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -187,7 +187,6 @@ import io.trino.sql.tree.WithQuery;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -55,6 +55,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TimestampArithmeticExpr;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.analysis.VarBinaryLiteral;
+import com.starrocks.analysis.VariableExpr;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.PrimitiveType;
@@ -186,6 +187,8 @@ import io.trino.sql.tree.WithQuery;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.DateTimeException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -200,6 +203,8 @@ import static com.starrocks.analysis.AnalyticWindow.BoundaryType.FOLLOWING;
 import static com.starrocks.analysis.AnalyticWindow.BoundaryType.PRECEDING;
 import static com.starrocks.analysis.AnalyticWindow.BoundaryType.UNBOUNDED_FOLLOWING;
 import static com.starrocks.analysis.AnalyticWindow.BoundaryType.UNBOUNDED_PRECEDING;
+import static com.starrocks.common.util.TimeUtils.parseDateTimeFromString;
+import static com.starrocks.common.util.TimeUtils.parseTimeZoneFromString;
 import static com.starrocks.connector.parser.trino.TrinoParserUtils.alignWithInputDatetimeType;
 import static com.starrocks.connector.trino.TrinoParserUnsupportedException.trinoParserUnsupportedException;
 import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
@@ -979,10 +984,17 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     protected ParseNode visitTimestampLiteral(TimestampLiteral node, ParseTreeContext context) {
         try {
             String value = node.getValue();
-            if (value.length() <= 10) {
-                value += " 00:00:00";
+            String formattedValue = value.length() <= 10 ? value + " 00:00:00" : value;
+            ZoneId zoneId = parseTimeZoneFromString(formattedValue);
+            if (zoneId == null) {
+                return new DateLiteral(formattedValue, Type.DATETIME);
+            } else {
+                return new FunctionCallExpr("convert_tz", List.of(
+                        new DateLiteral(parseDateTimeFromString(formattedValue), Type.DATETIME),
+                        new VariableExpr("time_zone"),
+                        new com.starrocks.analysis.StringLiteral(zoneId.toString())
+                ));
             }
-            return new DateLiteral(value, Type.DATETIME);
         } catch (AnalysisException e) {
             throw unsupportedException(PARSER_ERROR_MSG.invalidDateFormat(node.getValue()));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/TimeUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/TimeUtilsTest.java
@@ -34,6 +34,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+
+import static com.starrocks.common.util.TimeUtils.DATETIME_WITH_TIME_ZONE_PATTERN;
 
 public class TimeUtilsTest {
 
@@ -249,5 +252,39 @@ public class TimeUtilsTest {
         } catch (DdlException e) {
             Assert.fail(e.getMessage());
         }
+    }
+    
+    @Test
+    public void testDateTimeWithTimeZonePattern() {
+        // Case1: date time string is '2024-09-10 Asia/Shanghai'
+        String value1 = "2024-09-10 Asia/Shanghai";
+        Matcher matcher1 = DATETIME_WITH_TIME_ZONE_PATTERN.matcher(value1);
+        Assert.assertTrue(matcher1.matches());
+        Assert.assertEquals("2024", matcher1.group("year"));
+        Assert.assertEquals("09", matcher1.group("month"));
+        Assert.assertEquals("10", matcher1.group("day"));
+        Assert.assertEquals("Asia/Shanghai", matcher1.group("timezone"));
+        Assert.assertNull(matcher1.group("hour"));
+        Assert.assertNull(matcher1.group("minute"));
+        Assert.assertNull(matcher1.group("second"));
+        Assert.assertNull(matcher1.group("fraction"));
+    
+        // Case2: date time string is '2024-09-10 01:01:01.123 Asia/Shanghai'
+        String value2 = "2024-09-10 01:01:01.123 Asia/Shanghai";
+        Matcher matcher2 = DATETIME_WITH_TIME_ZONE_PATTERN.matcher(value2);
+        Assert.assertTrue(matcher2.matches());
+        Assert.assertEquals("2024", matcher2.group("year"));
+        Assert.assertEquals("09", matcher2.group("month"));
+        Assert.assertEquals("10", matcher2.group("day"));
+        Assert.assertEquals("01", matcher2.group("hour"));
+        Assert.assertEquals("01", matcher2.group("minute"));
+        Assert.assertEquals("01", matcher2.group("second"));
+        Assert.assertEquals("123", matcher2.group("fraction"));
+        Assert.assertEquals("Asia/Shanghai", matcher2.group("timezone"));
+    
+        // Case3: date time string is ' 2024-09-10'. It will not match
+        String value3 = " 2024-09-10";
+        Matcher matcher3 = DATETIME_WITH_TIME_ZONE_PATTERN.matcher(value3);
+        Assert.assertFalse(matcher3.matches());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
@@ -81,7 +81,10 @@ public class TrinoParserNotSupportTest extends TrinoTestBase {
     @Test
     public void testTimeStampWithTimeZone() {
         String sql = "select TIMESTAMP '2014-03-14 09:30:00 Europe/Berlin'";
-        analyzeFail(sql, "Invalid date literal 2014-03-14 09:30:00 Europe/Berlin");
+        analyzeSuccess(sql);
+
+        sql = "select TIMESTAMP '2014-09-17 Europe/Berlin'";
+        analyzeSuccess(sql);
 
         sql = "SELECT TIMESTAMP '2014-03-14 09:30:00' AT TIME ZONE 'America/Los_Angeles'";
         analyzeFail(sql, "Unsupported expression [TIMESTAMP '2014-03-14 09:30:00' AT TIME ZONE 'America/Los_Angeles']");


### PR DESCRIPTION

## Why I'm doing:
When querying to_unixtime in the trino dialect, we will get `Invalid date literal` exception because the time zone in the string can not be paresd

## What I'm doing:
Add a regular expressions for parsing the time zone and use `convert_tz` method to convert the datetime to the given time zone.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
