### PR TITLE
[BugFix] Fix wrong result in left anti null aware join having other conjuncts

### DIFF
--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -1780,46 +1780,21 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
     size_t probe_row_count = _probe_state->probe_row_count;
     for (; i < probe_row_count; i++) {
         size_t build_index = _probe_state->next[i];
-        if (build_index == 0) {
-            bool change_flag = false;
-            if (_probe_state->null_array != nullptr && (*_probe_state->null_array)[i] == 1) {
-                // when left table col value is null needs match all rows in right table
-                for (size_t j = 1; j < _table_items->row_count + 1; j++) {
-                    change_flag = true;
-                    MATCH_RIGHT_TABLE_ROWS()
-                    RETURN_IF_CHUNK_FULL()
-                }
-            } else if (_table_items->key_columns[0]->is_nullable()) {
-                // when left table col value not hits in hash table needs match all null value rows in right table
-                auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(_table_items->key_columns[0]);
-                auto& null_array = nullable_column->null_column()->get_data();
-                for (size_t j = 1; j < _table_items->row_count + 1; j++) {
-                    if (null_array[j] == 1) {
-                        change_flag = true;
-                        MATCH_RIGHT_TABLE_ROWS()
-                        RETURN_IF_CHUNK_FULL()
-                    }
-                }
-            }
-
-            if (!change_flag) {
-                _probe_state->probe_index[match_count] = i;
-                _probe_state->build_index[match_count] = 0;
-                match_count++;
+        if (_probe_state->null_array != nullptr && (*_probe_state->null_array)[i] == 1) {
+            // when left table col value is null needs match all rows in right table
+            for (size_t j = 1; j < _table_items->row_count + 1; j++) {
+                MATCH_RIGHT_TABLE_ROWS()
                 RETURN_IF_CHUNK_FULL()
             }
-            _probe_state->cur_row_match_count = 0;
-            continue;
-        } else {
-            // left table col value hits in hash table, we also need match null values firstly then match hit rows.
-            if (_table_items->key_columns[0]->is_nullable()) {
-                auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(_table_items->key_columns[0]);
-                auto& null_array = nullable_column->null_column()->get_data();
-                for (size_t j = 1; j < _table_items->row_count + 1; j++) {
-                    if (null_array[j] == 1) {
-                        MATCH_RIGHT_TABLE_ROWS()
-                        RETURN_IF_CHUNK_FULL()
-                    }
+        } else if (_table_items->key_columns[0]->is_nullable()) {
+            // when left table col value not hits in hash table needs match all null value rows in right table
+            auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(_table_items->key_columns[0]);
+            auto& null_array = nullable_column->null_column()->get_data();
+            // TODO: optimize me
+            for (size_t j = 1; j < _table_items->row_count + 1; j++) {
+                if (null_array[j] == 1) {
+                    MATCH_RIGHT_TABLE_ROWS()
+                    RETURN_IF_CHUNK_FULL()
                 }
             }
         }

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -1779,7 +1779,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
 
     size_t probe_row_count = _probe_state->probe_row_count;
     for (; i < probe_row_count; i++) {
-        _probe_state->cur_row_match_count = 0;
         size_t build_index = _probe_state->next[i];
         if (build_index == 0) {
             bool change_flag = false;
@@ -1809,6 +1808,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
                 match_count++;
                 RETURN_IF_CHUNK_FULL()
             }
+            _probe_state->cur_row_match_count = 0;
             continue;
         } else {
             // left table col value hits in hash table, we also need match null values firstly then match hit rows.
@@ -1844,6 +1844,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
 
             RETURN_IF_CHUNK_FULL()
         }
+        _probe_state->cur_row_match_count = 0;
     }
     PROBE_OVER()
 }

--- a/test/sql/test_join/R/test_interleaving_join
+++ b/test/sql/test_join/R/test_interleaving_join
@@ -1,4 +1,4 @@
--- name: test interleaving join
+-- name: test_interleaving_join
 CREATE TABLE `lineitem` (
   `l_orderkey` int(11) NOT NULL COMMENT "",
   `l_partkey` int(11) NOT NULL COMMENT "",
@@ -71,14 +71,14 @@ set interleaving_group_size =0;
 -- !result
 select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
 -- result:
-3
+2
 -- !result
 set interleaving_group_size =-10;
 -- result:
 -- !result
 select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
 -- result:
-3
+2
 -- !result
 set interleaving_group_size =0;
 -- result:
@@ -186,14 +186,14 @@ set interleaving_group_size =0;
 -- !result
 select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
 -- result:
-3
+2
 -- !result
 set interleaving_group_size =-10;
 -- result:
 -- !result
 select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
 -- result:
-3
+2
 -- !result
 set interleaving_group_size =0;
 -- result:
@@ -301,14 +301,14 @@ set interleaving_group_size =0;
 -- !result
 select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
 -- result:
-3
+2
 -- !result
 set interleaving_group_size =-10;
 -- result:
 -- !result
 select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
 -- result:
-3
+2
 -- !result
 set interleaving_group_size =0;
 -- result:
@@ -416,14 +416,14 @@ set interleaving_group_size =0;
 -- !result
 select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
 -- result:
-3
+2
 -- !result
 set interleaving_group_size =-10;
 -- result:
 -- !result
 select count(*) as c from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey <> l1.l_suppkey );
 -- result:
-3
+2
 -- !result
 set interleaving_group_size =0;
 -- result:

--- a/test/sql/test_join/R/test_null_aware_anti_join
+++ b/test/sql/test_join/R/test_null_aware_anti_join
@@ -1,0 +1,72 @@
+-- name: test_null_aware_anti_join
+CREATE TABLE `lineitem` (
+  `l_orderkey` int(11) NOT NULL COMMENT "",
+  `l_partkey` int(11) NOT NULL COMMENT "",
+  `l_suppkey` int(11)
+) ENGINE=OLAP
+DUPLICATE KEY(`l_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into lineitem values (1,1,1),(1,2,1),(1,3,2),(11,1,11),(11,2,1),(2,3,2),(2,3,null);
+-- result:
+-- !result
+select * from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey = l1.l_suppkey ) order by 1,2,3;
+-- result:
+2	3	None
+-- !result
+select * from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey != l1.l_suppkey ) order by 1,2,3;
+-- result:
+2	3	None
+2	3	2
+-- !result
+CREATE TABLE `lineitem_nullable` (
+  `l_orderkey` int(11) COMMENT "",
+  `l_partkey` int(11)  COMMENT "",
+  `l_suppkey` int(11)
+) ENGINE=OLAP
+DUPLICATE KEY(`l_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into lineitem_nullable values (1,1,1),(1,2,1),(1,3,2),(11,1,11),(11,2,1),(2,3,2),(2,3,null),(null,null,null);
+-- result:
+-- !result
+select * from lineitem_nullable l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem_nullable l3 ) order by 1,2,3;
+-- result:
+-- !result
+select * from lineitem_nullable l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem_nullable l3 ) order by 1,2,3;
+-- result:
+1	1	1
+1	2	1
+1	3	2
+2	3	None
+2	3	2
+11	1	11
+11	2	1
+-- !result
+select * from lineitem_nullable l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem_nullable l3 where  l3.l_suppkey = l1.l_suppkey ) order by 1,2,3;
+-- result:
+None	None	None
+2	3	None
+-- !result
+select * from lineitem_nullable l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem_nullable l3 where  l3.l_suppkey != l1.l_suppkey ) order by 1,2,3;
+-- result:
+None	None	None
+2	3	None
+2	3	2
+-- !result

--- a/test/sql/test_join/T/test_interleaving_join
+++ b/test/sql/test_join/T/test_interleaving_join
@@ -1,4 +1,4 @@
--- name: test interleaving join
+-- name: test_interleaving_join
 CREATE TABLE `lineitem` (
   `l_orderkey` int(11) NOT NULL COMMENT "",
   `l_partkey` int(11) NOT NULL COMMENT "",

--- a/test/sql/test_join/T/test_null_aware_anti_join
+++ b/test/sql/test_join/T/test_null_aware_anti_join
@@ -1,0 +1,41 @@
+-- name: test_null_aware_anti_join
+
+CREATE TABLE `lineitem` (
+  `l_orderkey` int(11) NOT NULL COMMENT "",
+  `l_partkey` int(11) NOT NULL COMMENT "",
+  `l_suppkey` int(11)
+) ENGINE=OLAP
+DUPLICATE KEY(`l_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into lineitem values (1,1,1),(1,2,1),(1,3,2),(11,1,11),(11,2,1),(2,3,2),(2,3,null);
+select * from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey = l1.l_suppkey ) order by 1,2,3;
+select * from lineitem l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem l3 where  l3.l_suppkey != l1.l_suppkey ) order by 1,2,3;
+
+CREATE TABLE `lineitem_nullable` (
+  `l_orderkey` int(11) COMMENT "",
+  `l_partkey` int(11)  COMMENT "",
+  `l_suppkey` int(11)
+) ENGINE=OLAP
+DUPLICATE KEY(`l_orderkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into lineitem_nullable values (1,1,1),(1,2,1),(1,3,2),(11,1,11),(11,2,1),(2,3,2),(2,3,null),(null,null,null);
+select * from lineitem_nullable l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem_nullable l3 ) order by 1,2,3;
+select * from lineitem_nullable l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem_nullable l3 ) order by 1,2,3;
+select * from lineitem_nullable l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem_nullable l3 where  l3.l_suppkey = l1.l_suppkey ) order by 1,2,3;
+select * from lineitem_nullable l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem_nullable l3 where  l3.l_suppkey != l1.l_suppkey ) order by 1,2,3;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
