### PR TITLE
[BugFix] Fix EncryptionKeyPBAdapter not serialize key_desc

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/encryption/EncryptionKeyPBAdapter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/encryption/EncryptionKeyPBAdapter.java
@@ -36,6 +36,7 @@ public class EncryptionKeyPBAdapter
     public static final String ALGORITHM = "algorithm";
     public static final String ENCRYPTED_KEY = "encrypted_key";
     public static final String PLAIN_KEY = "plain_key";
+    public static final String KEY_DESC = "key_desc";
 
     @Override
     public JsonElement serialize(EncryptionKeyPB encryptionKeyPB, Type type,
@@ -63,6 +64,9 @@ public class EncryptionKeyPBAdapter
         if (encryptionKeyPB.plainKey != null) {
             String base64Encoded = Base64.getEncoder().encodeToString(encryptionKeyPB.plainKey);
             jsonObject.addProperty(PLAIN_KEY, base64Encoded);
+        }
+        if (encryptionKeyPB.keyDesc != null) {
+            jsonObject.addProperty(KEY_DESC, encryptionKeyPB.keyDesc);
         }
         return jsonObject;
     }
@@ -97,6 +101,9 @@ public class EncryptionKeyPBAdapter
         if (jsonObject.has(PLAIN_KEY)) {
             String base64Encoded = jsonObject.get(PLAIN_KEY).getAsString();
             encryptionKeyPB.plainKey = Base64.getDecoder().decode(base64Encoded);
+        }
+        if (jsonObject.has(KEY_DESC)) {
+            encryptionKeyPB.keyDesc = jsonObject.get(KEY_DESC).getAsString();
         }
         return encryptionKeyPB;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/encryption/NormalKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/encryption/NormalKeyTest.java
@@ -46,6 +46,7 @@ public class NormalKeyTest {
         pb.encryptedKey = new byte[16];
         pb.type = EncryptionKeyTypePB.NORMAL_KEY;
         pb.createTime = 3L;
+        pb.keyDesc = "desc";
         String js = GsonUtils.GSON.toJson(pb);
         EncryptionKeyPB pb2 = GsonUtils.GSON.fromJson(js, EncryptionKeyPB.class);
         assertEquals(pb.id, pb2.id);
@@ -53,6 +54,7 @@ public class NormalKeyTest {
         assertEquals(pb.algorithm, pb2.algorithm);
         assertEquals(pb.createTime, pb2.createTime);
         assertEquals(pb.type, pb2.type);
+        assertEquals(pb.keyDesc, pb2.keyDesc);
         assertArrayEquals(pb.encryptedKey, pb2.encryptedKey);
     }
 

--- a/gensrc/proto/encryption.proto
+++ b/gensrc/proto/encryption.proto
@@ -25,6 +25,7 @@ enum EncryptionAlgorithmPB {
     AES_128 = 1;
 }
 
+// NOTE: if add field to EncryptionKeyPB, EncryptionKeyPBAdapter must be modified accordingly
 message EncryptionKeyPB {
     optional int64 id = 1; // not required, e.g. DEK may not have an id
     optional int64 parent_id = 2; // not required, e.g. root key may not have parent


### PR DESCRIPTION
## Why I'm doing:

EncryptionKeyPBAdapter not serialize newly added key_desc field

## What I'm doing:

Add serialization, and add some notice in proto file

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
