### PR TITLE
[BugFix] Fix check overflow for widening conversion (backport #51280)

### DIFF
--- a/be/src/exprs/vectorized/cast_expr.cpp
+++ b/be/src/exprs/vectorized/cast_expr.cpp
@@ -390,7 +390,7 @@ DEFINE_UNARY_FN_WITH_IMPL(ImplicitToNumber, value) {
 }
 
 DEFINE_UNARY_FN_WITH_IMPL(NumberCheck, value) {
-    return check_number_overflow<Type, ResultType>(value);
+    return check_signed_number_overflow<Type, ResultType>(value);
 }
 
 DEFINE_UNARY_FN_WITH_IMPL(NumberCheckWithThrowException, value) {

--- a/be/src/formats/json/numeric_column.cpp
+++ b/be/src/formats/json/numeric_column.cpp
@@ -19,7 +19,11 @@ static inline bool checked_cast(const FromType& from, ToType* to) {
 #if defined(__clang__)
     DIAGNOSTIC_IGNORE("-Wimplicit-const-int-float-conversion")
 #endif
-    return check_number_overflow<FromType, ToType>(from);
+    // When the value is in the range [2^63, 2^64), FromType is uint64_t. In this case, using check_signed_number_overflow is fine:
+    // - If ToType is int8_t~int64_t, check_signed_number_overflow will return true.
+    // - If ToType is float, double or int128_t, check_signed_number_overflow will return false,
+    //   because the widening conversion branch is hit.
+    return check_signed_number_overflow<FromType, ToType>(from);
     DIAGNOSTIC_POP
 }
 

--- a/be/src/util/numeric_types.h
+++ b/be/src/util/numeric_types.h
@@ -17,42 +17,56 @@
 #include <limits>
 #include <type_traits>
 
+#include "common/compiler_util.h"
+
 namespace starrocks {
 
+DIAGNOSTIC_PUSH
+#if defined(__clang__)
+DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
+#endif
+
 template <typename FromType, typename ToType>
-static constexpr FromType floating_to_intergral_lower_bound =
+static constexpr FromType floating_to_integral_lower_bound =
         static_cast<FromType>(std::numeric_limits<ToType>::lowest());
 
 template <typename FromType, typename ToType>
-static constexpr FromType floating_to_intergral_upper_bound = static_cast<FromType>(2) *
-                                                              (std::numeric_limits<ToType>::max() / 2 + 1);
+static constexpr FromType floating_to_integral_upper_bound = static_cast<FromType>(2) *
+                                                             (std::numeric_limits<ToType>::max() / 2 + 1);
 
 /// Check whether the value of type `FromType` overflows when converted to type `ToType`.
-/// If overflow, return true; otherwise, return false.
+/// If overflowed, return true; otherwise, return false.
+/// NOTE that `FromType` and `ToType` must be signed number types.
 template <typename FromType, typename ToType>
-bool check_number_overflow(FromType value) {
-    if constexpr (std::is_floating_point_v<FromType> && std::is_integral_v<ToType>) {
-        // For floating-point numbers, we cannot use `value > (Type)std::numeric_limits<ResultType>::max()` to
-        // determine whether `value` exceeds the maximum value of ResultType. The reason is as follows:
-        //
-        // `std::numeric_limits<ResultType>::max()` is `2^n-1`, where n is 63, 31, 15 or 7, this number cannot be
-        // exactly represented by floating-point numbers, so when converted to Type, it will be rounded up to `2^n`.
-        // Therefore, when `value` is `2^n`, `value > (Type)std::numeric_limits<ResultType>::max()` will return false.
-        // However, in actual conversion, overflow will occur, resulting in the maximum or minimum value of ResultType,
-        // depending on the architecture, compiler, and compilation parameters.
-        //
-        // Because `2^n` can be exactly represented by floating-point numbers, we use `value >= (Type)2^n` to determine
-        // whether it is overflow, rather than `value > (Type)2^n-1`.
-        return !(value >= floating_to_intergral_lower_bound<FromType, ToType> &&
-                 value < floating_to_intergral_upper_bound<FromType, ToType>);
-    } else {
-        // std::numeric_limits<T>::lowest() is a finite value x such that there is no other
-        // finite value y where y < x.
-        // This is different from std::numeric_limits<T>::min() for floating-point types.
-        // So we use lowest instead of min for lower bound of all types.
-        return (value < (FromType)std::numeric_limits<ToType>::lowest()) |
-               (value > (FromType)std::numeric_limits<ToType>::max());
+bool check_signed_number_overflow(FromType value) {
+    if constexpr (std::numeric_limits<ToType>::max() >= std::numeric_limits<FromType>::max()) { // Widening conversion
+        return false;
+    } else { // Narrowing conversion
+        if constexpr (std::is_floating_point_v<FromType> && std::is_integral_v<ToType>) {
+            // For floating-point numbers, we cannot use `value > (Type)std::numeric_limits<ResultType>::max()` to
+            // determine whether `value` exceeds the maximum value of ResultType. The reason is as follows:
+            //
+            // `std::numeric_limits<ResultType>::max()` is `2^n-1`, where n is 63, 31, 15 or 7, this number cannot be
+            // exactly represented by floating-point numbers, so when converted to Type, it will be rounded up to `2^n`.
+            // Therefore, when `value` is `2^n`, `value > (Type)std::numeric_limits<ResultType>::max()` will return false.
+            // However, in actual conversion, overflow will occur, resulting in the maximum or minimum value of ResultType,
+            // depending on the architecture, compiler, and compilation parameters.
+            //
+            // Because `2^n` can be exactly represented by floating-point numbers, we use `value >= (Type)2^n` to determine
+            // whether it is overflow, rather than `value > (Type)2^n-1`.
+            return !(value >= floating_to_integral_lower_bound<FromType, ToType> &&
+                     value < floating_to_integral_upper_bound<FromType, ToType>);
+        } else {
+            // std::numeric_limits<T>::lowest() is a finite value x such that there is no other
+            // finite value y where y < x.
+            // This is different from std::numeric_limits<T>::min() for floating-point types.
+            // So we use lowest instead of min for lower bound of all types.
+            return (value < (FromType)std::numeric_limits<ToType>::lowest()) |
+                   (value > (FromType)std::numeric_limits<ToType>::max());
+        }
     }
 }
+
+DIAGNOSTIC_POP
 
 } // namespace starrocks

--- a/be/test/util/numeric_types_test.cpp
+++ b/be/test/util/numeric_types_test.cpp
@@ -16,54 +16,56 @@
 
 #include <gtest/gtest.h>
 
+#include "column/datum.h"
+
 namespace starrocks {
 
-TEST(TestNumericTypes, test_check_number_overflow) {
-    EXPECT_FALSE((check_number_overflow<double, int64_t>(9223372036854775000.0)));
-    EXPECT_TRUE((check_number_overflow<double, int64_t>(9223372036854775807.0)));
-    EXPECT_TRUE((check_number_overflow<double, int64_t>(9223372036854775807.3)));
-    EXPECT_TRUE((check_number_overflow<double, int64_t>(9223372036854775808.0)));
-    EXPECT_TRUE((check_number_overflow<double, int64_t>(9223372036854775809.0)));
+TEST(TestNumericTypes, test_check_signed_number_overflow_floating_to_integral) {
+    EXPECT_FALSE((check_signed_number_overflow<double, int64_t>(9223372036854775000.0)));
+    EXPECT_TRUE((check_signed_number_overflow<double, int64_t>(9223372036854775807.0)));
+    EXPECT_TRUE((check_signed_number_overflow<double, int64_t>(9223372036854775807.3)));
+    EXPECT_TRUE((check_signed_number_overflow<double, int64_t>(9223372036854775808.0)));
+    EXPECT_TRUE((check_signed_number_overflow<double, int64_t>(9223372036854775809.0)));
 
-    EXPECT_FALSE((check_number_overflow<double, int64_t>(-9223372036854675807.0)));
-    EXPECT_FALSE((check_number_overflow<double, int64_t>(-9223372036854775807.0)));
-    EXPECT_FALSE((check_number_overflow<double, int64_t>(-9223372036854775808.0)));
-    EXPECT_FALSE((check_number_overflow<double, int64_t>(-9223372036854775809.0)));
-    EXPECT_TRUE((check_number_overflow<double, int64_t>(-9223372036854778808.0)));
+    EXPECT_FALSE((check_signed_number_overflow<double, int64_t>(-9223372036854675807.0)));
+    EXPECT_FALSE((check_signed_number_overflow<double, int64_t>(-9223372036854775807.0)));
+    EXPECT_FALSE((check_signed_number_overflow<double, int64_t>(-9223372036854775808.0)));
+    EXPECT_FALSE((check_signed_number_overflow<double, int64_t>(-9223372036854775809.0)));
+    EXPECT_TRUE((check_signed_number_overflow<double, int64_t>(-9223372036854778808.0)));
 
-    EXPECT_FALSE((check_number_overflow<float, int32_t>(2147483000.0)));
-    EXPECT_TRUE((check_number_overflow<float, int32_t>(2147483647.0)));
-    EXPECT_TRUE((check_number_overflow<float, int32_t>(2147483647.3)));
-    EXPECT_TRUE((check_number_overflow<float, int32_t>(2147483648.0)));
-    EXPECT_TRUE((check_number_overflow<float, int32_t>(2147483649.0)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int32_t>(2147483000.0)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int32_t>(2147483647.0)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int32_t>(2147483647.3)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int32_t>(2147483648.0)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int32_t>(2147483649.0)));
 
-    EXPECT_FALSE((check_number_overflow<float, int32_t>(-2147473647.0)));
-    EXPECT_FALSE((check_number_overflow<float, int32_t>(-2147483647.0)));
-    EXPECT_FALSE((check_number_overflow<float, int32_t>(-2147483648.0)));
-    EXPECT_FALSE((check_number_overflow<float, int32_t>(-2147483649.0)));
-    EXPECT_TRUE((check_number_overflow<float, int32_t>(-2147494649.0)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int32_t>(-2147473647.0)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int32_t>(-2147483647.0)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int32_t>(-2147483648.0)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int32_t>(-2147483649.0)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int32_t>(-2147494649.0)));
 
-    EXPECT_FALSE((check_number_overflow<float, int16_t>(32767)));
-    EXPECT_TRUE((check_number_overflow<float, int16_t>(32768)));
-    EXPECT_TRUE((check_number_overflow<float, int16_t>(32769)));
-    EXPECT_FALSE((check_number_overflow<float, int16_t>(-32765)));
-    EXPECT_FALSE((check_number_overflow<float, int16_t>(-32767)));
-    EXPECT_FALSE((check_number_overflow<float, int16_t>(-32768)));
-    EXPECT_TRUE((check_number_overflow<float, int16_t>(-32770)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int16_t>(32767)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int16_t>(32768)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int16_t>(32769)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int16_t>(-32765)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int16_t>(-32767)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int16_t>(-32768)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int16_t>(-32770)));
 
-    EXPECT_FALSE((check_number_overflow<float, int8_t>(127)));
-    EXPECT_TRUE((check_number_overflow<float, int8_t>(128)));
-    EXPECT_TRUE((check_number_overflow<float, int8_t>(129)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int8_t>(127)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int8_t>(128)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int8_t>(129)));
 
-    EXPECT_FALSE((check_number_overflow<float, int8_t>(-127)));
-    EXPECT_FALSE((check_number_overflow<float, int8_t>(-128)));
-    EXPECT_TRUE((check_number_overflow<float, int8_t>(-129)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int8_t>(-127)));
+    EXPECT_FALSE((check_signed_number_overflow<float, int8_t>(-128)));
+    EXPECT_TRUE((check_signed_number_overflow<float, int8_t>(-129)));
 
     {
         double d_value = 9223372036854775000.0;
         for (int i = 0; i < 10000; i++) {
             d_value -= 10000.0;
-            EXPECT_FALSE((check_number_overflow<double, int64_t>(d_value)));
+            EXPECT_FALSE((check_signed_number_overflow<double, int64_t>(d_value)));
         }
     }
 
@@ -71,7 +73,7 @@ TEST(TestNumericTypes, test_check_number_overflow) {
         double d_value = 9223372036854775808.0;
         for (int i = 0; i < 10000; i++) {
             d_value += 10000.0;
-            EXPECT_TRUE((check_number_overflow<double, int64_t>(d_value)));
+            EXPECT_TRUE((check_signed_number_overflow<double, int64_t>(d_value)));
         }
     }
 
@@ -79,7 +81,7 @@ TEST(TestNumericTypes, test_check_number_overflow) {
         float d_value = 2147483000.0;
         for (int i = 0; i < 10000; i++) {
             d_value -= 1000.0;
-            EXPECT_FALSE((check_number_overflow<float, int32_t>(d_value)));
+            EXPECT_FALSE((check_signed_number_overflow<float, int32_t>(d_value)));
         }
     }
 
@@ -87,9 +89,183 @@ TEST(TestNumericTypes, test_check_number_overflow) {
         float d_value = 2147483649.0;
         for (int i = 0; i < 10000; i++) {
             d_value += 1000.0;
-            EXPECT_TRUE((check_number_overflow<float, int32_t>(d_value)));
+            EXPECT_TRUE((check_signed_number_overflow<float, int32_t>(d_value)));
         }
     }
+}
+
+TEST(TestNumericTypes, test_check_signed_number_overflow_widen_conversion) {
+    // from int8_t
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, int16_t>(std::numeric_limits<int8_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, int16_t>(std::numeric_limits<int8_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, int32_t>(std::numeric_limits<int8_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, int32_t>(std::numeric_limits<int8_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, int64_t>(std::numeric_limits<int8_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, int64_t>(std::numeric_limits<int8_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, int128_t>(std::numeric_limits<int8_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, int128_t>(std::numeric_limits<int8_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, float>(std::numeric_limits<int8_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, float>(std::numeric_limits<int8_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, double>(std::numeric_limits<int8_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int8_t, double>(std::numeric_limits<int8_t>::min())));
+
+    // from int16_t
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, int32_t>(std::numeric_limits<int16_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, int32_t>(std::numeric_limits<int16_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, int64_t>(std::numeric_limits<int16_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, int64_t>(std::numeric_limits<int16_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, int128_t>(std::numeric_limits<int16_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, int128_t>(std::numeric_limits<int16_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, float>(std::numeric_limits<int16_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, float>(std::numeric_limits<int16_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, double>(std::numeric_limits<int16_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, double>(std::numeric_limits<int16_t>::min())));
+
+    // from int32_t
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, int64_t>(std::numeric_limits<int32_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, int64_t>(std::numeric_limits<int32_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, int128_t>(std::numeric_limits<int32_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, int128_t>(std::numeric_limits<int32_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, float>(std::numeric_limits<int32_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, float>(std::numeric_limits<int32_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, double>(std::numeric_limits<int32_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, double>(std::numeric_limits<int32_t>::min())));
+
+    // from int64_t
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, int128_t>(std::numeric_limits<int64_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, int128_t>(std::numeric_limits<int64_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, float>(std::numeric_limits<int64_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, float>(std::numeric_limits<int64_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, double>(std::numeric_limits<int64_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, double>(std::numeric_limits<int64_t>::min())));
+
+    // from int128_t
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, float>(std::numeric_limits<int128_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, float>(std::numeric_limits<int128_t>::min())));
+
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, double>(std::numeric_limits<int128_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, double>(std::numeric_limits<int128_t>::min())));
+
+    // from float
+    EXPECT_FALSE((check_signed_number_overflow<float, double>(std::numeric_limits<float>::lowest())));
+    EXPECT_FALSE((check_signed_number_overflow<float, double>(std::numeric_limits<float>::min())));
+}
+
+TEST(TestNumericTypes, test_check_signed_number_overflow_integral_narrow_conversion) {
+    // from int128_t
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, int8_t>(std::numeric_limits<int8_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, int8_t>(std::numeric_limits<int8_t>::min())));
+    EXPECT_TRUE((check_signed_number_overflow<int128_t, int8_t>(
+            static_cast<int128_t>(std::numeric_limits<int8_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<int128_t, int8_t>(
+            static_cast<int128_t>(std::numeric_limits<int8_t>::min()) - 1)));
+
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, int16_t>(std::numeric_limits<int16_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, int16_t>(std::numeric_limits<int16_t>::min())));
+    EXPECT_TRUE((check_signed_number_overflow<int128_t, int16_t>(
+            static_cast<int128_t>(std::numeric_limits<int16_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<int128_t, int16_t>(
+            static_cast<int128_t>(std::numeric_limits<int16_t>::min()) - 1)));
+
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, int32_t>(std::numeric_limits<int32_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, int32_t>(std::numeric_limits<int32_t>::min())));
+    EXPECT_TRUE((check_signed_number_overflow<int128_t, int32_t>(
+            static_cast<int128_t>(std::numeric_limits<int32_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<int128_t, int32_t>(
+            static_cast<int128_t>(std::numeric_limits<int32_t>::min()) - 1)));
+
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, int64_t>(std::numeric_limits<int64_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int128_t, int64_t>(std::numeric_limits<int64_t>::min())));
+    EXPECT_TRUE((check_signed_number_overflow<int128_t, int64_t>(
+            static_cast<int128_t>(std::numeric_limits<int64_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<int128_t, int64_t>(
+            static_cast<int128_t>(std::numeric_limits<int64_t>::min()) - 1)));
+
+    // from int64_t
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, int8_t>(std::numeric_limits<int8_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, int8_t>(std::numeric_limits<int8_t>::min())));
+    EXPECT_TRUE((check_signed_number_overflow<int64_t, int8_t>(
+            static_cast<int64_t>(std::numeric_limits<int8_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<int64_t, int8_t>(
+            static_cast<int64_t>(std::numeric_limits<int8_t>::min()) - 1)));
+
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, int16_t>(std::numeric_limits<int16_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, int16_t>(std::numeric_limits<int16_t>::min())));
+    EXPECT_TRUE((check_signed_number_overflow<int64_t, int16_t>(
+            static_cast<int64_t>(std::numeric_limits<int16_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<int64_t, int16_t>(
+            static_cast<int64_t>(std::numeric_limits<int16_t>::min()) - 1)));
+
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, int32_t>(std::numeric_limits<int32_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int64_t, int32_t>(std::numeric_limits<int32_t>::min())));
+    EXPECT_TRUE((check_signed_number_overflow<int64_t, int32_t>(
+            static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<int64_t, int32_t>(
+            static_cast<int64_t>(std::numeric_limits<int32_t>::min()) - 1)));
+
+    // from int32_t
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, int8_t>(std::numeric_limits<int8_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, int8_t>(std::numeric_limits<int8_t>::min())));
+    EXPECT_TRUE((check_signed_number_overflow<int32_t, int8_t>(
+            static_cast<int32_t>(std::numeric_limits<int8_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<int32_t, int8_t>(
+            static_cast<int32_t>(std::numeric_limits<int8_t>::min()) - 1)));
+
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, int16_t>(std::numeric_limits<int16_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int32_t, int16_t>(std::numeric_limits<int16_t>::min())));
+    EXPECT_TRUE((check_signed_number_overflow<int32_t, int16_t>(
+            static_cast<int32_t>(std::numeric_limits<int16_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<int32_t, int16_t>(
+            static_cast<int32_t>(std::numeric_limits<int16_t>::min()) - 1)));
+
+    // from int16_t
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, int8_t>(std::numeric_limits<int8_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<int16_t, int8_t>(std::numeric_limits<int8_t>::min())));
+    EXPECT_TRUE((check_signed_number_overflow<int16_t, int8_t>(
+            static_cast<int16_t>(std::numeric_limits<int8_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<int16_t, int8_t>(
+            static_cast<int16_t>(std::numeric_limits<int8_t>::min()) - 1)));
+
+    // from double to float
+    EXPECT_FALSE((check_signed_number_overflow<double, float>(std::numeric_limits<float>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<double, float>(std::numeric_limits<float>::lowest())));
+    EXPECT_TRUE(
+            (check_signed_number_overflow<double, float>(static_cast<double>(std::numeric_limits<float>::max()) * 2)));
+    EXPECT_TRUE((check_signed_number_overflow<double, float>(static_cast<double>(std::numeric_limits<float>::lowest()) *
+                                                             2)));
+}
+
+// JSON will use check_signed_number_overflow to check whether an uint64_t converted to a signed number type will overflow.
+// Se checked_cast in formats/json/numeric_column.cpp for details.
+TEST(TestNumericTypes, test_check_signed_number_overflow_from_uint64_t) {
+    EXPECT_TRUE((check_signed_number_overflow<uint64_t, int8_t>(
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<uint64_t, int16_t>(
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<uint64_t, int32_t>(
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1)));
+    EXPECT_TRUE((check_signed_number_overflow<uint64_t, int64_t>(
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1)));
+
+    EXPECT_FALSE((check_signed_number_overflow<uint64_t, int128_t>(
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1)));
+    EXPECT_FALSE((check_signed_number_overflow<uint64_t, int128_t>(std::numeric_limits<uint64_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<uint64_t, float>(std::numeric_limits<uint64_t>::max())));
+    EXPECT_FALSE((check_signed_number_overflow<uint64_t, double>(std::numeric_limits<uint64_t>::max())));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
CP from #51280.

## Why I'm doing:

Introduced by PR #49707. It fixes an issue in the overflow check when casting a `double` to an integral type. And it abstracts `CastExpr::NumberCheck` into `check_number_overflow`, allowing the same issue to be resolved for both **Json and Avro formats**. 

However, `CastExpr::NumberCheck` only handles narrowing conversions, not widening conversions, because it is invoked only during narrowing conversions.

```cpp
#define UNARY_FN_CAST_VALID(FROM_TYPE, TO_TYPE, UNARY_IMPL)                                                            \
    template <bool AllowThrowException>                                                                                \
    struct CastFn<FROM_TYPE, TO_TYPE, AllowThrowException> {                                                           \
        static ColumnPtr cast_fn(ColumnPtr& column) {                                                                  \
            if constexpr (std::numeric_limits<RunTimeCppType<TO_TYPE>>::max() <                                        \
                          std::numeric_limits<RunTimeCppType<FROM_TYPE>>::max()) {                                     \
                if constexpr (!AllowThrowException) {                                                                  \
                    return VectorizedInputCheckUnaryFunction<UNARY_IMPL, NumberCheck>::template evaluate<FROM_TYPE,    \
                                                                                                         TO_TYPE>(     \
                            column);                                                                                   \
                } else {                                                                                               \
                    return VectorizedInputCheckUnaryFunction<                                                          \
                            UNARY_IMPL, NumberCheckWithThrowException>::template evaluate<FROM_TYPE, TO_TYPE>(column); \
                }                                                                                                      \
            }                                                                                                          \
            return VectorizedStrictUnaryFunction<UNARY_IMPL>::template evaluate<FROM_TYPE, TO_TYPE>(column);           \
        }                                                                                                              \
    };
```

When performing a widening conversion, the expression `value > (**FromType**)std::numeric_limits<ToType>::max()` may returns **true**. This occurs because converting the maximum value of a larger type (`ToType`) into a smaller type (`FromType`) results in an overflow and a negative value.

### Issues in Json Import:
- **int64 to double**: This can result in the issue described above. Casting a `double` to `int64` might lead to undefined behavior.
  - **Release mode**: Luckily, converting the maximum `double` value to `int64` will give the maximum `int64` value, so no issue arises.
  - **Debug mode**: In debug mode, converting the maximum `double` value to `int64` could result in the minimum `int64` value, causing problems.

### Issues in Avro Import:
- **int64 to double**: The same issue as in the Json import.
- **int32 to int64**: This also suffers from the overflow issue during widening conversions.

### Special Case: Values in the Range $[2^{63}, 2^{64})$
When the value falls within the range $$[2^{63}, 2^{64})$$, Json interprets the `FromType` as `uint64_t`. In such cases, using `check_signed_number_overflow` remains correct:
- If the `ToType` is any signed integer (`int8_t` to `int64_t`), `check_signed_number_overflow` will return `true`, indicating overflow.
- If the `ToType` is `float`, `double`, or `int128_t`, `check_signed_number_overflow` will return `false` since the widening conversion path is followed.


## What I'm doing:


Fixes https://github.com/StarRocks/StarRocksTest/issues/8603

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
<hr>This is an automatic backport of pull request #51280 done by [Mergify](https://mergify.com).
## Why I'm doing:

Introduced by PR #49707. It fixes an issue in the overflow check when casting a `double` to an integral type. And it abstracts `CastExpr::NumberCheck` into `check_number_overflow`, allowing the same issue to be resolved for both **Json and Avro formats**. 

However, `CastExpr::NumberCheck` only handles narrowing conversions, not widening conversions, because it is invoked only during narrowing conversions.

```cpp
#define UNARY_FN_CAST_VALID(FROM_TYPE, TO_TYPE, UNARY_IMPL)                                                            \
    template <bool AllowThrowException>                                                                                \
    struct CastFn<FROM_TYPE, TO_TYPE, AllowThrowException> {                                                           \
        static ColumnPtr cast_fn(ColumnPtr& column) {                                                                  \
            if constexpr (std::numeric_limits<RunTimeCppType<TO_TYPE>>::max() <                                        \
                          std::numeric_limits<RunTimeCppType<FROM_TYPE>>::max()) {                                     \
                if constexpr (!AllowThrowException) {                                                                  \
                    return VectorizedInputCheckUnaryFunction<UNARY_IMPL, NumberCheck>::template evaluate<FROM_TYPE,    \
                                                                                                         TO_TYPE>(     \
                            column);                                                                                   \
                } else {                                                                                               \
                    return VectorizedInputCheckUnaryFunction<                                                          \
                            UNARY_IMPL, NumberCheckWithThrowException>::template evaluate<FROM_TYPE, TO_TYPE>(column); \
                }                                                                                                      \
            }                                                                                                          \
            return VectorizedStrictUnaryFunction<UNARY_IMPL>::template evaluate<FROM_TYPE, TO_TYPE>(column);           \
        }                                                                                                              \
    };
```

When performing a widening conversion, the expression `value > (**FromType**)std::numeric_limits<ToType>::max()` may returns **true**. This occurs because converting the maximum value of a larger type (`ToType`) into a smaller type (`FromType`) results in an overflow and a negative value.

### Issues in Json Import:
- **int64 to double**: This can result in the issue described above. Casting a `double` to `int64` might lead to undefined behavior.
  - **Release mode**: Luckily, converting the maximum `double` value to `int64` will give the maximum `int64` value, so no issue arises.
  - **Debug mode**: In debug mode, converting the maximum `double` value to `int64` could result in the minimum `int64` value, causing problems.

### Issues in Avro Import:
- **int64 to double**: The same issue as in the Json import.
- **int32 to int64**: This also suffers from the overflow issue during widening conversions.

### Special Case: Values in the Range $[2^{63}, 2^{64})$
When the value falls within the range $$[2^{63}, 2^{64})$$, Json interprets the `FromType` as `uint64_t`. In such cases, using `check_signed_number_overflow` remains correct:
- If the `ToType` is any signed integer (`int8_t` to `int64_t`), `check_signed_number_overflow` will return `true`, indicating overflow.
- If the `ToType` is `float`, `double`, or `int128_t`, `check_signed_number_overflow` will return `false` since the widening conversion path is followed.


## What I'm doing:


Fixes https://github.com/StarRocks/StarRocksTest/issues/8603

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr


