### PR TITLE
[BugFix] fix lake compaction compaction sorter bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -131,8 +131,9 @@ public class CompactionMgr implements MemoryTrackable {
 
     @NotNull
     List<PartitionIdentifier> choosePartitionsToCompact(Set<Long> excludeTables) {
-        List<PartitionStatistics> selection = sorter.sort(selector.select(partitionStatisticsHashMap.values(), excludeTables));
-        return selection.stream().map(PartitionStatistics::getPartition).collect(Collectors.toList());
+        List<PartitionStatisticsSnapshot> selection = sorter.sort(
+                selector.select(partitionStatisticsHashMap.values(), excludeTables));
+        return selection.stream().map(PartitionStatisticsSnapshot::getPartition).collect(Collectors.toList());
     }
 
     @NotNull

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionStatistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionStatistics.java
@@ -143,6 +143,10 @@ public class PartitionStatistics {
         this.setPriority(CompactionPriority.DEFAULT);
     }
 
+    public PartitionStatisticsSnapshot getSnapshot() {
+        return new PartitionStatisticsSnapshot(this);
+    }
+
     @Override
     public String toString() {
         return new Gson().toJson(this);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionStatisticsSnapshot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionStatisticsSnapshot.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.lake.compaction;
+
+import javax.validation.constraints.NotNull;
+
+// simplified version of `PartitionStatistics`, only contains necessary copied info for compaction sorter
+public class PartitionStatisticsSnapshot {
+    private final PartitionIdentifier partition;
+    // deep copy
+    private final PartitionStatistics.CompactionPriority priority;
+    // deep copy
+    private final Quantiles compactionScore;
+
+    public PartitionStatisticsSnapshot(@NotNull PartitionStatistics ps) {
+        this.partition = ps.getPartition();
+        this.priority = ps.getPriority();
+        this.compactionScore = new Quantiles(ps.getCompactionScore());
+    }
+
+    PartitionIdentifier getPartition() {
+        return partition;
+    }
+
+    PartitionStatistics.CompactionPriority getPriority() {
+        return priority;
+    }
+
+    Quantiles getCompactionScore() {
+        return compactionScore;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/Quantiles.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/Quantiles.java
@@ -50,6 +50,10 @@ public class Quantiles implements Comparable<Quantiles> {
         this.max = max;
     }
 
+    public Quantiles(@NotNull Quantiles q) {
+        this(q.getAvg(), q.getP50(), q.getMax());
+    }
+
     public double getAvg() {
         return avg;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/RandomSorter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/RandomSorter.java
@@ -25,10 +25,10 @@ public class RandomSorter implements Sorter {
     }
 
     @NotNull
-    public List<PartitionStatistics> sort(@NotNull List<PartitionStatistics> partitionStatistics) {
+    public List<PartitionStatisticsSnapshot> sort(@NotNull List<PartitionStatisticsSnapshot> partitionStatistics) {
         Collections.shuffle(partitionStatistics);
         return partitionStatistics.stream()
-                .sorted(Comparator.comparingInt((PartitionStatistics stats) -> stats.getPriority().getValue())
+                .sorted(Comparator.comparingInt((PartitionStatisticsSnapshot stats) -> stats.getPriority().getValue())
                         .reversed())
                 .collect(Collectors.toList());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/ScoreSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/ScoreSelector.java
@@ -24,10 +24,9 @@ import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 public class ScoreSelector implements Selector {
-
     @Override
     @NotNull
-    public List<PartitionStatistics> select(@NotNull Collection<PartitionStatistics> statistics,
+    public List<PartitionStatisticsSnapshot> select(@NotNull Collection<PartitionStatistics> statistics,
             @NotNull Set<Long> excludeTables) {
         double minScore = Config.lake_compaction_score_selector_min_score;
         long now = System.currentTimeMillis();
@@ -37,6 +36,8 @@ public class ScoreSelector implements Selector {
                 // When manual compaction is triggered, we just skip min score and time check
                 .filter(p -> (p.getPriority() != PartitionStatistics.CompactionPriority.DEFAULT
                         || (p.getNextCompactionTime() <= now && p.getCompactionScore().getMax() >= minScore)))
+                .map(p -> {
+                    return p.getSnapshot(); })
                 .collect(Collectors.toList());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/ScoreSorter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/ScoreSorter.java
@@ -23,11 +23,11 @@ import javax.validation.constraints.NotNull;
 public class ScoreSorter implements Sorter {
     @Override
     @NotNull
-    public List<PartitionStatistics> sort(@NotNull List<PartitionStatistics> partitionStatistics) {
+    public List<PartitionStatisticsSnapshot> sort(@NotNull List<PartitionStatisticsSnapshot> partitionStatistics) {
         return partitionStatistics.stream()
                 .filter(p -> p.getCompactionScore() != null)
-                .sorted(Comparator.comparingInt((PartitionStatistics stats) -> stats.getPriority().getValue()).reversed()
-                        .thenComparing(Comparator.comparing(PartitionStatistics::getCompactionScore).reversed()))
+                .sorted(Comparator.comparingInt((PartitionStatisticsSnapshot stats) -> stats.getPriority().getValue()).reversed()
+                        .thenComparing(Comparator.comparing(PartitionStatisticsSnapshot::getCompactionScore).reversed()))
                 .collect(Collectors.toList());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/Selector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/Selector.java
@@ -22,5 +22,6 @@ import javax.validation.constraints.NotNull;
 
 public interface Selector {
     @NotNull
-    List<PartitionStatistics> select(@NotNull Collection<PartitionStatistics> statistics, @NotNull Set<Long> excludeTables);
+    List<PartitionStatisticsSnapshot> select(@NotNull Collection<PartitionStatistics> statistics,
+                                             @NotNull Set<Long> excludeTables);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/SimpleSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/SimpleSelector.java
@@ -36,12 +36,15 @@ public class SimpleSelector implements Selector {
 
     @Override
     @NotNull
-    public List<PartitionStatistics> select(Collection<PartitionStatistics> statistics, Set<Long> excludeTables) {
+    public List<PartitionStatisticsSnapshot> select(Collection<PartitionStatistics> statistics, Set<Long> excludeTables) {
         long now = System.currentTimeMillis();
         return statistics.stream()
+                .filter(p -> p.getCompactionScore() != null)
                 .filter(p -> p.getNextCompactionTime() <= now)
                 .filter(p -> !excludeTables.contains(p.getPartition().getTableId()))
                 .filter(p -> isReadyForCompaction(p, now))
+                .map(p -> {
+                    return p.getSnapshot(); })
                 .collect(Collectors.toList());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/Sorter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/Sorter.java
@@ -20,5 +20,5 @@ import javax.validation.constraints.NotNull;
 
 public interface Sorter {
     @NotNull
-    List<PartitionStatistics> sort(@NotNull List<PartitionStatistics> partitionStatistics);
+    List<PartitionStatisticsSnapshot> sort(@NotNull List<PartitionStatisticsSnapshot> partitionStatistics);
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
@@ -54,12 +54,14 @@ public class CompactionMgrTest {
 
         Set<Long> excludeTables = new HashSet<>();
         for (int i = 1; i <= Config.lake_compaction_simple_selector_threshold_versions - 1; i++) {
-            compactionManager.handleLoadingFinished(partition1, i, System.currentTimeMillis(), null);
-            compactionManager.handleLoadingFinished(partition2, i, System.currentTimeMillis(), null);
+            compactionManager.handleLoadingFinished(partition1, i, System.currentTimeMillis(),
+                                                    Quantiles.compute(Lists.newArrayList(1d)));
+            compactionManager.handleLoadingFinished(partition2, i, System.currentTimeMillis(),
+                                                    Quantiles.compute(Lists.newArrayList(1d)));
             Assert.assertEquals(0, compactionManager.choosePartitionsToCompact(excludeTables).size());
         }
         compactionManager.handleLoadingFinished(partition1, Config.lake_compaction_simple_selector_threshold_versions,
-                System.currentTimeMillis(), null);
+                System.currentTimeMillis(), Quantiles.compute(Lists.newArrayList(1d)));
         List<PartitionIdentifier> compactionList = compactionManager.choosePartitionsToCompact(excludeTables);
         Assert.assertEquals(1, compactionList.size());
         Assert.assertSame(partition1, compactionList.get(0));
@@ -67,7 +69,7 @@ public class CompactionMgrTest {
         Assert.assertEquals(compactionList, compactionManager.choosePartitionsToCompact(excludeTables));
 
         compactionManager.handleLoadingFinished(partition2, Config.lake_compaction_simple_selector_threshold_versions,
-                System.currentTimeMillis(), null);
+                System.currentTimeMillis(), Quantiles.compute(Lists.newArrayList(1d)));
 
         compactionList = compactionManager.choosePartitionsToCompact(excludeTables);
         Assert.assertEquals(2, compactionList.size());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/PartitionStatisticsSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/PartitionStatisticsSnapshotTest.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.compaction;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+public class PartitionStatisticsSnapshotTest {
+    @Test
+    public void testBasic() {
+        PartitionStatistics statistics = new PartitionStatistics(new PartitionIdentifier(100, 200, 300));
+        Quantiles q1 = new Quantiles(1.0, 2.0, 3.0);
+        statistics.setCompactionScore(q1);
+        statistics.resetPriority();
+        PartitionStatisticsSnapshot stat = new PartitionStatisticsSnapshot(statistics);
+        Assert.assertEquals(stat.getPartition(), statistics.getPartition());
+        Assert.assertEquals(stat.getPriority(), statistics.getPriority());
+        Assert.assertTrue(stat.getCompactionScore().compareTo(statistics.getCompactionScore()) == 0);
+
+        // change does not affect `stat`
+        Quantiles q2 = new Quantiles(4.0, 5.0, 6.0);
+        statistics.setCompactionScore(q2);
+        statistics.setPriority(PartitionStatistics.CompactionPriority.MANUAL_COMPACT);
+        Assert.assertNotEquals(stat.getPriority(), statistics.getPriority());
+        Assert.assertFalse(stat.getCompactionScore().compareTo(statistics.getCompactionScore()) == 0);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/QuantilesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/QuantilesTest.java
@@ -19,6 +19,13 @@ import org.junit.Test;
 
 public class QuantilesTest {
     @Test
+    public void testBasic() {
+        Quantiles q1 = new Quantiles(1.0, 2.0, 3.0);
+        Quantiles q2 = new Quantiles(q1);
+        Assert.assertTrue(q1.compareTo(q2) == 0);
+    }
+
+    @Test
     public void testCompare() {
         // avg
         {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/ScoreSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/ScoreSelectorTest.java
@@ -53,7 +53,7 @@ public class ScoreSelectorTest {
         statistics.setCompactionScore(Quantiles.compute(Collections.singleton(1.1)));
         statisticsList.add(statistics);
 
-        List<PartitionStatistics> targetList = selector.select(statisticsList, new HashSet<Long>());
+        List<PartitionStatisticsSnapshot> targetList = selector.select(statisticsList, new HashSet<Long>());
         Assert.assertEquals(2, targetList.size());
         Assert.assertEquals(5, targetList.get(0).getPartition().getPartitionId());
         Assert.assertEquals(6, targetList.get(1).getPartition().getPartitionId());
@@ -80,7 +80,7 @@ public class ScoreSelectorTest {
         statistics.setCompactionScore(Quantiles.compute(Collections.singleton(1.1)));
         statisticsList.add(statistics);
 
-        List<PartitionStatistics> targetList = selector.select(statisticsList, new HashSet<Long>());
+        List<PartitionStatisticsSnapshot> targetList = selector.select(statisticsList, new HashSet<Long>());
         Assert.assertEquals(4, targetList.size());
         Assert.assertEquals(3, targetList.get(0).getPartition().getPartitionId());
         Assert.assertEquals(4, targetList.get(1).getPartition().getPartitionId());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/ScoreSorterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/ScoreSorterTest.java
@@ -26,26 +26,26 @@ public class ScoreSorterTest {
 
     @Test
     public void test() {
-        List<PartitionStatistics> statisticsList = new ArrayList<>();
+        List<PartitionStatisticsSnapshot> statisticsList = new ArrayList<>();
         PartitionStatistics statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 3));
         statistics.setCompactionScore(Quantiles.compute(Arrays.asList(0.0, 0.0, 0.0)));
-        statisticsList.add(statistics);
+        statisticsList.add(new PartitionStatisticsSnapshot(statistics));
 
         statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 6));
         statistics.setCompactionScore(Quantiles.compute(Arrays.asList(1.1, 1.1, 1.2)));
-        statisticsList.add(statistics);
+        statisticsList.add(new PartitionStatisticsSnapshot(statistics));
 
         statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 4));
         statistics.setCompactionScore(Quantiles.compute(Arrays.asList(0.99, 0.99, 0.99)));
-        statisticsList.add(statistics);
+        statisticsList.add(new PartitionStatisticsSnapshot(statistics));
 
         statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 5));
         statistics.setCompactionScore(Quantiles.compute(Arrays.asList(1.0, 1.0)));
-        statisticsList.add(statistics);
+        statisticsList.add(new PartitionStatisticsSnapshot(statistics));
 
         ScoreSorter sorter = new ScoreSorter();
 
-        List<PartitionStatistics> sortedList = sorter.sort(statisticsList);
+        List<PartitionStatisticsSnapshot> sortedList = sorter.sort(statisticsList);
         Assert.assertEquals(4, sortedList.size());
         Assert.assertEquals(6, sortedList.get(0).getPartition().getPartitionId());
         Assert.assertEquals(5, sortedList.get(1).getPartition().getPartitionId());
@@ -55,31 +55,58 @@ public class ScoreSorterTest {
 
     @Test
     public void testPriority() {
-        List<PartitionStatistics> statisticsList = new ArrayList<>();
-        PartitionStatistics statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 3));
-        statistics.setCompactionScore(Quantiles.compute(Arrays.asList(0.0, 0.0, 0.0)));
-        statisticsList.add(statistics);
+        // no priority
+        {
+            List<PartitionStatisticsSnapshot> statisticsList = new ArrayList<>();
+            PartitionStatistics statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 3));
+            statistics.setCompactionScore(Quantiles.compute(Arrays.asList(0.0, 0.0, 0.0)));
+            statisticsList.add(new PartitionStatisticsSnapshot(statistics));
 
-        statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 4));
-        statistics.setCompactionScore(Quantiles.compute(Arrays.asList(1.1, 1.1, 1.2)));
-        statisticsList.add(statistics);
+            statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 4));
+            statistics.setCompactionScore(Quantiles.compute(Arrays.asList(1.1, 1.1, 1.2)));
+            statisticsList.add(new PartitionStatisticsSnapshot(statistics));
 
-        ScoreSorter sorter = new ScoreSorter();
+            ScoreSorter sorter = new ScoreSorter();
+            List<PartitionStatisticsSnapshot> sortedList = sorter.sort(statisticsList);
+            Assert.assertEquals(4, sortedList.get(0).getPartition().getPartitionId());
+            Assert.assertEquals(3, sortedList.get(1).getPartition().getPartitionId());
+        }
 
-        List<PartitionStatistics> sortedList = sorter.sort(statisticsList);
-        Assert.assertEquals(4, sortedList.get(0).getPartition().getPartitionId());
-        Assert.assertEquals(3, sortedList.get(1).getPartition().getPartitionId());
+        // with priority
+        {
+            List<PartitionStatisticsSnapshot> statisticsList = new ArrayList<>();
+            PartitionStatistics statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 3));
+            statistics.setCompactionScore(Quantiles.compute(Arrays.asList(0.0, 0.0, 0.0)));
+            statistics.setPriority(PartitionStatistics.CompactionPriority.MANUAL_COMPACT);
+            statisticsList.add(new PartitionStatisticsSnapshot(statistics));
 
-        // sort by priority first
-        statisticsList.get(0).setPriority(PartitionStatistics.CompactionPriority.MANUAL_COMPACT);
-        sortedList = sorter.sort(statisticsList);
-        Assert.assertEquals(3, sortedList.get(0).getPartition().getPartitionId());
-        Assert.assertEquals(4, sortedList.get(1).getPartition().getPartitionId());
+            statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 4));
+            statistics.setCompactionScore(Quantiles.compute(Arrays.asList(1.1, 1.1, 1.2)));
+            statisticsList.add(new PartitionStatisticsSnapshot(statistics));
 
-        // when having same priority value, should compare by compaction score
-        statisticsList.get(1).setPriority(PartitionStatistics.CompactionPriority.MANUAL_COMPACT);
-        sortedList = sorter.sort(statisticsList);
-        Assert.assertEquals(4, sortedList.get(0).getPartition().getPartitionId());
-        Assert.assertEquals(3, sortedList.get(1).getPartition().getPartitionId());
+            ScoreSorter sorter = new ScoreSorter();
+            List<PartitionStatisticsSnapshot> sortedList = sorter.sort(statisticsList);
+            Assert.assertEquals(3, sortedList.get(0).getPartition().getPartitionId());
+            Assert.assertEquals(4, sortedList.get(1).getPartition().getPartitionId());
+        }
+
+        // same priority, should sort by compaction score
+        {
+            List<PartitionStatisticsSnapshot> statisticsList = new ArrayList<>();
+            PartitionStatistics statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 3));
+            statistics.setCompactionScore(Quantiles.compute(Arrays.asList(0.0, 0.0, 0.0)));
+            statistics.setPriority(PartitionStatistics.CompactionPriority.MANUAL_COMPACT);
+            statisticsList.add(new PartitionStatisticsSnapshot(statistics));
+
+            statistics = new PartitionStatistics(new PartitionIdentifier(1, 2, 4));
+            statistics.setCompactionScore(Quantiles.compute(Arrays.asList(1.1, 1.1, 1.2)));
+            statistics.setPriority(PartitionStatistics.CompactionPriority.MANUAL_COMPACT);
+            statisticsList.add(new PartitionStatisticsSnapshot(statistics));
+
+            ScoreSorter sorter = new ScoreSorter();
+            List<PartitionStatisticsSnapshot> sortedList = sorter.sort(statisticsList);
+            Assert.assertEquals(4, sortedList.get(0).getPartition().getPartitionId());
+            Assert.assertEquals(3, sortedList.get(1).getPartition().getPartitionId());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/SimpleSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/SimpleSelectorTest.java
@@ -64,16 +64,20 @@ public class SimpleSelectorTest {
         final PartitionIdentifier partitionIdentifier1 = new PartitionIdentifier(1, 2, 3);
         PartitionStatistics statistics1 = new PartitionStatistics(partitionIdentifier1);
         statistics1.setCompactionVersion(new PartitionVersion(1, 0));
+        statistics1.setCompactionScore(new Quantiles(0.0, 0.0, 0.0));
         statistics1.setCurrentVersion(new PartitionVersion(MIN_COMPACTION_VERSIONS, System.currentTimeMillis()));
         statisticsList.add(statistics1);
 
         final PartitionIdentifier partitionIdentifier2 = new PartitionIdentifier(1, 2, 4);
         PartitionStatistics statistics2 = new PartitionStatistics(partitionIdentifier2);
         statistics2.setCompactionVersion(new PartitionVersion(1, 0));
+        statistics2.setCompactionScore(new Quantiles(0.0, 0.0, 0.0));
         statistics2.setCurrentVersion(new PartitionVersion(MIN_COMPACTION_VERSIONS + 1, System.currentTimeMillis()));
         statisticsList.add(statistics2);
 
-        Assert.assertSame(statistics2, selector.select(statisticsList, new HashSet<Long>()).get(0));
+        PartitionStatisticsSnapshot stat = new PartitionStatisticsSnapshot(statistics2);
+        Assert.assertEquals(stat.getPartition(),
+                            selector.select(statisticsList, new HashSet<Long>()).get(0).getPartition());
     }
 
     @Test
@@ -83,15 +87,16 @@ public class SimpleSelectorTest {
         final PartitionIdentifier partitionIdentifier = new PartitionIdentifier(1, 2, 4);
         PartitionStatistics statistics = new PartitionStatistics(partitionIdentifier);
         statistics.setCompactionVersion(new PartitionVersion(1, 0));
+        statistics.setCompactionScore(new Quantiles(0.0, 0.0, 0.0));
         statistics.setCurrentVersion(new PartitionVersion(MIN_COMPACTION_VERSIONS + 1, System.currentTimeMillis()));
         statisticsList.add(statistics);
 
         statistics.setNextCompactionTime(System.currentTimeMillis() + 60 * 1000);
-
         Assert.assertEquals(0, selector.select(statisticsList, new HashSet<Long>()).size());
 
         statistics.setNextCompactionTime(System.currentTimeMillis() - 10);
-
-        Assert.assertSame(statistics, selector.select(statisticsList, new HashSet<Long>()).get(0));
+        PartitionStatisticsSnapshot stat = new PartitionStatisticsSnapshot(statistics);
+        Assert.assertEquals(stat.getPartition(),
+                            selector.select(statisticsList, new HashSet<Long>()).get(0).getPartition());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

get a snapshot of partition info before sort in case compaction score changed during the sort

```
2024-09-14 20:38:33.127Z ERROR (COMPACTION_DISPATCH|258) [Daemon.run():109] daemon thread got exception. name: COMPACTION_DISPATCH
 java.lang.IllegalArgumentException: Comparison method violates its general contract!
         at java.util.TimSort.mergeHi(TimSort.java:903) ~[?:?]
         at java.util.TimSort.mergeAt(TimSort.java:520) ~[?:?]
         at java.util.TimSort.mergeForceCollapse(TimSort.java:461) ~[?:?]
         at java.util.TimSort.sort(TimSort.java:254) ~[?:?]
         at java.util.Arrays.sort(Arrays.java:1307) ~[?:?]
         at java.util.ArrayList.sort(ArrayList.java:1721) ~[?:?]
         at java.util.stream.SortedOps$RefSortingSink.end(SortedOps.java:392) ~[?:?]
         at java.util.stream.Sink$ChainedReference.end(Sink.java:258) ~[?:?]
         at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510) ~[?:?]
         at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
         at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
         at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
         at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
         at com.starrocks.lake.compaction.ScoreSorter.sort(ScoreSorter.java:31) ~[starrocks-fe.jar:?]
         at com.starrocks.lake.compaction.CompactionMgr.choosePartitionsToCompact(CompactionMgr.java:135) ~[starrocks-fe.jar:?]
         at com.starrocks.lake.compaction.CompactionMgr.choosePartitionsToCompact(CompactionMgr.java:130) ~[starrocks-fe.jar:?]
         at com.starrocks.lake.compaction.CompactionScheduler.schedule(CompactionScheduler.java:209) ~[starrocks-fe.jar:?]
         at com.starrocks.lake.compaction.CompactionScheduler.runOneCycle(CompactionScheduler.java:113) ~[starrocks-fe.jar:?]
         at com.starrocks.common.util.Daemon.run(Daemon.java:107) ~[starrocks-fe.jar:?]
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
