### PR TITLE
[BugFix] Fix checkActionInDb get wrong privileges by ranger

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ranger/starrocks/RangerStarRocksAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ranger/starrocks/RangerStarRocksAccessController.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
 import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.privilege.ObjectType;
 import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.privilege.ranger.RangerAccessController;
 import com.starrocks.qe.ConnectContext;
@@ -162,6 +163,11 @@ public class RangerStarRocksAccessController extends RangerAccessController {
     @Override
     public void checkViewAction(UserIdentity currentUser, Set<Long> roleIds, TableName tableName, PrivilegeType privilegeType)
             throws AccessDeniedException {
+        if (!GlobalStateMgr.getCurrentState().getAuthorizationMgr()
+                .isAvailablePrivType(ObjectType.VIEW, privilegeType)) {
+            return;
+        }
+
         hasPermission(
                 RangerStarRocksResource.builder()
                         .setCatalog(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)
@@ -209,6 +215,11 @@ public class RangerStarRocksAccessController extends RangerAccessController {
     @Override
     public void checkMaterializedViewAction(UserIdentity currentUser, Set<Long> roleIds, TableName tableName,
                                             PrivilegeType privilegeType) throws AccessDeniedException {
+        if (!GlobalStateMgr.getCurrentState().getAuthorizationMgr()
+                .isAvailablePrivType(ObjectType.MATERIALIZED_VIEW, privilegeType)) {
+            return;
+        }
+
         hasPermission(
                 RangerStarRocksResource.builder()
                         .setCatalog(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)


### PR DESCRIPTION
## Why I'm doing:
get wrong privileges by ranger.

Through the logs, it tries to get the insert permission for the materialized view, while the mv doesn't have this privilege.
so skip it.
```
RangerStarRocksAccessRequest | RangerAccessRequestImpl={resource={RangerResourceImpl={ownerUser={null} elements={database=example_db; catalog=default_catalog; materialized_view=order_mv; } }} accessType={insert} user={root} userGroups={} userRoles={} accessTime={Wed Sep 18 21:41:19 CST 2024} clientIPAddress={%} forwardedAddresses={} remoteIPAddress={null} clientType={starrocks} action={null} requestData={null} sessionId={null} resourceMatchingScope={SELF} clusterName={starrocks} clusterType={null} context={} }
```

## What I'm doing:

Fixes #51124

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
