### PR TITLE
[Enhancement] Make frontend config enable_udf mutable

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -1345,7 +1345,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: No
+- Is mutable: Yes
 - Description: Whether to enable UDF.
 - Introduced in: -
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1346,7 +1346,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值：false
 - 类型：Boolean
 - 单位：-
-- 是否动态：否
+- 是否动态：是
 - 描述：是否开启 UDF。
 - 引入版本：-
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1321,7 +1321,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int skip_whole_phase_lock_mv_limit = 5;
 
-    @ConfField
+    @ConfField(mutable = true)
     public static boolean enable_udf = false;
 
     @ConfField(mutable = true)


### PR DESCRIPTION
## Why I'm doing:
The configuration `enable_udf` is already mutable, we should tag it with mutable attribute.

## What I'm doing:
Make frontend configuration `enable_udf` mutable.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
