### PR TITLE
[Enhancement] Support recovery FE metadata from meta dir

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -633,7 +633,7 @@ public class Config extends ConfigBase {
      * (Because most of the follower data has been damaged).
      */
     @ConfField
-    public static String bdbje_reset_election_group = "false";
+    public static boolean bdbje_reset_election_group = false;
 
     /**
      * If the bdb data is corrupted, and you want to start the cluster only with image, set this param to true

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -377,7 +377,8 @@ public class JournalEntity implements Writable {
             case OperationType.OP_ADD_FRONTEND_V2:
             case OperationType.OP_ADD_FIRST_FRONTEND_V2:
             case OperationType.OP_UPDATE_FRONTEND_V2:
-            case OperationType.OP_REMOVE_FRONTEND_V2: {
+            case OperationType.OP_REMOVE_FRONTEND_V2:
+            case OperationType.OP_RESET_FRONTENDS: {
                 data = GsonUtils.GSON.fromJson(Text.readString(in), Frontend.class);
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -174,7 +174,7 @@ public class BDBEnvironment {
 
     protected void initConfigs(boolean isElectable) throws JournalException {
         // Almost never used, just in case the master can not restart
-        if (Config.bdbje_reset_election_group.equals("true")) {
+        if (Config.bdbje_reset_election_group) {
             if (!isElectable) {
                 String errMsg = "Current node is not in the electable_nodes list. will exit";
                 LOG.error(errMsg);
@@ -339,7 +339,7 @@ public class BDBEnvironment {
         }
 
         // Almost never used, just in case the master can not restart
-        if (Config.bdbje_reset_election_group.equals("true")) {
+        if (Config.bdbje_reset_election_group) {
             LOG.info("skip check local environment because metadata_failure_recovery = true");
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -472,6 +472,11 @@ public class EditLog {
                     globalStateMgr.getNodeMgr().replayUpdateFrontend(fe);
                     break;
                 }
+                case OperationType.OP_RESET_FRONTENDS: {
+                    Frontend fe = (Frontend) journal.getData();
+                    globalStateMgr.getNodeMgr().replayResetFrontends(fe);
+                    break;
+                }
                 case OperationType.OP_TIMESTAMP_V2: {
                     Timestamp stamp = (Timestamp) journal.getData();
                     globalStateMgr.setSynchronizedTime(stamp.getTimestamp());
@@ -1389,6 +1394,10 @@ public class EditLog {
 
     public void logLeaderInfo(LeaderInfo info) {
         logJsonObject(OperationType.OP_LEADER_INFO_CHANGE_V2, info);
+    }
+
+    public void logResetFrontends(Frontend frontend) {
+        logEdit(OperationType.OP_RESET_FRONTENDS, frontend);
     }
 
     public void logMetaVersion(MetaVersion metaVersion) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -257,6 +257,9 @@ public class OperationType {
 
     public static final short OP_ALTER_MATERIALIZED_VIEW_BASE_TABLE_INFOS = 10098;
 
+    // manage system node info 10101 ~ 10120
+    // manage compute node 10201 ~ 10220
+
     @IgnorableOnReplayFailed
     public static final short OP_ADD_COMPUTE_NODE = 10201;
 
@@ -509,6 +512,9 @@ public class OperationType {
     public static final short OP_TIMESTAMP_V2 = 13040;
 
     public static final short OP_LEADER_INFO_CHANGE_V2 = 13041;
+
+    @IgnorableOnReplayFailed
+    public static final short OP_RESET_FRONTENDS = 13042;
 
     @IgnorableOnReplayFailed
     public static final short OP_ADD_FUNCTION_V2 = 13050;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1257,6 +1257,10 @@ public class GlobalStateMgr {
                 editLog.logAddFirstFrontend(self);
             }
 
+            if (Config.bdbje_reset_election_group) {
+                nodeMgr.resetFrontends();
+            }
+
             // MUST set leader ip before starting checkpoint thread.
             // because checkpoint thread need this info to select non-leader FE to push image
             nodeMgr.setLeaderInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -165,6 +165,13 @@ public class NodeMgr {
         this.brokerMgr = new BrokerMgr();
     }
 
+    // For test
+    protected NodeMgr(FrontendNodeType role, String nodeName, Pair<String, Integer> selfNode) {
+        this.role = role;
+        this.nodeName = nodeName;
+        this.selfNode = selfNode;
+    }
+
     public void initialize(String[] args) throws Exception {
         getCheckedSelfHostPort();
         getHelperNodes(args);

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -664,7 +664,7 @@ public class NodeMgr {
      * frontend log is deleted because of checkpoint.
      */
     public void checkCurrentNodeExist() {
-        if (Config.bdbje_reset_election_group.equals("true")) {
+        if (Config.bdbje_reset_election_group) {
             return;
         }
 
@@ -1174,6 +1174,19 @@ public class NodeMgr {
 
     public ConcurrentHashMap<String, Frontend> getFrontends() {
         return frontends;
+    }
+
+    public void resetFrontends() {
+        frontends.clear();
+        Frontend self = new Frontend(role, nodeName, selfNode.first, selfNode.second);
+        frontends.put(self.getNodeName(), self);
+
+        GlobalStateMgr.getCurrentState().getEditLog().logResetFrontends(self);
+    }
+
+    public void replayResetFrontends(Frontend frontend) {
+        frontends.clear();
+        frontends.put(frontend.getNodeName(), frontend);
     }
 
     public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {

--- a/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
@@ -37,18 +37,13 @@ package com.starrocks.system;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Config;
-import com.starrocks.common.io.Text;
-import com.starrocks.common.io.Writable;
+import com.starrocks.common.io.JsonWriter;
 import com.starrocks.ha.BDBHA;
 import com.starrocks.ha.FrontendNodeType;
-import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.HeartbeatResponse.HbStatus;
 
-import java.io.DataOutput;
-import java.io.IOException;
-
-public class Frontend implements Writable {
+public class Frontend extends JsonWriter {
     @SerializedName(value = "r")
     private FrontendNodeType role;
     @SerializedName(value = "n")
@@ -208,11 +203,6 @@ public class Frontend implements Writable {
         }
 
         return isChanged;
-    }
-
-    @Override
-    public void write(DataOutput out) throws IOException {
-        Text.writeString(out, GsonUtils.GSON.toJson(this));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/persist/OperationTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/OperationTypeTest.java
@@ -147,6 +147,7 @@ public class OperationTypeTest {
         Assert.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_MODIFY_DICTIONARY_MGR));
         Assert.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_REPLICATION_JOB));
         Assert.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_DELETE_REPLICATION_JOB));
+        Assert.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_RESET_FRONTENDS));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/server/NodeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/NodeMgrTest.java
@@ -14,17 +14,27 @@
 
 package com.starrocks.server;
 
+import com.starrocks.common.Pair;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.FrontendHbResponse;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.UUID;
 
 public class NodeMgrTest {
+
+    @BeforeClass
+    public static void setUp() {
+        UtFrameUtils.setUpForPersistTest();
+    }
 
     @Test(expected = UnknownHostException.class)
     public void testCheckFeExistByIpOrFqdnException() throws UnknownHostException {
@@ -70,5 +80,23 @@ public class NodeMgrTest {
         Assert.assertFalse(nodeMgr.isVersionAndRoleFilesNotExist());
         nodeMgr.removeClusterIdAndRole();
         Assert.assertTrue(nodeMgr.isVersionAndRoleFilesNotExist());
+    }
+
+    @Test
+    public void testResetFrontends() throws Exception {
+        FrontendNodeType role = FrontendNodeType.FOLLOWER;
+        String nodeName = "node1";
+        Pair<String, Integer> selfNode = Pair.create("192.168.3.5", 9010);
+        NodeMgr leaderNodeMgr = new NodeMgr(role, nodeName, selfNode);
+        leaderNodeMgr.resetFrontends();
+
+        UtFrameUtils.PseudoJournalReplayer.replayJournalToEnd();
+
+        List<Frontend> frontends = GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(FrontendNodeType.FOLLOWER);
+        Assert.assertEquals(1, frontends.size());
+        Assert.assertEquals(role, frontends.get(0).getRole());
+        Assert.assertEquals(nodeName, frontends.get(0).getNodeName());
+        Assert.assertEquals(selfNode.first, frontends.get(0).getHost());
+        Assert.assertEquals((int) selfNode.second, frontends.get(0).getEditLogPort());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/NodeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/NodeMgrTest.java
@@ -20,7 +20,6 @@ import com.starrocks.system.Frontend;
 import com.starrocks.system.FrontendHbResponse;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 


### PR DESCRIPTION
## Why I'm doing:
With this patch, it is possible to recover FE metadata if all machines are unavailable but the meta directory still exists.
1. Start a FE node with the backup meta using config `bdbje_reset_election_group = true` in fe.conf. 
2. If the node is started, there will be a frontend in the cluster, and the IP address is the IP address of the new host.
3. Check metadata.
4. If everything is ok, remove the config `bdbje_reset_election_group = true` from fe.conf, and restart the node.
5. Through the above steps, the cluster has been recovered and has only one follower node.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
