### PR TITLE
[BugFix] fix pk concurrent apply issue

### DIFF
--- a/be/src/storage/base_tablet.h
+++ b/be/src/storage/base_tablet.h
@@ -117,9 +117,9 @@ public:
 
     virtual size_t num_rows() const = 0;
 
-protected:
     virtual void on_shutdown() {}
 
+protected:
     void _gen_tablet_path();
 
     TabletState _state;

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -335,7 +335,6 @@ public:
     // set true when start to drop tablet. only set in `TabletManager::drop_tablet` right now
     void set_is_dropping(bool is_dropping) { _is_dropping = is_dropping; }
 
-protected:
     void on_shutdown() override;
 
 private:

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -504,6 +504,7 @@ private:
             _last_compaction_time_ms = UnixMillis();
         }
     }
+    bool is_apply_stop() { return _apply_stopped.load(); }
 
     bool compaction_running() { return _compaction_running; }
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3722,4 +3722,11 @@ TEST_F(TabletUpdatesTest, test_get_compaction_status) {
     test_horizontal_compaction(false, true);
 }
 
+TEST_F(TabletUpdatesTest, test_drop_tablet_with_keep_meta_and_files) {
+    _tablet = create_tablet(rand(), rand());
+    ASSERT_FALSE(_tablet->updates()->is_apply_stop());
+    StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id(), kKeepMetaAndFiles);
+    ASSERT_TRUE(_tablet->updates()->is_apply_stop());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
If we drop tablet with flag `kKeepMetaAndFiles`, we will remove this tablet from memory directly. However, if the tablet is the primary key table, there might still be ongoing apply tasks. We should stop the background apply tasks before deleting it; otherwise, if a new tablet is created, there could be a scenario where apply tasks are executed simultaneously.
e.g.
1. drop and clone a new tablet with the same tablet_id.
2.  compact rocksdb meta and reload tablet again.

## What I'm doing:
Stop running apply task first before remove the tablet from memory.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
