### PR TITLE
[Enhancement] Support insert match column by name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -320,7 +320,7 @@ public enum ErrorCode {
             "No partitions have data available for loading. If you are sure there may be no data to be loaded, " +
                     "you can use `ADMIN SET FRONTEND CONFIG ('empty_load_as_error' = 'false')` " +
                     "to ensure such load jobs can succeed"),
-    ERR_INSERTED_COLUMN_MISMATCH(5604, new byte[] {'2', '2', '0', '0', '0'},
+    ERR_INSERT_COLUMN_COUNT_MISMATCH(5604, new byte[] {'2', '2', '0', '0', '0'},
             "Inserted target column count: %d doesn't match select/value column count: %d"),
     ERR_ILLEGAL_BYTES_LENGTH(5605, new byte[] {'4', '2', '0', '0', '0'}, "The valid bytes length for '%s' is [%d, %d]"),
     ERR_TOO_MANY_ERROR_ROWS(5606, new byte[] {'2', '2', '0', '0', '0'},
@@ -329,6 +329,7 @@ public enum ErrorCode {
     ERR_ROUTINE_LOAD_OFFSET_INVALID(5607, new byte[] {'0', '2', '0', '0', '0'},
             "Consume offset: %d is greater than the latest offset: %d in kafka partition: %d. " +
             "You can modify 'kafka_offsets' property through ALTER ROUTINE LOAD and RESUME the job"),
+    ERR_INSERT_COLUMN_NAME_MISMATCH(5608, new byte[] {'2', '2', '0', '0', '0'}, "%s column: %s has no matching %s column"),
 
     /**
      * 5700 - 5799: Partition

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -46,6 +46,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DefaultValueExpr;
 import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.InsertStmt.ColumnMatchPolicy;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.QueryRelation;
@@ -213,13 +214,11 @@ public class InsertAnalyzer {
         if (insertStmt.getTargetColumnNames() == null) {
             if (table instanceof OlapTable) {
                 targetColumns = new ArrayList<>(((OlapTable) table).getBaseSchemaWithoutGeneratedColumn());
-                mentionedColumns =
-                        ((OlapTable) table).getBaseSchemaWithoutGeneratedColumn().stream()
-                                .map(Column::getName).collect(Collectors.toSet());
+                mentionedColumns.addAll(((OlapTable) table).getBaseSchemaWithoutGeneratedColumn().stream().map(Column::getName)
+                        .collect(Collectors.toSet()));
             } else {
                 targetColumns = new ArrayList<>(table.getBaseSchema());
-                mentionedColumns =
-                        table.getBaseSchema().stream().map(Column::getName).collect(Collectors.toSet());
+                mentionedColumns.addAll(table.getBaseSchema().stream().map(Column::getName).collect(Collectors.toSet()));
             }
         } else {
             targetColumns = new ArrayList<>();
@@ -235,7 +234,7 @@ public class InsertAnalyzer {
                     throw new SemanticException("generated column '%s' can not be specified", colName);
                 }
                 if (!mentionedColumns.add(colName)) {
-                    throw new SemanticException("Column '%s' specified twice", colName);
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_DUP_FIELDNAME, colName);
                 }
                 requiredKeyColumns.remove(colName.toLowerCase());
                 targetColumns.add(column);
@@ -274,13 +273,40 @@ public class InsertAnalyzer {
         if ((table.isIcebergTable() || table.isHiveTable()) && insertStmt.isStaticKeyPartitionInsert()) {
             // full column size = mentioned column size + partition column size for static partition insert
             mentionedColumnSize -= table.getPartitionColumnNames().size();
+            mentionedColumns.removeAll(table.getPartitionColumnNames());
         }
 
+        // check target and source columns match
         QueryRelation query = insertStmt.getQueryStatement().getQueryRelation();
-        if (query.getRelationFields().size() != mentionedColumnSize) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_INSERTED_COLUMN_MISMATCH, mentionedColumnSize,
-                    query.getRelationFields().size());
+        if (insertStmt.isColumnMatchByPosition()) {
+            if (query.getRelationFields().size() != mentionedColumnSize) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_INSERT_COLUMN_COUNT_MISMATCH, mentionedColumnSize,
+                        query.getRelationFields().size());
+            }
+        } else {
+            Preconditions.checkState(insertStmt.isColumnMatchByName());
+            if (query instanceof ValuesRelation) {
+                throw new SemanticException("Insert match column by name does not support values()");
+            }
+
+            Set<String> selectColumnNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+            for (String colName : insertStmt.getQueryStatement().getQueryRelation().getColumnOutputNames()) {
+                if (!selectColumnNames.add(colName)) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_DUP_FIELDNAME, colName);
+                }
+            }
+            if (!selectColumnNames.containsAll(mentionedColumns)) {
+                mentionedColumns.removeAll(selectColumnNames);
+                ErrorReport.reportSemanticException(
+                        ErrorCode.ERR_INSERT_COLUMN_NAME_MISMATCH, "Target", String.join(", ", mentionedColumns), "source");
+            }
+            if (!mentionedColumns.containsAll(selectColumnNames)) {
+                selectColumnNames.removeAll(mentionedColumns);
+                ErrorReport.reportSemanticException(
+                        ErrorCode.ERR_INSERT_COLUMN_NAME_MISMATCH, "Source", String.join(", ", selectColumnNames), "target");
+            }
         }
+
         // check default value expr
         if (query instanceof ValuesRelation) {
             ValuesRelation valuesRelation = (ValuesRelation) query;
@@ -308,15 +334,29 @@ public class InsertAnalyzer {
 
     private static void analyzeProperties(InsertStmt insertStmt, ConnectContext session) {
         Map<String, String> properties = insertStmt.getProperties();
+
+        // column match by related properties
+        // parse the property and remove it for 'LoadStmt.checkProperties' validation
+        if (properties.containsKey(InsertStmt.PROPERTY_MATCH_COLUMN_BY)) {
+            String property = properties.remove(InsertStmt.PROPERTY_MATCH_COLUMN_BY);
+            ColumnMatchPolicy columnMatchPolicy = ColumnMatchPolicy.fromString(property);
+            if (columnMatchPolicy == null) {
+                String msg = String.format("%s (case insensitive)", String.join(", ", ColumnMatchPolicy.getCandidates()));
+                ErrorReport.reportSemanticException(
+                        ErrorCode.ERR_INVALID_VALUE, InsertStmt.PROPERTY_MATCH_COLUMN_BY, property, msg);
+            }
+            insertStmt.setColumnMatchPolicy(columnMatchPolicy);
+        }
+
+        // check common properties
         // use session variable if not set max_filter_ratio property
         if (!properties.containsKey(LoadStmt.MAX_FILTER_RATIO_PROPERTY)) {
             properties.put(LoadStmt.MAX_FILTER_RATIO_PROPERTY,
                     String.valueOf(session.getSessionVariable().getInsertMaxFilterRatio()));
         }
         // use session variable if not set strict_mode property
-        if (!properties.containsKey(LoadStmt.STRICT_MODE) &&
-                session.getSessionVariable().getEnableInsertStrict()) {
-            properties.put(LoadStmt.STRICT_MODE, "true");
+        if (!properties.containsKey(LoadStmt.STRICT_MODE)) {
+            properties.put(LoadStmt.STRICT_MODE, String.valueOf(session.getSessionVariable().getEnableInsertStrict()));
         }
 
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -53,6 +54,7 @@ import static com.google.common.base.Preconditions.checkState;
  */
 public class InsertStmt extends DmlStmt {
     public static final String STREAMING = "STREAMING";
+    public static final String PROPERTY_MATCH_COLUMN_BY = "match_column_by";
 
     private final TableName tblName;
     private PartitionNames targetPartitionNames;
@@ -95,6 +97,9 @@ public class InsertStmt extends DmlStmt {
     private final Map<String, String> tableFunctionProperties;
 
     private boolean isVersionOverwrite = false;
+
+    // column match by position or name
+    private ColumnMatchPolicy columnMatchPolicy = ColumnMatchPolicy.POSITION;
 
     public InsertStmt(TableName tblName, PartitionNames targetPartitionNames, String label, List<String> cols,
                       QueryStatement queryStatement, boolean isOverwrite, Map<String, String> insertProperties,
@@ -327,5 +332,35 @@ public class InsertStmt extends DmlStmt {
         checkState(tableFunctionAsTargetTable, "tableFunctionAsTargetTable is false");
         List<Column> columns = collectSelectedFieldsFromQueryStatement();
         return new TableFunctionTable(columns, getTableFunctionProperties(), sessionVariable);
+    }
+
+    public enum ColumnMatchPolicy {
+        POSITION,
+        NAME;
+
+        public static ColumnMatchPolicy fromString(String value) {
+            for (ColumnMatchPolicy policy : values()) {
+                if (policy.name().equalsIgnoreCase(value)) {
+                    return policy;
+                }
+            }
+            return null;
+        }
+
+        public static List<String> getCandidates() {
+            return Arrays.stream(values()).map(p -> p.name().toLowerCase()).collect(Collectors.toList());
+        }
+    }
+
+    public boolean isColumnMatchByPosition() {
+        return columnMatchPolicy == ColumnMatchPolicy.POSITION;
+    }
+
+    public boolean isColumnMatchByName() {
+        return columnMatchPolicy == ColumnMatchPolicy.NAME;
+    }
+
+    public void setColumnMatchPolicy(ColumnMatchPolicy columnMatchPolicy) {
+        this.columnMatchPolicy = columnMatchPolicy;
     }
 }

--- a/test/sql/test_insert_empty/R/test_insert_by_name
+++ b/test/sql/test_insert_empty/R/test_insert_by_name
@@ -1,0 +1,126 @@
+-- name: test_insert_by_name
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1 (k1 int, k2 varchar(100));
+
+insert into t1 properties("match_column_by" = "name") select "a" as k2, 1 as k1;
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+1	a
+-- !result
+
+truncate table t1;
+-- result:
+-- !result
+
+insert into t1 (k2, k1) properties("match_column_by" = "name") select 2 as k1, "b" as k2;
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+2	b
+-- !result
+
+truncate table t1;
+-- result:
+-- !result
+
+insert into t1 (k2, k1) properties("match_column_by" = "position") select "d" as k1, 4 as k2;
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+4	d
+-- !result
+
+truncate table t1;
+-- result:
+-- !result
+
+insert into t1 properties("match_column_by" = "name") values(1, "a");
+-- result:
+[REGEX].*Insert match column by name does not support values\(\).
+-- !result
+
+insert into t1 properties("match_column_by" = "name") select "a" as k2, 1 as k1, 2 as k3;
+-- result:
+[REGEX].*Source column: k3 has no matching target column.
+-- !result
+
+insert into t1 properties("match_column_by" = "name") select 1 as k1;
+-- result:
+[REGEX].*Target column: k2 has no matching source column.
+-- !result
+
+insert into t1 properties("match_column_by" = "invalid_value") values(1, "a");
+-- result:
+[REGEX].*Invalid match_column_by: 'invalid_value'. Expected values should be position, name \(case insensitive\).
+-- !result
+
+
+create table t2 (k1 int, k2 varchar(100), k3 int default "10");
+
+insert into t1 values(3, "c");
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+3	c
+-- !result
+
+insert into t2 (k1, k2) properties("match_column_by" = "name") select * from t1;
+-- result:
+-- !result
+
+select * from t2;
+-- result:
+3	c	10
+-- !result
+
+truncate table t2;
+-- result:
+-- !result
+
+insert into t2 properties("match_column_by" = "name") select *, 11 as k3 from t1;
+-- result:
+-- !result
+
+select * from t2;
+-- result:
+3	c	11
+-- !result
+
+truncate table t2;
+-- result:
+-- !result
+
+insert into t2 properties("match_column_by" = "name") select k1 + 1 as k1, k2, 12 as k3 from t1;
+-- result:
+-- !result
+
+select * from t2;
+-- result:
+4	c	12
+-- !result
+
+truncate table t2;
+-- result:
+-- !result
+
+insert into t2 properties("match_column_by" = "name") select * from t1;
+-- result:
+[REGEX].*Target column: k3 has no matching source column.
+-- !result
+
+insert into t2 properties("match_column_by" = "name") select k1 + 1 as k1, k1, 12 as k3 from t1;
+-- result:
+[REGEX].*Duplicate column name 'k1'.
+-- !result

--- a/test/sql/test_insert_empty/T/test_insert_by_name
+++ b/test/sql/test_insert_empty/T/test_insert_by_name
@@ -1,0 +1,46 @@
+-- name: test_insert_by_name
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1 (k1 int, k2 varchar(100));
+
+insert into t1 properties("match_column_by" = "name") select "a" as k2, 1 as k1;
+select * from t1;
+truncate table t1;
+
+insert into t1 (k2, k1) properties("match_column_by" = "name") select 2 as k1, "b" as k2;
+select * from t1;
+truncate table t1;
+
+insert into t1 (k2, k1) properties("match_column_by" = "position") select "d" as k1, 4 as k2;
+select * from t1;
+truncate table t1;
+
+-- error case
+insert into t1 properties("match_column_by" = "name") values(1, "a");
+insert into t1 properties("match_column_by" = "name") select "a" as k2, 1 as k1, 2 as k3;
+insert into t1 properties("match_column_by" = "name") select 1 as k1;
+insert into t1 properties("match_column_by" = "invalid_value") values(1, "a");
+
+
+create table t2 (k1 int, k2 varchar(100), k3 int default "10");
+
+insert into t1 values(3, "c");
+select * from t1;
+
+insert into t2 (k1, k2) properties("match_column_by" = "name") select * from t1;
+select * from t2;
+truncate table t2;
+
+insert into t2 properties("match_column_by" = "name") select *, 11 as k3 from t1;
+select * from t2;
+truncate table t2;
+
+insert into t2 properties("match_column_by" = "name") select k1 + 1 as k1, k2, 12 as k3 from t1;
+select * from t2;
+truncate table t2;
+
+-- error case
+insert into t2 properties("match_column_by" = "name") select * from t1;
+insert into t2 properties("match_column_by" = "name") select k1 + 1 as k1, k1, 12 as k3 from t1;


### PR DESCRIPTION
## Why I'm doing:
currently, insert only supports matching column by position,
the order that values are inserted into the columns of the table is determined by the order that the columns were declared  in values or select column list.

## What I'm doing:
support matching by name.
this allows the order of the columns in the table differs from the order of the select columns in select statement.

```
insert into t1 (k1, k2) properties("match_column_by" = "name") select k2, k1 from t2;
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
