### PR TITLE
[BugFix] Do not abort ingestion txn due to preload rowset failed

### DIFF
--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -571,7 +571,7 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
     // and we can still commit the txn.
     if (st.is_mem_limit_exceeded()) {
         return Status::OK();
-    }       
+    }
     return st;
 }
 

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -566,6 +566,12 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
 
     VLOG(1) << "UpdateManager::on_rowset_finished finish tablet:" << tablet->tablet_id()
             << " rowset:" << rowset_unique_id;
+
+    // if failed due to memory limit which is not a critical issue. we don't need to abort the ingestion
+    // and we can still commit the txn.
+    if (st.is_mem_limit_exceeded()) {
+        return Status::OK();
+    }       
     return st;
 }
 

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -27,6 +27,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_meta_manager.h"
+#include "util/failpoint/fail_point.h"
 #include "util/pretty_printer.h"
 #include "util/starrocks_metrics.h"
 #include "util/time.h"
@@ -498,6 +499,7 @@ Status UpdateManager::set_cached_del_vec(const TabletSegmentId& tsid, const DelV
     return Status::OK();
 }
 
+DEFINE_FAIL_POINT(on_rowset_finished_failed_due_to_mem);
 Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
     SCOPED_THREAD_LOCAL_MEM_SETTER(GlobalEnv::GetInstance()->process_mem_tracker(), config::enable_pk_strict_memcheck);
     SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(config::enable_pk_strict_memcheck ? mem_tracker() : nullptr);
@@ -567,6 +569,8 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
     VLOG(1) << "UpdateManager::on_rowset_finished finish tablet:" << tablet->tablet_id()
             << " rowset:" << rowset_unique_id;
 
+    FAIL_POINT_TRIGGER_EXECUTE(on_rowset_finished_failed_due_to_mem,
+                               { st = Status::MemoryLimitExceeded("on_rowset_finished failed"); });
     // if failed due to memory limit which is not a critical issue. we don't need to abort the ingestion
     // and we can still commit the txn.
     if (st.is_mem_limit_exceeded()) {


### PR DESCRIPTION
## Why I'm doing:
The ingestion task will failed if we preload rowset failed during commit txn. However, if the failed reason is exceed memory limit which is not a critical issue, we don't need to abort the transaction.

## What I'm doing:
return success if preload rowset failed due to memory limit.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
