### PR TITLE
[BugFix] fix character set issues of string literal in jdbc

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/StringLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/StringLiteral.java
@@ -283,7 +283,7 @@ public class StringLiteral extends LiteralExpr {
         }
         byte[] bytes = new byte[strLen];
         data.get(bytes);
-        value = new String(bytes);
+        value = new String(bytes, StandardCharsets.UTF_8);
     }
 
     public static StringLiteral create(String value) {


### PR DESCRIPTION
## Why I'm doing:
fix character set issues of string literal in jdbc

![image](https://github.com/user-attachments/assets/bae841bd-a89a-4e13-a8c8-fdc05f5947f4)

![image](https://github.com/user-attachments/assets/5bd29d1c-4fc6-40e6-bd61-e7fc396a312f)


## What I'm doing:
using uft8 encoding when parse string parameter

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
