### PR TITLE
[Enhancement] (MV For TimeSeries Scene: Part 2)  Support date_trunc with day/month/year rollup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TimeUnitUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TimeUnitUtils.java
@@ -21,6 +21,7 @@ public class TimeUnitUtils {
     public static final String SECOND = "second";
     public static final String MINUTE = "minute";
     public static final String HOUR = "hour";
+    public static final String WEEK = "week";
     public static final String DAY = "day";
     public static final String MONTH = "month";
     public static final String QUARTER = "quarter";
@@ -29,12 +30,24 @@ public class TimeUnitUtils {
     // "week" can not exist in timeMap due "month" not sure contains week
     public static final ImmutableMap<String, Integer> TIME_MAP =
             new ImmutableMap.Builder<String, Integer>()
-                    .put("second", 1)
-                    .put("minute", 2)
-                    .put("hour", 3)
-                    .put("day", 4)
-                    .put("month", 5)
-                    .put("quarter", 6)
-                    .put("year", 7)
+                    .put(SECOND, 1)
+                    .put(MINUTE, 2)
+                    .put(HOUR, 3)
+                    .put(DAY, 4)
+                    .put(MONTH, 5)
+                    .put(QUARTER, 6)
+                    .put(YEAR, 7)
+                    .build();
+
+    public static final ImmutableMap<String, Integer> ALL_TIME_MAP =
+            new ImmutableMap.Builder<String, Integer>()
+                    .put(SECOND, 1)
+                    .put(MINUTE, 2)
+                    .put(HOUR, 3)
+                    .put(DAY, 4)
+                    .put(WEEK, 5)
+                    .put(MONTH, 6)
+                    .put(QUARTER, 7)
+                    .put(YEAR, 8)
                     .build();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TimeUnitUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TimeUnitUtils.java
@@ -39,7 +39,8 @@ public class TimeUnitUtils {
                     .put(YEAR, 7)
                     .build();
 
-    public static final ImmutableMap<String, Integer> ALL_TIME_MAP =
+    // all time units which date_trunc supported
+    public static final ImmutableMap<String, Integer> DATE_TRUNC_SUPPORTED_TIME_MAP =
             new ImmutableMap.Builder<String, Integer>()
                     .put(SECOND, 1)
                     .put(MINUTE, 2)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -138,6 +138,7 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
                 return null;
             }
         }
+        rewriteContext.setRollup(isRollup);
 
         // normalize mv's aggs by using query's table ref and query ec
         Map<ColumnRefOperator, ScalarOperator> mvProjection =
@@ -264,7 +265,7 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
             return null;
         }
         if (!isAllExprReplaced(rewritten, originalColumnSet)) {
-            // it means there is some column that can not be rewritten by outputs of mv
+            // it means there is some column that cannot be rewritten by outputs of mv
             return null;
         }
         return rewritten;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -42,6 +42,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregateFunctionRollupUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.EquivalentShuttleContext;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.IRewriteEquivalent;
 import com.starrocks.sql.optimizer.rule.tree.pdagg.AggregatePushDownContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -127,7 +128,7 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
             boolean mvHasDistinctAggFunc =
                     mvAggOp.getAggregations().values().stream().anyMatch(callOp -> callOp.isDistinct()
                             && !callOp.getFnName().equalsIgnoreCase(FunctionSet.ARRAY_AGG));
-            boolean queryHasDistinctAggFunc = 
+            boolean queryHasDistinctAggFunc =
                     queryAggOp.getAggregations().values().stream().anyMatch(callOp -> callOp.isDistinct());
             if (mvHasDistinctAggFunc && queryHasDistinctAggFunc) {
                 OptimizerTraceUtil.logMVRewriteFailReason(
@@ -181,7 +182,7 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         // rewrite group by + aggregate functions
         for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : swappedQueryColumnMap.entrySet()) {
             ScalarOperator scalarOp = entry.getValue();
-            ScalarOperator rewritten = rewriteScalarOperator(scalarOp,
+            ScalarOperator rewritten = rewriteScalarOperator(rewriteContext, scalarOp,
                         queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
                         originalColumnSet, aggregateFunctionRewriter);
             if (rewritten == null) {
@@ -203,7 +204,7 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
                 ScalarOperator scalarOp = entry.getValue();
                 ScalarOperator mapped = rewriteContext.getQueryColumnRefRewriter().rewrite(scalarOp.clone());
                 ScalarOperator swapped = columnRewriter.rewriteByQueryEc(mapped);
-                ScalarOperator rewritten = rewriteScalarOperator(swapped,
+                ScalarOperator rewritten = rewriteScalarOperator(rewriteContext, swapped,
                         queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
                         originalColumnSet, aggregateFunctionRewriter);
                 if (rewritten == null) {
@@ -216,7 +217,7 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
             for (ColumnRefOperator groupKey : queryAggregationOperator.getGroupingKeys()) {
                 ScalarOperator mapped = rewriteContext.getQueryColumnRefRewriter().rewrite(groupKey.clone());
                 ScalarOperator swapped = columnRewriter.rewriteByQueryEc(mapped);
-                ScalarOperator rewritten = rewriteScalarOperator(swapped,
+                ScalarOperator rewritten = rewriteScalarOperator(rewriteContext, swapped,
                         queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
                         originalColumnSet, aggregateFunctionRewriter);
                 if (rewritten == null) {
@@ -244,7 +245,8 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         return mvOptExpr;
     }
 
-    private ScalarOperator rewriteScalarOperator(ScalarOperator scalarOp,
+    private ScalarOperator rewriteScalarOperator(RewriteContext rewriteContext,
+                                                 ScalarOperator scalarOp,
                                                  EquationRewriter equationRewriter,
                                                  Map<ColumnRefOperator, ColumnRefOperator> columnMapping,
                                                  ColumnRefSet originalColumnSet,
@@ -254,7 +256,10 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         }
         equationRewriter.setAggregateFunctionRewriter(aggregateFunctionRewriter);
         equationRewriter.setOutputMapping(columnMapping);
-        ScalarOperator rewritten = equationRewriter.replaceExprWithTarget(scalarOp);
+
+        Pair<ScalarOperator, EquivalentShuttleContext> result =
+                equationRewriter.replaceExprWithEquivalent(rewriteContext, scalarOp);
+        ScalarOperator rewritten = result.first;
         if (rewritten == null || scalarOp == rewritten) {
             return null;
         }
@@ -370,7 +375,7 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         Map<ColumnRefOperator, ScalarOperator> queryColumnRefToScalarMap = Maps.newHashMap();
 
         // rewrite group by keys by using mv
-        List<ScalarOperator> newQueryGroupKeys = rewriteGroupKeys(queryGroupingKeys, equationRewriter,
+        List<ScalarOperator> newQueryGroupKeys = rewriteGroupKeys(rewriteContext, queryGroupingKeys, equationRewriter,
                 rewriteContext.getOutputMapping(), new ColumnRefSet(rewriteContext.getQueryColumnSet()));
         if (newQueryGroupKeys == null) {
             OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext.getMVName(),
@@ -608,14 +613,17 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
     /**
      * Rewrite group by keys by using MV.
      */
-    private List<ScalarOperator> rewriteGroupKeys(List<ScalarOperator> groupKeys,
+    private List<ScalarOperator> rewriteGroupKeys(RewriteContext rewriteContext,
+                                                  List<ScalarOperator> groupKeys,
                                                   EquationRewriter equationRewriter,
                                                   Map<ColumnRefOperator, ColumnRefOperator> mapping,
                                                   ColumnRefSet queryColumnSet) {
         List<ScalarOperator> newGroupByKeys = Lists.newArrayList();
         equationRewriter.setOutputMapping(mapping);
         for (ScalarOperator key : groupKeys) {
-            ScalarOperator newGroupByKey = equationRewriter.replaceExprWithTarget(key);
+            Pair<ScalarOperator, EquivalentShuttleContext> result = equationRewriter.replaceExprWithEquivalent(rewriteContext,
+                    key, IRewriteEquivalent.RewriteEquivalentType.PREDICATE);
+            ScalarOperator newGroupByKey = result.first;
             if (key.isVariable() && key == newGroupByKey) {
                 OptimizerTraceUtil.logMVRewriteFailReason(mvRewriteContext.getMVName(),
                         "Rewrite group by key failed: {}", key.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
@@ -49,7 +49,7 @@ public class EquationRewriter {
     boolean underAggFunctionRewriteContext;
 
     private final EquivalentShuttle defaultShuttle = new EquivalentShuttle(new EquivalentShuttleContext(null,
-            false, true));
+            false, true, IRewriteEquivalent.RewriteEquivalentType.AGGREGATE));
 
     public EquationRewriter() {
         this.equationMap = ArrayListMultimap.create();
@@ -123,13 +123,27 @@ public class EquationRewriter {
 
         private ScalarOperator rewriteByEquivalent(ScalarOperator input,
                                                    IRewriteEquivalent.RewriteEquivalentType type) {
-            if (!shuttleContext.isUseEquivalent() || !rewriteEquivalents.containsKey(type)) {
+            if (!shuttleContext.isUseEquivalent()) {
                 return null;
             }
-            for (RewriteEquivalent equivalent : rewriteEquivalents.get(type)) {
-                ScalarOperator replaced = equivalent.rewrite(shuttleContext, columnMapping, input);
-                if (replaced != null) {
-                    return replaced;
+            if (type.isAny()) {
+                for (List<RewriteEquivalent> equivalents : rewriteEquivalents.values()) {
+                    for (RewriteEquivalent equivalent : equivalents) {
+                        ScalarOperator replaced = equivalent.rewrite(shuttleContext, columnMapping, input);
+                        if (replaced != null) {
+                            return replaced;
+                        }
+                    }
+                }
+            } else {
+                if (!rewriteEquivalents.containsKey(type)) {
+                    return null;
+                }
+                for (RewriteEquivalent equivalent : rewriteEquivalents.get(type)) {
+                    ScalarOperator replaced = equivalent.rewrite(shuttleContext, columnMapping, input);
+                    if (replaced != null) {
+                        return replaced;
+                    }
                 }
             }
             return null;
@@ -144,7 +158,7 @@ public class EquationRewriter {
             }
 
             // rewrite by equivalent
-            ScalarOperator rewritten = rewriteByEquivalent(call, IRewriteEquivalent.RewriteEquivalentType.AGGREGATE);
+            ScalarOperator rewritten = rewriteByEquivalent(call, shuttleContext.getRewriteEquivalentType());
             if (rewritten != null) {
                 shuttleContext.setRewrittenByEquivalent(true);
                 return rewritten;
@@ -228,10 +242,29 @@ public class EquationRewriter {
      */
     public Pair<ScalarOperator, EquivalentShuttleContext> replaceExprWithRollup(RewriteContext rewriteContext,
                                                                                 ScalarOperator expr) {
+        return replaceExprWithEquivalent(rewriteContext, expr, IRewriteEquivalent.RewriteEquivalentType.AGGREGATE);
+    }
+
+    /**
+     * Replace expr with equivalent shuttle
+     * @param rewriteContext rewrite context
+     * @param expr input expr to be rewritten
+     * @param type equivalent type which is used for call operator rewrite to deduce rewriting strategy
+     * @return rewritten expr and equivalent shuttle context
+     */
+    public Pair<ScalarOperator, EquivalentShuttleContext> replaceExprWithEquivalent(
+            RewriteContext rewriteContext,
+            ScalarOperator expr,
+            IRewriteEquivalent.RewriteEquivalentType type) {
         final EquivalentShuttleContext shuttleContext = new EquivalentShuttleContext(rewriteContext,
-                true, true);
+                true, true, type);
         final EquivalentShuttle shuttle = new EquivalentShuttle(shuttleContext);
         return Pair.create(expr.accept(shuttle, null), shuttleContext);
+    }
+
+    public Pair<ScalarOperator, EquivalentShuttleContext> replaceExprWithEquivalent(RewriteContext rewriteContext,
+                                                                                    ScalarOperator expr) {
+        return replaceExprWithEquivalent(rewriteContext, expr, IRewriteEquivalent.RewriteEquivalentType.ANY);
     }
 
     public boolean containsKey(ScalarOperator scalarOperator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
@@ -246,7 +246,7 @@ public class EquationRewriter {
     }
 
     /**
-     * Replace expr with equivalent shuttle
+     * Replace expr with equivalent shuttle with specific type.
      * @param rewriteContext rewrite context
      * @param expr input expr to be rewritten
      * @param type equivalent type which is used for call operator rewrite to deduce rewriting strategy
@@ -256,12 +256,17 @@ public class EquationRewriter {
             RewriteContext rewriteContext,
             ScalarOperator expr,
             IRewriteEquivalent.RewriteEquivalentType type) {
+        boolean isRollup = rewriteContext.isRollup();
         final EquivalentShuttleContext shuttleContext = new EquivalentShuttleContext(rewriteContext,
-                true, true, type);
+                isRollup, true, type);
         final EquivalentShuttle shuttle = new EquivalentShuttle(shuttleContext);
         return Pair.create(expr.accept(shuttle, null), shuttleContext);
     }
 
+    /**
+     * Replace expr with equivalent shuttle, by default, we can rewrite call operator with any type of equivalent
+     * since call operator can be aggregate or predicate or group by keys.
+     */
     public Pair<ScalarOperator, EquivalentShuttleContext> replaceExprWithEquivalent(RewriteContext rewriteContext,
                                                                                     ScalarOperator expr) {
         return replaceExprWithEquivalent(rewriteContext, expr, IRewriteEquivalent.RewriteEquivalentType.ANY);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateExtractor.java
@@ -68,8 +68,7 @@ public class PredicateExtractor extends ScalarOperatorVisitor<RangePredicate, Pr
     }
 
     @Override
-    public RangePredicate visitBinaryPredicate(
-            BinaryPredicateOperator predicate, PredicateExtractorContext context) {
+    public RangePredicate visitBinaryPredicate(BinaryPredicateOperator predicate, PredicateExtractorContext context) {
         RangePredicate rangePredicate = rewriteBinaryPredicate(predicate);
         if (rangePredicate != null) {
             return rangePredicate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RewriteContext.java
@@ -47,6 +47,8 @@ public class RewriteContext {
     private BiMap<Integer, Integer> queryToMvRelationIdMapping;
     private ScalarOperator unionRewriteQueryExtraPredicate;
     private AggregatePushDownContext aggregatePushDownContext;
+    // whether this rewritten query is a rollup query
+    private boolean isRollup;
 
     public RewriteContext(OptExpression queryExpression,
                           PredicateSplit queryPredicateSplit,
@@ -170,5 +172,13 @@ public class RewriteContext {
 
     public void setAggregatePushDownContext(AggregatePushDownContext aggregatePushDownContext) {
         this.aggregatePushDownContext = aggregatePushDownContext;
+    }
+
+    public boolean isRollup() {
+        return isRollup;
+    }
+
+    public void setRollup(boolean rollup) {
+        isRollup = rollup;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncEquivalent.java
@@ -25,7 +25,7 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
 
 import java.util.Set;
 
-import static com.starrocks.sql.common.TimeUnitUtils.ALL_TIME_MAP;
+import static com.starrocks.sql.common.TimeUnitUtils.DATE_TRUNC_SUPPORTED_TIME_MAP;
 
 public class DateTruncEquivalent extends IPredicateRewriteEquivalent {
     public static final DateTruncEquivalent INSTANCE = new DateTruncEquivalent();
@@ -124,13 +124,13 @@ public class DateTruncEquivalent extends IPredicateRewriteEquivalent {
                 return null;
             }
             ConstantOperator newChild0 = (ConstantOperator) newCall.getChild(0);
-            if (!ALL_TIME_MAP.containsKey(oldChild0.getVarchar()) ||
-                    !ALL_TIME_MAP.containsKey(newChild0.getVarchar())) {
+            if (!DATE_TRUNC_SUPPORTED_TIME_MAP.containsKey(oldChild0.getVarchar()) ||
+                    !DATE_TRUNC_SUPPORTED_TIME_MAP.containsKey(newChild0.getVarchar())) {
                 // only can rewrite date_trunc('day', col) to date_trunc('month', col)
                 return null;
             }
-            int oldTimeUnit = ALL_TIME_MAP.get(oldChild0.getVarchar());
-            int newTimeUnit = ALL_TIME_MAP.get(newChild0.getVarchar());
+            int oldTimeUnit = DATE_TRUNC_SUPPORTED_TIME_MAP.get(oldChild0.getVarchar());
+            int newTimeUnit = DATE_TRUNC_SUPPORTED_TIME_MAP.get(newChild0.getVarchar());
             if (oldTimeUnit > newTimeUnit) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncEquivalent.java
@@ -36,7 +36,7 @@ public class DateTruncEquivalent extends IPredicateRewriteEquivalent {
      * TODO: we can support this later.
      * Change date_trunc('month', col) to col = '2023-12-01' will get a wrong result.
      * MV       : select date_trunc('day', col) as dt from t
-     * Query    : select date_trunc('day, col) from t where date_trunc('month', col) = '2023-11-01'
+     * Query    : select date_trunc('month, col) from t where date_trunc('month', col) = '2023-11-01'
      */
     private static Set<BinaryType> SUPPORTED_BINARY_TYPES = ImmutableSet.of(
             BinaryType.GE,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/EquivalentShuttleContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/EquivalentShuttleContext.java
@@ -21,11 +21,14 @@ public class EquivalentShuttleContext {
     private final boolean isRollup;
     private boolean isUseEquivalent;
     private boolean isRewrittenByEquivalent;
+    private IRewriteEquivalent.RewriteEquivalentType rewriteEquivalentType;
 
-    public EquivalentShuttleContext(RewriteContext rewriteContext, boolean isRollup, boolean isRewrittenByEquivalent) {
+    public EquivalentShuttleContext(RewriteContext rewriteContext, boolean isRollup, boolean isRewrittenByEquivalent,
+                                    IRewriteEquivalent.RewriteEquivalentType type) {
         this.rewriteContext = rewriteContext;
         this.isRollup = isRollup;
         this.isUseEquivalent = isRewrittenByEquivalent;
+        this.rewriteEquivalentType = type;
     }
 
     public boolean isUseEquivalent() {
@@ -46,5 +49,9 @@ public class EquivalentShuttleContext {
 
     public RewriteContext getRewriteContext() {
         return rewriteContext;
+    }
+
+    public IRewriteEquivalent.RewriteEquivalentType getRewriteEquivalentType() {
+        return rewriteEquivalentType;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
@@ -32,10 +32,12 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 public interface IRewriteEquivalent {
     /**
-     * Different {@code RewriteEquivalentType} will be used to rewrite different scalar operators.
+     * Different {@code RewriteEquivalentType} will be used to rewrite different scalar operators which can deduce lookup
+     * time to rewrite specific input expression.
      * eg:
-     *  `PREDICATE` will be used to rewrite for `BinaryPredicateOperator`;
-     *  `CallOperator` will be used to rewrite for `BinaryPredicateOperator`;
+     *  `PREDICATE` will be used to rewrite for `BinaryPredicateOperator` by using Predicate equivalents;
+     *  `AGGREGATE` will be used to rewrite for `CallOperator` by using Aggregate equivalents;
+     *  `ANY` type can be used to rewrite `CallOperator` for both `PREDICATE` type and `AGGREGATE` equivalents.
      */
     enum RewriteEquivalentType {
         PREDICATE,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
@@ -39,7 +39,8 @@ public interface IRewriteEquivalent {
      */
     enum RewriteEquivalentType {
         PREDICATE,
-        AGGREGATE;
+        AGGREGATE,
+        ANY;
 
         public boolean isPredicate() {
             return this == PREDICATE;
@@ -47,6 +48,10 @@ public interface IRewriteEquivalent {
 
         public boolean isAggregate() {
             return this == AGGREGATE;
+        }
+
+        public boolean isAny() {
+            return this == ANY;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -56,17 +56,16 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         starRocksAssert.useTable("dependents");
 
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `customer_unique` (\n" +
-                "    `c_custkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `c_name` varchar(26) NOT NULL COMMENT \"\",\n" +
-                "    `c_address` varchar(41) NOT NULL COMMENT \"\",\n" +
-                "    `c_city` varchar(11) NOT NULL COMMENT \"\",\n" +
-                "    `c_nation` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `c_region` varchar(13) NOT NULL COMMENT \"\",\n" +
-                "    `c_phone` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `c_mktsegment` varchar(11) NOT NULL COMMENT \"\"\n" +
+                "    `c_custkey` int(11) NOT NULL,\n" +
+                "    `c_name` varchar(26) NOT NULL,\n" +
+                "    `c_address` varchar(41) NOT NULL,\n" +
+                "    `c_city` varchar(11) NOT NULL,\n" +
+                "    `c_nation` varchar(16) NOT NULL,\n" +
+                "    `c_region` varchar(13) NOT NULL,\n" +
+                "    `c_phone` varchar(16) NOT NULL,\n" +
+                "    `c_mktsegment` varchar(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "UNIQUE KEY(`c_custkey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -75,17 +74,16 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")\n");
 
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `customer_primary` (\n" +
-                "    `c_custkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `c_name` varchar(26) NOT NULL COMMENT \"\",\n" +
-                "    `c_address` varchar(41) NOT NULL COMMENT \"\",\n" +
-                "    `c_city` varchar(11) NOT NULL COMMENT \"\",\n" +
-                "    `c_nation` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `c_region` varchar(13) NOT NULL COMMENT \"\",\n" +
-                "    `c_phone` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `c_mktsegment` varchar(11) NOT NULL COMMENT \"\"\n" +
+                "    `c_custkey` int(11) NOT NULL,\n" +
+                "    `c_name` varchar(26) NOT NULL,\n" +
+                "    `c_address` varchar(41) NOT NULL,\n" +
+                "    `c_city` varchar(11) NOT NULL,\n" +
+                "    `c_nation` varchar(16) NOT NULL,\n" +
+                "    `c_region` varchar(13) NOT NULL,\n" +
+                "    `c_phone` varchar(16) NOT NULL,\n" +
+                "    `c_mktsegment` varchar(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "PRIMARY KEY(`c_custkey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -94,17 +92,16 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")\n");
 
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `customer_null` (\n" +
-                "    `c_custkey` int(11) NULL COMMENT \"\",\n" +
-                "    `c_name` varchar(26) NULL COMMENT \"\",\n" +
-                "    `c_address` varchar(41) NULL COMMENT \"\",\n" +
-                "    `c_city` varchar(11) NULL COMMENT \"\",\n" +
-                "    `c_nation` varchar(16) NULL COMMENT \"\",\n" +
-                "    `c_region` varchar(13) NULL COMMENT \"\",\n" +
-                "    `c_phone` varchar(16) NULL COMMENT \"\",\n" +
-                "    `c_mktsegment` varchar(11) NULL COMMENT \"\"\n" +
+                "    `c_custkey` int(11) NULL,\n" +
+                "    `c_name` varchar(26) NULL,\n" +
+                "    `c_address` varchar(41) NULL,\n" +
+                "    `c_city` varchar(11) NULL,\n" +
+                "    `c_nation` varchar(16) NULL,\n" +
+                "    `c_region` varchar(13) NULL,\n" +
+                "    `c_phone` varchar(16) NULL,\n" +
+                "    `c_mktsegment` varchar(11) NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`c_custkey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -114,17 +111,16 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")\n");
 
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `customer` (\n" +
-                "    `c_custkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `c_name` varchar(26) NOT NULL COMMENT \"\",\n" +
-                "    `c_address` varchar(41) NOT NULL COMMENT \"\",\n" +
-                "    `c_city` varchar(11) NOT NULL COMMENT \"\",\n" +
-                "    `c_nation` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `c_region` varchar(13) NOT NULL COMMENT \"\",\n" +
-                "    `c_phone` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `c_mktsegment` varchar(11) NOT NULL COMMENT \"\"\n" +
+                "    `c_custkey` int(11) NOT NULL,\n" +
+                "    `c_name` varchar(26) NOT NULL,\n" +
+                "    `c_address` varchar(41) NOT NULL,\n" +
+                "    `c_city` varchar(11) NOT NULL,\n" +
+                "    `c_nation` varchar(16) NOT NULL,\n" +
+                "    `c_region` varchar(13) NOT NULL,\n" +
+                "    `c_phone` varchar(16) NOT NULL,\n" +
+                "    `c_mktsegment` varchar(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`c_custkey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -133,26 +129,25 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "    \"unique_constraints\" = \"c_custkey\"\n" +
                 ")\n");
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `dates` (\n" +
-                "    `d_datekey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_date` varchar(20) NOT NULL COMMENT \"\",\n" +
-                "    `d_dayofweek` varchar(10) NOT NULL COMMENT \"\",\n" +
-                "    `d_month` varchar(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_year` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_yearmonthnum` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_yearmonth` varchar(9) NOT NULL COMMENT \"\",\n" +
-                "    `d_daynuminweek` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_daynuminmonth` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_daynuminyear` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_monthnuminyear` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_weeknuminyear` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_sellingseason` varchar(14) NOT NULL COMMENT \"\",\n" +
-                "    `d_lastdayinweekfl` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_lastdayinmonthfl` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_holidayfl` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `d_weekdayfl` int(11) NOT NULL COMMENT \"\"\n" +
+                "    `d_datekey` int(11) NOT NULL,\n" +
+                "    `d_date` varchar(20) NOT NULL,\n" +
+                "    `d_dayofweek` varchar(10) NOT NULL,\n" +
+                "    `d_month` varchar(11) NOT NULL,\n" +
+                "    `d_year` int(11) NOT NULL,\n" +
+                "    `d_yearmonthnum` int(11) NOT NULL,\n" +
+                "    `d_yearmonth` varchar(9) NOT NULL,\n" +
+                "    `d_daynuminweek` int(11) NOT NULL,\n" +
+                "    `d_daynuminmonth` int(11) NOT NULL,\n" +
+                "    `d_daynuminyear` int(11) NOT NULL,\n" +
+                "    `d_monthnuminyear` int(11) NOT NULL,\n" +
+                "    `d_weeknuminyear` int(11) NOT NULL,\n" +
+                "    `d_sellingseason` varchar(14) NOT NULL,\n" +
+                "    `d_lastdayinweekfl` int(11) NOT NULL,\n" +
+                "    `d_lastdayinmonthfl` int(11) NOT NULL,\n" +
+                "    `d_holidayfl` int(11) NOT NULL,\n" +
+                "    `d_weekdayfl` int(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`d_datekey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -161,18 +156,17 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "    \"unique_constraints\" = \"d_datekey\"\n" +
                 ")");
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `part` (\n" +
-                "    `p_partkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `p_name` varchar(23) NOT NULL COMMENT \"\",\n" +
-                "    `p_mfgr` varchar(7) NOT NULL COMMENT \"\",\n" +
-                "    `p_category` varchar(8) NOT NULL COMMENT \"\",\n" +
-                "    `p_brand` varchar(10) NOT NULL COMMENT \"\",\n" +
-                "    `p_color` varchar(12) NOT NULL COMMENT \"\",\n" +
-                "    `p_type` varchar(26) NOT NULL COMMENT \"\",\n" +
-                "    `p_size` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `p_container` varchar(11) NOT NULL COMMENT \"\"\n" +
+                "    `p_partkey` int(11) NOT NULL,\n" +
+                "    `p_name` varchar(23) NOT NULL,\n" +
+                "    `p_mfgr` varchar(7) NOT NULL,\n" +
+                "    `p_category` varchar(8) NOT NULL,\n" +
+                "    `p_brand` varchar(10) NOT NULL,\n" +
+                "    `p_color` varchar(12) NOT NULL,\n" +
+                "    `p_type` varchar(26) NOT NULL,\n" +
+                "    `p_size` int(11) NOT NULL,\n" +
+                "    `p_container` varchar(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`p_partkey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -181,16 +175,15 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "    \"unique_constraints\" = \"p_partkey\"\n" +
                 ")");
         starRocksAssert.withTable(" CREATE TABLE IF NOT EXISTS `supplier` (\n" +
-                "    `s_suppkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `s_name` varchar(26) NOT NULL COMMENT \"\",\n" +
-                "    `s_address` varchar(26) NOT NULL COMMENT \"\",\n" +
-                "    `s_city` varchar(11) NOT NULL COMMENT \"\",\n" +
-                "    `s_nation` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `s_region` varchar(13) NOT NULL COMMENT \"\",\n" +
-                "    `s_phone` varchar(16) NOT NULL COMMENT \"\"\n" +
+                "    `s_suppkey` int(11) NOT NULL,\n" +
+                "    `s_name` varchar(26) NOT NULL,\n" +
+                "    `s_address` varchar(26) NOT NULL,\n" +
+                "    `s_city` varchar(11) NOT NULL,\n" +
+                "    `s_nation` varchar(16) NOT NULL,\n" +
+                "    `s_region` varchar(13) NOT NULL,\n" +
+                "    `s_phone` varchar(16) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`s_suppkey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -200,26 +193,25 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")");
 
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `lineorder` (\n" +
-                "    `lo_orderkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_linenumber` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_custkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_partkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_suppkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_orderdate` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_orderpriority` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `lo_shippriority` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_quantity` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_extendedprice` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_ordtotalprice` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_discount` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_revenue` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_supplycost` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_tax` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_commitdate` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_shipmode` varchar(11) NOT NULL COMMENT \"\"\n" +
+                "    `lo_orderkey` int(11) NOT NULL,\n" +
+                "    `lo_linenumber` int(11) NOT NULL,\n" +
+                "    `lo_custkey` int(11) NOT NULL,\n" +
+                "    `lo_partkey` int(11) NOT NULL,\n" +
+                "    `lo_suppkey` int(11) NOT NULL,\n" +
+                "    `lo_orderdate` int(11) NOT NULL,\n" +
+                "    `lo_orderpriority` varchar(16) NOT NULL,\n" +
+                "    `lo_shippriority` int(11) NOT NULL,\n" +
+                "    `lo_quantity` int(11) NOT NULL,\n" +
+                "    `lo_extendedprice` int(11) NOT NULL,\n" +
+                "    `lo_ordtotalprice` int(11) NOT NULL,\n" +
+                "    `lo_discount` int(11) NOT NULL,\n" +
+                "    `lo_revenue` int(11) NOT NULL,\n" +
+                "    `lo_supplycost` int(11) NOT NULL,\n" +
+                "    `lo_tax` int(11) NOT NULL,\n" +
+                "    `lo_commitdate` int(11) NOT NULL,\n" +
+                "    `lo_shipmode` varchar(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`lo_orderkey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "PARTITION BY RANGE(`lo_orderdate`)\n" +
                 "(\n" +
                 "    PARTITION p1 VALUES [(\"-2147483648\"), (\"19930101\")),\n" +
@@ -241,26 +233,25 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")");
 
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `lineorder_primary` (\n" +
-                "    `lo_custkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_orderkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_linenumber` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_partkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_suppkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_orderdate` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_orderpriority` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `lo_shippriority` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_quantity` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_extendedprice` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_ordtotalprice` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_discount` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_revenue` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_supplycost` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_tax` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_commitdate` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_shipmode` varchar(11) NOT NULL COMMENT \"\"\n" +
+                "    `lo_custkey` int(11) NOT NULL,\n" +
+                "    `lo_orderkey` int(11) NOT NULL,\n" +
+                "    `lo_linenumber` int(11) NOT NULL,\n" +
+                "    `lo_partkey` int(11) NOT NULL,\n" +
+                "    `lo_suppkey` int(11) NOT NULL,\n" +
+                "    `lo_orderdate` int(11) NOT NULL,\n" +
+                "    `lo_orderpriority` varchar(16) NOT NULL,\n" +
+                "    `lo_shippriority` int(11) NOT NULL,\n" +
+                "    `lo_quantity` int(11) NOT NULL,\n" +
+                "    `lo_extendedprice` int(11) NOT NULL,\n" +
+                "    `lo_ordtotalprice` int(11) NOT NULL,\n" +
+                "    `lo_discount` int(11) NOT NULL,\n" +
+                "    `lo_revenue` int(11) NOT NULL,\n" +
+                "    `lo_supplycost` int(11) NOT NULL,\n" +
+                "    `lo_tax` int(11) NOT NULL,\n" +
+                "    `lo_commitdate` int(11) NOT NULL,\n" +
+                "    `lo_shipmode` varchar(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "PRIMARY KEY(`lo_custkey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`lo_custkey`) BUCKETS 48\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -268,26 +259,25 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")");
 
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `lineorder_unique` (\n" +
-                "    `lo_custkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_orderkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_linenumber` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_partkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_suppkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_orderdate` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_orderpriority` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `lo_shippriority` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_quantity` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_extendedprice` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_ordtotalprice` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_discount` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_revenue` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_supplycost` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_tax` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_commitdate` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_shipmode` varchar(11) NOT NULL COMMENT \"\"\n" +
+                "    `lo_custkey` int(11) NOT NULL,\n" +
+                "    `lo_orderkey` int(11) NOT NULL,\n" +
+                "    `lo_linenumber` int(11) NOT NULL,\n" +
+                "    `lo_partkey` int(11) NOT NULL,\n" +
+                "    `lo_suppkey` int(11) NOT NULL,\n" +
+                "    `lo_orderdate` int(11) NOT NULL,\n" +
+                "    `lo_orderpriority` varchar(16) NOT NULL,\n" +
+                "    `lo_shippriority` int(11) NOT NULL,\n" +
+                "    `lo_quantity` int(11) NOT NULL,\n" +
+                "    `lo_extendedprice` int(11) NOT NULL,\n" +
+                "    `lo_ordtotalprice` int(11) NOT NULL,\n" +
+                "    `lo_discount` int(11) NOT NULL,\n" +
+                "    `lo_revenue` int(11) NOT NULL,\n" +
+                "    `lo_supplycost` int(11) NOT NULL,\n" +
+                "    `lo_tax` int(11) NOT NULL,\n" +
+                "    `lo_commitdate` int(11) NOT NULL,\n" +
+                "    `lo_shipmode` varchar(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "UNIQUE KEY(`lo_custkey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`lo_custkey`) BUCKETS 48\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -295,26 +285,25 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")");
 
         starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `lineorder_null` (\n" +
-                "    `lo_orderkey` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_linenumber` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_custkey` int(11) COMMENT \"\",\n" +
-                "    `lo_partkey` int(11) COMMENT \"\",\n" +
-                "    `lo_suppkey` int(11) COMMENT \"\",\n" +
-                "    `lo_orderdate` int(11) COMMENT \"\",\n" +
-                "    `lo_orderpriority` varchar(16) NOT NULL COMMENT \"\",\n" +
-                "    `lo_shippriority` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_quantity` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_extendedprice` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_ordtotalprice` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_discount` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_revenue` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_supplycost` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_tax` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_commitdate` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `lo_shipmode` varchar(11) NOT NULL COMMENT \"\"\n" +
+                "    `lo_orderkey` int(11) NOT NULL,\n" +
+                "    `lo_linenumber` int(11) NOT NULL,\n" +
+                "    `lo_custkey` int(11),\n" +
+                "    `lo_partkey` int(11),\n" +
+                "    `lo_suppkey` int(11),\n" +
+                "    `lo_orderdate` int(11),\n" +
+                "    `lo_orderpriority` varchar(16) NOT NULL,\n" +
+                "    `lo_shippriority` int(11) NOT NULL,\n" +
+                "    `lo_quantity` int(11) NOT NULL,\n" +
+                "    `lo_extendedprice` int(11) NOT NULL,\n" +
+                "    `lo_ordtotalprice` int(11) NOT NULL,\n" +
+                "    `lo_discount` int(11) NOT NULL,\n" +
+                "    `lo_revenue` int(11) NOT NULL,\n" +
+                "    `lo_supplycost` int(11) NOT NULL,\n" +
+                "    `lo_tax` int(11) NOT NULL,\n" +
+                "    `lo_commitdate` int(11) NOT NULL,\n" +
+                "    `lo_shipmode` varchar(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`lo_orderkey`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "PARTITION BY RANGE(`lo_orderdate`)\n" +
                 "(\n" +
                 "    PARTITION p1 VALUES [(\"-2147483648\"), (\"19930101\")),\n" +
@@ -335,12 +324,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")");
 
         starRocksAssert.withTable(" CREATE TABLE IF NOT EXISTS `t2` (\n" +
-                "    `c5` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                "    `c5` int(11) NOT NULL,\n" +
+                "    `c6` int(11) NOT NULL,\n" +
+                "    `c7` int(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`c5`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`c5`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -350,12 +338,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")");
 
         starRocksAssert.withTable(" CREATE TABLE IF NOT EXISTS `t3` (\n" +
-                "    `c5` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                "    `c5` int(11) NOT NULL,\n" +
+                "    `c6` int(11) NOT NULL,\n" +
+                "    `c7` int(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`c5`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`c5`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -365,12 +352,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")");
 
         starRocksAssert.withTable(" CREATE TABLE IF NOT EXISTS `t1` (\n" +
-                "    `c1` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `c2` int(11) NOT NULL COMMENT \"\",\n" +
-                "    `c3` int(11) NOT NULL COMMENT \"\"\n" +
+                "    `c1` int(11) NOT NULL,\n" +
+                "    `c2` int(11) NOT NULL,\n" +
+                "    `c3` int(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`c1`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`c1`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
@@ -389,12 +375,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 .withTable(userTagTable);
 
         String eventTable = "CREATE TABLE `event1` (\n" +
-                "  `event_id` int(11) NOT NULL COMMENT \"\",\n" +
-                "  `event_type` varchar(26) NOT NULL COMMENT \"\",\n" +
-                "  `event_time` datetime NOT NULL COMMENT \"\"\n" +
+                "  `event_id` int(11) NOT NULL,\n" +
+                "  `event_type` varchar(26) NOT NULL,\n" +
+                "  `event_time` datetime NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`event_id`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`event_id`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "\"replication_num\" = \"1\"\n" +
@@ -2368,12 +2353,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     public void testViewDeltaColumnCaseSensitiveOnDuplicate() throws Exception {
         {
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_03` (\n" +
-                    "    `c5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `c5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c5`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c5`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2382,12 +2366,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "    \"unique_constraints\" = \"C5\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_02` (\n" +
-                    "    `c5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `c5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c5`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c5`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2396,13 +2379,12 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "    \"unique_constraints\" = \"C5\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_01` (\n" +
-                    "    `c1` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C2` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c3` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C4` decimal(38, 19) NOT NULL COMMENT \"\"\n" +
+                    "    `c1` int(11) NOT NULL,\n" +
+                    "    `C2` int(11) NOT NULL,\n" +
+                    "    `c3` int(11) NOT NULL,\n" +
+                    "    `C4` decimal(38, 19) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c1`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c1`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2426,12 +2408,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         {
             // multi key columns
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_03` (\n" +
-                    "    `c5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `c5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c5`, `c6`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c5`, `c6`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2439,12 +2420,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "    \"unique_constraints\" = \"C5\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_02` (\n" +
-                    "    `C5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `C5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`C5`, `C6`, `c7`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`C5`, `C6`, `c7`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2452,13 +2432,12 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "    \"unique_constraints\" = \"C5, C6, c7\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_01` (\n" +
-                    "    `c1` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C2` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c3` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C4` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `c1` int(11) NOT NULL,\n" +
+                    "    `C2` int(11) NOT NULL,\n" +
+                    "    `c3` int(11) NOT NULL,\n" +
+                    "    `C4` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c1`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c1`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2482,12 +2461,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     public void testViewDeltaColumnCaseSensitiveOnPrimary() throws Exception {
         {
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_03` (\n" +
-                    "    `c5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `c5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c5`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c5`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2496,12 +2474,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "    \"unique_constraints\" = \"C5\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_02` (\n" +
-                    "    `c5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `c5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "PRIMARY KEY(`c5`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c5`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2509,13 +2486,12 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "    \"in_memory\" = \"false\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_01` (\n" +
-                    "    `c1` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C2` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c3` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C4` decimal(38, 19) NOT NULL COMMENT \"\"\n" +
+                    "    `c1` int(11) NOT NULL,\n" +
+                    "    `C2` int(11) NOT NULL,\n" +
+                    "    `c3` int(11) NOT NULL,\n" +
+                    "    `C4` decimal(38, 19) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c1`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c1`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2539,12 +2515,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         {
             // multi key columns
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_03` (\n" +
-                    "    `c5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `c5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c5`, `c6`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c5`, `c6`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2552,25 +2527,23 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "    \"unique_constraints\" = \"C5\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_02` (\n" +
-                    "    `C5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `C5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "PRIMARY KEY(`C5`, `C6`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`C5`, `C6`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
                     "    \"in_memory\" = \"false\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_01` (\n" +
-                    "    `c1` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C2` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c3` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C4` decimal(38, 19) NOT NULL COMMENT \"\"\n" +
+                    "    `c1` int(11) NOT NULL,\n" +
+                    "    `C2` int(11) NOT NULL,\n" +
+                    "    `c3` int(11) NOT NULL,\n" +
+                    "    `C4` decimal(38, 19) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c1`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c1`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2595,12 +2568,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     public void testViewDeltaColumnCaseSensitiveOnUnique() throws Exception {
         {
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_03` (\n" +
-                    "    `c5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `c5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c5`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c5`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2608,25 +2580,23 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "    \"unique_constraints\" = \"C5\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_02` (\n" +
-                    "    `C5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `C5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "UNIQUE KEY(`C5`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`C5`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
                     "    \"in_memory\" = \"false\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_01` (\n" +
-                    "    `c1` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C2` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c3` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C4` decimal(38, 19) NOT NULL COMMENT \"\"\n" +
+                    "    `c1` int(11) NOT NULL,\n" +
+                    "    `C2` int(11) NOT NULL,\n" +
+                    "    `c3` int(11) NOT NULL,\n" +
+                    "    `C4` decimal(38, 19) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c1`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c1`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2649,12 +2619,11 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         {
             // multi key columns
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_03` (\n" +
-                    "    `c5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `c5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c5`, `c6`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c5`, `c6`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -2662,25 +2631,23 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "    \"unique_constraints\" = \"C5\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_02` (\n" +
-                    "    `C5` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c6` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c7` int(11) NOT NULL COMMENT \"\"\n" +
+                    "    `C5` int(11) NOT NULL,\n" +
+                    "    `c6` int(11) NOT NULL,\n" +
+                    "    `c7` int(11) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "UNIQUE KEY(`C5`, `C6`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`C5`, `C6`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
                     "    \"in_memory\" = \"false\"\n" +
                     ");");
             starRocksAssert.withTable("CREATE TABLE IF NOT EXISTS `tbl_01` (\n" +
-                    "    `c1` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C2` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `c3` int(11) NOT NULL COMMENT \"\",\n" +
-                    "    `C4` decimal(38, 19) NOT NULL COMMENT \"\"\n" +
+                    "    `c1` int(11) NOT NULL,\n" +
+                    "    `C2` int(11) NOT NULL,\n" +
+                    "    `c3` int(11) NOT NULL,\n" +
+                    "    `C4` decimal(38, 19) NOT NULL\n" +
                     ") ENGINE=OLAP\n" +
                     "DUPLICATE KEY(`c1`)\n" +
-                    "COMMENT \"OLAP\"\n" +
                     "DISTRIBUTED BY HASH(`c1`) BUCKETS 12\n" +
                     "PROPERTIES (\n" +
                     "    \"replication_num\" = \"1\",\n" +
@@ -3044,22 +3011,21 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     @Test
     public void testQueryWithLimitRewrite() throws Exception {
         starRocksAssert.withTable("CREATE TABLE `aggregate_table_with_null` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` datetime NULL COMMENT \"\",\n" +
-                "  `k3` char(20) NULL COMMENT \"\",\n" +
-                "  `k4` varchar(20) NULL COMMENT \"\",\n" +
-                "  `k5` boolean NULL COMMENT \"\",\n" +
-                "  `v1` bigint(20) SUM NULL COMMENT \"\",\n" +
-                "  `v2` bigint(20) SUM NULL COMMENT \"\",\n" +
-                "  `v3` bigint(20) SUM NULL COMMENT \"\",\n" +
-                "  `v4` bigint(20) MAX NULL COMMENT \"\",\n" +
-                "  `v5` largeint(40) MAX NULL COMMENT \"\",\n" +
-                "  `v6` float MIN NULL COMMENT \"\",\n" +
-                "  `v7` double MIN NULL COMMENT \"\",\n" +
-                "  `v8` decimal128(38, 9) SUM NULL COMMENT \"\"\n" +
+                "  `k1` date NULL,\n" +
+                "  `k2` datetime NULL,\n" +
+                "  `k3` char(20) NULL,\n" +
+                "  `k4` varchar(20) NULL,\n" +
+                "  `k5` boolean NULL,\n" +
+                "  `v1` bigint(20) SUM NULL,\n" +
+                "  `v2` bigint(20) SUM NULL,\n" +
+                "  `v3` bigint(20) SUM NULL,\n" +
+                "  `v4` bigint(20) MAX NULL,\n" +
+                "  `v5` largeint(40) MAX NULL,\n" +
+                "  `v6` float MIN NULL,\n" +
+                "  `v7` double MIN NULL,\n" +
+                "  `v8` decimal128(38, 9) SUM NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "AGGREGATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3\n" +
                 "PROPERTIES (\n" +
                 "\"replication_num\" = \"1\",\n" +
@@ -3071,22 +3037,21 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ");");
 
         starRocksAssert.withTable("CREATE TABLE `duplicate_table_with_null_partition` (\n" +
-                "  `k1` date NULL COMMENT \"\",\n" +
-                "  `k2` datetime NULL COMMENT \"\",\n" +
-                "  `k3` char(20) NULL COMMENT \"\",\n" +
-                "  `k4` varchar(20) NULL COMMENT \"\",\n" +
-                "  `k5` boolean NULL COMMENT \"\",\n" +
-                "  `k6` tinyint(4) NULL COMMENT \"\",\n" +
-                "  `k7` smallint(6) NULL COMMENT \"\",\n" +
-                "  `k8` int(11) NULL COMMENT \"\",\n" +
-                "  `k9` bigint(20) NULL COMMENT \"\",\n" +
-                "  `k10` largeint(40) NULL COMMENT \"\",\n" +
-                "  `k11` float NULL COMMENT \"\",\n" +
-                "  `k12` double NULL COMMENT \"\",\n" +
-                "  `k13` decimal128(27, 9) NULL COMMENT \"\"\n" +
+                "  `k1` date NULL,\n" +
+                "  `k2` datetime NULL,\n" +
+                "  `k3` char(20) NULL,\n" +
+                "  `k4` varchar(20) NULL,\n" +
+                "  `k5` boolean NULL,\n" +
+                "  `k6` tinyint(4) NULL,\n" +
+                "  `k7` smallint(6) NULL,\n" +
+                "  `k8` int(11) NULL,\n" +
+                "  `k9` bigint(20) NULL,\n" +
+                "  `k10` largeint(40) NULL,\n" +
+                "  `k11` float NULL,\n" +
+                "  `k12` double NULL,\n" +
+                "  `k13` decimal128(27, 9) NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "PARTITION BY RANGE(`k1`)\n" +
                 "(PARTITION p202006 VALUES [(\"0000-01-01\"), (\"2020-07-01\")),\n" +
                 "PARTITION p202007 VALUES [(\"2020-07-01\"), (\"2020-08-01\")),\n" +
@@ -3306,11 +3271,10 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     @Test
     public void testTimeSliceRewrite() throws Exception {
         starRocksAssert.withTable(" CREATE TABLE IF NOT EXISTS `t_time_slice` (\n" +
-                "    `dt` datetime NOT NULL COMMENT \"\",\n" +
-                "    `c1` int(11) NOT NULL COMMENT \"\"\n" +
+                "    `dt` datetime NOT NULL,\n" +
+                "    `c1` int(11) NOT NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`dt`)\n" +
-                "COMMENT \"OLAP\"\n" +
                 "PARTITION BY RANGE(`dt`)\n" +
                 "(\n" +
                 "    PARTITION p1 VALUES [(\"2023-06-01\"), (\"2023-06-02\")),\n" +
@@ -3361,7 +3325,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     " on lo_custkey = c_custkey";
             // left outer join will be converted to inner join because query has null-rejecting predicate: c_name = 'name'
             // c_name = 'name' is a null-rejecting predicate, so do not add the compensated predicate
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey where c_name = 'name'";
             testRewriteOK(mv, query);
@@ -3374,7 +3338,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     " group by lo_orderkey, c_name";
             // left outer join will be converted to inner join because query has null-rejecting predicate: c_name = 'name'
             // c_name = 'name' is a null-rejecting predicate, so do not add the compensated predicate
-            String query =  "select lo_orderkey, c_name, sum(lo_revenue) as total_revenue" +
+            String query = "select lo_orderkey, c_name, sum(lo_revenue) as total_revenue" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey where c_name = 'name'" +
                     " group by lo_orderkey, c_name";
@@ -3386,7 +3350,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey" +
                     " group by lo_orderkey, c_custkey";
-            String query =  "select lo_orderkey, c_custkey, sum(lo_revenue) as total_revenue" +
+            String query = "select lo_orderkey, c_custkey, sum(lo_revenue) as total_revenue" +
                     " from lineorder inner join customer" +
                     " on lo_custkey = c_custkey" +
                     " group by lo_orderkey, c_custkey";
@@ -3402,7 +3366,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey where c_name = 'name'";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3417,7 +3381,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey where c_custkey = 1";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3432,7 +3396,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder inner join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3447,7 +3411,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey and lo_shipmode = c_name";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, lo_shipmode, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, lo_shipmode, c_name" +
                     " from lineorder inner join customer" +
                     " on lo_custkey = c_custkey and lo_shipmode = c_name";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3461,7 +3425,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey where c_name = 'name' and c_custkey = 100";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3478,7 +3442,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue" +
                     " from lineorder left anti join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3497,7 +3461,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     " on lo_custkey = c_custkey";
             // left outer join will be converted to inner join because query has null-rejecting predicate: c_name = 'name'
             // c_name = 'name' is a null-rejecting predicate, so do not add the compensated predicate
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey where lo_orderkey = 10";
             testRewriteOK(mv, query);
@@ -3508,7 +3472,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey where lo_linenumber = 10";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3525,7 +3489,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     " group by lo_orderkey, lo_custkey";
             // left outer join will be converted to inner join because query has null-rejecting predicate: c_name = 'name'
             // c_name = 'name' is a null-rejecting predicate, so do not add the compensated predicate
-            String query =  "select lo_orderkey, lo_custkey, sum(lo_revenue) as total_revenue" +
+            String query = "select lo_orderkey, lo_custkey, sum(lo_revenue) as total_revenue" +
                     " from lineorder inner join customer" +
                     " on lo_custkey = c_custkey where lo_orderkey = 10" +
                     " group by lo_orderkey, lo_custkey";
@@ -3537,7 +3501,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey" +
                     " group by lo_custkey, c_name";
-            String query =  "select lo_custkey, c_name, sum(lo_revenue) as total_revenue" +
+            String query = "select lo_custkey, c_name, sum(lo_revenue) as total_revenue" +
                     " from lineorder inner join customer" +
                     " on lo_custkey = c_custkey" +
                     " group by lo_custkey, c_name";
@@ -3552,7 +3516,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey where lo_orderkey = 1";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3567,7 +3531,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
                     " from lineorder inner join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3582,7 +3546,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, lo_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey and lo_shipmode = c_name";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, lo_shipmode, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, lo_shipmode, c_name" +
                     " from lineorder inner join customer" +
                     " on lo_custkey = c_custkey and lo_shipmode = c_name";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3597,7 +3561,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey where lo_linenumber = 10 and lo_quantity = 100";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3614,7 +3578,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_custkey, c_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select c_name" +
+            String query = "select c_name" +
                     " from lineorder right anti join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3629,7 +3593,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, lo_shipmode, c_name" +
                     " from lineorder inner join customer_primary" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, lo_shipmode" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, lo_shipmode" +
                     " from lineorder left semi join customer_primary" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3642,7 +3606,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, lo_shipmode, c_name" +
                     " from lineorder inner join customer_unique" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, lo_shipmode" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, lo_shipmode" +
                     " from lineorder left semi join customer_unique" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3655,7 +3619,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, lo_shipmode, c_name" +
                     " from lineorder inner join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, lo_shipmode" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey, lo_shipmode" +
                     " from lineorder left semi join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3668,7 +3632,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, lo_shipmode, c_name" +
                     " from lineorder_primary inner join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select c_name" +
+            String query = "select c_name" +
                     " from lineorder_primary right semi join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3681,7 +3645,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, lo_shipmode, c_name" +
                     " from lineorder_unique inner join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select c_name" +
+            String query = "select c_name" +
                     " from lineorder_unique right semi join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3694,7 +3658,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, lo_shipmode, c_name" +
                     " from lineorder inner join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select c_name" +
+            String query = "select c_name" +
                     " from lineorder right semi join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3708,7 +3672,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder full outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3722,7 +3686,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder_null full outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder_null left outer join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3736,7 +3700,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder full outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder right outer join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3750,7 +3714,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder full outer join customer_null" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder right outer join customer_null" +
                     " on lo_custkey = c_custkey";
             testRewriteFail(mv, query);
@@ -3760,7 +3724,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder full outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder inner join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3774,7 +3738,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder full outer join customer_null" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder inner join customer_null" +
                     " on lo_custkey = c_custkey";
             testRewriteFail(mv, query);
@@ -3784,7 +3748,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder_null full outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
+            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder_null inner join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -4295,7 +4259,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "ON t1.fplat_form_itg2 = t2.fplat_form_itg2\n" +
                     "WHERE t1.fdate = 20230705\n" +
                     "GROUP BY fplat_form_itg2_name;";
-                    testRewriteOK(mv, query);
+            testRewriteOK(mv, query);
         } finally {
             starRocksAssert.dropTable("test_sr_table_join");
             starRocksAssert.dropTable("dim_test_sr_table");
@@ -5621,5 +5585,147 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "0:OlapScanNode\n" +
                     "TABLE: mv0");
         }
+    }
+
+    @Test
+    public void testAggRollupWithTimeUnit1() throws Exception {
+        String sql = "CREATE TABLE `t0` (\n" +
+                "  `date_col` date NOT NULL,\n" +
+                "  `id` int(11) NOT NULL,\n" +
+                "  `int_col` int(11) NOT NULL,\n" +
+                "  `float_col_1` float NOT NULL,\n" +
+                "  `float_col_2` float NOT NULL,\n" +
+                "  `varchar_col` varchar(255) NOT NULL,\n" +
+                "  `tinyint_col` tinyint(4) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`date_col`, `id`)\n" +
+                "DISTRIBUTED BY HASH(`id`)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");\n";
+        starRocksAssert.withTable(sql);
+        String mv1 = "create MATERIALIZED VIEW date_mv\n" +
+                "DISTRIBUTED BY RANDOM\n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")   as select tinyint_col, date_col , sum(float_col_1 * int_col) as sum_value " +
+                "from t0 group by tinyint_col, date_col;";
+        starRocksAssert.withMaterializedView(mv1);
+
+        // date column should be the same with date_trunc('day', ct)
+        {
+            String query = "select tinyint_col, date_trunc('day', date_col) as date_col, " +
+                    "   sum(float_col_1 * int_col) as sum_value from t0 " +
+                    "group by tinyint_col, date_trunc('day', date_col);";
+            String plan = sql(query).getExecPlan();
+            System.out.println(plan);
+            Assert.assertTrue(plan.contains("date_mv"));
+        }
+        {
+            String query = "select tinyint_col, date_trunc('month', date_col) as date_col, " +
+                    "   sum(float_col_1 * int_col) as sum_value from t0 " +
+                    "group by tinyint_col, date_trunc('month', date_col);";
+            String plan = sql(query).getExecPlan();
+            System.out.println(plan);
+            Assert.assertTrue(plan.contains("date_mv"));
+        }
+        starRocksAssert.dropTable("t0");
+        starRocksAssert.dropMaterializedView("date_mv");
+    }
+
+    @Test
+    public void testAggRollupWithTimeUnit2() throws Exception {
+        String sql = "CREATE TABLE `t0` (\n" +
+                "  `date_col` datetime NOT NULL,\n" +
+                "  `id` int(11) NOT NULL,\n" +
+                "  `int_col` int(11) NOT NULL,\n" +
+                "  `float_col_1` float NOT NULL,\n" +
+                "  `float_col_2` float NOT NULL,\n" +
+                "  `varchar_col` varchar(255) NOT NULL,\n" +
+                "  `tinyint_col` tinyint(4) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`date_col`, `id`)\n" +
+                "DISTRIBUTED BY HASH(`id`)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");\n";
+        starRocksAssert.withTable(sql);
+        String mv1 = "create MATERIALIZED VIEW date_mv\n" +
+                "DISTRIBUTED BY RANDOM\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")   as select tinyint_col, date_trunc('day', date_col), sum(float_col_1 * int_col) as sum_value " +
+                "from t0 group by tinyint_col, date_trunc('day', date_col);";
+        starRocksAssert.withMaterializedView(mv1);
+
+        // date column should be the same with date_trunc('day', ct)
+        {
+            String query = "select tinyint_col, date_trunc('day', date_col) as date_col, " +
+                    "   sum(float_col_1 * int_col) as sum_value from t0 " +
+                    "group by tinyint_col, date_trunc('day', date_col);";
+            String plan = sql(query).getExecPlan();
+            System.out.println(plan);
+            Assert.assertTrue(plan.contains("date_mv"));
+        }
+        {
+            String query = "select tinyint_col, date_trunc('month', date_col) as date_col, " +
+                    "   sum(float_col_1 * int_col) as sum_value from t0 " +
+                    "group by tinyint_col, date_trunc('month', date_col);";
+            String plan = sql(query).getExecPlan();
+            System.out.println(plan);
+            Assert.assertTrue(plan.contains("date_mv"));
+            Assert.assertTrue(plan.contains("  |  <slot 15> : date_trunc('month', 12: date_trunc('day', date_col))"));
+        }
+        starRocksAssert.dropTable("t0");
+        starRocksAssert.dropMaterializedView("date_mv");
+    }
+
+    @Test
+    public void testAggRollupWithTimeUnit3() throws Exception {
+        String sql = "CREATE TABLE `t0` (\n" +
+                "  `date_col` datetime NOT NULL,\n" +
+                "  `id` int(11) NOT NULL,\n" +
+                "  `int_col` int(11) NOT NULL,\n" +
+                "  `float_col_1` float NOT NULL,\n" +
+                "  `float_col_2` float NOT NULL,\n" +
+                "  `varchar_col` varchar(255) NOT NULL,\n" +
+                "  `tinyint_col` tinyint(4) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`date_col`, `id`)\n" +
+                "PARTITION BY range(`date_col`)\n" +
+                "(PARTITION p1 VALUES [ (\"20230702\"),(\"20230703\")),\n" +
+                "PARTITION p2 VALUES [ (\"20230703\"),(\"20230704\")),\n" +
+                "PARTITION p3 VALUES [ (\"20230704\"),(\"20230705\")),\n" +
+                "PARTITION p4 VALUES [ (\"20230705\"),(\"20230706\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`id`)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");\n";
+        starRocksAssert.withTable(sql);
+        String mv1 = "create MATERIALIZED VIEW date_mv\n" +
+                "PARTITION BY (dt)\n" +
+                "DISTRIBUTED BY RANDOM\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")   as select tinyint_col, date_trunc('day', date_col) as dt, sum(float_col_1 * int_col) as sum_value " +
+                "from t0 group by tinyint_col, date_trunc('day', date_col);";
+        starRocksAssert.withMaterializedView(mv1);
+
+        // date column should be the same with date_trunc('day', ct)
+        {
+            String query = "select tinyint_col,  " +
+                    "   sum(float_col_1 * int_col) as sum_value from t0 " +
+                    "where date_col >= '2024-09-18 01:00:00' group by tinyint_col ";
+            String plan = sql(query).getExecPlan();
+            System.out.println(plan);
+            Assert.assertTrue(plan.contains("date_mv"));
+        }
+
+        starRocksAssert.dropTable("t0");
+        starRocksAssert.dropMaterializedView("date_mv");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -5675,6 +5675,23 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             {
                 String query = "select tinyint_col,  " +
                         "   sum(float_col_1 * int_col) as sum_value from t0 " +
+                        "where date_trunc('"+ timeUnit +"',  date_col) >= '2024-01-01' group by tinyint_col ";
+                String plan = sql(query).getExecPlan();
+                PlanTestBase.assertContains(plan, "date_mv");
+            }
+
+            {
+                // TODO: we can support this later.
+                String query = "select tinyint_col,  " +
+                        "   sum(float_col_1 * int_col) as sum_value from t0 " +
+                        "where date_trunc('"+ timeUnit +"',  date_col) = '2024-01-01' group by tinyint_col ";
+                String plan = sql(query).getExecPlan();
+                PlanTestBase.assertNotContains(plan, "date_mv");
+            }
+
+            {
+                String query = "select tinyint_col,  " +
+                        "   sum(float_col_1 * int_col) as sum_value from t0 " +
                         "where date_col >= '2024-09-18 01:00:01' group by tinyint_col ";
                 String plan = sql(query).getExecPlan();
                 PlanTestBase.assertNotContains(plan, "date_mv");

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_date_trunc_rollup
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_date_trunc_rollup
@@ -33,58 +33,58 @@ INSERT INTO t1 VALUES ('2020-10-22','2020-10-22 12:12:12','k3','k4',0,1,2,3,4,5,
 -- !result
 CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
 PARTITION BY dt
-REFRESH DEFERRED ASYNC
+REFRESH DEFERRED MANUAL
 as 
 select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);
 -- result:
 -- !result
 refresh materialized view test_mv1 with sync mode;
-set enable_materialized_view_rewrite = false;
+set enable_materialized_view_rewrite = true;
 -- result:
 -- !result
 function: print_hit_materialized_view("select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2);", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2);", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, date_trunc('quarter', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('quarter', k2);", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, date_trunc('year', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('year', k2);", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) >= '2020-10-22' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) >= '2020-10-19' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) >= '2020-10-01' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) >= '2020-10-01' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) >= '2020-01-01' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) = '2020-10-22' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1;", "test_mv1")
 -- result:
@@ -195,47 +195,47 @@ INSERT INTO t1 VALUES ('2020-10-24','2020-10-24 12:12:12','k3','k4',0,1,2,3,4,5,
 -- !result
 function: print_hit_materialized_view("select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2);", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2);", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, date_trunc('quarter', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('quarter', k2);", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, date_trunc('year', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('year', k2);", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) >= '2020-10-22' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) >= '2020-10-19' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) >= '2020-10-01' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) >= '2020-10-01' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) >= '2020-01-01' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) = '2020-10-22' group by k1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1;", "test_mv1")
 -- result:

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_date_trunc_rollup
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_date_trunc_rollup
@@ -1,0 +1,198 @@
+-- name: test_mv_rewrite_with_date_trunc_rollup
+CREATE TABLE `t1` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY RANGE(`k2`) 
+(
+PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23")), 
+PARTITION p20201023 VALUES [("2020-10-23"), ("2020-10-24")), 
+PARTITION p20201024 VALUES [("2020-10-24"), ("2020-10-25"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 
+PROPERTIES (
+"replication_num" = "1"
+) ;
+-- result:
+-- !result
+INSERT INTO t1 VALUES ('2020-10-22','2020-10-22 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+ ('2020-10-23','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+  ('2020-10-24','2020-10-24 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY dt
+REFRESH DEFERRED ASYNC
+as 
+select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+function: print_hit_materialized_view("select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2);", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2);", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, date_trunc('quarter', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('quarter', k2);", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, date_trunc('year', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('year', k2);", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) >= '2020-10-22' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) >= '2020-10-19' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) >= '2020-10-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) >= '2020-10-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) >= '2020-01-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) = '2020-10-22' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) = '2020-10-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) = '2020-10-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) = '2020-01-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2) order by 1;
+-- result:
+2020-10-22	2020-10-22 00:00:00	1	2	3	1
+2020-10-23	2020-10-23 00:00:00	1	2	3	1
+2020-10-24	2020-10-24 00:00:00	1	2	3	1
+-- !result
+select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2) order by 1;
+-- result:
+2020-10-22	2020-10-19 00:00:00	1	2	3	1
+2020-10-23	2020-10-19 00:00:00	1	2	3	1
+2020-10-24	2020-10-19 00:00:00	1	2	3	1
+-- !result
+select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2) order by 1;
+-- result:
+2020-10-22	2020-10-01 00:00:00	1	2	3	1
+2020-10-23	2020-10-01 00:00:00	1	2	3	1
+2020-10-24	2020-10-01 00:00:00	1	2	3	1
+-- !result
+select k1, date_trunc('quarter', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('quarter', k2) order by 1;
+-- result:
+2020-10-22	2020-10-01 00:00:00	1	2	3	1
+2020-10-23	2020-10-01 00:00:00	1	2	3	1
+2020-10-24	2020-10-01 00:00:00	1	2	3	1
+-- !result
+select k1, date_trunc('year', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('year', k2) order by 1;
+-- result:
+2020-10-22	2020-01-01 00:00:00	1	2	3	1
+2020-10-23	2020-01-01 00:00:00	1	2	3	1
+2020-10-24	2020-01-01 00:00:00	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) >= '2020-10-22' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) >= '2020-10-19' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) >= '2020-10-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) >= '2020-10-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) >= '2020-01-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) = '2020-10-22' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) = '2020-10-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) = '2020-10-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) = '2020-01-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	1	2	3	1
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop table t1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_date_trunc_rollup
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_date_trunc_rollup
@@ -190,6 +190,157 @@ select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc(
 2020-10-23	1	2	3	1
 2020-10-24	1	2	3	1
 -- !result
+INSERT INTO t1 VALUES ('2020-10-24','2020-10-24 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+-- result:
+-- !result
+function: print_hit_materialized_view("select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2);", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2);", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, date_trunc('quarter', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('quarter', k2);", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, date_trunc('year', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('year', k2);", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) >= '2020-10-22' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) >= '2020-10-19' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) >= '2020-10-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) >= '2020-10-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) >= '2020-01-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) = '2020-10-22' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) = '2020-10-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) = '2020-10-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) = '2020-01-01' group by k1;", "test_mv1")
+-- result:
+False
+-- !result
+select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2) order by 1;
+-- result:
+2020-10-22	2020-10-22 00:00:00	1	2	3	1
+2020-10-23	2020-10-23 00:00:00	1	2	3	1
+2020-10-24	2020-10-24 00:00:00	2	4	6	2
+-- !result
+select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2) order by 1;
+-- result:
+2020-10-22	2020-10-19 00:00:00	1	2	3	1
+2020-10-23	2020-10-19 00:00:00	1	2	3	1
+2020-10-24	2020-10-19 00:00:00	2	4	6	2
+-- !result
+select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2) order by 1;
+-- result:
+2020-10-22	2020-10-01 00:00:00	1	2	3	1
+2020-10-23	2020-10-01 00:00:00	1	2	3	1
+2020-10-24	2020-10-01 00:00:00	2	4	6	2
+-- !result
+select k1, date_trunc('quarter', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('quarter', k2) order by 1;
+-- result:
+2020-10-22	2020-10-01 00:00:00	1	2	3	1
+2020-10-23	2020-10-01 00:00:00	1	2	3	1
+2020-10-24	2020-10-01 00:00:00	2	4	6	2
+-- !result
+select k1, date_trunc('year', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('year', k2) order by 1;
+-- result:
+2020-10-22	2020-01-01 00:00:00	1	2	3	1
+2020-10-23	2020-01-01 00:00:00	1	2	3	1
+2020-10-24	2020-01-01 00:00:00	2	4	6	2
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) >= '2020-10-22' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	2	4	6	2
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) >= '2020-10-19' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	2	4	6	2
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) >= '2020-10-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	2	4	6	2
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) >= '2020-10-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	2	4	6	2
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) >= '2020-01-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	2	4	6	2
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) = '2020-10-22' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	2	4	6	2
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) = '2020-10-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	2	4	6	2
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) = '2020-10-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	2	4	6	2
+-- !result
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) = '2020-01-01' group by k1 order by 1;
+-- result:
+2020-10-22	1	2	3	1
+2020-10-23	1	2	3	1
+2020-10-24	2	4	6	2
+-- !result
 drop materialized view test_mv1;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_with_date_trunc_rollup
+++ b/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_with_date_trunc_rollup
@@ -1,0 +1,77 @@
+-- name: test_mv_rewrite_with_date_trunc_rollup
+
+CREATE TABLE `t1` (
+    `k1`  date not null, 
+    `k2`  datetime not null, 
+    `k3`  char(20), 
+    `k4`  varchar(20), 
+    `k5`  boolean, 
+    `k6`  tinyint, 
+    `k7`  smallint, 
+    `k8`  int, 
+    `k9`  bigint, 
+    `k10` largeint, 
+    `k11` float, 
+    `k12` double, 
+    `k13` decimal(27,9) ) 
+DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+PARTITION BY RANGE(`k2`) 
+(
+PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23")), 
+PARTITION p20201023 VALUES [("2020-10-23"), ("2020-10-24")), 
+PARTITION p20201024 VALUES [("2020-10-24"), ("2020-10-25"))
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 
+PROPERTIES (
+"replication_num" = "1"
+) ;
+
+INSERT INTO t1 VALUES ('2020-10-22','2020-10-22 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+ ('2020-10-23','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
+  ('2020-10-24','2020-10-24 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY dt
+REFRESH DEFERRED ASYNC
+as 
+select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);
+
+refresh materialized view test_mv1 with sync mode;
+
+set enable_materialized_view_rewrite = false;
+
+
+function: print_hit_materialized_view("select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);", "test_mv1")
+function: print_hit_materialized_view("select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2);", "test_mv1")
+function: print_hit_materialized_view("select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2);", "test_mv1")
+function: print_hit_materialized_view("select k1, date_trunc('quarter', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('quarter', k2);", "test_mv1")
+function: print_hit_materialized_view("select k1, date_trunc('year', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('year', k2);", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) >= '2020-10-22' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) >= '2020-10-19' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) >= '2020-10-01' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) >= '2020-10-01' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) >= '2020-01-01' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) = '2020-10-22' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) = '2020-10-01' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) = '2020-10-01' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) = '2020-01-01' group by k1;", "test_mv1")
+
+select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2) order by 1;
+select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2) order by 1;
+select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2) order by 1;
+select k1, date_trunc('quarter', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('quarter', k2) order by 1;
+select k1, date_trunc('year', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('year', k2) order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) >= '2020-10-22' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) >= '2020-10-19' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) >= '2020-10-01' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) >= '2020-10-01' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) >= '2020-01-01' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) = '2020-10-22' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) = '2020-10-01' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) = '2020-10-01' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) = '2020-01-01' group by k1 order by 1;
+ 
+drop materialized view test_mv1;
+drop table t1;

--- a/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_with_date_trunc_rollup
+++ b/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_with_date_trunc_rollup
@@ -40,7 +40,6 @@ refresh materialized view test_mv1 with sync mode;
 
 set enable_materialized_view_rewrite = false;
 
-
 function: print_hit_materialized_view("select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);", "test_mv1")
 function: print_hit_materialized_view("select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2);", "test_mv1")
 function: print_hit_materialized_view("select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2);", "test_mv1")
@@ -73,5 +72,39 @@ select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc(
 select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) = '2020-10-01' group by k1 order by 1;
 select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) = '2020-01-01' group by k1 order by 1;
  
+INSERT INTO t1 VALUES ('2020-10-24','2020-10-24 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
+
+function: print_hit_materialized_view("select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);", "test_mv1")
+function: print_hit_materialized_view("select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2);", "test_mv1")
+function: print_hit_materialized_view("select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2);", "test_mv1")
+function: print_hit_materialized_view("select k1, date_trunc('quarter', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('quarter', k2);", "test_mv1")
+function: print_hit_materialized_view("select k1, date_trunc('year', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('year', k2);", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) >= '2020-10-22' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) >= '2020-10-19' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) >= '2020-10-01' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) >= '2020-10-01' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) >= '2020-01-01' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) = '2020-10-22' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) = '2020-10-01' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) = '2020-10-01' group by k1;", "test_mv1")
+function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) = '2020-01-01' group by k1;", "test_mv1")
+
+select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2) order by 1;
+select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2) order by 1;
+select k1, date_trunc('month', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('month', k2) order by 1;
+select k1, date_trunc('quarter', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('quarter', k2) order by 1;
+select k1, date_trunc('year', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('year', k2) order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) >= '2020-10-22' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) >= '2020-10-19' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) >= '2020-10-01' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) >= '2020-10-01' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) >= '2020-01-01' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('day', k2) = '2020-10-22' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('month', k2) = '2020-10-01' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('quarter', k2) = '2020-10-01' group by k1 order by 1;
+select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('year', k2) = '2020-01-01' group by k1 order by 1;
+
 drop materialized view test_mv1;
 drop table t1;

--- a/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_with_date_trunc_rollup
+++ b/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_with_date_trunc_rollup
@@ -32,13 +32,13 @@ INSERT INTO t1 VALUES ('2020-10-22','2020-10-22 12:12:12','k3','k4',0,1,2,3,4,5,
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
 PARTITION BY dt
-REFRESH DEFERRED ASYNC
+REFRESH DEFERRED MANUAL
 as 
 select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);
 
 refresh materialized view test_mv1 with sync mode;
 
-set enable_materialized_view_rewrite = false;
+set enable_materialized_view_rewrite = true;
 
 function: print_hit_materialized_view("select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);", "test_mv1")
 function: print_hit_materialized_view("select k1, date_trunc('week', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('week', k2);", "test_mv1")


### PR DESCRIPTION
## Why I'm doing:

```
CREATE TABLE `t1` (
    `k1`  date not null, 
    `k2`  datetime not null, 
    `k3`  char(20), 
    `k4`  varchar(20), 
    `k5`  boolean, 
    `k6`  tinyint, 
    `k7`  smallint, 
    `k8`  int, 
    `k9`  bigint, 
    `k10` largeint, 
    `k11` float, 
    `k12` double, 
    `k13` decimal(27,9) ) 
DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
PARTITION BY RANGE(`k2`) 
(
PARTITION p20201022 VALUES [("2020-10-22"), ("2020-10-23")), 
PARTITION p20201023 VALUES [("2020-10-23"), ("2020-10-24")), 
PARTITION p20201024 VALUES [("2020-10-24"), ("2020-10-25"))
)
DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 
PROPERTIES (
"replication_num" = "1"
) ;

INSERT INTO t1 VALUES ('2020-10-22','2020-10-22 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
 ('2020-10-23','2020-10-23 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889),
  ('2020-10-24','2020-10-24 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);

CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
PARTITION BY dt
REFRESH DEFERRED MANUAL
as 
select k1, date_trunc('day', k2) as dt, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1 group by k1, date_trunc('day', k2);


-- Cannot Work!
select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where date_trunc('week', k2) = '2020-10-19' group by k1 order by 1;

```

Since `test_mv1` is rolluped from t1 with `date_trunc('day', k2)` with `day` granularity, query with 
`week`/`month`/`quarter`/`year` granularity should be rewritten by `test_mv1` either.


## What I'm doing:
-  Support date_trunc with day/month/year rollup.

Fixes https://github.com/StarRocks/starrocks/issues/51446

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
