### PR TITLE
[Enhancement]implement dayofweek in FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -244,6 +244,17 @@ public class ScalarOperatorFunctions {
     }
 
     @ConstantFunction.List(list = {
+            @ConstantFunction(name = "dayofweek", argTypes = {DATETIME}, returnType = INT),
+            @ConstantFunction(name = "dayofweek", argTypes = {DATE}, returnType = INT),
+            @ConstantFunction(name = "dayofweek", argTypes = {INT}, returnType = INT)
+    })
+    public static ConstantOperator dayofweek(ConstantOperator date) {
+        // LocalDateTime.getDayOfWeek is return day of the week, such as monday is 1 and sunday is 7.
+        // function of dayofweek in starrocks monday is 2 and sunday is 1, so need mod 7 and plus 1.
+        return ConstantOperator.createInt((date.getDatetime().getDayOfWeek().getValue()) % 7 + 1);
+    }
+
+    @ConstantFunction.List(list = {
             @ConstantFunction(name = "years_add", argTypes = {DATETIME,
                     INT}, returnType = DATETIME, isMonotonic = true),
             @ConstantFunction(name = "years_add", argTypes = {DATE, INT}, returnType = DATE, isMonotonic = true)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -131,6 +131,21 @@ public class ScalarOperatorFunctionsTest {
     }
 
     @Test
+    public void dayofweek() {
+        ConstantOperator testDate = ConstantOperator.createDatetime(LocalDateTime.of(2024, 2, 3, 13, 4, 5));
+        assertEquals(7,
+                ScalarOperatorFunctions.dayofweek(testDate).getInt());
+
+        testDate = ConstantOperator.createDatetime(LocalDateTime.of(2024, 2, 4, 13, 4, 5));
+        assertEquals(1,
+                ScalarOperatorFunctions.dayofweek(testDate).getInt());
+
+        testDate = ConstantOperator.createDatetime(LocalDateTime.of(2024, 2, 5, 13, 4, 5));
+        assertEquals(2,
+                ScalarOperatorFunctions.dayofweek(testDate).getInt());
+    }
+
+    @Test
     public void yearsAdd() {
         assertEquals("2025-03-23T09:23:55",
                 ScalarOperatorFunctions.yearsAdd(O_DT_20150323_092355, O_INT_10).getDatetime().toString());


### PR DESCRIPTION
## Why I'm doing:
If the where condition contains a partition condition that is compared with the dayofweek function, a full table scan will be required, and FE is required to implement the dayofweek function to perform partition pruning when generating the execution plan.
## What I'm doing:
implement dayofweek in FE
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

FE支持DAYOFWEEK 函数
实现前:
![image](https://github.com/user-attachments/assets/437a7930-fd71-4048-8f4b-04831089b584)
![image](https://github.com/user-attachments/assets/5f6276fd-ef20-4ce5-9764-b8ee16a2e660)

实现后:
![image](https://github.com/user-attachments/assets/7e505556-5f3b-44f8-8063-fc9d356dd869)
![image](https://github.com/user-attachments/assets/d6bfce24-a240-45ee-9441-0ab4bf2ef31e)


## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
