### PR TITLE
[Enhancement] Support recover FE metadata from backup meta

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -631,7 +631,7 @@ public class Config extends ConfigBase {
      * (Because most of the follower data has been damaged).
      */
     @ConfField
-    public static String bdbje_reset_election_group = "false";
+    public static boolean bdbje_reset_election_group = false;
 
     /**
      * If the bdb data is corrupted, and you want to start the cluster only with image, set this param to true

--- a/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
@@ -50,7 +50,6 @@ import com.sleepycat.je.rep.ReplicatedEnvironment;
 import com.sleepycat.je.rep.ReplicationGroup;
 import com.sleepycat.je.rep.ReplicationMutableConfig;
 import com.sleepycat.je.rep.ReplicationNode;
-import com.sleepycat.je.rep.UnknownMasterException;
 import com.sleepycat.je.rep.util.ReplicationGroupAdmin;
 import com.starrocks.journal.bdbje.BDBEnvironment;
 import com.starrocks.journal.bdbje.CloseSafeDatabase;
@@ -160,8 +159,8 @@ public class BDBHA implements HAProtocol {
             for (ReplicationNode replicationNode : replicationGroup.getSecondaryNodes()) {
                 ret.add(replicationNode.getSocketAddress());
             }
-        } catch (UnknownMasterException e) {
-            LOG.warn("Catch UnknownMasterException when calling getObserverNodes.", e);
+        } catch (Throwable t) {
+            LOG.warn("Catch Exception when calling getObserverNodes.", t);
             return Lists.newArrayList();
         }
         return ret;
@@ -185,8 +184,8 @@ public class BDBHA implements HAProtocol {
                     }
                 }
             }
-        } catch (UnknownMasterException e) {
-            LOG.warn("Catch UnknownMasterException when calling getElectableNodes.", e);
+        } catch (Throwable t) {
+            LOG.warn("catch exception when calling getElectableNodes.", t);
             return Lists.newArrayList();
         }
         return ret;

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -174,7 +174,7 @@ public class BDBEnvironment {
 
     protected void initConfigs(boolean isElectable) throws JournalException {
         // Almost never used, just in case the master can not restart
-        if (Config.bdbje_reset_election_group.equals("true")) {
+        if (Config.bdbje_reset_election_group) {
             if (!isElectable) {
                 String errMsg = "Current node is not in the electable_nodes list. will exit";
                 LOG.error(errMsg);
@@ -339,7 +339,7 @@ public class BDBEnvironment {
         }
 
         // Almost never used, just in case the master can not restart
-        if (Config.bdbje_reset_election_group.equals("true")) {
+        if (Config.bdbje_reset_election_group) {
             LOG.info("skip check local environment because metadata_failure_recovery = true");
             return;
         }


### PR DESCRIPTION
## Why I'm doing:
With this patch, it is possible to recover FE metadata if all machines are unavailable but the meta directory still exists.

1. Start a FE node with the backup meta using config `bdbje_reset_election_group = true` in fe.conf. We call this FE as `FE_TMP`.
2. Add another Follower node to this cluster. We call this FE as `FE_NORMAL`.
3. Make sure `FE_NORMAL` is added to cluster successfully. Stop `FE_TMP`, and this node will be never used.
4. Add `bdbje_reset_election_group = true` to fe.conf, and restart `FE_NORMAL`.
5. Connect `FE_NORMAL` and make sure the meta is normal.
6. Remove `bdbje_reset_election_group = true` from fe.conf, and restart `FE_NORMAL`.
7. Connect to `FE_NORMAL` and remove all the other FE nodes.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5