### PR TITLE
[Enhancement] Modify the matching rules of generic functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -919,12 +919,17 @@ public class FunctionSet {
         return null;
     }
 
-    private Function matchPolymorphicFunction(Function desc, Function.CompareMode mode, List<Function> fns) {
+    private Function matchPolymorphicFunction(Function desc, Function.CompareMode mode, List<Function> fns,
+                                              List<Function> standFns) {
         Function fn = matchFuncCandidates(desc, mode, fns);
         if (fn != null) {
             fn = PolymorphicFunctionAnalyzer.generatePolymorphicFunction(fn, desc.getArgs());
         }
         if (fn != null) {
+            Function newFn = matchStrictFunction(fn, mode, standFns);
+            if (newFn != null) {
+                return newFn;
+            }
             // check generate function is right
             return matchFuncCandidates(desc, mode, Collections.singletonList(fn));
         }
@@ -950,7 +955,7 @@ public class FunctionSet {
         }
 
         List<Function> polyFns = fns.stream().filter(Function::isPolymorphic).collect(Collectors.toList());
-        func = matchPolymorphicFunction(desc, mode, polyFns);
+        func = matchPolymorphicFunction(desc, mode, polyFns, standFns);
         if (func != null) {
             return func;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
@@ -261,6 +261,12 @@ public class FunctionSetTest {
         Assert.assertEquals(Type.ARRAY_BIGINT, fn.getReturnType());
         Assert.assertEquals(Type.BIGINT, fn.getArgs()[0]);
 
+        // arrays_overlap
+        argTypes = new Type[] {Type.ARRAY_BIGINT, Type.ARRAY_TINYINT };
+        desc = new Function(new FunctionName("arrays_overlap"), argTypes, Type.BOOLEAN, false);
+        fn = functionSet.getFunction(desc, Function.CompareMode.IS_SUPERTYPE_OF);
+        Assert.assertNotNull(fn);;
+        Assert.assertEquals(fn.functionId, 150216L);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
@@ -262,7 +262,7 @@ public class FunctionSetTest {
         Assert.assertEquals(Type.BIGINT, fn.getArgs()[0]);
 
         // arrays_overlap
-        argTypes = new Type[] {Type.ARRAY_BIGINT, Type.ARRAY_TINYINT };
+        argTypes = new Type[] {Type.ARRAY_BIGINT, Type.ARRAY_TINYINT};
         desc = new Function(new FunctionName("arrays_overlap"), argTypes, Type.BOOLEAN, false);
         fn = functionSet.getFunction(desc, Function.CompareMode.IS_SUPERTYPE_OF);
         Assert.assertNotNull(fn);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
@@ -265,7 +265,7 @@ public class FunctionSetTest {
         argTypes = new Type[] {Type.ARRAY_BIGINT, Type.ARRAY_TINYINT };
         desc = new Function(new FunctionName("arrays_overlap"), argTypes, Type.BOOLEAN, false);
         fn = functionSet.getFunction(desc, Function.CompareMode.IS_SUPERTYPE_OF);
-        Assert.assertNotNull(fn);;
+        Assert.assertNotNull(fn);
         Assert.assertEquals(fn.functionId, 150216L);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -60,12 +60,12 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         assertPlanContains(sql, "array_concat([1,2,3], [4,5,6])");
 
         sql = "select concat(c1, c2) from test_array";
-        assertPlanContains(sql, "array_concat(2: c1, CAST(3: c2 AS ARRAY<VARCHAR(65533)>))");
+        assertPlanContains(sql, "array_concat(2: c1, CAST(3: c2 AS ARRAY<VARCHAR>))");
 
         sql = "select concat(c1, c2, array[1,2], array[3,4]) from test_array";
-        assertPlanContains(sql, "array_concat(2: c1, CAST(3: c2 AS ARRAY<VARCHAR(65533)>), " +
-                "CAST([1,2] AS ARRAY<VARCHAR(65533)>), " +
-                "CAST([3,4] AS ARRAY<VARCHAR(65533)>)");
+        assertPlanContains(sql, "array_concat(2: c1, CAST(3: c2 AS ARRAY<VARCHAR>), " +
+                "CAST([1,2] AS ARRAY<VARCHAR>), " +
+                "CAST([3,4] AS ARRAY<VARCHAR>)");
 
         sql = "select concat(c2, 2) from test_array";
         assertPlanContains(sql, "array_concat(3: c2, CAST([2] AS ARRAY<INT>))");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -59,11 +59,11 @@ public class ArrayTypeTest extends PlanTestBase {
     public void testConcatArray() throws Exception {
         String sql = "select concat(c1, c2) from test_array";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "array_concat(2: c1, CAST(3: c2 AS ARRAY<VARCHAR(65533)>))");
+        assertContains(plan, "array_concat(2: c1, CAST(3: c2 AS ARRAY<VARCHAR>))");
 
         sql = "select concat(c1, c0) from test_array";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "array_concat(2: c1, CAST([1: c0] AS ARRAY<VARCHAR(65533)>))");
+        assertContains(plan, "array_concat(2: c1, CAST([1: c0] AS ARRAY<VARCHAR>))");
 
         sql = "select concat(c0, c2) from test_array";
         plan = getFragmentPlan(sql);
@@ -98,8 +98,8 @@ public class ArrayTypeTest extends PlanTestBase {
 
         sql = "select concat(v1, [1,2,3], s_1) from adec";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "array_concat(CAST([1: v1] AS ARRAY<VARCHAR(65533)>), " +
-                "CAST([1,2,3] AS ARRAY<VARCHAR(65533)>), 3: s_1)");
+        assertContains(plan, "array_concat(CAST([1: v1] AS ARRAY<VARCHAR>), " +
+                "CAST([1,2,3] AS ARRAY<VARCHAR>), 3: s_1)");
 
         sql = "select concat(1,2, [1,2])";
         plan = getFragmentPlan(sql);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

After specialization of the prototype function, if it can be strictly matched, replace it with a strictly matched function.

Performance test: 2.7s->1.3s

```
CREATE TABLE `t1` (                                                                                                                                                                                                                                                     
  `c1` bigint(20) NOT NULL COMMENT "",                                                                                                                                                                                                                                            
  `c2` array<bigint(20)> NOT NULL COMMENT "",                                                                                                                                                                                                                                     
  `c3` array<bigint(20)> NOT NULL COMMENT ""                                                                                                                                                                                                                                      
) ENGINE=OLAP                                                                                                                                                                                                                                                                     
DUPLICATE KEY(`c1`)                                                                                                                                                                                                                                                               
DISTRIBUTED BY HASH(`c1`) BUCKETS 1                                                                                                                                                                                                                                               
PROPERTIES (                                                                                                                                                                                                                                                                      
"compression" = "LZ4",                                                                                                                                                                                                                                                            
"fast_schema_evolution" = "true",                                                                                                                                                                                                                                                 
"replicated_storage" = "true",                                                                                                                                                                                                                                                    
"replication_num" = "1"                                                                                                                                                                                                                                                           
);

mysql> select count(*) from t1;                                                                                                                                                                                                                                                   
+----------+                                                                                                                                                                                                                                                                      
| count(*) |                                                                                                                                                                                                                                                                      
+----------+                                                                                                                                                                                                                                                                      
| 30000000 |                                                                                                                                                                                                                                                                      
+----------+

Before optimization: 2.68s

mysql> select count(*) from t1 where arrays_overlap(c2, [1, 11, 111, 1111, 11111, 111111]);                                                                                                                                                                                       
+----------+                                                                                                                                                                                                                                                                      
| count(*) |                                                                                                                                                                                                                                                                      
+----------+                                                                                                                                                                                                                                                                      
|     1204 |                                                                                                                                                                                                                                                                      
+----------+                                                                                                                                                                                                                                                                      
1 row in set (2.68 sec) 

After optimization: 1.31s

mysql> select count(*) from t1 where arrays_overlap(c2, [1, 11, 111, 1111, 11111, 111111]);
+----------+
| count(*) |
+----------+
|     1204 |
+----------+
1 row in set (1.31 sec)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
