### PR TITLE
[BugFix] Fix filter ratio for insert into external catalog table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2255,7 +2255,8 @@ public class StmtExecutor {
             }
 
             // insert will fail if 'filtered rows / total rows' exceeds max_filter_ratio
-            if (loadJob != null && !loadJob.checkDataQuality()) {
+            // for native table and external catalog table(without insert load job)
+            if (filteredRows > (filteredRows + loadedRows) * stmt.getMaxFilterRatio()) {
                 if (targetTable instanceof ExternalOlapTable) {
                     ExternalOlapTable externalTable = (ExternalOlapTable) targetTable;
                     RemoteTransactionMgr.abortRemoteTransaction(externalTable.getSourceTableDbId(), transactionId,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DmlStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DmlStmt.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.ast;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.analysis.TableName;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
@@ -50,5 +51,17 @@ public abstract class DmlStmt extends StatementBase {
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public double getMaxFilterRatio() {
+        if (properties.containsKey(LoadStmt.MAX_FILTER_RATIO_PROPERTY)) {
+            try {
+                return Double.parseDouble(properties.get(LoadStmt.MAX_FILTER_RATIO_PROPERTY));
+            } catch (NumberFormatException e) {
+                // ignore
+            }
+        }
+
+        return ConnectContext.get().getSessionVariable().getInsertMaxFilterRatio();
     }
 }


### PR DESCRIPTION
## Why I'm doing:
FE does not create insert load job for external catalog table, 
so should not check filter ratio only by load job.

## What I'm doing:

Fixes #49978

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
