### PR TITLE
[Tool] Increase timeout-minutes of clang-tidy

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -312,7 +312,7 @@ jobs:
       - name: UPDATE ECI & RUN Clang Tidy
         id: run_clang_tidy
         shell: bash
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           if [[ "${{ needs.be-checker.outputs.thirdparty_filter }}" == 'true' ]]; then


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Clang-tidy often times out, so increase the time limit

```
[1951](https://github.com/StarRocks/starrocks/actions/runs/10918829874/job/30309333392?pr=49736#step:4:1952)[ 93%] Building CXX object src/exec/CMakeFiles/Exec.dir/pipeline/analysis/analytic_source_operator.cpp.o
[1952](https://github.com/StarRocks/starrocks/actions/runs/10918829874/job/30309333392?pr=49736#step:4:1953)Error: The action 'UPDATE ECI & RUN Clang Tidy' has timed out after 60 minutes.
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
