### PR TITLE
[Enhancement] Set cookie path & http_only to make it more safe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/action/WebBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/WebBaseAction.java
@@ -272,6 +272,8 @@ public class WebBaseAction extends BaseAction {
         String key = UUID.randomUUID().toString();
         DefaultCookie cookie = new DefaultCookie(STARROCKS_SESSION_ID, key);
         cookie.setMaxAge(STARROCKS_SESSION_EXPIRED_TIME);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
         response.addCookie(cookie);
         HttpAuthManager.getInstance().addSessionValue(key, value);
     }


### PR DESCRIPTION
## Why I'm doing:
Using the HttpOnly flag when generating a cookie helps mitigate the risk of client side script accessing the protected cookie.

## What I'm doing:
Set cookie path & http_only to make it more safe

Fixes #51241 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
