### PR TITLE
[BugFix] Fix duplicate list partition when partition name exceed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -100,6 +100,8 @@ public class FeConstants {
 
     public static final int DEFAULT_UNPARTITIONED_TABLE_BUCKET_NUM = 16;
 
+    public static final int MAX_LIST_PARTITION_NAME_LENGTH = 50;
+
     public static final String DOCUMENT_SHOW_ALTER =
             "https://docs.starrocks.io/docs/sql-reference/sql-statements/data-manipulation/SHOW_ALTER";
     public static final String DOCUMENT_SHOW_ALTER_MATERIALIZED_VIEW =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -70,6 +70,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
@@ -1320,8 +1321,9 @@ public class AnalyzerUtils {
                     formattedPartitionValue.add(formatValue);
                 }
                 String partitionName = partitionPrefix + Joiner.on("_").join(formattedPartitionValue);
-                if (partitionName.length() > 50) {
-                    partitionName = partitionName.substring(0, 50) + "_" + System.currentTimeMillis();
+                if (partitionName.length() > FeConstants.MAX_LIST_PARTITION_NAME_LENGTH) {
+                    partitionName = partitionName.substring(0, FeConstants.MAX_LIST_PARTITION_NAME_LENGTH)
+                            + "_" + partitionName.hashCode();
                 }
                 if (!partitionColNames.contains(partitionName)) {
                     MultiItemListPartitionDesc multiItemListPartitionDesc = new MultiItemListPartitionDesc(true,

--- a/test/sql/test_automatic_partition/R/test_automatic_partition_list
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition_list
@@ -98,6 +98,18 @@ select * from t3;
 -- result:
 2022-04-01	1	1.00	hangzhou	1
 -- !result
+
+
+
+
+
+
+
+
+
+
+
+
 -- name: test_automatic_partition_list_limit
 CREATE TABLE list_auto_single (
     id bigint  ,
@@ -141,4 +153,36 @@ ALTER TABLE list_normal_single ADD PARTITION psingle VALUES IN ("2023-04-01");
 -- !result
 ALTER TABLE list_normal_single ADD PARTITION pmul VALUES IN ("2022-04-01", "2022-04-02");
 -- result:
+-- !result
+
+
+
+
+
+
+
+
+
+
+
+-- name: test_list_partition_name_exceed
+create table t(k string, v int)partition by (k) distributed by hash(v) buckets 1000;
+-- result:
+-- !result
+insert into t values('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 1),('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 2);
+-- result:
+-- !result
+show partitions from t;
+-- result:
+[REGEX]^[^\n]*$
+-- !result
+create table t1 like t;
+-- result:
+-- !result
+insert into t1 select * from t;
+-- result:
+-- !result
+show partitions from t1;
+-- result:
+[REGEX]^[^\n]*$
 -- !result

--- a/test/sql/test_automatic_partition/T/test_automatic_partition_list
+++ b/test/sql/test_automatic_partition/T/test_automatic_partition_list
@@ -93,3 +93,12 @@ PROPERTIES (
 );
 ALTER TABLE list_normal_single ADD PARTITION psingle VALUES IN ("2023-04-01");
 ALTER TABLE list_normal_single ADD PARTITION pmul VALUES IN ("2022-04-01", "2022-04-02");
+
+
+-- name: test_list_partition_name_exceed
+create table t(k string, v int)partition by (k) distributed by hash(v) buckets 1000;
+insert into t values('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 1),('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 2);
+show partitions from t;
+create table t1 like t;
+insert into t1 select * from t;
+show partitions from t1;


### PR DESCRIPTION
## Why I'm doing:
When the list partition name exceeds the limit, timestamp will be used as a suffix, which may cause duplicate partitions to be created with the same partition value.

```
create table t(k string, v int)partition by (k) distributed by hash(v) buckets 1000;
-- result:
-- !result
insert into t values('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 1),('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 2);
-- result:
-- !result
show partitions from t;
-- result:
562021  paaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_1727581928327        2       2024-09-29 11:52:09     0       NORMAL  k       (('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'))     v       1000    3       HDD     9999-12-31 23:59:59     None    0B      false   0       2       314038295384293376      TXN_NORMAL
-- !result
create table t1 like t;
-- result:
-- !result
insert into t1 select * from t;
-- result:
-- !result
show partitions from t1;
-- result:
570028  paaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_1727581930411        2       2024-09-29 11:52:11     0       NORMAL  k       (('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'))     v       1000    3       HDD     9999-12-31 23:59:59     None    0B      false   0       2       314038299731689472      TXN_NORMAL
574029  paaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_1727581930422        2       2024-09-29 11:52:11     0       NORMAL  k       (('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'))     v       1000    3       HDD     9999-12-31 23:59:59     None    0B      false   0       2       314038299849129984      TXN_NORMAL
-- !result
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
