### PR TITLE
[Enhancement] Temporarily ingore protobuf-java cve CVE-2024-7254

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# ignore protobuf cve temporary
+CVE-2024-7254

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -446,7 +446,7 @@ under the License.
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.16.3</version>
+                <version>3.25.5</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->


### PR DESCRIPTION
## Why I'm doing:
It's hard to fix it now because we've already using the latest `hadoop-common:3.4.0` component.

## What I'm doing:

Temporarily ingore protobuf-java cve CVE-2024-7254
Bump protobuf-java -> 3.25.5, which fixed this problem

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
