### PR TITLE
[BugFix] fix backup and restore Case-Sensitive Table Name Conflict

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
@@ -80,7 +80,7 @@ public class BackupRestoreAnalyzer {
             String dbName = getDbName(backupStmt.getDbName(), context);
             Database database = getDatabase(dbName, context);
             analyzeLabelAndRepo(backupStmt.getLabel(), backupStmt.getRepoName());
-            Map<String, TableRef> tblPartsMap = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+            Map<String, TableRef> tblPartsMap = Maps.newTreeMap();
             List<TableRef> tableRefs = backupStmt.getTableRefs();
             // If TableRefs is empty, it means that we do not specify any table in Backup stmt.
             // We should backup all table in current database.
@@ -253,7 +253,7 @@ public class BackupRestoreAnalyzer {
         public Void visitRestoreStatement(RestoreStmt restoreStmt, ConnectContext context) {
             List<TableRef> tableRefs = restoreStmt.getTableRefs();
             Set<String> aliasSet = Sets.newHashSet();
-            Map<String, TableRef> tblPartsMap = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+            Map<String, TableRef> tblPartsMap = Maps.newTreeMap();
             for (TableRef tableRef : tableRefs) {
                 TableName tableName = tableRef.getName();
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Fix backup and restore Case-Sensitive Table Name Conflict
```
mysql> BACKUP SNAPSHOT mydb.db_backup to s3_repo;
Query OK, 0 rows affected (0.08 sec)

mysql> SHOW BACKUP;
+-------+--------------+--------+----------+----------------------------------------------------------------------------------------------------------------------------------+---------------------+----------------------+---------------------+---------------------+-----------------+----------+------------+--------+---------+
| JobId | SnapshotName | DbName | State    | BackupObjs                                                                                                                       | CreateTime          | SnapshotFinishedTime | UploadFinishedTime  | FinishedTime        | UnfinishedTasks | Progress | TaskErrMsg | Status | Timeout |
+-------+--------------+--------+----------+----------------------------------------------------------------------------------------------------------------------------------+---------------------+----------------------+---------------------+---------------------+-----------------+----------+------------+--------+---------+
| 20011 | db_backup    | mydb   | FINISHED | [mydb.My_table], [mydb.my_table], [mydb.test_t1], [mydb.test_t2], [mydb.test_t3], [mydb.test_t4], [mydb.test_t5], [mydb.test_t6] | 2024-09-12 01:18:20 | 2024-09-12 01:18:25  | 2024-09-12 01:18:52 | 2024-09-12 01:18:58 |                 |          |            | [OK]   | 86400   |
+-------+--------------+--------+----------+----------------------------------------------------------------------------------------------------------------------------------+---------------------+----------------------+---------------------+---------------------+-----------------+----------+------------+--------+---------+

mysql> SHOW SNAPSHOT ON s3_repo;
+-----------+-------------------------+--------+
| Snapshot  | Timestamp               | Status |
+-----------+-------------------------+--------+
| db_backup | 2024-09-12-01-18-20-455 | OK     |
+-----------+-------------------------+--------+

mysql> drop table my_table;

mysql> drop table My_table;

mysql> RESTORE SNAPSHOT mydb.db_backup FROM s3_repo ON (My_table, my_table)  PROPERTIES("backup_timestamp"="2024-09-12-01-18-20-455", "replication_num" = "1");

mysql> select * from My_table;
+------------+------+------+
| date       | k1   | k2   |
+------------+------+------+
| 2022-03-11 |    3 | abc  |
| 2022-03-11 |    2 | acb  |
| 2022-03-11 |    4 | abc  |
| 2022-03-12 |    2 | bca  |
| 2022-03-12 |    4 | cba  |
| 2022-03-12 |    5 | cba  |
+------------+------+------+

mysql> select * from my_table;
+------------+------+------+
| date       | k1   | k2   |
+------------+------+------+
| 2022-03-12 |    2 | bca  |
| 2022-03-12 |    4 | cba  |
| 2022-03-12 |    5 | cba  |
| 2022-03-11 |    3 | abc  |
| 2022-03-11 |    2 | acb  |
| 2022-03-11 |    4 | abc  |
+------------+------+------+
```

Fixes #50949 

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
