### PR TITLE
[BugFix] fix BE crash during startup when its started from deep nested directory path

### DIFF
--- a/be/src/util/bfd_parser.cpp
+++ b/be/src/util/bfd_parser.cpp
@@ -116,7 +116,7 @@ BfdParser* BfdParser::create() {
     }
 
     char prog_name[1024];
-    if (fscanf(file, "%s ", prog_name) != 1) {
+    if (fscanf(file, "%1023s ", prog_name) != 1) {
         strcpy(prog_name, "read cmdline failed");
     }
     fclose(file);


### PR DESCRIPTION
## Why I'm doing:
BE crash during startup when its started from deep nested directory path

## What I'm doing:
max field width should be specified in fscanf() so that it does not overflow the buffer

I20240918 01:53:30.107084 135614079983936 starrocks_be.cpp:264] BE start step 10: start brpc server successfully
I20240918 01:53:30.108626 135614079983936 starrocks_be.cpp:273] BE start step 11: start http server successfully
I20240918 01:53:30.108730 135614079983936 thrift_server.cpp:384] heartbeat has started listening port on 9050
I20240918 01:53:30.108733 135614079983936 starrocks_be.cpp:291] BE start step 12: start heartbeat server successfully
I20240918 01:53:30.108734 135614079983936 starrocks_be.cpp:293] BE started successfully

Fixes #51074 

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
