### PR TITLE
[BugFix] fix incorrect result of yearweek

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -571,17 +571,6 @@ DEFINE_BINARY_FUNCTION_WITH_IMPL(year_week_with_modeImpl, t, m) {
     date_value.to_date(&year, &month, &day);
     uint to_year = 0;
     int week = TimeFunctions::compute_week(year, month, day, TimeFunctions::week_mode(m | 2), &to_year);
-
-    if (week == 53 && day >= 29 && !(m & 4)) {
-        int monday_first = m & WEEK_MONDAY_FIRST;
-        int daynr_of_last_day = TimeFunctions::compute_daynr(year, 12, 31);
-        int weekday_of_last_day = TimeFunctions::compute_weekday(daynr_of_last_day, !monday_first);
-
-        if (weekday_of_last_day - monday_first < 2) {
-            ++to_year;
-            week = 1;
-        }
-    }
     return to_year * 100 + week;
 }
 DEFINE_TIME_BINARY_FN(year_week_with_mode, TYPE_DATETIME, TYPE_INT, TYPE_INT);

--- a/test/sql/test_datetime/R/test_yearweek
+++ b/test/sql/test_datetime/R/test_yearweek
@@ -3,3 +3,99 @@ select yearweek('2023-12-31', 2), yearweek('2024-01-01', 2);
 -- result:
 202353	202353
 -- !result
+select yearweek('1900-01-01', 0), yearweek('1900-12-31', 0), yearweek('2000-01-01', 0), yearweek('2000-12-31', 0);
+-- result:
+189953	190052	199952	200053
+-- !result
+select yearweek('1900-01-01', 1), yearweek('1900-12-31', 1), yearweek('2000-01-01', 1), yearweek('2000-12-31', 1);
+-- result:
+190001	190101	199952	200052
+-- !result
+select yearweek('1900-01-01', 2), yearweek('1900-12-31', 2), yearweek('2000-01-01', 2), yearweek('2000-12-31', 2);
+-- result:
+189953	190052	199952	200053
+-- !result
+select yearweek('1900-01-01', 3), yearweek('1900-12-31', 3), yearweek('2000-01-01', 3), yearweek('2000-12-31', 3);
+-- result:
+190001	190101	199952	200052
+-- !result
+select yearweek('1900-01-01', 4), yearweek('1900-12-31', 4), yearweek('2000-01-01', 4), yearweek('2000-12-31', 4);
+-- result:
+190001	190101	199952	200101
+-- !result
+select yearweek('1900-01-01', 5), yearweek('1900-12-31', 5), yearweek('2000-01-01', 5), yearweek('2000-12-31', 5);
+-- result:
+190001	190053	199952	200052
+-- !result
+select yearweek('1900-01-01', 6), yearweek('1900-12-31', 6), yearweek('2000-01-01', 6), yearweek('2000-12-31', 6);
+-- result:
+190001	190101	199952	200101
+-- !result
+select yearweek('1900-01-01', 7), yearweek('1900-12-31', 7), yearweek('2000-01-01', 7), yearweek('2000-12-31', 7);
+-- result:
+190001	190053	199952	200052
+-- !result
+select yearweek('1910-01-05', 0), yearweek('1910-12-27', 0), yearweek('2010-01-05', 0), yearweek('2010-12-27', 0);
+-- result:
+191001	191052	201001	201052
+-- !result
+select yearweek('1910-01-05', 1), yearweek('1910-12-27', 1), yearweek('2010-01-05', 1), yearweek('2010-12-27', 1);
+-- result:
+191001	191052	201001	201052
+-- !result
+select yearweek('1910-01-05', 2), yearweek('1910-12-27', 2), yearweek('2010-01-05', 2), yearweek('2010-12-27', 2);
+-- result:
+191001	191052	201001	201052
+-- !result
+select yearweek('1910-01-05', 3), yearweek('1910-12-27', 3), yearweek('2010-01-05', 3), yearweek('2010-12-27', 3);
+-- result:
+191001	191052	201001	201052
+-- !result
+select yearweek('1910-01-05', 4), yearweek('1910-12-27', 4), yearweek('2010-01-05', 4), yearweek('2010-12-27', 4);
+-- result:
+191001	191052	201001	201052
+-- !result
+select yearweek('1910-01-05', 5), yearweek('1910-12-27', 5), yearweek('2010-01-05', 5), yearweek('2010-12-27', 5);
+-- result:
+191001	191052	201001	201052
+-- !result
+select yearweek('1910-01-05', 6), yearweek('1910-12-27', 6), yearweek('2010-01-05', 6), yearweek('2010-12-27', 6);
+-- result:
+191001	191052	201001	201052
+-- !result
+select yearweek('1910-01-05', 7), yearweek('1910-12-27', 7), yearweek('2010-01-05', 7), yearweek('2010-12-27', 7);
+-- result:
+191001	191052	201001	201052
+-- !result
+select yearweek('1940-01-11', 0), yearweek('1940-12-21', 0), yearweek('2040-01-11', 0), yearweek('2040-12-21', 0);
+-- result:
+194001	194050	204002	204051
+-- !result
+select yearweek('1940-01-11', 1), yearweek('1940-12-21', 1), yearweek('2040-01-11', 1), yearweek('2040-12-21', 1);
+-- result:
+194002	194051	204002	204051
+-- !result
+select yearweek('1940-01-11', 2), yearweek('1940-12-21', 2), yearweek('2040-01-11', 2), yearweek('2040-12-21', 2);
+-- result:
+194001	194050	204002	204051
+-- !result
+select yearweek('1940-01-11', 3), yearweek('1940-12-21', 3), yearweek('2040-01-11', 3), yearweek('2040-12-21', 3);
+-- result:
+194002	194051	204002	204051
+-- !result
+select yearweek('1940-01-11', 4), yearweek('1940-12-21', 4), yearweek('2040-01-11', 4), yearweek('2040-12-21', 4);
+-- result:
+194002	194051	204002	204051
+-- !result
+select yearweek('1940-01-11', 5), yearweek('1940-12-21', 5), yearweek('2040-01-11', 5), yearweek('2040-12-21', 5);
+-- result:
+194002	194051	204002	204051
+-- !result
+select yearweek('1940-01-11', 6), yearweek('1940-12-21', 6), yearweek('2040-01-11', 6), yearweek('2040-12-21', 6);
+-- result:
+194002	194051	204002	204051
+-- !result
+select yearweek('1940-01-11', 7), yearweek('1940-12-21', 7), yearweek('2040-01-11', 7), yearweek('2040-12-21', 7);
+-- result:
+194002	194051	204002	204051
+-- !result

--- a/test/sql/test_datetime/R/test_yearweek
+++ b/test/sql/test_datetime/R/test_yearweek
@@ -1,0 +1,5 @@
+-- name: test_yearweek
+select yearweek('2023-12-31', 2), yearweek('2024-01-01', 2);
+-- result:
+202353	202353
+-- !result

--- a/test/sql/test_datetime/T/test_yearweek
+++ b/test/sql/test_datetime/T/test_yearweek
@@ -1,0 +1,2 @@
+-- name: test_yearweek
+select yearweek('2023-12-31', 2), yearweek('2024-01-01', 2);

--- a/test/sql/test_datetime/T/test_yearweek
+++ b/test/sql/test_datetime/T/test_yearweek
@@ -1,2 +1,26 @@
 -- name: test_yearweek
 select yearweek('2023-12-31', 2), yearweek('2024-01-01', 2);
+select yearweek('1900-01-01', 0), yearweek('1900-12-31', 0), yearweek('2000-01-01', 0), yearweek('2000-12-31', 0);
+select yearweek('1900-01-01', 1), yearweek('1900-12-31', 1), yearweek('2000-01-01', 1), yearweek('2000-12-31', 1);
+select yearweek('1900-01-01', 2), yearweek('1900-12-31', 2), yearweek('2000-01-01', 2), yearweek('2000-12-31', 2);
+select yearweek('1900-01-01', 3), yearweek('1900-12-31', 3), yearweek('2000-01-01', 3), yearweek('2000-12-31', 3);
+select yearweek('1900-01-01', 4), yearweek('1900-12-31', 4), yearweek('2000-01-01', 4), yearweek('2000-12-31', 4);
+select yearweek('1900-01-01', 5), yearweek('1900-12-31', 5), yearweek('2000-01-01', 5), yearweek('2000-12-31', 5);
+select yearweek('1900-01-01', 6), yearweek('1900-12-31', 6), yearweek('2000-01-01', 6), yearweek('2000-12-31', 6);
+select yearweek('1900-01-01', 7), yearweek('1900-12-31', 7), yearweek('2000-01-01', 7), yearweek('2000-12-31', 7);
+select yearweek('1910-01-05', 0), yearweek('1910-12-27', 0), yearweek('2010-01-05', 0), yearweek('2010-12-27', 0);
+select yearweek('1910-01-05', 1), yearweek('1910-12-27', 1), yearweek('2010-01-05', 1), yearweek('2010-12-27', 1);
+select yearweek('1910-01-05', 2), yearweek('1910-12-27', 2), yearweek('2010-01-05', 2), yearweek('2010-12-27', 2);
+select yearweek('1910-01-05', 3), yearweek('1910-12-27', 3), yearweek('2010-01-05', 3), yearweek('2010-12-27', 3);
+select yearweek('1910-01-05', 4), yearweek('1910-12-27', 4), yearweek('2010-01-05', 4), yearweek('2010-12-27', 4);
+select yearweek('1910-01-05', 5), yearweek('1910-12-27', 5), yearweek('2010-01-05', 5), yearweek('2010-12-27', 5);
+select yearweek('1910-01-05', 6), yearweek('1910-12-27', 6), yearweek('2010-01-05', 6), yearweek('2010-12-27', 6);
+select yearweek('1910-01-05', 7), yearweek('1910-12-27', 7), yearweek('2010-01-05', 7), yearweek('2010-12-27', 7);
+select yearweek('1940-01-11', 0), yearweek('1940-12-21', 0), yearweek('2040-01-11', 0), yearweek('2040-12-21', 0);
+select yearweek('1940-01-11', 1), yearweek('1940-12-21', 1), yearweek('2040-01-11', 1), yearweek('2040-12-21', 1);
+select yearweek('1940-01-11', 2), yearweek('1940-12-21', 2), yearweek('2040-01-11', 2), yearweek('2040-12-21', 2);
+select yearweek('1940-01-11', 3), yearweek('1940-12-21', 3), yearweek('2040-01-11', 3), yearweek('2040-12-21', 3);
+select yearweek('1940-01-11', 4), yearweek('1940-12-21', 4), yearweek('2040-01-11', 4), yearweek('2040-12-21', 4);
+select yearweek('1940-01-11', 5), yearweek('1940-12-21', 5), yearweek('2040-01-11', 5), yearweek('2040-12-21', 5);
+select yearweek('1940-01-11', 6), yearweek('1940-12-21', 6), yearweek('2040-01-11', 6), yearweek('2040-12-21', 6);
+select yearweek('1940-01-11', 7), yearweek('1940-12-21', 7), yearweek('2040-01-11', 7), yearweek('2040-12-21', 7);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
mysql> select yearweek('2023-12-31', 2), yearweek('2024-01-01', 2);
+---------------------------+---------------------------+
| yearweek('2023-12-31', 2) | yearweek('2024-01-01', 2) |
+---------------------------+---------------------------+
|                    202353 |                    202353 |
+---------------------------+---------------------------+

Fixes #51034

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
