### PR TITLE
[BugFix] Fix unexpected Hint when UPDATE Stmt has CTE

### DIFF
--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -50,7 +50,11 @@ public:
             column_value = down_cast<const DoubleColumn*>(columns[0])->get_data()[row_num];
         }
 
-        DCHECK(!columns[1]->only_null());
+        if (columns[1]->only_null()) {
+            ctx->set_error("For percentile_approx the second argument is expected to be non-null.", false);
+            return;
+        }
+
         DCHECK(!columns[1]->is_null(0));
 
         int64_t prev_memory = data(state).percentile->mem_usage();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/HintCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/HintCollector.java
@@ -101,7 +101,7 @@ public class HintCollector extends StarRocksBaseVisitor<Void> {
 
     @Override
     public Void visitUpdateStatement(StarRocksParser.UpdateStatementContext context) {
-        extractHintToRight(context);
+        extractHintToRight(context, context.UPDATE().getSymbol().getTokenIndex());
         if (!(context.fromClause() instanceof StarRocksParser.DualContext)) {
             StarRocksParser.FromContext fromContext = (StarRocksParser.FromContext) context.fromClause();
             if (fromContext.relations() != null) {
@@ -113,7 +113,7 @@ public class HintCollector extends StarRocksBaseVisitor<Void> {
 
     @Override
     public Void visitDeleteStatement(StarRocksParser.DeleteStatementContext context) {
-        extractHintToRight(context);
+        extractHintToRight(context, context.DELETE().getSymbol().getTokenIndex());
         if (context.using != null) {
             context.using.relation().stream().forEach(this::visit);
         }
@@ -192,6 +192,13 @@ public class HintCollector extends StarRocksBaseVisitor<Void> {
         Token semi = ctx.start;
         int i = semi.getTokenIndex();
         List<Token> hintTokens = tokenStream.getHiddenTokensToRight(i, HINT_CHANNEL);
+        if (hintTokens != null) {
+            contextWithTokenMap.computeIfAbsent(ctx, e -> new ArrayList<>()).addAll(hintTokens);
+        }
+    }
+
+    private void extractHintToRight(ParserRuleContext ctx, int fromIndex) {
+        List<Token> hintTokens = tokenStream.getHiddenTokensToRight(fromIndex, HINT_CHANNEL);
         if (hintTokens != null) {
             contextWithTokenMap.computeIfAbsent(ctx, e -> new ArrayList<>()).addAll(hintTokens);
         }

--- a/test/sql/test_user_variables/R/test_user_variable
+++ b/test/sql/test_user_variables/R/test_user_variable
@@ -47,3 +47,67 @@ select /*+ SET_USER_VARIABLE(@var2 = (select count(*) from (select l.c0 from t0 
 -- result:
 40960
 -- !result
+CREATE TABLE `always1` (
+  `c0` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into always1 values(1);
+-- result:
+-- !result
+CREATE TABLE `alwaysnull` (
+  `c0` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into alwaysnull values(null);
+-- result:
+-- !result
+select      /*+ set_user_variable(@a = (select c0 * 0.1 from always1)) */ percentile_approx(c0, @a)  from t0;
+-- result:
+4095.0
+-- !result
+select      /*+ set_user_variable(@a = (select c0 * 0.1 from alwaysnull)) */ percentile_approx(c0, @a)  from t0;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the second parameter's type is numeric type.")
+-- !result
+select      percentile_approx(c0, cast(null as double))  from t0;
+-- result:
+[REGEX].*For percentile_approx the second argument is expected to be non-null.*
+E: (1064, 'For percentile_approx the second argument is expected to be non-null.: BE:10004')
+-- !result
+CREATE TABLE `pk1` (
+  `c0` int(11) COMMENT "",
+  `dt` int(11) COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into pk1 values (1,1);
+-- result:
+-- !result
+with cte as (select* from pk1)
+update /*+ set_user_variable(@a = (select 2)) */ pk1 set dt = @a where c0 = 1;
+-- result:
+-- !result
+select * from pk1;
+-- result:
+1	2
+-- !result

--- a/test/sql/test_user_variables/R/test_user_variable
+++ b/test/sql/test_user_variables/R/test_user_variable
@@ -75,9 +75,9 @@ PROPERTIES (
 insert into alwaysnull values(null);
 -- result:
 -- !result
-select      /*+ set_user_variable(@a = (select c0 * 0.1 from always1)) */ percentile_approx(c0, @a)  from t0;
+select      /*+ set_user_variable(@a = (select c0 * 0.1 from always1)) */ percentile_approx(c0, @a) is not null  from t0;
 -- result:
-4095.0
+1
 -- !result
 select      /*+ set_user_variable(@a = (select c0 * 0.1 from alwaysnull)) */ percentile_approx(c0, @a)  from t0;
 -- result:
@@ -85,7 +85,6 @@ E: (1064, "Getting analyzing error. Detail message: percentile_approx requires t
 -- !result
 select      percentile_approx(c0, cast(null as double))  from t0;
 -- result:
-[REGEX].*For percentile_approx the second argument is expected to be non-null.*
 E: (1064, 'For percentile_approx the second argument is expected to be non-null.: BE:10004')
 -- !result
 CREATE TABLE `pk1` (

--- a/test/sql/test_user_variables/R/test_user_variable
+++ b/test/sql/test_user_variables/R/test_user_variable
@@ -85,7 +85,7 @@ E: (1064, "Getting analyzing error. Detail message: percentile_approx requires t
 -- !result
 select      percentile_approx(c0, cast(null as double))  from t0;
 -- result:
-E: (1064, 'For percentile_approx the second argument is expected to be non-null.: BE:10004')
+[REGEX] .*percentile_approx the second argument is expected to be non-null.*
 -- !result
 CREATE TABLE `pk1` (
   `c0` int(11) COMMENT "",

--- a/test/sql/test_user_variables/T/test_user_variable
+++ b/test/sql/test_user_variables/T/test_user_variable
@@ -55,7 +55,7 @@ PROPERTIES (
 
 insert into alwaysnull values(null);
 
-select      /*+ set_user_variable(@a = (select c0 * 0.1 from always1)) */ percentile_approx(c0, @a)  from t0;
+select      /*+ set_user_variable(@a = (select c0 * 0.1 from always1)) */ percentile_approx(c0, @a) is not null  from t0;
 select      /*+ set_user_variable(@a = (select c0 * 0.1 from alwaysnull)) */ percentile_approx(c0, @a)  from t0;
 select      percentile_approx(c0, cast(null as double))  from t0;
 

--- a/test/sql/test_user_variables/T/test_user_variable
+++ b/test/sql/test_user_variables/T/test_user_variable
@@ -30,3 +30,48 @@ select @var2;
 
 with tx as (select @var2 as x)
 select /*+ SET_USER_VARIABLE(@var2 = (select count(*) from (select l.c0 from t0 l join t0 r on l.c0 = r.c0 ) tb)) */ * from tx;
+
+CREATE TABLE `always1` (
+  `c0` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into always1 values(1);
+
+CREATE TABLE `alwaysnull` (
+  `c0` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into alwaysnull values(null);
+
+select      /*+ set_user_variable(@a = (select c0 * 0.1 from always1)) */ percentile_approx(c0, @a)  from t0;
+select      /*+ set_user_variable(@a = (select c0 * 0.1 from alwaysnull)) */ percentile_approx(c0, @a)  from t0;
+select      percentile_approx(c0, cast(null as double))  from t0;
+
+
+CREATE TABLE `pk1` (
+  `c0` int(11) COMMENT "",
+  `dt` int(11) COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into pk1 values (1,1);
+
+with cte as (select* from pk1)
+update /*+ set_user_variable(@a = (select 2)) */ pk1 set dt = @a where c0 = 1;
+select * from pk1;


### PR DESCRIPTION
## Why I'm doing:

reproduce 1
```
select percentile_approx(c0, cast(null as double))  from t0;
```
reproduce 2:
```
CREATE TABLE `pk1` (
  `c0` int(11) COMMENT "",
  `dt` int(11) COMMENT ""
) ENGINE=OLAP
PRIMARY KEY(`c0`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`c0`) BUCKETS 1
PROPERTIES (
"replication_num" = "1"
);
insert into pk1 values (1,1);

with cte as (select* from pk1)
update /*+ set_user_variable(@a = (select 2)) */ pk1 set dt = @a where c0 = 1;
select * from pk1;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
