### PR TITLE
[BugFix] retry UserException when cancelled by backend offline

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/InternalErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/InternalErrorCode.java
@@ -29,6 +29,8 @@ public enum InternalErrorCode {
     TABLE_ERR(6),
     META_NOT_FOUND_ERR(7),
     REPLICA_ENOUGH_ERR(8),
+    // query cancelled due to backend not alive: FeConstants.BACKEND_NODE_NOT_FOUND_ERROR
+    CANCEL_NODE_NOT_ALIVE_ERR(9),
 
     // for load job error
     MANUAL_PAUSE_ERR(100),

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -45,6 +45,7 @@ import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.Status;
 import com.starrocks.common.ThriftServer;
 import com.starrocks.common.UserException;
@@ -901,7 +902,12 @@ public class DefaultCoordinator extends Coordinator {
                 if (hostIndex != -1) {
                     errMsg = errMsg.substring(0, hostIndex);
                 }
-                throw new UserException(errMsg);
+                InternalErrorCode ec = InternalErrorCode.INTERNAL_ERR;
+                if (copyStatus.isCancelled() &&
+                        copyStatus.getErrorMsg().equals(FeConstants.BACKEND_NODE_NOT_FOUND_ERROR)) {
+                    ec = InternalErrorCode.CANCEL_NODE_NOT_ALIVE_ERR;
+                }
+                throw new UserException(ec, errMsg);
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
@@ -17,6 +17,8 @@ package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
 import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.thrift.TUniqueId;
 import mockit.Expectations;
@@ -41,6 +43,7 @@ public class CoordinatorMonitorTest {
             List<DefaultCoordinator> coordinators = ImmutableList.of(coord1, coord2, coord3);
 
             final QeProcessor qeProcessor = QeProcessorImpl.INSTANCE;
+            Pair<PPlanFragmentCancelReason, String> coord1Cancel = new Pair<>(null, null);
 
             CountDownLatch cancelInvocationLatch = new CountDownLatch(2);
             new Expectations(qeProcessor, coord1, coord2, coord3) {
@@ -51,19 +54,19 @@ public class CoordinatorMonitorTest {
 
                 {
                     coord1.getQueryId();
-                    result = new TUniqueId();
+                    result = new TUniqueId(0xaabbccddL, 0xaabbccddL);
                     minTimes = 0;
                 }
 
                 {
                     coord2.getQueryId();
-                    result = new TUniqueId();
+                    result = new TUniqueId(0xddccbbaaL, 0xddccbbaaL);
                     minTimes = 0;
                 }
 
                 {
                     coord3.getQueryId();
-                    result = new TUniqueId();
+                    result = new TUniqueId(0xccbbddaaL, 0xccddbbaaL);
                     minTimes = 0;
                 }
 
@@ -99,6 +102,8 @@ public class CoordinatorMonitorTest {
                     result = new mockit.Delegate<Boolean>() {
                         void cancel(PPlanFragmentCancelReason cancelReason, String cancelledMessage) {
                             cancelInvocationLatch.countDown();
+                            coord1Cancel.first = cancelReason;
+                            coord1Cancel.second = cancelledMessage;
                         }
                     };
                     times = 1;
@@ -130,6 +135,9 @@ public class CoordinatorMonitorTest {
 
             // Wait until invoking coord1.cancel and coord3.cancel once or timeout.
             Assert.assertTrue(cancelInvocationLatch.await(5, TimeUnit.SECONDS));
+
+            Assert.assertEquals(PPlanFragmentCancelReason.INTERNAL_ERROR, coord1Cancel.first);
+            Assert.assertEquals(FeConstants.BACKEND_NODE_NOT_FOUND_ERROR, coord1Cancel.second);
         } finally {
             Config.heartbeat_timeout_second = prevHeartbeatTimeout;
         }


### PR DESCRIPTION
* Coordinator records different internal error code (CANCEL_BACKEND_NOT_ALIVE) for cancelling with by backend not alive
* ExecuteExceptionHandler retry UserException with error code: CANCEL_BACKEND_NOT_ALIVE

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
