### PR TITLE
[BugFix] fix fs posix errno mapping rules

### DIFF
--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -94,12 +94,16 @@ static Status io_error(const std::string& context, int err_number) {
     switch (err_number) {
     case 0:
         return Status::OK();
+    case EIO:
+        return Status::IOError(fmt::format("{}: {}", context, std::strerror(err_number)));
     case ENOENT:
         return Status::NotFound(fmt::format("{}: {}", context, std::strerror(err_number)));
     case EEXIST:
         return Status::AlreadyExist(fmt::format("{}: {}", context, std::strerror(err_number)));
+    case ENOSPC:
+        return Status::CapacityLimitExceed(fmt::format("{}: {}", context, std::strerror(err_number)));
     default:
-        return Status::IOError(fmt::format("{}: {}", context, std::strerror(err_number)));
+        return Status::InternalError(fmt::format("{}: {}", context, std::strerror(err_number)));
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
In BE implementation, we will treat IO Error return from fs posix function as this disk met unrecover issue, and BE will try to clean tablet on this disk, so FE can schedule a repair task to fix this replica.
So the rules about errno mapping to status will be crucial.

## What I'm doing:
Distinguish between these error codes : `EIO`, `ENOSPC`. Only return IO Error when meet `EIO`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
