### PR TITLE
[BugFix] Fix refresh list partition with duplicate values error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -229,7 +229,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
             }
         }
 
-        // check related partition table
+        // check the related partition table
         Set<String> needRefreshMvPartitionNames = getMvPartitionNamesToRefresh(mvRangePartitionNames);
         if (needRefreshMvPartitionNames.isEmpty()) {
             LOG.info("No need to refresh materialized view partitions, mv: {}", mv.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
@@ -80,6 +80,16 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
                 .map(item -> new PListCell(ImmutableList.of(item)))
                 .collect(Collectors.toSet());
     }
+
+    public Set<PListAtom> toAtoms() {
+        if (partitionItems == null) {
+            return Sets.newHashSet();
+        }
+        return partitionItems.stream()
+                .map(item -> new PListAtom(item))
+                .collect(Collectors.toSet());
+    }
+
     /**
      * Add a list of partition items as the partition values
      * @param items new partition items

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_multi_columns
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_multi_columns
@@ -1,0 +1,144 @@
+-- name: test_mv_refresh_list_partitions_multi_columns
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+    dt varchar(20),
+    province string,
+    num int
+)
+DUPLICATE KEY(dt)
+PARTITION BY LIST(`dt`, `province`)
+(
+    PARTITION `p1` VALUES IN (("2020-07-01", "beijing"), ("2020-07-02", "beijing")),
+    PARTITION `p2` VALUES IN (("2020-07-01", "chengdu"), ("2020-07-03", "chengdu")),
+    PARTITION `p3` VALUES IN (("2020-07-02", "hangzhou"), ("2020-07-04", "hangzhou"))
+);
+-- result:
+-- !result
+INSERT INTO t1 VALUES 
+    ("2020-07-01", "beijing",  1), ("2020-07-01", "chengdu",  2),
+    ("2020-07-02", "beijing",  3), ("2020-07-02", "hangzhou", 4),
+    ("2020-07-03", "chengdu",  1),
+    ("2020-07-04", "hangzhou", 1);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 
+    PARTITION BY dt
+    REFRESH DEFERRED MANUAL 
+    PROPERTIES (
+        'partition_refresh_number' = '-1',
+        "replication_num" = "1"
+    )
+    AS SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province;
+-- result:
+-- !result
+;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by dt, province;
+-- result:
+2020-07-01	beijing	1
+2020-07-01	chengdu	2
+2020-07-02	beijing	3
+2020-07-02	hangzhou	4
+2020-07-03	chengdu	1
+2020-07-04	hangzhou	1
+-- !result
+function: print_hit_materialized_view("SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;", "mv1")
+-- result:
+True
+-- !result
+SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;
+-- result:
+2020-07-01	beijing	1
+2020-07-01	chengdu	2
+2020-07-02	beijing	3
+2020-07-02	hangzhou	4
+2020-07-03	chengdu	1
+2020-07-04	hangzhou	1
+-- !result
+INSERT INTO t1 VALUES 
+    ("2020-07-01", "beijing",  1), ("2020-07-01", "chengdu",  2),
+    ("2020-07-02", "beijing",  3), ("2020-07-02", "hangzhou", 4);
+-- result:
+-- !result
+SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;
+-- result:
+2020-07-01	beijing	2
+2020-07-01	chengdu	4
+2020-07-02	beijing	6
+2020-07-02	hangzhou	8
+2020-07-03	chengdu	1
+2020-07-04	hangzhou	1
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by dt, province;
+-- result:
+2020-07-01	beijing	2
+2020-07-01	chengdu	4
+2020-07-02	beijing	6
+2020-07-02	hangzhou	8
+2020-07-03	chengdu	1
+2020-07-04	hangzhou	1
+-- !result
+function: print_hit_materialized_view("SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;", "mv1")
+-- result:
+True
+-- !result
+SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;
+-- result:
+2020-07-01	beijing	2
+2020-07-01	chengdu	4
+2020-07-02	beijing	6
+2020-07-02	hangzhou	8
+2020-07-03	chengdu	1
+2020-07-04	hangzhou	1
+-- !result
+ALTER TABLE t1 ADD PARTITION p4 VALUES in (('2020-07-02', 'shenzhen'));
+-- result:
+-- !result
+ALTER TABLE t1 ADD PARTITION p5 VALUES in (('2020-07-05', 'shenzhen'));
+-- result:
+-- !result
+INSERT INTO t1 VALUES 
+    ("2020-07-02", "shenzhen",  3), ("2020-07-05", "shenzhen", 4);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by dt, province;
+-- result:
+2020-07-01	beijing	2
+2020-07-01	chengdu	4
+2020-07-02	beijing	6
+2020-07-02	hangzhou	8
+2020-07-02	shenzhen	3
+2020-07-03	chengdu	1
+2020-07-04	hangzhou	1
+2020-07-05	shenzhen	4
+-- !result
+function: print_hit_materialized_view("SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;", "mv1")
+-- result:
+True
+-- !result
+SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;
+-- result:
+2020-07-01	beijing	2
+2020-07-01	chengdu	4
+2020-07-02	beijing	6
+2020-07-02	hangzhou	8
+2020-07-02	shenzhen	3
+2020-07-03	chengdu	1
+2020-07-04	hangzhou	1
+2020-07-05	shenzhen	4
+-- !result
+drop materialized view mv1;
+-- result:
+-- !result
+drop table t1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_basic
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_basic
@@ -276,6 +276,7 @@ function: check_hit_materialized_view("select dt, province, sum(age) from t5 gro
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 drop materialized view test_mv1;
 
+-- test list partition with multi columns & duplicate single values
 drop table t3;
 drop table t4;
 drop table t5;

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_multi_columns
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_multi_columns
@@ -1,0 +1,60 @@
+-- name: test_mv_refresh_list_partitions_multi_columns
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE t1 (
+    dt varchar(20),
+    province string,
+    num int
+)
+DUPLICATE KEY(dt)
+PARTITION BY LIST(`dt`, `province`)
+(
+    PARTITION `p1` VALUES IN (("2020-07-01", "beijing"), ("2020-07-02", "beijing")),
+    PARTITION `p2` VALUES IN (("2020-07-01", "chengdu"), ("2020-07-03", "chengdu")),
+    PARTITION `p3` VALUES IN (("2020-07-02", "hangzhou"), ("2020-07-04", "hangzhou"))
+);
+INSERT INTO t1 VALUES 
+    ("2020-07-01", "beijing",  1), ("2020-07-01", "chengdu",  2),
+    ("2020-07-02", "beijing",  3), ("2020-07-02", "hangzhou", 4),
+    ("2020-07-03", "chengdu",  1),
+    ("2020-07-04", "hangzhou", 1);
+
+-- test list partition with multi columns & duplicate single values
+CREATE MATERIALIZED VIEW mv1 
+    PARTITION BY dt
+    REFRESH DEFERRED MANUAL 
+    PROPERTIES (
+        'partition_refresh_number' = '-1',
+        "replication_num" = "1"
+    )
+    AS SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province;
+;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+
+select * from mv1 order by dt, province;
+function: print_hit_materialized_view("SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;", "mv1")
+SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;
+
+INSERT INTO t1 VALUES 
+    ("2020-07-01", "beijing",  1), ("2020-07-01", "chengdu",  2),
+    ("2020-07-02", "beijing",  3), ("2020-07-02", "hangzhou", 4);
+SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by dt, province;
+
+function: print_hit_materialized_view("SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;", "mv1")
+SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;
+ALTER TABLE t1 ADD PARTITION p4 VALUES in (('2020-07-02', 'shenzhen'));
+ALTER TABLE t1 ADD PARTITION p5 VALUES in (('2020-07-05', 'shenzhen'));
+
+INSERT INTO t1 VALUES 
+    ("2020-07-02", "shenzhen",  3), ("2020-07-05", "shenzhen", 4);
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by dt, province;
+function: print_hit_materialized_view("SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;", "mv1")
+SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province order by dt, province;
+
+drop materialized view mv1;
+drop table t1;


### PR DESCRIPTION
## Why I'm doing:

- If base table contains multi columns list partitions, it may throw `duplicate values` when refreshing mv.
```
CREATE TABLE t1 (
    dt varchar(20),
    province string,
    num int
)
DUPLICATE KEY(dt)
PARTITION BY LIST(`dt`, `province`)
(
    PARTITION `p1` VALUES IN (("2020-07-01", "beijing"), ("2020-07-02", "beijing")),
    PARTITION `p2` VALUES IN (("2020-07-01", "chengdu"), ("2020-07-03", "chengdu")),
    PARTITION `p3` VALUES IN (("2020-07-02", "hangzhou"), ("2020-07-04", "hangzhou"))
);
INSERT INTO t1 VALUES 
    ("2020-07-01", "beijing",  1), ("2020-07-01", "chengdu",  2),
    ("2020-07-02", "beijing",  3), ("2020-07-02", "hangzhou", 4),
    ("2020-07-03", "chengdu",  1),
    ("2020-07-04", "hangzhou", 1)
;
CREATE MATERIALIZED VIEW mv1 
    PARTITION BY dt
    REFRESH DEFERRED MANUAL 
    PROPERTIES (
        'partition_refresh_number' = '-1',
        "replication_num" = "1"
    )
    AS SELECT dt,province,sum(num) FROM t1 GROUP BY dt,province;
;
REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
ERROR 1064 (HY000): execute task mv-11022 failed: Refresh materialized view mv1 failed after retrying 1 times(try-lock 0 times), error-msg : com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Duplicate values (2020-07-01) .
	at com.starrocks.sql.analyzer.AlterTableClauseAnalyzer.visitAddPartitionClause(AlterTableClauseAnalyzer.java:1089)
	at com.starrocks.sql.analyzer.AlterTableClauseAnalyzer.visitAddPartitionClause(AlterTableClauseAnalyzer.java:120)
	at com.starrocks.sql.ast.AddPartitionCl
```
## What I'm doing:
- Check duplicated list partition single values(atom) in refreshing mv to avoid duplicate  values.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
