### PR TITLE
[BugFix] Fix duplicate entries in be_logs; Add reset_delvec in script; Add BE id in error message when query failed

### DIFF
--- a/be/src/common/greplog.h
+++ b/be/src/common/greplog.h
@@ -48,6 +48,7 @@ Status grep_log(int64_t start_ts, int64_t end_ts, char level, const std::string&
  * Grep log file and return all line as whole string, parameters are same as grep_log
  * @return log string
  */
-std::string grep_log_as_string(int64_t start_ts, int64_t end_ts, char level, const std::string& pattern, size_t limit);
+std::string grep_log_as_string(int64_t start_ts, int64_t end_ts, const std::string& level, const std::string& pattern,
+                               size_t limit);
 
 } // namespace starrocks

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include "agent/master_info.h"
 #include "exec/pipeline/stream_pipeline_driver.h"
 #include "exec/workgroup/work_group.h"
 #include "gutil/strings/substitute.h"
@@ -167,6 +168,9 @@ void GlobalDriverExecutor::_worker_thread() {
             }
 
             if (!status.ok()) {
+                auto o_id = get_backend_id();
+                int64_t be_id = o_id.has_value() ? o_id.value() : -1;
+                status = status.clone_and_append(fmt::format("BE:{}", be_id));
                 LOG(WARNING) << "[Driver] Process error, query_id=" << print_id(driver->query_ctx()->query_id())
                              << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id())
                              << ", status=" << status;

--- a/be/src/exec/schema_scanner/schema_be_logs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_logs_scanner.cpp
@@ -48,7 +48,7 @@ Status SchemaBeLogsScanner::start(RuntimeState* state) {
     if (_param->log_end_ts > 0) {
         end_ts = _param->log_end_ts;
     }
-    string level;
+    string level = "I";
     string pattern;
     if (_param->log_level != nullptr) {
         level = *_param->log_level;

--- a/be/src/http/action/greplog_action.cpp
+++ b/be/src/http/action/greplog_action.cpp
@@ -66,7 +66,7 @@ void GrepLogAction::handle(HttpRequest* req) {
         return;
     }
 
-    auto ret = grep_log_as_string(start_ts, end_ts, std::toupper(level[0]), pattern, limit);
+    auto ret = grep_log_as_string(start_ts, end_ts, level, pattern, limit);
 
     HttpChannel::send_reply(req, HttpStatus::OK, ret);
 }

--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -30,6 +30,7 @@
 #include "io/io_profiler.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
+#include "storage/del_vector.h"
 #include "storage/primary_key_dump.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
@@ -355,6 +356,16 @@ public:
         }
     }
 
+    // this method is specifically used to recover "no delete vector found" error caused by corrupt pk tablet metadata
+    static std::string reset_delvec(int64_t tablet_id, int64_t segment_id, int64_t version) {
+        auto tablet = get_tablet(tablet_id);
+        RETURN_IF_UNLIKELY_NULL(tablet, "tablet not found");
+        DelVector dv;
+        dv.init(version, nullptr, 0);
+        auto st = TabletMetaManager::set_del_vector(tablet->data_dir()->get_meta(), tablet_id, segment_id, dv);
+        return st.to_string();
+    }
+
     static size_t submit_manual_compaction_task_for_table(int64_t table_id, int64_t rowset_size_threshold) {
         auto infos = get_tablet_infos(table_id, -1);
         for (auto& info : infos) {
@@ -552,6 +563,7 @@ public:
             REG_STATIC_METHOD(StorageEngineRef, get_tablet_info);
             REG_STATIC_METHOD(StorageEngineRef, get_tablet_infos);
             REG_STATIC_METHOD(StorageEngineRef, get_tablet_meta_json);
+            REG_STATIC_METHOD(StorageEngineRef, reset_delvec);
             REG_STATIC_METHOD(StorageEngineRef, get_tablet);
             REG_STATIC_METHOD(StorageEngineRef, drop_tablet);
             REG_STATIC_METHOD(StorageEngineRef, get_data_dirs);

--- a/be/src/service/backend_options.cpp
+++ b/be/src/service/backend_options.cpp
@@ -37,7 +37,14 @@ TBackend BackendOptions::_backend;
 bool BackendOptions::_bind_ipv6 = false;
 const char* _service_bind_address = "0.0.0.0";
 
-bool BackendOptions::init() {
+bool BackendOptions::_is_cn = false;
+
+bool BackendOptions::is_cn() {
+    return _is_cn;
+}
+
+bool BackendOptions::init(bool is_cn) {
+    _is_cn = is_cn;
     if (!analyze_priority_cidrs()) {
         return false;
     }

--- a/be/src/service/backend_options.h
+++ b/be/src/service/backend_options.h
@@ -30,13 +30,14 @@ class CIDR;
 
 class BackendOptions {
 public:
-    static bool init();
+    static bool init(bool is_cn);
     static std::string get_localhost();
     static TBackend get_localBackend();
     static const char* get_service_bind_address();
     static const char* get_service_bind_address_without_bracket();
     static void set_localhost(const std::string& host);
     static bool is_bind_ipv6();
+    static bool is_cn();
 
 private:
     static bool analyze_priority_cidrs();
@@ -46,6 +47,7 @@ private:
     static std::vector<CIDR> _s_priority_cidrs;
     static TBackend _backend;
     static bool _bind_ipv6;
+    static bool _is_cn;
 
     BackendOptions(const BackendOptions&) = delete;
     const BackendOptions& operator=(const BackendOptions&) = delete;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -161,7 +161,7 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     LOG(INFO) << process_name << " start step " << start_step++ << ": jdbc driver manager init successfully";
 
     // init network option
-    if (!BackendOptions::init()) {
+    if (!BackendOptions::init(as_cn)) {
         exit(-1);
     }
     LOG(INFO) << process_name << " start step " << start_step++ << ": backend network options init successfully";

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -16,6 +16,7 @@
 
 #include <random>
 
+#include "script/script.h"
 #include "storage/local_primary_key_recover.h"
 #include "storage/primary_key_dump.h"
 #include "util/failpoint/fail_point.h"
@@ -343,6 +344,12 @@ void TabletUpdatesTest::test_writeread(bool enable_persistent_index) {
     auto rs0 = create_rowset(_tablet, keys);
     ASSERT_TRUE(_tablet->rowset_commit(2, rs0).ok());
     ASSERT_EQ(2, _tablet->updates()->max_version());
+
+    string o;
+    ASSERT_TRUE(execute_script(fmt::format("StorageEngine.reset_delvec({}, {}, 2)", _tablet->tablet_id(), 0), o).ok());
+    ASSERT_TRUE(execute_script("System.print(ExecEnv.grep_log_as_string(0,0,\"I\",\"tablet_manager\",1))", o).ok());
+    LOG(INFO) << "grep log: " << o;
+
     auto rs1 = create_rowset(_tablet, keys);
     ASSERT_TRUE(_tablet->rowset_commit(3, rs1).ok());
     ASSERT_EQ(3, _tablet->updates()->max_version());

--- a/test/sql/test_array_fn/R/test_array_fn
+++ b/test/sql/test_array_fn/R/test_array_fn
@@ -4029,11 +4029,11 @@ None	None
 -- !result
 select d_6, d_5, all_match(d_6,d_5, (x,y)->x >y) from array_test order by pk;
 -- result:
-E: (1064, "Input array element's size is not equal in array_map().")
+[REGEX].*Input array element's size is not equal in array_map().*
 -- !result
 select d_6, d_5, any_match(d_6,d_5, (x,y)->x >y) from array_test order by pk;
 -- result:
-E: (1064, "Input array element's size is not equal in array_map().")
+[REGEX].*Input array element's size is not equal in array_map().*
 -- !result
 select all_match((x,y) -> x < y, []);
 -- result:

--- a/test/sql/test_array_fn/R/test_array_sortby
+++ b/test/sql/test_array_fn/R/test_array_sortby
@@ -408,19 +408,19 @@ select array_sortby([1,2,3,4,5,6], ['a', 'b', 'c', 'c', 'b', 'a'], cast(['2023-1
 -- !result
 select array_sortby([1,2,null,4,5,6], ['a', 'b', 'c', 'c', 'b', 'a', 1], [11, 22, 32, 31, 21, 12]);
 -- result:
-E: (1064, "Input arrays' size are not equal in array_sortby.")
+[REGEX].*Input arrays' size are not equal in array_sortby.*
 -- !result
 select array_sortby([1,2,null,4,5,6], ['a', 'b', 'c', 'c', 'b', 'a', 1], cast(null as array<int>), [11, 22, 32, 31, 21, 12]);
 -- result:
-E: (1064, "Input arrays' size are not equal in array_sortby.")
+[REGEX].*Input arrays' size are not equal in array_sortby.*
 -- !result
 select array_sortby([1,2,3,4,5,6], ['a', 'b', null, null, 'b', 'a', 1], [11, 22, 32, 31, 21, 12]);
 -- result:
-E: (1064, "Input arrays' size are not equal in array_sortby.")
+[REGEX].*Input arrays' size are not equal in array_sortby.*
 -- !result
 select array_sortby([1,2,3,4,5,6], ['a', 'b', null, null, 'b', 'a'], [11, 22, 32, 31, null, null, 1]);
 -- result:
-E: (1064, "Input arrays' size are not equal in array_sortby.")
+[REGEX].*Input arrays' size are not equal in array_sortby.*
 -- !result
 -- name: test_array_sortby_3
 with w1 as (select column_0 as source, column_1 as key1, column_2 as key2 from (values

--- a/test/sql/test_decimal/R/test_decimal_overflow
+++ b/test/sql/test_decimal/R/test_decimal_overflow
@@ -43,7 +43,7 @@ None
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
 -- result:
-E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
+[REGEX].*Expr evaluate meet error: The 'mul' operation involving decimal values overflows.*
 -- !result
 select cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
 -- result:
@@ -95,51 +95,51 @@ None
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
+[REGEX].*Expr evaluate meet error: The type cast from decimal to decimal overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
+[REGEX].*Expr evaluate meet error: The type cast from decimal to decimal overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
+[REGEX].*Expr evaluate meet error: The type cast from decimal to decimal overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
+[REGEX].*Expr evaluate meet error: The type cast from decimal to decimal overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
+[REGEX].*Expr evaluate meet error: The 'mul' operation involving decimal values overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
+[REGEX].*Expr evaluate meet error: The 'mul' operation involving decimal values overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
+[REGEX].*Expr evaluate meet error: The type cast from decimal to decimal overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
+[REGEX].*Expr evaluate meet error: The type cast from decimal to decimal overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
+[REGEX].*Expr evaluate meet error: The type cast from decimal to decimal overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
+[REGEX].*Expr evaluate meet error: The type cast from decimal to decimal overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
+[REGEX].*Expr evaluate meet error: The 'mul' operation involving decimal values overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
+[REGEX].*Expr evaluate meet error: The 'mul' operation involving decimal values overflows.*
 -- !result
 select c_id - 1.12345678901234567890 from t_decimal_overflow where c_id = 1;
 -- result:
@@ -155,9 +155,9 @@ select avg(c0- 2.8665963056616452*(lt - 3.062472673706541)) as adjust_lt from (s
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ max(lt- 2.8665963056616452*(c2 - 3.062472673706541)) as adjust_lt from (select c0, array_sum(c1) lt, c2 from avg_test) t group by c0;
 -- result:
-E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
+[REGEX].*Expr evaluate meet error: The 'mul' operation involving decimal values overflows.*
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ avg(lt- 2.8665963056616452*(c2 - 3.062472673706541)) as adjust_lt from (select c0, array_sum(c1) lt, c2 from avg_test) t group by c0;
 -- result:
-E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
+[REGEX].*Expr evaluate meet error: The 'mul' operation involving decimal values overflows.*
 -- !result

--- a/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
+++ b/test/sql/test_dict_mapping_function/R/test_dict_mapping_function
@@ -126,7 +126,7 @@ INSERT INTO t VALUES (1, NULL);
 -- !result
 SELECT dict_mapping("dict", col_1, col_2) FROM t;
 -- result:
-E: (1064, 'invalid parameter : get NULL paramenter')
+[REGEX].*invalid parameter : get NULL paramenter.*
 -- !result
 DROP DATABASE test_dictmapping_null_column;
 -- result:
@@ -291,11 +291,11 @@ insert into t_dictmapping_null_if_not_found values (1,default);
 -- !result
 select dict_mapping("t_dictmapping_null_if_not_found", 2);
 -- result:
-E: (1064, 'query failed if record not exist in dict table.')
+[REGEX].*query failed if record not exist in dict table.*
 -- !result
 select dict_mapping("t_dictmapping_null_if_not_found", 2, false);
 -- result:
-E: (1064, 'query failed if record not exist in dict table.')
+[REGEX].*query failed if record not exist in dict table.*
 -- !result
 select dict_mapping("t_dictmapping_null_if_not_found", 2, true);
 -- result:

--- a/test/sql/test_dictionary/R/test_dictionary
+++ b/test/sql/test_dictionary/R/test_dictionary
@@ -84,7 +84,7 @@ SELECT dictionary_get("test_dictionary_basic_operation", 1);
 -- !result
 SELECT dictionary_get("test_dictionary_basic_operation", 2);
 -- result:
-E: (1064, 'key not found in dictionary cache')
+[REGEX].*key not found in dictionary cache.*
 -- !result
 DROP DICTIONARY test_dictionary_basic_operation CACHE;
 -- result:
@@ -1353,11 +1353,11 @@ INSERT INTO t_dictionary_null_if_not_exist VALUES (2,2),(4,4);
 -- !result
 SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k) FROM t_dictionary_null_if_not_exist ORDER BY k;
 -- result:
-E: (1064, 'key not found in dictionary cache')
+[REGEX].*key not found in dictionary cache.*
 -- !result
 SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k, false) FROM t_dictionary_null_if_not_exist ORDER BY k;
 -- result:
-E: (1064, 'key not found in dictionary cache')
+[REGEX].*key not found in dictionary cache.*
 -- !result
 SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k, true) FROM t_dictionary_null_if_not_exist ORDER BY k;
 -- result:
@@ -1377,7 +1377,7 @@ SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k, tRuE) FROM t_di
 -- !result
 SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k, FaLsE) FROM t_dictionary_null_if_not_exist ORDER BY k;
 -- result:
-E: (1064, 'key not found in dictionary cache')
+[REGEX].*key not found in dictionary cache.*
 -- !result
 SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k, xxxx) FROM t_dictionary_null_if_not_exist ORDER BY k;
 -- result:
@@ -1423,7 +1423,7 @@ PROPERTIES (
 -- !result
 INSERT INTO t_dictionary_null_if_not_exist_gen_column VALUES (1),(2),(3),(4),(5);
 -- result:
-E: (5025, 'key not found in dictionary cache')
+[REGEX].*key not found in dictionary cache.*
 -- !result
 SELECT * FROM t_dictionary_null_if_not_exist_gen_column;
 -- result:
@@ -1478,11 +1478,11 @@ INSERT INTO t_dictionary_null_if_not_exist VALUES (2,2),(4,4);
 -- !result
 SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k) FROM t_dictionary_null_if_not_exist ORDER BY k;
 -- result:
-E: (1064, 'key not found in dictionary cache')
+[REGEX].*key not found in dictionary cache.*
 -- !result
 SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k, false) FROM t_dictionary_null_if_not_exist ORDER BY k;
 -- result:
-E: (1064, 'key not found in dictionary cache')
+[REGEX].*key not found in dictionary cache.*
 -- !result
 SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k, true) FROM t_dictionary_null_if_not_exist ORDER BY k;
 -- result:
@@ -1502,7 +1502,7 @@ SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k, tRuE) FROM t_di
 -- !result
 SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k, FaLsE) FROM t_dictionary_null_if_not_exist ORDER BY k;
 -- result:
-E: (1064, 'key not found in dictionary cache')
+[REGEX].*key not found in dictionary cache.*
 -- !result
 SELECT k, dictionary_get("test_dictionary_null_if_not_exist", k, xxxx) FROM t_dictionary_null_if_not_exist ORDER BY k;
 -- result:
@@ -1552,7 +1552,7 @@ PROPERTIES (
 -- !result
 INSERT INTO t_dictionary_null_if_not_exist_gen_column VALUES (1),(2),(3),(4),(5);
 -- result:
-E: (5025, 'key not found in dictionary cache')
+[REGEX].*key not found in dictionary cache.*
 -- !result
 SELECT * FROM t_dictionary_null_if_not_exist_gen_column;
 -- result:

--- a/test/sql/test_external_file/R/test_orc_predicates
+++ b/test/sql/test_external_file/R/test_orc_predicates
@@ -37,7 +37,7 @@ set sql_dialect='trino';
 -- !result
 select count(*) from split_orc_error where split(col1, 'a')[2]='x';
 -- result:
-E: (1064, 'Array subscript must be less than or equal to array length: 2 > 1')
+[REGEX].*Array subscript must be less than or equal to array length: 2 > 1.*
 -- !result
 drop table split_orc_error;
 -- result:

--- a/test/sql/test_function/R/test_time_slice
+++ b/test/sql/test_function/R/test_time_slice
@@ -68,23 +68,23 @@ select time_slice('2023-12-31 03:12:04',interval 2147483647 second);
 -- !result
 select time_slice('0000-01-01',interval 5 year);
 -- result:
-E: (1064, "time used with time_slice can't before 0001-01-01 00:00:00")
+[REGEX].*time used with time_slice can't before 0001-01-01 00:00:00.*
 -- !result
 select time_slice('0000-01-01',interval 5 month);
 -- result:
-E: (1064, "time used with time_slice can't before 0001-01-01 00:00:00")
+[REGEX].*time used with time_slice can't before 0001-01-01 00:00:00.*
 -- !result
 select time_slice('0000-01-01',interval 5 day);
 -- result:
-E: (1064, "time used with time_slice can't before 0001-01-01 00:00:00")
+[REGEX].*time used with time_slice can't before 0001-01-01 00:00:00.*
 -- !result
 select time_slice('0000-01-01',interval 5 quarter);
 -- result:
-E: (1064, "time used with time_slice can't before 0001-01-01 00:00:00")
+[REGEX].*time used with time_slice can't before 0001-01-01 00:00:00.*
 -- !result
 select time_slice('0000-01-01',interval 5 week);
 -- result:
-E: (1064, "time used with time_slice can't before 0001-01-01 00:00:00")
+[REGEX].*time used with time_slice can't before 0001-01-01 00:00:00.*
 -- !result
 select time_slice('9999-12-31',interval 5 year, ceil);
 -- result:
@@ -219,23 +219,23 @@ select time_slice('2023-12-31 03:12:04',interval 2147483647 second);
 -- !result
 select time_slice('0000-01-01',interval 5 year);
 -- result:
-E: (1064, "time used with time_slice can't before 0001-01-01 00:00:00")
+[REGEX].*time used with time_slice can't before 0001-01-01 00:00:00.*
 -- !result
 select time_slice('0000-01-01',interval 5 month);
 -- result:
-E: (1064, "time used with time_slice can't before 0001-01-01 00:00:00")
+[REGEX].*time used with time_slice can't before 0001-01-01 00:00:00.*
 -- !result
 select time_slice('0000-01-01',interval 5 day);
 -- result:
-E: (1064, "time used with time_slice can't before 0001-01-01 00:00:00")
+[REGEX].*time used with time_slice can't before 0001-01-01 00:00:00.*
 -- !result
 select time_slice('0000-01-01',interval 5 quarter);
 -- result:
-E: (1064, "time used with time_slice can't before 0001-01-01 00:00:00")
+[REGEX].*time used with time_slice can't before 0001-01-01 00:00:00.*
 -- !result
 select time_slice('0000-01-01',interval 5 week);
 -- result:
-E: (1064, "time used with time_slice can't before 0001-01-01 00:00:00")
+[REGEX].*time used with time_slice can't before 0001-01-01 00:00:00.*
 -- !result
 select time_slice('9999-12-31',interval 5 year, ceil);
 -- result:

--- a/test/sql/test_generate_series/R/test_generate_series
+++ b/test/sql/test_generate_series/R/test_generate_series
@@ -257,7 +257,7 @@ SELECT * FROM TABLE(generate_series(9223372036854775807, 9223372036854775807, 92
 -- name: test44
 SELECT * FROM TABLE(generate_series(1, 2, 0));
 -- result:
-E: (1064, 'step size cannot equal zero')
+[REGEX].*step size cannot equal zero.*
 -- !result
 -- name: test47
 SELECT * FROM TABLE(generate_series(-2147483640, -2147483647, -3));
@@ -293,7 +293,7 @@ INSERT INTO t1 VALUES(1, 2, 0);
 -- !result
 SELECT * FROM t1, LATERAL generate_series(c0, c1, c2);
 -- result:
-E: (1064, 'step size cannot equal zero')
+[REGEX].*step size cannot equal zero.*
 -- !result
 -- name: test49
 SELECT * FROM TABLE(generate_series(-128, -128, -3));

--- a/test/sql/test_group_execution/R/test_group_execution_join
+++ b/test/sql/test_group_execution/R/test_group_execution_join
@@ -374,7 +374,7 @@ select c0,c1 = (select c1 from t1 where c0 = 10) from (select l.c0, r.c1 from t0
 -- !result
 select c0,c1 = (select c1 from t1 where c0 != 10) from (select l.c0, r.c1 from t0 l join [colocate] t1 r on l.c0 = r.c0 and l.c1 = r.c1) tb order by 1, 2 limit 10000, 1;
 -- result:
-E: (1064, 'Expected LE 1 to be returned by expression ')
+[REGEX].*Expected LE 1 to be returned by expression.*
 -- !result
 select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [colocate] t1 r on l.c0 = r.c0 and l.c1 = r.c1 where l.c0=1 and l.c1=1;
 -- result:

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -498,7 +498,7 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column LIKE "AB%" A
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column match "ABC" OR text_column match "ABD";
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column match "AB%" AND text_column match "%C";
 -- result:
@@ -542,7 +542,7 @@ INSERT INTO t_gin_index_multiple_predicate_english VALUES
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column match "this" OR text_column match "abc";
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column not match "this" AND text_column not match "abc";
 -- result:
@@ -1260,7 +1260,7 @@ SELECT sum(id) FROM t_disable_global_dict_rewrite WHERE v1 MATCH "abc" GROUP BY 
 -- !result
 SELECT sum(id) FROM t_disable_global_dict_rewrite WHERE v2 MATCH "abc" GROUP BY v2;
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 SELECT id FROM t_disable_global_dict_rewrite WHERE v1 MATCH "abc" ORDER BY v1;
 -- result:
@@ -1268,7 +1268,7 @@ SELECT id FROM t_disable_global_dict_rewrite WHERE v1 MATCH "abc" ORDER BY v1;
 -- !result
 SELECT id FROM t_disable_global_dict_rewrite WHERE v2 MATCH "abc" ORDER BY v2;
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 DROP TABLE t_disable_global_dict_rewrite;
 -- result:
@@ -1393,7 +1393,7 @@ SET enable_gin_filter = false;
 -- !result
 SELECT * FROM t_gin_var WHERE v1 MATCH "abc";
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 SET enable_gin_filter = true;
 -- result:
@@ -1594,43 +1594,43 @@ insert into duplicate_table_demo_datatype_not_replicated_all_varchar values ('19
 -- !result
 select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 select * from test_view where DDD match 'msrjabmbwkxmjggulkiy';
 -- result:
-E: (1064, 'Match can only used as a pushdown predicate on column with GIN in a single query.')
+[REGEX].*Match can only used as a pushdown predicate on column with GIN in a single query.*
 -- !result
 DROP VIEW test_view;
 -- result:

--- a/test/sql/test_json/R/to_json
+++ b/test/sql/test_json/R/to_json
@@ -36,7 +36,7 @@ None
 -- !result
 select /*+SET_VAR(sql_mode='ONLY_FULL_GROUP_BY,ALLOW_THROW_EXCEPTION')*/ to_json(map{null:null});
 -- result:
-E: (1064, 'key of Map should not be null')
+[REGEX].*key of Map should not be null.*
 -- !result
 select /*+SET_VAR(sql_mode='ONLY_FULL_GROUP_BY')*/ to_json(map{null:null});
 -- result:

--- a/test/sql/test_string_functions/R/test_string_functions
+++ b/test/sql/test_string_functions/R/test_string_functions
@@ -498,11 +498,11 @@ E: (1064, "Getting analyzing error from line 1, column 7 to line 1, column 67. D
 -- !result
 select ngram_search("chi","chi",0);
 -- result:
-E: (1064, "ngram search's third parameter must be a positive number")
+[REGEX].*ngram search's third parameter must be a positive number.*
 -- !result
 select ngram_search("chi","chi",-1);
 -- result:
-E: (1064, "ngram search's third parameter must be a positive number")
+[REGEX].*ngram search's third parameter must be a positive number.*
 -- !result
 select ngram_search(date('2020-06-23'), "2020", 4);
 -- result:

--- a/test/sql/test_trino_dialect/R/test_trino_dialect
+++ b/test/sql/test_trino_dialect/R/test_trino_dialect
@@ -50,11 +50,11 @@ None	None
 -- !result
 select c2['not-existed'] from map_array_tbl order by c1;
 -- result:
-E: (1064, "Key not present in map: 'not-existed'")
+[REGEX].*Key not present in map: 'not-existed'.*
 -- !result
 select c3[100] from map_array_tbl order by c1;
 -- result:
-E: (1064, 'Array subscript must be less than or equal to array length: 100 > 1')
+[REGEX].*Array subscript must be less than or equal to array length: 100 > 1.*
 -- !result
 select element_at(c2, 'not-existed'), element_at(c3, 100) from map_array_tbl order by c1;
 -- result:

--- a/test/sql/test_udf/R/test_jvm_udf
+++ b/test/sql/test_udf/R/test_jvm_udf
@@ -73,7 +73,7 @@ select count(udtfstring) from t0, udtfstring(c1);
 -- !result
 select count(udtfstring_wrong_match) from t0, udtfstring_wrong_match(c1);
 -- result:
-E: (1064, 'Type not matched, expect class java.lang.Integer, but got class java.lang.String')
+[REGEX].*Type not matched, expect class java.lang.Integer, but got class java.lang.String.*
 -- !result
 select count(udtfint) from t0, udtfint(c1);
 -- result:


### PR DESCRIPTION
## Why I'm doing:

Their are duplicate entries when using be_logs with '.*' parttern.
There is no be ID in error message when query failed.

## What I'm doing:

Fix regex match bug in greplog;
Add BE id in error message;
Add a tool to fix corrupted metadata causing "no delete vector found" error;

Fixes #51190

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
