### PR TITLE
[BugFix] Make sure default warehouse is initialized before replaying journal

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/Checkpoint.java
@@ -243,6 +243,7 @@ public class Checkpoint extends FrontendDaemon {
         globalStateMgr.setJournal(journal);
         try {
             globalStateMgr.loadImage(imageDir);
+            globalStateMgr.initDefaultWarehouse();
             globalStateMgr.replayJournal(logVersion);
             globalStateMgr.clearExpiredJobs();
             globalStateMgr.saveImage();


### PR DESCRIPTION
## Why I'm doing:
mv is inactived when creating image and is force refreshed after restart, due to default warehouse is not created before `replayJournal`
```
2024-09-24 22:52:04.858+08:00 INFO (leaderCheckpointer|1454) [AlterJobMgr.alterMaterializedViewStatus():195] process change materialized view test_mv status to active, isReplay: true
2024-09-24 22:52:04.858+08:00 WARN (leaderCheckpointer|1454) [AlterJobMgr.replayAlterMaterializedViewStatus():339] replay alter materialized-view status failed: test_mv
com.starrocks.common.ErrorReportException: Warehouse id: 0 not exist.
        at com.starrocks.common.ErrorReportException.report(ErrorReportException.java:38) ~[starrocks-fe.jar:?]
        at com.starrocks.server.WarehouseManager.getWarehouse(WarehouseManager.java:100) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.MaterializedView.getMaterializedViewDdlStmt(MaterializedView.java:1315) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.AlterJobMgr.alterMaterializedViewStatus(AlterJobMgr.java:204) ~[starrocks-fe.jar:?]
        at com.starrocks.alter.AlterJobMgr.replayAlterMaterializedViewStatus(AlterJobMgr.java:337) ~[starrocks-fe.jar:?]
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:344) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:1935) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournal(GlobalStateMgr.java:1884) ~[starrocks-fe.jar:?]
        at com.starrocks.leader.Checkpoint.replayAndGenerateGlobalStateMgrImage(Checkpoint.java:246) ~[starrocks-fe.jar:?]
        at com.starrocks.leader.Checkpoint.createImage(Checkpoint.java:230) ~[starrocks-fe.jar:?]
        at com.starrocks.leader.Checkpoint.runAfterCatalogReady(Checkpoint.java:116) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:107) ~[starrocks-fe.jar:?]
2024-09-24 22:52:04.858+08:00 WARN (leaderCheckpointer|1454) [MaterializedView.setInactiveAndReason():542] set test_mv to inactive because of replay alter status failed: Warehouse id: 0 not exist.
2024-09-24 22:52:04.859+08:00 INFO (leaderCheckpointer|1454) [CachingMvPlanContextBuilder.invalidateAstFromCache():161] Remove mv test_mv from ast cache


2024-09-24 22:27:35.501+08:00 INFO (MVActiveChecker|62) [MVActiveChecker.tryToActivate():143] [MVActiveChecker] Start to activate MV test.test_mv because of its inactive reason: replay alter status failed: Warehouse id: 0 not exist.
2024-09-24 22:27:35.508+08:00 INFO (MVActiveChecker|62) [AlterJobMgr.alterMaterializedViewStatus():195] process change materialized view test_mv status to active, isReplay: false
2024-09-24 22:27:35.519+08:00 INFO (MVActiveChecker|62) [MaterializedView.setActive():534] set test_mv to active
2024-09-24 22:27:35.524+08:00 INFO (MVActiveChecker|62) [CachingMvPlanContextBuilder.putAstIfAbsent():182] Add mv test_mv input ast cache
2024-09-24 22:27:35.524+08:00 INFO (MVActiveChecker|62) [LocalMetastore.executeRefreshMvTask():3416] Start to execute refresh materialized view task, mv: test_mv, refreshType: ASYNC, executionOption:{"priority":50,"taskRunProperties":{"FORCE":"true"},"isMergeRedundant":true,"isManual":false,"isSync":false,"isReplay":false}
2024-09-24 22:27:35.528+08:00 INFO (MVActiveChecker|62) [MVActiveChecker.tryToActivate():152] [MVActiveChecker] activate MV test.test_mv successfully
```
## What I'm doing:
call `initDefaultWarehouse` before `replayJournal`
Fixes #issue
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
