### PR TITLE
[Feature] Support manully update datacache memory and disk quota online.

### DIFF
--- a/be/src/block_cache/cache_options.cpp
+++ b/be/src/block_cache/cache_options.cpp
@@ -14,38 +14,126 @@
 
 #include "block_cache/cache_options.h"
 
+#include <fmt/format.h>
+
 #include <filesystem>
 
 #include "common/logging.h"
+#include "fs/fs.h"
+#include "gutil/strings/split.h"
 #include "util/parse_util.h"
 
 namespace starrocks {
 
-int64_t parse_mem_size(const std::string& mem_size_str, int64_t mem_limit) {
-    return ParseUtil::parse_mem_spec(mem_size_str, mem_limit);
+Status parse_conf_datacache_mem_size(const std::string& conf_mem_size_str, int64_t mem_limit, size_t* mem_size) {
+    int64_t parsed_mem_size = ParseUtil::parse_mem_spec(conf_mem_size_str, mem_limit);
+    if (mem_limit > 0 && parsed_mem_size > mem_limit) {
+        LOG(WARNING) << "the configured datacache memory size exceeds the limit, decreased it to the limit value."
+                     << "mem_size: " << parsed_mem_size << ", mem_limit: " << mem_limit;
+        parsed_mem_size = mem_limit;
+    }
+
+    if (parsed_mem_size < 0) {
+        LOG(ERROR) << "invalid mem size for datacache: " << mem_size;
+        return Status::InvalidArgument("invalid mem size for datacache");
+    }
+    *mem_size = parsed_mem_size;
+    return Status::OK();
 }
 
-int64_t parse_disk_size(const std::string& disk_path, const std::string& disk_size_str, int64_t disk_limit) {
-    if (disk_limit == -1) {
+Status parse_conf_datacache_disk_size(const std::string& disk_path, const std::string& disk_size_str,
+                                      int64_t disk_limit, size_t* disk_size) {
+    if (disk_limit <= 0) {
         std::filesystem::path dpath(disk_path);
-        // The datacache directory may be created automatically later.
-        if (!std::filesystem::exists(dpath)) {
-            if (!dpath.has_parent_path()) {
-                LOG(ERROR) << "invalid disk path for datacache, disk_path: " << disk_path;
-                return -1;
-            }
-            dpath = dpath.parent_path();
-        }
-
         std::error_code ec;
         auto space_info = std::filesystem::space(dpath, ec);
         if (ec) {
             LOG(ERROR) << "fail to get disk space info, path: " << dpath << ", error: " << ec.message();
-            return -1;
+            return Status::InternalError("fail to get disk space info for datacache");
         }
         disk_limit = space_info.capacity;
     }
-    return ParseUtil::parse_mem_spec(disk_size_str, disk_limit);
+
+    int64_t parsed_disk_size = ParseUtil::parse_mem_spec(disk_size_str, disk_limit);
+    if (parsed_disk_size < 0) {
+        LOG(ERROR) << "invalid disk size for datacache: " << parsed_disk_size;
+        return Status::InvalidArgument("invalid disk size for datacache");
+    }
+    if (parsed_disk_size > disk_limit) {
+        LOG(WARNING) << "the configured datacache disk size exceeds the disk limit, decreased it to the limit value."
+                     << ", path: " << disk_path << ", disk_size: " << parsed_disk_size
+                     << ", disk_limit: " << disk_limit;
+        parsed_disk_size = disk_limit;
+    }
+    *disk_size = parsed_disk_size;
+    return Status::OK();
+}
+
+Status parse_conf_datacache_disk_paths(const std::string& config_path, std::vector<std::string>* paths,
+                                       bool ignore_broken_disk) {
+    if (config_path.empty()) {
+        return Status::OK();
+    }
+
+    size_t duplicated_count = 0;
+    std::vector<std::string> path_vec = strings::Split(config_path, ";", strings::SkipWhitespace());
+    for (auto& item : path_vec) {
+        StripWhiteSpace(&item);
+        item.erase(item.find_last_not_of('/') + 1);
+        if (item.empty() || item[0] != '/') {
+            LOG(WARNING) << "invalid datacache path. path: " << item;
+            continue;
+        }
+
+        Status status = FileSystem::Default()->create_dir_if_missing(item);
+        if (!status.ok()) {
+            LOG(WARNING) << "datacache path can not be created. path: " << item;
+            continue;
+        }
+
+        string canonicalized_path;
+        status = FileSystem::Default()->canonicalize(item, &canonicalized_path);
+        if (!status.ok()) {
+            LOG(WARNING) << "datacache path can not be canonicalized. may be not exist. path: " << item;
+            continue;
+        }
+        if (std::find(paths->begin(), paths->end(), canonicalized_path) != paths->end()) {
+            LOG(WARNING) << "duplicated datacache disk path: " << item << ", ignore it.";
+            ++duplicated_count;
+            continue;
+        }
+        paths->emplace_back(canonicalized_path);
+    }
+    if ((path_vec.size() != (paths->size() + duplicated_count) && ignore_broken_disk)) {
+        LOG(WARNING) << "fail to parse datacache_disk_path config. value: " << config_path;
+        return Status::InvalidArgument("fail to parse datacache_disk_path");
+    }
+    return Status::OK();
+}
+
+Status parse_conf_datacache_disk_spaces(const std::string& config_disk_path, const std::string& config_disk_size,
+                                        bool ignore_broken_disk, std::vector<DirSpace>* disk_spaces) {
+    std::vector<std::string> paths;
+    RETURN_IF_ERROR(parse_conf_datacache_disk_paths(config_disk_path, &paths, ignore_broken_disk));
+    for (auto& p : paths) {
+        size_t disk_size = 0;
+        RETURN_IF_ERROR(parse_conf_datacache_disk_size(p, config_disk_size, -1, &disk_size));
+        disk_spaces->push_back({.path = p, .size = static_cast<size_t>(disk_size)});
+    }
+    return Status::OK();
+}
+
+void clean_residual_datacache(const std::string& disk_path) {
+    auto st = FileSystem::Default()->iterate_dir2(disk_path, [&](DirEntry entry) {
+        if (!entry.is_dir.value_or(false) && entry.name.find("blockfile_") == 0) {
+            auto file = fmt::format("{}/{}", disk_path, entry.name);
+            auto ret = FileSystem::Default()->delete_file(file);
+            LOG_IF(WARNING, !ret.ok()) << "fail to delete residual datacache file: " << file
+                                       << ", reason: " << ret.message();
+        }
+        return true;
+    });
+    LOG_IF(WARNING, !st.ok()) << "fail to clean residual datacache data, reason: " << st.message();
 }
 
 } // namespace starrocks

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include "common/status.h"
+
 namespace starrocks {
 
 struct DirSpace {
@@ -75,8 +77,17 @@ struct ReadCacheOptions {
     } stats;
 };
 
-int64_t parse_mem_size(const std::string& mem_size_str, int64_t mem_limit = -1);
+Status parse_conf_datacache_mem_size(const std::string& conf_mem_size_str, int64_t mem_limit, size_t* mem_size);
 
-int64_t parse_disk_size(const std::string& disk_path, const std::string& disk_size_str, int64_t disk_limit = -1);
+Status parse_conf_datacache_disk_size(const std::string& disk_path, const std::string& disk_size_str,
+                                      int64_t disk_limit, size_t* disk_size);
+
+Status parse_conf_datacache_disk_paths(const std::string& config_path, std::vector<std::string>* paths,
+                                       bool ignore_broken_disk);
+
+Status parse_conf_datacache_disk_spaces(const std::string& config_disk_path, const std::string& config_disk_size,
+                                        bool ignore_broken_disk, std::vector<DirSpace>* disk_spaces);
+
+void clean_residual_datacache(const std::string& disk_path);
 
 } // namespace starrocks

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -94,6 +94,14 @@ Status CacheLibWrapper::remove(const std::string& key) {
     return Status::OK();
 }
 
+Status CacheLibWrapper::update_mem_quota(size_t quota_bytes) {
+    return Status::NotSupported("not support updating memory cache quota for cachelib");
+}
+
+Status update_disk_spaces(const std::vector<DirSpace>& spaces) {
+    return Status::NotSupported("not support updating disk cache spaces for cachelib");
+}
+
 std::unordered_map<std::string, double> CacheLibWrapper::cache_stats() {
     const auto navy_stats = _cache->getNvmCacheStatsMap().toMap();
     return navy_stats;

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -56,6 +56,10 @@ public:
 
     Status remove(const std::string& key) override;
 
+    Status update_mem_quota(size_t quota_bytes) override;
+
+    Status update_disk_spaces(const std::vector<DirSpace>& spaces) override;
+
     std::unordered_map<std::string, double> cache_stats() override;
 
     const DataCacheMetrics cache_metrics(int level) override;

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -64,6 +64,12 @@ public:
     // Remove data from cache. The offset must be aligned by block size
     virtual Status remove(const std::string& key) = 0;
 
+    // Update the datacache memory quota.
+    virtual Status update_mem_quota(size_t quota_bytes) = 0;
+
+    // Update the datacache disk space infomation, such as disk quota or disk path.
+    virtual Status update_disk_spaces(const std::vector<DirSpace>& spaces) = 0;
+
     virtual const DataCacheMetrics cache_metrics(int level) = 0;
 
     virtual void record_read_remote(size_t size, int64_t lateny_us) = 0;

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -131,6 +131,19 @@ Status StarCacheWrapper::remove(const std::string& key) {
     return Status::OK();
 }
 
+Status StarCacheWrapper::update_mem_quota(size_t quota_bytes) {
+    return to_status(_cache->update_mem_quota(quota_bytes));
+}
+
+Status StarCacheWrapper::update_disk_spaces(const std::vector<DirSpace>& spaces) {
+    std::vector<starcache::DirSpace> disk_spaces;
+    disk_spaces.reserve(spaces.size());
+    for (auto& dir : spaces) {
+        disk_spaces.push_back({.path = dir.path, .quota_bytes = dir.size});
+    }
+    return to_status(_cache->update_disk_spaces(disk_spaces));
+}
+
 const DataCacheMetrics StarCacheWrapper::cache_metrics(int level) {
     auto metrics = _cache->metrics(level);
     // Now the EEXIST is treated as an failed status in starcache, which will cause the write_fail_count too large

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -40,6 +40,10 @@ public:
 
     Status remove(const std::string& key) override;
 
+    Status update_mem_quota(size_t quota_bytes) override;
+
+    Status update_disk_spaces(const std::vector<DirSpace>& spaces) override;
+
     const DataCacheMetrics cache_metrics(int level) override;
 
     void record_read_remote(size_t size, int64_t lateny_us) override;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1069,11 +1069,11 @@ CONF_mInt64(max_length_for_to_base64, "200000");
 CONF_mInt64(max_length_for_bitmap_function, "1000000");
 
 // Configuration items for datacache
-CONF_Bool(datacache_enable, "false");
-CONF_String(datacache_mem_size, "10%");
-CONF_String(datacache_disk_size, "0");
-CONF_String(datacache_disk_path, "${STARROCKS_HOME}/datacache/");
-CONF_String(datacache_meta_path, "${STARROCKS_HOME}/datacache/");
+CONF_Bool(datacache_enable, "true");
+CONF_mString(datacache_mem_size, "10%");
+CONF_mString(datacache_disk_size, "0");
+CONF_String(datacache_disk_path, "");
+CONF_String(datacache_meta_path, "");
 CONF_Int64(datacache_block_size, "262144"); // 256K
 CONF_Bool(datacache_checksum_enable, "false");
 CONF_Bool(datacache_direct_io_enable, "false");

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -90,7 +90,7 @@ Status HiveDataSource::open(RuntimeState* state) {
     }
     RETURN_IF_ERROR(_check_all_slots_nullable());
 
-    _use_datacache = config::datacache_enable;
+    _use_datacache = config::datacache_enable && BlockCache::instance()->available();
     if (state->query_options().__isset.enable_scan_datacache) {
         _use_datacache &= state->query_options().enable_scan_datacache;
     }
@@ -106,8 +106,10 @@ Status HiveDataSource::open(RuntimeState* state) {
     if (state->query_options().__isset.datacache_evict_probability) {
         _datacache_evict_probability = state->query_options().datacache_evict_probability;
     }
+
+    _use_file_metacache = config::datacache_enable && BlockCache::instance()->has_mem_cache();
     if (state->query_options().__isset.enable_file_metacache) {
-        _use_file_metacache = state->query_options().enable_file_metacache;
+        _use_file_metacache &= state->query_options().enable_file_metacache;
     }
     if (state->query_options().__isset.enable_connector_split_io_tasks) {
         _enable_split_tasks = state->query_options().enable_connector_split_io_tasks;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -27,6 +27,7 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "exec/pipeline/query_context.h"
+#include "gutil/strings/join.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
 #include "runtime/jdbc_driver_manager.h"
@@ -52,7 +53,7 @@ DECLARE_bool(socket_keepalive);
 
 namespace starrocks {
 
-Status init_datacache(GlobalEnv* global_env) {
+Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& storage_paths) {
     if (!config::datacache_enable && config::block_cache_enable) {
         config::datacache_enable = true;
         config::datacache_mem_size = std::to_string(config::block_cache_mem_size);
@@ -83,18 +84,24 @@ Status init_datacache(GlobalEnv* global_env) {
         if (global_env->process_mem_tracker()->has_limit()) {
             mem_limit = global_env->process_mem_tracker()->limit();
         }
-        cache_options.mem_space_size = parse_mem_size(config::datacache_mem_size, mem_limit);
+        RETURN_IF_ERROR(
+                parse_conf_datacache_mem_size(config::datacache_mem_size, mem_limit, &cache_options.mem_space_size));
+        if (config::datacache_disk_path.empty()) {
+            // If the disk cache does not be configured for datacache, set default path according storage path.
+            std::vector<std::string> datacache_paths;
+            std::for_each(storage_paths.begin(), storage_paths.end(), [&](const StorePath& root_path) {
+                datacache_paths.push_back(root_path.path + "/datacache");
+            });
+            config::datacache_disk_path = JoinStrings(datacache_paths, ";");
 
-        std::vector<std::string> paths;
-        RETURN_IF_ERROR(parse_conf_datacache_paths(config::datacache_disk_path, &paths));
-        for (auto& p : paths) {
-            int64_t disk_size = parse_disk_size(p, config::datacache_disk_size);
-            if (disk_size < 0) {
-                LOG(ERROR) << "invalid disk size for datacache: " << disk_size;
-                return Status::InvalidArgument("invalid disk size for datacache");
+            // Clear the residual datacache files
+            std::filesystem::path old_path(std::string(getenv("STARROCKS_HOME")) + "/datacache");
+            if (std::filesystem::exists(old_path)) {
+                clean_residual_datacache(old_path.string());
             }
-            cache_options.disk_spaces.push_back({.path = p, .size = static_cast<size_t>(disk_size)});
         }
+        RETURN_IF_ERROR(parse_conf_datacache_disk_spaces(config::datacache_disk_path, config::datacache_disk_size,
+                                                         config::ignore_broken_disk, &cache_options.disk_spaces));
 
         // Adjust the default engine based on build switches.
         if (config::datacache_engine == "") {
@@ -177,7 +184,7 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     LOG(INFO) << process_name << " start step " << start_step++ << ": staros worker init successfully";
 #endif
 
-    if (!init_datacache(global_env).ok()) {
+    if (!init_datacache(global_env, paths).ok()) {
         LOG(ERROR) << "Fail to init datacache";
         exit(1);
     }

--- a/be/src/storage/options.cpp
+++ b/be/src/storage/options.cpp
@@ -160,38 +160,4 @@ Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>*
     return Status::OK();
 }
 
-Status parse_conf_datacache_paths(const std::string& config_path, std::vector<std::string>* paths) {
-    if (config_path.empty()) {
-        return Status::OK();
-    }
-    std::vector<string> path_vec = strings::Split(config_path, ";", strings::SkipWhitespace());
-    for (auto& item : path_vec) {
-        StripWhiteSpace(&item);
-        item.erase(item.find_last_not_of('/') + 1);
-        if (item.empty() || item[0] != '/') {
-            LOG(WARNING) << "invalid datacache path. path=" << item;
-            continue;
-        }
-
-        Status status = FileSystem::Default()->create_dir_if_missing(item);
-        if (!status.ok()) {
-            LOG(WARNING) << "datacache path can not be created. path=" << item;
-            continue;
-        }
-
-        string canonicalized_path;
-        status = FileSystem::Default()->canonicalize(item, &canonicalized_path);
-        if (!status.ok()) {
-            LOG(WARNING) << "datacache path can not be canonicalized. may be not exist. path=" << item;
-            continue;
-        }
-        paths->emplace_back(canonicalized_path);
-    }
-    if ((path_vec.size() != paths->size() && !config::ignore_broken_disk)) {
-        LOG(WARNING) << "fail to parse datacache_disk_path config. value=[" << config_path << "]";
-        return Status::InvalidArgument("fail to parse datacache_disk_path");
-    }
-    return Status::OK();
-}
-
 } // end namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Now we configure the memory and disk quota for datacache in be.conf. So, when updating the cache quota based on the current resource usege, we have to change be.conf and restart BE process.

This PR partially backports PR: 
https://github.com/StarRocks/starrocks/pull/43891

## What I'm doing:

* Support adjust memory and disk quota for datacache online, without restarting BE process.
You can update the memory and disk quota by your sql client as follows:
```sql
# update datacache memory quota for certain BE instance.
update be_configs set VALUE=1147483648 where NAME="datacache_mem_size" and BE_ID=10005;

# update datacache memory quota for all BE instance.
update be_configs set VALUE=1147483648 where NAME="datacache_mem_size" ;

# update datacache disk quota for all BE instance.
update be_configs set VALUE=107374182400 where NAME="datacache_disk_size";
```
* Change the default datacache disk path configuration to ensure that almost all users can use cache without modifying it.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

