### PR TITLE
[BugFix] Fix stream load load_finish_time updated unexpected after transaction committed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -145,6 +145,8 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
     private long startPreparingTimeMs;
     @SerializedName(value = "finishPreparingTimeMs")
     private long finishPreparingTimeMs;
+    @SerializedName(value = "commitTimeMs")
+    private long commitTimeMs;
     @SerializedName(value = "endTimeMs")
     private long endTimeMs;
     @SerializedName(value = "txnId")
@@ -616,7 +618,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         boolean exception = false;
         writeLock();
         try {
-            if (isFinalState()) {
+            if (isUnreversibleState()) {
                 if (state == State.CANCELLED) {
                     resp.setOKMsg("txn could not be prepared because task state is: " + state
                             + ", error_msg: " + errorMsg);
@@ -688,7 +690,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         boolean exception = false;
         readLock();
         try {
-            if (isFinalState()) {
+            if (isUnreversibleState()) {
                 if (state == State.CANCELLED) {
                     resp.setOKMsg("txn could not be committed because task state is: " + state
                             + ", error_msg: " + errorMsg);
@@ -868,7 +870,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         }
         readLock();
         try {
-            if (isFinalState()) {
+            if (isUnreversibleState()) {
                 if (state == State.CANCELLED) {
                     return "cur task state is: " + state
                             + ", error_msg: " + errorMsg;
@@ -956,7 +958,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
     public void beforePrepared(TransactionState txnState) throws TransactionException {
         writeLock();
         try {
-            if (isFinalState()) {
+            if (isUnreversibleState()) {
                 throw new TransactionException("txn could not be prepared because task state is: " + state);
             }
         } finally {
@@ -1000,7 +1002,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
     public void beforeCommitted(TransactionState txnState) throws TransactionException {
         writeLock();
         try {
-            if (isFinalState()) {
+            if (isUnreversibleState()) {
                 throw new TransactionException("txn could not be commited because task state is: " + state);
             }
             isCommitting = true;
@@ -1026,8 +1028,8 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                 this.channels.set(i, State.COMMITED);
             }
             this.state = State.COMMITED;
+            commitTimeMs = System.currentTimeMillis();
             isCommitting = false;
-            endTimeMs = System.currentTimeMillis();
         } finally {
             writeUnlock();
             // sync stream load related query info should unregister here
@@ -1118,8 +1120,8 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                 this.channels.set(i, State.COMMITED);
             }
             this.state = State.COMMITED;
+            commitTimeMs = txnState.getCommitTime();
             this.preparedChannelNum = this.channelNum;
-            this.endTimeMs = txnState.getCommitTime();
         } finally {
             writeUnlock();
         }
@@ -1138,7 +1140,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
 
         writeLock();
         try {
-            if (isFinalState()) {
+            if (isUnreversibleState()) {
                 return;
             }
             if (coord != null && !isSyncStreamLoad) {
@@ -1279,11 +1281,19 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         return createTimeMs;
     }
 
+    public long commitTimeMs() {
+        return commitTimeMs;
+    }
+
     public long endTimeMs() {
         return endTimeMs;
     }
 
     public boolean isFinalState() {
+        return state == State.CANCELLED || state == State.FINISHED;
+    }
+
+    public boolean isUnreversibleState() {
         return state == State.CANCELLED || state == State.COMMITED || state == State.FINISHED;
     }
 
@@ -1528,7 +1538,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
 
             info.setCreate_time(TimeUtils.longToTimeString(createTimeMs));
             info.setLoad_start_time(TimeUtils.longToTimeString(startLoadingTimeMs));
-            info.setLoad_commit_time(TimeUtils.longToTimeString(finishPreparingTimeMs));
+            info.setLoad_commit_time(TimeUtils.longToTimeString(commitTimeMs));
             info.setLoad_finish_time(TimeUtils.longToTimeString(endTimeMs));
 
             info.setType(getStringByType());

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
@@ -300,14 +300,13 @@ public class StreamLoadManagerTest {
 
         TransactionState state = new TransactionState();
         task.afterCommitted(state, true);
-        Assert.assertNotEquals(-1, task.endTimeMs());
+        Assert.assertNotEquals(-1, task.commitTimeMs());
 
-        state.setCommitTime(task.endTimeMs());
-        task.replayOnCommitted(state);
-        Assert.assertEquals(task.endTimeMs(), state.getCommitTime());
+        Assert.assertTrue(task.isUnreversibleState());
+        Assert.assertFalse(task.isFinalState());
 
         streamLoadManager.cleanSyncStreamLoadTasks();
-        Assert.assertEquals(0, streamLoadManager.getStreamLoadTaskCount());
+        Assert.assertEquals(1, streamLoadManager.getStreamLoadTaskCount());
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:
```
mysql> select * from _statistics_.loads_history where label='stream_load_1726737200632_4eM'\G;
*************************** 1. row ***************************
                  id: 20038
               label: stream_load_1726737200632_4eM
          profile_id: NULL
             db_name: ingestion_db
          table_name: duplicate_200_column_7CR
                user: root
           warehouse: NULL
               state: COMMITED
            progress: 0%
                type: STREAM_LOAD
            priority: NORMAL
           scan_rows: 0
          scan_bytes: -1
       filtered_rows: -1
     unselected_rows: -1
           sink_rows: -1
     runtime_details: {"begin_txn_time_ms": 0, "client_ip": "172.26.93.220", "load_id": "6648aa87-3649-e16b-8446-79b1dbf473b5", "plan_time_ms": 0, "receive_data_time_ms": 0, "txn_id": 8234}
         create_time: 2024-09-19 17:13:20
     load_start_time: NULL
    load_commit_time: NULL
    load_finish_time: 2024-09-19 17:13:46
          properties: {"timeout": 3600}
           error_msg: NULL
        tracking_sql: select tracking_log from information_schema.load_tracking_logs where job_id=20038
rejected_record_path: NULL
              job_id: 20038
*************************** 2. row ***************************
                  id: 20038
               label: stream_load_1726737200632_4eM
          profile_id: NULL
             db_name: ingestion_db
          table_name: duplicate_200_column_7CR
                user: root
           warehouse: NULL
               state: FINISHED
            progress: 100%
                type: STREAM_LOAD
            priority: NORMAL
           scan_rows: 0
          scan_bytes: 4849
       filtered_rows: 0
     unselected_rows: 0
           sink_rows: 1
     runtime_details: {"begin_txn_time_ms": 0, "client_ip": "172.26.93.220", "load_id": "6648aa87-3649-e16b-8446-79b1dbf473b5", "plan_time_ms": 8, "receive_data_time_ms": 0, "txn_id": 8234}
         create_time: 2024-09-19 17:13:20
     load_start_time: NULL
    load_commit_time: NULL
    load_finish_time: 2024-09-19 17:16:10
          properties: {"timeout": 3600}
           error_msg:
        tracking_sql: NULL
rejected_record_path: NULL
              job_id: 20038
2 rows in set (0.02 sec)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
