### PR TITLE
[BugFix] fix mysql external table clause

### DIFF
--- a/be/src/exec/mysql_scanner.cpp
+++ b/be/src/exec/mysql_scanner.cpp
@@ -164,35 +164,35 @@ Status MysqlScanner::query(const std::string& table, const std::vector<std::stri
 
     // In Filter part.
     if (filters_in.size() > 0) {
-        if (!is_filter_initial) {
-            is_filter_initial = true;
-            _sql_str += " WHERE (";
-        } else {
-            _sql_str += " AND (";
-        }
-
-        bool is_first_conjunct = true;
+        std::vector<std::string> conjuncts;
         for (auto& iter : filters_in) {
-            if (!is_first_conjunct) {
-                _sql_str += " AND (";
-            }
-            is_first_conjunct = false;
-            if (iter.second.size() > 0) {
-                auto curr = iter.second.begin();
-                auto end = iter.second.end();
-                _sql_str += iter.first + " in (";
-                _sql_str += *curr;
-                ++curr;
-
-                // collect optional values.
-                while (curr != end) {
-                    _sql_str += ", " + *curr;
-                    ++curr;
+            if (iter.second.size() > 0 || filters_null_in_set[iter.first]) {
+                std::string tmp;
+                tmp += "(" + iter.first + " in (";
+                for (auto& curr : iter.second) {
+                    tmp += curr + ",";
                 }
                 if (filters_null_in_set[iter.first]) {
-                    _sql_str += ", null";
+                    tmp += "null";
                 }
-                _sql_str += ")) ";
+                if (tmp.back() == ',') {
+                    tmp.pop_back();
+                }
+                tmp += "))";
+                conjuncts.emplace_back(tmp);
+            }
+        }
+
+        if (conjuncts.size() > 0) {
+            if (!is_filter_initial) {
+                is_filter_initial = true;
+                _sql_str += " WHERE ";
+            } else {
+                _sql_str += " AND ";
+            }
+            _sql_str += conjuncts.at(0);
+            for (size_t i = 1; i < conjuncts.size(); i++) {
+                _sql_str += " AND " + conjuncts.at(i);
             }
         }
     }

--- a/be/src/exec/mysql_scanner.cpp
+++ b/be/src/exec/mysql_scanner.cpp
@@ -180,6 +180,10 @@ Status MysqlScanner::query(const std::string& table, const std::vector<std::stri
                 }
                 tmp += "))";
                 conjuncts.emplace_back(tmp);
+            } else {
+                // there is in predicate, but no value in it
+                // so there is no row from mysql node.
+                conjuncts.emplace_back("(0 = 1)");
             }
         }
 

--- a/test/sql/test_external_mysql/R/test_external_mysql_clause
+++ b/test/sql/test_external_mysql/R/test_external_mysql_clause
@@ -1,0 +1,82 @@
+-- name: testExternalMysqlCaluse
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t00` (
+  `id` int,
+  `s` string  
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t00 values(1, "hello"), (2, "world"), (3, null);
+-- result:
+-- !result
+CREATE EXTERNAL TABLE mysql_ext
+(
+  `id` int,
+  `s` string  
+)
+ENGINE=mysql
+PROPERTIES
+(
+    "host" = "${mysql_host}",
+    "port" = "${mysql_port}",
+    "user" = "${mysql_user}",
+    "password" = "${mysql_password}",
+    "database" = "db_${uuid0}",
+    "table" = "t00"
+);
+-- result:
+-- !result
+set cbo_derive_join_is_null_predicate = true;
+-- result:
+-- !result
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id = 3;
+-- result:
+-- !result
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1, 2, 3);
+-- result:
+1	hello	1	hello
+2	world	2	world
+-- !result
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1, 2);
+-- result:
+1	hello	1	hello
+2	world	2	world
+-- !result
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1);
+-- result:
+1	hello	1	hello
+-- !result
+set cbo_derive_join_is_null_predicate = false;
+-- result:
+-- !result
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id = 3;
+-- result:
+-- !result
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1, 2, 3);
+-- result:
+1	hello	1	hello
+2	world	2	world
+-- !result
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1, 2);
+-- result:
+1	hello	1	hello
+2	world	2	world
+-- !result
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1);
+-- result:
+1	hello	1	hello
+-- !result

--- a/test/sql/test_external_mysql/T/test_external_mysql_clause
+++ b/test/sql/test_external_mysql/T/test_external_mysql_clause
@@ -1,0 +1,58 @@
+-- name: testExternalMysqlCaluse
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `t00` (
+  `id` int,
+  `s` string  
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+insert into t00 values(1, "hello"), (2, "world"), (3, null);
+
+CREATE EXTERNAL TABLE mysql_ext
+(
+  `id` int,
+  `s` string  
+)
+ENGINE=mysql
+PROPERTIES
+(
+    "host" = "${mysql_host}",
+    "port" = "${mysql_port}",
+    "user" = "${mysql_user}",
+    "password" = "${mysql_password}",
+    "database" = "db_${uuid0}",
+    "table" = "t00"
+);
+
+set cbo_derive_join_is_null_predicate = true;
+
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id = 3;
+
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1, 2, 3);
+
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1, 2);
+
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1);
+
+
+set cbo_derive_join_is_null_predicate = false;
+
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id = 3;
+
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1, 2, 3);
+
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1, 2);
+
+select * from mysql_ext x inner join t00 on x.s = t00.s where t00.id in (1);
+


### PR DESCRIPTION
## Why I'm doing:

To avoid this mysql stament

> SELECT id_tinyint, id_smallint, id_int, id_bigint, id_float, id_double, id_decimal, id_date, id_datetime, id_char, id_varchar FROM mysql_external_default WHERE (id_varchar IS NOT NULL) AND (

It happens only when runtime filter is involved:
- there is runtime filter on mysal scan node
- but there is no value in runtime filter
- we don't handle that properly and add "AND("  to sql stmt

## What I'm doing:

Fixes #50900 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
