### PR TITLE
[BugFix] Fix the stack overflow of array_distinct

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -1334,9 +1334,9 @@ StatusOr<ColumnPtr> ArrayFunctions::array_distinct_any_type(FunctionContext* ctx
 
     phmap::flat_hash_set<uint32_t> sets;
 
-    uint32_t hash[elements->size()];
-    memset(hash, 0, elements->size() * sizeof(uint32_t));
-    elements->fnv_hash(hash, 0, elements->size());
+    // TODO: Maybe consume large memory, need optimized later.
+    std::vector<uint32_t> hash(elements->size(), 0);
+    elements->fnv_hash(hash.data(), 0, elements->size());
 
     size_t rows = columns[0]->size();
     for (auto i = 0; i < rows; i++) {

--- a/test/sql/test_array_fn/R/test_array_distinct
+++ b/test/sql/test_array_fn/R/test_array_distinct
@@ -1,0 +1,29 @@
+-- name: test_array_distinct
+CREATE TABLE t1 (
+    c1 INT,
+    c2 ARRAY<BIGINT>
+)
+DUPLICATE KEY(C1)
+DISTRIBUTED BY HASH(C1) BUCKETS 1
+PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+CREATE TABLE t2 (
+    c1 INT,
+    c2 ARRAY<ARRAY<BIGINT>>
+)
+DUPLICATE KEY(C1)
+DISTRIBUTED BY HASH(C1) BUCKETS 1
+PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+insert into t1 select generate_series, array_append([], generate_series) from TABLE(generate_series(1, 5000000));
+-- result:
+-- !result
+insert into t2 select 1, array_agg(c2) from t1;
+-- result:
+-- !result
+select array_length(array_distinct(c2)) from t2;
+-- result:
+5000000
+-- !result

--- a/test/sql/test_array_fn/T/test_array_distinct
+++ b/test/sql/test_array_fn/T/test_array_distinct
@@ -1,0 +1,21 @@
+-- name: test_array_distinct
+
+CREATE TABLE t1 (
+    c1 INT,
+    c2 ARRAY<BIGINT>
+)
+DUPLICATE KEY(C1)
+DISTRIBUTED BY HASH(C1) BUCKETS 1
+PROPERTIES("replication_num"="1");
+
+CREATE TABLE t2 (
+    c1 INT,
+    c2 ARRAY<ARRAY<BIGINT>>
+)
+DUPLICATE KEY(C1)
+DISTRIBUTED BY HASH(C1) BUCKETS 1
+PROPERTIES("replication_num"="1");
+
+insert into t1 select generate_series, array_append([], generate_series) from TABLE(generate_series(1, 5000000));
+insert into t2 select 1, array_agg(c2) from t1;
+select array_length(array_distinct(c2)) from t2;


### PR DESCRIPTION
## Why I'm doing:

```
*** Aborted at 1726191146 (unix time) try "date -d @1726191146" if you are using GNU date ***
PC: @          0x99a52e4 starrocks::ArrayFunctions::array_distinct_any_type(starrocks::FunctionContext*, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > > const&)
*** SIGSEGV (@0x7f972945cb28) received by PID 3508434 (TID 0x7f9729c5c640) from PID 692439848; stack trace: ***
    @     0x7f98781e3ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xcf22069 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f987818c520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x99a52e4 starrocks::ArrayFunctions::array_distinct_any_type(starrocks::FunctionContext*, std::vector<std::shared_ptr<starrocks::Column>, std::al
locator<std::shared_ptr<starrocks::Column> > > const&)
    @          0x81461e2 starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0x5a40203 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0x8145f85 starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0x5a40203 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0x5a40712 starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0x7d914fc starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x5a8f0e3 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x5b1e370 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x9072432 starrocks::ThreadPool::dispatch_thread()
    @          0x906a6f9 starrocks::Thread::supervise_thread(void*)
    @     0x7f98781deac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f9878270850 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```

## What I'm doing:

Array will allocate memory on stack, If there are too many elements in array, it will cause stack overflow, so here we will use `std::vector` instead.

Current implementation will uses a lot of memory and needs to be optimized later.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
