### PR TITLE
[BugFix] fix thread pool size adjustment exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -235,5 +235,21 @@ public class ThreadPoolManager {
             }
         }
     }
+
+    public static void setFixedThreadPoolSize(ThreadPoolExecutor executor, int poolSize) {
+        int coreSize = executor.getCorePoolSize();
+        if (coreSize == poolSize) { // no change
+            return;
+        }
+        if (coreSize < poolSize) {
+            // increase the pool size, set the `MaximumPoolSize` first and then the `CoreSize`
+            executor.setMaximumPoolSize(poolSize);
+            executor.setCorePoolSize(poolSize);
+        } else {
+            // decrease the pool size, set `CoreSize` first and then the `MaximumPoolSize`
+            executor.setCorePoolSize(poolSize);
+            executor.setMaximumPoolSize(poolSize);
+        }
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
@@ -71,10 +71,7 @@ public class ThriftServer {
         server = new SRTThreadPoolServer(serverArgs);
 
         GlobalStateMgr.getCurrentState().getConfigRefreshDaemon().registerListener(() -> {
-            if (threadPoolExecutor.getMaximumPoolSize() != Config.thrift_server_max_worker_threads) {
-                threadPoolExecutor.setCorePoolSize(Config.thrift_server_max_worker_threads);
-                threadPoolExecutor.setMaximumPoolSize(Config.thrift_server_max_worker_threads);
-            }
+            ThreadPoolManager.setFixedThreadPoolSize(threadPoolExecutor, Config.thrift_server_max_worker_threads);
         });
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/LeaderTaskExecutor.java
@@ -119,18 +119,7 @@ public class LeaderTaskExecutor {
     }
 
     public void setPoolSize(int poolSize) {
-        // corePoolSize and maximumPoolSize are same.
-        // When the previous poolSize is larger than the poolSize to be set,
-        // you need to setCorePoolSize first and then setMaximumPoolSize, and vice versa.
-        // Otherwise, it will throw IllegalArgumentException
-        int prePoolSize = executor.getCorePoolSize();
-        if (poolSize < prePoolSize) {
-            executor.setCorePoolSize(poolSize);
-            executor.setMaximumPoolSize(poolSize);
-        } else {
-            executor.setMaximumPoolSize(poolSize);
-            executor.setCorePoolSize(poolSize);
-        }
+        ThreadPoolManager.setFixedThreadPoolSize(executor, poolSize);
     }
 
     private class TaskChecker implements Runnable {

--- a/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
@@ -111,18 +111,7 @@ public class PriorityLeaderTaskExecutor {
     }
 
     public void setPoolSize(int poolSize) {
-        // corePoolSize and maximumPoolSize are same.
-        // When the previous poolSize is larger than the poolSize to be set,
-        // you need to setCorePoolSize first and then setMaximumPoolSize, and vice versa.
-        // Otherwise, it will throw IllegalArgumentException
-        int prePoolSize = executor.getCorePoolSize();
-        if (poolSize < prePoolSize) {
-            executor.setCorePoolSize(poolSize);
-            executor.setMaximumPoolSize(poolSize);
-        } else {
-            executor.setMaximumPoolSize(poolSize);
-            executor.setCorePoolSize(poolSize);
-        }
+        ThreadPoolManager.setFixedThreadPoolSize(executor, poolSize);
     }
 
     private class TaskChecker implements Runnable {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -177,19 +177,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
             // DON'T LOG, otherwise the log line will repeat everytime the listener refreshes
             return;
         }
-
-        int oldNumThreads = lakeTaskExecutor.getMaximumPoolSize();
-        if (oldNumThreads == newNumThreads) {
-            return;
-        }
-
-        if (newNumThreads < oldNumThreads) { // scale in
-            lakeTaskExecutor.setCorePoolSize(newNumThreads);
-            lakeTaskExecutor.setMaximumPoolSize(newNumThreads);
-        } else { // scale out
-            lakeTaskExecutor.setMaximumPoolSize(newNumThreads);
-            lakeTaskExecutor.setCorePoolSize(newNumThreads);
-        }
+        ThreadPoolManager.setFixedThreadPoolSize(lakeTaskExecutor, newNumThreads);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
@@ -87,4 +87,35 @@ public class ThreadPoolManagerTest {
         Assert.assertEquals(4, testFixedThreaddPool.getCompletedTaskCount());
 
     }
+
+    @Test
+    public void testSetFixedThreadPoolSize() {
+        int expectedPoolSize = 2;
+        ThreadPoolExecutor testPool =
+                ThreadPoolManager.newDaemonFixedThreadPool(expectedPoolSize, 4096, "testPool", false);
+        Assert.assertEquals(expectedPoolSize, testPool.getCorePoolSize());
+        Assert.assertEquals(expectedPoolSize, testPool.getMaximumPoolSize());
+
+        { // increase the pool size, no problem
+            expectedPoolSize = 10;
+            int poolSize = expectedPoolSize;
+            ExceptionChecker.expectThrowsNoException(
+                    () -> ThreadPoolManager.setFixedThreadPoolSize(testPool, poolSize));
+            Assert.assertEquals(expectedPoolSize, testPool.getCorePoolSize());
+            Assert.assertEquals(expectedPoolSize, testPool.getMaximumPoolSize());
+        }
+
+        { // decrease the pool size, no problem
+            expectedPoolSize = 5;
+            int poolSize = expectedPoolSize;
+            ExceptionChecker.expectThrowsNoException(
+                    () -> ThreadPoolManager.setFixedThreadPoolSize(testPool, poolSize));
+            Assert.assertEquals(expectedPoolSize, testPool.getCorePoolSize());
+            Assert.assertEquals(expectedPoolSize, testPool.getMaximumPoolSize());
+        }
+
+        // can't set to <= 0
+        Assert.assertThrows(IllegalArgumentException.class, () -> ThreadPoolManager.setFixedThreadPoolSize(testPool, 0));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ThreadPoolManager.setFixedThreadPoolSize(testPool, -1));
+    }
 }


### PR DESCRIPTION
* Fixes #51130
* IllegalArgumentException will be thrown if corePoolSize < 0 or maximumPoolSize < corePoolSize

## Why I'm doing:

## What I'm doing:

Fixes #51130

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
