### PR TITLE
[Refactor] Remove charge_mode from lru cache

### DIFF
--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -320,7 +320,6 @@ Status CacheInputStream::read_at_fully(int64_t offset, void* out, int64_t count)
     char* p = static_cast<char*>(out);
     char* pe = p + count;
 
-    const int64_t _block_size = _cache->block_size();
     const int64_t start_block_id = offset / _block_size;
     const int64_t end_block_id = (end_offset - 1) / _block_size;
 

--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -193,10 +193,6 @@ void LRUCache::set_capacity(size_t capacity) {
     }
 }
 
-void LRUCache::set_charge_mode(ChargeMode charge_mode) {
-    _charge_mode = charge_mode;
-}
-
 uint64_t LRUCache::get_lookup_count() const {
     std::lock_guard l(_mutex);
     return _lookup_count;
@@ -406,7 +402,6 @@ ShardedLRUCache::ShardedLRUCache(size_t capacity, ChargeMode charge_mode)
     const size_t per_shard = (_capacity + (kNumShards - 1)) / kNumShards;
     for (auto& _shard : _shards) {
         _shard.set_capacity(per_shard);
-        _shard.set_charge_mode(_charge_mode);
     }
 }
 

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -274,8 +274,6 @@ public:
     // Separate from constructor so caller can easily make an array of LRUCache
     void set_capacity(size_t capacity);
 
-    void set_charge_mode(ChargeMode charge_mode);
-
     // Like Cache methods, but with an extra "hash" parameter.
     Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t charge,
                           void (*deleter)(const CacheKey& key, void* value),
@@ -299,8 +297,6 @@ private:
 
     // Initialized before use.
     size_t _capacity{0};
-
-    ChargeMode _charge_mode;
 
     // _mutex protects the following state.
     mutable std::mutex _mutex;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`charge_mode` is not used in `LRUCache`, so remove it.
Remove unused local var: _block_size.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
