### PR TITLE
[Refactor] Refactor UniqueConstraint.getUniqueColumnNames

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2962,7 +2962,7 @@ public class OlapTable extends Table {
         }
         if (keysType == KeysType.UNIQUE_KEYS || keysType == KeysType.PRIMARY_KEYS) {
             uniqueConstraints.add(
-                    new UniqueConstraint(this, getKeyColumns()
+                    new UniqueConstraint(null, null, null, getKeyColumns()
                             .stream().map(Column::getColumnId).collect(Collectors.toList())));
         }
         if (tableProperty != null && tableProperty.getUniqueConstraints() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/UniqueConstraint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/UniqueConstraint.java
@@ -68,10 +68,9 @@ public class UniqueConstraint extends Constraint {
             Column column = targetTable.getColumn(columnId);
             if (column == null) {
                 LOG.warn("Can not find column by column id: {}, the column may have been dropped", columnId);
-                result.add(columnId.getId());
-            } else {
-                result.add(column.getName());
+                continue;
             }
+            result.add(column.getName());
         }
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1102,6 +1102,9 @@ public class PropertyAnalyzer {
                     analyzedUniqueConstraints.add(new UniqueConstraint(tableName.getCatalog(), tableName.getDb(),
                             tableName.getTbl(), columnIds));
                 } else {
+                    if (GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName).isEmpty()) {
+                        throw new SemanticException(String.format("table: %s does not exist", tableName));
+                    }
                     List<ColumnId> columnIds = MetaUtils.getColumnIdsByColumnNames(table, columnNames);
                     analyzedUniqueConstraints.add(new UniqueConstraint(tableName.getCatalog(), tableName.getDb(),
                             tableName.getTbl(), columnIds));

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1102,9 +1102,6 @@ public class PropertyAnalyzer {
                     analyzedUniqueConstraints.add(new UniqueConstraint(tableName.getCatalog(), tableName.getDb(),
                             tableName.getTbl(), columnIds));
                 } else {
-                    if (GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(tableName).isEmpty()) {
-                        throw new SemanticException(String.format("table: %s does not exist", tableName));
-                    }
                     List<ColumnId> columnIds = MetaUtils.getColumnIdsByColumnNames(table, columnNames);
                     analyzedUniqueConstraints.add(new UniqueConstraint(tableName.getCatalog(), tableName.getDb(),
                             tableName.getTbl(), columnIds));

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
+import org.junit.function.ThrowingRunnable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -206,6 +207,39 @@ public class ShowCreateMaterializedViewStmtTest {
         Assertions.assertTrue(createTableStmt.get(0).contains(partitionBy), createTableStmt.get(0));
         Assertions.assertTrue(createTableStmt.get(0).contains(distribute), createTableStmt.get(0));
         Assertions.assertTrue(createTableStmt.get(0).contains(select), createTableStmt.get(0));
+    }
+
+    @Test
+    public void testMvUniqueConstraintsTableNotExist() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE test.tbl_constraint_test\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2020-02-01'),\n" +
+                        "    PARTITION p2 values less than('2020-03-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
+
+        String createMvSql = "create materialized view mv_constraint_test " +
+                "distributed by hash(k1) buckets 10 " +
+                "refresh manual " +
+                "properties(\"unique_constraints\" = \"tbl_constraint_test.k1\", " +
+                "\"foreign_key_constraints\" = \"tbl1(k1) REFERENCES tbl_constraint_test(k1)\") " +
+                "as select tbl1.k1, tbl_constraint_test.k2 " +
+                "from tbl1 join tbl_constraint_test on tbl1.k1 = tbl_constraint_test.k1;";
+        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(createMvSql, ctx);
+        GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
+        currentState.getLocalMetastore().createMaterializedView((CreateMaterializedViewStatement) statementBase);
+        Table table = currentState.getLocalMetastore().getDb("test").getTable("mv_constraint_test");
+        Assertions.assertEquals("k1", table.getUniqueConstraints().get(0).getUniqueColumnNames(table).get(0));
+
+        starRocksAssert.dropTable("tbl_constraint_test");
+        Assert.assertThrows(SemanticException.class, () -> table.getUniqueConstraints().get(0).getUniqueColumnNames(table));
     }
 
     public static Stream<Arguments> genTestArguments() {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
@@ -29,7 +29,6 @@ import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
-import org.junit.function.ThrowingRunnable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Get the target table from metastore only if selfTable is mv, so that OlapTable can get the columnNames even if it is not in the metastore.

Fixes SR-30617

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
