### PR TITLE
[BugFix] Fix asan stack-use-after-return when update starlet config

### DIFF
--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -253,82 +253,29 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         });
 
 #ifdef USE_STAROS
-        _config_callback.emplace("starlet_cache_thread_num", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_threadpool_size", value).empty()) {
-                LOG(WARNING) << "Failed to update cachemgr_threadpool_size";
-            }
-        });
-        _config_callback.emplace("starlet_cache_evict_low_water", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_low_water", value).empty()) {
-                LOG(WARNING) << "Failed to update cachemgr_evict_low_water";
-            }
-        });
-        _config_callback.emplace("starlet_cache_evict_percent", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_percent", value).empty()) {
-                LOG(WARNING) << "Failed to update cachemgr_evict_percent";
-            }
-        });
-        _config_callback.emplace("starlet_cache_evict_throughput_mb", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_throughput_mb", value).empty()) {
-                LOG(WARNING) << "Failed to update cachemgr_evict_throughput_mb";
-            }
-        });
-        _config_callback.emplace("starlet_cache_evict_high_water", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_high_water", value).empty()) {
-                LOG(WARNING) << "Failed to update cachemgr_evict_high_water";
-            }
-        });
-        _config_callback.emplace("starlet_fs_stream_buffer_size_bytes", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("fs_stream_buffer_size_bytes", value).empty()) {
-                LOG(WARNING) << "Failed to update fs_stream_buffer_size_bytes";
-            }
-        });
-        _config_callback.emplace("starlet_fs_read_prefetch_enable", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("fs_enable_buffer_prefetch", value).empty()) {
-                LOG(WARNING) << "Failed to update fs_enable_buffer_prefetch";
-            }
-        });
-        _config_callback.emplace("starlet_fs_read_prefetch_threadpool_size", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("fs_buffer_prefetch_threadpool_size", value)
-                        .empty()) {
-                LOG(WARNING) << "Failed to update fs_buffer_prefetch_threadpool_size";
-            }
-        });
-        _config_callback.emplace("starlet_cache_evict_interval", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_interval", value).empty()) {
-                LOG(WARNING) << "Failed to update cachemgr_evict_interval";
-            }
-        });
-        _config_callback.emplace("starlet_fslib_s3client_nonread_max_retries", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("fslib_s3client_nonread_max_retries", value)
-                        .empty()) {
-                LOG(WARNING) << "Failed to update fslib_s3client_nonread_max_retries";
-            }
-        });
-        _config_callback.emplace("starlet_fslib_s3client_nonread_retry_scale_factor", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("fslib_s3client_nonread_retry_scale_factor",
-                                                                      value)
-                        .empty()) {
-                LOG(WARNING) << "Failed to update fslib_s3client_nonread_retry_scale_factor";
-            }
-        });
-        _config_callback.emplace("starlet_fslib_s3client_connect_timeout_ms", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("fslib_s3client_connect_timeout_ms", value)
-                        .empty()) {
-                LOG(WARNING) << "Failed to update fslib_s3client_connect_timeout_ms";
-            }
-        });
-        _config_callback.emplace("s3_use_list_objects_v1", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("fslib_s3client_use_list_objects_v1", value)
-                        .empty()) {
-                LOG(WARNING) << "Failed to update fslib_s3client_use_list_objects_v1";
-            }
-        });
-        _config_callback.emplace("starlet_delete_files_max_key_in_batch", [&]() {
-            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("delete_files_max_key_in_batch", value).empty()) {
-                LOG(WARNING) << "Failed to update delete_files_max_key_in_batch";
-            }
-        });
+#define UPDATE_STARLET_CONFIG(BE_CONFIG, STARLET_CONFIG)                                             \
+    _config_callback.emplace(#BE_CONFIG, [value]() {                                                 \
+        if (staros::starlet::common::GFlagsUtils::UpdateFlagValue(#STARLET_CONFIG, value).empty()) { \
+            LOG(WARNING) << "Failed to update " << #STARLET_CONFIG;                                  \
+        }                                                                                            \
+    });
+
+        UPDATE_STARLET_CONFIG(starlet_cache_thread_num, cachemgr_threadpool_size);
+        UPDATE_STARLET_CONFIG(starlet_cache_evict_low_water, cachemgr_evict_low_water);
+        UPDATE_STARLET_CONFIG(starlet_cache_evict_high_water, cachemgr_evict_high_water);
+        UPDATE_STARLET_CONFIG(starlet_cache_evict_percent, cachemgr_evict_percent);
+        UPDATE_STARLET_CONFIG(starlet_cache_evict_throughput_mb, cachemgr_evict_throughput_mb);
+        UPDATE_STARLET_CONFIG(starlet_fs_stream_buffer_size_bytes, fs_stream_buffer_size_bytes);
+        UPDATE_STARLET_CONFIG(starlet_fs_read_prefetch_enable, fs_enable_buffer_prefetch);
+        UPDATE_STARLET_CONFIG(starlet_fs_read_prefetch_threadpool_size, fs_buffer_prefetch_threadpool_size);
+        UPDATE_STARLET_CONFIG(starlet_cache_evict_interval, cachemgr_evict_interval);
+        UPDATE_STARLET_CONFIG(starlet_fslib_s3client_nonread_max_retries, fslib_s3client_nonread_max_retries);
+        UPDATE_STARLET_CONFIG(starlet_fslib_s3client_nonread_retry_scale_factor,
+                              fslib_s3client_nonread_retry_scale_factor);
+        UPDATE_STARLET_CONFIG(starlet_fslib_s3client_connect_timeout_ms, fslib_s3client_connect_timeout_ms);
+        UPDATE_STARLET_CONFIG(s3_use_list_objects_v1, fslib_s3client_use_list_objects_v1);
+        UPDATE_STARLET_CONFIG(starlet_delete_files_max_key_in_batch, delete_files_max_key_in_batch);
+#undef UPDATE_STARLET_CONFIG
 #endif // USE_STAROS
     });
 

--- a/test/sql/test_conf/R/test_update_starlet_config
+++ b/test/sql/test_conf/R/test_update_starlet_config
@@ -1,0 +1,34 @@
+-- name: test_update_starlet_config
+
+update information_schema.be_configs set value = "32" where name = "starlet_cache_thread_num";
+-- result:
+-- !result
+select distinct value from information_schema.be_configs where name = "starlet_cache_thread_num";
+-- result:
+32
+-- !result
+update information_schema.be_configs set value = "16" where name = "starlet_cache_thread_num";
+-- result:
+-- !result
+
+update information_schema.be_configs set value = "0.2" where name = "starlet_cache_evict_low_water";
+-- result:
+-- !result
+select distinct value from information_schema.be_configs where name = "starlet_cache_evict_low_water";
+-- result:
+0.2
+-- !result
+update information_schema.be_configs set value = "0.1" where name = "starlet_cache_evict_low_water";
+-- result:
+-- !result
+
+update information_schema.be_configs set value = "true" where name = "starlet_fs_read_prefetch_enable";
+-- result:
+-- !result
+select distinct value from information_schema.be_configs where name = "starlet_fs_read_prefetch_enable";
+-- result:
+true
+-- !result
+update information_schema.be_configs set value = "false" where name = "starlet_fs_read_prefetch_enable";
+-- result:
+-- !result

--- a/test/sql/test_conf/R/test_update_starlet_config
+++ b/test/sql/test_conf/R/test_update_starlet_config
@@ -1,4 +1,4 @@
--- name: test_update_starlet_config
+-- name: test_update_starlet_config @cloud
 
 update information_schema.be_configs set value = "32" where name = "starlet_cache_thread_num";
 -- result:

--- a/test/sql/test_conf/T/test_update_starlet_config
+++ b/test/sql/test_conf/T/test_update_starlet_config
@@ -1,4 +1,4 @@
--- name: test_update_starlet_config
+-- name: test_update_starlet_config @cloud
 
 update information_schema.be_configs set value = "32" where name = "starlet_cache_thread_num";
 select distinct value from information_schema.be_configs where name = "starlet_cache_thread_num";

--- a/test/sql/test_conf/T/test_update_starlet_config
+++ b/test/sql/test_conf/T/test_update_starlet_config
@@ -1,0 +1,13 @@
+-- name: test_update_starlet_config
+
+update information_schema.be_configs set value = "32" where name = "starlet_cache_thread_num";
+select distinct value from information_schema.be_configs where name = "starlet_cache_thread_num";
+update information_schema.be_configs set value = "16" where name = "starlet_cache_thread_num";
+
+update information_schema.be_configs set value = "0.2" where name = "starlet_cache_evict_low_water";
+select distinct value from information_schema.be_configs where name = "starlet_cache_evict_low_water";
+update information_schema.be_configs set value = "0.1" where name = "starlet_cache_evict_low_water";
+
+update information_schema.be_configs set value = "true" where name = "starlet_fs_read_prefetch_enable";
+select distinct value from information_schema.be_configs where name = "starlet_fs_read_prefetch_enable";
+update information_schema.be_configs set value = "false" where name = "starlet_fs_read_prefetch_enable";


### PR DESCRIPTION
## Why I'm doing:
```
==665556==ERROR: AddressSanitizer: stack-use-after-return on address 0x7fcb5cfd99c0 at pc 0x00000f7d905e bp 0x7fcb5e887f50 sp 0x7fcb5e887f48
READ of size 8 at 0x7fcb5cfd99c0 thread T259
    #0 0xf7d905d in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_data() const /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:195:28
    #1 0xf7c87e4 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::c_str() const /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:2321:16
    #2 0x1f6c88a4 in staros::starlet::common::GFlagsUtils::UpdateFlagValue(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/disk3/sr-deps/thirdparty/installed/starlet/starlet_install/include/common/gflags_utils.h:121:65
    #3 0x21f29d3d in starrocks::UpdateConfigAction::update_config(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)::$_0::operator()() const::'lambda32'()::operator()() const be/build_ASAN/src/http/be/src/http/action/update_config_action.cpp:262:17
    #4 0x21f29b84 in void std::__invoke_impl<void, starrocks::UpdateConfigAction::update_config(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)::$_0::operator()() const::'lambda32'()&>(std::__invoke_other, starrocks::UpdateConfigAction::update_config(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)::$_0::operator()() const::'lambda32'()&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #5 0x21f29b34 in std::enable_if<is_invocable_r_v<void, starrocks::UpdateConfigAction::update_config(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)::$_0::operator()() const::'lambda32'()&>, void>::type std::__invoke_r<void, starrocks::UpdateConfigAction::update_config(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)::$_0::operator()() const::'lambda32'()&>(starrocks::UpdateConfigAction::update_config(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)::$_0::operator()() const::'lambda32'()&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #6 0x21f299fc in std::_Function_handler<void (), starrocks::UpdateConfigAction::update_config(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)::$_0::operator()() const::'lambda32'()>::_M_invoke(std::_Any_data const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:290:9
    #7 0xf8088d2 in std::function<void ()>::operator()() const /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:590:9
    #8 0x21ef2fec in starrocks::UpdateConfigAction::update_config(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) be/build_ASAN/src/http/be/src/http/action/update_config_action.cpp:339:13
    #9 0x1f606445 in starrocks::write_be_configs_table(starrocks::StarRocksNodesInfo const&, long, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column>>>&) be/build_ASAN/src/runtime/be/src/runtime/schema_table_sink.cpp:125:32
    #10 0x1f605426 in starrocks::SchemaTableSink::send_chunk(starrocks::RuntimeState*, starrocks::Chunk*) be/build_ASAN/src/runtime/be/src/runtime/schema_table_sink.cpp:147:16
    #11 0x1eea2d4a in starrocks::PlanFragmentExecutor::_open_internal_vectorized() be/build_ASAN/src/runtime/be/src/runtime/plan_fragment_executor.cpp:252:9
    #12 0x1eea13fa in starrocks::PlanFragmentExecutor::open() be/build_ASAN/src/runtime/be/src/runtime/plan_fragment_executor.cpp:205:21
    #13 0x1ee65924 in starrocks::FragmentExecState::execute() be/build_ASAN/src/runtime/be/src/runtime/fragment_mgr.cpp:202:9
    #14 0x1ee682ad in starrocks::FragmentMgr::exec_actual(std::shared_ptr<starrocks::FragmentExecState> const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&) be/build_ASAN/src/runtime/be/src/runtime/fragment_mgr.cpp:403:5
    #15 0x1ee7b604 in starrocks::FragmentMgr::exec_plan_fragment(starrocks::TExecPlanFragmentParams const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&)::$_3::operator()() const be/build_ASAN/src/runtime/be/src/runtime/fragment_mgr.cpp:466:66
    #16 0x1ee7b5b4 in void std::__invoke_impl<void, starrocks::FragmentMgr::exec_plan_fragment(starrocks::TExecPlanFragmentParams const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&)::$_3&>(std::__invoke_other, starrocks::FragmentMgr::exec_plan_fragment(starrocks::TExecPlanFragmentParams const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&)::$_3&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #17 0x1ee7b554 in std::enable_if<is_invocable_r_v<void, starrocks::FragmentMgr::exec_plan_fragment(starrocks::TExecPlanFragmentParams const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&)::$_3&>, void>::type std::__invoke_r<void, starrocks::FragmentMgr::exec_plan_fragment(starrocks::TExecPlanFragmentParams const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&)::$_3&>(starrocks::FragmentMgr::exec_plan_fragment(starrocks::TExecPlanFragmentParams const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&)::$_3&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #18 0x1ee7b2cc in std::_Function_handler<void (), starrocks::FragmentMgr::exec_plan_fragment(starrocks::TExecPlanFragmentParams const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&, std::function<void (starrocks::PlanFragmentExecutor*)> const&)::$_3>::_M_invoke(std::_Any_data const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:290:9
    #19 0xf8088d2 in std::function<void ()>::operator()() const /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:590:9
    #20 0x1fd822b8 in starrocks::FunctionRunnable::run() be/build_ASAN/src/util/be/src/util/threadpool.cpp:59:27
    #21 0x1fd6f132 in starrocks::ThreadPool::dispatch_thread() be/build_ASAN/src/util/be/src/util/threadpool.cpp:635:24
    #22 0x1fd945d3 in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #23 0x1fd944ac in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #24 0x1fd94434 in void std::_Bind<void (starrocks::ThreadPool::* (starrocks::ThreadPool*))()>::__call<void, 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #25 0x1fd942dd in void std::_Bind<void (starrocks::ThreadPool::* (starrocks::ThreadPool*))()>::operator()<void>() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #26 0x1fd941f4 in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::* (starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::* (starrocks::ThreadPool*))()>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #27 0x1fd94194 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::* (starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::* (starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::* (starrocks::ThreadPool*))()>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #28 0x1fd93efc in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::* (starrocks::ThreadPool*))()>>::_M_invoke(std::_Any_data const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:290:9
    #29 0xf8088d2 in std::function<void ()>::operator()() const /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:590:9
    #30 0x1fd4c4bf in starrocks::Thread::supervise_thread(void*) be/build_ASAN/src/util/be/src/util/thread.cpp:366:5
    #31 0x7fcc5e1d5ac2 in start_thread nptl/pthread_create.c:442:8
    #32 0x7fcc5e26784f  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

Address 0x7fcb5cfd99c0 is located in stack of thread T259 at offset 448 in frame
    #0 0x1f6055ef in starrocks::write_be_configs_table(starrocks::StarRocksNodesInfo const&, long, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column>>>&) be/build_ASAN/src/runtime/be/src/runtime/schema_table_sink.cpp:105

  This frame has 22 object(s):
    [32, 48) 'agg.tmp'
    [64, 160) 'ref.tmp' (line 111)
    [192, 256) 'ref.tmp15' (line 116)
    [288, 320) 'name' (line 117)
    [352, 416) 'ref.tmp25' (line 117)
    [448, 480) 'value' (line 118) <== Memory access at offset 448 is inside this variable
    [512, 576) 'ref.tmp38' (line 118)
    [608, 640) 'mode' (line 119)
    [672, 680) 's' (line 120)
    [704, 800) 'ref.tmp53' (line 122)
    [832, 864) 'ref.tmp59' (line 122)
    [896, 912) 'agg.tmp60'
    [928, 976) 'ref.tmp63' (line 122)
    [1008, 1056) 'ref.tmp66' (line 122)
    [1088, 1096) 'ref.tmp83' (line 125)
    [1120, 1128) 'ref.tmp92' (line 128)
    [1152, 1184) 'ref.tmp97' (line 129)
    [1216, 1232) 'agg.tmp98'
    [1248, 1296) 'ref.tmp101' (line 129)
    [1328, 1424) 'ref.tmp112' (line 132)
    [1456, 1552) 'ref.tmp137' (line 134)
    [1584, 1616) 'ref.tmp157' (line 134)
```

## What I'm doing:
capture `value` by value in the lambda function to ensure its validity in the callback

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
