### PR TITLE
[BugFix] fix broker load job hang when meet resource group pending timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -261,7 +261,7 @@ public abstract class BulkLoadJob extends LoadJob {
                 return;
             }
 
-            if (!failMsg.getMsg().contains("timeout")) {
+            if (!failMsg.getMsg().contains("timeout") || failMsg.getCancelType() == FailMsg.CancelType.USER_CANCEL) {
                 unprotectedExecuteCancel(failMsg, true);
                 logFinalOperation();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
@@ -73,6 +73,10 @@ public abstract class LoadTask extends PriorityLeaderTask {
             // callback on pending task finished
             callback.onTaskFinished(attachment);
             isFinished = true;
+        } catch (LoadException e) {
+            failMsg.setMsg(e.getMessage() == null ? "" : e.getMessage());
+            LOG.warn(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
+                    .add("error_msg", "Failed to execute load task").build(), e);
         } catch (UserException e) {
             failMsg.setMsg(e.getMessage() == null ? "" : e.getMessage());
             failMsg.setCancelType(FailMsg.CancelType.USER_CANCEL);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
@@ -75,6 +75,7 @@ public abstract class LoadTask extends PriorityLeaderTask {
             isFinished = true;
         } catch (UserException e) {
             failMsg.setMsg(e.getMessage() == null ? "" : e.getMessage());
+            failMsg.setCancelType(FailMsg.CancelType.USER_CANCEL);
             LOG.warn(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
                     .add("error_msg", "Failed to execute load task").build(), e);
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -431,6 +431,24 @@ public class BrokerLoadJobTest {
     }
 
     @Test
+    public void testTaskOnResourceGroupTaskFailed(@Injectable long taskId, @Injectable FailMsg failMsg) {
+        GlobalStateMgr.getCurrentState().setEditLog(new EditLog(new ArrayBlockingQueue<>(100)));
+        new MockUp<EditLog>() {
+            @Mock
+            public void logEndLoadJob(LoadJobFinalOperation loadJobFinalOperation) {
+
+            }
+        };
+
+        BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
+        failMsg = new FailMsg(FailMsg.CancelType.USER_CANCEL, "Failed to allocate resource to query: pending timeout");
+        brokerLoadJob.onTaskFailed(taskId, failMsg);
+
+        Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
+        Assert.assertEquals(0, idToTasks.size());
+    }
+
+    @Test
     public void testPendingTaskOnFinishedWithJobCancelled(@Injectable BrokerPendingTaskAttachment attachment) {
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
         Deencapsulation.setField(brokerLoadJob, "state", JobState.CANCELLED);


### PR DESCRIPTION
## Why I'm doing:
In previous PR #38183, we will skip cancel loading job when timeout happen. But when broker load met resource group pending timeout like:
```
com.starrocks.common.UserException: Failed to allocate resource to query: pending timeout [300], you could modify the session variable [query_queue_pending_timeout_second] to pending more time
at com.starrocks.qe.QueryQueueManager.maybeWait(QueryQueueManager.java:81) ~[starrocks-fe.jar:?]
at com.starrocks.qe.DefaultCoordinator.startScheduling(DefaultCoordinator.java:488) ~[starrocks-fe.jar:?]
at com.starrocks.qe.scheduler.Coordinator.startScheduling(Coordinator.java:102) ~[starrocks-fe.jar:?]
at com.starrocks.qe.scheduler.Coordinator.exec(Coordinator.java:85) ~[starrocks-fe.jar:?]
```

It's not a loading job timeout, but because error message contains `timeout`, so we will consider it as normal timeout and won't cancel it immediately, so load job will hang until timeout happens.

## What I'm doing:
When we met `resource group pending timeout`, we can set it as `USER_CANCEL`, so we can cancel it immediately.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
