### PR TITLE
[Enhancement] add jemalloc memory tracker

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -79,6 +79,9 @@ CONF_mInt64(auto_adjust_pagecache_interval_seconds, "10");
 // must larger than 0. and if larger than physical memory size,
 // it will be set to physical memory size.
 CONF_String(mem_limit, "90%");
+
+// Enable the jemalloc tracker, which is responsible for reserving memory
+CONF_Bool(enable_jemalloc_memory_tracker, "true");
 // Consider part of jemalloc memory as fragmentation: ratio * (RSS-allocated-metadata)
 CONF_mDouble(jemalloc_fragmentation_ratio, "0.3");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -79,6 +79,8 @@ CONF_mInt64(auto_adjust_pagecache_interval_seconds, "10");
 // must larger than 0. and if larger than physical memory size,
 // it will be set to physical memory size.
 CONF_String(mem_limit, "90%");
+// Consider part of jemalloc memory as fragmentation: ratio * (RSS-allocated-metadata)
+CONF_mDouble(jemalloc_fragmentation_ratio, "0.3");
 
 // The port heartbeat service used.
 CONF_Int32(heartbeat_service_port, "9050");

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -182,6 +182,80 @@ void calculate_metrics(void* arg_this) {
     }
 }
 
+struct JemallocStats {
+    int64_t allocated = 0;
+    int64_t active = 0;
+    int64_t metadata = 0;
+    int64_t resident = 0;
+    int64_t mapped = 0;
+    int64_t retained = 0;
+};
+
+static void retrieve_jemalloc_stats(JemallocStats* stats) {
+    uint64_t epoch = 1;
+    size_t sz = sizeof(epoch);
+    je_mallctl("epoch", &epoch, &sz, &epoch, sz);
+
+    int64_t value = 0;
+    sz = sizeof(value);
+    if (je_mallctl("stats.allocated", &value, &sz, nullptr, 0) == 0) {
+        stats->allocated = value;
+    }
+    if (je_mallctl("stats.active", &value, &sz, nullptr, 0) == 0) {
+        stats->active = value;
+    }
+    if (je_mallctl("stats.metadata", &value, &sz, nullptr, 0) == 0) {
+        stats->metadata = value;
+    }
+    if (je_mallctl("stats.resident", &value, &sz, nullptr, 0) == 0) {
+        stats->resident = value;
+    }
+    if (je_mallctl("stats.mapped", &value, &sz, nullptr, 0) == 0) {
+        stats->mapped = value;
+    }
+    if (je_mallctl("stats.retained", &value, &sz, nullptr, 0) == 0) {
+        stats->retained = value;
+    }
+}
+
+// Tracker the memory usage of jemalloc
+void jemalloc_tracker_daemon(void* arg_this) {
+    auto* daemon = static_cast<Daemon*>(arg_this);
+    while (!daemon->stopped()) {
+        JemallocStats stats;
+        retrieve_jemalloc_stats(&stats);
+
+        // metadata
+        if (GlobalEnv::GetInstance()->jemalloc_metadata_traker() && stats.metadata > 0) {
+            auto tracker = GlobalEnv::GetInstance()->jemalloc_metadata_traker();
+            int64_t delta = stats.metadata - tracker->consumption();
+            tracker->consume(delta);
+        }
+
+        // fragmentation
+        if (GlobalEnv::GetInstance()->jemalloc_fragmentation_traker()) {
+            if (stats.resident > 0 && stats.allocated > 0 && stats.metadata > 0) {
+                int64_t fragmentation = stats.resident - stats.allocated - stats.metadata;
+                fragmentation *= config::jemalloc_fragmentation_ratio;
+
+                // In case that released a lot of memory but not get purged, we would not consider it as fragmentation
+                bool released_a_lot = stats.allocated < (stats.resident * 0.5);
+                if (released_a_lot) {
+                    fragmentation = 0;
+                }
+
+                if (fragmentation >= 0) {
+                    auto tracker = GlobalEnv::GetInstance()->jemalloc_fragmentation_traker();
+                    int64_t delta = fragmentation - tracker->consumption();
+                    tracker->consume(delta);
+                }
+            }
+        }
+
+        nap_sleep(1, [daemon] { return daemon->stopped(); });
+    }
+}
+
 static void init_starrocks_metrics(const std::vector<StorePath>& store_paths) {
     bool init_system_metrics = config::enable_system_metrics;
     std::set<std::string> disk_devices;
@@ -282,6 +356,12 @@ void Daemon::init(bool as_cn, const std::vector<StorePath>& paths) {
         std::thread calculate_metrics_thread(calculate_metrics, this);
         Thread::set_thread_name(calculate_metrics_thread, "metrics_daemon");
         _daemon_threads.emplace_back(std::move(calculate_metrics_thread));
+    }
+
+    if (config::enable_jemalloc_memory_tracker) {
+        std::thread jemalloc_tracker_thread(jemalloc_tracker_daemon, this);
+        Thread::set_thread_name(jemalloc_tracker_thread, "jemalloc_tracker_daemon");
+        _daemon_threads.emplace_back(std::move(jemalloc_tracker_thread));
     }
 
     init_signals();

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -202,6 +202,8 @@ Status GlobalEnv::_init_mem_tracker() {
     }
 
     _process_mem_tracker = regist_tracker(MemTracker::PROCESS, bytes_limit, "process");
+    _jemalloc_metadata_tracker =
+            regist_tracker(MemTracker::JEMALLOC, -1, "jemalloc_metadata", _process_mem_tracker.get());
     int64_t query_pool_mem_limit =
             calc_max_query_memory(_process_mem_tracker->limit(), config::query_max_memory_limit_percent);
     _query_pool_mem_tracker =

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -204,6 +204,8 @@ Status GlobalEnv::_init_mem_tracker() {
     _process_mem_tracker = regist_tracker(MemTracker::PROCESS, bytes_limit, "process");
     _jemalloc_metadata_tracker =
             regist_tracker(MemTracker::JEMALLOC, -1, "jemalloc_metadata", _process_mem_tracker.get());
+    _jemalloc_fragmentation_tracker =
+            regist_tracker(MemTracker::JEMALLOC, -1, "jemalloc_fragmentation", _process_mem_tracker.get());
     int64_t query_pool_mem_limit =
             calc_max_query_memory(_process_mem_tracker->limit(), config::query_max_memory_limit_percent);
     _query_pool_mem_tracker =

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -147,6 +147,7 @@ public:
     MemTracker* consistency_mem_tracker() { return _consistency_mem_tracker.get(); }
     MemTracker* replication_mem_tracker() { return _replication_mem_tracker.get(); }
     MemTracker* datacache_mem_tracker() { return _datacache_mem_tracker.get(); }
+    MemTracker* jemalloc_metadata_traker() { return _jemalloc_metadata_tracker.get(); }
     std::vector<std::shared_ptr<MemTracker>>& mem_trackers() { return _mem_trackers; }
 
     int64_t get_storage_page_cache_size();
@@ -166,6 +167,9 @@ private:
 
     // root process memory tracker
     std::shared_ptr<MemTracker> _process_mem_tracker;
+
+    // Track metadata usage of jemalloc
+    std::shared_ptr<MemTracker> _jemalloc_metadata_tracker;
 
     // Limit the memory used by the query. At present, it can use 90% of the be memory limit
     std::shared_ptr<MemTracker> _query_pool_mem_tracker;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -148,6 +148,7 @@ public:
     MemTracker* replication_mem_tracker() { return _replication_mem_tracker.get(); }
     MemTracker* datacache_mem_tracker() { return _datacache_mem_tracker.get(); }
     MemTracker* jemalloc_metadata_traker() { return _jemalloc_metadata_tracker.get(); }
+    MemTracker* jemalloc_fragmentation_traker() { return _jemalloc_fragmentation_tracker.get(); }
     std::vector<std::shared_ptr<MemTracker>>& mem_trackers() { return _mem_trackers; }
 
     int64_t get_storage_page_cache_size();
@@ -168,8 +169,9 @@ private:
     // root process memory tracker
     std::shared_ptr<MemTracker> _process_mem_tracker;
 
-    // Track metadata usage of jemalloc
+    // Track usage of jemalloc
     std::shared_ptr<MemTracker> _jemalloc_metadata_tracker;
+    std::shared_ptr<MemTracker> _jemalloc_fragmentation_tracker;
 
     // Limit the memory used by the query. At present, it can use 90% of the be memory limit
     std::shared_ptr<MemTracker> _query_pool_mem_tracker;

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -102,7 +102,8 @@ public:
         COMPACTION,
         SCHEMA_CHANGE_TASK,
         RESOURCE_GROUP,
-        RESOURCE_GROUP_BIG_QUERY
+        RESOURCE_GROUP_BIG_QUERY,
+        JEMALLOC,
     };
 
     /// 'byte_limit' < 0 means no limit

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -334,8 +334,8 @@ void SystemMetrics::_update_memory_metrics() {
                 size_t fragmentation = resident - allocated - metadata;
                 fragmentation *= config::jemalloc_fragmentation_ratio;
                 // Handle the case that just release a lot of memory but not get purged
-                fragmentation = std::min(fragmentation, (size_t)(resident * config::jemalloc_fragmentation_ratio));
-                if (fragmentation > 0) {
+                bool mostly_allocated = allocated > (resident * 0.5);
+                if (fragmentation > 0 && mostly_allocated) {
                     GlobalEnv::GetInstance()->jemalloc_fragmentation_traker()->set(fragmentation);
                 }
             }

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -318,11 +318,15 @@ void SystemMetrics::_update_memory_metrics() {
     }
 #endif
 
+    // update the jemalloc tracker
+    GlobalEnv::GetInstance()->jemalloc_metadata_traker()->set(_memory_metrics->jemalloc_metadata_bytes.value());
+
 #define SET_MEM_METRIC_VALUE(tracker, key)                                                  \
     if (GlobalEnv::GetInstance()->tracker() != nullptr) {                                   \
         _memory_metrics->key.set_value(GlobalEnv::GetInstance()->tracker()->consumption()); \
     }
 
+    // update the metrics according to tracker value
     SET_MEM_METRIC_VALUE(process_mem_tracker, process_mem_bytes)
     SET_MEM_METRIC_VALUE(query_pool_mem_tracker, query_mem_bytes)
     SET_MEM_METRIC_VALUE(load_mem_tracker, load_mem_bytes)


### PR DESCRIPTION
## Why I'm doing:

Jemalloc metadata is a footprint of jemalloc, which cannot be used by starrocks process. It should be considered into the ProcessMemTracker, otherwise the memory usage would exceed the specified `mem_limit`. For some edge cases, it can exceed 10GB, which is significant.

And also, there would be some fragmentation in jemalloc, which means not all of memory can be used for allocation, we need to consider them into the MemTracker.

## What I'm doing:

1. Add a `jemalloc_metadata` MemTracker and update according to `stats.metadata` from jemalloc
2. Add a `jemalloc_fragmentation` MemTracker and set it to `0.3 * (rss-allocated-metadata)` 
3. Add a new configuration in be: `jemalloc_fragmentation_ratio`, whose default value is `0.3`
4. Put them into the ProcessMemTracker to reserve some memory 

Function configurations:
- `enable_jemalloc_memory_tracker`, whether enable this feature, default true
- `jemalloc_fragmentation_ratio`, the supposed fragmentation ratio of jemalloc


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
