### PR TITLE
[BugFix] fix list partition multi values' probelm

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -328,7 +328,7 @@ public class ListPartitionInfo extends PartitionInfo {
      * @param id
      * @return true if the partition can be pruned
      */
-    public boolean pruneById(long id) {
+    public boolean isSingleValuePartition(long id) {
         List<String> values = getIdToValues().get(id);
         if (values != null && values.size() == 1) {
             return true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -394,6 +394,12 @@ public class PartitionPruneTest extends PlanTestBase {
         starRocksAssert.query("select min(c1-1)+1, max(c1-1)-1 from t1_list_multi_values")
                 .explainContains("OlapScanNode");
 
+        // multi-value partition doesn't support partition prune
+        starRocksAssert.query("select * from t1_list_multi_values where c1 not in (10, 2, 8, 5)")
+                .explainContains("partitions=4/4");
+
+        starRocksAssert.query("select * from t1_list_multi_values where c1 != 10")
+                .explainContains("partitions=4/4");
 
         // TODO: not supported
         // multi-item list partition


### PR DESCRIPTION
## Why I'm doing:
if one partition column has multi values for one partition, like "PARTITION pCalifornia VALUES IN ("Los Angeles","San Francisco","San Diego")", then predicate like "city not in "Los Angeles" " can not be used to prune the whole partition.


## What I'm doing:
Right now we don't support multi values partition's partition prune, so just forbid it for "not in" for  the correctness of query. 


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
