### PR TITLE
[Enhancement] optimize ignore nulls

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -81,7 +81,7 @@ public:
     // Find the first non-null value in [start, end), return end if all null
     static size_t find_nonnull(const Column* col, size_t start, size_t end);
 
-    // Find the non-null value in reversed order in [start, end), return start if all null
+    // Find the non-null value in reversed order in [start, end), return end if all null
     static size_t last_nonnull(const Column* col, size_t start, size_t end);
 
     // Find first value in range [start, end) that not equal to target

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -538,7 +538,6 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
     using InputColumnType = typename ValueWindowFunction<LT, FirstValueState<LT>, T>::InputColumnType;
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
-        LOG(INFO) << "lead-lag:reset" << std::endl;
         this->data(state).value = {};
         this->data(state).is_null = false;
 
@@ -572,10 +571,6 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
-        LOG(INFO) << "lead-lag:update_batch_single_state_with_frame, peer_group_start: " << peer_group_start
-                  << ", peer_group_end: " << peer_group_end << ", frame_start: " << frame_start
-                  << ", frame_end: " << frame_end << std::endl;
-
         // for lead/lag, [peer_group_start, peer_group_end] equals to [partition_start, partition_end]
         // when lead/lag called, the whole partitoin's data has already been here, so we can just check all the way to the begining or the end
         if constexpr (ignoreNulls) {
@@ -706,7 +701,6 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
-        LOG(INFO) << "lead-lag:get_values" << std::endl;
         this->get_values_helper(state, dst, start, end);
     }
 

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -511,7 +511,7 @@ class LastValueWindowFunction final : public ValueWindowFunction<LT, LastValueSt
     std::string get_name() const override { return "nullable_last_value"; }
 };
 
-template <LogicalType LT, typename = guard::Guard>
+template <LogicalType LT, bool ignoreNulls>
 struct LeadLagState {
     using T = AggDataValueType<LT>;
     T value;
@@ -521,11 +521,24 @@ struct LeadLagState {
     bool default_is_null = false;
 };
 
+template <LogicalType LT>
+struct LeadLagState<LT, true> {
+    using T = AggDataValueType<LT>;
+    T value;
+    int64_t offset = 0;
+    T default_value;
+    bool is_null = false;
+    bool default_is_null = false;
+    int64_t target_not_null_index = 0; // recored the 'offset' not null value's position
+    size_t non_null_count;             // only used for lag
+};
+
 template <LogicalType LT, bool ignoreNulls, bool isLag, typename T = RunTimeCppType<LT>>
-class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<LT>, T> {
+class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<LT, ignoreNulls>, T> {
     using InputColumnType = typename ValueWindowFunction<LT, FirstValueState<LT>, T>::InputColumnType;
 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
+        LOG(INFO) << "lead-lag:reset" << std::endl;
         this->data(state).value = {};
         this->data(state).is_null = false;
 
@@ -549,27 +562,25 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
             auto value = ColumnHelper::get_const_value<LT>(arg2);
             AggDataTypeTraits<LT>::assign_value(this->data(state).default_value, value);
         }
+
+        if constexpr (ignoreNulls) {
+            this->data(state).target_not_null_index = INT64_MIN;
+            this->data(state).non_null_count = 0;
+        }
     }
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
-        // frame_start < peer_group_start is for lag function
-        // frame_end > peer_group_end is for lead function
-        if ((frame_start < peer_group_start) | (frame_end > peer_group_end)) {
-            if (this->data(state).default_is_null) {
-                this->data(state).is_null = true;
-            } else {
-                this->data(state).is_null = false;
-                this->data(state).value = this->data(state).default_value;
-            }
-            return;
-        }
+        LOG(INFO) << "lead-lag:update_batch_single_state_with_frame, peer_group_start: " << peer_group_start
+                  << ", peer_group_end: " << peer_group_end << ", frame_start: " << frame_start
+                  << ", frame_end: " << frame_end << std::endl;
 
         // for lead/lag, [peer_group_start, peer_group_end] equals to [partition_start, partition_end]
         // when lead/lag called, the whole partitoin's data has already been here, so we can just check all the way to the begining or the end
-        if (ignoreNulls) {
+        if constexpr (ignoreNulls) {
             const int64_t offset = this->data(state).offset;
+            DCHECK(offset > 0);
             // lead(v1 ignore nulls, <offset>) has window `ROWS BETWEEN UNBOUNDED PRECEDING AND <offset> FOLLOWING`
             //      frame_start = partition_start
             //      frame_end = current_row + <offset> + 1
@@ -587,33 +598,75 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
             }
 
             int64_t cnt = offset;
-            size_t value_index = current_row;
-            if (isLag) {
-                // Look backward, find <offset>-th non-null value
-                while (value_index > peer_group_start && cnt > 0) {
-                    int64_t next_index = ColumnHelper::last_nonnull(columns[0], peer_group_start, value_index);
-                    if (next_index == value_index) {
-                        break;
+            int64_t value_index = current_row;
+            bool found_target = false;
+            // for lag: at the begining of current round of 'update_batch_single_state_with_frame'
+            // non_null_count means: before current row, there are  at least 'non_null_count' non null elements. non_null_count <= offset
+            // target_not_null_index means: the leftmost element's index in 'non_null_count' non null element, if non_null_count == 0, target_not_null_index is undefined
+            if constexpr (isLag) {
+                DCHECK(this->data(state).non_null_count <= offset);
+                if (this->data(state).non_null_count == offset) {
+                    DCHECK(this->data(state).target_not_null_index >= 0);
+                    // before current_row we have 'offset' non null elements
+                    value_index = this->data(state).target_not_null_index;
+                    found_target = true;
+                    if (columns[0]->is_null(current_row)) {
+                        // no need to change target_not_null_index and non_null_count
+                    } else {
+                        // move target_not_null_index to the next right non-null element
+                        this->data(state).target_not_null_index = ColumnHelper::find_nonnull(
+                                columns[0], this->data(state).target_not_null_index + 1, current_row + 1);
+                        DCHECK(value_index < this->data(state).target_not_null_index);
                     }
-                    value_index = next_index;
-                    DCHECK_GE(value_index, peer_group_start);
-                    cnt--;
+                } else {
+                    // this means we don't find target non-null value
+                    found_target = false;
+                    // before current_row we don't have 'offset' non null elements
+                    if (columns[0]->is_null(current_row)) {
+                        // no need to change target_not_null_index and non_null_count
+                    } else {
+                        if (this->data(state).non_null_count == 0) {
+                            this->data(state).target_not_null_index = current_row;
+                        }
+                        this->data(state).non_null_count++;
+                    }
                 }
             } else {
-                // Look forward, find <offset>-th non-null value
-                while (value_index < peer_group_end && cnt > 0) {
-                    int64_t next_index = ColumnHelper::find_nonnull(columns[0], value_index + 1, peer_group_end);
-                    if (next_index == peer_group_end) {
-                        break;
+                // first time after reset
+                if (frame_start == peer_group_start) return;
+                // first time after reset, Look forward, find <offset>-th non-null value
+                if (this->data(state).target_not_null_index == INT64_MIN) {
+                    while (value_index < peer_group_end && cnt > 0) {
+                        int64_t next_index = ColumnHelper::find_nonnull(columns[0], value_index + 1, peer_group_end);
+                        if (next_index == peer_group_end) {
+                            value_index = next_index;
+                            break;
+                        }
+                        value_index = next_index;
+                        DCHECK_LE(value_index, peer_group_end);
+                        cnt--;
                     }
-                    value_index = next_index;
-                    DCHECK_LE(value_index, peer_group_end);
-                    cnt--;
+                    found_target = (cnt == 0);
+                } else if (this->data(state).target_not_null_index == peer_group_end) {
+                    // we don't have 'offset' not null values
+                    value_index = peer_group_end;
+                    found_target = false;
+                } else {
+                    if (columns[0]->is_null(current_row)) {
+                        value_index = this->data(state).target_not_null_index;
+                    } else {
+                        value_index = this->data(state).target_not_null_index;
+                        int64_t next_index = ColumnHelper::find_nonnull(columns[0], value_index + 1, peer_group_end);
+                        value_index = next_index;
+                    }
+                    found_target = (value_index < peer_group_end);
                 }
+                this->data(state).target_not_null_index = value_index;
             }
-            DCHECK_GE(value_index, peer_group_start);
+
+            DCHECK_GE(value_index, peer_group_start - 1);
             DCHECK_LE(value_index, peer_group_end);
-            if (cnt > 0 || value_index == peer_group_end || columns[0]->is_null(value_index)) {
+            if (!found_target || columns[0]->is_null(value_index)) {
                 if (this->data(state).default_is_null) {
                     this->data(state).is_null = true;
                 } else {
@@ -627,6 +680,18 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
                                                     AggDataTypeTraits<LT>::get_row_ref(*column, value_index));
             }
         } else {
+            // frame_start < peer_group_start is for lag function
+            // frame_end > peer_group_end is for lead function
+            if ((frame_start < peer_group_start) | (frame_end > peer_group_end)) {
+                if (this->data(state).default_is_null) {
+                    this->data(state).is_null = true;
+                } else {
+                    this->data(state).is_null = false;
+                    this->data(state).value = this->data(state).default_value;
+                }
+                return;
+            }
+
             if (!columns[0]->is_null(frame_end - 1)) {
                 this->data(state).is_null = false;
                 const Column* data_column = ColumnHelper::get_data_column(columns[0]);
@@ -641,6 +706,7 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
+        LOG(INFO) << "lead-lag:get_values" << std::endl;
         this->get_values_helper(state, dst, start, end);
     }
 

--- a/test/sql/test_window_function/R/test_ignore_nulls
+++ b/test/sql/test_window_function/R/test_ignore_nulls
@@ -1,0 +1,566 @@
+-- name: test_lead_lag_ignore_nulls
+CREATE TABLE `t0` (
+  `v1` int(11) NULL,
+  `v2` int(11) NULL,
+  `v3` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `t0` (v1, v2, v3) values
+    (1, 1, 1),
+    (1, 2, 2),
+    (1, 3, 3),
+    (1, 4, 4),
+    (2, 1, NULL),
+    (2, 2, 2),
+    (2, 3, 3),
+    (2, 4, 4),
+    (3, 1, 1),
+    (3, 2, NULL),
+    (3, 3, 3),
+    (3, 4, 4),
+    (4, 1, 1),
+    (4, 2, 2),
+    (4, 3, NULL),
+    (4, 4, 4),
+    (5, 1, 1),
+    (5, 2, 2),
+    (5, 3, 3),
+    (5, 4, NULL),
+    (6, 1, 1),
+    (6, 2, NULL),
+    (6, 3, NULL),
+    (6, 4, 4);
+-- result:
+-- !result
+SELECT v1, v2, v3, first_value(v3 IGNORE NULLS) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	1
+1	2	2	1
+1	3	3	1
+1	4	4	1
+2	1	None	1
+2	2	2	1
+2	3	3	1
+2	4	4	1
+3	1	1	1
+3	2	None	1
+3	3	3	1
+3	4	4	1
+4	1	1	1
+4	2	2	1
+4	3	None	1
+4	4	4	1
+5	1	1	1
+5	2	2	1
+5	3	3	1
+5	4	None	1
+6	1	1	1
+6	2	None	1
+6	3	None	1
+6	4	4	1
+-- !result
+SELECT v1, v2, v3, first_value(v3 IGNORE NULLS) OVER(ORDER BY v1, v2 rows between 1 preceding and 1 following) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	1
+1	2	2	1
+1	3	3	2
+1	4	4	3
+2	1	None	4
+2	2	2	2
+2	3	3	2
+2	4	4	3
+3	1	1	4
+3	2	None	1
+3	3	3	3
+3	4	4	3
+4	1	1	4
+4	2	2	1
+4	3	None	2
+4	4	4	4
+5	1	1	4
+5	2	2	1
+5	3	3	2
+5	4	None	3
+6	1	1	1
+6	2	None	1
+6	3	None	4
+6	4	4	4
+-- !result
+SELECT v1, v2, v3, first_value(v3 IGNORE NULLS) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	1
+1	2	2	1
+1	3	3	1
+1	4	4	1
+2	1	None	None
+2	2	2	2
+2	3	3	2
+2	4	4	2
+3	1	1	1
+3	2	None	1
+3	3	3	1
+3	4	4	1
+4	1	1	1
+4	2	2	1
+4	3	None	1
+4	4	4	1
+5	1	1	1
+5	2	2	1
+5	3	3	1
+5	4	None	1
+6	1	1	1
+6	2	None	1
+6	3	None	1
+6	4	4	1
+-- !result
+SELECT v1, v2, v3, first_value(v3 IGNORE NULLS) OVER(partition BY v1 ORDER BY v2 rows between 1 preceding and 1 following) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	1
+1	2	2	1
+1	3	3	2
+1	4	4	3
+2	1	None	2
+2	2	2	2
+2	3	3	2
+2	4	4	3
+3	1	1	1
+3	2	None	1
+3	3	3	3
+3	4	4	3
+4	1	1	1
+4	2	2	1
+4	3	None	2
+4	4	4	4
+5	1	1	1
+5	2	2	1
+5	3	3	2
+5	4	None	3
+6	1	1	1
+6	2	None	1
+6	3	None	4
+6	4	4	4
+-- !result
+SELECT v1, v2, v3, last_value(v3 IGNORE NULLS) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	1
+1	2	2	2
+1	3	3	3
+1	4	4	4
+2	1	None	4
+2	2	2	2
+2	3	3	3
+2	4	4	4
+3	1	1	1
+3	2	None	1
+3	3	3	3
+3	4	4	4
+4	1	1	1
+4	2	2	2
+4	3	None	2
+4	4	4	4
+5	1	1	1
+5	2	2	2
+5	3	3	3
+5	4	None	3
+6	1	1	1
+6	2	None	1
+6	3	None	1
+6	4	4	4
+-- !result
+SELECT v1, v2, v3, last_value(v3 IGNORE NULLS) OVER(ORDER BY v1, v2 rows between 1 preceding and 1 following) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	2
+1	2	2	3
+1	3	3	4
+1	4	4	4
+2	1	None	2
+2	2	2	3
+2	3	3	4
+2	4	4	1
+3	1	1	1
+3	2	None	3
+3	3	3	4
+3	4	4	1
+4	1	1	2
+4	2	2	2
+4	3	None	4
+4	4	4	1
+5	1	1	2
+5	2	2	3
+5	3	3	3
+5	4	None	1
+6	1	1	1
+6	2	None	1
+6	3	None	4
+6	4	4	4
+-- !result
+SELECT v1, v2, v3, last_value(v3 IGNORE NULLS) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	1
+1	2	2	2
+1	3	3	3
+1	4	4	4
+2	1	None	None
+2	2	2	2
+2	3	3	3
+2	4	4	4
+3	1	1	1
+3	2	None	1
+3	3	3	3
+3	4	4	4
+4	1	1	1
+4	2	2	2
+4	3	None	2
+4	4	4	4
+5	1	1	1
+5	2	2	2
+5	3	3	3
+5	4	None	3
+6	1	1	1
+6	2	None	1
+6	3	None	1
+6	4	4	4
+-- !result
+SELECT v1, v2, v3, last_value(v3 IGNORE NULLS) OVER(partition BY v1 ORDER BY v2 rows between 1 preceding and 1 following) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	2
+1	2	2	3
+1	3	3	4
+1	4	4	4
+2	1	None	2
+2	2	2	3
+2	3	3	4
+2	4	4	4
+3	1	1	1
+3	2	None	3
+3	3	3	4
+3	4	4	4
+4	1	1	2
+4	2	2	2
+4	3	None	4
+4	4	4	4
+5	1	1	2
+5	2	2	3
+5	3	3	3
+5	4	None	3
+6	1	1	1
+6	2	None	1
+6	3	None	4
+6	4	4	4
+-- !result
+SELECT v1, v2, v3, lead(v3 IGNORE NULLS, 1) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	2
+1	2	2	3
+1	3	3	4
+1	4	4	2
+2	1	None	2
+2	2	2	3
+2	3	3	4
+2	4	4	1
+3	1	1	3
+3	2	None	3
+3	3	3	4
+3	4	4	1
+4	1	1	2
+4	2	2	4
+4	3	None	4
+4	4	4	1
+5	1	1	2
+5	2	2	3
+5	3	3	1
+5	4	None	1
+6	1	1	4
+6	2	None	4
+6	3	None	4
+6	4	4	None
+-- !result
+SELECT v1, v2, v3, lead(v3 IGNORE NULLS, 1) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	2
+1	2	2	3
+1	3	3	4
+1	4	4	None
+2	1	None	2
+2	2	2	3
+2	3	3	4
+2	4	4	None
+3	1	1	3
+3	2	None	3
+3	3	3	4
+3	4	4	None
+4	1	1	2
+4	2	2	4
+4	3	None	4
+4	4	4	None
+5	1	1	2
+5	2	2	3
+5	3	3	None
+5	4	None	None
+6	1	1	4
+6	2	None	4
+6	3	None	4
+6	4	4	None
+-- !result
+SELECT v1, v2, v3, lead(v3 IGNORE NULLS, 2) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	3
+1	2	2	4
+1	3	3	2
+1	4	4	3
+2	1	None	3
+2	2	2	4
+2	3	3	1
+2	4	4	3
+3	1	1	4
+3	2	None	4
+3	3	3	1
+3	4	4	2
+4	1	1	4
+4	2	2	1
+4	3	None	1
+4	4	4	2
+5	1	1	3
+5	2	2	1
+5	3	3	4
+5	4	None	4
+6	1	1	None
+6	2	None	None
+6	3	None	None
+6	4	4	None
+-- !result
+SELECT v1, v2, v3, lead(v3 IGNORE NULLS, 2) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	3
+1	2	2	4
+1	3	3	None
+1	4	4	None
+2	1	None	3
+2	2	2	4
+2	3	3	None
+2	4	4	None
+3	1	1	4
+3	2	None	4
+3	3	3	None
+3	4	4	None
+4	1	1	4
+4	2	2	None
+4	3	None	None
+4	4	4	None
+5	1	1	3
+5	2	2	None
+5	3	3	None
+5	4	None	None
+6	1	1	None
+6	2	None	None
+6	3	None	None
+6	4	4	None
+-- !result
+SELECT v1, v2, v3, lag(v3 IGNORE NULLS, 1) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	None
+1	2	2	1
+1	3	3	2
+1	4	4	3
+2	1	None	4
+2	2	2	4
+2	3	3	2
+2	4	4	3
+3	1	1	4
+3	2	None	1
+3	3	3	1
+3	4	4	3
+4	1	1	4
+4	2	2	1
+4	3	None	2
+4	4	4	2
+5	1	1	4
+5	2	2	1
+5	3	3	2
+5	4	None	3
+6	1	1	3
+6	2	None	1
+6	3	None	1
+6	4	4	1
+-- !result
+SELECT v1, v2, v3, lag(v3 IGNORE NULLS, 1) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	None
+1	2	2	1
+1	3	3	2
+1	4	4	3
+2	1	None	None
+2	2	2	None
+2	3	3	2
+2	4	4	3
+3	1	1	None
+3	2	None	1
+3	3	3	1
+3	4	4	3
+4	1	1	None
+4	2	2	1
+4	3	None	2
+4	4	4	2
+5	1	1	None
+5	2	2	1
+5	3	3	2
+5	4	None	3
+6	1	1	None
+6	2	None	1
+6	3	None	1
+6	4	4	1
+-- !result
+SELECT v1, v2, v3, lag(v3 IGNORE NULLS, 2) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	None
+1	2	2	None
+1	3	3	1
+1	4	4	2
+2	1	None	3
+2	2	2	3
+2	3	3	4
+2	4	4	2
+3	1	1	3
+3	2	None	4
+3	3	3	4
+3	4	4	1
+4	1	1	3
+4	2	2	4
+4	3	None	1
+4	4	4	1
+5	1	1	2
+5	2	2	4
+5	3	3	1
+5	4	None	2
+6	1	1	2
+6	2	None	3
+6	3	None	3
+6	4	4	3
+-- !result
+SELECT v1, v2, v3, lag(v3 IGNORE NULLS, 2) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+-- result:
+1	1	1	None
+1	2	2	None
+1	3	3	1
+1	4	4	2
+2	1	None	None
+2	2	2	None
+2	3	3	None
+2	4	4	2
+3	1	1	None
+3	2	None	None
+3	3	3	None
+3	4	4	1
+4	1	1	None
+4	2	2	None
+4	3	None	1
+4	4	4	1
+5	1	1	None
+5	2	2	None
+5	3	3	1
+5	4	None	2
+6	1	1	None
+6	2	None	None
+6	3	None	None
+6	4	4	None
+-- !result
+-- name: test_lead_lag_ignore_nulls_all_nulls
+CREATE TABLE `t_all_null` (
+  `v1` int(11) NULL,
+  `v2` int(11) NULL,
+  `v3` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `t_all_null` (v1, v2, v3) values
+    (1, 1, NULL),
+    (1, 2, NULL),
+    (1, 3, NULL),
+    (1, 4, NULL),
+    (2, 1, NULL),
+    (2, 2, NULL),
+    (2, 3, NULL),
+    (2, 4, NULL),
+    (3, 1, NULL),
+    (3, 2, NULL),
+    (3, 3, NULL),
+    (3, 4, NULL),
+    (4, 1, NULL),
+    (4, 2, NULL),
+    (4, 3, NULL),
+    (4, 4, NULL),
+    (5, 1, NULL),
+    (5, 2, NULL),
+    (5, 3, NULL),
+    (5, 4, NULL),
+    (6, 1, NULL),
+    (6, 2, NULL),
+    (6, 3, NULL),
+    (6, 4, NULL);
+-- result:
+-- !result
+SELECT v1, v2, v3, lead(v3 IGNORE NULLS, 1) OVER(partition BY v1 ORDER BY v2) FROM t_all_null ORDER BY v1, v2;
+-- result:
+1	1	None	None
+1	2	None	None
+1	3	None	None
+1	4	None	None
+2	1	None	None
+2	2	None	None
+2	3	None	None
+2	4	None	None
+3	1	None	None
+3	2	None	None
+3	3	None	None
+3	4	None	None
+4	1	None	None
+4	2	None	None
+4	3	None	None
+4	4	None	None
+5	1	None	None
+5	2	None	None
+5	3	None	None
+5	4	None	None
+6	1	None	None
+6	2	None	None
+6	3	None	None
+6	4	None	None
+-- !result
+SELECT v1, v2, v3, lag(v3 IGNORE NULLS, 1) OVER(partition BY v1 ORDER BY v2) FROM t_all_null ORDER BY v1, v2;
+-- result:
+1	1	None	None
+1	2	None	None
+1	3	None	None
+1	4	None	None
+2	1	None	None
+2	2	None	None
+2	3	None	None
+2	4	None	None
+3	1	None	None
+3	2	None	None
+3	3	None	None
+3	4	None	None
+4	1	None	None
+4	2	None	None
+4	3	None	None
+4	4	None	None
+5	1	None	None
+5	2	None	None
+5	3	None	None
+5	4	None	None
+6	1	None	None
+6	2	None	None
+6	3	None	None
+6	4	None	None
+-- !result

--- a/test/sql/test_window_function/T/test_ignore_nulls
+++ b/test/sql/test_window_function/T/test_ignore_nulls
@@ -1,0 +1,95 @@
+-- name: test_lead_lag_ignore_nulls
+CREATE TABLE `t0` (
+  `v1` int(11) NULL,
+  `v2` int(11) NULL,
+  `v3` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+  "replication_num" = "1"
+);
+
+INSERT INTO `t0` (v1, v2, v3) values
+    (1, 1, 1),
+    (1, 2, 2),
+    (1, 3, 3),
+    (1, 4, 4),
+    (2, 1, NULL),
+    (2, 2, 2),
+    (2, 3, 3),
+    (2, 4, 4),
+    (3, 1, 1),
+    (3, 2, NULL),
+    (3, 3, 3),
+    (3, 4, 4),
+    (4, 1, 1),
+    (4, 2, 2),
+    (4, 3, NULL),
+    (4, 4, 4),
+    (5, 1, 1),
+    (5, 2, 2),
+    (5, 3, 3),
+    (5, 4, NULL),
+    (6, 1, 1),
+    (6, 2, NULL),
+    (6, 3, NULL),
+    (6, 4, 4);
+
+SELECT v1, v2, v3, first_value(v3 IGNORE NULLS) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, first_value(v3 IGNORE NULLS) OVER(ORDER BY v1, v2 rows between 1 preceding and 1 following) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, first_value(v3 IGNORE NULLS) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, first_value(v3 IGNORE NULLS) OVER(partition BY v1 ORDER BY v2 rows between 1 preceding and 1 following) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, last_value(v3 IGNORE NULLS) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, last_value(v3 IGNORE NULLS) OVER(ORDER BY v1, v2 rows between 1 preceding and 1 following) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, last_value(v3 IGNORE NULLS) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, last_value(v3 IGNORE NULLS) OVER(partition BY v1 ORDER BY v2 rows between 1 preceding and 1 following) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, lead(v3 IGNORE NULLS, 1) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, lead(v3 IGNORE NULLS, 1) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, lead(v3 IGNORE NULLS, 2) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, lead(v3 IGNORE NULLS, 2) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, lag(v3 IGNORE NULLS, 1) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, lag(v3 IGNORE NULLS, 1) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, lag(v3 IGNORE NULLS, 2) OVER(ORDER BY v1, v2) FROM t0 ORDER BY v1, v2;
+SELECT v1, v2, v3, lag(v3 IGNORE NULLS, 2) OVER(partition BY v1 ORDER BY v2) FROM t0 ORDER BY v1, v2;
+
+-- name: test_lead_lag_ignore_nulls_all_nulls
+CREATE TABLE `t_all_null` (
+  `v1` int(11) NULL,
+  `v2` int(11) NULL,
+  `v3` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+  "replication_num" = "1"
+);
+
+INSERT INTO `t_all_null` (v1, v2, v3) values
+    (1, 1, NULL),
+    (1, 2, NULL),
+    (1, 3, NULL),
+    (1, 4, NULL),
+    (2, 1, NULL),
+    (2, 2, NULL),
+    (2, 3, NULL),
+    (2, 4, NULL),
+    (3, 1, NULL),
+    (3, 2, NULL),
+    (3, 3, NULL),
+    (3, 4, NULL),
+    (4, 1, NULL),
+    (4, 2, NULL),
+    (4, 3, NULL),
+    (4, 4, NULL),
+    (5, 1, NULL),
+    (5, 2, NULL),
+    (5, 3, NULL),
+    (5, 4, NULL),
+    (6, 1, NULL),
+    (6, 2, NULL),
+    (6, 3, NULL),
+    (6, 4, NULL);
+
+SELECT v1, v2, v3, lead(v3 IGNORE NULLS, 1) OVER(partition BY v1 ORDER BY v2) FROM t_all_null ORDER BY v1, v2;
+SELECT v1, v2, v3, lag(v3 IGNORE NULLS, 1) OVER(partition BY v1 ORDER BY v2) FROM t_all_null ORDER BY v1, v2;


### PR DESCRIPTION
## Why I'm doing:
lead/lag ignore nulls' implementation is O(N^2) at worst time when partition is all null. 
For example, every round lag will try to find 'offset' non-null elments before current row, and found nothing when visit the first element in partition.

## What I'm doing:
use two fileds to remeber some status before this round, so time complexity is O(N)

this is my test result, one thread with one partition, whose row number is increseing, you can see the different

```
row number| before | after
--     |  --      |     --
10w | 2.34s | 0.33s
20w | 9.20s | 0.60s
40w | 36.40s | 1.16s
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
