### PR TITLE
[Enhancement] add metric for running txn number of per db

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -75,6 +75,7 @@ import com.starrocks.service.ExecuteEnv;
 import com.starrocks.staros.StarMgrServer;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.transaction.DatabaseTransactionMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -804,6 +805,9 @@ public final class MetricRepo {
         //collect connections for per user
         collectUserConnMetrics(visitor);
 
+        // collect runnning txns of per db
+        collectDbRunningTxnMetrics(visitor);
+
         // collect starmgr related metrics as well
         StarMgrServer.getCurrentState().visitMetrics(visitor);
 
@@ -923,6 +927,23 @@ public final class MetricRepo {
             metricConnect.setValue(connValue.get());
             visitor.visit(metricConnect);
         });
+    }
+
+    // collect runnning txns of per db
+    private static void collectDbRunningTxnMetrics(MetricVisitor visitor) {
+        Map<Long, DatabaseTransactionMgr> dbIdToDatabaseTransactionMgrs =
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getAllDatabaseTransactionMgrs();
+        for (DatabaseTransactionMgr mgr : dbIdToDatabaseTransactionMgrs.values()) {
+            GaugeMetricImpl<Long> txnNum = new GaugeMetricImpl<>("running_txn_num", MetricUnit.NOUNIT,
+                     "number of running transactions");
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mgr.getDbId());
+            if (null == db) {
+                continue;
+            }
+            txnNum.addLabel(new MetricLabel("db", db.getFullName()));
+            txnNum.setValue(mgr.getRunningTxnNumsWithLock());
+            visitor.visit(txnNum);
+        }
     }
 
     public static synchronized List<Metric> getMetricsByName(String name) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -934,7 +934,7 @@ public final class MetricRepo {
         Map<Long, DatabaseTransactionMgr> dbIdToDatabaseTransactionMgrs =
                 GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getAllDatabaseTransactionMgrs();
         for (DatabaseTransactionMgr mgr : dbIdToDatabaseTransactionMgrs.values()) {
-            GaugeMetricImpl<Long> txnNum = new GaugeMetricImpl<>("running_txn_num", MetricUnit.NOUNIT,
+            GaugeMetricImpl<Long> txnNum = new GaugeMetricImpl<>("txn_running", MetricUnit.NOUNIT,
                      "number of running transactions");
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mgr.getDbId());
             if (null == db) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -639,6 +639,15 @@ public class DatabaseTransactionMgr {
         return runningTxnNums;
     }
 
+    public long getRunningTxnNumsWithLock() {
+        readLock();
+        try {
+            return runningTxnNums;
+        } finally {
+            readUnlock();
+        }
+    }
+
     @VisibleForTesting
     protected int getRunningRoutineLoadTxnNums() {
         return runningRoutineLoadTxnNums;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -115,6 +115,10 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         return databaseTransactionMgr;
     }
 
+    public Map<Long, DatabaseTransactionMgr> getAllDatabaseTransactionMgrs() {
+        return dbIdToDatabaseTransactionMgrs;
+    }
+
     public void addDatabaseTransactionMgr(Long dbId) {
         if (dbIdToDatabaseTransactionMgrs.putIfAbsent(dbId, new DatabaseTransactionMgr(dbId, globalStateMgr)) == null) {
             LOG.debug("add database transaction manager for db {}", dbId);


### PR DESCRIPTION
## Why I'm doing:

We now have a limit on the number of running txn per database, but no metrics per database running txn.

## What I'm doing:

Add metric for running txn number of per database.

![image](https://github.com/user-attachments/assets/7d97ccd7-4746-4bb8-b1b5-837fbc378946)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
