### PR TITLE
[BugFix] Check the datacache usability before calling its function in case that the uninitialized members are called in some cases. (backport #51158)

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -810,7 +810,7 @@ void ExecEnv::try_release_resource_before_core_dump() {
         storage_page_cache->set_capacity(0);
         LOG(INFO) << "release storage page cache memory";
     }
-    if (_block_cache != nullptr && need_release("data_cache")) {
+    if (_block_cache != nullptr && _block_cache->available() && need_release("data_cache")) {
         // TODO: Currently, block cache don't support shutdown now,
         //  so here will temporary use update_mem_quota instead to release memory.
         (void)_block_cache->update_mem_quota(0, false);


### PR DESCRIPTION
## Why I'm doing:
Now we call datacache `update_mem_quota` functions to release the memory resource before coredump. However, in some cases, especially for unittests, the datacache instance may not be initialized, which cause an unintialized datacache instance is used and result in unexpected error.

## What I'm doing:
Check the datacache usability before calling its function.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

