### PR TITLE
[BugFix] Fix concurrentModificationException in materializedViewMetricsRegistry

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
@@ -16,7 +16,6 @@ package com.starrocks.metric;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.Maps;
 import com.starrocks.catalog.MvId;
 import com.starrocks.common.Config;
 import com.starrocks.common.ThreadPoolManager;
@@ -26,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -33,12 +33,12 @@ public class MaterializedViewMetricsRegistry {
     private static final Logger LOG = LogManager.getLogger(MaterializedViewMetricsRegistry.class);
 
     private final MetricRegistry metricRegistry = new MetricRegistry();
-    private final Map<MvId, MaterializedViewMetricsEntity> idToMVMetrics;
+    private final ConcurrentHashMap<MvId, MaterializedViewMetricsEntity> idToMVMetrics;
     private final ScheduledThreadPoolExecutor timer;
     private static final MaterializedViewMetricsRegistry INSTANCE = new MaterializedViewMetricsRegistry();
 
     private MaterializedViewMetricsRegistry() {
-        idToMVMetrics = Maps.newHashMap();
+        idToMVMetrics = new ConcurrentHashMap<>();
         // clear all metrics everyday
         timer = ThreadPoolManager.newDaemonScheduledThreadPool(1, "MaterializedView-Metrics-Cleaner", true);
         // add initial delay to avoid all metrics are cleared at the same time


### PR DESCRIPTION
## Why I'm doing:

A ConcurrentModificationException is thrown when collecting materialized view metrics due to concurrent modifications of the idToMVMetrics map in MaterializedViewMetricsRegistry. This exception disrupts metric collection and logs unnecessary warnings.

## What I'm doing:

Replaced the non-thread-safe HashMap with ConcurrentHashMap for the idToMVMetrics map to ensure thread-safe operations. This change prevents ConcurrentModificationException when the map is accessed concurrently by multiple threads.

Fixes #51140

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
