### PR TITLE
[Enhancement] support derive predicate from callOperator predicate

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
@@ -122,6 +122,10 @@ public class JoinPredicatePushdownTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "PREDICATES: all_match(array_map(<slot 7> -> <slot 7> > 1, [4: v4])), 4: v4 > 2");
 
+        sql = "select * from t0 join t1 on v1 <=> v4 where all_match(x -> x > 1, [v1]) and v1 > 2";
+        plan = getFragmentPlan(sql);
+        assertNotContains(plan, "PREDICATES: all_match(array_map(<slot 7> -> <slot 7> > 1, [4: v4])), 4: v4 > 2");
+
         sql = "select * from t0 join t1 on v1 = v4 join t2 on v4 = v7 where all_match(x -> x > 1, [v1]) and v7 > 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "PREDICATES: 4: v4 > 2, all_match(array_map(<slot 10> -> <slot 10> > 1, [4: v4]))");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdownTest.java
@@ -115,4 +115,15 @@ public class JoinPredicatePushdownTest extends PlanTestBase {
                 "  |  equal join conjunct: 1: v1 = 4: v4");
         PlanTestBase.assertNotContains(plan2, "LEFT OUTER JOIN");
     }
+
+    @Test
+    public void testFunctionDerived() throws Exception {
+        String sql = "select * from t0 join t1 on v1 = v4 where all_match(x -> x > 1, [v1]) and v1 > 2";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: all_match(array_map(<slot 7> -> <slot 7> > 1, [4: v4])), 4: v4 > 2");
+
+        sql = "select * from t0 join t1 on v1 = v4 join t2 on v4 = v7 where all_match(x -> x > 1, [v1]) and v7 > 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 4: v4 > 2, all_match(array_map(<slot 10> -> <slot 10> > 1, [4: v4]))");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Like https://github.com/StarRocks/starrocks/pull/50851, it support derive a equivelent predicate from one side table to the other side. 
This pr support derive a equivelent predicate from the top filter to both sides of join.

## What I'm doing:
add callOperator predicate to candidate map.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
