### PR TITLE
[Enhancement] Support complex data types (eg. Array/Struct/Map) when get table schema.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseResult.java
@@ -44,33 +44,42 @@ import java.lang.annotation.Target;
 
 // Base restful result
 public class RestBaseResult {
+
+    private static final Gson GSON = new Gson();
+
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.FIELD, ElementType.METHOD})
     public @interface Legacy {
     }
 
     private static final RestBaseResult OK = new RestBaseResult();
+
     // For compatibility, status still exists in /api/v1, removed in /api/v2 and later version.
     @Legacy
+    @SerializedName("status")
     public ActionStatus status;
+
     @SerializedName("code")
     public String code;
+
     // For compatibility, msg still exists in /api/v1, removed in /api/v2 and later version.
     @Legacy
+    @SerializedName("msg")
     public String msg;
+
     @SerializedName("message")
     public String message;
 
     public RestBaseResult() {
         status = ActionStatus.OK;
-        code = "" + ActionStatus.OK.ordinal();
+        code = Integer.toString(ActionStatus.OK.ordinal());
         msg = "Success";
         message = "OK";
     }
 
     public RestBaseResult(String msg) {
         status = ActionStatus.FAILED;
-        code = "" + ActionStatus.FAILED.ordinal();
+        code = Integer.toString(ActionStatus.FAILED.ordinal());
         this.msg = msg;
         this.message = msg;
     }
@@ -81,8 +90,7 @@ public class RestBaseResult {
 
     @Legacy
     public String toJson() {
-        Gson gson = new Gson();
-        return gson.toJson(this);
+        return GSON.toJson(this);
     }
 
     public String getCode() {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/RestBaseResultV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/RestBaseResultV2.java
@@ -26,6 +26,19 @@ import java.util.Objects;
 
 public class RestBaseResultV2<T> extends RestBaseResult {
 
+    private static final Gson GSON = new GsonBuilder()
+            .setExclusionStrategies(new ExclusionStrategy() {
+                @Override
+                public boolean shouldSkipField(FieldAttributes f) {
+                    return f.getAnnotation(Legacy.class) != null;
+                }
+
+                @Override
+                public boolean shouldSkipClass(Class<?> clazz) {
+                    return false;
+                }
+            }).create();
+
     @SerializedName("result")
     private T result;
 
@@ -58,19 +71,7 @@ public class RestBaseResultV2<T> extends RestBaseResult {
 
     @Override
     public String toJson() {
-        Gson gson = new GsonBuilder()
-                .setExclusionStrategies(new ExclusionStrategy() {
-                    @Override
-                    public boolean shouldSkipField(FieldAttributes f) {
-                        return f.getAnnotation(Legacy.class) != null;
-                    }
-
-                    @Override
-                    public boolean shouldSkipClass(Class<?> clazz) {
-                        return false;
-                    }
-                }).create();
-        return gson.toJson(this);
+        return GSON.toJson(this);
     }
 
     public T getResult() {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/IndexView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/IndexView.java
@@ -15,13 +15,14 @@
 package com.starrocks.http.rest.v2.vo;
 
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Index;
+import com.starrocks.http.rest.v2.vo.ColumnView.IdView;
 import com.starrocks.sql.ast.IndexDef;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class IndexView {
 
@@ -35,7 +36,7 @@ public class IndexView {
     private String indexType;
 
     @SerializedName("columns")
-    private List<ColumnId> columns;
+    private List<IdView> columns;
 
     @SerializedName("comment")
     private String comment;
@@ -53,10 +54,15 @@ public class IndexView {
         IndexView ivo = new IndexView();
         ivo.setIndexId(index.getIndexId());
         ivo.setIndexName(index.getIndexName());
+
         Optional.ofNullable(index.getIndexType())
                 .map(IndexDef.IndexType::getDisplayName)
                 .ifPresent(ivo::setIndexType);
-        ivo.setColumns(index.getColumns());
+
+        Optional.ofNullable(index.getColumns())
+                .map(cols -> cols.stream().map(IdView::createFrom).collect(Collectors.toList()))
+                .ifPresent(ivo::setColumns);
+
         ivo.setComment(index.getComment());
         ivo.setProperties(index.getProperties());
         return ivo;
@@ -86,11 +92,11 @@ public class IndexView {
         this.indexType = indexType;
     }
 
-    public List<ColumnId> getColumns() {
+    public List<IdView> getColumns() {
         return columns;
     }
 
-    public void setColumns(List<ColumnId> columns) {
+    public void setColumns(List<IdView> columns) {
         this.columns = columns;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
@@ -477,13 +477,12 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
 
     private static RestBaseResultV2<PagedResult<PartitionView>> parseResponseBody(String body) {
         try {
-            System.out.println("resp: " + body);
             return GsonUtils.GSON.fromJson(
                     body,
                     new TypeToken<RestBaseResultV2<PagedResult<PartitionView>>>() {
                     }.getType());
         } catch (Exception e) {
-            fail("invalid resp body: " + body);
+            fail(e.getMessage() + ", resp: " + body);
             throw new IllegalStateException(e);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TableSchemaActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TableSchemaActionTest.java
@@ -14,10 +14,15 @@
 
 package com.starrocks.http.rest.v2;
 
+import com.google.common.collect.Lists;
 import com.google.gson.Gson;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 import com.starrocks.analysis.StringLiteral;
-import com.starrocks.catalog.AggregateType;
+import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
@@ -25,11 +30,14 @@ import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.MapType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.StructField;
+import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableIndexes;
 import com.starrocks.catalog.TableProperty;
@@ -41,13 +49,13 @@ import com.starrocks.http.rest.v2.vo.IndexView;
 import com.starrocks.http.rest.v2.vo.MaterializedIndexMetaView;
 import com.starrocks.http.rest.v2.vo.PartitionInfoView;
 import com.starrocks.http.rest.v2.vo.TableSchemaView;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.IndexDef;
 import com.starrocks.thrift.TStorageType;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.assertj.core.util.Lists;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -72,6 +80,27 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
 
     private static final Long TB_GET_TABLE_SCHEMA_ID = testTableId + 10000L;
     private static final String TB_GET_TABLE_SCHEMA_NAME = "tb_table_schema_test";
+
+    private static final Gson GSON = GsonUtils.GSON.newBuilder()
+            .registerTypeAdapter(ColumnView.TypeView.class,
+                    (JsonDeserializer<ColumnView.TypeView>) (json, typeOf, context) -> {
+                        JsonObject jsonObj = json.getAsJsonObject();
+                        JsonElement nameElement = jsonObj.get("name");
+                        if (nameElement == null) {
+                            throw new JsonParseException("Missing 'name' field in JSON.");
+                        }
+
+                        String typeName = nameElement.getAsString();
+                        if (ColumnView.ArrayTypeView.TYPE_NAME.equalsIgnoreCase(typeName)) {
+                            return context.deserialize(json, ColumnView.ArrayTypeView.class);
+                        } else if (ColumnView.StructTypeView.TYPE_NAME.equalsIgnoreCase(typeName)) {
+                            return context.deserialize(json, ColumnView.StructTypeView.class);
+                        } else if (ColumnView.MapTypeView.TYPE_NAME.equalsIgnoreCase(typeName)) {
+                            return context.deserialize(json, ColumnView.MapTypeView.class);
+                        } else {
+                            return context.deserialize(json, ColumnView.ScalarTypeView.class);
+                        }
+                    }).create();
 
     @Override
     protected void doSetUp() {
@@ -104,15 +133,16 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
             assertTrue(tableSchema.getCreateTime() > 0L);
 
             List<ColumnView> columns = tableSchema.getColumns();
-            assertEquals(2, columns.size());
+            assertEquals(8, columns.size());
             {
                 ColumnView column = columns.get(0);
                 assertEquals("c1", column.getName());
-                assertEquals(PrimitiveType.DOUBLE.toString(), column.getPrimitiveType());
-                assertEquals(8, column.getPrimitiveTypeSize().intValue());
-                assertEquals(Type.DOUBLE.getColumnSize(), column.getColumnSize());
-                assertEquals(0, column.getPrecision().intValue());
-                assertEquals(0, column.getScale().intValue());
+                ColumnView.ScalarTypeView colType = (ColumnView.ScalarTypeView) column.getType();
+                assertEquals(PrimitiveType.DOUBLE.name(), colType.getName());
+                assertEquals(Type.DOUBLE.getTypeSize(), colType.getTypeSize().intValue());
+                assertEquals(Type.DOUBLE.getColumnSize(), colType.getColumnSize());
+                assertEquals(0, colType.getPrecision().intValue());
+                assertEquals(0, colType.getScale().intValue());
                 assertNull(column.getAggregationType());
                 assertTrue(column.getKey());
                 assertFalse(column.getAllowNull());
@@ -127,12 +157,13 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
             {
                 ColumnView column = columns.get(1);
                 assertEquals("c2", column.getName());
-                assertEquals(PrimitiveType.DECIMAL64.toString(), column.getPrimitiveType());
-                assertEquals(8, column.getPrimitiveTypeSize().intValue());
-                assertEquals(Type.DEFAULT_DECIMAL64.getColumnSize(), column.getColumnSize());
-                assertEquals(18, column.getPrecision().intValue());
-                assertEquals(6, column.getScale().intValue());
-                assertEquals(AggregateType.SUM.toSql(), column.getAggregationType());
+                ColumnView.ScalarTypeView colType = (ColumnView.ScalarTypeView) column.getType();
+                assertEquals(PrimitiveType.DECIMAL64.name(), colType.getName());
+                assertEquals(Type.DEFAULT_DECIMAL64.getTypeSize(), colType.getTypeSize().intValue());
+                assertEquals(Type.DEFAULT_DECIMAL64.getColumnSize(), colType.getColumnSize());
+                assertEquals(Type.DEFAULT_DECIMAL64.getPrecision(), colType.getPrecision());
+                assertEquals(Type.DEFAULT_DECIMAL64.getScalarScale(), colType.getScale().intValue());
+                assertNull(column.getAggregationType());
                 assertFalse(column.getKey());
                 assertTrue(column.getAllowNull());
                 assertFalse(column.getAutoIncrement());
@@ -141,6 +172,202 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
                 assertNull(column.getDefaultExpr());
                 assertEquals("cc2", column.getComment());
                 assertEquals(2, column.getUniqueId().intValue());
+            }
+
+            {
+                ColumnView column = columns.get(2);
+                assertEquals("c3", column.getName());
+
+                ColumnView.ArrayTypeView colType = (ColumnView.ArrayTypeView) column.getType();
+                assertEquals(ColumnView.ArrayTypeView.TYPE_NAME, colType.getName());
+                {
+                    ColumnView.ScalarTypeView itemType = (ColumnView.ScalarTypeView) colType.getItemType();
+                    assertEquals(PrimitiveType.INT.name(), itemType.getName());
+                    assertEquals(Type.INT.getTypeSize(), itemType.getTypeSize().intValue());
+                    assertEquals(Type.INT.getColumnSize(), itemType.getColumnSize());
+                    assertEquals(0, itemType.getPrecision().intValue());
+                    assertEquals(0, itemType.getScale().intValue());
+                }
+
+                assertNull(column.getAggregationType());
+                assertFalse(column.getKey());
+                assertTrue(column.getAllowNull());
+                assertFalse(column.getAutoIncrement());
+                assertNull(column.getDefaultValue());
+                assertEquals("NULL", column.getDefaultValueType());
+                assertNull(column.getDefaultExpr());
+                assertEquals("cc3", column.getComment());
+                assertEquals(3, column.getUniqueId().intValue());
+            }
+
+            {
+                ColumnView column = columns.get(3);
+                assertEquals("c4", column.getName());
+
+                ColumnView.StructTypeView colType = (ColumnView.StructTypeView) column.getType();
+                assertEquals(ColumnView.StructTypeView.TYPE_NAME, colType.getName());
+                {
+                    List<ColumnView.StructTypeView.FieldView> structFields = colType.getFields();
+                    assertEquals(2, structFields.size());
+
+                    {
+                        ColumnView.StructTypeView.FieldView field = structFields.get(0);
+                        assertEquals("c4_a", field.getName());
+                        ColumnView.ArrayTypeView fieldType = (ColumnView.ArrayTypeView) field.getType();
+                        assertEquals(ColumnView.ArrayTypeView.TYPE_NAME, fieldType.getName());
+
+                        ColumnView.ScalarTypeView fieldItemType = (ColumnView.ScalarTypeView) fieldType.getItemType();
+                        assertEquals(PrimitiveType.INT.name(), fieldItemType.getName());
+                        assertEquals(Type.INT.getTypeSize(), fieldItemType.getTypeSize().intValue());
+                        assertEquals(Type.INT.getColumnSize(), fieldItemType.getColumnSize());
+                        assertEquals(0, fieldItemType.getPrecision().intValue());
+                        assertEquals(0, fieldItemType.getScale().intValue());
+                    }
+
+                    {
+                        ColumnView.StructTypeView.FieldView field = structFields.get(1);
+                        assertEquals("c4_b", field.getName());
+                        ColumnView.StructTypeView fieldType = (ColumnView.StructTypeView) field.getType();
+                        assertEquals(ColumnView.StructTypeView.TYPE_NAME, fieldType.getName());
+
+                        List<ColumnView.StructTypeView.FieldView> subStructFields = fieldType.getFields();
+                        assertEquals(1, subStructFields.size());
+
+                        {
+                            ColumnView.StructTypeView.FieldView subField = subStructFields.get(0);
+                            assertEquals("c4_b_1", subField.getName());
+                            ColumnView.ScalarTypeView subFieldType = (ColumnView.ScalarTypeView) subField.getType();
+                            assertEquals(PrimitiveType.VARCHAR.name(), subFieldType.getName());
+                            assertEquals(Type.VARCHAR.getTypeSize(), subFieldType.getTypeSize().intValue());
+                            assertEquals(Type.VARCHAR.getColumnSize(), subFieldType.getColumnSize());
+                            assertEquals(0, subFieldType.getPrecision().intValue());
+                            assertEquals(0, subFieldType.getScale().intValue());
+                        }
+
+                    }
+                }
+
+                assertNull(column.getAggregationType());
+                assertFalse(column.getKey());
+                assertTrue(column.getAllowNull());
+                assertFalse(column.getAutoIncrement());
+                assertNull(column.getDefaultValue());
+                assertEquals("NULL", column.getDefaultValueType());
+                assertNull(column.getDefaultExpr());
+                assertEquals("cc4", column.getComment());
+                assertEquals(4, column.getUniqueId().intValue());
+            }
+
+            {
+                ColumnView column = columns.get(4);
+                assertEquals("c5", column.getName());
+
+                ColumnView.MapTypeView colType = (ColumnView.MapTypeView) column.getType();
+                assertEquals(ColumnView.MapTypeView.TYPE_NAME, colType.getName());
+
+                {
+                    ColumnView.ScalarTypeView keyType = (ColumnView.ScalarTypeView) colType.getKeyType();
+                    assertEquals(PrimitiveType.BIGINT.name(), keyType.getName());
+                    assertEquals(Type.BIGINT.getTypeSize(), keyType.getTypeSize().intValue());
+                    assertEquals(Type.BIGINT.getColumnSize(), keyType.getColumnSize());
+                    assertEquals(0, keyType.getPrecision().intValue());
+                    assertEquals(0, keyType.getScale().intValue());
+                }
+
+                {
+                    ColumnView.MapTypeView valueType = (ColumnView.MapTypeView) colType.getValueType();
+                    assertEquals(ColumnView.MapTypeView.TYPE_NAME, valueType.getName());
+
+                    ColumnView.ScalarTypeView valKeyType = (ColumnView.ScalarTypeView) valueType.getKeyType();
+                    assertEquals(PrimitiveType.INT.name(), valKeyType.getName());
+                    assertEquals(Type.INT.getTypeSize(), valKeyType.getTypeSize().intValue());
+                    assertEquals(Type.INT.getColumnSize(), valKeyType.getColumnSize());
+                    assertEquals(0, valKeyType.getPrecision().intValue());
+                    assertEquals(0, valKeyType.getScale().intValue());
+
+                    ColumnView.ScalarTypeView valValueType = (ColumnView.ScalarTypeView) valueType.getValueType();
+                    assertEquals(PrimitiveType.VARCHAR.name(), valValueType.getName());
+                    assertEquals(Type.VARCHAR.getTypeSize(), valValueType.getTypeSize().intValue());
+                    assertEquals(Type.VARCHAR.getColumnSize(), valValueType.getColumnSize());
+                    assertEquals(0, valValueType.getPrecision().intValue());
+                    assertEquals(0, valValueType.getScale().intValue());
+                }
+
+                assertNull(column.getAggregationType());
+                assertFalse(column.getKey());
+                assertFalse(column.getAllowNull());
+                assertFalse(column.getAutoIncrement());
+                assertNull(column.getDefaultValue());
+                assertEquals("NULL", column.getDefaultValueType());
+                assertNull(column.getDefaultExpr());
+                assertEquals("cc5", column.getComment());
+                assertEquals(5, column.getUniqueId().intValue());
+            }
+
+            {
+                ColumnView column = columns.get(5);
+                assertEquals("c6", column.getName());
+
+                ColumnView.ScalarTypeView colType = (ColumnView.ScalarTypeView) column.getType();
+                assertEquals(PrimitiveType.JSON.name(), colType.getName());
+                assertEquals(Type.JSON.getTypeSize(), colType.getTypeSize().intValue());
+                assertEquals(Type.JSON.getColumnSize(), colType.getColumnSize());
+                assertEquals(0, colType.getPrecision().intValue());
+                assertEquals(0, colType.getScale().intValue());
+
+                assertNull(column.getAggregationType());
+                assertFalse(column.getKey());
+                assertFalse(column.getAllowNull());
+                assertFalse(column.getAutoIncrement());
+                assertNull(column.getDefaultValue());
+                assertEquals("NULL", column.getDefaultValueType());
+                assertNull(column.getDefaultExpr());
+                assertEquals("cc6", column.getComment());
+                assertEquals(6, column.getUniqueId().intValue());
+            }
+
+            {
+                ColumnView column = columns.get(6);
+                assertEquals("c7", column.getName());
+
+                ColumnView.ScalarTypeView colType = (ColumnView.ScalarTypeView) column.getType();
+                assertEquals(PrimitiveType.BITMAP.name(), colType.getName());
+                assertEquals(Type.BITMAP.getTypeSize(), colType.getTypeSize().intValue());
+                assertEquals(Type.BITMAP.getColumnSize(), colType.getColumnSize());
+                assertEquals(0, colType.getPrecision().intValue());
+                assertEquals(0, colType.getScale().intValue());
+
+                assertNull(column.getAggregationType());
+                assertFalse(column.getKey());
+                assertFalse(column.getAllowNull());
+                assertFalse(column.getAutoIncrement());
+                assertNull(column.getDefaultValue());
+                assertEquals("NULL", column.getDefaultValueType());
+                assertNull(column.getDefaultExpr());
+                assertEquals("cc7", column.getComment());
+                assertEquals(7, column.getUniqueId().intValue());
+            }
+
+            {
+                ColumnView column = columns.get(7);
+                assertEquals("c8", column.getName());
+
+                ColumnView.ScalarTypeView colType = (ColumnView.ScalarTypeView) column.getType();
+                assertEquals(PrimitiveType.HLL.name(), colType.getName());
+                assertEquals(Type.HLL.getTypeSize(), colType.getTypeSize().intValue());
+                assertEquals(Type.HLL.getColumnSize(), colType.getColumnSize());
+                assertEquals(0, colType.getPrecision().intValue());
+                assertEquals(0, colType.getScale().intValue());
+
+                assertNull(column.getAggregationType());
+                assertFalse(column.getKey());
+                assertFalse(column.getAllowNull());
+                assertFalse(column.getAutoIncrement());
+                assertNull(column.getDefaultValue());
+                assertEquals("NULL", column.getDefaultValueType());
+                assertNull(column.getDefaultExpr());
+                assertEquals("cc8", column.getComment());
+                assertEquals(8, column.getUniqueId().intValue());
             }
 
             List<MaterializedIndexMetaView> indexMetas = tableSchema.getIndexMetas();
@@ -177,7 +404,7 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
                 assertEquals("idx1", idx.getIndexName());
                 assertEquals(IndexDef.IndexType.BITMAP.getDisplayName(), idx.getIndexType());
                 assertEquals(1, idx.getColumns().size());
-                assertEquals(ColumnId.create("c1"), idx.getColumns().get(0));
+                assertEquals("c1", idx.getColumns().get(0).getId());
                 assertEquals("c_idx1", idx.getComment());
                 assertTrue(idx.getProperties().isEmpty());
             }
@@ -188,7 +415,7 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
                 assertEquals("idx2", idx.getIndexName());
                 assertEquals(IndexDef.IndexType.NGRAMBF.getDisplayName(), idx.getIndexType());
                 assertEquals(1, idx.getColumns().size());
-                assertEquals(ColumnId.create("c2"), idx.getColumns().get(0));
+                assertEquals("c2", idx.getColumns().get(0).getId());
                 assertEquals("c_idx2", idx.getComment());
                 assertTrue(idx.getProperties().isEmpty());
             }
@@ -208,9 +435,20 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
         GlobalStateMgr.getCurrentState().getTabletInvertedIndex().clear();
 
         Column c1 = new Column("c1", Type.DOUBLE, true, null, null, false, null, "cc1", 1);
-        Column c2 = new Column("c2", Type.DEFAULT_DECIMAL64, false, AggregateType.SUM, null, true,
+        Column c2 = new Column("c2", Type.DEFAULT_DECIMAL64, false, null, null, true,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "cc2", 2);
-        List<Column> columns = Lists.newArrayList(c1, c2);
+        Column c3 = new Column("c3", new ArrayType(Type.INT), false, null, null, true, null, "cc3", 3);
+        Column c4 = new Column("c4", new StructType(
+                Lists.newArrayList(
+                        new StructField("c4_a", new ArrayType(Type.INT)),
+                        new StructField("c4_b", new StructType(Lists.newArrayList(new StructField("c4_b_1", Type.VARCHAR))))
+                )), false, null, null, true, null, "cc4", 4);
+        Column c5 = new Column("c5", new MapType(Type.BIGINT,
+                new MapType(Type.INT, Type.VARCHAR)), false, null, null, false, null, "cc5", 5);
+        Column c6 = new Column("c6", Type.JSON, false, null, null, false, null, "cc6", 6);
+        Column c7 = new Column("c7", Type.BITMAP, false, null, null, false, null, "cc7", 7);
+        Column c8 = new Column("c8", Type.HLL, false, null, null, false, null, "cc8", 8);
+        List<Column> columns = Lists.newArrayList(c1, c2, c3, c4, c5, c6, c7, c8);
 
         PartitionInfo partitionInfo = new RangePartitionInfo(
                 Lists.newArrayList(c1)
@@ -264,13 +502,11 @@ public class TableSchemaActionTest extends StarRocksHttpTestCase {
 
     private static RestBaseResultV2<TableSchemaView> parseResponseBody(String body) {
         try {
-            System.out.println("resp: " + body);
-            Gson gson = new Gson();
-            return gson.fromJson(body, new TypeToken<RestBaseResultV2<TableSchemaView>>() {
+            return GSON.fromJson(body, new TypeToken<RestBaseResultV2<TableSchemaView>>() {
             }.getType());
         } catch (Exception e) {
-            fail("invalid resp body: " + body);
-            throw new IllegalStateException(e);
+            fail(e.getMessage() + ", resp: " + body);
+            throw new IllegalStateException(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

You can learn about the background from PR [#38466](https://github.com/StarRocks/starrocks/pull/38466).

## What I'm doing:

This PR is a supplement to [#41938](https://github.com/StarRocks/starrocks/pull/41938). In `#41938`, we implemented the V2 version of the REST interface for getting `OlapTable` schema info. However, this interface currently only returns type information of scalar type columns. Therefore, this PR improves it and adds support for complex data types such as `ARRAY/STRUCT/MAP`.

For example, for a column with the following data type:

```sql
MAP<BIGINT, STRUCT<name STRING, age INT, hobbies ARRAY<STRING>>>
```

The `JSON` format data returned by calling the V2 interface is as follows:

```json
{
  "name": "MAP",
  "keyType": {
    "name": "BIGINT",
    "typeSize": 8,
    "columnSize": 19,
    "precision": 0,
    "scale": 0
  },
  "valueType": {
    "name": "STRUCT",
    "fields": [
      {
        "name": "name",
        "type": {
          "name": "VARCHAR",
          "typeSize": 16,
          "columnSize": 65533,
          "precision": 0,
          "scale": 0
        }
      },
      {
        "name": "age",
        "type": {
          "name": "INT",
          "typeSize": 4,
          "columnSize": 10,
          "precision": 0,
          "scale": 0
        }
      },
      {
        "name": "hobbies",
        "type": {
          "name": "ARRAY",
          "itemType": {
            "name": "VARCHAR",
            "typeSize": 16,
            "columnSize": 65533,
            "precision": 0,
            "scale": 0
          }
        }
      }
    ]
  }
}
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
