### PR TITLE
[BugFix] fix pk dump coredump

### DIFF
--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1606,7 +1606,7 @@ void PrimaryIndex::reset_cancel_major_compaction() {
 Status PrimaryIndex::pk_dump(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb) {
     if (_persistent_index != nullptr) {
         RETURN_IF_ERROR(_persistent_index->pk_dump(dump, dump_pb));
-    } else {
+    } else if (_pkey_to_rssid_rowid != nullptr) {
         PrimaryIndexDumpPB* level = dump_pb->add_primary_index_levels();
         level->set_filename("memory primary index");
         RETURN_IF_ERROR(_pkey_to_rssid_rowid->pk_dump(dump, level));


### PR DESCRIPTION
## Why I'm doing:
After primary key index unload, `_persistent_index` and `_pkey_to_rssid_rowid` could be both null, and it will cause be crash like:
```
*** Aborted at 1727044018 (unix time) try "date -d @1727044018" if you are using GNU date ***
PC: @          0x5eb2fdc starrocks::PrimaryIndex::pk_dump(starrocks::PrimaryKeyDump*, starrocks::PrimaryIndexMultiLevelPB*)
*** SIGSEGV (@0x0) received by PID 128429 (TID 0x7f406d43a700) from PID 0; stack trace: ***
    @     0x7f42bb9d920b __pthread_once_slow
    @          0x7a93740 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f42bc85254f os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x7f42bc8583b8 JVM_handle_linux_signal
    @     0x7f42bc849db8 signalHandler(int, siginfo_t*, void*)
    @     0x7f42bb9e2630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x5eb2fdc starrocks::PrimaryIndex::pk_dump(starrocks::PrimaryKeyDump*, starrocks::PrimaryIndexMultiLevelPB*)
    @          0x5ff6f14 starrocks::TabletUpdates::primary_index_dump(starrocks::PrimaryKeyDump*, starrocks::PrimaryIndexMultiLevelPB*)
    @          0x6292403 starrocks::PrimaryKeyDump::dump()
    @          0x60039e5 starrocks::TabletUpdates::generate_pk_dump_if_in_error_state()
    @          0x5f7f949 starrocks::TabletManager::generate_pk_dump()
    @          0x5ea7255 starrocks::StorageEngine::_pk_dump_thread_callback(void*)
    @          0xc1cadf0 execute_native_thread_routine
    @     0x7f42bb9daea5 start_thread
    @     0x7f42baddbb0d __clone
```

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8605

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
