### PR TITLE
[BugFix] Fix session variable load image bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -36,7 +36,6 @@ import com.starrocks.persist.ChangeMaterializedViewRefreshSchemeLog;
 import com.starrocks.persist.ModifyTablePropertyOperationLog;
 import com.starrocks.persist.RenameMaterializedViewLog;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.Task;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -193,7 +193,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 String varKey = entry.getKey().substring(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX.length());
                 SystemVariable variable = new SystemVariable(varKey, new StringLiteral(entry.getValue()));
                 try {
-                    VariableMgr.checkSystemVariableExist(variable);
+                    GlobalStateMgr.getCurrentState().getVariableMgr().checkSystemVariableExist(variable);
                 } catch (DdlException e) {
                     throw new SemanticException(e.getMessage());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
@@ -27,7 +27,6 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.Pair;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
@@ -211,7 +210,7 @@ public class UserProperty {
         GlobalStateMgr.getCurrentState().getVariableMgr().checkSystemVariableExist(variable);
 
         // check whether the value is valid
-        Field field = VariableMgr.getField(sessionKey);
+        Field field = GlobalStateMgr.getCurrentState().getVariableMgr().getField(sessionKey);
         if (field == null || !canAssignValue(field, value)) {
             ErrorReport.reportDdlException(ErrorCode.ERR_WRONG_TYPE_FOR_VAR, value);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserProperty.java
@@ -208,7 +208,7 @@ public class UserProperty {
         }
         // check whether the variable exists
         SystemVariable variable = new SystemVariable(sessionKey, new StringLiteral(value));
-        VariableMgr.checkSystemVariableExist(variable);
+        GlobalStateMgr.getCurrentState().getVariableMgr().checkSystemVariableExist(variable);
 
         // check whether the value is valid
         Field field = VariableMgr.getField(sessionKey);
@@ -217,7 +217,7 @@ public class UserProperty {
         }
 
         // check flags of the variable, e.g. whether the variable is read-only
-        VariableMgr.checkUpdate(variable);
+        GlobalStateMgr.getCurrentState().getVariableMgr().checkUpdate(variable);
     }
 
     // check whether the catalog exist

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1598,7 +1598,7 @@ public class PropertyAnalyzer {
                 List<SetListItem> setListItems = Lists.newArrayList();
                 for (Map.Entry<String, String> entry : properties.entrySet()) {
                     SystemVariable variable = getMVSystemVariable(properties, entry);
-                    VariableMgr.checkSystemVariableExist(variable);
+                    GlobalStateMgr.getCurrentState().getVariableMgr().checkSystemVariableExist(variable);
                     setListItems.add(variable);
                 }
                 SetStmtAnalyzer.analyze(new SetStmt(setListItems), null);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -72,7 +72,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.StorageVolumeMgr;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -45,6 +45,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.threeten.extra.PeriodDuration;
@@ -144,7 +145,7 @@ public class TimeUtils {
         if (ConnectContext.get() != null) {
             timezone = ConnectContext.get().getSessionVariable().getTimeZone();
         } else {
-            timezone = VariableMgr.getDefaultSessionVariable().getTimeZone();
+            timezone = GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultSessionVariable().getTimeZone();
         }
         return TimeZone.getTimeZone(ZoneId.of(timezone, TIME_ZONE_ALIAS_MAP));
     }
@@ -353,7 +354,7 @@ public class TimeUtils {
         if (ConnectContext.get() != null) {
             timezone = ConnectContext.get().getSessionVariable().getTimeZone();
         } else {
-            timezone = VariableMgr.getDefaultSessionVariable().getTimeZone();
+            timezone = GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultSessionVariable().getTimeZone();
         }
         return timezone;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -44,7 +44,6 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/VariableAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/VariableAction.java
@@ -22,7 +22,7 @@ import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
-import com.starrocks.qe.VariableMgr;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.SetType;
 import io.netty.handler.codec.http.HttpMethod;
 
@@ -68,7 +68,8 @@ public class VariableAction extends WebBaseAction {
     private void appendVariableInfo(StringBuilder buffer) {
         buffer.append("<h2>Variable Info</h2>");
         buffer.append("<pre>");
-        List<List<String>> variableInfo = VariableMgr.dump(SetType.GLOBAL, null, null);
+        List<List<String>> variableInfo = GlobalStateMgr.getCurrentState().getVariableMgr()
+                .dump(SetType.GLOBAL, null, null);
         for (List<String> list : variableInfo) {
             buffer.append(list.get(0) + "=" + list.get(1) + "\n");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
@@ -55,6 +55,7 @@ import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.sql.ast.KillStmt;
 import com.starrocks.sql.ast.QueryStatement;
@@ -262,7 +263,7 @@ public class ExecuteSqlAction extends RestBaseAction {
         if (customVariable != null) {
             try {
                 for (String key : customVariable.keySet()) {
-                    VariableMgr.setSystemVariable(context.getSessionVariable(),
+                    GlobalStateMgr.getCurrentState().getVariableMgr().setSystemVariable(context.getSessionVariable(),
                             new SystemVariable(key, new StringLiteral(customVariable.get(key))), true);
                 }
                 context.setThreadLocalInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
@@ -54,7 +54,6 @@ import com.starrocks.qe.ConnectScheduler;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.sql.ast.KillStmt;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -83,7 +83,6 @@ import com.starrocks.privilege.RolePrivilegeCollectionV2;
 import com.starrocks.privilege.UserPrivilegeCollectionV2;
 import com.starrocks.proto.EncryptionKeyPB;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.replication.ReplicationJob;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.mv.MVEpoch;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -894,7 +894,7 @@ public class EditLog {
                 }
                 case OperationType.OP_GLOBAL_VARIABLE_V2: {
                     GlobalVarPersistInfo info = (GlobalVarPersistInfo) journal.getData();
-                    VariableMgr.replayGlobalVariableV2(info);
+                    globalStateMgr.getVariableMgr().replayGlobalVariableV2(info);
                     break;
                 }
                 case OperationType.OP_SWAP_TABLE: {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/GlobalVarPersistInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/GlobalVarPersistInfo.java
@@ -61,13 +61,17 @@ public class GlobalVarPersistInfo implements Writable {
     // the modified variable info will be saved as a json string
     private String persistJsonString;
 
-    private GlobalVarPersistInfo() {
+    public GlobalVarPersistInfo() {
         // for persist
     }
 
     public GlobalVarPersistInfo(SessionVariable defaultSessionVariable, List<String> varNames) {
         this.defaultSessionVariable = defaultSessionVariable;
         this.varNames = varNames;
+    }
+
+    public void setPersistJsonString(String persistJsonString) {
+        this.persistJsonString = persistJsonString;
     }
 
     public String getPersistJsonString() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -402,7 +402,8 @@ public class ConnectContext {
 
     public void modifySystemVariable(SystemVariable setVar, boolean onlySetSessionVar) throws DdlException {
         GlobalStateMgr.getCurrentState().getVariableMgr().setSystemVariable(sessionVariable, setVar, onlySetSessionVar);
-        if (!SetType.GLOBAL.equals(setVar.getType()) && VariableMgr.shouldForwardToLeader(setVar.getVariable())) {
+        if (!SetType.GLOBAL.equals(setVar.getType()) && GlobalStateMgr.getCurrentState().getVariableMgr()
+                .shouldForwardToLeader(setVar.getVariable())) {
             modifiedSessionVariables.put(setVar.getVariable(), setVar);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -271,7 +271,7 @@ public class ConnectContext {
         serverCapability = MysqlCapability.DEFAULT_CAPABILITY;
         isKilled = false;
         serializer = MysqlSerializer.newInstance();
-        sessionVariable = VariableMgr.newSessionVariable();
+        sessionVariable = GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable();
         userVariables = new ConcurrentHashMap<>();
         command = MysqlCommand.COM_SLEEP;
         queryDetail = null;
@@ -401,7 +401,7 @@ public class ConnectContext {
     }
 
     public void modifySystemVariable(SystemVariable setVar, boolean onlySetSessionVar) throws DdlException {
-        VariableMgr.setSystemVariable(sessionVariable, setVar, onlySetSessionVar);
+        GlobalStateMgr.getCurrentState().getVariableMgr().setSystemVariable(sessionVariable, setVar, onlySetSessionVar);
         if (!SetType.GLOBAL.equals(setVar.getType()) && VariableMgr.shouldForwardToLeader(setVar.getVariable())) {
             modifiedSessionVariables.put(setVar.getVariable(), setVar);
         }
@@ -497,7 +497,7 @@ public class ConnectContext {
     }
 
     public void resetSessionVariable() {
-        this.sessionVariable = VariableMgr.newSessionVariable();
+        this.sessionVariable = GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable();
         modifiedSessionVariables.clear();
     }
 
@@ -1126,8 +1126,10 @@ public class ConnectContext {
             // set session variables
             Map<String, String> sessionVariables = userProperty.getSessionVariables();
             for (Map.Entry<String, String> entry : sessionVariables.entrySet()) {
-                String currentValue = VariableMgr.getValue(sessionVariable, new VariableExpr(entry.getKey()));
-                if (!currentValue.equalsIgnoreCase(VariableMgr.getDefaultValue(entry.getKey()))) {
+                String currentValue = GlobalStateMgr.getCurrentState().getVariableMgr().getValue(
+                        sessionVariable, new VariableExpr(entry.getKey()));
+                if (!currentValue.equalsIgnoreCase(
+                        GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultValue(entry.getKey()))) {
                     // If the current session variable is not default value, we should respect it.
                     continue;
                 }
@@ -1136,8 +1138,9 @@ public class ConnectContext {
             }
 
             // set catalog and database
-            boolean dbHasBeenSetByUser = !getCurrentCatalog().equals(VariableMgr.getDefaultValue(SessionVariable.CATALOG)) ||
-                    !getDatabase().isEmpty();
+            boolean dbHasBeenSetByUser = !getCurrentCatalog().equals(
+                    GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultValue(SessionVariable.CATALOG))
+                    || !getDatabase().isEmpty();
             if (!dbHasBeenSetByUser) {
                 String catalog = userProperty.getCatalog();
                 String database = userProperty.getDatabase();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/LeaderOpExecutor.java
@@ -149,7 +149,8 @@ public class LeaderOpExecutor {
                 SetStmt stmt = (SetStmt) parsedStmt;
                 for (SetListItem var : stmt.getSetListItems()) {
                     if (var instanceof SystemVariable) {
-                        VariableMgr.setSystemVariable(ctx.getSessionVariable(), (SystemVariable) var, true);
+                        GlobalStateMgr.getCurrentState().getVariableMgr().setSystemVariable(
+                                ctx.getSessionVariable(), (SystemVariable) var, true);
                     }
                 }
             } catch (DdlException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -966,7 +966,8 @@ public class ShowExecutor {
                 matcher = PatternMatcher.createMysqlPattern(statement.getPattern(),
                         CaseSensibility.VARIABLES.getCaseSensibility());
             }
-            List<List<String>> rows = VariableMgr.dump(statement.getType(), context.getSessionVariable(), matcher);
+            List<List<String>> rows = GlobalStateMgr.getCurrentState().getVariableMgr().dump(statement.getType(),
+                    context.getSessionVariable(), matcher);
             return new ShowResultSet(statement.getMetaData(), rows);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -794,7 +794,7 @@ public class StmtExecutor {
                         clonedSessionVariable = (SessionVariable) context.sessionVariable.clone();
                     }
                     for (Map.Entry<String, String> entry : hint.getValue().entrySet()) {
-                        VariableMgr.setSystemVariable(clonedSessionVariable,
+                        GlobalStateMgr.getCurrentState().getVariableMgr().setSystemVariable(clonedSessionVariable,
                                 new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue())), true);
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -494,6 +494,8 @@ public class GlobalStateMgr {
     private final GtidGenerator gtidGenerator;
     private final GlobalConstraintManager globalConstraintManager;
 
+    private final VariableMgr variableMgr;
+
     private final SqlParser sqlParser;
     private final Analyzer analyzer;
     private final Authorizer authorizer;
@@ -774,6 +776,8 @@ public class GlobalStateMgr {
 
         this.keyMgr = new KeyMgr();
         this.keyRotationDaemon = new KeyRotationDaemon(keyMgr);
+
+        this.variableMgr = new VariableMgr();
 
         nodeMgr.registerLeaderChangeListener(globalSlotProvider::leaderChangeListener);
 
@@ -1283,7 +1287,7 @@ public class GlobalStateMgr {
                 // configuration. If it is upgraded from an old version, the original
                 // configuration is retained to avoid system stability problems caused by
                 // changes in concurrency
-                VariableMgr.setSystemVariable(VariableMgr.getDefaultSessionVariable(), new SystemVariable(SetType.GLOBAL,
+                variableMgr.setSystemVariable(variableMgr.getDefaultSessionVariable(), new SystemVariable(SetType.GLOBAL,
                                         SessionVariable.ENABLE_ADAPTIVE_SINK_DOP,
                                         LiteralExpr.create("true", Type.BOOLEAN)),
                             false);
@@ -1488,7 +1492,7 @@ public class GlobalStateMgr {
                     .put(SRMetaBlockID.LOCAL_META_STORE, localMetastore::load)
                     .put(SRMetaBlockID.ALTER_MGR, alterJobMgr::load)
                     .put(SRMetaBlockID.CATALOG_RECYCLE_BIN, recycleBin::load)
-                    .put(SRMetaBlockID.VARIABLE_MGR, VariableMgr::load)
+                    .put(SRMetaBlockID.VARIABLE_MGR, variableMgr::load)
                     .put(SRMetaBlockID.RESOURCE_MGR, resourceMgr::loadResourcesV2)
                     .put(SRMetaBlockID.EXPORT_MGR, exportMgr::loadExportJobV2)
                     .put(SRMetaBlockID.BACKUP_MGR, backupHandler::loadBackupHandlerV2)
@@ -1687,7 +1691,7 @@ public class GlobalStateMgr {
                 localMetastore.save(imageWriter);
                 alterJobMgr.save(imageWriter);
                 recycleBin.save(imageWriter);
-                VariableMgr.save(imageWriter);
+                variableMgr.save(imageWriter);
                 resourceMgr.saveResourcesV2(imageWriter);
                 exportMgr.saveExportJobV2(imageWriter);
                 backupHandler.saveBackupHandlerV2(imageWriter);
@@ -2602,5 +2606,9 @@ public class GlobalStateMgr {
 
     public MetaRecoveryDaemon getMetaRecoveryDaemon() {
         return metaRecoveryDaemon;
+    }
+
+    public VariableMgr getVariableMgr() {
+        return variableMgr;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2969,11 +2969,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         // validate hint
         Map<String, String> optHints = Maps.newHashMap();
         if (stmt.isExistQueryScopeHint()) {
-            SessionVariable sessionVariable = VariableMgr.newSessionVariable();
+            SessionVariable sessionVariable = GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable();
             for (HintNode hintNode : stmt.getAllQueryScopeHints()) {
                 if (hintNode instanceof SetVarHint) {
                     for (Map.Entry<String, String> entry : hintNode.getValue().entrySet()) {
-                        VariableMgr.setSystemVariable(sessionVariable,
+                        GlobalStateMgr.getCurrentState().getVariableMgr().setSystemVariable(sessionVariable,
                                 new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue())), true);
                         optHints.put(entry.getKey(), entry.getValue());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -177,7 +177,6 @@ import com.starrocks.privilege.ObjectType;
 import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.Task;

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -135,7 +135,6 @@ import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.QueryStatisticsInfo;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowMaterializedViewStatus;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
 import com.starrocks.server.GlobalStateMgr;
@@ -1043,8 +1042,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             return result;
         }
         SetType setType = SetType.fromThrift(params.getVarType());
-        List<List<String>> rows = VariableMgr.dump(setType, ctx.getSessionVariable(),
-                null);
+        List<List<String>> rows = GlobalStateMgr.getCurrentState().getVariableMgr().dump(setType,
+                ctx.getSessionVariable(), null);
         if (setType != SetType.VERBOSE) {
             for (List<String> row : rows) {
                 map.put(row.get(0), row.get(1));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1456,7 +1456,7 @@ public class ExpressionAnalyzer {
         @Override
         public Void visitVariableExpr(VariableExpr node, Scope context) {
             try {
-                VariableMgr.fillValue(session.getSessionVariable(), node);
+                GlobalStateMgr.getCurrentState().getVariableMgr().fillValue(session.getSessionVariable(), node);
                 if (!Strings.isNullOrEmpty(node.getName()) &&
                         node.getName().equalsIgnoreCase(SessionVariable.SQL_MODE)) {
                     node.setType(Type.VARCHAR);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -88,7 +88,6 @@ import com.starrocks.privilege.RolePrivilegeCollectionV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.ArrayExpr;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
@@ -94,7 +94,7 @@ public class PipeAnalyzer {
             if (propertyName.toUpperCase().startsWith(TASK_VARIABLES_PREFIX)) {
                 // Task execution variable
                 String taskVariableName = StringUtils.removeStartIgnoreCase(propertyName, TASK_VARIABLES_PREFIX);
-                if (!VariableMgr.containsVariable(taskVariableName)) {
+                if (!GlobalStateMgr.getCurrentState().getVariableMgr().containsVariable(taskVariableName)) {
                     ErrorReport.reportSemanticException(ErrorCode.ERR_UNKNOWN_PROPERTY, propertyName);
                 }
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PipeAnalyzer.java
@@ -30,7 +30,6 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.load.pipe.FilePipeSource;
 import com.starrocks.load.pipe.Pipe;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.InsertStmt;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -41,7 +41,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SessionVariableConstants;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectList;
@@ -96,7 +95,8 @@ public class SetStmtAnalyzer {
 
         if (unResolvedExpression == null) {
             // SET var = DEFAULT
-            resolvedExpression = new StringLiteral(GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultValue(var.getVariable()));
+            resolvedExpression = new StringLiteral(GlobalStateMgr.getCurrentState().getVariableMgr().
+                    getDefaultValue(var.getVariable()));
         } else if (unResolvedExpression instanceof SlotRef) {
             resolvedExpression = new StringLiteral(((SlotRef) unResolvedExpression).getColumnName());
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -96,7 +96,7 @@ public class SetStmtAnalyzer {
 
         if (unResolvedExpression == null) {
             // SET var = DEFAULT
-            resolvedExpression = new StringLiteral(VariableMgr.getDefaultValue(var.getVariable()));
+            resolvedExpression = new StringLiteral(GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultValue(var.getVariable()));
         } else if (unResolvedExpression instanceof SlotRef) {
             resolvedExpression = new StringLiteral(((SlotRef) unResolvedExpression).getColumnName());
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -22,7 +22,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.VectorSearchOptions;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -95,7 +95,7 @@ public class OptimizerContext {
         this.globalStateMgr = GlobalStateMgr.getCurrentState();
         this.taskScheduler = SeriallyTaskScheduler.create();
         this.columnRefFactory = columnRefFactory;
-        this.sessionVariable = VariableMgr.newSessionVariable();
+        this.sessionVariable = GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable();
         this.optimizerConfig = new OptimizerConfig();
         this.queryId = UUID.randomUUID();
         this.allLogicalOlapScanOperators = Collections.emptyList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpInfo.java
@@ -25,6 +25,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.MaterializedViewOptimizer;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
@@ -78,7 +79,7 @@ public class QueryDumpInfo implements DumpInfo {
 
     public QueryDumpInfo() {
         this.connectContext = null;
-        this.sessionVariable = VariableMgr.newSessionVariable();
+        this.sessionVariable = GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpInfo.java
@@ -24,7 +24,6 @@ import com.starrocks.catalog.View;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.MaterializedViewOptimizer;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -31,7 +31,6 @@ import com.starrocks.connector.statistics.ConnectorTableColumnKey;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatisticUtils;
 import org.apache.logging.log4j.LogManager;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -169,7 +169,8 @@ public class CachedStatisticStorage implements StatisticStorage {
             CompletableFuture<Map<ConnectorTableColumnKey, Optional<ConnectorTableColumnStats>>> result =
                     connectorTableCachedStatistics.getAll(cacheKeys);
 
-            SessionVariable sessionVariable = ConnectContext.get() == null ? VariableMgr.newSessionVariable() :
+            SessionVariable sessionVariable = ConnectContext.get() == null ?
+                    GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable() :
                     ConnectContext.get().getSessionVariable();
             result.whenCompleteAsync((res, e) -> {
                 if (e != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/UserPropertyTest.java
@@ -22,7 +22,6 @@ import com.starrocks.privilege.PrivilegeException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateRoleStmt;
 import com.starrocks.sql.ast.CreateUserStmt;

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/UserPropertyTest.java
@@ -185,7 +185,9 @@ public class UserPropertyTest {
             userProperty = new UserProperty();
             userProperty.update("root", properties);
             Assert.assertEquals(UserProperty.MAX_CONN_DEFAULT_VALUE, userProperty.getMaxConn());
-            Assert.assertEquals(VariableMgr.getDefaultValue(SessionVariable.CATALOG), userProperty.getCatalog());
+            Assert.assertEquals(
+                    GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultValue(SessionVariable.CATALOG),
+                    userProperty.getCatalog());
             Assert.assertEquals(0, userProperty.getSessionVariables().size());
         } catch (Exception e) {
             throw e;

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -38,6 +38,7 @@ import com.starrocks.common.util.concurrent.lock.LockManager;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.persist.EditLog;
+import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.system.Backend;
@@ -88,6 +89,7 @@ public class TabletSchedulerTest {
     TabletSchedulerStat tabletSchedulerStat;
     FakeEditLog fakeEditLog;
     LockManager lockManager;
+    VariableMgr variableMgr;
 
     @Before
     public void setup() throws Exception {
@@ -96,6 +98,8 @@ public class TabletSchedulerTest {
         tabletSchedulerStat = new TabletSchedulerStat();
         fakeEditLog = new FakeEditLog();
         lockManager = new LockManager();
+        variableMgr = new VariableMgr();
+
 
         new Expectations() {
             {
@@ -130,6 +134,10 @@ public class TabletSchedulerTest {
                 globalStateMgr.getGtidGenerator();
                 minTimes = 0;
                 result = new GtidGenerator();
+
+                globalStateMgr.getVariableMgr();
+                minTimes = 0;
+                result = variableMgr;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendsProcDirTest.java
@@ -40,6 +40,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.persist.EditLog;
+import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.server.RunMode;
@@ -77,6 +78,8 @@ public class BackendsProcDirTest {
 
     @Mocked
     private NodeMgr nodeMgr;
+
+    private final VariableMgr variableMgr = new VariableMgr();
 
     public BackendsProcDirTest() {
     }
@@ -149,6 +152,10 @@ public class BackendsProcDirTest {
                 globalStateMgr.getStarOSAgent();
                 minTimes = 0;
                 result = starOsAgent;
+
+                globalStateMgr.getVariableMgr();
+                minTimes = 0;
+                result = variableMgr;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/ComputeNodeProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/ComputeNodeProcDirTest.java
@@ -17,6 +17,7 @@ package com.starrocks.common.proc;
 import com.google.common.collect.Lists;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.lake.StarOSAgent;
+import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.server.RunMode;
@@ -50,6 +51,8 @@ public class ComputeNodeProcDirTest {
     @Mocked
     private RunMode runMode;
 
+    private final VariableMgr variableMgr = new VariableMgr();
+
     @Before
     public void setUp() {
         b1 = new ComputeNode(1000, "host1", 10000);
@@ -80,6 +83,10 @@ public class ComputeNodeProcDirTest {
                 globalStateMgr.getStarOSAgent();
                 minTimes = 0;
                 result = starOsAgent;
+
+                globalStateMgr.getVariableMgr();
+                minTimes = 0;
+                result = variableMgr;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/LocalTabletsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/LocalTabletsProcDirTest.java
@@ -36,6 +36,7 @@ import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
@@ -77,12 +78,18 @@ public class LocalTabletsProcDirTest {
         idToBackend.put(backendId, b1);
         idToBackend.put(backendId + 1, b2);
 
+        VariableMgr variableMgr = new VariableMgr();
+
         new Expectations() {
             {
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
                 result = systemInfoService;
                 systemInfoService.getIdToBackend();
                 result = ImmutableMap.copyOf(idToBackend);
+
+                GlobalStateMgr.getCurrentState().getVariableMgr();
+                minTimes = 0;
+                result = variableMgr;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/MockedBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/MockedBase.java
@@ -45,6 +45,7 @@ import com.starrocks.connector.informationschema.InformationSchemaConnector;
 import com.starrocks.connector.metadata.TableMetaConnector;
 import com.starrocks.credential.aliyun.AliyunCloudConfiguration;
 import com.starrocks.credential.aliyun.AliyunCloudCredential;
+import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
@@ -82,6 +83,7 @@ public class MockedBase {
     protected static OdpsConnector odpsConnector = Mockito.mock(OdpsConnector.class);
     protected static OdpsMetadata odpsMetadata = Mockito.mock(OdpsMetadata.class);
     protected static ConnectorContext context = Mockito.mock(ConnectorContext.class);
+    protected static VariableMgr variableMgr = new VariableMgr();
 
     @Mock
     static TableReadSessionBuilder mockTableReadSessionBuilder = Mockito.mock(TableReadSessionBuilder.class);
@@ -177,6 +179,7 @@ public class MockedBase {
         when(globalStateMgr.getCatalogMgr()).thenReturn(catalogMgr);
         when(globalStateMgr.getConnectorMgr()).thenReturn(connectorMgr);
         when(globalStateMgr.getMetadataMgr()).thenReturn(metadataMgr);
+        when(globalStateMgr.getVariableMgr()).thenReturn(variableMgr);
         when(connectorMgr.getConnector(anyString())).thenReturn(new CatalogConnector(
                 odpsConnector, new InformationSchemaConnector("catalog"), new TableMetaConnector("catalog", "odps")));
         when(odpsMetadata.getCloudConfiguration()).thenReturn(new AliyunCloudConfiguration(aliyunCloudCredential));

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
@@ -47,7 +47,6 @@ import com.starrocks.proto.DeleteDataRequest;
 import com.starrocks.proto.DeleteDataResponse;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryStateException;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
@@ -47,6 +47,8 @@ import com.starrocks.proto.DeleteDataRequest;
 import com.starrocks.proto.DeleteDataResponse;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryStateException;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.VariableMgr;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.RpcException;
@@ -104,6 +106,7 @@ public class DeleteTest {
     private Database db;
     private ConnectContext connectContext = new ConnectContext();
     private DeleteMgr deleteHandler;
+    private VariableMgr variableMgr = new VariableMgr();
 
     private Database createDb() {
         // Schema
@@ -170,6 +173,7 @@ public class DeleteTest {
     @Before
     public void setUp() {
         connectContext.setGlobalStateMgr(globalStateMgr);
+        connectContext.setSessionVariable(variableMgr.newSessionVariable());
         deleteHandler = new DeleteMgr();
         db = createDb();
     }
@@ -335,7 +339,6 @@ public class DeleteTest {
 
                 GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
                 result = globalTransactionMgr;
-
             }
         };
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
@@ -43,6 +43,7 @@ import com.starrocks.load.DeleteJob.DeleteState;
 import com.starrocks.persist.EditLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryStateException;
+import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.analyzer.Analyzer;
@@ -103,6 +104,7 @@ public class DeleteHandlerTest {
     private GlobalTransactionMgr globalTransactionMgr;
     private TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
     private ConnectContext connectContext = new ConnectContext();
+    private VariableMgr variableMgr = new VariableMgr();
 
     @Before
     public void setUp() {
@@ -110,6 +112,7 @@ public class DeleteHandlerTest {
 
         globalTransactionMgr = new GlobalTransactionMgr(globalStateMgr);
         connectContext.setGlobalStateMgr(globalStateMgr);
+        connectContext.setSessionVariable(variableMgr.newSessionVariable());
         deleteHandler = new DeleteMgr();
         try {
             db = CatalogMocker.mockDb();
@@ -172,6 +175,10 @@ public class DeleteHandlerTest {
                 globalStateMgr.getEditLog();
                 minTimes = 0;
                 result = editLog;
+
+                globalStateMgr.getVariableMgr();
+                minTimes = 0;
+                result = variableMgr;
             }
         };
         globalTransactionMgr.addDatabaseTransactionMgr(db.getId());

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
@@ -23,6 +23,7 @@ import com.starrocks.common.util.OrderByPair;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.UserIdentity;
@@ -39,20 +40,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class ExportMgrTest {
-    @Mocked
-    GlobalStateMgr globalStateMgr;
-    @Mocked
-    Authorizer authorizer;
 
     @Test
     public void testExpiredJob() throws Exception {
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-            }
-        };
         Config.history_job_keep_max_second = 10;
         ExportMgr mgr = new ExportMgr();
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
@@ -23,13 +23,9 @@ import com.starrocks.common.util.OrderByPair;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
@@ -24,6 +24,7 @@ import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.GlobalTransactionMgr;
@@ -39,6 +40,8 @@ import static org.junit.Assert.assertNotNull;
 public class LoadLoadingTaskTest {
     @Injectable
     private ConnectContext connectContext;
+
+    private VariableMgr variableMgr = new VariableMgr();
 
     @Test
     public void testBuilder(
@@ -83,6 +86,10 @@ public class LoadLoadingTaskTest {
 
                 GlobalStateMgr.getCurrentState();
                 result = globalStateMgr;
+
+                globalStateMgr.getVariableMgr();
+                minTimes = 0;
+                result = variableMgr;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/persist/GlobalVarPersistInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/GlobalVarPersistInfoTest.java
@@ -36,7 +36,6 @@ package com.starrocks.persist;
 
 import com.google.common.collect.Lists;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import org.junit.After;
 import org.junit.Test;

--- a/fe/fe-core/src/test/java/com/starrocks/persist/GlobalVarPersistInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/GlobalVarPersistInfoTest.java
@@ -37,6 +37,7 @@ package com.starrocks.persist;
 import com.google.common.collect.Lists;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.server.GlobalStateMgr;
 import org.junit.After;
 import org.junit.Test;
 
@@ -64,7 +65,7 @@ public class GlobalVarPersistInfoTest {
         file.createNewFile();
         DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
 
-        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
+        SessionVariable sessionVariable = GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable();
         List<String> varNames = Lists.newArrayList();
         varNames.add("exec_mem_limit");
         varNames.add("default_rowset_type");

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -66,6 +66,8 @@ public class ConnectContextTest {
     @Mocked
     private ConnectScheduler connectScheduler;
 
+    private VariableMgr variableMgr = new VariableMgr();
+
     @Before
     public void setUp() throws Exception {
         new Expectations() {
@@ -83,6 +85,10 @@ public class ConnectContextTest {
 
                 executor.cancel("set up");
                 minTimes = 0;
+
+                globalStateMgr.getVariableMgr();
+                minTimes = 0;
+                result = variableMgr;
             }
         };
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -69,7 +69,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.PatternMatcher;
 import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.proc.ComputeNodeProcDir;
@@ -597,48 +596,6 @@ public class ShowExecutorTest {
             e.printStackTrace();
             Assert.fail();
         }
-    }
-
-    @Test
-    public void testShowVariable() throws AnalysisException, DdlException {
-        // Mock variable
-        VariableMgr variableMgr = new VariableMgr();
-        List<List<String>> rows = Lists.newArrayList();
-        rows.add(Lists.newArrayList("var1", "abc"));
-        rows.add(Lists.newArrayList("var2", "abc"));
-        new Expectations(variableMgr) {
-            {
-                VariableMgr.dump((SetType) any, (SessionVariable) any, (PatternMatcher) any);
-                minTimes = 0;
-                result = rows;
-
-                VariableMgr.dump((SetType) any, (SessionVariable) any, null);
-                minTimes = 0;
-                result = rows;
-            }
-        };
-
-        ShowVariablesStmt stmt = new ShowVariablesStmt(SetType.SESSION, "var%");
-
-        ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
-        Assert.assertEquals(2, resultSet.getMetaData().getColumnCount());
-        Assert.assertEquals(2, resultSet.getResultRows().get(0).size());
-
-        Assert.assertTrue(resultSet.next());
-        Assert.assertEquals("var1", resultSet.getString(0));
-        Assert.assertTrue(resultSet.next());
-        Assert.assertEquals("var2", resultSet.getString(0));
-        Assert.assertFalse(resultSet.next());
-
-        stmt = new ShowVariablesStmt(SetType.SESSION, null);
-
-        resultSet = ShowExecutor.execute(stmt, ctx);
-
-        Assert.assertTrue(resultSet.next());
-        Assert.assertEquals("var1", resultSet.getString(0));
-        Assert.assertTrue(resultSet.next());
-        Assert.assertEquals("var2", resultSet.getString(0));
-        Assert.assertFalse(resultSet.next());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -89,7 +89,8 @@ public class VariableMgrTest {
 
     @Test
     public void testNormal() throws IllegalAccessException, NoSuchFieldException, UserException {
-        SessionVariable var = VariableMgr.newSessionVariable();
+        VariableMgr variableMgr = new VariableMgr();
+        SessionVariable var = variableMgr.newSessionVariable();
         Assert.assertEquals(2147483648L, var.getMaxExecMemByte());
         Assert.assertEquals(300, var.getQueryTimeoutS());
         Assert.assertEquals(false, var.isEnableProfile());
@@ -113,84 +114,84 @@ public class VariableMgrTest {
         // Set global variable
         SystemVariable setVar = new SystemVariable(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(12999934L));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), null);
-        VariableMgr.setSystemVariable(var, setVar, false);
+        variableMgr.setSystemVariable(var, setVar, false);
         Assert.assertEquals(12999934L, var.getMaxExecMemByte());
-        var = VariableMgr.newSessionVariable();
+        var = variableMgr.newSessionVariable();
         Assert.assertEquals(12999934L, var.getMaxExecMemByte());
 
         SystemVariable setVar2 = new SystemVariable(SetType.GLOBAL, "parallel_fragment_exec_instance_num", new IntLiteral(5L));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar2)), null);
-        VariableMgr.setSystemVariable(var, setVar2, false);
+        variableMgr.setSystemVariable(var, setVar2, false);
         Assert.assertEquals(5L, var.getParallelExecInstanceNum());
-        var = VariableMgr.newSessionVariable();
+        var = variableMgr.newSessionVariable();
         Assert.assertEquals(5L, var.getParallelExecInstanceNum());
 
         SystemVariable setVar3 = new SystemVariable(SetType.GLOBAL, "time_zone", new StringLiteral("Asia/Shanghai"));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar3)), null);
-        VariableMgr.setSystemVariable(var, setVar3, false);
+        variableMgr.setSystemVariable(var, setVar3, false);
         Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
-        var = VariableMgr.newSessionVariable();
+        var = variableMgr.newSessionVariable();
         Assert.assertEquals("Asia/Shanghai", var.getTimeZone());
 
         setVar3 = new SystemVariable(SetType.GLOBAL, "time_zone", new StringLiteral("CST"));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar3)), null);
-        VariableMgr.setSystemVariable(var, setVar3, false);
+        variableMgr.setSystemVariable(var, setVar3, false);
         Assert.assertEquals("CST", var.getTimeZone());
-        var = VariableMgr.newSessionVariable();
+        var = variableMgr.newSessionVariable();
         Assert.assertEquals("CST", var.getTimeZone());
 
         // Set session variable
         setVar = new SystemVariable(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(12999934L));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), null);
-        VariableMgr.setSystemVariable(var, setVar, false);
+        variableMgr.setSystemVariable(var, setVar, false);
         Assert.assertEquals(12999934L, var.getMaxExecMemByte());
 
         // onlySessionVar
         setVar = new SystemVariable(SetType.GLOBAL, "exec_mem_limit", new IntLiteral(12999935L));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), null);
-        VariableMgr.setSystemVariable(var, setVar, true);
+        variableMgr.setSystemVariable(var, setVar, true);
         Assert.assertEquals(12999935L, var.getMaxExecMemByte());
 
         setVar3 = new SystemVariable(SetType.SESSION, "time_zone", new StringLiteral("Asia/Jakarta"));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar3)), null);
-        VariableMgr.setSystemVariable(var, setVar3, false);
+        variableMgr.setSystemVariable(var, setVar3, false);
         Assert.assertEquals("Asia/Jakarta", var.getTimeZone());
 
         // exec_mem_limit in expr style
         setVar = new SystemVariable(SetType.GLOBAL, "exec_mem_limit", new StringLiteral("20G"));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), null);
-        VariableMgr.setSystemVariable(var, setVar, true);
+        variableMgr.setSystemVariable(var, setVar, true);
         Assert.assertEquals(21474836480L, var.getMaxExecMemByte());
         setVar = new SystemVariable(SetType.GLOBAL, "exec_mem_limit", new StringLiteral("20m"));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), null);
-        VariableMgr.setSystemVariable(var, setVar, true);
+        variableMgr.setSystemVariable(var, setVar, true);
         Assert.assertEquals(20971520L, var.getMaxExecMemByte());
 
         // Get from name
         VariableExpr desc = new VariableExpr("exec_mem_limit");
-        Assert.assertEquals(var.getMaxExecMemByte() + "", VariableMgr.getValue(var, desc));
+        Assert.assertEquals(var.getMaxExecMemByte() + "", variableMgr.getValue(var, desc));
 
         SystemVariable setVar4 = new SystemVariable(SetType.SESSION, "sql_mode", new StringLiteral(
                 SqlModeHelper.encode("PIPES_AS_CONCAT").toString()));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar4)), null);
-        VariableMgr.setSystemVariable(var, setVar4, false);
+        variableMgr.setSystemVariable(var, setVar4, false);
         Assert.assertEquals(2L, var.getSqlMode());
 
         // Test checkTimeZoneValidAndStandardize
         SystemVariable setVar5 = new SystemVariable(SetType.GLOBAL, "time_zone", new StringLiteral("+8:00"));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar5)), null);
-        VariableMgr.setSystemVariable(var, setVar5, false);
-        Assert.assertEquals("+08:00", VariableMgr.newSessionVariable().getTimeZone());
+        variableMgr.setSystemVariable(var, setVar5, false);
+        Assert.assertEquals("+08:00", variableMgr.newSessionVariable().getTimeZone());
 
         SystemVariable setVar6 = new SystemVariable(SetType.GLOBAL, "time_zone", new StringLiteral("8:00"));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar6)), null);
-        VariableMgr.setSystemVariable(var, setVar6, false);
-        Assert.assertEquals("+08:00", VariableMgr.newSessionVariable().getTimeZone());
+        variableMgr.setSystemVariable(var, setVar6, false);
+        Assert.assertEquals("+08:00", variableMgr.newSessionVariable().getTimeZone());
 
         SystemVariable setVar7 = new SystemVariable(SetType.GLOBAL, "time_zone", new StringLiteral("-8:00"));
         SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar7)), null);
-        VariableMgr.setSystemVariable(var, setVar7, false);
-        Assert.assertEquals("-08:00", VariableMgr.newSessionVariable().getTimeZone());
+        variableMgr.setSystemVariable(var, setVar7, false);
+        Assert.assertEquals("-08:00", variableMgr.newSessionVariable().getTimeZone());
     }
 
     @Test(expected = SemanticException.class)
@@ -248,12 +249,13 @@ public class VariableMgrTest {
 
     @Test(expected = DdlException.class)
     public void testReadOnly() throws AnalysisException, DdlException {
+        VariableMgr variableMgr = new VariableMgr();
         VariableExpr desc = new VariableExpr("version_comment");
-        LOG.info(VariableMgr.getValue(null, desc));
+        LOG.info(variableMgr.getValue(null, desc));
 
         // Set global variable
         SystemVariable setVar = new SystemVariable(SetType.SESSION, "version_comment", null);
-        VariableMgr.setSystemVariable(null, setVar, false);
+        variableMgr.setSystemVariable(null, setVar, false);
         Assert.fail("No exception throws.");
     }
 
@@ -280,8 +282,9 @@ public class VariableMgrTest {
     public void testWarehouseVar() {
         SystemVariable systemVariable =
                 new SystemVariable(SetType.GLOBAL, SessionVariable.WAREHOUSE_NAME, new StringLiteral("warehouse_1"));
+        VariableMgr variableMgr = new VariableMgr();
         try {
-            VariableMgr.setSystemVariable(null, systemVariable, false);
+            variableMgr.setSystemVariable(null, systemVariable, false);
         } catch (DdlException e) {
             Assert.assertEquals("Variable 'warehouse' is a SESSION variable and can't be used with SET GLOBAL",
                     e.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -97,7 +97,7 @@ public class VariableMgrTest {
         Assert.assertEquals(32L, var.getSqlMode());
         Assert.assertEquals(true, var.isInnodbReadOnly());
 
-        List<List<String>> rows = VariableMgr.dump(SetType.SESSION, var, null);
+        List<List<String>> rows = variableMgr.dump(SetType.SESSION, var, null);
         Assert.assertTrue(rows.size() > 5);
         for (List<String> row : rows) {
             if (row.get(0).equalsIgnoreCase("exec_mem_limit")) {
@@ -261,20 +261,21 @@ public class VariableMgrTest {
 
     @Test
     public void testDumpInvisible() {
+        VariableMgr variableMgr = new VariableMgr();
         SessionVariable sv = new SessionVariable();
-        List<List<String>> vars = VariableMgr.dump(SetType.SESSION, sv, null);
+        List<List<String>> vars = variableMgr.dump(SetType.SESSION, sv, null);
         Assert.assertFalse(vars.toString().contains("enable_show_all_variables"));
         Assert.assertFalse(vars.toString().contains("cbo_use_correlated_join_estimate"));
 
         sv.setEnableShowAllVariables(true);
-        vars = VariableMgr.dump(SetType.SESSION, sv, null);
+        vars = variableMgr.dump(SetType.SESSION, sv, null);
         Assert.assertTrue(vars.toString().contains("cbo_use_correlated_join_estimate"));
 
-        vars = VariableMgr.dump(SetType.SESSION, null, null);
-        List<List<String>> vars1 = VariableMgr.dump(SetType.GLOBAL, null, null);
+        vars = variableMgr.dump(SetType.SESSION, null, null);
+        List<List<String>> vars1 = variableMgr.dump(SetType.GLOBAL, null, null);
         Assert.assertTrue(vars.size() < vars1.size());
 
-        List<List<String>> vars2 = VariableMgr.dump(SetType.SESSION, null, null);
+        List<List<String>> vars2 = variableMgr.dump(SetType.SESSION, null, null);
         Assert.assertTrue(vars.size() == vars2.size());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -396,16 +396,17 @@ class ParserTest {
 
     @Test
     void testWrongVariableName() {
-        String res = VariableMgr.findSimilarVarNames("disable_coloce_join");
+        VariableMgr variableMgr = new VariableMgr();
+        String res = variableMgr.findSimilarVarNames("disable_coloce_join");
         assertContains(res, "{'disable_colocate_join', 'disable_join_reorder', 'disable_function_fold_constants'}");
 
-        res = VariableMgr.findSimilarVarNames("SQL_AUTO_NULL");
+        res = variableMgr.findSimilarVarNames("SQL_AUTO_NULL");
         assertContains(res, "{'SQL_AUTO_IS_NULL', 'sql_dialect', 'spill_storage_volume'}");
 
-        res = VariableMgr.findSimilarVarNames("pipeline");
+        res = variableMgr.findSimilarVarNames("pipeline");
         assertContains(res, "{'pipeline_dop', 'pipeline_sink_dop', 'pipeline_profile_level'}");
 
-        res = VariableMgr.findSimilarVarNames("disable_joinreorder");
+        res = variableMgr.findSimilarVarNames("disable_joinreorder");
         assertContains(res, "{'disable_join_reorder', 'disable_colocate_join'");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -19,6 +19,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -182,7 +183,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
     public void testGroupByLimit() throws Exception {
         // check can generate 1 phase with limit 1
         // This test has column statistics and accurate table row count
-        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
+        SessionVariable sessionVariable = GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable();
         sessionVariable.setNewPlanerAggStage(1);
         Pair<QueryDumpInfo, String> replayPair =
                 getCostPlanFragment(getDumpInfoFromFile("query_dump/groupby_limit"), sessionVariable);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -18,7 +18,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
@@ -25,6 +25,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TExplainLevel;
@@ -127,7 +128,7 @@ public class ReplayFromDumpTestBase {
     }
 
     public SessionVariable getTestSessionVariable() {
-        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
+        SessionVariable sessionVariable = GlobalStateMgr.getCurrentState().getVariableMgr().newSessionVariable();
         sessionVariable.setMaxTransformReorderJoins(8);
         sessionVariable.setEnableGlobalRuntimeFilter(true);
         sessionVariable.setEnableMultiColumnsOnGlobbalRuntimeFilter(true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
@@ -24,7 +24,6 @@ import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.system.BackendResourceStat;

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -1368,7 +1368,7 @@ public class UtFrameUtils {
                     clonedSessionVariable = (SessionVariable) context.getSessionVariable().clone();
                 }
                 for (Map.Entry<String, String> entry : hint.getValue().entrySet()) {
-                    VariableMgr.setSystemVariable(clonedSessionVariable,
+                    GlobalStateMgr.getCurrentState().getVariableMgr().setSystemVariable(clonedSessionVariable,
                                 new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue())), true);
                 }
             } else if (hint instanceof UserVariableHint) {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -94,7 +94,6 @@ import com.starrocks.qe.ConnectProcessor;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;


### PR DESCRIPTION
## Why I'm doing:
The VariableMgr should be an attribute of the GlobalStateMgr for saving image, and cannot be singleton. Because the checkpoint uses another memory.

## What I'm doing:
Change VariableMgr to the attribute of GlobalStateMgr.

Fixes #50922

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
