### PR TITLE
[Refactor] Fix the clang-tidy check

### DIFF
--- a/be/src/storage/lake/pk_tablet_writer.h
+++ b/be/src/storage/lake/pk_tablet_writer.h
@@ -56,7 +56,6 @@ protected:
 private:
     std::unique_ptr<RowsetTxnMetaPB> _rowset_txn_meta;
     std::unique_ptr<RowsMapperBuilder> _rows_mapper_builder;
-    const std::map<std::string, std::string>* _column_to_expr_value = nullptr;
 };
 
 class VerticalPkTabletWriter : public VerticalGeneralTabletWriter {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
[ 62%] Building CXX object src/runtime/CMakeFiles/Runtime.dir/runtime_state.cpp.o
/root/starrocks/be/src/storage/lake/pk_tablet_writer.h:59:47: error: private field '_column_to_expr_value' is not used [clang-diagnostic-unused-private-field]
    const std::map<std::string, std::string>* _column_to_expr_value = nullptr;
                                              ^
8444 warnings and 1 error generated.
Error while processing /root/starrocks/be/src/storage/lake/pk_tablet_writer.cpp.
Suppressed 8447 warnings (8440 in non-user code, 3 NOLINT, 4 with check filters).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
