### PR TITLE
[UT]Use beforeClass in RangerInterfaceTest to avoid timeout

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/privilege/InvalidateObjectTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/InvalidateObjectTest.java
@@ -26,22 +26,22 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class InvalidateObjectTest {
-    private ConnectContext ctx;
+    private static ConnectContext ctx;
     private static final String DB_NAME = "db";
     private static final String TABLE_NAME_0 = "tbl0";
     private static final String TABLE_NAME_1 = "tbl1";
     private UserIdentity testUser = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
-    private long publicRoleId;
+    private static long publicRoleId;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
         UtFrameUtils.createMinStarRocksCluster();
         UtFrameUtils.setUpForPersistTest();

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/ranger/RangerInterfaceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/ranger/RangerInterfaceTest.java
@@ -49,7 +49,7 @@ import org.apache.ranger.plugin.policyengine.RangerAccessResult;
 import org.apache.ranger.plugin.policyengine.RangerAccessResultProcessor;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -60,12 +60,11 @@ import java.util.List;
 import java.util.Map;
 
 public class RangerInterfaceTest {
+    static ConnectContext connectContext;
+    static StarRocksAssert starRocksAssert;
 
-    ConnectContext connectContext;
-    StarRocksAssert starRocksAssert;
-
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
         new MockUp<RangerBasePlugin>() {
             @Mock
             void init() {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
