### PR TITLE
[Enhancement] split chunk of HashTable

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -1003,6 +1003,11 @@ else()
     message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
 endif()
 
+if (NOT BUILD_FORMAT_LIB)
+    # skip the STARROCKS_MEMORY_DEPENDENCIES_LIBS only when BUILD_FORMAT_LIB=ON
+    set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} ${STARROCKS_MEMORY_DEPENDENCIES_LIBS})
+endif()
+
 if (NOT ("${MAKE_TEST}" STREQUAL "ON" AND "${BUILD_FOR_SANITIZE}" STREQUAL "ON"))
     # In other words, turn to dynamic link when MAKE_TEST and BUILD_TYPE == *SAN
     # otherwise do static link gcc's lib

--- a/be/src/bench/shuffle_chunk_bench.cpp
+++ b/be/src/bench/shuffle_chunk_bench.cpp
@@ -16,14 +16,15 @@
 #include <testutil/assert.h>
 
 #include <memory>
+#include <random>
 
 #include "column/chunk.h"
 #include "column/column_helper.h"
-#include "column/datum_tuple.h"
+#include "column/vectorized_fwd.h"
 #include "common/config.h"
-#include "runtime/chunk_cursor.h"
-#include "runtime/runtime_state.h"
 #include "runtime/types.h"
+#include "storage/chunk_helper.h"
+#include "types/logical_type.h"
 
 namespace starrocks {
 
@@ -196,6 +197,136 @@ static void bench_func(benchmark::State& state) {
     perf.do_bench(state);
 }
 
+class SegmentedChunkPerf {
+public:
+    SegmentedChunkPerf() = default;
+
+    void do_bench_segmented_chunk_clone(benchmark::State& state) {
+        // std::cerr << "chunk_size: " << _dest_chunk_size << std::endl;
+        // std::cerr << "segment_size: " << _segment_size << std::endl;
+        // std::cerr << "segmented_chunk_size: " << _segment_chunk_size << std::endl;
+
+        state.PauseTiming();
+        SegmentedChunkPtr seg_chunk = prepare_chunk();
+        CHECK_EQ(seg_chunk->num_rows(), _segment_chunk_size);
+
+        // random select
+        std::vector<uint32_t> select;
+        random_select(select, _dest_chunk_size, seg_chunk->num_rows());
+        state.ResumeTiming();
+
+        // clone_selective
+        size_t items = 0;
+        for (auto _ : state) {
+            for (auto& column : seg_chunk->columns()) {
+                auto cloned = column->clone_selective(select.data(), 0, select.size());
+            }
+            items += select.size();
+        }
+        state.SetItemsProcessed(items);
+    }
+
+    void do_bench_chunk_clone(benchmark::State& state) {
+        state.PauseTiming();
+        ChunkPtr chunk = build_chunk(_segment_size);
+        CHECK_EQ(chunk->num_rows(), _segment_size);
+        std::vector<uint32_t> select;
+        random_select(select, _dest_chunk_size, chunk->num_rows());
+        state.ResumeTiming();
+
+        size_t items = 0;
+        for (auto _ : state) {
+            ChunkPtr empty = chunk->clone_empty();
+            empty->append_selective(*chunk, select.data(), 0, select.size());
+            items += select.size();
+        }
+        state.SetItemsProcessed(items);
+    }
+
+    SegmentedChunkPtr prepare_chunk() {
+        if (_seg_chunk) {
+            return _seg_chunk;
+        }
+        ChunkPtr chunk = build_chunk(_dest_chunk_size);
+
+        for (int i = 0; i < (_segment_chunk_size / _dest_chunk_size); i++) {
+            if (!_seg_chunk) {
+                _seg_chunk = SegmentedChunk::create(_segment_size);
+                ChunkPtr chunk = build_chunk(_dest_chunk_size);
+                auto map = chunk->get_slot_id_to_index_map();
+                for (auto entry : map) {
+                    _seg_chunk->append_column(chunk->get_column_by_slot_id(entry.first), entry.first);
+                }
+                _seg_chunk->build_columns();
+            } else {
+                // std::cerr << " append " << chunk->num_rows() << "rows, become " << _seg_chunk->num_rows() << std::endl;
+                _seg_chunk->append_chunk(chunk);
+            }
+        }
+        return _seg_chunk;
+    }
+
+    void random_select(std::vector<uint32_t>& select, size_t count, size_t range) {
+        select.resize(count);
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dis(0, range - 1);
+        std::generate(select.begin(), select.end(), [&]() { return dis(gen); });
+    }
+
+    ChunkPtr build_chunk(size_t chunk_size) {
+        auto chunk = std::make_unique<Chunk>();
+        for (int i = 0; i < _column_count; i++) {
+            if (i % 2 == 0) {
+                _types.emplace_back(TypeDescriptor::create_varchar_type(128));
+            } else {
+                _types.emplace_back(LogicalType::TYPE_INT);
+            }
+            auto col = init_dest_column(_types[i], chunk_size);
+            chunk->append_column(col, i);
+        }
+        return chunk;
+    }
+
+    ColumnPtr init_dest_column(const TypeDescriptor& type, size_t chunk_size) {
+        auto c1 = ColumnHelper::create_column(type, true);
+        c1->reserve(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            if (type.is_string_type()) {
+                std::string str = fmt::format("str{}", i);
+                c1->append_datum(Slice(str));
+            } else if (type.is_integer_type()) {
+                c1->append_datum(i);
+            } else {
+                CHECK(false) << "not supported";
+            }
+        }
+        return c1;
+    }
+
+private:
+    int _column_count = 4;
+    size_t _dest_chunk_size = 4096;
+    size_t _segment_size = 65536;
+    size_t _num_segments = 10;
+    size_t _segment_chunk_size = _segment_size * _num_segments;
+
+    SegmentedChunkPtr _seg_chunk;
+    std::vector<TypeDescriptor> _types;
+};
+
+static void bench_segmented_chunk_clone(benchmark::State& state) {
+    google::InstallFailureSignalHandler();
+    SegmentedChunkPerf perf;
+    perf.do_bench_segmented_chunk_clone(state);
+}
+
+static void bench_chunk_clone(benchmark::State& state) {
+    google::InstallFailureSignalHandler();
+    SegmentedChunkPerf perf;
+    perf.do_bench_chunk_clone(state);
+}
+
 static void process_args(benchmark::internal::Benchmark* b) {
     // chunk_count, column_count, node_count, src_chunk_size, null percent
     b->Args({400, 400, 140, 4096, 80});
@@ -226,6 +357,9 @@ static void process_args(benchmark::internal::Benchmark* b) {
 }
 
 BENCHMARK(bench_func)->Apply(process_args);
+
+BENCHMARK(bench_chunk_clone);
+BENCHMARK(bench_segmented_chunk_clone);
 
 } // namespace starrocks
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -47,7 +47,15 @@ void BinaryColumnBase<T>::check_or_die() const {
 }
 
 template <typename T>
+void BinaryColumnBase<T>::append(const Slice& str) {
+    _bytes.insert(_bytes.end(), str.data, str.data + str.size);
+    _offsets.emplace_back(_bytes.size());
+    _slices_cache = false;
+}
+
+template <typename T>
 void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count) {
+    DCHECK(offset + count <= src.size());
     const auto& b = down_cast<const BinaryColumnBase<T>&>(src);
     const unsigned char* p = &b._bytes[b._offsets[offset]];
     const unsigned char* e = &b._bytes[b._offsets[offset + count]];

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -32,7 +32,7 @@ public:
 
     using Offset = T;
     using Offsets = Buffer<T>;
-
+    using Byte = uint8_t;
     using Bytes = starrocks::raw::RawVectorPad16<uint8_t, ColumnAllocator<uint8_t>>;
 
     struct BinaryDataProxyContainer {
@@ -172,11 +172,7 @@ public:
     // No complain about the overloaded-virtual for this function
     DIAGNOSTIC_PUSH
     DIAGNOSTIC_IGNORE("-Woverloaded-virtual")
-    void append(const Slice& str) {
-        _bytes.insert(_bytes.end(), str.data, str.data + str.size);
-        _offsets.emplace_back(_bytes.size());
-        _slices_cache = false;
-    }
+    void append(const Slice& str);
     DIAGNOSTIC_POP
 
     void append_datum(const Datum& datum) override {

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -25,6 +25,7 @@
 #include "column/vectorized_fwd.h"
 #include "gutil/casts.h"
 #include "simd/simd.h"
+#include "storage/chunk_helper.h"
 #include "types/logical_type_infra.h"
 #include "util/date_func.h"
 #include "util/percentile_value.h"
@@ -465,7 +466,7 @@ size_t ChunkSliceTemplate<Ptr>::skip(size_t skip_rows) {
 
 // Cutoff required rows from this chunk
 template <class Ptr>
-Ptr ChunkSliceTemplate<Ptr>::cutoff(size_t required_rows) {
+ChunkUniquePtr ChunkSliceTemplate<Ptr>::cutoff(size_t required_rows) {
     DCHECK(!empty());
     size_t cut_rows = std::min(rows(), required_rows);
     auto res = chunk->clone_empty(cut_rows);
@@ -478,7 +479,35 @@ Ptr ChunkSliceTemplate<Ptr>::cutoff(size_t required_rows) {
     return res;
 }
 
+// Specialized for SegmentedChunkPtr
+template <>
+ChunkUniquePtr ChunkSliceTemplate<SegmentedChunkPtr>::cutoff(size_t required_rows) {
+    DCHECK(!empty());
+    // cutoff a chunk from current segment, if it doesn't meet the requirement just let it be
+    ChunkPtr segment = chunk->segments()[segment_id];
+    size_t segment_offset = offset % chunk->segment_size();
+    size_t cut_rows = std::min(segment->num_rows() - segment_offset, required_rows);
+
+    auto res = segment->clone_empty(cut_rows);
+    res->append(*segment, segment_offset, cut_rows);
+    offset += cut_rows;
+
+    // move to next segment and release previous one
+    size_t new_segment_id = offset / chunk->segment_size();
+    if (new_segment_id != segment_id) {
+        chunk->segments()[segment_id].reset();
+        segment_id = new_segment_id;
+    }
+
+    if (empty()) {
+        chunk.reset();
+        offset = 0;
+    }
+    return res;
+}
+
 template struct ChunkSliceTemplate<ChunkPtr>;
 template struct ChunkSliceTemplate<ChunkUniquePtr>;
+template struct ChunkSliceTemplate<SegmentedChunkPtr>;
 
 } // namespace starrocks

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -492,15 +492,11 @@ ChunkUniquePtr ChunkSliceTemplate<SegmentedChunkPtr>::cutoff(size_t required_row
     res->append(*segment, segment_offset, cut_rows);
     offset += cut_rows;
 
-    // move to next segment and release previous one
-    size_t new_segment_id = offset / chunk->segment_size();
-    if (new_segment_id != segment_id) {
-        chunk->segments()[segment_id].reset();
-        segment_id = new_segment_id;
-    }
+    // move to next segment
+    segment_id = offset / chunk->segment_size();
 
     if (empty()) {
-        chunk.reset();
+        chunk->reset();
         offset = 0;
     }
     return res;

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -372,8 +372,6 @@ public:
         }
     }
 
-    static SegmentedColumnPtr get_data_column(SegmentedColumnPtr column);
-
     static BinaryColumn* get_binary_column(Column* column) { return down_cast<BinaryColumn*>(get_data_column(column)); }
 
     static bool is_all_const(const Columns& columns);
@@ -538,12 +536,13 @@ public:
 template <class Ptr = ChunkUniquePtr>
 struct ChunkSliceTemplate {
     Ptr chunk;
+    size_t segment_id = 0;
     size_t offset = 0;
 
     bool empty() const;
     size_t rows() const;
     size_t skip(size_t skip_rows);
-    Ptr cutoff(size_t required_rows);
+    ChunkUniquePtr cutoff(size_t required_rows);
     void reset(Ptr input);
 };
 
@@ -573,5 +572,6 @@ APPLY_FOR_ALL_STRING_TYPE(GET_CONTAINER)
 
 using ChunkSlice = ChunkSliceTemplate<ChunkUniquePtr>;
 using ChunkSharedSlice = ChunkSliceTemplate<ChunkPtr>;
+using SegmentedChunkSlice = ChunkSliceTemplate<SegmentedChunkPtr>;
 
 } // namespace starrocks

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -372,6 +372,8 @@ public:
         }
     }
 
+    static SegmentedColumnPtr get_data_column(SegmentedColumnPtr column);
+
     static BinaryColumn* get_binary_column(Column* column) { return down_cast<BinaryColumn*>(get_data_column(column)); }
 
     static bool is_all_const(const Columns& columns);

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -26,6 +26,8 @@ class ConstColumn final : public ColumnFactory<Column, ConstColumn> {
     friend class ColumnFactory<Column, ConstColumn>;
 
 public:
+    using ValueType = void;
+
     explicit ConstColumn(ColumnPtr data_column);
     ConstColumn(ColumnPtr data_column, size_t size);
 

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -33,6 +33,8 @@ class NullableColumn : public ColumnFactory<Column, NullableColumn> {
     friend class ColumnFactory<Column, NullableColumn>;
 
 public:
+    using ValueType = void;
+
     inline static ColumnPtr wrap_if_necessary(ColumnPtr column) {
         if (column->is_nullable()) {
             return column;

--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -112,6 +112,12 @@ using ChunkPtr = std::shared_ptr<Chunk>;
 using ChunkUniquePtr = std::unique_ptr<Chunk>;
 using Chunks = std::vector<ChunkPtr>;
 
+class SegmentedColumn;
+class SegmentedChunk;
+using SegmentedColumnPtr = std::shared_ptr<SegmentedColumn>;
+using SegmentedColumns = std::vector<SegmentedColumnPtr>;
+using SegmentedChunkPtr = std::shared_ptr<SegmentedChunk>;
+
 using SchemaPtr = std::shared_ptr<Schema>;
 
 using Fields = std::vector<std::shared_ptr<Field>>;

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -486,6 +486,7 @@ void JoinHashTable::_init_build_column(const HashTableParam& param) {
             _table_items->build_column_count++;
         }
     }
+    _table_items->build_chunk->build_columns();
 }
 
 void JoinHashTable::_init_mor_reader() {

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -647,7 +647,6 @@ void JoinHashTable::merge_ht(const JoinHashTable& ht) {
     for (size_t i = 0; i < _table_items->build_column_count; i++) {
         if (!columns[i]->is_nullable() && other_columns[i]->is_nullable()) {
             // upgrade to nullable column
-            // columns[i] = NullableColumn::create(columns[i], NullColumn::create(columns[i]->size(), 0));
             columns[i]->upgrade_to_nullable();
         }
     }

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -511,13 +511,9 @@ void JoinHashTable::_init_mor_reader() {
 
 void JoinHashTable::_init_join_keys() {
     for (const auto& key_desc : _table_items->join_keys) {
-        if (key_desc.col_ref) {
-            _table_items->key_columns.emplace_back(nullptr);
-        } else {
-            auto key_column = ColumnHelper::create_column(*key_desc.type, false);
-            key_column->append_default();
-            _table_items->key_columns.emplace_back(key_column);
-        }
+        auto key_column = ColumnHelper::create_column(*key_desc.type, false);
+        key_column->append_default();
+        _table_items->key_columns.emplace_back(key_column);
     }
 }
 

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -335,7 +335,7 @@ void JoinHashTable::create(const HashTableParam& param) {
         _probe_state->probe_counter = param.probe_counter;
     }
 
-    _table_items->build_chunk = std::make_shared<Chunk>();
+    _table_items->build_chunk = std::make_shared<SegmentedChunk>();
     _table_items->with_other_conjunct = param.with_other_conjunct;
     _table_items->join_type = param.join_type;
     _table_items->mor_reader_mode = param.mor_reader_mode;
@@ -626,7 +626,7 @@ Status JoinHashTable::probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* e
 }
 
 void JoinHashTable::append_chunk(const ChunkPtr& chunk, const Columns& key_columns) {
-    Columns& columns = _table_items->build_chunk->columns();
+    auto& columns = _table_items->build_chunk->columns();
 
     for (size_t i = 0; i < _table_items->build_column_count; i++) {
         SlotDescriptor* slot = _table_items->build_slots[i].slot;
@@ -659,8 +659,8 @@ void JoinHashTable::append_chunk(const ChunkPtr& chunk, const Columns& key_colum
 void JoinHashTable::merge_ht(const JoinHashTable& ht) {
     _table_items->row_count += ht._table_items->row_count;
 
-    Columns& columns = _table_items->build_chunk->columns();
-    Columns& other_columns = ht._table_items->build_chunk->columns();
+    auto& columns = _table_items->build_chunk->columns();
+    auto& other_columns = ht._table_items->build_chunk->columns();
 
     for (size_t i = 0; i < _table_items->build_column_count; i++) {
         if (!columns[i]->is_nullable() && other_columns[i]->is_nullable()) {

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "storage/chunk_helper.h"
 #include "util/runtime_profile.h"
 #define JOIN_HASH_MAP_H
 
@@ -100,8 +101,8 @@ struct HashTableSlotDescriptor {
 
 struct JoinHashTableItems {
     //TODO: memory continues problem?
-    ChunkPtr build_chunk = nullptr;
-    Columns key_columns;
+    SegmentedChunkPtr build_chunk = nullptr;
+    SegmentedColumns key_columns;
     std::vector<HashTableSlotDescriptor> build_slots;
     std::vector<HashTableSlotDescriptor> probe_slots;
     // A hash value is the bucket index of the hash map. "JoinHashTableItems.first" is the
@@ -393,7 +394,7 @@ public:
     using ColumnType = typename RunTimeTypeTraits<LT>::ColumnType;
 
     static void prepare(RuntimeState* runtime, JoinHashTableItems* table_items);
-    static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items);
+    static const Buffer<CppType>& get_key_data(const JoinHashTableItems& table_items, size_t segment_index);
     static void construct_hash_table(RuntimeState* state, JoinHashTableItems* table_items,
                                      HashTableProbeState* probe_state);
 };
@@ -838,7 +839,7 @@ public:
     // convert input column to spill schema order
     ChunkPtr convert_to_spill_schema(const ChunkPtr& chunk) const;
 
-    const ChunkPtr& get_build_chunk() const { return _table_items->build_chunk; }
+    const SegmentedChunkPtr& get_build_chunk() const { return _table_items->build_chunk; }
     Columns& get_key_columns() { return _table_items->key_columns; }
     const Columns& get_key_columns() const { return _table_items->key_columns; }
     uint32_t get_row_count() const { return _table_items->row_count; }

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -100,7 +100,6 @@ struct HashTableSlotDescriptor {
 };
 
 struct JoinHashTableItems {
-    //TODO: memory continues problem?
     SegmentedChunkPtr build_chunk = nullptr;
     Columns key_columns;
     std::vector<HashTableSlotDescriptor> build_slots;
@@ -297,7 +296,7 @@ struct HashTableParam {
     bool mor_reader_mode = false;
 
     // TODO: optimize this according to chunk width
-    size_t build_chunk_segment_size = 2 << 15;
+    size_t build_chunk_segment_size = 1 << 16;
 };
 
 template <class T>

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -59,6 +59,7 @@ void JoinBuildFunc<LT>::construct_hash_table(RuntimeState* state, JoinHashTableI
     if (table_items->key_columns[0]->is_nullable()) {
         auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(table_items->key_columns[0]);
         auto& null_array = nullable_column->null_column()->get_data();
+        DCHECK_EQ(data.size(), table_items->row_count + 1);
         for (size_t i = 1; i < table_items->row_count + 1; i++) {
             if (null_array[i] == 0) {
                 uint32_t bucket_num = JoinHashMapHelper::calc_bucket_num<CppType>(data[i], table_items->bucket_size);
@@ -67,6 +68,7 @@ void JoinBuildFunc<LT>::construct_hash_table(RuntimeState* state, JoinHashTableI
             }
         }
     } else {
+        DCHECK_EQ(data.size(), table_items->row_count + 1);
         for (size_t i = 1; i < table_items->row_count + 1; i++) {
             uint32_t bucket_num = JoinHashMapHelper::calc_bucket_num<CppType>(data[i], table_items->bucket_size);
             table_items->next[i] = table_items->first[bucket_num];

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -414,7 +414,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe_prepare(RuntimeState* state) {
 
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
 void JoinHashMap<LT, BuildFunc, ProbeFunc>::build(RuntimeState* state) {
-    _table_items->build_chunk->append_finished();
     BuildFunc().construct_hash_table(state, _table_items, _probe_state);
 }
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -264,7 +264,7 @@ StatusOr<std::function<StatusOr<ChunkPtr>()>> SpillableHashJoinBuildOperator::_c
             }
         }
 
-        auto chunk = _hash_table_build_chunk_slice.cutoff(runtime_state()->chunk_size());
+        ChunkPtr chunk = _hash_table_build_chunk_slice.cutoff(runtime_state()->chunk_size());
         RETURN_IF_ERROR(chunk->downgrade());
         RETURN_IF_ERROR(append_hash_columns(chunk));
         _join_builder->update_build_rows(chunk->num_rows());

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
@@ -66,7 +66,7 @@ private:
 
     size_t _hash_table_iterate_idx = 0;
     std::vector<JoinHashTable*> _hash_tables;
-    ChunkSharedSlice _hash_table_build_chunk_slice;
+    SegmentedChunkSlice _hash_table_build_chunk_slice;
     std::function<StatusOr<ChunkPtr>()> _hash_table_slice_iterator;
     bool _is_first_time_spill = true;
     DECLARE_ONCE_DETECTOR(_set_finishing_once);

--- a/be/src/exec/spill/mem_table.cpp
+++ b/be/src/exec/spill/mem_table.cpp
@@ -167,7 +167,7 @@ Status OrderedMemTable::finalize(workgroup::YieldContext& yield_ctx, const Spill
             return Status::OK();
         }
         SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
-        auto chunk = _chunk_slice.cutoff(_runtime_state->chunk_size());
+        ChunkPtr chunk = _chunk_slice.cutoff(_runtime_state->chunk_size());
         bool need_aligned = _runtime_state->spill_enable_direct_io();
 
         RETURN_IF_ERROR(serde->serialize(_runtime_state, serde_ctx, chunk, output, need_aligned));

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -859,7 +859,7 @@ void SegmentedChunk::append(const SegmentedChunkPtr& chunk, size_t offset) {
     }
 }
 
-void SegmentedChunk::append_finished() {
+void SegmentedChunk::build_columns() {
     DCHECK(_segments.size() >= 1);
     size_t num_columns = _segments[0]->num_columns();
     for (int i = 0; i < num_columns; i++) {

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -621,10 +621,10 @@ template <typename T>
 struct has_value_type<T, std::void_t<typename T::ValueType>> : std::true_type {};
 
 template <class ColumnT>
-inline constexpr bool is_object =
-        std::is_same_v<ColumnT, ArrayColumn> || std::is_same_v<ColumnT, StructColumn> ||
-        std::is_same_v<ColumnT, MapColumn> || std::is_same_v<ColumnT, JsonColumn> ||
-        (has_value_type<ColumnT>::value && std::is_same_v<ObjectColumn<typename ColumnT::ValueType>, ColumnT>);
+inline constexpr bool is_object = std::is_same_v<ColumnT, ArrayColumn> || std::is_same_v<ColumnT, StructColumn> ||
+                                  std::is_same_v<ColumnT, MapColumn> || std::is_same_v<ColumnT, JsonColumn> ||
+                                  (has_value_type<ColumnT>::value &&
+                                   std::is_same_v<ObjectColumn<typename ColumnT::ValueType>, ColumnT>);
 
 template <class ColumnT>
 inline constexpr bool is_fixed_or_binary =

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -614,10 +614,17 @@ bool ChunkPipelineAccumulator::is_finished() const {
     return _finalized && _out_chunk == nullptr && _in_chunk == nullptr;
 }
 
+template <typename T, typename = void>
+struct has_value_type : std::false_type {};
+
+template <typename T>
+struct has_value_type<T, std::void_t<typename T::ValueType>> : std::true_type {};
+
 template <class ColumnT>
-inline constexpr bool is_object = std::is_same_v<ColumnT, ArrayColumn> || std::is_same_v<ColumnT, StructColumn> ||
-                                  std::is_same_v<ColumnT, MapColumn> || std::is_same_v<ColumnT, JsonColumn> ||
-                                  std::is_same_v<ObjectColumn<typename ColumnT::ValueType>, ColumnT>;
+inline constexpr bool is_object =
+        std::is_same_v<ColumnT, ArrayColumn> || std::is_same_v<ColumnT, StructColumn> ||
+        std::is_same_v<ColumnT, MapColumn> || std::is_same_v<ColumnT, JsonColumn> ||
+        (has_value_type<ColumnT>::value && std::is_same_v<ObjectColumn<typename ColumnT::ValueType>, ColumnT>);
 
 template <class ColumnT>
 inline constexpr bool is_fixed_or_binary =

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -724,7 +724,7 @@ SegmentedColumn::SegmentedColumn(SegmentedChunkPtr chunk, size_t column_index) :
     }
 }
 
-SegmentedColumn::SegmentedColumn(const std::vector<ColumnPtr>& columns) : _columns(columns) {}
+SegmentedColumn::SegmentedColumn(std::vector<ColumnPtr> columns) : _columns(std::move(columns)) {}
 
 ColumnPtr SegmentedColumn::clone_selective(const uint32_t* indexes, uint32_t from, uint32_t size) {
     SegmentedColumnSelectiveCopy visitor(shared_from_this(), indexes, from, size);

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -156,7 +156,7 @@ private:
 class SegmentedColumn final : public std::enable_shared_from_this<SegmentedColumn> {
 public:
     SegmentedColumn(SegmentedChunkPtr chunk, size_t column_index);
-    SegmentedColumn(std::vector<ColumnPtr> columns);
+    SegmentedColumn(std::vector<ColumnPtr> columns, size_t segment_size);
     ~SegmentedColumn() = default;
 
     ColumnPtr clone_selective(const uint32_t* indexes, uint32_t from, uint32_t size);
@@ -171,6 +171,7 @@ public:
 private:
     SegmentedChunkPtr _chunk;        // The chunk it belongs to
     std::vector<ColumnPtr> _columns; // All segmented columns
+    size_t _segment_size;
 };
 
 // A big-chunk would be segmented into multi small ones, to avoid allocating large-continuous memory

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -156,7 +156,7 @@ private:
 class SegmentedColumn final : public std::enable_shared_from_this<SegmentedColumn> {
 public:
     SegmentedColumn(SegmentedChunkPtr chunk, size_t column_index);
-    SegmentedColumn(const std::vector<ColumnPtr>& columns);
+    SegmentedColumn(std::vector<ColumnPtr> columns);
     ~SegmentedColumn() = default;
 
     ColumnPtr clone_selective(const uint32_t* indexes, uint32_t from, uint32_t size);

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -153,9 +153,10 @@ private:
     bool _finalized = false;
 };
 
-class SegmentedColumn : std::enable_shared_from_this<SegmentedColumn> {
+class SegmentedColumn final : public std::enable_shared_from_this<SegmentedColumn> {
 public:
     SegmentedColumn(SegmentedChunkPtr chunk, size_t column_index);
+    SegmentedColumn(const std::vector<ColumnPtr>& columns);
     ~SegmentedColumn() = default;
 
     ColumnPtr clone_selective(const uint32_t* indexes, uint32_t from, uint32_t size);
@@ -174,7 +175,7 @@ private:
 
 // A big-chunk would be segmented into multi small ones, to avoid allocating large-continuous memory
 // It's not a transparent replacement for Chunk, but must be aware of and set a reasonale chunk_size
-class SegmentedChunk : std::enable_shared_from_this<SegmentedChunk> {
+class SegmentedChunk final : public std::enable_shared_from_this<SegmentedChunk> {
 public:
     SegmentedChunk(size_t segment_size);
     ~SegmentedChunk() = default;

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -166,13 +166,15 @@ public:
     bool has_null() const;
     size_t size() const;
     void upgrade_to_nullable();
-    const std::vector<ColumnPtr>& columns() const;
     size_t segment_size() const;
+    std::vector<ColumnPtr> columns() const;
 
 private:
-    SegmentedChunkPtr _chunk;        // The chunk it belongs to
-    std::vector<ColumnPtr> _columns; // All segmented columns
-    size_t _segment_size;
+    SegmentedChunkPtr _chunk; // The chunk it belongs to
+    size_t _column_index;     // The index in original chunk
+    const size_t _segment_size;
+
+    std::vector<ColumnPtr> _cached_columns; // Only used for SelectiveCopy
 };
 
 // A big-chunk would be segmented into multi small ones, to avoid allocating large-continuous memory

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -161,6 +161,7 @@ public:
     ~SegmentedColumn() = default;
 
     ColumnPtr clone_selective(const uint32_t* indexes, uint32_t from, uint32_t size);
+    ColumnPtr materialize() const;
 
     bool is_nullable() const;
     bool has_null() const;
@@ -192,17 +193,18 @@ public:
     void append(const SegmentedChunkPtr& chunk, size_t offset);
     void build_columns();
 
-    size_t memory_usage() const;
-    size_t num_rows() const;
+    SegmentedColumnPtr get_column_by_slot_id(SlotId slot_id);
     const SegmentedColumns& columns() const;
     SegmentedColumns& columns();
     size_t num_segments() const;
     const std::vector<ChunkPtr>& segments() const;
     std::vector<ChunkPtr>& segments();
-    size_t segment_size() const;
-    void reset();
     ChunkUniquePtr clone_empty(size_t reserve);
 
+    size_t segment_size() const;
+    void reset();
+    size_t memory_usage() const;
+    size_t num_rows() const;
     Status upgrade_if_overflow();
     Status downgrade();
     bool has_large_column() const;

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -206,6 +206,7 @@ public:
     Status upgrade_if_overflow();
     Status downgrade();
     bool has_large_column() const;
+    void check_or_die();
 
 private:
     std::vector<ChunkPtr> _segments;

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -181,6 +181,8 @@ public:
     SegmentedChunk(size_t segment_size);
     ~SegmentedChunk() = default;
 
+    static SegmentedChunkPtr create(size_t segment_size);
+
     void append_column(ColumnPtr column, SlotId slot_id);
     void append_chunk(const ChunkPtr& chunk, const std::vector<SlotId>& slots);
     void append_chunk(const ChunkPtr& chunk);
@@ -196,6 +198,7 @@ public:
     std::vector<ChunkPtr>& segments();
     size_t segment_size() const;
     void reset();
+    ChunkUniquePtr clone_empty(size_t reserve);
 
     Status upgrade_if_overflow();
     Status downgrade();

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <queue>
 
 #include "column/column_visitor.h"
@@ -187,7 +188,7 @@ public:
     void append_chunk(const ChunkPtr& chunk, const std::vector<SlotId>& slots);
     void append_chunk(const ChunkPtr& chunk);
     void append(const SegmentedChunkPtr& chunk, size_t offset);
-    void append_finished();
+    void build_columns();
 
     size_t memory_usage() const;
     size_t num_rows() const;

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -98,6 +98,7 @@ SegmentedChunkPtr ChunkHelperTest::build_segmented_chunk() {
     auto* tuple_desc = _create_simple_desc();
     auto segmented_chunk = SegmentedChunk::create(1 << 16);
     segmented_chunk->append_column(Int32Column::create(), 0);
+    segmented_chunk->build_columns();
 
     // put 100 chunks into the segmented chunk
     int row_id = 0;
@@ -110,7 +111,6 @@ SegmentedChunkPtr ChunkHelperTest::build_segmented_chunk() {
 
         segmented_chunk->append_chunk(std::move(chunk));
     }
-    segmented_chunk->append_finished();
     return segmented_chunk;
 }
 


### PR DESCRIPTION
## Why I'm doing:

```c++
@          0x2f9d4b5  malloc
@          0x8f9c745  operator new()
@          0x2ddb2ee  std::vector<>::_M_range_insert<>()
@          0x2dde914  starrocks::BinaryColumnBase<>::append()
@          0x365fa4e  starrocks::NullableColumn::append()
@          0x37458f9  starrocks::JoinHashTable::append_chunk()
@          0x3c86e80  starrocks::HashJoinBuilder::append_chunk()
@          0x3c8100c  starrocks::HashJoiner::append_chunk_to_ht()
@          0x3ab6649  starrocks::pipeline::HashJoinBuildOperator::push_chunk()
@          0x3a6769c  starrocks::pipeline::PipelineDriver::process()
@          0x3a58b9e  starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
@          0x305ebac  starrocks::ThreadPool::dispatch_thread()
@          0x305882a  starrocks::Thread::supervise_thread()
```

`JoinHashTable::build_chunk` is a `Chunk` which contains all data from build side, it means it can be very large for particular cases. As a result, it can easily encounter the memory allocation issue, when jemalloc/os cannot allocate a large continuous memory, as above exception.

The particular cases can be:
- use string column as build side
- use array column as build side

## What I'm doing:

Split that chunk into multiple smaller segments(whose rows is usually 131072) to get rid of this issue:
- Introduce a `SegmentedChunk` and `SegmentedColumn` to replace original `Chunk` and `Column`
- They're not transparent replacement, but implemented most of required interfaces. So minimal code changes are required
- To deal with the address problem(map the global offset to segment offset): we choose to translate the index just-in-time, like `offset%segment_size`, rather than maintaining a index for it. It's effective enough with static segment_size.
- We use static segment_size rather than dynamic, which is easier to implement and more efficient

Potential downside and considerations of this approach: 
- When generate output for `JoinHashMap`, it needs to randomly copy data from the `build_chunk` according to `build_index`. With `SegmentedChunk`, since the memory address is not continuous anymore, we need to lookup the segment first then lookup the record in it. To deal with it, we try best to use the `SegmentedChunkVisitor` to reduce this overhead via eliminating the virtual function call
- The `key_column` of `JoinHashMap` cannot not use columns of `build_chunk` anymore. Since their memory layout is different, `key_column` use a continuous column, but `build_chunk` uses a segmented way. It would introduce some memory overhead and memory copy overhead.
  - Why not make the `key_column` segmented ? The overhead is relatively larger for the probe procedure, and also it needs to change a lot of code, which is beyond the scope. So we choose the easy path

## Performance
```
Running ./shuffle_chunk_bench
Run on (104 X 3200.25 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x52)
  L1 Instruction 32 KiB (x52)
  L2 Unified 1024 KiB (x52)
  L3 Unified 36608 KiB (x2)
Load Average: 100.59, 89.61, 83.99
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
bench_chunk_clone 3992519949343932 ns     21223730 ns            1 items_per_second=192.992k/s
bench_segmented_chunk_clone 3992510186082870 ns     22087674 ns            1 items_per_second=185.443k/s
```

The `bench_segmented_chunk_clone` is still slower than regular `chunk_clone`, it mostly comes from the unpredictable random memory access during copy. Considering it can help memory allocation, i think it's worth to do it.

We can further optimize the performance through make the memory access more sequential.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
