### PR TITLE
[Enhancement] Add tablet_metadata_exists to avoid not found exception

### DIFF
--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -46,6 +46,10 @@ Status Tablet::delete_metadata(int64_t version) {
     return _mgr->delete_tablet_metadata(_id, version);
 }
 
+Status Tablet::metadata_exists(int64_t version) {
+    return _mgr->tablet_metadata_exists(_id, version);
+}
+
 Status Tablet::put_txn_log(const TxnLog& log) {
     return _mgr->put_txn_log(log);
 }

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -66,6 +66,8 @@ public:
 
     Status delete_metadata(int64_t version);
 
+    Status metadata_exists(int64_t version);
+
     Status put_txn_log(const TxnLog& log);
 
     Status put_txn_log(const TxnLogPtr& log);

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -280,6 +280,26 @@ Status TabletManager::delete_tablet_metadata(int64_t tablet_id, int64_t version)
     return fs::delete_file(location);
 }
 
+Status TabletManager::tablet_metadata_exists(int64_t tablet_id, int64_t version) {
+    if (version <= kInitialVersion) {
+        // Handle tablet initial metadata
+        auto status = tablet_metadata_exists(tablet_initial_metadata_location(tablet_id));
+        if (status.ok()) {
+            return status;
+        }
+    }
+    return tablet_metadata_exists(tablet_metadata_location(tablet_id, version));
+}
+
+Status TabletManager::tablet_metadata_exists(const std::string& path) {
+    if (auto ptr = _metacache->lookup_tablet_metadata(path); ptr != nullptr) {
+        TRACE("got cached tablet metadata");
+        return Status::OK();
+    }
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
+    return fs->path_exists(path);
+}
+
 StatusOr<TabletMetadataIter> TabletManager::list_tablet_metadata(int64_t tablet_id) {
     std::vector<std::string> objects{};
     // TODO: construct prefix in LocationProvider

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -86,6 +86,12 @@ public:
 
     Status delete_tablet_metadata(int64_t tablet_id, int64_t version);
 
+    // Use this function instead of get_tablet_metadata where you just need to check if tablet metadata exists
+    Status tablet_metadata_exists(int64_t tablet_id, int64_t version);
+
+    // Do not use this function except in a list dir
+    Status tablet_metadata_exists(const std::string& path);
+
     Status put_txn_log(const TxnLog& log);
 
     Status put_txn_log(const TxnLogPtr& log);

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -87,7 +87,7 @@ int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64
     if (index_version > version) {
         // There is a possibility that the index version is newer than the version in remote storage.
         // Check whether the index version exists in remote storage. If not, clear and rebuild the index.
-        auto res = tablet_mgr->get_tablet_metadata(tablet_id, index_version);
+        auto res = tablet_mgr->tablet_metadata_exists(tablet_id, index_version);
         if (res.ok()) {
             version = index_version;
         } else {

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -87,11 +87,13 @@ TEST_F(LakeTabletManagerTest, tablet_meta_write_and_read) {
     rowset_meta_pb->set_data_size(1024);
     rowset_meta_pb->set_num_rows(5);
     EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(_tablet_manager->tablet_metadata_exists(12345, 2));
     auto res = _tablet_manager->get_tablet_metadata(12345, 2);
     EXPECT_TRUE(res.ok());
     EXPECT_EQ(res.value()->id(), 12345);
     EXPECT_EQ(res.value()->version(), 2);
     EXPECT_OK(_tablet_manager->delete_tablet_metadata(12345, 2));
+    EXPECT_STATUS(Status::NotFound(""), _tablet_manager->tablet_metadata_exists(12345, 2));
     res = _tablet_manager->get_tablet_metadata(12345, 2);
     EXPECT_TRUE(res.status().is_not_found());
 }


### PR DESCRIPTION
## Why I'm doing:
Many not found exceptions are thrown when using hdfs to deploy shared-data cluster, causing be.out is very large.

## What I'm doing:
Add tablet_metadata_exists instead of get_tablet_metadata where you just need to check if tablet metadata exists to avoid not found exception.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
