### PR TITLE
[BugFix] Add a cachelib library for building starrocks BE on ubuntu22.

### DIFF
--- a/thirdparty/vars-ubuntu22-x86_64.sh
+++ b/thirdparty/vars-ubuntu22-x86_64.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#####################################################
+# Download url, filename and unpaced filename
+# of all thirdparties
+# 
+# vars-${arch}.sh defines the thirdparties that are
+# architecure-related.
+#####################################################
+
+# cachelib
+CACHELIB_DOWNLOAD="https://cdn-thirdparty.starrocks.com/cachelib/cachelib-ubuntu22-20240926.tar.gz"
+CACHELIB_NAME="cachelib.tar.gz"
+CACHELIB_SOURCE="cachelib"
+CACHELIB_MD5SUM="a5974c4f198c105f08f40adeb6ec940f"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -32,3 +32,9 @@ ASYNC_PROFILER_DOWNLOAD="https://github.com/async-profiler/async-profiler/releas
 ASYNC_PROFILER_NAME="async-profiler-2.9-linux-x64.tar.gz"
 ASYNC_PROFILER_SOURCE="async-profiler-2.9-linux-x64"
 ASYNC_PROFILER_MD5SUM="29127cee36b7acf069d31603b4558361"
+
+# cachelib
+CACHELIB_DOWNLOAD="https://cdn-thirdparty.starrocks.com/cachelib/cachelib-20230130.tar.gz"
+CACHELIB_NAME="cachelib.tar.gz"
+CACHELIB_SOURCE="cachelib"
+CACHELIB_MD5SUM="7cc245be5cb10afa6aeea0121ec77e9e"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -74,6 +74,13 @@ if [ ! -f ${TP_DIR}/${VARS_TARGET} ]; then
 fi
 . ${TP_DIR}/${VARS_TARGET}
 
+if [ -f /etc/lsb-release ]; then
+    source /etc/lsb-release
+    if [[ $DISTRIB_ID = "Ubuntu" && $DISTRIB_RELEASE =~ 22.* ]]; then
+        . ${TP_DIR}/vars-ubuntu22-${MACHINE_TYPE}.sh
+    fi
+fi
+
 # libevent
 # the last release version of libevent is 2.1.8, which was released on 26 Jan 2017, that is too old.
 # so we use the master version of libevent, which is downloaded on 22 Jun 2018, with commit 24236aed01798303745470e6c498bf606e88724a
@@ -328,12 +335,6 @@ FAST_FLOAT_DOWNLOAD="https://github.com/fastfloat/fast_float/archive/refs/tags/v
 FAST_FLOAT_NAME="fast-float-3.5.1.tar.gz"
 FAST_FLOAT_SOURCE="fast-float-3.5.1"
 FAST_FLOAT_MD5SUM="adb3789b99f47e0cd971b4d90727d4d0"
-
-# cachelib
-CACHELIB_DOWNLOAD="https://cdn-thirdparty.starrocks.com/cachelib/cachelib-20230130.tar.gz"
-CACHELIB_NAME="cachelib.tar.gz"
-CACHELIB_SOURCE="cachelib"
-CACHELIB_MD5SUM="7cc245be5cb10afa6aeea0121ec77e9e"
 
 # streamvbyte
 STREAMVBYTE_DOWNLOAD="https://github.com/lemire/streamvbyte/archive/refs/tags/v0.5.1.tar.gz"


### PR DESCRIPTION
## Why I'm doing:
The old cachelib library is built for centos platform, and there may be some compatibility issues on ubuntu system.

## What I'm doing:
Add a new cachelib library for ubuntu.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [x] 2.5
