### PR TITLE
[BugFix] remove static Column

### DIFF
--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -32,10 +32,6 @@
 
 namespace starrocks {
 
-NullColumnPtr ColumnHelper::one_size_not_null_column = NullColumn::create(1, 0);
-
-NullColumnPtr ColumnHelper::one_size_null_column = NullColumn::create(1, 1);
-
 Filter& ColumnHelper::merge_nullable_filter(Column* column) {
     if (column->is_nullable()) {
         auto* nullable_column = down_cast<NullableColumn*>(column);

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -503,10 +503,6 @@ public:
     static ColumnPtr create_const_null_column(size_t chunk_size);
 
     static ColumnPtr convert_time_column_from_double_to_str(const ColumnPtr& column);
-
-    static NullColumnPtr one_size_not_null_column;
-
-    static NullColumnPtr one_size_null_column;
 };
 
 // Hold a slice of chunk

--- a/be/src/column/column_viewer.cpp
+++ b/be/src/column/column_viewer.cpp
@@ -15,6 +15,7 @@
 #include "column/column_viewer.h"
 
 #include "column/column_helper.h"
+#include "runtime/global_variables.h"
 #include "types/logical_type_infra.h"
 #include "util/percentile_value.h"
 #include "util/phmap/phmap.h"
@@ -33,20 +34,20 @@ template <LogicalType Type>
 ColumnViewer<Type>::ColumnViewer(const ColumnPtr& column)
         : _not_const_mask(not_const_mask(column)), _null_mask(null_mask(column)) {
     if (column->only_null()) {
-        _null_column = ColumnHelper::one_size_null_column;
+        _null_column = GlobalVariables::GetInstance()->one_size_null_column();
         _column = RunTimeColumnType<Type>::create();
         _column->append_default();
     } else if (column->is_constant()) {
         auto v = ColumnHelper::as_raw_column<ConstColumn>(column);
         _column = ColumnHelper::cast_to<Type>(v->data_column());
-        _null_column = ColumnHelper::one_size_not_null_column;
+        _null_column = GlobalVariables::GetInstance()->one_size_not_null_column();
     } else if (column->is_nullable()) {
         auto v = ColumnHelper::as_raw_column<NullableColumn>(column);
         _column = ColumnHelper::cast_to<Type>(v->data_column());
         _null_column = ColumnHelper::as_column<NullColumn>(v->null_column());
     } else {
         _column = ColumnHelper::cast_to<Type>(column);
-        _null_column = ColumnHelper::one_size_not_null_column;
+        _null_column = GlobalVariables::GetInstance()->one_size_not_null_column();
     }
 
     _data = _column->get_data().data();

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -29,6 +29,7 @@ set(RUNTIME_FILES
     datetime_value.cpp
     descriptors.cpp
     exec_env.cpp
+    global_variables.cpp
     user_function_cache.cpp
     jdbc_driver_manager.cpp
     mem_pool.cpp

--- a/be/src/runtime/global_variables.cpp
+++ b/be/src/runtime/global_variables.cpp
@@ -18,11 +18,10 @@ namespace starrocks {
 
 bool GlobalVariables::_is_init = false;
 
-Status GlobalVariables::init() {
+GlobalVariables::GlobalVariables() {
     _one_size_not_null_column = NullColumn::create(1, 0);
     _one_size_null_column = NullColumn::create(1, 1);
     _is_init = true;
-    return Status::OK();
 }
 
 } // namespace starrocks

--- a/be/src/runtime/global_variables.cpp
+++ b/be/src/runtime/global_variables.cpp
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/global_variables.h"
+
+namespace starrocks {
+
+bool GlobalVariables::_is_init = false;
+
+Status GlobalVariables::init() {
+    _one_size_not_null_column = NullColumn::create(1, 0);
+    _one_size_null_column = NullColumn::create(1, 1);
+    _is_init = true;
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/runtime/global_variables.h
+++ b/be/src/runtime/global_variables.h
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/nullable_column.h"
+#include "common/status.h"
+
+namespace starrocks {
+
+class GlobalVariables {
+public:
+    static GlobalVariables* GetInstance() {
+        static GlobalVariables s_global_vars;
+        return &s_global_vars;
+    }
+
+    GlobalVariables() = default;
+    ~GlobalVariables() { _is_init = false; }
+
+    Status init();
+
+    const NullColumnPtr& one_size_not_null_column() const {
+        DCHECK(_is_init);
+        return _one_size_not_null_column;
+    }
+    const NullColumnPtr& one_size_null_column() const {
+        DCHECK(_is_init);
+        return _one_size_null_column;
+    }
+
+private:
+    static bool _is_init;
+
+    NullColumnPtr _one_size_not_null_column;
+    NullColumnPtr _one_size_null_column;
+};
+} // namespace starrocks

--- a/be/src/runtime/global_variables.h
+++ b/be/src/runtime/global_variables.h
@@ -26,10 +26,10 @@ public:
         return &s_global_vars;
     }
 
-    GlobalVariables() = default;
+    GlobalVariables();
     ~GlobalVariables() { _is_init = false; }
 
-    Status init();
+    bool is_init() const { return _is_init; }
 
     const NullColumnPtr& one_size_not_null_column() const {
         DCHECK(_is_init);
@@ -42,7 +42,6 @@ public:
 
 private:
     static bool _is_init;
-
     NullColumnPtr _one_size_not_null_column;
     NullColumnPtr _one_size_null_column;
 };

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -172,8 +172,9 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     EXIT_IF_ERROR(global_env->init());
     LOG(INFO) << process_name << " start step " << start_step++ << ": global env init successfully";
 
+    // make sure global variables are initialized
     auto* global_vars = GlobalVariables::GetInstance();
-    EXIT_IF_ERROR(global_vars->init());
+    CHECK(global_vars->is_init()) << "global variables not initialized";
     LOG(INFO) << process_name << " start step " << start_step++ << ": global variables init successfully";
 
     auto* storage_engine = init_storage_engine(global_env, paths, as_cn);

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -29,6 +29,7 @@
 #include "gutil/strings/join.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
+#include "runtime/global_variables.h"
 #include "runtime/jdbc_driver_manager.h"
 #include "service/brpc.h"
 #include "service/service.h"
@@ -170,6 +171,10 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     auto* global_env = GlobalEnv::GetInstance();
     EXIT_IF_ERROR(global_env->init());
     LOG(INFO) << process_name << " start step " << start_step++ << ": global env init successfully";
+
+    auto* global_vars = GlobalVariables::GetInstance();
+    EXIT_IF_ERROR(global_vars->init());
+    LOG(INFO) << process_name << " start step " << start_step++ << ": global variables init successfully";
 
     auto* storage_engine = init_storage_engine(global_env, paths, as_cn);
     LOG(INFO) << process_name << " start step " << start_step++ << ": storage engine init successfully";

--- a/be/src/testutil/init_test_env.h
+++ b/be/src/testutil/init_test_env.h
@@ -97,10 +97,6 @@ int init_test_env(int argc, char** argv) {
     auto st = global_env->init();
     CHECK(st.ok()) << st;
 
-    auto* global_vars = GlobalEnv::GetInstance();
-    st = global_vars->init();
-    CHECK(st.ok()) << st;
-
     auto* exec_env = ExecEnv::GetInstance();
     // Pagecache is turned on by default, and some test cases require cache to be turned on,
     // and some test cases do not. For easy management, we turn cache off during unit test

--- a/be/src/testutil/init_test_env.h
+++ b/be/src/testutil/init_test_env.h
@@ -96,6 +96,11 @@ int init_test_env(int argc, char** argv) {
     config::disable_storage_page_cache = true;
     auto st = global_env->init();
     CHECK(st.ok()) << st;
+
+    auto* global_vars = GlobalEnv::GetInstance();
+    st = global_vars->init();
+    CHECK(st.ok()) << st;
+
     auto* exec_env = ExecEnv::GetInstance();
     // Pagecache is turned on by default, and some test cases require cache to be turned on,
     // and some test cases do not. For easy management, we turn cache off during unit test


### PR DESCRIPTION
## Why I'm doing:
![img_v3_02ek_0552bc4d-d932-4b71-a1d2-c2761fed6fcg](https://github.com/user-attachments/assets/51884518-8ba6-4914-acc6-948d4a06ff21)

## What I'm doing:

We maintain two static ColumnPtr in ColumnHelper, which will be used by ColumnViewer.
However, the allocator of column buffer depends on thread local variables, and the life cycle of thread local variables is shorter than that of static variables, which will cause ASAN to report the above error.

Solution: Move static variables to the GlobalVariables


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
