### PR TITLE
[BugFix] Fix sync publish failed after BE restart

### DIFF
--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -249,11 +249,15 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                                             tablet_info.tablet_id, partition_version.version, transaction_id);
             } else {
                 const int64_t max_continuous_version =
-                        enable_sync_publish ? tablet->max_continuous_version() : tablet->max_readable_version();
+                        enable_sync_publish ? tablet->max_readable_version() : tablet->max_continuous_version();
                 if (max_continuous_version > 0) {
                     auto& pair = tablet_versions.emplace_back();
                     pair.__set_tablet_id(tablet_info.tablet_id);
                     pair.__set_version(max_continuous_version);
+                }
+
+                if (tablet_tasks.empty() && max_continuous_version < partition_version.version) {
+                    error_tablet_ids.push_back(tablet_info.tablet_id);
                 }
             }
         }

--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -256,7 +256,7 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                     pair.__set_version(max_continuous_version);
                 }
 
-                if (tablet_tasks.empty() && max_continuous_version < partition_version.version) {
+                if (enable_sync_publish && tablet_tasks.empty() && max_continuous_version < partition_version.version) {
                     error_tablet_ids.push_back(tablet_info.tablet_id);
                 }
             }

--- a/be/test/storage/publish_version_task_test.cpp
+++ b/be/test/storage/publish_version_task_test.cpp
@@ -265,6 +265,21 @@ TEST_F(PublishVersionTaskTest, test_publish_version) {
                          ->new_token(ThreadPool::ExecutionMode::CONCURRENT);
     std::unordered_set<DataDir*> affected_dirs;
     std::vector<TFinishTaskRequest> finish_task_requests;
+    {
+        auto& finish_task_request = finish_task_requests.emplace_back();
+        TPublishVersionRequest publish_version_req;
+        publish_version_req.transaction_id = 3333;
+        TPartitionVersionInfo pvinfo;
+        pvinfo.partition_id = 10;
+        pvinfo.version = 10;
+        publish_version_req.partition_version_infos.push_back(pvinfo);
+        publish_version_req.enable_sync_publish = true;
+        std::vector<TabletInfo> tablet_infos;
+        StorageEngine::instance()->tablet_manager()->get_tablets_by_partition(10, tablet_infos);
+        ASSERT_TRUE(tablet_infos.size() > 0);
+        run_publish_version_task(token.get(), publish_version_req, finish_task_request, affected_dirs, 0);
+        ASSERT_EQ(1, finish_task_request.error_tablet_ids.size());
+    }
     auto& finish_task_request = finish_task_requests.emplace_back();
     // create req
     TPublishVersionRequest publish_version_req;


### PR DESCRIPTION
## Why I'm doing:
We will return publish success after tablet apply finished if we enable sync publish to avoid waiting apply during query. However, if BE restart, we will return publish success even though the apply is not finished. So the query may get `query time out` issue after BE restarted.

The reason is the transaction related tablets is lost after BE restart. For primary key table, if BE receive publish request, BE will delete committed rowset meta and rewrite rowset meta into `TabletMeta`, so the transaction related tablet info are lost if we restart BE during waiting apply finished. 

## What I'm doing:
If BE restarted, add the tablet which `max_readable_version` less than `request_version` into `error_tablet_ids`. Then the transaction will be visible until all those tablets apply finished.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
