### PR TITLE
[BugFix] Adding dynamic partition failure for one table may block other tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -474,7 +474,7 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
                     GlobalStateMgr.getCurrentState().getLocalMetastore().addPartitions(ctx,
                                 db, tableName, addPartitionClause);
                     clearCreatePartitionFailedMsg(tableName);
-                } catch (DdlException e) {
+                } catch (Exception e) {
                     recordCreatePartitionFailedMsg(db.getOriginName(), tableName, e.getMessage());
                 }
             }


### PR DESCRIPTION
## Why I'm doing:
This bug is introduced by #47106. It changes [`DdlException` to `SemanticException`](https://github.com/StarRocks/starrocks/pull/47106/files#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cR1035) which leads to `DynamicPartitionScheduler.executeDynamicPartitionForTable` can't catch the DdlException if adding partition fails. As a result, the current round of scheduling will stop, and other tables' partitions will not be created.

A way to reproduce is as following. Create a partition named  `p20241008` explicitly which will conflict with the dynamic partition to create.  Dynamic partition will report exception `Getting analyzing error. Detail message: Duplicate partition name p20241008`. Note that change `p20241008` to the current day you execute the sql. 

```
admin set frontend config ('dynamic_partition_check_interval_seconds' = '5');
admin set frontend config ('default_replication_num' = '1');

create database test;
CREATE TABLE test.site_access1(
    event_day DATE,
    site_id INT DEFAULT '10',
    city_code VARCHAR(100),
    user_name VARCHAR(32) DEFAULT '',
    pv BIGINT DEFAULT '0'
)
DUPLICATE KEY(event_day, site_id, city_code, user_name)
PARTITION BY RANGE(event_day)(
PARTITION p20241008 VALUES LESS THAN ("2020-03-25")
)
DISTRIBUTED BY HASH(event_day, site_id)
PROPERTIES(
    "dynamic_partition.enable" = "true",
    "dynamic_partition.time_unit" = "DAY",
    "dynamic_partition.end" = "3",
    "dynamic_partition.prefix" = "p",
    "dynamic_partition.history_partition_num" = "0"
);
```

## What I'm doing:

catch `Exception` rather than `DdlException` in `DynamicPartitionScheduler.executeDynamicPartitionForTable`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
