### PR TITLE
[BugFix] Fix deadlock when starting exclusive resource group executor

### DIFF
--- a/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
+++ b/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
@@ -110,8 +110,8 @@ const CpuUtil::CpuIds& ExecutorsManager::get_cpuids_of_workgroup(WorkGroup* wg) 
 /// The `PipelineExecutorSet::start()` registers metrics, which acquires the metric lock. However, the metric collector
 /// first acquires the metric lock and then requests the `WorkGroupManager` lock to update the metric.
 /// Therefore, during `start`, it is crucial not to hold the `WorkGroupManager` lock to avoid a potential deadlock.
-std::unique_ptr<PipelineExecutorSet> ExecutorsManager::maybe_create_exclusive_executors_unlocked(WorkGroup* wg) const {
-    const auto& cpuids = get_cpuids_of_workgroup(wg);
+std::unique_ptr<PipelineExecutorSet> ExecutorsManager::maybe_create_exclusive_executors_unlocked(
+        WorkGroup* wg, const CpuUtil::CpuIds& cpuids) const {
     if (wg->exclusive_cpu_cores() == 0 || cpuids.empty()) {
         LOG(INFO) << "[WORKGROUP] assign shared executors to workgroup "
                   << "[workgroup=" << wg->to_string() << "] ";

--- a/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
+++ b/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
@@ -19,7 +19,10 @@
 namespace starrocks::workgroup {
 
 ExecutorsManager::ExecutorsManager(WorkGroupManager* parent, PipelineExecutorSetConfig conf)
-        : _parent(parent), _conf(std::move(conf)) {
+        : _parent(parent),
+          _conf(std::move(conf)),
+          _shared_executors(std::make_unique<PipelineExecutorSet>(_conf, "com", _conf.total_cpuids,
+                                                                  std::vector<CpuUtil::CpuIds>{})) {
     _wg_to_cpuids[COMMON_WORKGROUP] = _conf.total_cpuids;
     for (auto cpuid : _conf.total_cpuids) {
         _cpu_owners[cpuid].set_wg(COMMON_WORKGROUP);
@@ -30,9 +33,7 @@ void ExecutorsManager::close() const {
     for_each_executors([](auto& executors) { executors.close(); });
 }
 
-Status ExecutorsManager::start_shared_executors() {
-    _shared_executors =
-            std::make_unique<PipelineExecutorSet>(_conf, "com", _conf.total_cpuids, std::vector<CpuUtil::CpuIds>{});
+Status ExecutorsManager::start_shared_executors_unlocked() const {
     return _shared_executors->start();
 }
 
@@ -106,13 +107,15 @@ const CpuUtil::CpuIds& ExecutorsManager::get_cpuids_of_workgroup(WorkGroup* wg) 
     return it->second;
 }
 
-PipelineExecutorSet* ExecutorsManager::create_and_assign_executors(WorkGroup* wg) const {
+/// The `PipelineExecutorSet::start()` registers metrics, which acquires the metric lock. However, the metric collector
+/// first acquires the metric lock and then requests the `WorkGroupManager` lock to update the metric.
+/// Therefore, during `start`, it is crucial not to hold the `WorkGroupManager` lock to avoid a potential deadlock.
+std::unique_ptr<PipelineExecutorSet> ExecutorsManager::maybe_create_exclusive_executors_unlocked(WorkGroup* wg) const {
     const auto& cpuids = get_cpuids_of_workgroup(wg);
     if (wg->exclusive_cpu_cores() == 0 || cpuids.empty()) {
         LOG(INFO) << "[WORKGROUP] assign shared executors to workgroup "
                   << "[workgroup=" << wg->to_string() << "] ";
-        wg->set_executors(_shared_executors.get());
-        return _shared_executors.get();
+        return nullptr;
     }
 
     auto executors = std::make_unique<PipelineExecutorSet>(_conf, std::to_string(wg->id()), cpuids,
@@ -126,14 +129,12 @@ PipelineExecutorSet* ExecutorsManager::create_and_assign_executors(WorkGroup* wg
         LOG(INFO) << "[WORKGROUP] assign shared executors to workgroup "
                   << "[workgroup=" << wg->to_string() << "] ";
         executors->close();
-        wg->set_executors(_shared_executors.get());
-        return _shared_executors.get();
+        return nullptr;
     }
 
     LOG(INFO) << "[WORKGROUP] assign dedicated executors to workgroup "
               << "[workgroup=" << wg->to_string() << "] ";
-    wg->set_exclusive_executors(std::move(executors));
-    return wg->executors();
+    return executors;
 }
 
 void ExecutorsManager::change_num_connector_scan_threads(uint32_t num_connector_scan_threads) {

--- a/be/src/exec/workgroup/pipeline_executor_set_manager.h
+++ b/be/src/exec/workgroup/pipeline_executor_set_manager.h
@@ -38,14 +38,15 @@ namespace starrocks::workgroup {
 /// - shared_executors: when closing BE process.
 ///
 /// ExecutorsManager is owned by WorkGroupManager.
-/// All the methods need to be protected by the `WorkGroupManager::_mutex` outside by callers.
+/// All the methods need to be protected by the `WorkGroupManager::_mutex` outside by callers, except the methods
+/// with `unlocked` as suffix.
 class ExecutorsManager {
 public:
     ExecutorsManager(WorkGroupManager* parent, PipelineExecutorSetConfig conf);
 
     void close() const;
 
-    Status start_shared_executors();
+    Status start_shared_executors_unlocked() const;
     void update_shared_executors() const;
     PipelineExecutorSet* shared_executors() const { return _shared_executors.get(); }
 
@@ -53,7 +54,7 @@ public:
     void reclaim_cpuids_from_worgroup(WorkGroup* wg);
     const CpuUtil::CpuIds& get_cpuids_of_workgroup(WorkGroup* wg) const;
 
-    PipelineExecutorSet* create_and_assign_executors(WorkGroup* wg) const;
+    std::unique_ptr<PipelineExecutorSet> maybe_create_exclusive_executors_unlocked(WorkGroup* wg) const;
 
     void change_num_connector_scan_threads(uint32_t num_connector_scan_threads);
     void change_enable_resource_group_cpu_borrowing(bool val);
@@ -71,7 +72,7 @@ private:
     WorkGroupManager* const _parent;
     PipelineExecutorSetConfig _conf;
     std::unordered_map<WorkGroup*, CpuUtil::CpuIds> _wg_to_cpuids;
-    std::unique_ptr<PipelineExecutorSet> _shared_executors;
+    const std::unique_ptr<PipelineExecutorSet> _shared_executors;
 
     struct CpuOwnerContext {
         std::shared_ptr<WorkGroup> wg;

--- a/be/src/exec/workgroup/pipeline_executor_set_manager.h
+++ b/be/src/exec/workgroup/pipeline_executor_set_manager.h
@@ -38,8 +38,9 @@ namespace starrocks::workgroup {
 /// - shared_executors: when closing BE process.
 ///
 /// ExecutorsManager is owned by WorkGroupManager.
+///
 /// All the methods need to be protected by the `WorkGroupManager::_mutex` outside by callers, except the methods
-/// with `unlocked` as suffix.
+/// with `unlocked` suffix. And the methods with `unlocked`suffix should not call other protected methods.
 class ExecutorsManager {
 public:
     ExecutorsManager(WorkGroupManager* parent, PipelineExecutorSetConfig conf);
@@ -54,7 +55,8 @@ public:
     void reclaim_cpuids_from_worgroup(WorkGroup* wg);
     const CpuUtil::CpuIds& get_cpuids_of_workgroup(WorkGroup* wg) const;
 
-    std::unique_ptr<PipelineExecutorSet> maybe_create_exclusive_executors_unlocked(WorkGroup* wg) const;
+    std::unique_ptr<PipelineExecutorSet> maybe_create_exclusive_executors_unlocked(WorkGroup* wg,
+                                                                                   const CpuUtil::CpuIds& cpuids) const;
 
     void change_num_connector_scan_threads(uint32_t num_connector_scan_threads);
     void change_enable_resource_group_cpu_borrowing(bool val);

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -564,8 +564,19 @@ void WorkGroupManager::create_workgroup_unlocked(const WorkGroupPtr& wg, UniqueL
     _workgroup_versions[wg->id()] = wg->version();
 
     _executors_manager.assign_cpuids_to_workgroup(wg.get());
-    _executors_manager.create_and_assign_executors(wg.get());
     _executors_manager.update_shared_executors();
+
+    std::unique_ptr<PipelineExecutorSet> exclusive_executors = nullptr;
+    {
+        unique_lock.unlock();
+        DeferOp unlock_guard([&unique_lock] { unique_lock.lock(); });
+        exclusive_executors = _executors_manager.maybe_create_exclusive_executors_unlocked(wg.get());
+    }
+    if (exclusive_executors != nullptr) {
+        wg->set_exclusive_executors(std::move(exclusive_executors));
+    } else {
+        wg->set_shared_executors(_executors_manager.shared_executors());
+    }
 
     // Update metrics
     add_metrics_unlocked(wg, unique_lock);
@@ -623,8 +634,7 @@ void WorkGroupManager::for_each_workgroup(const WorkGroupConsumer& consumer) con
 }
 
 Status WorkGroupManager::start() {
-    std::unique_lock write_lock(_mutex);
-    return _executors_manager.start_shared_executors();
+    return _executors_manager.start_shared_executors_unlocked();
 }
 
 void WorkGroupManager::close() {

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -568,9 +568,10 @@ void WorkGroupManager::create_workgroup_unlocked(const WorkGroupPtr& wg, UniqueL
 
     std::unique_ptr<PipelineExecutorSet> exclusive_executors = nullptr;
     {
+        const auto& cpuids = _executors_manager.get_cpuids_of_workgroup(wg.get());
         unique_lock.unlock();
         DeferOp unlock_guard([&unique_lock] { unique_lock.lock(); });
-        exclusive_executors = _executors_manager.maybe_create_exclusive_executors_unlocked(wg.get());
+        exclusive_executors = _executors_manager.maybe_create_exclusive_executors_unlocked(wg.get(), cpuids);
     }
     if (exclusive_executors != nullptr) {
         wg->set_exclusive_executors(std::move(exclusive_executors));

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -197,7 +197,7 @@ public:
     void incr_cpu_runtime_ns(int64_t delta_ns) { _cpu_runtime_ns += delta_ns; }
     int64_t cpu_runtime_ns() const { return _cpu_runtime_ns; }
 
-    void set_executors(PipelineExecutorSet* executors) { _executors = executors; }
+    void set_shared_executors(PipelineExecutorSet* executors) { _executors = executors; }
     void set_exclusive_executors(std::unique_ptr<PipelineExecutorSet> executors) {
         _exclusive_executors = std::move(executors);
         _executors = _exclusive_executors.get();

--- a/be/test/exec/pipeline/mem_limited_chunk_queue_test.cpp
+++ b/be/test/exec/pipeline/mem_limited_chunk_queue_test.cpp
@@ -45,7 +45,7 @@ public:
                                                           workgroup::WorkGroup::DEFAULT_VERSION, 4, 100.0, 0, 1.0,
                                                           workgroup::WorkGroupType::WG_DEFAULT);
         dummy_wg->init();
-        dummy_wg->set_executors(ExecEnv::GetInstance()->workgroup_manager()->shared_executors());
+        dummy_wg->set_shared_executors(ExecEnv::GetInstance()->workgroup_manager()->shared_executors());
 
         dummy_dir_mgr = std::make_unique<spill::DirManager>();
         ASSERT_OK(dummy_dir_mgr->init(path));

--- a/test/sql/test_resource_group/R/test_resource_group_metrics_dead_lock
+++ b/test/sql/test_resource_group/R/test_resource_group_metrics_dead_lock
@@ -1,0 +1,240 @@
+-- name: test_resource_group_metrics_dead_lock
+CREATE RESOURCE GROUP rgd1_${uuid0} 
+    TO ( user='user_${uuid0}' ) 
+    WITH ( 'exclusive_cpu_cores' = '2', 'mem_limit' = '0.99' );
+-- result:
+-- !result
+
+CONCURRENCY {
+-- thread name 1:
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
+-- result:
+-- !result
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
+-- result:
+-- !result
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
+-- result:
+-- !result
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
+-- result:
+-- !result
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
+-- result:
+-- !result
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
+-- result:
+-- !result
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
+-- result:
+-- !result
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
+-- result:
+-- !result
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
+-- result:
+-- !result
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
+-- result:
+-- !result
+
+-- thread name 2:
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+-- result:
+0
+(count(1)) > 0
+1
+-- !result
+
+} END CONCURRENCY
+
+select count(1) > 0 from information_schema.be_metrics;
+-- result:
+1
+-- !result

--- a/test/sql/test_resource_group/R/test_resource_group_metrics_dead_lock
+++ b/test/sql/test_resource_group/R/test_resource_group_metrics_dead_lock
@@ -37,6 +37,9 @@ ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
 ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
 -- result:
 -- !result
+DROP RESOURCE GROUP rgd1_${uuid0};
+-- result:
+-- !result
 
 -- thread name 2:
 [UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"

--- a/test/sql/test_resource_group/T/test_resource_group_metrics_dead_lock
+++ b/test/sql/test_resource_group/T/test_resource_group_metrics_dead_lock
@@ -1,0 +1,60 @@
+-- name: test_resource_group_metrics_dead_lock
+
+CREATE RESOURCE GROUP rgd1_${uuid0} 
+    TO ( user='user_${uuid0}' ) 
+    WITH ( 'exclusive_cpu_cores' = '2', 'mem_limit' = '0.99' );
+
+CONCURRENCY {
+
+-- thread name 1:
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
+ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
+
+
+-- thread name 2:
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+[UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"
+
+
+} END CONCURRENCY
+
+select count(1) > 0 from information_schema.be_metrics;
+

--- a/test/sql/test_resource_group/T/test_resource_group_metrics_dead_lock
+++ b/test/sql/test_resource_group/T/test_resource_group_metrics_dead_lock
@@ -17,7 +17,7 @@ ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
 ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
 ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '3' );
 ALTER RESOURCE GROUP rgd1_${uuid0} WITH ( 'exclusive_cpu_cores' = '2' );
-
+DROP RESOURCE GROUP rgd1_${uuid0};
 
 -- thread name 2:
 [UC]shell: mysql -h${mysql_host} -P${mysql_port} -u${mysql_user} --password='${mysql_password}'  --comments -e "select count(1) > 0 from information_schema.be_metrics;"


### PR DESCRIPTION
## Why I'm doing:

The `PipelineExecutorSet::start()` registers metrics, which acquires the metric lock. 

However, the metric collector first acquires the metric lock and then requests the `WorkGroupManager` lock to update the metric.

Therefore, during `start`, it is crucial not to hold the `WorkGroupManager` lock to avoid a potential deadlock.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8612

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
