### PR TITLE
[BugFix] Fix CTE lowcardinality array couldn't found DictExpr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -45,6 +45,7 @@ public class MultiCastPlanFragment extends PlanFragment {
         this.children.addAll(planFragment.getChildren());
         this.setLoadGlobalDicts(planFragment.loadGlobalDicts);
         this.setQueryGlobalDicts(planFragment.queryGlobalDicts);
+        this.setQueryGlobalDictExprs(planFragment.queryGlobalDictExprs);
     }
 
     public List<PlanFragment> getDestFragmentList() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -175,6 +175,17 @@ public class LowCardinalityArrayTest extends PlanTestBase {
     }
 
     @Test
+    public void testWithCTE() throws Exception {
+        connectContext.getSessionVariable().setCboCteReuse(true);
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        String sql = "with cte as (select * from supplier_nullable, unnest(S_ADDRESS)) " +
+                "select * from cte union all select * from cte";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "41: DictDefine(39: S_ADDRESS, [<place-holder>])");
+        connectContext.getSessionVariable().setCboCteReuse(false);
+    }
+
+    @Test
     public void testArrayPredicate3() throws Exception {
         String sql = "select S_ADDRESS from supplier_nullable where S_ADDRESS = ['a', 'b']";
         String plan = getVerboseExplain(sql);


### PR DESCRIPTION
## Why I'm doing:
reproduce case:
```
 CREATE TABLE `uid_connections` (
  `uid` int(11) NOT NULL COMMENT "",
  `connections` array<varchar(65533)> NOT NULL COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`uid`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`uid`) BUCKETS 4 
PROPERTIES (
"compression" = "LZ4",
"fast_schema_evolution" = "true",
"replicated_storage" = "false",
"replication_num" = "1"
);

insert into uid_connections values (1, ['k1','k2','k3']);
set cbo_cte_reuse_rate=0;

with tmp as (select * from (select * from uid_connections)t, unnest(connections) where unnest in ('k1','k2','k3')) select *
from tmp union all select* from tmp;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
