### PR TITLE
[BugFix] fix tablet writer add chunk when larger than 2GB

### DIFF
--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -673,9 +673,9 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             }
             auto closure = _add_batch_closures[_current_request_index];
             serialize_to_iobuf<PTabletWriterAddChunksRequest>(request, &closure->cntl.request_attachment());
-            PHttpRequest fake_request;
-            res.value()->tablet_writer_add_chunks_via_http(&closure->cntl, &fake_request, &closure->result, closure);
-            VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = " << request.ByteSizeLong();
+            res.value()->tablet_writer_add_chunks_via_http(&closure->cntl, nullptr, &closure->result, closure);
+            VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = "
+                    << closure->cntl.request_attachment().size();
         } else {
             _stub->tablet_writer_add_chunks(&_add_batch_closures[_current_request_index]->cntl, &request,
                                             &_add_batch_closures[_current_request_index]->result,
@@ -695,9 +695,9 @@ Status NodeChannel::_send_request(bool eos, bool finished) {
             auto closure = _add_batch_closures[_current_request_index];
             serialize_to_iobuf<PTabletWriterAddChunkRequest>(*request.mutable_requests(0),
                                                              &closure->cntl.request_attachment());
-            PHttpRequest fake_request;
-            res.value()->tablet_writer_add_chunk_via_http(&closure->cntl, &fake_request, &closure->result, closure);
-            VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = " << request.ByteSizeLong();
+            res.value()->tablet_writer_add_chunk_via_http(&closure->cntl, nullptr, &closure->result, closure);
+            VLOG(2) << "NodeChannel::_send_request() issue a http rpc, request size = "
+                    << closure->cntl.request_attachment().size();
         } else {
             _stub->tablet_writer_add_chunk(
                     &_add_batch_closures[_current_request_index]->cntl, request.mutable_requests(0),

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -548,6 +548,15 @@ Status NodeChannel::_filter_indexes_with_where_expr(Chunk* input, const std::vec
     return Status::OK();
 }
 
+// Seperate chunk from protobuf, so `SerializeToZeroCopyStream` won't fail because of >2GB serialize.
+//
+// IOBuf format:
+// | protobuf len |
+// | protobuf (without chunk) |
+// | chunk (1) |
+// | chunk (2) |
+// | chunk (...) |
+// | chunk (N) |
 template <typename T>
 void serialize_to_iobuf(T& proto_obj, butil::IOBuf* iobuf) {
     butil::IOBuf proto_iobuf; // used for store protbuf serialize data

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -48,7 +48,7 @@ class OlapTableSink;    // forward declaration
 class TabletSinkSender; // forward declaration
 
 template <typename T>
-void serialize_to_iobuf(const T& proto_obj, butil::IOBuf* iobuf);
+void serialize_to_iobuf(T& proto_obj, butil::IOBuf* iobuf);
 
 // The counter of add_batch rpc of a single node
 struct AddBatchCounter {

--- a/be/src/service/service_be/internal_service.cpp
+++ b/be/src/service/service_be/internal_service.cpp
@@ -98,21 +98,39 @@ void BackendInternalServiceImpl<T>::tablet_writer_add_chunks(google::protobuf::R
 
 template <typename T>
 static bool parse_from_iobuf(butil::IOBuf& iobuf, T* proto_obj) {
-    // deserialize
-    size_t request_size = 0;
-    if (!iobuf.cutn(&request_size, sizeof(request_size))) {
-        LOG(ERROR) << "Failed to read request size";
+    // 1. deserialize protobuf
+    size_t protobuf_size = 0;
+    if (!iobuf.cutn(&protobuf_size, sizeof(protobuf_size))) {
+        LOG(ERROR) << "Failed to read protobuf_size";
         return false;
     }
-    butil::IOBuf request_from;
-    if (!iobuf.cutn(&request_from, request_size)) {
-        LOG(ERROR) << "Failed to cut the required size from the io buffer";
+    butil::IOBuf protobuf_buf;
+    if (!iobuf.cutn(&protobuf_buf, protobuf_size)) {
+        LOG(ERROR) << "Failed to cut the protobuf_size from the io buffer";
         return false;
     }
-    butil::IOBufAsZeroCopyInputStream wrapper(request_from);
+    butil::IOBufAsZeroCopyInputStream wrapper(protobuf_buf);
     if (!proto_obj->ParseFromZeroCopyStream(&wrapper)) {
-        LOG(ERROR) << "Failed to parse the request";
+        LOG(ERROR) << "Failed to parse the protobuf";
         return false;
+    }
+    // 2. deserialize chunks
+    if constexpr (std::is_same<T, PTabletWriterAddChunkRequest>::value) {
+        auto chunk = proto_obj->mutable_chunk();
+        auto size = iobuf.cutn(chunk->mutable_data(), chunk->data_size());
+        if (size != chunk->data_size()) {
+            LOG(ERROR) << fmt::format("iobuf read {} != expected {}.", size, chunk->data_size());
+            return false;
+        }
+    } else if constexpr (std::is_same<T, PTabletWriterAddChunksRequest>::value) {
+        for (int i = 0; i < proto_obj->requests_size(); i++) {
+            auto chunk = proto_obj->mutable_requests(i)->mutable_chunk();
+            auto size = iobuf.cutn(chunk->mutable_data(), chunk->data_size());
+            if (size != chunk->data_size()) {
+                LOG(ERROR) << fmt::format("iobuf read {} != expected {}.", size, chunk->data_size());
+                return false;
+            }
+        }
     }
     return true;
 }

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -163,7 +163,7 @@ public:
         }
         // create
         auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint);
-        if (!stub->reset_channel().ok()) {
+        if (!stub->reset_channel("http").ok()) {
             return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
                                         std::to_string(taddr.port));
         }

--- a/be/src/util/internal_service_recoverable_stub.cpp
+++ b/be/src/util/internal_service_recoverable_stub.cpp
@@ -49,13 +49,18 @@ PInternalService_RecoverableStub::PInternalService_RecoverableStub(const butil::
 
 PInternalService_RecoverableStub::~PInternalService_RecoverableStub() = default;
 
-Status PInternalService_RecoverableStub::reset_channel() {
+Status PInternalService_RecoverableStub::reset_channel(const std::string protocal) {
     std::lock_guard<std::mutex> l(_mutex);
     brpc::ChannelOptions options;
     options.connect_timeout_ms = config::rpc_connect_timeout_ms;
+    if (protocal == "http") {
+        options.protocol = protocal;
+    } else {
+        // http does not support these.
+        options.connection_type = config::brpc_connection_type;
+        options.connection_group = std::to_string(_connection_group++);
+    }
     options.max_retry = 3;
-    options.connection_type = config::brpc_connection_type;
-    options.connection_group = std::to_string(_connection_group++);
     std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
     if (channel->Init(_endpoint, &options)) {
         LOG(WARNING) << "Fail to init channel " << _endpoint;

--- a/be/src/util/internal_service_recoverable_stub.cpp
+++ b/be/src/util/internal_service_recoverable_stub.cpp
@@ -49,7 +49,7 @@ PInternalService_RecoverableStub::PInternalService_RecoverableStub(const butil::
 
 PInternalService_RecoverableStub::~PInternalService_RecoverableStub() = default;
 
-Status PInternalService_RecoverableStub::reset_channel(const std::string protocal) {
+Status PInternalService_RecoverableStub::reset_channel(const std::string& protocal) {
     std::lock_guard<std::mutex> l(_mutex);
     brpc::ChannelOptions options;
     options.connect_timeout_ms = config::rpc_connect_timeout_ms;

--- a/be/src/util/internal_service_recoverable_stub.cpp
+++ b/be/src/util/internal_service_recoverable_stub.cpp
@@ -49,12 +49,12 @@ PInternalService_RecoverableStub::PInternalService_RecoverableStub(const butil::
 
 PInternalService_RecoverableStub::~PInternalService_RecoverableStub() = default;
 
-Status PInternalService_RecoverableStub::reset_channel(const std::string& protocal) {
+Status PInternalService_RecoverableStub::reset_channel(const std::string& protocol) {
     std::lock_guard<std::mutex> l(_mutex);
     brpc::ChannelOptions options;
     options.connect_timeout_ms = config::rpc_connect_timeout_ms;
-    if (protocal == "http") {
-        options.protocol = protocal;
+    if (protocol == "http") {
+        options.protocol = protocol;
     } else {
         // http does not support these.
         options.connection_type = config::brpc_connection_type;

--- a/be/src/util/internal_service_recoverable_stub.h
+++ b/be/src/util/internal_service_recoverable_stub.h
@@ -29,7 +29,7 @@ public:
     PInternalService_RecoverableStub(const butil::EndPoint& endpoint);
     ~PInternalService_RecoverableStub();
 
-    Status reset_channel(const std::string protocal = "");
+    Status reset_channel(const std::string& protocal = "");
 
 #ifdef BE_TEST
     PInternalService_Stub* stub() { return _stub.get(); }

--- a/be/src/util/internal_service_recoverable_stub.h
+++ b/be/src/util/internal_service_recoverable_stub.h
@@ -29,7 +29,7 @@ public:
     PInternalService_RecoverableStub(const butil::EndPoint& endpoint);
     ~PInternalService_RecoverableStub();
 
-    Status reset_channel();
+    Status reset_channel(const std::string protocal = "");
 
 #ifdef BE_TEST
     PInternalService_Stub* stub() { return _stub.get(); }

--- a/be/src/util/internal_service_recoverable_stub.h
+++ b/be/src/util/internal_service_recoverable_stub.h
@@ -29,7 +29,7 @@ public:
     PInternalService_RecoverableStub(const butil::EndPoint& endpoint);
     ~PInternalService_RecoverableStub();
 
-    Status reset_channel(const std::string& protocal = "");
+    Status reset_channel(const std::string& protocol = "");
 
 #ifdef BE_TEST
     PInternalService_Stub* stub() { return _stub.get(); }


### PR DESCRIPTION
## Why I'm doing:
There two issues now when handle >2GB chunk:

1. `starrocks.PTabletWriterAddChunksRequest exceeded maximum protobuf size of 2GB: 4194416177`
```
void serialize_to_iobuf(const T& proto_obj, butil::IOBuf* iobuf) {
    butil::IOBuf tmp_iobuf;
    butil::IOBufAsZeroCopyOutputStream wrapper(&tmp_iobuf);
    proto_obj.SerializeToZeroCopyStream(&wrapper);
```

`SerializeToZeroCopyStream` will fail when handle >2GB chunk.

2. In previous pr #40229, It introduced a bug about missing set `http` protocol for BRPC client.
```
 input_messenger.cpp:96] A message from 172.26.94.64:39672(protocol=baidu_std) is bigger than 2147483648 bytes, the connection will be closed. Set max_body_size to allow bigger messages
```

## What I'm doing:
Fix these two issues:
1. Seperate chunk from protobuf, so `SerializeToZeroCopyStream` won't fail because of >2GB serialize.
2. Set http protocol for `brpc::ChannelOptions` when handle >2GB RPC.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
