### PR TITLE
[Enhancement] Enhance the information display and error messaging for resource group (backport #51386)

### DIFF
--- a/be/src/agent/resource_group_usage_recorder.cpp
+++ b/be/src/agent/resource_group_usage_recorder.cpp
@@ -62,6 +62,7 @@ std::vector<TResourceGroupUsage> ResourceGroupUsageRecorder::get_resource_group_
         }
 
         int32_t cpu_core_used_permille = (cpu_runtime_ns - prev_runtime_ns) * 1000 / delta_ns;
+        cpu_core_used_permille = std::clamp(cpu_core_used_permille, 0, CpuInfo::num_cores());
         group_to_usage[group_id].__set_cpu_core_used_permille(cpu_core_used_permille);
     }
     _group_to_cpu_runtime_ns = std::move(curr_group_to_cpu_runtime_ns);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -63,6 +63,9 @@ public class ResourceGroup {
     public static final Set<String> BUILTIN_WG_NAMES =
             ImmutableSet.of(DEFAULT_RESOURCE_GROUP_NAME, DEFAULT_MV_RESOURCE_GROUP_NAME);
 
+    // BE actually stores nanoseconds, so the maximum value needs to be limited to prevent overflow.
+    public static final long MAX_BIG_QUERY_CPU_SECOND_LIMIT = Long.MAX_VALUE / 1_000_000_000L;
+
     private static class ColumnMeta {
         public ColumnMeta(Column column, BiFunction<ResourceGroup, ResourceGroupClassifier, String> valueSupplier) {
             this(column, valueSupplier, true);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -90,6 +90,7 @@ public class ResourceGroupMgr implements Writable {
     private final Map<Long, Long> minVersionPerBe = new HashMap<>();
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
     private int sumExclusiveCpuCores = 0;
+    private volatile boolean hasCreatedDefaultResourceGroups = false;
 
     private void readLock() {
         lock.readLock().lock();
@@ -531,6 +532,9 @@ public class ResourceGroupMgr implements Writable {
             shortQueryResourceGroup = wg;
         }
         sumExclusiveCpuCores += wg.getNormalizedExclusiveCpuCores();
+        if (ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME.equals(wg.getName())) {
+            hasCreatedDefaultResourceGroups = true;
+        }
     }
 
     public List<TWorkGroupOp> getResourceGroupsNeedToDeliver(Long beId) {
@@ -648,6 +652,16 @@ public class ResourceGroupMgr implements Writable {
 
     public void createBuiltinResourceGroupsIfNotExist() {
         try {
+            if (hasCreatedDefaultResourceGroups) {
+                return;
+            }
+
+            // Create default resource groups only when there are BEs.
+            // Otherwise, we cannot get the number of cores of BE as `cpu_weight`.
+            if (BackendResourceStat.getInstance().getNumBes() <= 0) {
+                return;
+            }
+
             ResourceGroup defaultWg = getResourceGroup(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME);
             if (defaultWg != null) {
                 return;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
@@ -159,112 +159,119 @@ public class ResourceGroupAnalyzer {
         for (Map.Entry<String, String> e : properties.entrySet()) {
             String key = e.getKey();
             String value = e.getValue();
-            if (key.equalsIgnoreCase(ResourceGroup.CPU_CORE_LIMIT) || key.equalsIgnoreCase(ResourceGroup.CPU_WEIGHT)) {
-                int cpuWeight = Integer.parseInt(value);
-                if (cpuWeight > avgCoreNum) {
-                    throw new SemanticException(
-                            String.format("%s should range from 0 to %d", ResourceGroup.CPU_WEIGHT, avgCoreNum));
+            try {
+                if (key.equalsIgnoreCase(ResourceGroup.CPU_CORE_LIMIT) || key.equalsIgnoreCase(ResourceGroup.CPU_WEIGHT)) {
+                    int cpuWeight = Integer.parseInt(value);
+                    if (cpuWeight > avgCoreNum) {
+                        throw new SemanticException(
+                                String.format("%s should range from 0 to %d", ResourceGroup.CPU_WEIGHT, avgCoreNum));
+                    }
+                    resourceGroup.setCpuWeight(cpuWeight);
+                    continue;
                 }
-                resourceGroup.setCpuWeight(cpuWeight);
-                continue;
-            }
-            if (key.equalsIgnoreCase(ResourceGroup.EXCLUSIVE_CPU_CORES)) {
-                final int exclusiveCpuCores = Integer.parseInt(value);
-                final int minCoreNum = BackendResourceStat.getInstance().getMinNumHardwareCoresOfBe();
-                if (exclusiveCpuCores >= minCoreNum) {
-                    throw new SemanticException(String.format(
-                            "%s cannot exceed the minimum number of CPU cores available on the backends minus one [%d]",
-                            ResourceGroup.EXCLUSIVE_CPU_CORES, minCoreNum - 1));
+                if (key.equalsIgnoreCase(ResourceGroup.EXCLUSIVE_CPU_CORES)) {
+                    final int exclusiveCpuCores = Integer.parseInt(value);
+                    final int minCoreNum = BackendResourceStat.getInstance().getMinNumHardwareCoresOfBe();
+                    if (exclusiveCpuCores >= minCoreNum) {
+                        throw new SemanticException(String.format(
+                                "%s cannot exceed the minimum number of CPU cores available on the backends minus one [%d]",
+                                ResourceGroup.EXCLUSIVE_CPU_CORES, minCoreNum - 1));
+                    }
+                    resourceGroup.setExclusiveCpuCores(exclusiveCpuCores);
+                    continue;
                 }
-                resourceGroup.setExclusiveCpuCores(exclusiveCpuCores);
-                continue;
-            }
-            if (key.equalsIgnoreCase(ResourceGroup.MAX_CPU_CORES)) {
-                int maxCpuCores = Integer.parseInt(value);
-                if (maxCpuCores > avgCoreNum) {
-                    throw new SemanticException(String.format("max_cpu_cores should range from 0 to %d", avgCoreNum));
+                if (key.equalsIgnoreCase(ResourceGroup.MAX_CPU_CORES)) {
+                    int maxCpuCores = Integer.parseInt(value);
+                    if (maxCpuCores > avgCoreNum) {
+                        throw new SemanticException(String.format("max_cpu_cores should range from 0 to %d", avgCoreNum));
+                    }
+                    resourceGroup.setMaxCpuCores(maxCpuCores);
+                    continue;
                 }
-                resourceGroup.setMaxCpuCores(maxCpuCores);
-                continue;
-            }
-            if (key.equalsIgnoreCase(ResourceGroup.MEM_LIMIT)) {
-                double memLimit;
-                if (value.endsWith("%")) {
-                    value = value.substring(0, value.length() - 1);
-                    memLimit = Double.parseDouble(value) / 100;
-                } else {
-                    memLimit = Double.parseDouble(value);
+                if (key.equalsIgnoreCase(ResourceGroup.MEM_LIMIT)) {
+                    double memLimit;
+                    if (value.endsWith("%")) {
+                        value = value.substring(0, value.length() - 1);
+                        memLimit = Double.parseDouble(value) / 100;
+                    } else {
+                        memLimit = Double.parseDouble(value);
+                    }
+                    if (memLimit <= 0.0 || memLimit > 1.0) {
+                        throw new SemanticException("mem_limit should range from 0.00(exclude) to 1.00(include)");
+                    }
+                    resourceGroup.setMemLimit(memLimit);
+                    continue;
                 }
-                if (memLimit <= 0.0 || memLimit > 1.0) {
-                    throw new SemanticException("mem_limit should range from 0.00(exclude) to 1.00(include)");
-                }
-                resourceGroup.setMemLimit(memLimit);
-                continue;
-            }
 
-            if (key.equalsIgnoreCase(ResourceGroup.BIG_QUERY_MEM_LIMIT)) {
-                long bigQueryMemLimit = Long.parseLong(value);
-                if (bigQueryMemLimit < 0) {
-                    throw new SemanticException("big_query_mem_limit should greater than 0 or equal to 0");
+                if (key.equalsIgnoreCase(ResourceGroup.BIG_QUERY_MEM_LIMIT)) {
+                    long bigQueryMemLimit = Long.parseLong(value);
+                    if (bigQueryMemLimit < 0) {
+                        throw new SemanticException("big_query_mem_limit should greater than 0 or equal to 0");
+                    }
+                    resourceGroup.setBigQueryMemLimit(bigQueryMemLimit);
+                    continue;
                 }
-                resourceGroup.setBigQueryMemLimit(bigQueryMemLimit);
-                continue;
-            }
 
-            if (key.equalsIgnoreCase(ResourceGroup.BIG_QUERY_SCAN_ROWS_LIMIT)) {
-                long bigQueryScanRowsLimit = Long.parseLong(value);
-                if (bigQueryScanRowsLimit < 0) {
-                    throw new SemanticException("big_query_scan_rows_limit should greater than 0 or equal to 0");
+                if (key.equalsIgnoreCase(ResourceGroup.BIG_QUERY_SCAN_ROWS_LIMIT)) {
+                    long bigQueryScanRowsLimit = Long.parseLong(value);
+                    if (bigQueryScanRowsLimit < 0) {
+                        throw new SemanticException("big_query_scan_rows_limit should greater than 0 or equal to 0");
+                    }
+                    resourceGroup.setBigQueryScanRowsLimit(bigQueryScanRowsLimit);
+                    continue;
                 }
-                resourceGroup.setBigQueryScanRowsLimit(bigQueryScanRowsLimit);
-                continue;
-            }
 
-            if (key.equalsIgnoreCase(ResourceGroup.BIG_QUERY_CPU_SECOND_LIMIT)) {
-                long bigQueryCpuCoreSecondLimit = Long.parseLong(value);
-                if (bigQueryCpuCoreSecondLimit < 0) {
-                    throw new SemanticException("big_query_cpu_second_limit should greater than 0 or equal to 0");
+                if (key.equalsIgnoreCase(ResourceGroup.BIG_QUERY_CPU_SECOND_LIMIT)) {
+                    long bigQueryCpuSecondLimit = Long.parseLong(value);
+                    if (bigQueryCpuSecondLimit < 0 || bigQueryCpuSecondLimit > ResourceGroup.MAX_BIG_QUERY_CPU_SECOND_LIMIT) {
+                        throw new SemanticException(
+                                String.format("The range of `%s` should be (0, %d]", ResourceGroup.BIG_QUERY_CPU_SECOND_LIMIT,
+                                        ResourceGroup.MAX_BIG_QUERY_CPU_SECOND_LIMIT));
+                    }
+                    resourceGroup.setBigQueryCpuSecondLimit(bigQueryCpuSecondLimit);
+                    continue;
                 }
-                resourceGroup.setBigQueryCpuSecondLimit(bigQueryCpuCoreSecondLimit);
-                continue;
-            }
 
-            if (key.equalsIgnoreCase(ResourceGroup.CONCURRENCY_LIMIT)) {
-                int concurrencyLimit = Integer.parseInt(value);
-                if (concurrencyLimit < 0) {
-                    throw new SemanticException("concurrency_limit should be greater than 0");
+                if (key.equalsIgnoreCase(ResourceGroup.CONCURRENCY_LIMIT)) {
+                    int concurrencyLimit = Integer.parseInt(value);
+                    if (concurrencyLimit < 0) {
+                        throw new SemanticException("concurrency_limit should be greater than 0");
+                    }
+                    resourceGroup.setConcurrencyLimit(concurrencyLimit);
+                    continue;
                 }
-                resourceGroup.setConcurrencyLimit(concurrencyLimit);
-                continue;
-            }
 
-            if (key.equalsIgnoreCase(ResourceGroup.SPILL_MEM_LIMIT_THRESHOLD)) {
-                double spillMemLimitThreshold;
-                if (value.endsWith("%")) {
-                    value = value.substring(0, value.length() - 1);
-                    spillMemLimitThreshold = Double.parseDouble(value) / 100;
-                } else {
-                    spillMemLimitThreshold = Double.parseDouble(value);
+                if (key.equalsIgnoreCase(ResourceGroup.SPILL_MEM_LIMIT_THRESHOLD)) {
+                    double spillMemLimitThreshold;
+                    if (value.endsWith("%")) {
+                        value = value.substring(0, value.length() - 1);
+                        spillMemLimitThreshold = Double.parseDouble(value) / 100;
+                    } else {
+                        spillMemLimitThreshold = Double.parseDouble(value);
+                    }
+                    if (spillMemLimitThreshold <= 0.0 || spillMemLimitThreshold >= 1.0) {
+                        throw new SemanticException("spill_mem_limit_threshold should range from 0.00(exclude) to 1.00(exclude)");
+                    }
+                    resourceGroup.setSpillMemLimitThreshold(spillMemLimitThreshold);
+                    continue;
                 }
-                if (spillMemLimitThreshold <= 0.0 || spillMemLimitThreshold >= 1.0) {
-                    throw new SemanticException("spill_mem_limit_threshold should range from 0.00(exclude) to 1.00(exclude)");
-                }
-                resourceGroup.setSpillMemLimitThreshold(spillMemLimitThreshold);
-                continue;
-            }
 
-            if (key.equalsIgnoreCase(ResourceGroup.GROUP_TYPE)) {
-                try {
-                    resourceGroup.setResourceGroupType(TWorkGroupType.valueOf("WG_" + value.toUpperCase()));
-                    if (resourceGroup.getResourceGroupType() != TWorkGroupType.WG_NORMAL &&
-                            resourceGroup.getResourceGroupType() != TWorkGroupType.WG_SHORT_QUERY &&
-                            resourceGroup.getResourceGroupType() != TWorkGroupType.WG_MV) {
+                if (key.equalsIgnoreCase(ResourceGroup.GROUP_TYPE)) {
+                    try {
+                        resourceGroup.setResourceGroupType(TWorkGroupType.valueOf("WG_" + value.toUpperCase()));
+                        if (resourceGroup.getResourceGroupType() != TWorkGroupType.WG_NORMAL &&
+                                resourceGroup.getResourceGroupType() != TWorkGroupType.WG_SHORT_QUERY &&
+                                resourceGroup.getResourceGroupType() != TWorkGroupType.WG_MV) {
+                            throw new SemanticException("Only support 'normal', 'mv' and 'short_query' type");
+                        }
+                    } catch (Exception ignored) {
                         throw new SemanticException("Only support 'normal', 'mv' and 'short_query' type");
                     }
-                } catch (Exception ignored) {
-                    throw new SemanticException("Only support 'normal', 'mv' and 'short_query' type");
+                    continue;
                 }
-                continue;
+            } catch (NumberFormatException exception) {
+                throw new SemanticException(String.format("The value type of the property `%s` must be a valid numeric type, " +
+                        "but it is set to `%s`", e.getKey(), e.getValue()));
             }
 
             throw new SemanticException("Unknown property: " + key);

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -188,6 +188,8 @@ public class HeartbeatMgr extends FrontendDaemon {
         // write edit log
         GlobalStateMgr.getCurrentState().getEditLog().logHeartbeat(hbPackage);
 
+        GlobalStateMgr.getCurrentState().getResourceGroupMgr().createBuiltinResourceGroupsIfNotExist();
+
         // set sleep time to (heartbeat_timeout - timeUsed),
         // so that the frequency of calling the heartbeat rpc can be stabilized at heartbeat_timeout
         setInterval(Math.max(1L, Config.heartbeat_timeout_second * 1000L - (System.currentTimeMillis() - startTime)));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
@@ -32,9 +32,11 @@ import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.QueryStatisticsItem;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.scheduler.dag.JobSpec;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TLoadJobType;
@@ -147,6 +149,8 @@ public class JobSpecTest extends SchedulerTestBase {
      */
     @Test
     public void testQueryResourceGroup() throws Exception {
+        BackendResourceStat.getInstance().setNumHardwareCoresOfBe(BACKEND1_ID, 16);
+        GlobalStateMgr.getCurrentState().getResourceGroupMgr().createBuiltinResourceGroupsIfNotExist();
 
         new MockUp<ResourceGroupMgr>() {
             @Mock

--- a/test/sql/test_resource_group/R/test_default_resource_group
+++ b/test/sql/test_resource_group/R/test_default_resource_group
@@ -1,0 +1,5 @@
+-- name: test_default_resource_group
+SHOW RESOURCE GROUP default_wg;
+-- result:
+[REGEX].*default_wg	2	([2-9]\d*|\d\d+).*$
+-- !result

--- a/test/sql/test_resource_group/T/test_default_resource_group
+++ b/test/sql/test_resource_group/T/test_default_resource_group
@@ -1,0 +1,5 @@
+-- name: test_default_resource_group
+
+-- The cpu_weight of `default_wg` should be greater than 1.
+SHOW RESOURCE GROUP default_wg;
+


### PR DESCRIPTION
CP from #51386.

## Why I'm doing:


1. **Restricting `BEInUseCpuCores` Value Range**:
   - The `BEInUseCpuCores` metric may sometimes exceed the actual number of CPU cores on the BE or be negative (when updating resource group configurations). To address this, the displayed value should be constrained to the range `[0, BE's CPU core count]`.

2. **Clearer Error Messages for Invalid Property Values**:
   - When creating a resource group, if a property's value is not a valid numeric type, the error message can be misleading. It should be more explicit. The error message will be changed from: `For input string: "a"` to `The value type of the property 'exclusive_cpu_cores' must be a valid numeric type, but it is set to 'a'.`
   
   For example:
   ```sql
   mysql> CREATE RESOURCE GROUP tpcds_100g TO (query_type in ('select'), db='tpcds_100g') WITH (
       'exclusive_cpu_cores' = '1','mem_limit'='a'
   );
   ERROR 1064 (HY000): For input string: "a"
   ```

3. **Limiting the `max_big_query_cpu_second_limit` Property**:
   - The `max_big_query_cpu_second_limit` property is stored in nanoseconds on the BE. To prevent overflow, the maximum value of this property needs to be limited within a reasonable range to avoid potential issues due to excessively large values.


4. **default_wg.cpu_weight**:
    - Create default resource groups only when there are BEs. Otherwise, we cannot get the number of cores of BE as `cpu_weight.`

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8613, https://github.com/StarRocks/StarRocksTest/issues/8614

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

