### PR TITLE
[BugFix] Fix dict_mapping expression crash caused by multiple open in ExprContext::clone

### DIFF
--- a/be/src/exprs/dict_query_expr.cpp
+++ b/be/src/exprs/dict_query_expr.cpp
@@ -107,6 +107,11 @@ Status DictQueryExpr::open(RuntimeState* state, ExprContext* context, FunctionCo
     // init parent open
     RETURN_IF_ERROR(Expr::open(state, context, scope));
 
+    // make sure ExprContext::clone will not open DictQueryExpr again
+    if (scope == FunctionContext::THREAD_LOCAL) {
+        return Status::OK();
+    }
+
     TGetDictQueryParamRequest request;
     request.__set_db_name(_dict_query_expr.db_name);
     request.__set_table_name(_dict_query_expr.tbl_name);

--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -307,3 +307,29 @@ drop table t_dictmapping_null_if_not_found;
 drop database test_dictmapping_null_if_not_found;
 -- result:
 -- !result
+-- name: test_dictmapping_multiple_open_crash
+CREATE TABLE `t_dictmapping_multiple_open_crash` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AUTO_INCREMENT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_dictmapping_multiple_open_crash VALUES (1, DEFAULT);
+-- result:
+-- !result
+select dict_mapping("t_dictmapping_multiple_open_crash", k) from t where dict_mapping("t_dictmapping_multiple_open_crash", k) != 0;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_635994ed9f8b4b06bb4c07ef77387ab8.t'.")
+-- !result
+DROP TABLE t_dictmapping_multiple_open_crash;
+-- result:
+-- !result

--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -326,9 +326,9 @@ PROPERTIES (
 INSERT INTO t_dictmapping_multiple_open_crash VALUES (1, DEFAULT);
 -- result:
 -- !result
-select dict_mapping("t_dictmapping_multiple_open_crash", k) from t where dict_mapping("t_dictmapping_multiple_open_crash", k) != 0;
+select dict_mapping("t_dictmapping_multiple_open_crash", k) from t_dictmapping_multiple_open_crash where dict_mapping("t_dictmapping_multiple_open_crash", k) != 0;
 -- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_635994ed9f8b4b06bb4c07ef77387ab8.t'.")
+1
 -- !result
 DROP TABLE t_dictmapping_multiple_open_crash;
 -- result:

--- a/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/T/test_dict_mapping_function
@@ -189,3 +189,22 @@ select dict_mapping("t_dictmapping_null_if_not_found", 2, true);
 
 drop table t_dictmapping_null_if_not_found;
 drop database test_dictmapping_null_if_not_found;
+
+-- name: test_dictmapping_multiple_open_crash
+CREATE TABLE `t_dictmapping_multiple_open_crash` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AUTO_INCREMENT
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_dictmapping_multiple_open_crash VALUES (1, DEFAULT);
+select dict_mapping("t_dictmapping_multiple_open_crash", k) from t where dict_mapping("t_dictmapping_multiple_open_crash", k) != 0;
+DROP TABLE t_dictmapping_multiple_open_crash;


### PR DESCRIPTION
## Why I'm doing:
ExprContext::clone may re-open a opened expression with scope as FunctionContext::THREAD_LOCAL. But dictQueryExpr do not support open for multiple time and make BE crash when evaluate.

## What I'm doing:
Skip open in dictQueryExpr::open if scope is FunctionContext::THREAD_LOCAL (by ExprContext::clone)

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
