### PR TITLE
[Enhancement]Add session variable enable_compare_for_null to support compare null …

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -173,6 +173,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String QUERY_CACHE_TYPE = "query_cache_type";
     public static final String INTERACTIVE_TIMEOUT = "interactive_timeout";
     public static final String WAIT_TIMEOUT = "wait_timeout";
+    public static final String ENABLE_COMPARE_FOR_NULL = "enable_compare_for_null";
 
     public static final String CATALOG = "catalog";
     public static final String NET_WRITE_TIMEOUT = "net_write_timeout";
@@ -1008,6 +1009,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // The number of seconds the server waits for activity on a noninteractive connection before closing it.
     @VariableMgr.VarAttr(name = WAIT_TIMEOUT)
     private int waitTimeout = 28800;
+
+    @VariableMgr.VarAttr(name = ENABLE_COMPARE_FOR_NULL)
+    private boolean enableCompareForNull = false;
 
     // The number of seconds to wait for a block to be written to a connection before aborting the write
     @VariableMgr.VarAttr(name = NET_WRITE_TIMEOUT)
@@ -2619,6 +2623,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getWaitTimeoutS() {
         return waitTimeout;
+    }
+
+    public boolean isEnableCompareForNull() {
+        return enableCompareForNull;
     }
 
     public long getSqlMode() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -6155,7 +6155,12 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     private static BinaryType getComparisonOperator(Token symbol) {
         switch (symbol.getType()) {
             case StarRocksParser.EQ:
-                return BinaryType.EQ;
+                if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable() != null
+                        && ConnectContext.get().getSessionVariable().isEnableCompareForNull()) {
+                    return BinaryType.EQ_FOR_NULL;
+                } else {
+                    return BinaryType.EQ;
+                }
             case StarRocksParser.NEQ:
                 return BinaryType.NE;
             case StarRocksParser.LT:


### PR DESCRIPTION
…when use =
need use = to compare null = null and want to it return true
## Why I'm doing:
Some services migrated from other systems want to use = for null comparison, but do not want to modify the SQL
## What I'm doing:
add the session variable enable_compare_for_null to support compare null with =
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5