### PR TITLE
[BugFix] Make cpu_weight always store positive default value (backport #51005)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -89,7 +89,7 @@ public class ResourceGroup {
                     (rg, classifier) -> "" + rg.getId()),
             new ColumnMeta(
                     new Column(CPU_WEIGHT, ScalarType.createVarchar(200)),
-                    (rg, classifier) -> "" + rg.getCpuWeight()),
+                    (rg, classifier) -> "" + rg.geNormalizedCpuWeight()),
             new ColumnMeta(
                     new Column(EXCLUSIVE_CPU_CORES, ScalarType.createVarchar(200)),
                     (rg, classifier) -> "" + rg.getNormalizedExclusiveCpuCores()),
@@ -272,10 +272,25 @@ public class ResourceGroup {
         this.cpuWeight = cpuWeight;
     }
 
+    public int geNormalizedCpuWeight() {
+        if (exclusiveCpuCores != null && exclusiveCpuCores > 0) {
+            return 0;
+        }
+        return cpuWeight;
+    }
+
+    public void normalizeCpuWeight() {
+        // The old version considers cpu_weight as a positive integer, but now it can be non-positive.
+        // To be compatible with the old version, if cpu_weight is non-positive, it is stored as 1.
+        // And use geNormalizedCpuWeight() to get the normalized value when using cpu_weight.
+        if (cpuWeight == null || cpuWeight <= 0) {
+            cpuWeight = 1;
+        }
+    }
+
     public Integer getExclusiveCpuCores() {
         return exclusiveCpuCores;
     }
-
     public int getNormalizedExclusiveCpuCores() {
         if (exclusiveCpuCores != null && exclusiveCpuCores > 0) {
             return exclusiveCpuCores;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -264,7 +264,7 @@ public class ResourceGroup {
         return twg;
     }
 
-    public Integer getCpuWeight() {
+    public Integer getRawCpuWeight() {
         return cpuWeight;
     }
 
@@ -279,10 +279,12 @@ public class ResourceGroup {
         return cpuWeight;
     }
 
+    /**
+     * The old version considers cpu_weight as a positive integer, but now it can be non-positive.
+     * To be compatible with the old version, if cpu_weight is non-positive, it is stored as 1.
+     * And use geNormalizedCpuWeight() to get the normalized value when using cpu_weight.
+     */
     public void normalizeCpuWeight() {
-        // The old version considers cpu_weight as a positive integer, but now it can be non-positive.
-        // To be compatible with the old version, if cpu_weight is non-positive, it is stored as 1.
-        // And use geNormalizedCpuWeight() to get the normalized value when using cpu_weight.
         if (cpuWeight == null || cpuWeight <= 0) {
             cpuWeight = 1;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -150,9 +150,7 @@ public class ResourceGroupMgr implements Writable {
                 dropResourceGroupUnlocked(wg.getName());
             }
 
-            if (wg.getCpuWeight() == null) {
-                wg.setCpuWeight(0);
-            }
+            wg.normalizeCpuWeight();
 
             if (ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME.equals(wg.getName())) {
                 wg.setId(ResourceGroup.DEFAULT_WG_ID);
@@ -369,7 +367,7 @@ public class ResourceGroupMgr implements Writable {
 
                 Integer cpuWeight = changedProperties.getCpuWeight();
                 if (cpuWeight == null) {
-                    cpuWeight = wg.getCpuWeight();
+                    cpuWeight = wg.geNormalizedCpuWeight();
                 }
                 Integer exclusiveCpuCores = changedProperties.getExclusiveCpuCores();
                 if (exclusiveCpuCores == null) {
@@ -394,6 +392,7 @@ public class ResourceGroupMgr implements Writable {
                 if (cpuWeight != null) {
                     wg.setCpuWeight(cpuWeight);
                 }
+                wg.normalizeCpuWeight();
 
                 if (exclusiveCpuCores != null) {
                     sumExclusiveCpuCores -= wg.getNormalizedExclusiveCpuCores();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -365,7 +365,7 @@ public class ResourceGroupMgr implements Writable {
             } else if (cmd instanceof AlterResourceGroupStmt.AlterProperties) {
                 ResourceGroup changedProperties = stmt.getChangedProperties();
 
-                Integer cpuWeight = changedProperties.getCpuWeight();
+                Integer cpuWeight = changedProperties.getRawCpuWeight();
                 if (cpuWeight == null) {
                     cpuWeight = wg.geNormalizedCpuWeight();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterResourceGroupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterResourceGroupStmt.java
@@ -77,7 +77,7 @@ public class AlterResourceGroupStmt extends DdlStmt {
             if (changedProperties.getResourceGroupType() != null) {
                 throw new SemanticException("type of ResourceGroup is immutable");
             }
-            if (changedProperties.getCpuWeight() == null &&
+            if (changedProperties.getRawCpuWeight() == null &&
                     changedProperties.getExclusiveCpuCores() == null &&
                     changedProperties.getMemLimit() == null &&
                     changedProperties.getConcurrencyLimit() == null &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateResourceGroupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateResourceGroupStmt.java
@@ -95,7 +95,7 @@ public class CreateResourceGroupStmt extends DdlStmt {
             throw new SemanticException(SHORT_QUERY_SET_EXCLUSIVE_CPU_CORES_ERR_MSG);
         }
 
-        ResourceGroup.validateCpuParameters(resourceGroup.getCpuWeight(), resourceGroup.getExclusiveCpuCores());
+        ResourceGroup.validateCpuParameters(resourceGroup.getRawCpuWeight(), resourceGroup.getExclusiveCpuCores());
 
         if (resourceGroup.getMemLimit() == null) {
             throw new SemanticException("property 'mem_limit' is absent");


### PR DESCRIPTION
CP from #51005.

## Why I'm doing:

Recently, a change was made allowing the resource parameter `cpu_weight`, which previously had to be positive, to now be non-positive. 

After downgrading from current version, since the old version of BE expects `cpu_weight` to be positive (e.g., using it as a divisor), this could lead to crashes or unexpected behavior.


## What I'm doing:

To address this, ensure that when a resource group is persisted, the stored value is always a positive integer. 

Additionally, when using the value, the `getNormalizedCpuWeight()` method will ensure that `cpu_weight` returns 0  when `exclusive_cpu_cores` is positive.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

