### PR TITLE
[BugFix] List partition values should not contain NULL partition value if this column is not nullable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1594,6 +1594,16 @@ public class OlapTable extends Table {
         return idToPartition.values();
     }
 
+    /**
+     * Return all visible partitions except shadow partitions.
+     */
+    public List<Partition> getVisiblePartitions() {
+        return nameToPartition.entrySet().stream()
+                .filter(e -> !e.getKey().startsWith(ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX))
+                .map(e -> e.getValue())
+                .collect(Collectors.toList());
+    }
+
     public List<Partition> getNonEmptyPartitions() {
         return idToPartition.values().stream().filter(Partition::hasData).collect(Collectors.toList());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -811,7 +811,7 @@ public class OlapScanNode extends ScanNode {
 
         if (detailLevel != TExplainLevel.VERBOSE) {
             output.append(prefix).append(String.format("partitions=%s/%s\n", selectedPartitionNum,
-                    olapTable.getPartitions().size()));
+                    olapTable.getVisiblePartitionNames().size()));
 
             String indexName = olapTable.getIndexNameById(selectedIndexId);
             output.append(prefix).append(String.format("rollup: %s\n", indexName));
@@ -838,7 +838,7 @@ public class OlapScanNode extends ScanNode {
             output.append(prefix).append(String.format(
                             "partitionsRatio=%s/%s",
                             selectedPartitionNum,
-                            olapTable.getPartitions().size())).append(", ")
+                            olapTable.getVisiblePartitionNames().size())).append(", ")
                     .append(String.format("tabletsRatio=%s/%s", selectedTabletsNum, totalTabletsNum)).append("\n");
 
             if (scanTabletIds.size() > 10) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
@@ -210,7 +210,7 @@ public class Explain {
             String partitionAndBucketInfo = "partitionRatio: " +
                     scan.getSelectedPartitionId().size() +
                     "/" +
-                    ((OlapTable) scan.getTable()).getPartitions().size() +
+                    ((OlapTable) scan.getTable()).getVisiblePartitionNames().size() +
                     ", tabletRatio: " +
                     scan.getSelectedTabletId().size() +
                     "/" +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
@@ -105,6 +105,8 @@ public class ListPartitionDesc extends PartitionDesc {
         this.analyzeSingleListPartition(tableProperties, columnDefList);
         // analyze multi list partition
         this.analyzeMultiListPartition(tableProperties, columnDefList);
+        // list partition values should not contain NULL partition value if this column is not nullable.
+        this.postAnalyzePartitionColumns(columnDefList);
     }
 
     public List<ColumnDef> analyzePartitionColumns(List<ColumnDef> columnDefs) throws AnalysisException {
@@ -139,6 +141,39 @@ public class ListPartitionDesc extends PartitionDesc {
             }
         }
         return partitionColumns;
+    }
+
+    private void postAnalyzePartitionColumns(List<ColumnDef> columnDefs) throws AnalysisException {
+        // list partition values should not contain NULL partition value if this column is not nullable.
+        int partitionColSize = columnDefs.size();
+        for (int i = 0; i < columnDefs.size(); i++) {
+            ColumnDef columnDef = columnDefs.get(i);
+            if (columnDef.isAllowNull()) {
+                continue;
+            }
+            String partitionCol = columnDef.getName();
+            for (SingleItemListPartitionDesc desc : singleListPartitionDescs) {
+                for (LiteralExpr literalExpr : desc.getLiteralExprValues()) {
+                    if (literalExpr.isNullable()) {
+                        throw new AnalysisException("Partition column[" + partitionCol + "] could not be null but " +
+                                "contains null value in partition[" + desc.getPartitionName() + "]");
+                    }
+                }
+            }
+            for (MultiItemListPartitionDesc desc : multiListPartitionDescs) {
+                for (List<LiteralExpr> literalExprs : desc.getMultiLiteralExprValues()) {
+                    if (literalExprs.size() != partitionColSize) {
+                        throw new AnalysisException("Partition column[" + partitionCol + "] size should be equal to " +
+                                "partition column size but contains " + literalExprs.size() + " values in partition[" +
+                                desc.getPartitionName() + "]");
+                    }
+                    if (literalExprs.get(i).isNullable()) {
+                        throw new AnalysisException("Partition column[" + partitionCol + "] could not be null but " +
+                                "contains null value in partition[" + desc.getPartitionName() + "]");
+                    }
+                }
+            }
+        }
     }
 
     public void analyzeExternalPartitionColumns(List<ColumnDef> columnDefs, String engineName) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -77,7 +77,7 @@ public class OptOlapPartitionPruner {
 
         if (selectedPartitionIds == null) {
             selectedPartitionIds =
-                    table.getPartitions().stream().filter(Partition::hasData).map(Partition::getId).collect(
+                    table.getVisiblePartitions().stream().filter(Partition::hasData).map(Partition::getId).collect(
                             Collectors.toList());
             // some test cases need to perceive partitions pruned, so we can not filter empty partitions.
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -3752,7 +3752,6 @@ public class CreateMaterializedViewTest {
         starRocksAssert.dropTable("list_partition_tbl1");
     }
 
-
     @Test
     public void testCreateMaterializedViewOnListPartitionTables3() {
         String createSQL = "CREATE TABLE test.list_partition_tbl1 (\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -492,14 +492,6 @@ public class RestoreJobMaterializedViewTest {
     }
 
     @Test
-    public void testMVRestore() {
-        RestoreJob job = createRestoreJob(ImmutableList.of(UnitTestUtil.MATERIALIZED_VIEW_NAME));
-
-        checkJobRun(job);
-        assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
-    }
-
-    @Test
     public void testMVRestoreMVWithBaseTable1() {
         // gen BackupJobInfo
         RestoreJob job = createRestoreJob(ImmutableList.of(TABLE_NAME, MATERIALIZED_VIEW_NAME));

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -35,6 +35,7 @@
 package com.starrocks.catalog;
 
 import com.starrocks.alter.AlterJobException;
+import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
@@ -70,6 +71,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class CreateTableTest {
     private static ConnectContext connectContext;
@@ -91,8 +93,8 @@ public class CreateTableTest {
         String createDbStmtStr = "create database test;";
         CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName());
-
         UtFrameUtils.setUpForPersistTest();
+        starRocksAssert.useDatabase("test");
     }
 
     private static void createTable(String sql) throws Exception {
@@ -2101,5 +2103,61 @@ public class CreateTableTest {
         String createTableSql = starRocksAssert.showCreateTable("show create table news_rt_non_pk;");
         starRocksAssert.dropTable("news_rt_non_pk");
         starRocksAssert.withTable(createTableSql);
+    }
+
+    @Test
+    public void testCreateTableWithNullableColumns1() throws Exception {
+        String createSQL = "CREATE TABLE list_partition_tbl1 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) \n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN ((NULL),(\"chongqing\")) ,\n" +
+                "     PARTITION p2 VALUES IN ((\"guangdong\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");";
+        starRocksAssert.withTable(createSQL);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(),
+                "list_partition_tbl1");
+        PartitionInfo info = table.getPartitionInfo();
+        Assert.assertTrue(info.isListPartition());
+        ListPartitionInfo listPartitionInfo = (ListPartitionInfo) info;
+        Map<Long, List<List<LiteralExpr>>> long2Literal =  listPartitionInfo.getMultiLiteralExprValues();
+        Assert.assertEquals(2, long2Literal.size());
+    }
+
+    @Test
+    public void testCreateTableWithNullableColumns2() {
+        String createSQL = "\n" +
+                "CREATE TABLE t3 (\n" +
+                "  dt date,\n" +
+                "  city varchar(20),\n" +
+                "  name varchar(20),\n" +
+                "  num int\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY(dt, city, name)\n" +
+                "PARTITION BY LIST (dt) (\n" +
+                "    PARTITION p1 VALUES IN ((NULL), (\"2022-04-01\")),\n" +
+                "    PARTITION p2 VALUES IN ((\"2022-04-02\")),\n" +
+                "    PARTITION p3 VALUES IN ((\"2022-04-03\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(dt) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");";
+        try {
+            starRocksAssert.withTable(createSQL);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Partition column[dt] could not be null but contains null " +
+                    "value in partition[p1]."));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -686,7 +686,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                             "     rollup: t2");
                                 PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/0\n" +
+                                            "     partitions=0/0\n" +
                                             "     rollup: t4");
 
                                 Collection<Partition> partitions = materializedView.getPartitions();
@@ -777,7 +777,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                             "     partitions=1/3");
                                 PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/0\n" +
+                                            "     partitions=0/0\n" +
                                             "     rollup: t5");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(3, partitions.size());
@@ -862,7 +862,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                             "     partitions=1/3");
                                 PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/0\n" +
+                                            "     partitions=0/0\n" +
                                             "     rollup: t5");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(3, partitions.size());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -541,7 +541,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                                 PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/2");
+                                            "     partitions=1/1");
 
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(1, partitions.size());
@@ -559,7 +559,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                                 PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/3");
+                                            "     partitions=1/2");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(2, partitions.size());
                             }
@@ -600,7 +600,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                                 PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/2");
+                                            "     partitions=1/1");
 
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(1, partitions.size());
@@ -621,7 +621,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                                 PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=2/3");
+                                            "     partitions=2/2");
 
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(1, partitions.size());
@@ -639,7 +639,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                                 PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/4");
+                                            "     partitions=1/3");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(2, partitions.size());
                             }
@@ -686,7 +686,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                             "     rollup: t2");
                                 PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/1\n" +
+                                            "     partitions=1/0\n" +
                                             "     rollup: t4");
 
                                 Collection<Partition> partitions = materializedView.getPartitions();
@@ -714,7 +714,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                             "     partitions=1/3");
                                 PlanTestBase.assertContains(plan, "     TABLE: t4\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/2");
+                                            "     partitions=1/1");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(3, partitions.size());
                             }
@@ -777,7 +777,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                             "     partitions=1/3");
                                 PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/1\n" +
+                                            "     partitions=1/0\n" +
                                             "     rollup: t5");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(3, partitions.size());
@@ -800,7 +800,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                             "     rollup: t1");
                                 PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/2");
+                                            "     partitions=1/1");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(3, partitions.size());
                             }
@@ -862,7 +862,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                             "     partitions=1/3");
                                 PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/1\n" +
+                                            "     partitions=1/0\n" +
                                             "     rollup: t5");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(3, partitions.size());
@@ -874,7 +874,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 executeInsertSql(connectContext, insertSql);
                                 // t5 add a new partition
                                 addListPartition("t5", "p1", "beijing", "2022-01-01");
-                                insertSql = "insert into t5 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                insertSql = "insert into t5 partition(p1) values(1, 1, '2022-01-01', 'beijing');";
                                 executeInsertSql(connectContext, insertSql);
 
                                 ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
@@ -884,7 +884,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                             "     partitions=2/3");
                                 PlanTestBase.assertContains(plan, "     TABLE: t5\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/2");
+                                            "     partitions=1/1");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(3, partitions.size());
                             }
@@ -919,13 +919,13 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                             {
                                 // add a new partition
                                 addListPartition("t6", "p1", "beijing", "2022-01-01");
-                                String insertSql = "insert into t6 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
+                                String insertSql = "insert into t6 partition(p1) values(1, 1, '2021-01-01', 'beijing');";
                                 ExecPlan execPlan = getExecPlanAfterInsert(taskRun, insertSql);
 
                                 String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                                 PlanTestBase.assertContains(plan, "     TABLE: t6\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/2");
+                                            "     partitions=1/1");
 
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(1, partitions.size());
@@ -946,7 +946,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                                 PlanTestBase.assertContains(plan, "     TABLE: t6\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=2/3");
+                                            "     partitions=2/2");
 
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(1, partitions.size());
@@ -964,7 +964,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                                 PlanTestBase.assertContains(plan, "     TABLE: t6\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/4");
+                                            "     partitions=1/3");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(2, partitions.size());
                             }
@@ -977,7 +977,7 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
                                 String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
                                 PlanTestBase.assertContains(plan, "    TABLE: t6\n" +
                                             "     PREAGGREGATION: ON\n" +
-                                            "     partitions=1/5");
+                                            "     partitions=1/4");
                                 Collection<Partition> partitions = materializedView.getPartitions();
                                 Assert.assertEquals(3, partitions.size());
                             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
@@ -2065,7 +2065,7 @@ public class OptimizerTaskTest {
                 result = 0;
                 minTimes = 0;
 
-                olapTable1.getPartitions();
+                olapTable1.getVisiblePartitions();
                 result = Lists.newArrayList(p1);
                 minTimes = 0;
 
@@ -2091,7 +2091,7 @@ public class OptimizerTaskTest {
                 result = 1;
                 minTimes = 0;
 
-                olapTable2.getPartitions();
+                olapTable2.getVisiblePartitions();
                 result = Lists.newArrayList(p2);
                 minTimes = 0;
 
@@ -2287,7 +2287,7 @@ public class OptimizerTaskTest {
                 result = 0;
                 minTimes = 0;
 
-                olapTable1.getPartitions();
+                olapTable1.getVisiblePartitions();
                 result = Lists.newArrayList(p1);
                 minTimes = 0;
 
@@ -2309,7 +2309,7 @@ public class OptimizerTaskTest {
                 result = 1;
                 minTimes = 0;
 
-                olapTable2.getPartitions();
+                olapTable2.getVisiblePartitions();
                 result = Lists.newArrayList(p2);
                 minTimes = 0;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -258,55 +258,55 @@ public class PartitionPruneTest extends PlanTestBase {
     public void testGeneratedColumnPrune() throws Exception {
         // c2
         starRocksAssert.query("select count(*) from t_gen_col where c2 = 1 ")
-                .explainContains("partitions=3/7");
+                .explainContains("partitions=3/6");
 
         // c1
         starRocksAssert.query("select count(*) from t_gen_col where c1 = '2024-01-01' ")
-                .explainContains("partitions=2/7");
+                .explainContains("partitions=2/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 = '2024-02-01' ")
-                .explainContains("partitions=2/7");
+                .explainContains("partitions=2/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 < '2024-02-01' ")
-                .explainContains("partitions=4/7");
+                .explainContains("partitions=4/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 <= '2024-02-01' ")
-                .explainContains("partitions=4/7");
+                .explainContains("partitions=4/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 > '2024-02-01' ")
-                .explainContains("partitions=4/7");
+                .explainContains("partitions=4/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 >= '2024-02-01' ")
-                .explainContains("partitions=4/7");
+                .explainContains("partitions=4/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 in ('2024-02-01') ")
-                .explainContains("partitions=2/7");
+                .explainContains("partitions=2/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 in ('2024-02-01', '2024-01-01') ")
-                .explainContains("partitions=4/7");
+                .explainContains("partitions=4/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 in ('2027-01-01') ")
-                .explainContains("partitions=0/7");
+                .explainContains("partitions=0/6");
 
         // c1 not supported
         starRocksAssert.query("select count(*) from t_gen_col where c1 != '2024-02-01' ")
-                .explainContains("partitions=7/7");
+                .explainContains("partitions=6/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 = c2 ")
-                .explainContains("partitions=7/7");
+                .explainContains("partitions=6/6");
         starRocksAssert.query("select count(*) from t_gen_col where date_trunc('year', c1) = '2024-02-01' ")
-                .explainContains("partitions=7/7");
+                .explainContains("partitions=6/6");
         starRocksAssert.query("select count(*) from t_gen_col where date_trunc('year', c1) = '2024-02-01' ")
-                .explainContains("partitions=7/7");
+                .explainContains("partitions=6/6");
 
         // compound
         starRocksAssert.query("select count(*) from t_gen_col where c1 >= '2024-02-01' and c1 <= '2024-03-01' ")
-                .explainContains("partitions=4/7");
+                .explainContains("partitions=4/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 >= '2024-02-01' and c1 = '2027-03-01' ")
-                .explainContains("partitions=0/7");
+                .explainContains("partitions=0/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 = '2024-02-01' or c1 = '2024-03-01' ")
-                .explainContains("partitions=4/7");
+                .explainContains("partitions=4/6");
         starRocksAssert.query("select count(*) from t_gen_col where c1 = '2024-02-01' or c1 = '2027-03-01' ")
-                .explainContains("partitions=2/7");
+                .explainContains("partitions=2/6");
 
         // c1 && c2
         starRocksAssert.query("select * from t_gen_col where c1 = '2024-01-01' and c2 = 1 ")
-                .explainContains("partitions=1/7");
+                .explainContains("partitions=1/6");
 
         // non-monotonic function
         starRocksAssert.query("select count(*) from t_gen_col_1 where c1 = '2024-01-01' ")
-                .explainContains("partitions=2/2");
+                .explainContains("partitions=1/1");
     }
 
     @Test

--- a/test/sql/test_list_partition/R/test_list_partition_prune
+++ b/test/sql/test_list_partition/R/test_list_partition_prune
@@ -72,7 +72,7 @@ SELECT COUNT(*) FROM partitions_multi_column_1 WHERE TRUE AND c2=1 ;
 -- result:
 1
 -- !result
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND c2=1', 'partitions=1/4')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND c2=1', 'partitions=1/3')
 -- result:
 None
 -- !result
@@ -84,15 +84,15 @@ function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_
 -- result:
 None
 -- !result
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2<>1', 'partitions=2/4')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2<>1', 'partitions=2/3')
 -- result:
 None
 -- !result
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND TRUE', 'partitions=1/4')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND TRUE', 'partitions=1/3')
 -- result:
 None
 -- !result
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE TRUE AND c2=1', 'partitions=1/4')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE TRUE AND c2=1', 'partitions=1/3')
 -- result:
 None
 -- !result
@@ -105,7 +105,7 @@ INSERT INTO partitions_multi_column_1 VALUES(2,3,5);
 INSERT INTO partitions_multi_column_1 VALUES(3,4,6);
 -- result:
 -- !result
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND c2<>1', 'partitions=1/7')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND c2<>1', 'partitions=1/6')
 -- result:
 None
 -- !result
@@ -113,15 +113,15 @@ function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_
 -- result:
 None
 -- !result
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2=2', 'partitions=1/7')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2=2', 'partitions=1/6')
 -- result:
 None
 -- !result
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND TRUE', 'partitions=2/7')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND TRUE', 'partitions=2/6')
 -- result:
 None
 -- !result
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE TRUE AND c2=1', 'partitions=1/7')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE TRUE AND c2=1', 'partitions=1/6')
 -- result:
 None
 -- !result

--- a/test/sql/test_list_partition/T/test_list_partition_prune
+++ b/test/sql/test_list_partition/T/test_list_partition_prune
@@ -47,18 +47,18 @@ SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2<>1;
 SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND TRUE;
 SELECT COUNT(*) FROM partitions_multi_column_1 WHERE TRUE AND c2=1 ;
 
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND c2=1', 'partitions=1/4')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND c2=1', 'partitions=1/3')
 function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND c2<>1', 'EMPTYSET')
 function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2=1', 'EMPTYSET')
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2<>1', 'partitions=2/4')
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND TRUE', 'partitions=1/4')
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE TRUE AND c2=1', 'partitions=1/4')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2<>1', 'partitions=2/3')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND TRUE', 'partitions=1/3')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE TRUE AND c2=1', 'partitions=1/3')
 
 INSERT INTO partitions_multi_column_1 VALUES(1,2,4);
 INSERT INTO partitions_multi_column_1 VALUES(2,3,5);
 INSERT INTO partitions_multi_column_1 VALUES(3,4,6);
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND c2<>1', 'partitions=1/7')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND c2<>1', 'partitions=1/6')
 function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2=1', 'EMPTYSET')
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2=2', 'partitions=1/7')
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND TRUE', 'partitions=2/7')
-function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE TRUE AND c2=1', 'partitions=1/7')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1<>1 AND c2=2', 'partitions=1/6')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE c1=1 AND TRUE', 'partitions=2/6')
+function: assert_explain_contains('SELECT COUNT(*) FROM partitions_multi_column_1 WHERE TRUE AND c2=1', 'partitions=1/6')


### PR DESCRIPTION
## Why I'm doing:

Bug1: Primary key column is not null by default, add a `null` value partition should not be valid.
```
CREATE TABLE t3 (
  dt date,
  city varchar(20),
  name varchar(20),
  num int
) ENGINE=OLAP
PRIMARY KEY(dt, city, name)
COMMENT "OLAP"
PARTITION BY LIST (dt) (
    PARTITION p1 VALUES IN ((NULL), ("2022-04-01")),
    PARTITION p2 VALUES IN (("2022-04-02")),
    PARTITION p3 VALUES IN (("2022-04-03"))
)
DISTRIBUTED BY HASH(dt) BUCKETS 3
PROPERTIES (
    "replication_num" = "1"
);

INSERT INTO t3 VALUES ('2022-04-01', 'beijing', 'jack', 1),
                      ('2022-04-02', 'beijing', 'jack', 2),
                      ('2022-04-02', 'beijing', 'jack', 3),
                      ('2022-04-02', 'shanghai', 'nacy', 3),
                      (null, 'shanghai', 'nacy', 6);

 (1064, 'invalid date literal in partition column, date=TDateLiteral(value=) backend [id=10002] [host=172.26.95.121]'
 
```

Bug2: `t3` only contains 3 partitions but displays `partitionsRatio=3/4`
```

| PLAN FRAGMENT 2(F00)                                                                                                 |                                                                                                                                                                                                                                            |                                                                                                                      |                                                                                                                                                                                                                                            |   Input Partition: RANDOM                                                                                            |                                                                                                                                                                                                                                            |   OutPut Partition: HASH_PARTITIONED: 8: dt, 9: province                                                             |                                                                                                                                                                                                                                            |   OutPut Exchange Id: 02                                                                                             |                                                                                                                                                                                                                                            |                                                                                                                      |                                                                                                                                                                                                                                            |   1:AGGREGATE (update serialize)                                                                                     |                                                                                                                                                                                                                                            |   |  STREAMING                                                                                                       |                                                                                                                                                                                                                                            |   |  aggregate: sum[([3: num, INT, true]); args: INT; result: BIGINT; args nullable: true; result nullable: true]    |                                                                                                                                                                                                                                            |   |  group by: [8: dt, INT, true], [9: province, INT, true]                                                          |                                                                                                                                                                                                                                            |   |  cardinality: 5                                                                                                  |                                                                                                                                                                                                                                            |   |  column statistics:                                                                                              |                                                                                                                                                                                                                                            |   |  * dt-->[-Infinity, Infinity, 0.0, 10.0, 3.0] ESTIMATE                                                           |                                                                                                                                                                                                                                            |   |  * province-->[-Infinity, Infinity, 0.0, 7.25, 3.0] ESTIMATE                                                     |                                                                                                                                                                                                                                            |   |  * sum-->[1.0, 5.0, 0.0, 8.0, 4.0] ESTIMATE                                                                      |                                                                                                                                                                                                                                            |   |                                                                                                                  |                                                                                                                                                                                                                                            |   0:OlapScanNode                                                                                                     |                                                                                                                                                                                                                                            |      table: t1, rollup: t1                                                                                           |                                                                                                                                                                                                                                            |      preAggregation: on                                                                                              |                                                                                                                                                                                                                                            |      dict_col=dt,province                                                                                            |                                                                                                                                                                                                                                            |      partitionsRatio=3/4, tabletsRatio=3/3                                                                           |                                                                                                                                                                                                                                            |      tabletList=90891,90885,90888                                                                                    |                                                                                                                                                                                                                                            |      actualRows=5, avgRowSize=21.25                                                                                  |                                                                                                                                                                                                                                            |      cardinality: 5                                                                                                  |                                                                                                                                                                                                                                            |      column statistics:                                                                                              |                                                                                                                                                                                                                                            |      * dt-->[-Infinity, Infinity, 0.0, 10.0, 3.0] ESTIMATE                                                           |                                                                                                                                                                                                                                            |      * province-->[-Infinity, Infinity, 0.0, 7.25, 3.0] ESTIMATE                                                     |                                                                                                                                                                                                                                            |      * num-->[1.0, 4.0, 0.0, 4.0, 4.0] ESTIMATE                                                                      |                                                                                                                                                                                                                                            +----------------------------------------------------------------------------------------------------------------------+                                                                                                                                                                                                                                            83 rows in set (1 min 53.25 sec)
```
## What I'm doing:
- List partition values should not contain NULL partition value if this column is not nullable
- Display partition values should use visible partitions' size rather than all partitions.

Fixes https://github.com/StarRocks/StarRocksTest/issues/8590

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
