### PR TITLE
[BugFix] primary key table support storage medium cool down (backport #50916)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -467,9 +467,6 @@ public class OlapTableFactory implements AbstractTableFactory {
             if (properties != null) {
                 if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME)) {
-                    if (table.getKeysType() == KeysType.PRIMARY_KEYS) {
-                        throw new DdlException("Primary key table does not support storage medium cool down currently.");
-                    }
                     if (partitionInfo instanceof ListPartitionInfo) {
                         throw new DdlException("List partition table does not support storage medium cool down currently.");
                     }
@@ -482,8 +479,9 @@ public class OlapTableFactory implements AbstractTableFactory {
                                     "does not support storage medium cool down currently.");
                         }
                         Column column = partitionColumns.get(0);
-                        if (!column.getType().getPrimitiveType().isDateType()) {
-                            throw new DdlException("Only support partition is date type for" +
+                        if (!column.getType().getPrimitiveType().isDateType() &&
+                                !column.getType().getPrimitiveType().isIntegerType()) {
+                            throw new DdlException("Only support partition is date/integer type for" +
                                     " storage medium cool down currently.");
                         }
                     }


### PR DESCRIPTION
1. alter primary key table set storage_medium is ok, so cool down should support
2. partition and dynamic_partition is support date/integer, so cool down can support date/integer

## Why I'm doing:
1. alter primary key table set storage_medium is ok, so cool down should support
2. partition and dynamic_partition is support date/integer, so cool down can support date/integer

## What I'm doing:
Remove restrictions on `primary key table`
add support partition  by `integer` 

Fixes #50916 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5