### PR TITLE
[Enhancement] Move rowset item as newest entry in lru cache when query

### DIFF
--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -47,6 +47,10 @@ size_t MetadataCache::get_memory_usage() const {
     return _cache->get_memory_usage();
 }
 
+void MetadataCache::set_capacity(size_t capacity) {
+    _cache->set_capacity(capacity);
+}
+
 void MetadataCache::_insert(const std::string& key, Rowset* ptr, size_t size) {
     Cache::Handle* handle = _cache->insert(CacheKey(key), ptr, size, _cache_value_deleter);
     _cache->release(handle);

--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -39,6 +39,10 @@ void MetadataCache::evict_rowset(Rowset* ptr) {
     _erase(ptr->rowset_id_str());
 }
 
+void MetadataCache::warmup_rowset(Rowset* ptr) {
+    _ping(ptr->rowset_id_str());
+}
+
 size_t MetadataCache::get_memory_usage() const {
     return _cache->get_memory_usage();
 }
@@ -55,6 +59,13 @@ void MetadataCache::_erase(const std::string& key) {
 void MetadataCache::_cache_value_deleter(const CacheKey& /*key*/, void* value) {
     // close this rowset, release metadata memory
     reinterpret_cast<Rowset*>(value)->close();
+}
+
+void MetadataCache::_warmup(const std::string& key) {
+    Cache::Handle* handle = _cache->lookup(CacheKey(key));
+    if (handle != nullptr) {
+        _cache->release(handle);
+    }
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -40,7 +40,7 @@ void MetadataCache::evict_rowset(Rowset* ptr) {
 }
 
 void MetadataCache::warmup_rowset(Rowset* ptr) {
-    _ping(ptr->rowset_id_str());
+    _warmup(ptr->rowset_id_str());
 }
 
 size_t MetadataCache::get_memory_usage() const {

--- a/be/src/storage/rowset/metadata_cache.h
+++ b/be/src/storage/rowset/metadata_cache.h
@@ -51,6 +51,9 @@ public:
     // Memory usage of lru cache
     size_t get_memory_usage() const;
 
+    // Adjust capacity
+    void set_capacity(size_t capacity);
+
 private:
     void _insert(const std::string& key, Rowset* ptr, size_t size);
     void _erase(const std::string& key);

--- a/be/src/storage/rowset/metadata_cache.h
+++ b/be/src/storage/rowset/metadata_cache.h
@@ -45,12 +45,16 @@ public:
     // evict this rowset manually, will be called before rowset destroy.
     void evict_rowset(Rowset* ptr);
 
+    // warmup rowset, so we can make this rowset as newest entry in lru cache.
+    void warmup_rowset(Rowset* ptr);
+
     // Memory usage of lru cache
     size_t get_memory_usage() const;
 
 private:
     void _insert(const std::string& key, Rowset* ptr, size_t size);
     void _erase(const std::string& key);
+    void _warmup(const std::string& key);
     static void _cache_value_deleter(const CacheKey& /*key*/, void* value);
 
     static MetadataCache* _s_instance;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -93,6 +93,7 @@ Status Rowset::load() {
     // if the state is ROWSET_UNLOADING it means close() is called
     // and the rowset is already loaded, and the resource is not closed yet.
     if (_rowset_state_machine.rowset_state() == ROWSET_LOADED) {
+        warmup_lrucache();
         return Status::OK();
     }
     // after lock, if rowset state is ROWSET_UNLOADING, it is ok to return
@@ -192,6 +193,16 @@ Status Rowset::do_load() {
     }
 #endif
     return Status::OK();
+}
+
+void Rowset::warmup_lrucache() {
+#ifndef BE_TEST
+    if (config::metadata_cache_memory_limit_percent > 0 && _keys_type != PRIMARY_KEYS) {
+        // Move this item to newest item in lru cache.
+        // ONLY support non-pk table now.
+        MetadataCache::instance()->warmup_rowset(this);
+    }
+#endif
 }
 
 // this function is only used for partial update so far

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -390,6 +390,9 @@ protected:
     // release resources in this api
     void do_close();
 
+    // Move this item to newest item in lru cache.
+    void warmup_lrucache();
+
     // allow subclass to add custom logic when rowset is being published
     virtual void make_visible_extra(Version version) {}
 

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -157,14 +157,8 @@ TEST_F(MetadataCacheTest, test_warmup) {
             metadata_cache_ptr->cache_rowset(rowset_ptr.get());
             rowsets.push_back(rowset_ptr);
         }
-        size_t capacity = 0;
-        for (int i = 0; i < 5 * 32; i++) {
-            capacity += rowsets[i]->segment_memory_usage();
-        }
-        // evict 0-4
-        metadata_cache_ptr->set_capacity(capacity);
+        metadata_cache_ptr->set_capacity(rowsets[0]->segment_memory_usage() * 32);
         ASSERT_TRUE(rowsets[0]->segment_memory_usage() == 0);
-        ASSERT_TRUE(rowsets[10 * 32 - 1]->segment_memory_usage() > 0);
     }
     {
         vector<RowsetSharedPtr> rowsets;
@@ -177,16 +171,10 @@ TEST_F(MetadataCacheTest, test_warmup) {
             metadata_cache_ptr->cache_rowset(rowset_ptr.get());
             rowsets.push_back(rowset_ptr);
         }
-        size_t capacity = 0;
-        for (int i = 0; i < 5 * 32; i++) {
-            capacity += rowsets[i]->segment_memory_usage();
-            // warmup
-            metadata_cache_ptr->warmup_rowset(rowsets[i].get());
-        }
-        // evict 5-9
-        metadata_cache_ptr->set_capacity(capacity);
-        ASSERT_TRUE(rowsets[5 * 32 - 1]->segment_memory_usage() > 0);
-        ASSERT_TRUE(rowsets[10 * 32 - 1]->segment_memory_usage() == 0);
+        // warmup first rowset
+        metadata_cache_ptr->warmup_rowset(rowsets[0].get());
+        metadata_cache_ptr->set_capacity(rowsets[0]->segment_memory_usage() * 32);
+        ASSERT_TRUE(rowsets[0]->segment_memory_usage() > 0);
     }
 }
 

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -132,9 +132,11 @@ TEST_F(MetadataCacheTest, test_manual_evcit) {
         rowsets.push_back(rowset_ptr);
     }
     for (int i = 0; i < 10; i++) {
+        metadata_cache_ptr->warmup_rowset(rowsets[i].get());
         ASSERT_TRUE(rowsets[i]->segment_memory_usage() > 0);
         metadata_cache_ptr->evict_rowset(rowsets[i].get());
         ASSERT_TRUE(rowsets[i]->segment_memory_usage() == 0);
+        metadata_cache_ptr->warmup_rowset(rowsets[i].get());
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
When query hit rowset which already loaded, we won't move this item as newest entry in LRU cache, so this rowset lru cache won't work well.

## What I'm doing:
Fix it.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
