### PR TITLE
[BugFix] Fix query error when drop table and recreate with same table name for delta lake

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeEngine.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeEngine.java
@@ -30,13 +30,13 @@ public class DeltaLakeEngine extends DefaultEngine {
     private final Configuration hadoopConf;
     private final DeltaLakeCatalogProperties properties;
     // Cache for checkpoint metadata, key is file path and read schema, value is list of ColumnarBatch
-    private final LoadingCache<Pair<String, StructType>, List<ColumnarBatch>> checkpointCache;
+    private final LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache;
     // Cache for json metadata, key is file path, value is list of JsonNode
-    private final LoadingCache<String, List<JsonNode>> jsonCache;
+    private final LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache;
 
     protected DeltaLakeEngine(Configuration hadoopConf, DeltaLakeCatalogProperties properties,
-                              LoadingCache<Pair<String, StructType>, List<ColumnarBatch>> checkpointCache,
-                              LoadingCache<String, List<JsonNode>> jsonCache) {
+                              LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache,
+                              LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache) {
         super(hadoopConf);
         this.hadoopConf = hadoopConf;
         this.properties = properties;
@@ -57,8 +57,8 @@ public class DeltaLakeEngine extends DefaultEngine {
     }
 
     public static DeltaLakeEngine create(Configuration hadoopConf, DeltaLakeCatalogProperties properties,
-                                         LoadingCache<Pair<String, StructType>, List<ColumnarBatch>> checkpointCache,
-                                         LoadingCache<String, List<JsonNode>> jsonCache) {
+                                         LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache,
+                                         LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache) {
         return new DeltaLakeEngine(hadoopConf, properties, checkpointCache, jsonCache);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeFileStatus.java
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import io.delta.kernel.utils.FileStatus;
+
+import java.util.Objects;
+
+public class DeltaLakeFileStatus {
+    private final String path;
+    private final long size;
+    private final long modificationTime;
+
+    protected DeltaLakeFileStatus(String path, long size, long modificationTime) {
+        this.path = path;
+        this.size = size;
+        this.modificationTime = modificationTime;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DeltaLakeFileStatus that = (DeltaLakeFileStatus) o;
+        return size == that.size && modificationTime == that.modificationTime && Objects.equals(path, that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, size, modificationTime);
+    }
+
+    public static DeltaLakeFileStatus of(FileStatus fileStatus) {
+        return new DeltaLakeFileStatus(fileStatus.getPath(), fileStatus.getSize(), fileStatus.getModificationTime());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetastore.java
@@ -56,8 +56,8 @@ public abstract class DeltaLakeMetastore implements IDeltaLakeMetastore {
     protected final Configuration hdfsConfiguration;
     protected final DeltaLakeCatalogProperties properties;
 
-    private final LoadingCache<Pair<String, StructType>, List<ColumnarBatch>> checkpointCache;
-    private final LoadingCache<String, List<JsonNode>> jsonCache;
+    private final LoadingCache<Pair<DeltaLakeFileStatus, StructType>, List<ColumnarBatch>> checkpointCache;
+    private final LoadingCache<DeltaLakeFileStatus, List<JsonNode>> jsonCache;
 
     public DeltaLakeMetastore(String catalogName, IMetastore metastore, Configuration hdfsConfiguration,
                               DeltaLakeCatalogProperties properties) {
@@ -77,8 +77,8 @@ public abstract class DeltaLakeMetastore implements IDeltaLakeMetastore {
                 .build(new CacheLoader<>() {
                     @NotNull
                     @Override
-                    public List<ColumnarBatch> load(@NotNull Pair<String, StructType> pair) {
-                        return DeltaLakeParquetHandler.readParquetFile(pair.first, pair.second, hdfsConfiguration);
+                    public List<ColumnarBatch> load(@NotNull Pair<DeltaLakeFileStatus, StructType> pair) {
+                        return DeltaLakeParquetHandler.readParquetFile(pair.first.getPath(), pair.second, hdfsConfiguration);
                     }
                 });
 
@@ -90,8 +90,8 @@ public abstract class DeltaLakeMetastore implements IDeltaLakeMetastore {
                 .build(new CacheLoader<>() {
                     @NotNull
                     @Override
-                    public List<JsonNode> load(@NotNull String filePath) throws IOException {
-                        return DeltaLakeJsonHandler.readJsonFile(filePath, hdfsConfiguration);
+                    public List<JsonNode> load(@NotNull DeltaLakeFileStatus fileStatus) throws IOException {
+                        return DeltaLakeJsonHandler.readJsonFile(fileStatus.getPath(), hdfsConfiguration);
                     }
                 });
     }


### PR DESCRIPTION
## Why I'm doing:
#51353
## What I'm doing:
The delta lake meta cache (json cache/checkpoint cache) can not use file path as key, it may be same when drop table and recreate with same table name. for example: s3://xxxx/delta_table/_delta_log/00000001.json, the metadata file path are same.
Use DeltaLakeFileStatus to represent the unique key 

Fixes #51353

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
