### PR TITLE
[Enhancement] List Partition For AMV(Part 5): Support partial refresh list partition for mv 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
@@ -118,7 +118,7 @@ public class ExecuteOption {
             return false;
         }
         if (containsKey(TaskRun.PARTITION_START) || containsKey(TaskRun.PARTITION_END)
-                || containsKey(TaskRun.START_TASK_RUN_ID)) {
+                || containsKey(TaskRun.START_TASK_RUN_ID) || containsKey(TaskRun.PARTITION_VALUES)) {
             return true;
         }
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -47,6 +47,8 @@ public class MvTaskRunContext extends TaskRunContext {
 
     private String nextPartitionStart = null;
     private String nextPartitionEnd = null;
+    // The next list partition values to be processed
+    private String nextListPartitionValues = null;
     private ExecPlan execPlan = null;
 
     private int partitionTTLNumber = TableProperty.INVALID;
@@ -91,6 +93,14 @@ public class MvTaskRunContext extends TaskRunContext {
 
     public void setNextPartitionEnd(String nextPartitionEnd) {
         this.nextPartitionEnd = nextPartitionEnd;
+    }
+
+    public String getNextListPartitionValues() {
+        return nextListPartitionValues;
+    }
+
+    public void setNextListPartitionValues(String nextListPartitionValues) {
+        this.nextListPartitionValues = nextListPartitionValues;
     }
 
     public Map<Table, Map<String, Range<PartitionKey>>> getRefBaseTableRangePartitionMap() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -48,7 +48,7 @@ public class MvTaskRunContext extends TaskRunContext {
     private String nextPartitionStart = null;
     private String nextPartitionEnd = null;
     // The next list partition values to be processed
-    private String nextListPartitionValues = null;
+    private String nextPartitionValues = null;
     private ExecPlan execPlan = null;
 
     private int partitionTTLNumber = TableProperty.INVALID;
@@ -76,7 +76,7 @@ public class MvTaskRunContext extends TaskRunContext {
     }
 
     public boolean hasNextBatchPartition() {
-        return nextPartitionStart != null && nextPartitionEnd != null;
+        return (nextPartitionStart != null && nextPartitionEnd != null) || (nextPartitionValues != null);
     }
 
     public String getNextPartitionStart() {
@@ -95,12 +95,12 @@ public class MvTaskRunContext extends TaskRunContext {
         this.nextPartitionEnd = nextPartitionEnd;
     }
 
-    public String getNextListPartitionValues() {
-        return nextListPartitionValues;
+    public String getNextPartitionValues() {
+        return nextPartitionValues;
     }
 
-    public void setNextListPartitionValues(String nextListPartitionValues) {
-        this.nextListPartitionValues = nextListPartitionValues;
+    public void setNextPartitionValues(String nextPartitionValues) {
+        this.nextPartitionValues = nextPartitionValues;
     }
 
     public Map<Table, Map<String, Range<PartitionKey>>> getRefBaseTableRangePartitionMap() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -66,6 +66,7 @@ import com.starrocks.scheduler.mv.MVPCTRefreshNonPartitioner;
 import com.starrocks.scheduler.mv.MVPCTRefreshPartitioner;
 import com.starrocks.scheduler.mv.MVPCTRefreshPlanBuilder;
 import com.starrocks.scheduler.mv.MVPCTRefreshRangePartitioner;
+import com.starrocks.scheduler.mv.MVRefreshParams;
 import com.starrocks.scheduler.mv.MVTraceUtils;
 import com.starrocks.scheduler.mv.MVVersionManager;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
@@ -234,7 +235,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                            Map<TableSnapshotInfo, Set<String>> baseTableCandidatePartitions)
             throws AnalysisException, LockTimeoutException {
         // collect partition infos of ref base tables
-        LOG.info("start to sync and check partitions for mv: {}", materializedView.getName());
+        LOG.debug("Start to sync and check partitions for mv: {}", materializedView.getName());
         int retryNum = 0;
         boolean checked = false;
         Stopwatch stopwatch = Stopwatch.createStarted();
@@ -268,7 +269,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
         Tracers.record("MVRefreshSyncPartitionsRetryTimes", String.valueOf(retryNum));
 
-        LOG.info("materialized view {} after checking partitions change {} times: {}, costs: {} ms",
+        LOG.info("Sync and check materialized view {} partition changing after {} times: {}, costs: {} ms",
                 materializedView.getName(), retryNum, checked, stopwatch.elapsed(TimeUnit.MILLISECONDS));
         return checked;
     }
@@ -302,9 +303,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     tentative);
             int partitionRefreshNumber = materializedView.getTableProperty().getPartitionRefreshNumber();
             LOG.info("Filter partitions to refresh for materialized view {}, partitionRefreshNumber={}, " +
-                            "partitionsToRefresh:{}, mvPotentialPartitionNames:{}, next start:{}, next end:{}",
+                            "partitionsToRefresh:{}, mvPotentialPartitionNames:{}, next start:{}, next end:{}, " +
+                            "next list values:{}",
                     materializedView.getName(), partitionRefreshNumber, mvToRefreshedPartitions, mvPotentialPartitionNames,
-                    mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd());
+                    mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), mvContext.getNextListPartitionValues());
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), materializedView.getId(), LockType.READ);
         }
@@ -357,7 +359,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                                                 IMaterializedViewMetricsEntity mvEntity) throws DmlException {
         // Use current connection variables instead of mvContext's session variables to be better debug.
         int maxRefreshMaterializedViewRetryNum = getMaxRefreshMaterializedViewRetryNum(taskRunContext.getCtx());
-        LOG.info("Start to refresh mv:{} with retry times:{}, try lock failure retry times:{}",
+        LOG.info("Start to refresh mv:{} with retry times:{}",
                 materializedView.getName(), maxRefreshMaterializedViewRetryNum);
 
         Throwable lastException = null;
@@ -448,7 +450,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             // ref table of materialized view : refreshed partition names
             refTablePartitionNames = refTableRefreshPartitions.entrySet().stream()
                     .collect(Collectors.toMap(x -> x.getKey().getName(), Map.Entry::getValue));
-            LOG.info("materialized:{}, mvToRefreshedPartitions:{}, refTableRefreshPartitions:{}",
+            LOG.info("Check mv {} to refresh partitions: mvToRefreshedPartitions:{}, " +
+                            "refTableRefreshPartitions:{}",
                     materializedView.getName(), mvToRefreshedPartitions, refTableRefreshPartitions);
             // add a message into information_schema
             logMvToRefreshInfoIntoTaskRun(mvToRefreshedPartitions, refTablePartitionNames);
@@ -520,6 +523,16 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             locker.unlock();
         }
 
+        updateTaskRunStatus(status -> {
+            MVTaskRunExtraMessage message = status.getMvTaskRunExtraMessage();
+            if (message == null) {
+                return;
+            }
+            Map<String, String> planBuildMessage = planBuilder.getPlanBuilderMessage();
+            LOG.info("MV Refresh PlanBuilderMessage: {}", planBuildMessage);
+            message.setPlanBuilderMessage(planBuildMessage);
+        });
+
         QueryDebugOptions debugOptions = ctx.getSessionVariable().getQueryDebugOptions();
         // log the final mv refresh plan for each refresh for better trace and debug
         if (LOG.isDebugEnabled() || debugOptions.isEnableQueryTraceLog()) {
@@ -536,7 +549,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     materializedView.getName(), String.join(",", mvToRefreshedPartitions), refTablePartitionNames);
         }
         mvContext.setExecPlan(execPlan);
-        LOG.info("prepared refresh plan for mv:{}", materializedView.getName());
+        LOG.info("Finished mv refresh plan for {}", materializedView.getName());
         return insertStmt;
     }
 
@@ -668,6 +681,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
         newProperties.put(TaskRun.PARTITION_START, mvContext.getNextPartitionStart());
         newProperties.put(TaskRun.PARTITION_END, mvContext.getNextPartitionEnd());
+        newProperties.put(TaskRun.PARTITION_VALUES, mvContext.getNextListPartitionValues());
         if (mvContext.getStatus() != null) {
             newProperties.put(TaskRun.START_TASK_RUN_ID, mvContext.getStatus().getStartTaskRunId());
         }
@@ -723,7 +737,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             // refresh old table
             Table table = optTable.get();
             if (table.isNativeTableOrMaterializedView() || table.isConnectorView()) {
-                LOG.info("No need to refresh table:{} because it is native table or materialized view or connector view",
+                LOG.debug("No need to refresh table:{} because it is native table or materialized view or connector view",
                         baseTableInfo.getTableInfoStr());
                 continue;
             }
@@ -921,7 +935,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         // do sync partitions (add or drop partitions) for materialized view
         boolean result = mvRefreshPartitioner.syncAddOrDropPartitions();
-        LOG.info("finish sync partitions. mv:{}, cost(ms): {}", materializedView.getName(),
+        LOG.info("Finish sync mv:{} partitions, cost(ms): {}", materializedView.getName(),
                 stopwatch.elapsed(TimeUnit.MILLISECONDS));
         return result;
     }
@@ -934,20 +948,18 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                                                  Set<String> mvPotentialPartitionNames,
                                                                  boolean tentative)
             throws AnalysisException {
-        String start = properties.get(TaskRun.PARTITION_START);
-        String end = properties.get(TaskRun.PARTITION_END);
-        boolean force = Boolean.parseBoolean(properties.get(TaskRun.FORCE));
         PartitionInfo partitionInfo = materializedView.getPartitionInfo();
+        MVRefreshParams mvRefreshParams = new MVRefreshParams(materializedView, properties, tentative);
         Set<String> needRefreshMvPartitionNames = getPartitionsToRefreshForMaterializedView(partitionInfo,
-                start, end, tentative || force, mvPotentialPartitionNames);
+                mvRefreshParams, mvPotentialPartitionNames);
 
         // update mv extra message
         if (!tentative) {
             updateTaskRunStatus(status -> {
                 MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
-                extraMessage.setForceRefresh(force);
-                extraMessage.setPartitionStart(start);
-                extraMessage.setPartitionEnd(end);
+                extraMessage.setForceRefresh(mvRefreshParams.isForce());
+                extraMessage.setPartitionStart(mvRefreshParams.getRangeStart());
+                extraMessage.setPartitionEnd(mvRefreshParams.getRangeEnd());
             });
         }
 
@@ -967,25 +979,21 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     /**
      * @param mvPartitionInfo : materialized view's partition info
-     * @param start           : materialized view's refresh start in this task run
-     * @param end             : materialized view's refresh end in this task run
-     * @param force           : whether this task run is force or not
+     * @param mvRefreshParams : materialized view's refresh params
      * @return the partitions to refresh for materialized view
      * @throws AnalysisException
      */
-    private Set<String> getPartitionsToRefreshForMaterializedView(
-            PartitionInfo mvPartitionInfo,
-            String start,
-            String end,
-            boolean force,
-            Set<String> mvPotentialPartitionNames) throws AnalysisException {
-        if (force && start == null && end == null) {
+    private Set<String> getPartitionsToRefreshForMaterializedView(PartitionInfo mvPartitionInfo,
+                                                                  MVRefreshParams mvRefreshParams,
+                                                                  Set<String> mvPotentialPartitionNames)
+            throws AnalysisException {
+        if (mvRefreshParams.isForceCompleteRefresh()) {
             // Force refresh
             int partitionTTLNumber = mvContext.getPartitionTTLNumber();
             return mvRefreshPartitioner.getMVPartitionsToRefreshWithForce(partitionTTLNumber);
         } else {
             return mvRefreshPartitioner.getMVPartitionsToRefresh(mvPartitionInfo, snapshotBaseTables,
-                    start, end, force, mvPotentialPartitionNames);
+                    mvRefreshParams, mvPotentialPartitionNames);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -694,7 +694,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
             extraMessage.setNextPartitionStart(mvContext.getNextPartitionStart());
             extraMessage.setNextPartitionEnd(mvContext.getNextPartitionEnd());
-            extraMessage.setNextPartitionEnd(mvContext.getNextPartitionValues());
+            extraMessage.setNextPartitionValues(mvContext.getNextPartitionValues());
         });
 
         // Partition refreshing task run should have the HIGHEST priority, and be scheduled before other tasks

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -681,6 +681,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
         newProperties.put(TaskRun.PARTITION_START, mvContext.getNextPartitionStart());
         newProperties.put(TaskRun.PARTITION_END, mvContext.getNextPartitionEnd());
+        //TODO: partition values may be too long, need to be optimized later.
         newProperties.put(TaskRun.PARTITION_VALUES, mvContext.getNextListPartitionValues());
         if (mvContext.getStatus() != null) {
             newProperties.put(TaskRun.START_TASK_RUN_ID, mvContext.getStatus().getStartTaskRunId());
@@ -949,7 +950,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                                                  boolean tentative)
             throws AnalysisException {
         PartitionInfo partitionInfo = materializedView.getPartitionInfo();
-        MVRefreshParams mvRefreshParams = new MVRefreshParams(materializedView, properties, tentative);
+        MVRefreshParams mvRefreshParams = new MVRefreshParams(partitionInfo, properties, tentative);
         Set<String> needRefreshMvPartitionNames = getPartitionsToRefreshForMaterializedView(partitionInfo,
                 mvRefreshParams, mvPotentialPartitionNames);
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -53,13 +53,13 @@ public class TaskRun implements Comparable<TaskRun> {
     public static final String MV_ID = "mvId";
     public static final String PARTITION_START = "PARTITION_START";
     public static final String PARTITION_END = "PARTITION_END";
+    // list partition values to be refreshed
+    public static final String PARTITION_VALUES = "PARTITION_VALUES";
     public static final String FORCE = "FORCE";
     public static final String START_TASK_RUN_ID = "START_TASK_RUN_ID";
     // All properties that can be set in TaskRun
-    public static final Set<String> TASK_RUN_PROPERTIES =
-            ImmutableSet.of(
-                    MV_ID, PARTITION_START, PARTITION_END,
-                    FORCE, START_TASK_RUN_ID);
+    public static final Set<String> TASK_RUN_PROPERTIES = ImmutableSet.of(
+            MV_ID, PARTITION_START, PARTITION_END, FORCE, START_TASK_RUN_ID, PARTITION_VALUES);
 
     // Only used in FE's UT
     public static final String IS_TEST = "__IS_TEST__";

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -314,16 +314,16 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             mappedPartitionsToRefresh.put(partitionName, listCell);
         }
         int refreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
-        Set<PListCell> nextPartitionCells = filterPartitionsByNumber(mappedPartitionsToRefresh, refreshNumber);
+        Set<PListCell> nextPartitionValues = filterPartitionsByNumber(mappedPartitionsToRefresh, refreshNumber);
         // do filter input mvPartitionsToRefresh since it's a reference
         mvPartitionsToRefresh.retainAll(mappedPartitionsToRefresh.keySet());
-        if (CollectionUtils.isEmpty(nextPartitionCells)) {
+        if (CollectionUtils.isEmpty(nextPartitionValues)) {
             return;
         }
         if (!tentative) {
             // partitionNameIter has just been traversed, and endPartitionName is not updated
             // will cause endPartitionName == null
-            mvContext.setNextListPartitionValues(PListCell.batchSerialize(nextPartitionCells));
+            mvContext.setNextPartitionValues(PListCell.batchSerialize(nextPartitionValues));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -17,6 +17,7 @@ package com.starrocks.scheduler.mv;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.IsNullPredicate;
@@ -30,7 +31,6 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -49,6 +49,7 @@ import com.starrocks.sql.common.ListPartitionDiffResult;
 import com.starrocks.sql.common.ListPartitionDiffer;
 import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -97,7 +98,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             for (String mvPartitionName : deletes.keySet()) {
                 dropPartition(db, mv, mvPartitionName);
             }
-            LOG.info("The process of synchronizing materialized view [{}] delete partitions range [{}]",
+            LOG.info("The process of synchronizing materialized view [{}] delete partitions list [{}]",
                     mv.getName(), deletes);
 
             // add partitions
@@ -196,16 +197,16 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     @Override
     public Set<String> getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
                                                 Map<Long, TableSnapshotInfo> snapshotBaseTables,
-                                                String start, String end, boolean force,
+                                                MVRefreshParams mvRefreshParams,
                                                 Set<String> mvPotentialPartitionNames) {
         // list partitioned materialized view
         boolean isAutoRefresh = mvContext.getTaskType().isAutoRefresh();
         int partitionTTLNumber = mvContext.getPartitionTTLNumber();
-        Set<String> mvListPartitionNames = getMVPartitionNamesWithTTL(mv, start, end, partitionTTLNumber, isAutoRefresh);
+        Set<String> mvListPartitionNames = getMVPartitionNamesWithTTL(mv, mvRefreshParams, partitionTTLNumber, isAutoRefresh);
 
         // check non-ref base tables
-        if (force || needsRefreshBasedOnNonRefTables(snapshotBaseTables)) {
-            if (start == null && end == null) {
+        if (mvRefreshParams.isForce() || needsRefreshBasedOnNonRefTables(snapshotBaseTables)) {
+            if (mvRefreshParams.isCompleteRefresh()) {
                 // if non-partition table changed, should refresh all partitions of materialized view
                 return mvListPartitionNames;
             } else {
@@ -221,10 +222,34 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
 
     @Override
     public Set<String> getMVPartitionNamesWithTTL(MaterializedView materializedView,
-                                                  String start, String end,
+                                                  MVRefreshParams mvRefreshParams,
                                                   int partitionTTLNumber,
                                                   boolean isAutoRefresh) {
         int autoRefreshPartitionsLimit = materializedView.getTableProperty().getAutoRefreshPartitionsLimit();
+
+        // if the user specifies the start and end ranges, only refresh the specified partitions
+        boolean isCompleteRefresh = mvRefreshParams.isCompleteRefresh();
+        if (!isCompleteRefresh) {
+            Set<PListCell> pListCells = mvRefreshParams.getListValues();
+            Map<String, PListCell> mvPartitions = materializedView.getListPartitionItems();
+            Set<String> result = Sets.newHashSet();
+            for (Map.Entry<String, PListCell> e : mvPartitions.entrySet()) {
+                PListCell mvListCell = e.getValue();
+                if (mvListCell.getItemSize() == 1) {
+                    // if list value is a single value, check it directly
+                    if (pListCells.contains(e.getValue()))  {
+                        result.add(e.getKey());
+                    }
+                } else {
+                    // if list values is multi values, split it into single values and check it then.
+                    if (mvListCell.toSingleValueCells().stream().anyMatch(i -> pListCells.contains(i))) {
+                        result.add(e.getKey());
+                    }
+                }
+            }
+            return result;
+        }
+
         int lastPartitionNum;
         if (partitionTTLNumber > 0 && isAutoRefresh && autoRefreshPartitionsLimit > 0) {
             lastPartitionNum = Math.min(partitionTTLNumber, autoRefreshPartitionsLimit);
@@ -244,38 +269,33 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
      * @param filterNumber the number to filter/reserve
      * @return <startPartitionName, endPartitionName> pair after the reserved partition_ttl_number
      */
-    private Pair<String, String> filterPartitionsByNumber(Map<String, PListCell> inputPartitions,
-                                                          int filterNumber) {
+    private Set<PListCell> filterPartitionsByNumber(Map<String, PListCell> inputPartitions,
+                                                    int filterNumber) {
         if (filterNumber <= 0 || filterNumber >= inputPartitions.size()) {
             return null;
         }
         // TODO: Sort by List Partition's value is weird because there maybe meaningless or un-sortable,
         // users should take care of `partition_ttl_number` for list partition.
         LinkedHashMap<String, PListCell> sortedPartition = inputPartitions.entrySet().stream()
-                .sorted(Map.Entry.comparingByValue())
+                .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue())) // reverse order(max heap)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
-        Iterator<String> iter = sortedPartition.keySet().iterator();
+        Iterator<Map.Entry<String, PListCell>> iter = sortedPartition.entrySet().iterator();
         // iterate partition_ttl_number times
         for (int i = 0; i < filterNumber; i++) {
             if (iter.hasNext()) {
                 iter.next();
             }
         }
-        String start = null;
-        String end = null;
-        if (iter.hasNext()) {
-            String startPartitionName = iter.next();
-            start = startPartitionName;
-            end = startPartitionName;
-            inputPartitions.remove(end);
-        }
+        Set<PListCell> remains = Sets.newHashSet();
         while (iter.hasNext()) {
-            end = iter.next();
-            inputPartitions.remove(end);
+            Map.Entry<String, PListCell> entry = iter.next();
+            remains.add(entry.getValue());
+            // remove the partition which is not reserved
+            inputPartitions.remove(entry.getKey());
         }
-        LOG.info("Filter partitions by partition_ttl_number, ttl_number:{}, start: {}, end: {}, result:{}",
-                filterNumber, start, end, inputPartitions);
-        return Pair.create(start, end);
+        LOG.info("Filter partitions by partition_ttl_number, ttl_number:{}, result:{}, remains:{}",
+                filterNumber, inputPartitions, remains);
+        return remains;
     }
 
     @Override
@@ -292,15 +312,16 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             mappedPartitionsToRefresh.put(partitionName, listCell);
         }
         int refreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
-        Pair<String, String> result = filterPartitionsByNumber(mappedPartitionsToRefresh, refreshNumber);
-        if (result == null) {
+        Set<PListCell> remains = filterPartitionsByNumber(mappedPartitionsToRefresh, refreshNumber);
+        // do filter input mvPartitionsToRefresh since it's a reference
+        mvPartitionsToRefresh.retainAll(mappedPartitionsToRefresh.keySet());
+        if (CollectionUtils.isEmpty(remains)) {
             return;
         }
         if (!tentative) {
             // partitionNameIter has just been traversed, and endPartitionName is not updated
             // will cause endPartitionName == null
-            mvContext.setNextPartitionStart(result.first);
-            mvContext.setNextPartitionEnd(result.second);
+            mvContext.setNextListPartitionValues(PListCell.serializePListCells(remains));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -60,10 +60,10 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     @Override
     public Set<String> getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
                                                 Map<Long, TableSnapshotInfo> snapshotBaseTables,
-                                                String start, String end, boolean force,
+                                                MVRefreshParams mvRefreshParams,
                                                 Set<String> mvPotentialPartitionNames) {
         // non-partitioned materialized view
-        if (force || isNonPartitionedMVNeedToRefresh(snapshotBaseTables, mv)) {
+        if (mvRefreshParams.isForce() || isNonPartitionedMVNeedToRefresh(snapshotBaseTables, mv)) {
             return mv.getVisiblePartitionNames();
         }
         return Sets.newHashSet();
@@ -71,7 +71,7 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
 
     @Override
     public Set<String> getMVPartitionNamesWithTTL(MaterializedView materializedView,
-                                                  String start, String end,
+                                                  MVRefreshParams mvRefreshParams,
                                                   int partitionTTLNumber,
                                                   boolean isAutoRefresh) {
         return Sets.newHashSet();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -98,7 +98,7 @@ public abstract class MVPCTRefreshPartitioner {
      */
     public abstract Set<String> getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
                                                          Map<Long, TableSnapshotInfo> snapshotBaseTables,
-                                                         String start, String end, boolean force,
+                                                         MVRefreshParams mvRefreshParams,
                                                          Set<String> mvPotentialPartitionNames) throws AnalysisException;
     public abstract Set<String> getMVPartitionsToRefreshWithForce(int partitionTTLNumber) throws AnalysisException;
 
@@ -113,7 +113,7 @@ public abstract class MVPCTRefreshPartitioner {
      * @throws AnalysisException
      */
     public abstract Set<String> getMVPartitionNamesWithTTL(MaterializedView materializedView,
-                                                           String start, String end,
+                                                           MVRefreshParams mvRefreshParams,
                                                            int partitionTTLNumber,
                                                            boolean isAutoRefresh) throws AnalysisException;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
@@ -66,29 +66,30 @@ public class MVPCTRefreshPlanBuilder {
 
     // push down partition predicates into table relation
     private static final String EXTRA_PREDICATE_KEY = "_EXTRA_";
-    private final Map<String, String> pbMessage = Maps.newLinkedHashMap();
+    // record mv's plan builder message to trace push-downed partition names and predicates
+    private final Map<String, String> mvPlanBuildMessage = Maps.newLinkedHashMap();
 
     private void tracePartitionNames(Table table, Set<String> partitionNames) {
         if (table == null || CollectionUtils.isEmpty(partitionNames)) {
             return;
         }
-        pbMessage.put(table.getName(), Joiner.on(",").join(partitionNames));
+        mvPlanBuildMessage.put(table.getName(), Joiner.on(",").join(partitionNames));
     }
 
     private void tracePartitionPredicate(Table table, Expr partitionPredicate) {
         if (table == null || partitionPredicate == null) {
             return;
         }
-        pbMessage.put(table.getName(), partitionPredicate.debugString());
+        mvPlanBuildMessage.put(table.getName(), partitionPredicate.debugString());
     }
 
     private void tracePartitionPredicates(List<Expr> partitionPredicate) {
-        pbMessage.put(EXTRA_PREDICATE_KEY,
+        mvPlanBuildMessage.put(EXTRA_PREDICATE_KEY,
                 partitionPredicate.stream().map(Expr::debugString).collect(Collectors.joining(",")));
     }
 
     public Map<String, String> getPlanBuilderMessage() {
-        return pbMessage;
+        return mvPlanBuildMessage;
     }
 
     public MVPCTRefreshPlanBuilder(MaterializedView mv,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.analysis.Expr;
@@ -62,6 +63,33 @@ public class MVPCTRefreshPlanBuilder {
     private final MvTaskRunContext mvContext;
     private final MVPCTRefreshPartitioner mvRefreshPartitioner;
     private final boolean isRefreshFailOnFilterData;
+
+    // push down partition predicates into table relation
+    private static final String EXTRA_PREDICATE_KEY = "_EXTRA_";
+    private final Map<String, String> pbMessage = Maps.newLinkedHashMap();
+
+    private void tracePartitionNames(Table table, Set<String> partitionNames) {
+        if (table == null || CollectionUtils.isEmpty(partitionNames)) {
+            return;
+        }
+        pbMessage.put(table.getName(), Joiner.on(",").join(partitionNames));
+    }
+
+    private void tracePartitionPredicate(Table table, Expr partitionPredicate) {
+        if (table == null || partitionPredicate == null) {
+            return;
+        }
+        pbMessage.put(table.getName(), partitionPredicate.debugString());
+    }
+
+    private void tracePartitionPredicates(List<Expr> partitionPredicate) {
+        pbMessage.put(EXTRA_PREDICATE_KEY,
+                partitionPredicate.stream().map(Expr::debugString).collect(Collectors.joining(",")));
+    }
+
+    public Map<String, String> getPlanBuilderMessage() {
+        return pbMessage;
+    }
 
     public MVPCTRefreshPlanBuilder(MaterializedView mv,
                                    MvTaskRunContext mvContext,
@@ -186,6 +214,7 @@ public class MVPCTRefreshPlanBuilder {
                     mv.getName(), numOfPushDownIntoTables);
             return insertStmt;
         }
+        tracePartitionPredicates(extraPartitionPredicates);
         if (queryRelation instanceof SelectRelation) {
             SelectRelation selectRelation = (SelectRelation) queryRelation;
             extraPartitionPredicates.add(selectRelation.getWhereClause());
@@ -242,6 +271,7 @@ public class MVPCTRefreshPlanBuilder {
                 mv.getName(), tableRelation.getName(), Joiner.on(",").join(tablePartitionNames));
         tableRelation.setPartitionNames(
                 new PartitionNames(false, new ArrayList<>(tablePartitionNames)));
+        tracePartitionNames(table, tablePartitionNames);
         return true;
     }
 
@@ -280,6 +310,7 @@ public class MVPCTRefreshPlanBuilder {
                         "relation {},  partition predicate:{} ",
                 mv.getName(), tableRelation.getName(), partitionPredicate.toSql());
         tableRelation.setPartitionPredicate(partitionPredicate);
+        tracePartitionPredicate(table, partitionPredicate);
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -58,7 +58,6 @@ import com.starrocks.sql.common.RangePartitionDiffer;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -187,20 +186,23 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
     @Override
     public Set<String> getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
                                                 Map<Long, TableSnapshotInfo> snapshotBaseTables,
-                                                String start, String end, boolean force,
+                                                MVRefreshParams mvRefreshParams,
                                                 Set<String> mvPotentialPartitionNames) throws AnalysisException {
         // range partitioned materialized views
         boolean isAutoRefresh = mvContext.getTaskType().isAutoRefresh();
         int partitionTTLNumber = mvContext.getPartitionTTLNumber();
         boolean isRefreshMvBaseOnNonRefTables = needsRefreshBasedOnNonRefTables(snapshotBaseTables);
-        Set<String> mvRangePartitionNames = getMVPartitionNamesWithTTL(mv, start, end, partitionTTLNumber, isAutoRefresh);
+        String start = mvRefreshParams.getRangeStart();
+        String end = mvRefreshParams.getRangeEnd();
+        boolean force = mvRefreshParams.isForce();
+        Set<String> mvRangePartitionNames = getMVPartitionNamesWithTTL(mv, mvRefreshParams, partitionTTLNumber, isAutoRefresh);
         LOG.info("Get partition names by range with partition limit, start: {}, end: {}, force:{}, " +
                         "partitionTTLNumber: {}, isAutoRefresh: {}, mvRangePartitionNames: {}, isRefreshMvBaseOnNonRefTables:{}",
                 start, end, force, partitionTTLNumber, isAutoRefresh, mvRangePartitionNames, isRefreshMvBaseOnNonRefTables);
 
         // check non-ref base tables or force refresh
         if (force || isRefreshMvBaseOnNonRefTables) {
-            if (start == null && end == null) {
+            if (mvRefreshParams.isCompleteRefresh()) {
                 // if non-partition table changed, should refresh all partitions of materialized view
                 return mvRangePartitionNames;
             } else {
@@ -269,12 +271,14 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
     }
 
     @Override
-    public Set<String> getMVPartitionNamesWithTTL(MaterializedView materializedView, String start, String end,
+    public Set<String> getMVPartitionNamesWithTTL(MaterializedView materializedView, MVRefreshParams mvRefreshParams,
                                                   int partitionTTLNumber, boolean isAutoRefresh) throws AnalysisException {
         int autoRefreshPartitionsLimit = materializedView.getTableProperty().getAutoRefreshPartitionsLimit();
-        boolean hasPartitionRange = StringUtils.isNoneEmpty(start) || StringUtils.isNoneEmpty(end);
+        boolean hasPartitionRange = !mvRefreshParams.isCompleteRefresh();
 
         if (hasPartitionRange) {
+            String start = mvRefreshParams.getRangeStart();
+            String end = mvRefreshParams.getRangeEnd();
             Set<String> result = Sets.newHashSet();
             Column partitionColumn = materializedView.getPartitionColumn().get();
             Range<PartitionKey> rangeToInclude = createRange(start, end, partitionColumn);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.scheduler.TaskRun;
+import com.starrocks.sql.common.PListCell;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+import java.util.Set;
+
+public class MVRefreshParams {
+    private final String rangeStart;
+    private final String rangeEnd;
+    private final boolean isForce;
+    private final Set<PListCell> listValues;
+    private final PartitionInfo mvPartitionInfo;
+
+    public MVRefreshParams(MaterializedView mv,
+                           Map<String, String> properties,
+                           boolean tentative) {
+        Preconditions.checkArgument(mv != null, "MaterializedView is null");
+        Preconditions.checkArgument(properties != null, "Properties is null");
+        this.rangeStart = properties.get(TaskRun.PARTITION_START);
+        this.rangeEnd = properties.get(TaskRun.PARTITION_END);
+        this.isForce = tentative | Boolean.parseBoolean(properties.get(TaskRun.FORCE));
+        this.listValues = PListCell.deserializePListCells(properties.get(TaskRun.PARTITION_VALUES));
+        this.mvPartitionInfo = mv.getPartitionInfo();
+    }
+
+    public boolean isForceCompleteRefresh() {
+        return isForce && isCompleteRefresh();
+    }
+
+    public boolean isForce() {
+        return isForce;
+    }
+
+    public boolean isCompleteRefresh() {
+        if (mvPartitionInfo.isListPartition())  {
+            return isListCompleteRefresh();
+        } else if (mvPartitionInfo.isUnPartitioned()) {
+            return true;
+        } else {
+            return isRangeCompleteRefresh();
+        }
+    }
+
+    private boolean isRangeCompleteRefresh() {
+        return StringUtils.isEmpty(rangeStart) && StringUtils.isEmpty(rangeEnd);
+    }
+
+    private boolean isListCompleteRefresh() {
+        return CollectionUtils.isEmpty(listValues);
+    }
+
+    public String getRangeEnd() {
+        return rangeEnd;
+    }
+
+    public String getRangeStart() {
+        return rangeStart;
+    }
+
+    public Set<PListCell> getListValues() {
+        return listValues;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshParams.java
@@ -15,7 +15,6 @@
 package com.starrocks.scheduler.mv;
 
 import com.google.common.base.Preconditions;
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.sql.common.PListCell;
@@ -25,6 +24,9 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * MVRefreshParams is used to store the parameters for refreshing a materialized view.
+ */
 public class MVRefreshParams {
     private final String rangeStart;
     private final String rangeEnd;
@@ -32,16 +34,16 @@ public class MVRefreshParams {
     private final Set<PListCell> listValues;
     private final PartitionInfo mvPartitionInfo;
 
-    public MVRefreshParams(MaterializedView mv,
+    public MVRefreshParams(PartitionInfo partitionInfo,
                            Map<String, String> properties,
                            boolean tentative) {
-        Preconditions.checkArgument(mv != null, "MaterializedView is null");
+        Preconditions.checkArgument(partitionInfo != null, "MaterializedView's partition info is null");
         Preconditions.checkArgument(properties != null, "Properties is null");
         this.rangeStart = properties.get(TaskRun.PARTITION_START);
         this.rangeEnd = properties.get(TaskRun.PARTITION_END);
         this.isForce = tentative | Boolean.parseBoolean(properties.get(TaskRun.FORCE));
-        this.listValues = PListCell.deserializePListCells(properties.get(TaskRun.PARTITION_VALUES));
-        this.mvPartitionInfo = mv.getPartitionInfo();
+        this.listValues = PListCell.batchDeserialize(properties.get(TaskRun.PARTITION_VALUES));
+        this.mvPartitionInfo = partitionInfo;
     }
 
     public boolean isForceCompleteRefresh() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -169,7 +169,7 @@ public class MVTaskRunExtraMessage implements Writable {
     }
 
     public void setNextPartitionEnd(String nextPartitionEnd) {
-        this.nextPartitionEnd = MvUtils.shrinkToSize(nextPartitionEnd, 1024);
+        this.nextPartitionEnd = nextPartitionEnd;
     }
 
     public String getNextPartitionValues() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -65,6 +65,9 @@ public class MVTaskRunExtraMessage implements Writable {
     @SerializedName("executeOption")
     private ExecuteOption executeOption = new ExecuteOption(true);
 
+    @SerializedName("planBuilderMessage")
+    public Map<String, String> planBuilderMessage = Maps.newHashMap();
+
     public MVTaskRunExtraMessage() {
     }
 
@@ -173,6 +176,11 @@ public class MVTaskRunExtraMessage implements Writable {
 
     public void setProcessStartTime(long processStartTime) {
         this.processStartTime = processStartTime;
+    }
+
+    public void setPlanBuilderMessage(Map<String, String> planBuilderMessage) {
+        this.planBuilderMessage = MvUtils.shrinkToSize(planBuilderMessage,
+                Config.max_mv_task_run_meta_message_values_length);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -56,6 +56,8 @@ public class MVTaskRunExtraMessage implements Writable {
     private String nextPartitionStart;
     @SerializedName("nextPartitionEnd")
     private String nextPartitionEnd;
+    @SerializedName("nextPartitionValues")
+    private String nextPartitionValues;
 
     // task run starts to process time
     // NOTE: finishTime - processStartTime = process task run time(exclude pending time)
@@ -167,7 +169,15 @@ public class MVTaskRunExtraMessage implements Writable {
     }
 
     public void setNextPartitionEnd(String nextPartitionEnd) {
-        this.nextPartitionEnd = nextPartitionEnd;
+        this.nextPartitionEnd = MvUtils.shrinkToSize(nextPartitionEnd, 1024);
+    }
+
+    public String getNextPartitionValues() {
+        return nextPartitionValues;
+    }
+
+    public void setNextPartitionValues(String nextPartitionValues) {
+        this.nextPartitionValues = nextPartitionValues;
     }
 
     public long getProcessStartTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -372,11 +372,9 @@ public class TaskRunStatus implements Writable {
         if (!state.isFinishState()) {
             return false;
         }
-        if (!Strings.isNullOrEmpty(mvTaskRunExtraMessage.getNextPartitionEnd()) ||
-                !Strings.isNullOrEmpty(mvTaskRunExtraMessage.getNextPartitionStart())) {
-            return false;
-        }
-        return true;
+        return Strings.isNullOrEmpty(mvTaskRunExtraMessage.getNextPartitionEnd()) &&
+                Strings.isNullOrEmpty(mvTaskRunExtraMessage.getNextPartitionStart()) &&
+                Strings.isNullOrEmpty(mvTaskRunExtraMessage.getNextPartitionValues());
     }
 
     public long calculateRefreshProcessDuration() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3214,7 +3214,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             } else if (!partitionDesc.getSecond().isEmpty()) {
                 Set<PListCell> list = partitionDesc.right();
                 if (!CollectionUtils.isEmpty(list)) {
-                    taskRunProperties.put(TaskRun.PARTITION_VALUES, PListCell.serializePListCells(list));
+                    taskRunProperties.put(TaskRun.PARTITION_VALUES, PListCell.batchSerialize(list));
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -228,9 +228,11 @@ import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
+import com.starrocks.sql.util.EitherOr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.TabletTaskExecutor;
@@ -3190,20 +3192,32 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         return materializedView;
     }
 
-    public String refreshMaterializedView(String dbName, String mvName, boolean force, PartitionRangeDesc range,
+    public String refreshMaterializedView(String dbName, String mvName, boolean force,
+                                          EitherOr<PartitionRangeDesc, Set<PListCell>> partitionDesc,
                                           int priority, boolean mergeRedundant, boolean isManual)
             throws DdlException, MetaNotFoundException {
-        return refreshMaterializedView(dbName, mvName, force, range, priority, mergeRedundant, isManual, false);
+        return refreshMaterializedView(dbName, mvName, force, partitionDesc, priority, mergeRedundant, isManual, false);
     }
 
-    public String refreshMaterializedView(String dbName, String mvName, boolean force, PartitionRangeDesc range,
+    public String refreshMaterializedView(String dbName, String mvName, boolean force,
+                                          EitherOr<PartitionRangeDesc, Set<PListCell>> partitionDesc,
                                           int priority, boolean mergeRedundant, boolean isManual, boolean isSync)
             throws DdlException, MetaNotFoundException {
         MaterializedView materializedView = getMaterializedViewToRefresh(dbName, mvName);
 
         HashMap<String, String> taskRunProperties = new HashMap<>();
-        taskRunProperties.put(TaskRun.PARTITION_START, range == null ? null : range.getPartitionStart());
-        taskRunProperties.put(TaskRun.PARTITION_END, range == null ? null : range.getPartitionEnd());
+        if (partitionDesc != null) {
+            if (!partitionDesc.getFirst().isEmpty()) {
+                PartitionRangeDesc range = partitionDesc.left();
+                taskRunProperties.put(TaskRun.PARTITION_START, range == null ? null : range.getPartitionStart());
+                taskRunProperties.put(TaskRun.PARTITION_END, range == null ? null : range.getPartitionEnd());
+            } else if (!partitionDesc.getSecond().isEmpty()) {
+                Set<PListCell> list = partitionDesc.right();
+                if (!CollectionUtils.isEmpty(list)) {
+                    taskRunProperties.put(TaskRun.PARTITION_VALUES, PListCell.serializePListCells(list));
+                }
+            }
+        }
         taskRunProperties.put(TaskRun.FORCE, Boolean.toString(force));
 
         ExecuteOption executeOption = new ExecuteOption(priority, mergeRedundant, taskRunProperties);
@@ -3218,8 +3232,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         String dbName = refreshMaterializedViewStatement.getMvName().getDb();
         String mvName = refreshMaterializedViewStatement.getMvName().getTbl();
         boolean force = refreshMaterializedViewStatement.isForceRefresh();
-        PartitionRangeDesc range = refreshMaterializedViewStatement.getPartitionRangeDesc();
-        return refreshMaterializedView(dbName, mvName, force, range, Constants.TaskRunPriority.HIGH.value(),
+        EitherOr<PartitionRangeDesc, Set<PListCell>> partitionDesc = refreshMaterializedViewStatement.getPartitionDesc();
+        return refreshMaterializedView(dbName, mvName, force, partitionDesc, Constants.TaskRunPriority.HIGH.value(),
                 Config.enable_mv_refresh_sync_refresh_mergeable, true, refreshMaterializedViewStatement.isSync());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -80,6 +80,7 @@ import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SetOperationRelation;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.ViewRelation;
+import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -1167,21 +1168,38 @@ public class MaterializedViewAnalyzer {
                         "] is not active. You can try to active it with ALTER MATERIALIZED VIEW " + mv.getName()
                         + " ACTIVE; ", mvName.getPos());
             }
-            if (statement.getPartitionRangeDesc() == null) {
-                return null;
-            }
-            if (table.getPartitionInfo().isUnPartitioned()) {
-                throw new SemanticException("Not support refresh by partition for single partition mv",
-                        mvName.getPos());
-            }
-            Column partitionColumn = table.getPartitionInfo().getPartitionColumns(table.getIdToColumn()).get(0);
-            if (partitionColumn.getType().isDateType()) {
-                validateDateTypePartition(statement.getPartitionRangeDesc());
-            } else if (partitionColumn.getType().isIntegerType()) {
-                validateNumberTypePartition(statement.getPartitionRangeDesc());
-            } else {
-                throw new SemanticException(
-                        "Unsupported batch partition build type:" + partitionColumn.getType());
+            PartitionInfo partitionInfo = mv.getPartitionInfo();
+            if (statement.getPartitionRangeDesc() != null) {
+                if (partitionInfo.isUnPartitioned()) {
+                    throw new SemanticException("Not support refresh by partition for single partition mv",
+                            mvName.getPos());
+                }
+                if (!partitionInfo.isExprRangePartitioned()) {
+                    throw new SemanticException("Not support refresh by partition for non range partitioned mv",
+                            mvName.getPos());
+                }
+                Column partitionColumn = partitionInfo.getPartitionColumns(table.getIdToColumn()).get(0);
+                if (partitionColumn.getType().isDateType()) {
+                    validateDateTypePartition(statement.getPartitionRangeDesc());
+                } else if (partitionColumn.getType().isIntegerType()) {
+                    validateNumberTypePartition(statement.getPartitionRangeDesc());
+                } else {
+                    throw new SemanticException(
+                            "Unsupported batch partition build type:" + partitionColumn.getType());
+                }
+            } else if (statement.getPartitionListDesc() != null) {
+                if (partitionInfo.isUnPartitioned()) {
+                    throw new SemanticException("Not support refresh by partition for single partition mv",
+                            mvName.getPos());
+                }
+                if (!partitionInfo.isListPartition()) {
+                    throw new SemanticException("Not support refresh by partition for non list partitioned mv",
+                            mvName.getPos());
+                }
+                Set<PListCell> listCells = statement.getPartitionListDesc();
+                if (CollectionUtils.isEmpty(listCells)) {
+                    throw new SemanticException("Refresh list partition values is empty");
+                }
             }
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
@@ -17,7 +17,10 @@ package com.starrocks.sql.common;
 import com.google.api.client.util.Lists;
 import com.google.api.client.util.Sets;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.connector.PartitionUtil;
+import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.sql.ast.PartitionValue;
 import org.apache.commons.collections4.CollectionUtils;
@@ -35,6 +38,14 @@ import java.util.stream.Collectors;
  *  partitionItems  : ((1, 'a'), (2, 'b'))
  */
 public final class PListCell extends PCell implements Comparable<PListCell> {
+    // default partition values which may contain null value, and should be compared in the end
+    public static Set<String> DEFAULT_PARTITION_VALUES = new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
+            .add(PartitionValue.STARROCKS_DEFAULT_PARTITION_VALUE)
+            .add(PartitionUtil.ICEBERG_DEFAULT_PARTITION)
+            .add(HiveMetaClient.PARTITION_NULL_VALUE)
+            .add(HiveMetaClient.HUDI_PARTITION_NULL_VALUE)
+            .build();
+
     // multi values: the order is only associated comparing.
     @SerializedName(("partitionItems"))
     private final List<List<String>> partitionItems;
@@ -133,7 +144,7 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
     }
 
     private boolean isDefaultPartitionValue(String val) {
-        return PartitionValue.STARROCKS_DEFAULT_PARTITION_VALUE.equalsIgnoreCase(val);
+        return DEFAULT_PARTITION_VALUES.contains(val);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
@@ -19,6 +19,7 @@ import com.google.api.client.util.Sets;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.persist.gson.GsonUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
@@ -149,13 +150,16 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
     }
 
     /**
-     * Serialize the partition items to string
-     * @return
+     * Serialize the PListCell to string
      */
     public String serialize() {
         return GsonUtils.GSON.toJson(this);
     }
 
+    /**
+     * Deserialize PListCell items from string
+     * @param str serialized partition items string
+     */
     public static PListCell deserialize(String str) {
         if (StringUtils.isEmpty(str)) {
             return null;
@@ -163,11 +167,14 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
         return GsonUtils.GSON.fromJson(str, PListCell.class);
     }
 
-    public static class BatchPListCellJSONRecord {
+    /**
+     * PListCellBatchRecord represents a batch of PListCell which is used to serialize and deserialize PListCells.
+     */
+    private static class PListCellBatchRecord {
         @SerializedName("data")
         private final Set<PListCell> pListCells;
 
-        public BatchPListCellJSONRecord(Set<PListCell> pListCells) {
+        public PListCellBatchRecord(Set<PListCell> pListCells) {
             this.pListCells = pListCells;
         }
 
@@ -175,24 +182,32 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
             return pListCells;
         }
 
-        public static BatchPListCellJSONRecord fromJson(String json) {
-            return GsonUtils.GSON.fromJson(json, BatchPListCellJSONRecord.class);
+        public static PListCellBatchRecord fromJson(String json) {
+            return GsonUtils.GSON.fromJson(json, PListCellBatchRecord.class);
         }
     }
 
-    public static String serializePListCells(Set<PListCell> partitionValues) {
-        if (partitionValues == null) {
+    /**
+     * Serialize the PListCell values to string
+     * @param partitionValues list partition values
+     */
+    public static String batchSerialize(Set<PListCell> partitionValues) {
+        if (CollectionUtils.isEmpty(partitionValues)) {
             return null;
         }
-        BatchPListCellJSONRecord batch = new BatchPListCellJSONRecord(partitionValues);
+        PListCellBatchRecord batch = new PListCellBatchRecord(partitionValues);
         return GsonUtils.GSON.toJson(batch);
     }
 
-    public static Set<PListCell> deserializePListCells(String partitionValues) {
+    /**
+     * Deserialize the PListCell values from string
+     * @param partitionValues serialized partition values string
+     */
+    public static Set<PListCell> batchDeserialize(String partitionValues) {
         if (StringUtils.isEmpty(partitionValues)) {
             return null;
         }
-        BatchPListCellJSONRecord batch = BatchPListCellJSONRecord.fromJson(partitionValues);
+        PListCellBatchRecord batch = PListCellBatchRecord.fromJson(partitionValues);
         return batch.getPListCells();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
@@ -19,6 +19,7 @@ import com.google.api.client.util.Sets;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.sql.ast.PartitionValue;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -112,6 +113,15 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
                 return Integer.compare(atom1.size(), atom2.size());
             }
             for (int j = 0; j < atom1.size(); j++) {
+                String value1 = atom1.get(j);
+                String value2 = atom2.get(j);
+                // if one of the partition item is default partition value, prefer the other one
+                if (isDefaultPartitionValue(value1)) {
+                    return -1;
+                }
+                if (isDefaultPartitionValue(value2)) {
+                    return 1;
+                }
                 ans = atom1.get(j).compareTo(atom2.get(j));
                 if (ans != 0) {
                     return ans;
@@ -120,6 +130,10 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
         }
         // compare len if all partition items are equal
         return Integer.compare(len1, len2);
+    }
+
+    private boolean isDefaultPartitionValue(String val) {
+        return PartitionValue.STARROCKS_DEFAULT_PARTITION_VALUE.equalsIgnoreCase(val);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -462,6 +462,8 @@ import com.starrocks.sql.ast.pipe.DescPipeStmt;
 import com.starrocks.sql.ast.pipe.DropPipeStmt;
 import com.starrocks.sql.ast.pipe.PipeName;
 import com.starrocks.sql.ast.pipe.ShowPipeStmt;
+import com.starrocks.sql.common.PListCell;
+import com.starrocks.sql.util.EitherOr;
 import com.starrocks.transaction.GtidGenerator;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
@@ -491,6 +493,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -2017,14 +2020,30 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             StarRocksParser.RefreshMaterializedViewStatementContext context) {
         QualifiedName mvQualifiedName = getQualifiedName(context.qualifiedName());
         TableName mvName = qualifiedNameToTableName(mvQualifiedName);
-        PartitionRangeDesc partitionRangeDesc = null;
+        PartitionRangeDesc rangePartitionDesc = null;
+        Set<PListCell> cells = null;
         if (context.partitionRangeDesc() != null) {
-            partitionRangeDesc =
+            rangePartitionDesc =
                     (PartitionRangeDesc) visit(context.partitionRangeDesc());
+        } else if (context.listPartitionValues() != null) {
+            StarRocksParser.ListPartitionValuesContext listPartitionValuesContext =
+                    context.listPartitionValues();
+            if (listPartitionValuesContext.multiListPartitionValues() != null) {
+                List<List<String>> multiListValues =
+                        parseMultiListPartitionValues(listPartitionValuesContext.multiListPartitionValues());
+                cells = multiListValues.stream()
+                        .map(items -> new PListCell(ImmutableList.of(items)))
+                        .collect(Collectors.toSet());
+            } else {
+                List<String> singleListValues =
+                        parseSingleListPartitionValues(listPartitionValuesContext.singleListPartitionValues());
+                cells = singleListValues.stream()
+                        .map(item -> new PListCell(item))
+                        .collect(Collectors.toSet());
+            }
         }
-        return new RefreshMaterializedViewStatement(mvName, partitionRangeDesc, context.FORCE() != null,
-                context.SYNC() != null,
-                createPos(context));
+        return new RefreshMaterializedViewStatement(mvName, new EitherOr(rangePartitionDesc, cells),
+                context.FORCE() != null, context.SYNC() != null, createPos(context));
     }
 
     @Override
@@ -7285,7 +7304,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 createPos(context));
     }
 
-    public List<String> parseListPartitionValueList(StarRocksParser.ListPartitionValueListContext valueListContext) {
+    public List<String> parseSingleListPartitionValues(StarRocksParser.SingleListPartitionValuesContext valueListContext) {
         return valueListContext.listPartitionValue().stream().map(x -> {
             if (x.NULL() != null) {
                 return PartitionValue.STARROCKS_DEFAULT_PARTITION_VALUE;
@@ -7297,7 +7316,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitSingleItemListPartitionDesc(StarRocksParser.SingleItemListPartitionDescContext context) {
-        List<String> values = parseListPartitionValueList(context.listPartitionValueList());
+        List<String> values = parseSingleListPartitionValues(context.singleListPartitionValues());
         boolean ifNotExists = context.IF() != null;
         Map<String, String> properties = null;
         if (context.propertyList() != null) {
@@ -7311,12 +7330,16 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 values, properties, createPos(context));
     }
 
+    private List<List<String>> parseMultiListPartitionValues(StarRocksParser.MultiListPartitionValuesContext context) {
+        return context.singleListPartitionValues().stream()
+                .map(this::parseSingleListPartitionValues)
+                .collect(toList());
+    }
+
     @Override
     public ParseNode visitMultiItemListPartitionDesc(StarRocksParser.MultiItemListPartitionDescContext context) {
         boolean ifNotExists = context.IF() != null;
-        List<List<String>> multiValues = context.listPartitionValueList().stream()
-                .map(l -> parseListPartitionValueList(l))
-                .collect(toList());
+        List<List<String>> multiValues = parseMultiListPartitionValues(context.multiListPartitionValues());
         Map<String, String> properties = null;
         if (context.propertyList() != null) {
             properties = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -653,7 +653,7 @@ alterMaterializedViewStatement
     ;
 
 refreshMaterializedViewStatement
-    : REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION partitionRangeDesc)? FORCE? (WITH (SYNC | ASYNC) MODE)?
+    : REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION (partitionRangeDesc | listPartitionValues))? FORCE? (WITH (SYNC | ASYNC) MODE)?
     ;
 
 cancelRefreshMaterializedViewStatement
@@ -2470,15 +2470,24 @@ listPartitionDesc
     ;
 
 singleItemListPartitionDesc
-    : PARTITION (IF NOT EXISTS)? identifier VALUES IN listPartitionValueList propertyList?
+    : PARTITION (IF NOT EXISTS)? identifier VALUES IN singleListPartitionValues propertyList?
     ;
 
 multiItemListPartitionDesc
-    : PARTITION (IF NOT EXISTS)? identifier VALUES IN '(' listPartitionValueList (',' listPartitionValueList)* ')' propertyList?
+    : PARTITION (IF NOT EXISTS)? identifier VALUES IN  multiListPartitionValues propertyList?
     ;
 
-listPartitionValueList
-    : '(' listPartitionValue (',' listPartitionValue)* ')'
+multiListPartitionValues
+    :'(' singleListPartitionValues (',' singleListPartitionValues)* ')' // list partition values with multi partition columns: ('a, 'b', 'c'), ('d', 'e', 'f')
+    ;
+
+singleListPartitionValues
+    : '(' listPartitionValue (',' listPartitionValue)* ')' // list partition value: ('a, 'b', 'c')
+    ;
+
+listPartitionValues // list partition values which can be with single or multi partition columns
+    : singleListPartitionValues
+    | multiListPartitionValues
     ;
 
 listPartitionValue

--- a/fe/fe-core/src/main/java/com/starrocks/sql/util/EitherOr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/util/EitherOr.java
@@ -18,33 +18,38 @@ import com.google.common.base.Preconditions;
 
 import java.util.Optional;
 
-public class EitherOr<T> {
-    private final T first;
-    private final T second;
+public class EitherOr<L, R> {
+    private final L first;
+    private final R second;
 
-    private EitherOr(T first, T second) {
-        Preconditions.checkArgument((first == null && second != null) || (first != null && second == null));
+    public EitherOr(L first, R second) {
+        Preconditions.checkArgument((first == null && second != null) || (first != null && second == null)
+                || (first == null && second == null));
         this.first = first;
         this.second = second;
     }
 
-    public static <T> EitherOr<T> either(T first) {
+    public static <L, R> EitherOr<L, R> left(L first) {
         return new EitherOr<>(first, null);
     }
 
-    public static <T> EitherOr<T> or(T second) {
+    public static <L, R> EitherOr<L, R> right(R second) {
         return new EitherOr<>(null, second);
     }
 
-    public Optional<T> getFirst() {
+    public Optional<L> getFirst() {
         return Optional.ofNullable(first);
     }
 
-    public Optional<T> getSecond() {
+    public Optional<R> getSecond() {
         return Optional.ofNullable(second);
     }
 
-    public T get() {
-        return (first != null) ? first : second;
+    public L left() {
+        return first;
+    }
+
+    public R right() {
+        return second;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.analysis;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
@@ -33,6 +35,7 @@ import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
+import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.UtFrameUtils;
@@ -73,6 +76,20 @@ public class RefreshMaterializedViewTest extends MvRewriteTestBase {
                         ")\n" +
                         "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
                         "PROPERTIES('replication_num' = '1');")
+                // table whose partitions have only single values
+                .withTable("CREATE TABLE s2 (\n" +
+                        "      id BIGINT,\n" +
+                        "      age SMALLINT,\n" +
+                        "      dt VARCHAR(10),\n" +
+                        "      province VARCHAR(64) not null\n" +
+                        ")\n" +
+                        "DUPLICATE KEY(id)\n" +
+                        "PARTITION BY LIST (dt) (\n" +
+                        "     PARTITION p1 VALUES IN (\"20240101\") ,\n" +
+                        "     PARTITION p2 VALUES IN (\"20240102\") ,\n" +
+                        "     PARTITION p3 VALUES IN (\"20240103\") \n" +
+                        ")\n" +
+                        "DISTRIBUTED BY RANDOM\n")
                 .withMaterializedView("create materialized view mv_to_refresh\n" +
                         "distributed by hash(k2) buckets 3\n" +
                         "refresh manual\n" +
@@ -1089,5 +1106,54 @@ public class RefreshMaterializedViewTest extends MvRewriteTestBase {
         starRocksAssert.dropTable("t1");
         starRocksAssert.dropTable("t2");
         starRocksAssert.dropMaterializedView("mv1");
+    }
+
+    @Test
+    public void testRefreshListPartitionMV1() {
+        starRocksAssert.withMaterializedView("create materialized view test_mv1\n" +
+                        "partition by dt \n" +
+                        "distributed by random \n" +
+                        "REFRESH DEFERRED MANUAL \n" +
+                        "properties ('partition_refresh_number' = '1')" +
+                        "as select dt, province, sum(age) from s2 group by dt, province;",
+                (obj) -> {
+                    {
+                        String sql = "REFRESH MATERIALIZED VIEW test_mv1 PARTITION ('20240101') FORCE;";
+                        RefreshMaterializedViewStatement statement =
+                                (RefreshMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                        Assert.assertTrue(statement.isForceRefresh());
+                        Assert.assertNull(statement.getPartitionRangeDesc());
+                        Set<PListCell> expect = ImmutableSet.of(
+                                new PListCell("20240101")
+                        );
+                        Assert.assertEquals(expect, statement.getPartitionListDesc());
+                    }
+                    {
+                        String sql = "REFRESH MATERIALIZED VIEW test_mv1 PARTITION ('20240101', '20240102') FORCE;";
+                        RefreshMaterializedViewStatement statement =
+                                (RefreshMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                        Assert.assertTrue(statement.isForceRefresh());
+                        Assert.assertNull(statement.getPartitionRangeDesc());
+                        Set<PListCell> expect = ImmutableSet.of(
+                                        new PListCell("20240101"),
+                                        new PListCell("20240102")
+                                );
+                        Assert.assertEquals(expect, statement.getPartitionListDesc());
+                    }
+                    // multi partition columns may be supported in the future
+                    {
+                        String sql = "REFRESH MATERIALIZED VIEW test_mv1 PARTITION (('20240101', 'beijing'), ('20240101', " +
+                                "'nanjing')) FORCE;";
+                        RefreshMaterializedViewStatement statement =
+                                (RefreshMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                        Assert.assertTrue(statement.isForceRefresh());
+                        Assert.assertNull(statement.getPartitionRangeDesc());
+                        Set<PListCell> expect = ImmutableSet.of(
+                                new PListCell(ImmutableList.of(ImmutableList.of("20240101", "beijing"))),
+                                new PListCell(ImmutableList.of(ImmutableList.of("20240101", "nanjing")))
+                        );
+                        Assert.assertEquals(expect, statement.getPartitionListDesc());
+                    }
+                });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -492,14 +492,6 @@ public class RestoreJobMaterializedViewTest {
     }
 
     @Test
-    public void testMVRestore() {
-        RestoreJob job = createRestoreJob(ImmutableList.of(UnitTestUtil.MATERIALIZED_VIEW_NAME));
-
-        checkJobRun(job);
-        assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
-    }
-
-    @Test
     public void testMVRestoreMVWithBaseTable1() {
         // gen BackupJobInfo
         RestoreJob job = createRestoreJob(ImmutableList.of(TABLE_NAME, MATERIALIZED_VIEW_NAME));

--- a/fe/fe-core/src/test/java/com/starrocks/common/PListCellTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PListCellTest.java
@@ -1,0 +1,148 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.starrocks.sql.common.PListCell;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Set;
+
+public class PListCellTest {
+    @Test
+    public void testSerializeDeserialize() {
+        // one value with one partition column
+        {
+            PListCell s1 = new PListCell(ImmutableList.of(ImmutableList.of("2024-01-01")));
+            String ser = s1.serialize();
+            System.out.println(ser);
+            PListCell s2 = PListCell.deserialize(ser);
+            Assert.assertEquals(s1, s2);
+        }
+        // one value with multi partition columns
+        {
+            PListCell s1 = new PListCell(ImmutableList.of(ImmutableList.of("beijing", "2024-01-01")));
+            String ser = s1.serialize();
+            System.out.println(ser);
+            PListCell s2 = PListCell.deserialize(ser);
+            Assert.assertEquals(s1, s2);
+        }
+        // multi values with multi partition columns
+        {
+            PListCell s1 = new PListCell(ImmutableList.of(
+                    ImmutableList.of("beijing", "2024-01-01"),
+                    ImmutableList.of("shanghai", "2024-01-02")
+            ));
+            String ser = s1.serialize();
+            System.out.println(ser);
+            PListCell s2 = PListCell.deserialize(ser);
+            Assert.assertEquals(s1, s2);
+        }
+    }
+
+    @Test
+    public void testBatchSerializeDeserialize() {
+        // one value with one partition column
+        {
+            Set<PListCell> s1 =
+                    ImmutableSet.of(
+                            new PListCell(ImmutableList.of(ImmutableList.of("2024-01-01"))),
+                            new PListCell(ImmutableList.of(ImmutableList.of("2024-01-02")))
+                    );
+            String ser = PListCell.serializePListCells(s1);
+            System.out.println(ser);
+            Set<PListCell> s2 = PListCell.deserializePListCells(ser);
+            Assert.assertEquals(s1, s2);
+        }
+        // one value with multi partition columns
+        {
+            Set<PListCell> s1 =
+                    ImmutableSet.of(
+                            new PListCell(ImmutableList.of(ImmutableList.of("beijing", "2024-01-01"))),
+                            new PListCell(ImmutableList.of(ImmutableList.of("beijing", "2024-01-02")))
+                    );
+            String ser = PListCell.serializePListCells(s1);
+            System.out.println(ser);
+            Set<PListCell> s2 = PListCell.deserializePListCells(ser);
+            Assert.assertEquals(s1, s2);
+        }
+        // multi values with multi partition columns
+        {
+            PListCell s1 = new PListCell(ImmutableList.of(
+                    ImmutableList.of("beijing", "2024-01-01"),
+                    ImmutableList.of("shanghai", "2024-01-02")
+            ));
+            String ser = s1.serialize();
+            System.out.println(ser);
+            PListCell s2 = PListCell.deserialize(ser);
+            Assert.assertEquals(s1, s2);
+        }
+        {
+            Set<PListCell> s1 =
+                    ImmutableSet.of(
+                            new PListCell(ImmutableList.of(
+                                    ImmutableList.of("beijing", "2024-01-01"),
+                                    ImmutableList.of("shanghai", "2024-01-02")
+                            )),
+                            new PListCell(ImmutableList.of(
+                                    ImmutableList.of("beijing", "2024-01-03"),
+                                    ImmutableList.of("shanghai", "2024-01-04")
+                            ))
+                    );
+            String ser = PListCell.serializePListCells(s1);
+            System.out.println(ser);
+            Set<PListCell> s2 = PListCell.deserializePListCells(ser);
+            Assert.assertEquals(s1, s2);
+        }
+    }
+
+    @Test
+    public void testPListCellCompare() {
+        {
+            PListCell c1 = new PListCell(ImmutableList.of(ImmutableList.of("2024-01-01")));
+            PListCell c2 = new PListCell(ImmutableList.of(ImmutableList.of("2024-01-01")));
+            Assert.assertEquals(0, c1.compareTo(c2));
+        }
+        {
+            PListCell c1 = new PListCell(ImmutableList.of(ImmutableList.of("2024-01-01")));
+            PListCell c2 = new PListCell(ImmutableList.of(ImmutableList.of("2024-01-02")));
+            Assert.assertEquals(-1, c1.compareTo(c2));
+        }
+        {
+            PListCell c1 = new PListCell(ImmutableList.of(
+                    ImmutableList.of("beijing", "2024-01-01"),
+                    ImmutableList.of("shanghai", "2024-01-02")
+            ));
+            PListCell c2 = new PListCell(ImmutableList.of(
+                    ImmutableList.of("beijing", "2024-01-01"),
+                    ImmutableList.of("shanghai", "2024-01-02")
+            ));
+            Assert.assertEquals(0, c1.compareTo(c2));
+        }
+        {
+            PListCell c1 = new PListCell(ImmutableList.of(
+                    ImmutableList.of("beijing", "2024-01-01"),
+                    ImmutableList.of("shanghai", "2024-01-02")
+            ));
+            PListCell c2 = new PListCell(ImmutableList.of(
+                    ImmutableList.of("beijing", "2024-01-03"),
+                    ImmutableList.of("shanghai", "2024-01-04")
+            ));
+            Assert.assertEquals(-2, c1.compareTo(c2));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/PListCellTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PListCellTest.java
@@ -63,9 +63,9 @@ public class PListCellTest {
                             new PListCell(ImmutableList.of(ImmutableList.of("2024-01-01"))),
                             new PListCell(ImmutableList.of(ImmutableList.of("2024-01-02")))
                     );
-            String ser = PListCell.serializePListCells(s1);
+            String ser = PListCell.batchSerialize(s1);
             System.out.println(ser);
-            Set<PListCell> s2 = PListCell.deserializePListCells(ser);
+            Set<PListCell> s2 = PListCell.batchDeserialize(ser);
             Assert.assertEquals(s1, s2);
         }
         // one value with multi partition columns
@@ -75,9 +75,9 @@ public class PListCellTest {
                             new PListCell(ImmutableList.of(ImmutableList.of("beijing", "2024-01-01"))),
                             new PListCell(ImmutableList.of(ImmutableList.of("beijing", "2024-01-02")))
                     );
-            String ser = PListCell.serializePListCells(s1);
+            String ser = PListCell.batchSerialize(s1);
             System.out.println(ser);
-            Set<PListCell> s2 = PListCell.deserializePListCells(ser);
+            Set<PListCell> s2 = PListCell.batchDeserialize(ser);
             Assert.assertEquals(s1, s2);
         }
         // multi values with multi partition columns
@@ -103,9 +103,9 @@ public class PListCellTest {
                                     ImmutableList.of("shanghai", "2024-01-04")
                             ))
                     );
-            String ser = PListCell.serializePListCells(s1);
+            String ser = PListCell.batchSerialize(s1);
             System.out.println(ser);
-            Set<PListCell> s2 = PListCell.deserializePListCells(ser);
+            Set<PListCell> s2 = PListCell.batchDeserialize(ser);
             Assert.assertEquals(s1, s2);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -1097,7 +1097,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
                         Map<String, String> props = Maps.newHashMap();
                         PListCell partitionValues = new PListCell("20240102");
-                        props.put(TaskRun.PARTITION_VALUES, PListCell.serializePListCells(ImmutableSet.of(partitionValues)));
+                        props.put(TaskRun.PARTITION_VALUES, PListCell.batchSerialize(ImmutableSet.of(partitionValues)));
                         TaskRun taskRun = TaskRunBuilder.newBuilder(task)
                                 .properties(props)
                                 .build();
@@ -1144,7 +1144,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
                         Map<String, String> props = Maps.newHashMap();
                         PListCell partitionValues = new PListCell("beijing");
-                        props.put(TaskRun.PARTITION_VALUES, PListCell.serializePListCells(ImmutableSet.of(partitionValues)));
+                        props.put(TaskRun.PARTITION_VALUES, PListCell.batchSerialize(ImmutableSet.of(partitionValues)));
                         TaskRun taskRun = TaskRunBuilder.newBuilder(task)
                                 .properties(props)
                                 .build();
@@ -1190,7 +1190,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                         Map<String, String> props = Maps.newHashMap();
                         // even base table has multi partition columns, mv only contain one column
                         PListCell partitionValues = new PListCell(ImmutableList.of(ImmutableList.of("beijing")));
-                        props.put(TaskRun.PARTITION_VALUES, PListCell.serializePListCells(ImmutableSet.of(partitionValues)));
+                        props.put(TaskRun.PARTITION_VALUES, PListCell.batchSerialize(ImmutableSet.of(partitionValues)));
                         TaskRun taskRun = TaskRunBuilder.newBuilder(task)
                                 .properties(props)
                                 .build();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -15,12 +15,16 @@
 package com.starrocks.scheduler;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -36,6 +40,9 @@ import org.junit.runners.MethodSorters;
 
 import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.starrocks.sql.plan.PlanTestBase.cleanupEphemeralMVs;
 
@@ -47,6 +54,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
     private static String T4;
     private static String T5;
     private static String T6;
+    private static String S2;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -77,6 +85,20 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                     "     PARTITION p2 VALUES IN (\"guangdong\") \n" +
                     ")\n" +
                     "DISTRIBUTED BY RANDOM\n";
+        // table whose partitions have only single values
+        S2 = "CREATE TABLE s2 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (dt) (\n" +
+                "     PARTITION p1 VALUES IN (\"20240101\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"20240102\") ,\n" +
+                "     PARTITION p3 VALUES IN (\"20240103\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n";
         // table whose partitions have multi columns
         T3 = "CREATE TABLE t3 (\n" +
                     "      id BIGINT,\n" +
@@ -86,9 +108,9 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                     ")\n" +
                     "DUPLICATE KEY(id)\n" +
                     "PARTITION BY LIST (province, dt) (\n" +
-                    "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-01\"))  ,\n" +
+                    "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-01\")),\n" +
                     "     PARTITION p2 VALUES IN ((\"guangdong\", \"2024-01-01\")), \n" +
-                    "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-01-02\"))  ,\n" +
+                    "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-01-02\")),\n" +
                     "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-01-02\")) \n" +
                     ")\n" +
                     "DISTRIBUTED BY RANDOM\n";
@@ -141,13 +163,21 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
 
     private ExecPlan getExecPlan(TaskRun taskRun) {
         try {
-            initAndExecuteTaskRun(taskRun);
-
-            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
-                        taskRun.getProcessor();
+            PartitionBasedMvRefreshProcessor processor = getProcessor(taskRun);
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             return execPlan;
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+            return null;
+        }
+    }
+
+    private PartitionBasedMvRefreshProcessor getProcessor(TaskRun taskRun) {
+        try {
+            initAndExecuteTaskRun(taskRun);
+            return (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();
@@ -982,6 +1012,202 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 Assert.assertEquals(3, partitions.size());
                             }
                         });
+        });
+    }
+
+    @Test
+    public void testPartialRefreshSingleColumnMVWithSingleValues1() {
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        starRocksAssert.withTable(S2, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by dt \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '1')" +
+                            "as select dt, province, sum(age) from s2 group by dt, province;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState()
+                                .getLocalMetastore().getTable(testDb.getFullName(), mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                        ExecPlan execPlan = getExecPlan(taskRun);
+                        Assert.assertEquals(null, execPlan);
+                        List<String> partitions =
+                                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                        .collect(Collectors.toList());
+                        Assert.assertEquals("[p1, p2, p3]", partitions.toString());
+                    });
+        });
+    }
+
+    @Test
+    public void testPartialRefreshSingleColumnMVWithSingleValues2() {
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        starRocksAssert.withTable(S2, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by dt \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties (" +
+                            "   'partition_refresh_number' = '1'," +
+                            "   'partition_ttl_number' = '1'" +
+                            ")" +
+                            "as select dt, province, sum(age) from s2 group by dt, province;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState()
+                                .getLocalMetastore().getTable(testDb.getFullName(), mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                        ExecPlan execPlan = getExecPlan(taskRun);
+                        Assert.assertEquals(null, execPlan);
+                        List<String> partitions =
+                                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                                        .collect(Collectors.toList());
+                        // If mv has partition_ttl_number, ensure only create ttl number partitions.
+                        Assert.assertEquals("[p3]", partitions.toString());
+                    });
+        });
+    }
+
+    @Test
+    public void testPartialRefreshSingleColumnMVWithSingleValues3() {
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        starRocksAssert.withTable(S2, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by dt \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties (" +
+                            "   'partition_refresh_number' = '1'" +
+                            ")" +
+                            "as select dt, province, sum(age) from s2 group by dt, province;",
+                    (obj) -> {
+                        // update base table
+                        {
+                            String insertSQL = "INSERT INTO s2 partition(p1) values(1, 1, '20240101', 'beijing')";
+                            executeInsertSql(insertSQL);
+                            insertSQL = "INSERT INTO s2 partition(p2) values(2, 2, '20240102', 'nanjing')";
+                            executeInsertSql(insertSQL);
+                        }
+                        String mvName = (String) obj;
+                        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState()
+                                .getLocalMetastore().getTable(testDb.getFullName(), mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        Map<String, String> props = Maps.newHashMap();
+                        PListCell partitionValues = new PListCell("20240102");
+                        props.put(TaskRun.PARTITION_VALUES, PListCell.serializePListCells(ImmutableSet.of(partitionValues)));
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task)
+                                .properties(props)
+                                .build();
+                        PartitionBasedMvRefreshProcessor processor = getProcessor(taskRun);
+                        MvTaskRunContext mvTaskRunContext = processor.getMvContext();
+                        Assert.assertNull(mvTaskRunContext.getNextListPartitionValues());
+                        MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
+                        Assert.assertEquals("p2", message.getMvPartitionsToRefreshString());
+                        Assert.assertEquals("{s2=[p2]}", message.getBasePartitionsToRefreshMapString());
+                        ExecPlan execPlan = mvTaskRunContext.getExecPlan();
+                        Assert.assertNotEquals(null, execPlan);
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                                "     TABLE: s2\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=1/3");
+                    });
+        });
+    }
+
+    @Test
+    public void testPartialRefreshSingleColumnMVWithSingleValuesMultiValues1() {
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        starRocksAssert.withTable(T1, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '1')" +
+                            "as select dt, province, sum(age) from t1 group by dt, province;",
+                    (obj) -> {
+                        {
+                            String insertSql = "insert into t1 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                            executeInsertSql(insertSql);
+                            insertSql = "INSERT INTO t1 partition(p3) values(1, 1, '2022-01-01', 'hangzhou')";
+                            executeInsertSql(insertSql);
+                        }
+
+                        String mvName = (String) obj;
+                        MaterializedView materializedView =
+                                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(testDb.getFullName(), mvName));
+
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        Map<String, String> props = Maps.newHashMap();
+                        PListCell partitionValues = new PListCell("beijing");
+                        props.put(TaskRun.PARTITION_VALUES, PListCell.serializePListCells(ImmutableSet.of(partitionValues)));
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task)
+                                .properties(props)
+                                .build();
+                        PartitionBasedMvRefreshProcessor processor = getProcessor(taskRun);
+                        MvTaskRunContext mvTaskRunContext = processor.getMvContext();
+                        Assert.assertNull(mvTaskRunContext.getNextListPartitionValues());
+                        MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
+                        Assert.assertEquals("p1", message.getMvPartitionsToRefreshString());
+                        Assert.assertEquals("{t1=[p1]}", message.getBasePartitionsToRefreshMapString());
+                        ExecPlan execPlan = mvTaskRunContext.getExecPlan();
+                        Assert.assertNotEquals(null, execPlan);
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                                "     TABLE: t1\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=1/2");
+                    });
+        });
+    }
+
+    @Test
+    public void testPartialRefreshMultiColumnMV1() {
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        starRocksAssert.withTable(T3, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                            "partition by province \n" +
+                            "distributed by random \n" +
+                            "REFRESH DEFERRED MANUAL \n" +
+                            "properties ('partition_refresh_number' = '1')" +
+                            "as select dt, province, sum(age) from t3 group by dt, province;",
+                    (obj) -> {
+                        {
+                            String insertSql = "insert into t3 partition(p1) values(1, 1, '2024-01-01', 'beijing');";
+                            executeInsertSql(insertSql);
+                            insertSql = "insert into t3 partition(p3) values(1, 1, '2024-01-02', 'beijing');";
+                            executeInsertSql(insertSql);
+                        }
+                        String mvName = (String) obj;
+                        MaterializedView materializedView =
+                                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(testDb.getFullName(), mvName));
+                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                        Map<String, String> props = Maps.newHashMap();
+                        // even base table has multi partition columns, mv only contain one column
+                        PListCell partitionValues = new PListCell(ImmutableList.of(ImmutableList.of("beijing")));
+                        props.put(TaskRun.PARTITION_VALUES, PListCell.serializePListCells(ImmutableSet.of(partitionValues)));
+                        TaskRun taskRun = TaskRunBuilder.newBuilder(task)
+                                .properties(props)
+                                .build();
+                        PartitionBasedMvRefreshProcessor processor = getProcessor(taskRun);
+                        MvTaskRunContext mvTaskRunContext = processor.getMvContext();
+                        Assert.assertNull(mvTaskRunContext.getNextListPartitionValues());
+                        MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
+                        Assert.assertEquals("p1", message.getMvPartitionsToRefreshString());
+                        Assert.assertEquals("{t3=[p1, p3]}", message.getBasePartitionsToRefreshMapString());
+                        ExecPlan execPlan = mvTaskRunContext.getExecPlan();
+                        Assert.assertNotEquals(null, execPlan);
+                        String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+                        PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                                "     TABLE: t3\n" +
+                                "     PREAGGREGATION: ON\n" +
+                                "     partitions=2/4");
+                    });
         });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -1103,7 +1103,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 .build();
                         PartitionBasedMvRefreshProcessor processor = getProcessor(taskRun);
                         MvTaskRunContext mvTaskRunContext = processor.getMvContext();
-                        Assert.assertNull(mvTaskRunContext.getNextListPartitionValues());
+                        Assert.assertNull(mvTaskRunContext.getNextPartitionValues());
                         MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
                         Assert.assertEquals("p2", message.getMvPartitionsToRefreshString());
                         Assert.assertEquals("{s2=[p2]}", message.getBasePartitionsToRefreshMapString());
@@ -1150,7 +1150,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 .build();
                         PartitionBasedMvRefreshProcessor processor = getProcessor(taskRun);
                         MvTaskRunContext mvTaskRunContext = processor.getMvContext();
-                        Assert.assertNull(mvTaskRunContext.getNextListPartitionValues());
+                        Assert.assertNull(mvTaskRunContext.getNextPartitionValues());
                         MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
                         Assert.assertEquals("p1", message.getMvPartitionsToRefreshString());
                         Assert.assertEquals("{t1=[p1]}", message.getBasePartitionsToRefreshMapString());
@@ -1196,7 +1196,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 .build();
                         PartitionBasedMvRefreshProcessor processor = getProcessor(taskRun);
                         MvTaskRunContext mvTaskRunContext = processor.getMvContext();
-                        Assert.assertNull(mvTaskRunContext.getNextListPartitionValues());
+                        Assert.assertNull(mvTaskRunContext.getNextPartitionValues());
                         MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
                         Assert.assertEquals("p1", message.getMvPartitionsToRefreshString());
                         Assert.assertEquals("{t3=[p1, p3]}", message.getBasePartitionsToRefreshMapString());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -56,11 +56,11 @@ public class TaskRunHistoryTest {
         TaskRunStatus status = new TaskRunStatus();
         String json = status.toJSON();
         assertEquals("{\"taskId\":0,\"createTime\":0,\"expireTime\":0,\"priority\":0,\"mergeRedundant\":false," +
-                "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0," +
-                "\"state\":\"PENDING\",\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false," +
-                "\"mvPartitionsToRefresh\":[],\"refBasePartitionsToRefreshMap\":{}," +
-                "\"basePartitionsToRefreshMap\":{},\"processStartTime\":0,\"executeOption\":{\"priority\":0," +
-                "\"isMergeRedundant\":true,\"isManual\":false,\"isSync\":false,\"isReplay\":false}}}", json);
+                "\"source\":\"CTAS\",\"errorCode\":0,\"finishTime\":0,\"processStartTime\":0,\"state\":\"PENDING\"," +
+                "\"progress\":0,\"mvExtraMessage\":{\"forceRefresh\":false,\"mvPartitionsToRefresh\":[]," +
+                "\"refBasePartitionsToRefreshMap\":{},\"basePartitionsToRefreshMap\":{},\"processStartTime\":0," +
+                "\"executeOption\":{\"priority\":0,\"isMergeRedundant\":true,\"isManual\":false,\"isSync\":false," +
+                "\"isReplay\":false},\"planBuilderMessage\":{}}}", json);
 
         TaskRunStatus b = TaskRunStatus.fromJson(json);
         assertEquals(status.toJSON(), b.toJSON());
@@ -220,28 +220,6 @@ public class TaskRunHistoryTest {
         history.addHistory(run2);
         assertEquals(2, history.getInMemoryHistory().size());
 
-        // run the normal vacuum
-        new Expectations() {
-            {
-                repo.executeDML(
-                        "INSERT INTO _statistics_.task_run_history (task_id, task_run_id, task_name, task_state, " +
-                                "create_time, finish_time, expire_time, history_content_json) VALUES(0, 'q2', 't2'," +
-                                " 'SUCCESS', '1970-01-01 08:00:00', '1970-01-01 08:00:00', '2024-07-05 15:38:00', " +
-                                "'{\\\"queryId\\\":\\\"q2\\\",\\\"taskId\\\":0,\\\"taskName\\\":\\\"t2\\\"," +
-                                "\\\"createTime\\\":0," +
-                                "\\\"expireTime\\\":1720165080904,\\\"priority\\\":0,\\\"mergeRedundant\\\":false," +
-                                "\\\"source\\\":\\\"CTAS\\\",\\\"errorCode\\\":0,\\\"finishTime\\\":0,\\\"" +
-                                "processStartTime\\\":0," +
-                                "\\\"state\\\":\\\"SUCCESS\\\",\\\"progress\\\":0,\\\"mvExtraMessage\\\":{\\\"" +
-                                "forceRefresh\\\":false," +
-                                "\\\"mvPartitionsToRefresh\\\":[],\\\"refBasePartitionsToRefreshMap\\\":{}," +
-                                "\\\"basePartitionsToRefreshMap\\\":{},\\\"processStartTime\\\":0," +
-                                "\\\"executeOption\\\":{\\\"priority\\\":0,\\\"isMergeRedundant\\\":true,\\\"" +
-                                "isManual\\\":false," +
-                                "\\\"isSync\\\":false,\\\"isReplay\\\":false}}}')");
-
-            }
-        };
         history.vacuum();
         assertEquals(1, history.getInMemoryHistory().size());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/util/TestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/util/TestUtil.java
@@ -49,9 +49,9 @@ public class TestUtil {
 
     @Test
     public void testEitherOr() {
-        EitherOr<String> a = EitherOr.either("abcd");
-        EitherOr<String> b = EitherOr.or("abcd");
-        Assert.assertEquals(a.get(), b.get());
+        EitherOr<String, String> a = EitherOr.left("abcd");
+        EitherOr<String, String> b = EitherOr.right("abcd");
+        Assert.assertEquals(a.left(), b.right());
         Assert.assertTrue(a.getFirst().isPresent());
         Assert.assertFalse(a.getSecond().isPresent());
         Assert.assertFalse(b.getFirst().isPresent());

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_basic
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_basic
@@ -469,8 +469,7 @@ as select dt, province, sum(age) from t5 group by dt, province;
 refresh materialized view  test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
 -- result:
-2024-01-01	beijing	80
-2024-01-01	guangdong	20
+2024-01-02	guangdong	20
 -- !result
 function: assert_table_partitions_num("test_mv1", 1)
 -- result:
@@ -489,7 +488,7 @@ select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
 -- result:
 -- !result
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 -- result:
 None
 -- !result
@@ -516,7 +515,8 @@ as select dt, province, sum(age) from t5 group by dt, province;
 refresh materialized view  test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
 -- result:
-2024-01-01	beijing	100
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
 -- !result
 function: assert_table_partitions_num("test_mv1", 1)
 -- result:
@@ -535,7 +535,7 @@ select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
 -- result:
 -- !result
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 -- result:
 None
 -- !result
@@ -566,8 +566,7 @@ None
 -- !result
 select * from test_mv1 order by 1, 2;
 -- result:
-2024-01-01	beijing	120
-2024-01-01	guangdong	20
+2024-01-02	guangdong	20
 -- !result
 function: assert_table_partitions_num("test_mv1", 1)
 -- result:
@@ -586,7 +585,7 @@ select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
 -- result:
 -- !result
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 -- result:
 None
 -- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_partial_refresh
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_partial_refresh
@@ -1,0 +1,557 @@
+-- name: test_mv_refresh_list_partitions_partial_refresh
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t3 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY LIST (province, dt) (
+     PARTITION p1 VALUES IN (("beijing", "2024-01-01"))  ,
+     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")), 
+     PARTITION p3 VALUES IN (("beijing", "2024-01-02"))  ,
+     PARTITION p4 VALUES IN (("guangdong", "2024-01-02")) 
+)
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO t3 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+-- result:
+-- !result
+CREATE TABLE t4 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+PARTITION BY (province) 
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO t4 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+-- result:
+-- !result
+CREATE TABLE t5 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (province, dt) 
+DISTRIBUTED BY RANDOM;
+-- result:
+-- !result
+INSERT INTO t5 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition ('2024-01-01') with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t3 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+True
+-- !result
+select dt, province, sum(age) from t3 where dt='2024-01-01'  group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+-- !result
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t3 where dt='2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t3 where dt='2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+-- result:
+-- !result
+refresh materialized view test_mv1 partition ('beijing') with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t3 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+True
+-- !result
+select dt, province, sum(age) from t3  where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+-- !result
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t3  where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t3  where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+-- result:
+-- !result
+refresh materialized view test_mv1 partition ('2024-01-01');
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t3  where dt='2024-01-01'  group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+True
+-- !result
+select dt, province, sum(age) from t3  where dt='2024-01-01'  group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+-- !result
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t3  where dt='2024-01-01'  group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t3  where dt='2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition ('beijing') with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+True
+-- !result
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+-- !result
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition ('beijing') with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+True
+-- !result
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+-- !result
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition ('beijing');
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+True
+-- !result
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+-- !result
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition ('2024-01-01') with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+True
+-- !result
+select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	20
+2024-01-01	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+2024-01-01	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition ('beijing') with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t5  where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+True
+-- !result
+select dt, province, sum(age) from t5  where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	40
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t5  where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t5  where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition ('2024-01-01');
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+True
+-- !result
+select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	60
+2024-01-01	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition('2024-01-01') with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+-- !result
+function: assert_table_partitions_num("test_mv1", 1)
+-- result:
+None
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	80
+2024-01-01	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	100
+2024-01-01	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition ('beijing') with sync mode;
+select * from test_mv1 order by 1, 2;
+-- result:
+-- !result
+function: assert_table_partitions_num("test_mv1", 1)
+-- result:
+None
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	100
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	120
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition('2024-01-01');
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+-- result:
+None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+-- !result
+function: assert_table_partitions_num("test_mv1", 1)
+-- result:
+None
+-- !result
+function: print_hit_materialized_view("select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+False
+-- !result
+select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	120
+2024-01-01	guangdong	20
+-- !result
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+-- result:
+-- !result
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+-- result:
+None
+-- !result
+select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
+-- result:
+2024-01-01	beijing	140
+2024-01-01	guangdong	20
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop table t3;
+-- result:
+-- !result
+drop table t4;
+-- result:
+-- !result
+drop table t5;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_nullable
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_nullable
@@ -455,8 +455,7 @@ as select dt, province, sum(age) from t5 group by dt, province;
 refresh materialized view  test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
 -- result:
-2024-01-01	beijing	80
-2024-01-01	guangdong	20
+2024-01-02	guangdong	20
 -- !result
 function: assert_table_partitions_num("test_mv1", 1)
 -- result:
@@ -476,7 +475,7 @@ None	None	None
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
 -- result:
 -- !result
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 -- result:
 None
 -- !result
@@ -505,7 +504,8 @@ as select dt, province, sum(age) from t5 group by dt, province;
 refresh materialized view  test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
 -- result:
-None	None	None
+2024-01-01	guangdong	20
+2024-01-02	guangdong	20
 -- !result
 function: assert_table_partitions_num("test_mv1", 1)
 -- result:
@@ -558,8 +558,7 @@ None
 -- !result
 select * from test_mv1 order by 1, 2;
 -- result:
-2024-01-01	beijing	120
-2024-01-01	guangdong	20
+2024-01-02	guangdong	20
 -- !result
 function: assert_table_partitions_num("test_mv1", 1)
 -- result:
@@ -579,7 +578,7 @@ None	None	None
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
 -- result:
 -- !result
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 -- result:
 None
 -- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_basic
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_basic
@@ -231,7 +231,7 @@ function: assert_table_partitions_num("test_mv1", 1)
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 drop materialized view test_mv1;
 
@@ -251,7 +251,7 @@ function: assert_table_partitions_num("test_mv1", 1)
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 drop materialized view test_mv1;
 
@@ -272,7 +272,7 @@ function: assert_table_partitions_num("test_mv1", 1)
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 drop materialized view test_mv1;
 

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_partial_refresh
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_partial_refresh
@@ -1,0 +1,281 @@
+-- name: test_mv_refresh_list_partitions_partial_refresh
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE t3 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY LIST (province, dt) (
+     PARTITION p1 VALUES IN (("beijing", "2024-01-01"))  ,
+     PARTITION p2 VALUES IN (("guangdong", "2024-01-01")), 
+     PARTITION p3 VALUES IN (("beijing", "2024-01-02"))  ,
+     PARTITION p4 VALUES IN (("guangdong", "2024-01-02")) 
+)
+DISTRIBUTED BY RANDOM;
+INSERT INTO t3 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+
+CREATE TABLE t4 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10)
+)
+DUPLICATE KEY(id)
+PARTITION BY (province) 
+DISTRIBUTED BY RANDOM;
+INSERT INTO t4 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+
+CREATE TABLE t5 (
+      id BIGINT,
+      province VARCHAR(64) not null,
+      age SMALLINT,
+      dt VARCHAR(10) not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (province, dt) 
+DISTRIBUTED BY RANDOM;
+INSERT INTO t5 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '2024-01-01'), (3, 'guangdong', 20, '2024-01-02');
+
+--------- t3 ---------
+-- test sync refresh & partition_refresh_number= -1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+refresh materialized view  test_mv1 partition ('2024-01-01') with sync mode;
+select * from test_mv1 order by 1, 2;
+function: print_hit_materialized_view("select dt, province, sum(age) from t3 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 where dt='2024-01-01'  group by dt, province order by 1, 2;
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+function: print_hit_materialized_view("select dt, province, sum(age) from t3 where dt='2024-01-02' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3 where dt='2024-01-01' group by dt, province order by 1, 2;
+
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+refresh materialized view test_mv1 partition ('beijing') with sync mode;
+select * from test_mv1 order by 1, 2;
+function: print_hit_materialized_view("select dt, province, sum(age) from t3 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3  where province='beijing' group by dt, province order by 1, 2;
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+function: print_hit_materialized_view("select dt, province, sum(age) from t3  where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3  where province='beijing' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t3 group by dt, province;
+refresh materialized view test_mv1 partition ('2024-01-01');
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: print_hit_materialized_view("select dt, province, sum(age) from t3  where dt='2024-01-01'  group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3  where dt='2024-01-01'  group by dt, province order by 1, 2;
+INSERT INTO t3 VALUES (2, 'beijing', 20, '2024-01-01');
+function: print_hit_materialized_view("select dt, province, sum(age) from t3  where dt='2024-01-01'  group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t3  where dt='2024-01-01' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+--------- t4 ---------
+-- test sync refresh & partition_refresh_number= -1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+refresh materialized view  test_mv1 partition ('beijing') with sync mode;
+select * from test_mv1 order by 1, 2;
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+refresh materialized view  test_mv1 partition ('beijing') with sync mode;
+select * from test_mv1 order by 1, 2;
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t4 group by dt, province;
+refresh materialized view  test_mv1 partition ('beijing');
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+INSERT INTO t4 VALUES (2, 'beijing', 20, '2024-01-01');
+function: print_hit_materialized_view("select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t4 where province='beijing' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+--------- t5 ---------
+-- test sync refresh & partition_refresh_number= -1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 partition ('2024-01-01') with sync mode;
+select * from test_mv1 order by 1, 2;
+function: print_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: print_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 partition ('beijing') with sync mode;
+select * from test_mv1 order by 1, 2;
+function: print_hit_materialized_view("select dt, province, sum(age) from t5  where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5  where province='beijing' group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: print_hit_materialized_view("select dt, province, sum(age) from t5  where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5  where province='beijing' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 partition ('2024-01-01');
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: print_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: print_hit_materialized_view("select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+--------- t6 ---------
+-- test sync refresh & partition_refresh_number= -1 && partition_ttl_number =1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+'partition_refresh_number' = '-1',
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 partition('2024-01-01') with sync mode;
+select * from test_mv1 order by 1, 2;
+function: assert_table_partitions_num("test_mv1", 1)
+function: print_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test sync refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by province
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 partition ('beijing') with sync mode;
+select * from test_mv1 order by 1, 2;
+function: assert_table_partitions_num("test_mv1", 1)
+function: print_hit_materialized_view("select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+-- test async refresh & partition_refresh_number= 1
+create materialized view test_mv1
+partition by dt
+REFRESH DEFERRED MANUAL
+distributed by hash(dt, province) buckets 10 
+PROPERTIES (
+"replication_num" = "1",
+"partition_ttl_number" = "1"
+) 
+as select dt, province, sum(age) from t5 group by dt, province;
+refresh materialized view  test_mv1 partition('2024-01-01');
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
+select * from test_mv1 order by 1, 2;
+function: assert_table_partitions_num("test_mv1", 1)
+function: print_hit_materialized_view("select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
+INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
+function: check_no_hit_materialized_view("select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
+select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
+drop materialized view test_mv1;
+
+drop table t3;
+drop table t4;
+drop table t5;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_nullable
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_nullable
@@ -225,7 +225,7 @@ function: assert_table_partitions_num("test_mv1", 1)
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 drop materialized view test_mv1;
 
@@ -268,7 +268,7 @@ function: assert_table_partitions_num("test_mv1", 1)
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
+function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 drop materialized view test_mv1;
 


### PR DESCRIPTION
## Why I'm doing:
Since materialized view has supported list partition, but we cannot refresh it  with partial partitions.

The only way to refresh list materialized view is :
```
create materialized view test_mv1
partition by dt
REFRESH DEFERRED MANUAL
distributed by hash(dt, province) buckets 10 
PROPERTIES (
'partition_refresh_number' = '1',
"replication_num" = "1"
) 
as select dt, province, sum(age) from t3 group by dt, province;

refresh materialized view  test_mv1
```

## What I'm doing:
- Support partial refresh list partition for mv:


1: refresh one partition for list mv:
```
refresh materialized view  test_mv1 partition ('2024-01-01') with sync mode;
```


2.  refresh two partitions for list mv:
```
refresh materialized view  test_mv1 partition ('2024-01-01', '2024-01-02') with sync mode;
```
- Enhance list partition with `partition_ttl_number` and `partition_refresh_number`
- Add more tests.

TODO:
- Even though StarRocks' mv only supports one partition column, but I have supported multi partition column in AST define  which we can supported later.
```
 : REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION (partitionRangeDesc | listPartitionValues))? FORCE? (WITH (SYNC | ASYNC) MODE)?

multiListPartitionValues
    :'(' singleListPartitionValues (',' singleListPartitionValues)* ')' // list partition values with multi partition columns: ('a, 'b', 'c'), ('d', 'e', 'f')
    ;

singleListPartitionValues
    : '(' listPartitionValue (',' listPartitionValue)* ')' // list partition value: ('a, 'b', 'c')
    ;

listPartitionValues // list partition values which can be with single or multi partition columns
    : singleListPartitionValues
    | multiListPartitionValues
    ;
```


Fixes https://github.com/StarRocks/starrocks/issues/46087

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
