### PR TITLE
[Enhancement]implement to_days function in FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -233,6 +233,17 @@ public class ScalarOperatorFunctions {
     }
 
     @ConstantFunction.List(list = {
+            @ConstantFunction(name = "to_days", argTypes = {DATETIME}, returnType = INT, isMonotonic = true),
+            @ConstantFunction(name = "to_days", argTypes = {DATE}, returnType = INT, isMonotonic = true)
+    })
+    public static ConstantOperator to_days(ConstantOperator first) {
+        ConstantOperator second = ConstantOperator.createDatetime(LocalDateTime.of(0000, 01, 01, 00, 00, 00));
+        return ConstantOperator.createInt((int) Duration.between(
+                second.getDatetime().truncatedTo(ChronoUnit.DAYS),
+                first.getDatetime().truncatedTo(ChronoUnit.DAYS)).toDays());
+    }
+
+    @ConstantFunction.List(list = {
             @ConstantFunction(name = "years_add", argTypes = {DATETIME,
                     INT}, returnType = DATETIME, isMonotonic = true),
             @ConstantFunction(name = "years_add", argTypes = {DATE, INT}, returnType = DATE, isMonotonic = true)

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -126,6 +126,11 @@ public class ScalarOperatorFunctionsTest {
     }
 
     @Test
+    public void to_days() {
+        assertEquals(734443, ScalarOperatorFunctions.to_days(O_DT_20101102_183010).getInt());
+    }
+
+    @Test
     public void yearsAdd() {
         assertEquals("2025-03-23T09:23:55",
                 ScalarOperatorFunctions.yearsAdd(O_DT_20150323_092355, O_INT_10).getDatetime().toString());


### PR DESCRIPTION
## Why I'm doing:
If the where condition contains a partition condition that is compared with the to_days function, a full table scan will be required, and FE is required to implement the to_days function to perform partition pruning when generating the execution plan.
## What I'm doing:
implement to_days function in FE

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

实现前:
<img width="711" alt="截屏2024-09-26 17 17 24" src="https://github.com/user-attachments/assets/47e287e5-1db5-4713-82ed-e2a0338f095f">

实现后:
<img width="606" alt="截屏2024-09-26 17 17 37" src="https://github.com/user-attachments/assets/1b08f8ee-7e92-4eff-8d0a-be3161a82a46">

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
