### PR TITLE
[BugFix] Fix thread local variable initialization problem

### DIFF
--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -63,6 +63,7 @@ inline thread_local MemTracker* tls_exceed_mem_tracker = nullptr;
 // you can add a new check tracker by set up `tls_singleton_check_mem_tracker`.
 inline thread_local MemTracker* tls_singleton_check_mem_tracker = nullptr;
 inline thread_local bool tls_is_thread_status_init = false;
+inline thread_local bool tls_is_catched = false;
 
 class CurrentThread {
 private:
@@ -283,13 +284,13 @@ public:
         tls_singleton_check_mem_tracker = mem_tracker;
     }
 
-    bool set_is_catched(bool is_catched) {
-        bool old = _is_catched;
-        _is_catched = is_catched;
+    static bool set_is_catched(bool is_catched) {
+        bool old = tls_is_catched;
+        tls_is_catched = is_catched;
         return old;
     }
 
-    bool is_catched() const { return _is_catched; }
+    static bool is_catched() { return tls_is_catched; }
 
     void mem_consume(int64_t size) {
         _mem_cache_manager.consume(size);
@@ -371,7 +372,6 @@ private:
     TUniqueId _fragment_instance_id;
     std::string _custom_coredump_msg{};
     int32_t _driver_id = 0;
-    bool _is_catched = false;
     bool _check = true;
     bool _reserve_mod = false;
 };

--- a/be/src/service/mem_hook.cpp
+++ b/be/src/service/mem_hook.cpp
@@ -80,7 +80,7 @@
     } while (0)
 #define SET_EXCEED_MEM_TRACKER() \
     starrocks::tls_exceed_mem_tracker = starrocks::GlobalEnv::GetInstance()->process_mem_tracker()
-#define IS_BAD_ALLOC_CATCHED() starrocks::tls_thread_status.is_catched()
+#define IS_BAD_ALLOC_CATCHED() starrocks::tls_is_catched
 #else
 std::atomic<int64_t> g_mem_usage(0);
 #define MEMORY_CONSUME_SIZE(size) g_mem_usage.fetch_add(size)


### PR DESCRIPTION
## Why I'm doing:

```
void* my_malloc(size_t size) __THROW {
    STARROCKS_REPORT_LARGE_MEM_ALLOC(size);
    int64_t alloc_size = STARROCKS_NALLOX(size, 0);
    SET_DELTA_MEMORY(alloc_size);
    if (IS_BAD_ALLOC_CATCHED()) {
```

## What I'm doing:

`my_malloc` will use `tls_thread_status.is_catched`  to determine which code branch to execute, but if memory is allocated before `tls_thread_status` is constructed, , behavior is undefined, it is easy to trigger some strange problems.

So define `is_catched` as an independent thread local variable,

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
