### PR TITLE
[Enhancement] Add enable_tde global var

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/encryption/KeyMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/encryption/KeyMgr.java
@@ -27,6 +27,7 @@ import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.proto.EncryptionKeyPB;
 import com.starrocks.proto.EncryptionMetaPB;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TGetKeysRequest;
 import com.starrocks.thrift.TGetKeysResponse;
@@ -102,6 +103,7 @@ public class KeyMgr {
 
     public void initDefaultMasterKey() {
         String defaultMasterKeySpec = Config.default_master_key;
+        GlobalVariable.enableTde = isEncrypted();
         keysLock.writeLock().lock();
         try {
             if (defaultMasterKeySpec.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.Version;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.encryption.KeyMgr;
 import com.starrocks.system.BackendResourceStat;
 
 import java.lang.reflect.Field;
@@ -75,6 +76,7 @@ public final class GlobalVariable {
     public static final String QUERY_QUEUE_MAX_QUEUED_QUERIES = "query_queue_max_queued_queries";
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN = "activate_all_roles_on_login";
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN_V2 = "activate_all_roles_on_login_v2";
+    public static final String ENABLE_TDE = "enable_tde";
 
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH;
@@ -172,6 +174,9 @@ public final class GlobalVariable {
     @VariableMgr.VarAttr(name = ACTIVATE_ALL_ROLES_ON_LOGIN_V2, flag = VariableMgr.GLOBAL,
             alias = ACTIVATE_ALL_ROLES_ON_LOGIN, show = ACTIVATE_ALL_ROLES_ON_LOGIN)
     private static boolean activateAllRolesOnLogin = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_TDE, flag = VariableMgr.GLOBAL | VariableMgr.READ_ONLY)
+    public static boolean enableTde = KeyMgr.isEncrypted();
 
     public static boolean isEnableQueryQueueSelect() {
         return enableQueryQueueSelect;


### PR DESCRIPTION
## Why I'm doing:

It hard for user to know if cluster is configed with TDE

## What I'm doing:

Add a enable_tde global var to show if cluste is configed with TDE


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
