### PR TITLE
[BugFix] Fix UDTF wrong result when miss multibyte UTF-8

### DIFF
--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -406,14 +406,11 @@ jobject JVMFunctionHelper::newString(const char* data, size_t size) {
     return nstr;
 }
 
-size_t JVMFunctionHelper::string_length(jstring jstr) {
-    return _env->GetStringUTFLength(jstr);
-}
-
 Slice JVMFunctionHelper::sliceVal(jstring jstr, std::string* buffer) {
-    size_t length = this->string_length(jstr);
-    buffer->resize(length);
-    _env->GetStringUTFRegion(jstr, 0, length, buffer->data());
+    const size_t utf_length = _env->GetStringUTFLength(jstr);
+    buffer->resize(utf_length);
+    const size_t string_length = _env->GetStringLength(jstr);
+    _env->GetStringUTFRegion(jstr, 0, string_length, buffer->data());
     return {buffer->data(), buffer->length()};
 }
 

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -128,7 +128,6 @@ public:
     DECLARE_NEW_BOX(double, double, Double)
 
     jobject newString(const char* data, size_t size);
-    size_t string_length(jstring jstr);
 
     Slice sliceVal(jstring jstr, std::string* buffer);
     jclass string_clazz() { return _string_class; }

--- a/test/sql/test_udf/R/test_jvm_udf
+++ b/test/sql/test_udf/R/test_jvm_udf
@@ -91,6 +91,34 @@ select count(udtfdouble) from t0, udtfdouble(c1);
 -- result:
 81920
 -- !result
+select * from TABLE(udtfstring(""));
+-- result:
+-- !result
+select * from TABLE(udtfstring("▁▂▃▄▅▆▇█"));
+-- result:
+▁▂▃▄▅▆▇█
+▁▂▃▄▅▆▇█
+-- !result
+select * from TABLE(udtfstring("中文测试"));
+-- result:
+中文测试
+中文测试
+-- !result
+select * from TABLE(udtfstring("∀∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂӥẄɐː⍎אԱა"));
+-- result:
+∀∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂӥẄɐː⍎אԱა
+∀∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂӥẄɐː⍎אԱა
+-- !result
+select * from TABLE(udtfstring("2H₂ + O₂ ⇌ 2H₂O"));
+-- result:
+2H₂ + O₂ ⇌ 2H₂O
+2H₂ + O₂ ⇌ 2H₂O
+-- !result
+select * from TABLE(udtfstring("ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ"));
+-- result:
+ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ
+ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ
+-- !result
 set streaming_preaggregation_mode="force_streaming";
 -- result:
 -- !result

--- a/test/sql/test_udf/T/test_jvm_udf
+++ b/test/sql/test_udf/T/test_jvm_udf
@@ -66,6 +66,14 @@ select count(udtfint) from t0, udtfint(c1);
 select count(udtfbigint) from t0, udtfbigint(c1);
 select count(udtffloat) from t0, udtffloat(c1);
 select count(udtfdouble) from t0, udtfdouble(c1);
+-- test udtf with utf8 case
+select * from TABLE(udtfstring(""));
+select * from TABLE(udtfstring("▁▂▃▄▅▆▇█"));
+select * from TABLE(udtfstring("中文测试"));
+select * from TABLE(udtfstring("∀∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂӥẄɐː⍎אԱა"));
+select * from TABLE(udtfstring("2H₂ + O₂ ⇌ 2H₂O"));
+select * from TABLE(udtfstring("ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ"));
+
 
 -- test group by limit case:
 set streaming_preaggregation_mode="force_streaming";


### PR DESCRIPTION
## Why I'm doing:
introduced by https://github.com/StarRocks/starrocks/pull/50615

```
mysql> select * from TABLE(udtfstring("中文"))
    -> ;
+------------+
| udtfstring |
+------------+
|            |
|            |
+------------+
2 rows in set (0.10 sec)
```
expected:
```
mysql> select * from TABLE(udtfstring("中文测试"));
+--------------+
| udtfstring   |
+--------------+
| 中文测试     |
| 中文测试     |
+--------------+
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
