### PR TITLE
[Enhancement] Compare mv rowCount when both mv dimensions contains query dimensions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -794,6 +794,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return refreshScheme.getLastRefreshTime();
     }
 
+    public long getMaxPartitionRowCount() {
+        long maxRowCount = 0;
+        for (Partition partition : idToPartition.values()) {
+            maxRowCount = Math.max(maxRowCount, partition.getBaseIndex().getRowCount());
+        }
+        return maxRowCount;
+    }
+
     /**
      * Check weather this materialized view's staleness is satisfied.
      *

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -379,7 +379,11 @@ public class MaterializationContext {
                 // select sum(v1) from t1 group by a, b, d;
                 // query: select sum(v1) from t1 where b = 'a' group by a;
 
-                // when many mvs satisfy query, prefer mv with less rows, so choose mv1.
+                // When many mvs satisfy query, prefer mv with fewer rows, like mv1.
+                // But `RewriteOrdering` is only used for sorting when there are too many candidate mvs
+                // and candidate mv list need to be trimmed to a limited size.
+                // So `mv1` in above example is just a candidate, it doesn't mean mv1 is the final chosen mv.
+                // Actually `BestMvSelector` is the final place to judge which mv is used after rewrite rule.
                 boolean mvHasDifferentRows = orderingRowCount(o1) != 0 && orderingRowCount(o2) != 0
                         && orderingRowCount(o1) != orderingRowCount(o2);
                 return Comparator

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
@@ -146,8 +146,19 @@ public class BestMvSelector {
     public static class CandidateContextComparator implements Comparator<CandidateContext> {
         @Override
         public int compare(CandidateContext context1, CandidateContext context2) {
+            int ret;
+            // compare by row number if both row number is greater than 0
+            if (context1.getMvStatistics().getOutputRowCount() > 0 &&
+                    context2.getMvStatistics().getOutputRowCount() > 0) {
+                ret = Double.compare(context1.getMvStatistics().getOutputRowCount(),
+                        context2.getMvStatistics().getOutputRowCount());
+                if (ret != 0) {
+                    return ret;
+                }
+            }
+
             // compare group by key num
-            int ret = Integer.compare(context1.getGroupbyColumnNum(), context2.getGroupbyColumnNum());
+            ret = Integer.compare(context1.getGroupbyColumnNum(), context2.getGroupbyColumnNum());
             if (ret != 0) {
                 return ret;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
@@ -146,25 +146,8 @@ public class BestMvSelector {
     public static class CandidateContextComparator implements Comparator<CandidateContext> {
         @Override
         public int compare(CandidateContext context1, CandidateContext context2) {
-            int ret;
-            // compare by row number if both row number is greater than 0
-            if (context1.getMvStatistics().getOutputRowCount() > 0 &&
-                    context2.getMvStatistics().getOutputRowCount() > 0) {
-                ret = Double.compare(context1.getMvStatistics().getOutputRowCount(),
-                        context2.getMvStatistics().getOutputRowCount());
-                if (ret != 0) {
-                    return ret;
-                }
-            }
-
-            // compare group by key num
-            ret = Integer.compare(context1.getGroupbyColumnNum(), context2.getGroupbyColumnNum());
-            if (ret != 0) {
-                return ret;
-            }
-
             // larger is better
-            ret = Integer.compare(context2.sortScore, context1.sortScore);
+            int ret = Integer.compare(context2.sortScore, context1.sortScore);
             if (ret != 0) {
                 return ret;
             }
@@ -172,6 +155,12 @@ public class BestMvSelector {
             // compare by row number
             ret = Double.compare(context1.getMvStatistics().getOutputRowCount(),
                     context2.getMvStatistics().getOutputRowCount());
+            if (ret != 0) {
+                return ret;
+            }
+
+            // compare group by key num
+            ret = Integer.compare(context1.getGroupbyColumnNum(), context2.getGroupbyColumnNum());
             if (ret != 0) {
                 return ret;
             }


### PR DESCRIPTION
## Why I'm doing:

```sql
-- rows: 100 mv1: 
select sum(v1) from t1 group by a, b, c, f; 

-- rows: 10000 mv2: 
select sum(v1) from t1 group by a, b, d; 

query: select sum(v1) from t1 where b = 'a' group by a;
```
Before: prefer mv with less dimensions -> mv2, but mv2 has more rows which is not expected.
After: when many mvs satisfy query, prefer mv with less rows, so choose mv1.

## What I'm doing:


1. `MaterializationContext.RewriteOrdering` decides which MVs are retained in case too many MV candidates and candidate list should be truncated.  `MaterializationContext.RewriteOrdering` should compare MV's maxPartitionRowCount rather than MV's total row count, in case a MV is with less partitions and total row count but maxPartitionRowCount is large.
3. `BestMvSelector` is the actually place to decide which MV should be chose. The comparator in `BestMvSelector` should consider row count first if MV's outputRowCount is not zero in statistics.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
