### PR TITLE
[BugFix] avoid hudi context npe when cache reload in background

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
@@ -28,10 +28,15 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class RemoteFileScanContext {
     public RemoteFileScanContext(Table table) {
-        this.table = table;
+        this.tableLocation = table.getTableLocation();
     }
 
-    public Table table = null;
+    public RemoteFileScanContext(String tableLocation) {
+        this.tableLocation = tableLocation;
+    }
+
+    public String tableLocation = null;
+
     // ---- concurrent initialization -----
     public AtomicBoolean init = new AtomicBoolean(false);
     public ReentrantLock lock = new ReentrantLock();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
@@ -20,6 +20,7 @@ public class RemotePathKey {
     private final String path;
     private final boolean isRecursive;
     private RemoteFileScanContext scanContext;
+    private String tableLocation;
 
     public static RemotePathKey of(String path, boolean isRecursive) {
         return new RemotePathKey(path, isRecursive);
@@ -38,6 +39,10 @@ public class RemotePathKey {
 
     public String getPath() {
         return path;
+    }
+
+    public String getTableLocation() {
+        return tableLocation;
     }
 
     public boolean isRecursive() {
@@ -79,6 +84,7 @@ public class RemotePathKey {
 
     public void setScanContext(RemoteFileScanContext ctx) {
         scanContext = ctx;
+        tableLocation = ctx.tableLocation;
     }
 
     public RemoteFileScanContext getScanContext() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
@@ -29,6 +29,8 @@ public class RemotePathKey {
     public RemotePathKey(String path, boolean isRecursive) {
         this.path = path;
         this.isRecursive = isRecursive;
+        this.scanContext = null;
+        this.tableLocation = null;
     }
 
     public boolean approximateMatchPath(String basePath, boolean isRecursive) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.hudi;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -128,7 +129,8 @@ public class HudiRemoteFileIO implements RemoteFileIO {
     }
 
     @NotNull
-    private static RemoteFileScanContext getScanContext(RemotePathKey pathKey, String tableLocation) {
+    @VisibleForTesting
+    public static RemoteFileScanContext getScanContext(RemotePathKey pathKey, String tableLocation) {
         RemoteFileScanContext scanContext = pathKey.getScanContext();
         // scan context is nullptr when cache is doing reload, and we don't have place to set scan context.
         if (scanContext == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -40,6 +40,7 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.hadoop.HadoopStorageConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Iterator;
 import java.util.List;
@@ -69,7 +70,7 @@ public class HudiRemoteFileIO implements RemoteFileIO {
             HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(configuration);
             HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
             HoodieTableMetaClient metaClient =
-                    HoodieTableMetaClient.builder().setConf(configuration).setBasePath(ctx.table.getTableLocation()).build();
+                    HoodieTableMetaClient.builder().setConf(configuration).setBasePath(ctx.tableLocation).build();
             // metaClient.reloadActiveTimeline();
             HoodieTimeline timeline = metaClient.getCommitsAndCompactionTimeline().filterCompletedInstants();
             Option<HoodieInstant> lastInstant = timeline.lastInstant();
@@ -86,11 +87,13 @@ public class HudiRemoteFileIO implements RemoteFileIO {
 
     @Override
     public Map<RemotePathKey, List<RemoteFileDesc>> getRemoteFiles(RemotePathKey pathKey) {
-        RemoteFileScanContext scanContext = pathKey.getScanContext();
-        String tableLocation = scanContext.table.getTableLocation();
+        String tableLocation = pathKey.getTableLocation();
         if (tableLocation == null) {
             throw new StarRocksConnectorException("Missing hudi table base location on %s", pathKey);
         }
+        // scan context allows `getRemoteFiles` on set of `pathKey` to share a same context and avoid duplicated function calls.
+        // so in most cases, scan context has been created and set outside, so scan context is not nullptr.
+        RemoteFileScanContext scanContext = getScanContext(pathKey, tableLocation);
 
         String partitionPath = pathKey.getPath();
         String partitionName = FSUtils.getRelativePartitionPath(new StoragePath(tableLocation), new StoragePath(partitionPath));
@@ -122,6 +125,16 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                     pathKey, e.getMessage());
         }
         return resultPartitions.put(pathKey, fileDescs).build();
+    }
+
+    @NotNull
+    private static RemoteFileScanContext getScanContext(RemotePathKey pathKey, String tableLocation) {
+        RemoteFileScanContext scanContext = pathKey.getScanContext();
+        // scan context is nullptr when cache is doing reload, and we don't have place to set scan context.
+        if (scanContext == null) {
+            scanContext = new RemoteFileScanContext(tableLocation);
+        }
+        return scanContext;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -29,6 +29,7 @@ import com.starrocks.connector.hive.MockedRemoteFileSystem;
 import com.starrocks.connector.hive.Partition;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
 import com.starrocks.connector.hive.TextFileFormatDesc;
+import com.starrocks.connector.hudi.HudiRemoteFileIO;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.hadoop.conf.Configuration;
@@ -334,4 +335,20 @@ public class RemoteFileOperationsTest {
         }
     }
 
+    @Test
+    public void testRemotePathKeySetFileScanContext() {
+        RemotePathKey pathKey = new RemotePathKey("hello", true);
+        Assert.assertNull(pathKey.getTableLocation());
+        Assert.assertNull(pathKey.getScanContext());
+
+        RemoteFileScanContext scanContext = null;
+        scanContext = HudiRemoteFileIO.getScanContext(pathKey, "tableLocation");
+        Assert.assertNotNull(scanContext);
+        pathKey.setScanContext(scanContext);
+        Assert.assertEquals(pathKey.getTableLocation(), "tableLocation");
+        Assert.assertTrue(pathKey.getScanContext() == scanContext);
+
+        RemoteFileScanContext scanContext1 = HudiRemoteFileIO.getScanContext(pathKey, "null");
+        Assert.assertTrue(pathKey.getScanContext() == scanContext1);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -16,6 +16,7 @@ package com.starrocks.connector;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.HudiTable;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -73,7 +74,8 @@ public class RemoteFileOperationsTest {
         Map<String, Partition> partitions = metastore.getPartitionsByNames("db1", "table1", partitionNames);
 
         List<RemoteFileInfo> remoteFileInfos =
-                ops.getRemoteFiles(null, Lists.newArrayList(partitions.values()), GetRemoteFilesParams.newBuilder().build());
+                ops.getRemoteFiles(new HudiTable(), Lists.newArrayList(partitions.values()),
+                        GetRemoteFilesParams.newBuilder().build());
         Assert.assertEquals(2, remoteFileInfos.size());
         Assert.assertTrue(remoteFileInfos.get(0).toString().contains("emoteFileInfo{format=ORC, files=["));
 


### PR DESCRIPTION
## Why I'm doing:

I see a lot of warning in fe.out

```
Sep 11, 2024 7:12:30 PM com.google.common.cache.LocalCache$Segment lambda$loadAsync$0
WARNING: Exception thrown during refresh
java.util.concurrent.ExecutionException: java.lang.NullPointerException
        at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:592)
        at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:551)
        at com.google.common.util.concurrent.FluentFuture$TrustedFuture.get(FluentFuture.java:91)
        at com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly(Uninterruptibles.java:247)
        at com.google.common.cache.LocalCache$Segment.getAndRecordStats(LocalCache.java:2345)
        at com.google.common.cache.LocalCache$Segment.lambda$loadAsync$0(LocalCache.java:2325)
        at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
        at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1286)
        at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:1055)
        at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:807)
        at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:105)
        at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
        at com.google.common.util.concurrent.ExecutionList.executeListener(ExecutionList.java:145)
        at com.google.common.util.concurrent.ExecutionList.execute(ExecutionList.java:134)
        at com.google.common.util.concurrent.ListenableFutureTask.done(ListenableFutureTask.java:113)
        at java.base/java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:381)
        at java.base/java.util.concurrent.FutureTask.setException(FutureTask.java:250)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:269)
        at com.starrocks.connector.ReentrantExecutor.lambda$execute$1(ReentrantExecutor.java:46)
        at com.starrocks.connector.BoundedExecutor.releaseQueue(BoundedExecutor.java:77)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.NullPointerException
        at com.starrocks.connector.hudi.HudiRemoteFileIO.createHudiContext(HudiRemoteFileIO.java:61)
        at com.starrocks.connector.hudi.HudiRemoteFileIO.getRemoteFiles(HudiRemoteFileIO.java:99)
        at com.starrocks.connector.CachingRemoteFileIO.loadRemoteFiles(CachingRemoteFileIO.java:93)
        at com.starrocks.connector.CachingRemoteFileIO$1.load(CachingRemoteFileIO.java:54)
        at com.starrocks.connector.CachingRemoteFileIO$1.load(CachingRemoteFileIO.java:51)
        at com.google.common.cache.CacheLoader.reload(CacheLoader.java:100)
        at com.google.common.cache.CacheLoader$1.lambda$reload$0(CacheLoader.java:198)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        ... 5 more
```

It's because when cache reload in background, `RemotePathKey` does not have scan context object, which leads to NPE.

but in most cases, scan context has been set before listing files.

## What I'm doing:

Create scan context when it's nullptr.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
