### PR TITLE
[BugFix] MaxBy/MinBy not filter nulls (backport #51354)

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -390,7 +390,8 @@ Status Aggregator::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile
 
             // Because max_by and min_by function have two input types,
             // so we use its second arguments type as input.
-            if (fn.name.function_name == "max_by" || fn.name.function_name == "min_by") {
+            if (fn.name.function_name == "max_by" || fn.name.function_name == "min_by" ||
+                fn.name.function_name == "max_by_v2" || fn.name.function_name == "min_by_v2") {
                 arg_type = TypeDescriptor::from_thrift(fn.arg_types[1]);
             }
 

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -213,7 +213,13 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
                 real_fn_name += "_in";
                 _need_partition_materializing = true;
             }
-            func = get_window_function(real_fn_name, arg_type.type, return_type.type, is_input_nullable, fn.binary_type,
+            const auto& fname = fn.name.function_name;
+            auto real_arg_type = arg_type.type;
+            if (fname == "max_by" || fname == "min_by" || fname == "max_by_v2" || fname == "min_by_v2") {
+                const TypeDescriptor arg1_type = TypeDescriptor::from_thrift(fn.arg_types[1]);
+                real_arg_type = arg1_type.type;
+            }
+            func = get_window_function(real_fn_name, real_arg_type, return_type.type, is_input_nullable, fn.binary_type,
                                        state->func_version());
             if (func == nullptr) {
                 return Status::InternalError(strings::Substitute(

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -122,10 +122,10 @@ public:
     template <LogicalType LT>
     static auto MakeMaxAggregateFunction();
 
-    template <LogicalType LT>
+    template <LogicalType LT, bool not_filter_nulls>
     static auto MakeMaxByAggregateFunction();
 
-    template <LogicalType LT>
+    template <LogicalType LT, bool not_filter_nulls>
     static auto MakeMinByAggregateFunction();
 
     template <LogicalType LT>
@@ -290,16 +290,16 @@ auto AggregateFactory::MakeMaxAggregateFunction() {
     return std::make_shared<MaxMinAggregateFunction<LT, MaxAggregateData<LT>, MaxElement<LT, MaxAggregateData<LT>>>>();
 }
 
-template <LogicalType LT>
+template <LogicalType LT, bool not_filter_nulls>
 auto AggregateFactory::MakeMaxByAggregateFunction() {
-    return std::make_shared<
-            MaxMinByAggregateFunction<LT, MaxByAggregateData<LT>, MaxByElement<LT, MaxByAggregateData<LT>>>>();
+    using AggData = MaxByAggregateData<LT, not_filter_nulls>;
+    return std::make_shared<MaxMinByAggregateFunction<LT, AggData, MaxByElement<LT, AggData>>>();
 }
 
-template <LogicalType LT>
+template <LogicalType LT, bool not_filter_nulls>
 auto AggregateFactory::MakeMinByAggregateFunction() {
-    return std::make_shared<
-            MaxMinByAggregateFunction<LT, MinByAggregateData<LT>, MinByElement<LT, MinByAggregateData<LT>>>>();
+    using AggData = MinByAggregateData<LT, not_filter_nulls>;
+    return std::make_shared<MaxMinByAggregateFunction<LT, AggData, MinByElement<LT, AggData>>>();
 }
 
 template <LogicalType LT>

--- a/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
@@ -75,11 +75,15 @@ struct MaxMinByDispatcherInner {
         if constexpr ((lt_is_aggregate<arg_type> || lt_is_json<arg_type>)&&(lt_is_aggregate<ret_type> ||
                                                                             lt_is_json<ret_type>)) {
             if constexpr (is_max_by) {
-                resolver->add_aggregate_mapping_variadic<arg_type, ret_type, MaxByAggregateData<arg_type>>(
-                        "max_by", true, AggregateFactory::MakeMaxByAggregateFunction<arg_type>());
+                resolver->add_aggregate_mapping_notnull<arg_type, ret_type>(
+                        "max_by", true, AggregateFactory::MakeMaxByAggregateFunction<arg_type, false>());
+                resolver->add_aggregate_mapping_notnull<arg_type, ret_type>(
+                        "max_by_v2", true, AggregateFactory::MakeMaxByAggregateFunction<arg_type, true>());
             } else {
-                resolver->add_aggregate_mapping_variadic<arg_type, ret_type, MinByAggregateData<arg_type>>(
-                        "min_by", true, AggregateFactory::MakeMinByAggregateFunction<arg_type>());
+                resolver->add_aggregate_mapping_notnull<arg_type, ret_type>(
+                        "min_by", true, AggregateFactory::MakeMinByAggregateFunction<arg_type, false>());
+                resolver->add_aggregate_mapping_notnull<arg_type, ret_type>(
+                        "min_by_v2", true, AggregateFactory::MakeMinByAggregateFunction<arg_type, true>());
             }
         }
     }

--- a/be/src/exprs/agg/maxmin_by.h
+++ b/be/src/exprs/agg/maxmin_by.h
@@ -27,33 +27,37 @@
 
 namespace starrocks {
 
-template <LogicalType LT, typename = guard::Guard>
+template <LogicalType LT, bool not_filter_nulls, typename = guard::Guard>
 struct MaxByAggregateData {};
 
-template <LogicalType LT>
-struct MaxByAggregateData<LT, AggregateComplexLTGuard<LT>> {
+template <LogicalType LT, bool not_filter_nulls>
+struct MaxByAggregateData<LT, not_filter_nulls, AggregateComplexLTGuard<LT>> {
+    static constexpr auto not_filter_nulls_flag = not_filter_nulls;
     using T = AggDataValueType<LT>;
     raw::RawVector<uint8_t> buffer_result;
     T value = RunTimeTypeLimits<LT>::min_value();
-
+    bool null_result = true;
     void reset() {
         buffer_result.clear();
         value = RunTimeTypeLimits<LT>::min_value();
+        null_result = true;
     }
 };
 
-template <LogicalType LT, typename = guard::Guard>
+template <LogicalType LT, bool not_filter_nulls, typename = guard::Guard>
 struct MinByAggregateData {};
 
-template <LogicalType LT>
-struct MinByAggregateData<LT, AggregateComplexLTGuard<LT>> {
+template <LogicalType LT, bool not_filter_nulls>
+struct MinByAggregateData<LT, not_filter_nulls, AggregateComplexLTGuard<LT>> {
+    static constexpr auto not_filter_nulls_flag = not_filter_nulls;
     using T = AggDataValueType<LT>;
     raw::RawVector<uint8_t> buffer_result;
     T value = RunTimeTypeLimits<LT>::max_value();
-
+    bool null_result = true;
     void reset() {
         buffer_result.clear();
         value = RunTimeTypeLimits<LT>::max_value();
+        null_result = true;
     }
 };
 
@@ -62,16 +66,40 @@ struct MaxByElement {
     using T = RunTimeCppType<LT>;
     void operator()(State& state, Column* col, size_t row_num, const T& right) const {
         if (right > state.value) {
-            state.value = right;
-            state.buffer_result.resize(col->serialize_size(row_num));
-            col->serialize(row_num, state.buffer_result.data());
+            bool is_null = col->only_null() || col->is_null(row_num);
+            if (is_null) {
+                if constexpr (State::not_filter_nulls_flag) {
+                    state.value = right;
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                }
+            } else {
+                state.value = right;
+                auto* data_col = ColumnHelper::get_data_column(col);
+                state.buffer_result.resize(data_col->serialize_size(row_num));
+                data_col->serialize(row_num, state.buffer_result.data());
+                state.null_result = false;
+            }
         }
     }
-    void operator()(State& state, const char* buffer, size_t size, const T& right) const {
-        if (right > state.value) {
-            state.value = right;
-            state.buffer_result.resize(size);
-            memcpy(state.buffer_result.data(), buffer, size);
+    void operator()(State& state, bool is_null, const char* buffer, size_t size, const T& right) const {
+        if (right >= state.value) {
+            if constexpr (State::not_filter_nulls_flag) {
+                state.value = right;
+                if (is_null) {
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                } else {
+                    state.buffer_result.resize(size);
+                    memcpy(state.buffer_result.data(), buffer, size);
+                    state.null_result = false;
+                }
+            } else {
+                state.value = right;
+                state.buffer_result.resize(size);
+                memcpy(state.buffer_result.data(), buffer, size);
+                state.null_result = false;
+            }
         }
     }
 };
@@ -81,17 +109,41 @@ struct MaxByElement<LT, State, JsonGuard<LT>> {
     using T = RunTimeCppType<LT>;
 
     void operator()(State& state, Column* col, size_t row_num, const T& right) const {
-        if (*right > state.value) {
-            AggDataTypeTraits<LT>::assign_value(state.value, right);
-            state.buffer_result.resize(col->serialize_size(row_num));
-            col->serialize(row_num, state.buffer_result.data());
+        if (*right >= state.value) {
+            bool is_null = col->only_null() || col->is_null(row_num);
+            if (is_null) {
+                if constexpr (State::not_filter_nulls_flag) {
+                    AggDataTypeTraits<LT>::assign_value(state.value, right);
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                }
+            } else {
+                auto* data_col = ColumnHelper::get_data_column(col);
+                AggDataTypeTraits<LT>::assign_value(state.value, right);
+                state.buffer_result.resize(data_col->serialize_size(row_num));
+                data_col->serialize(row_num, state.buffer_result.data());
+                state.null_result = false;
+            }
         }
     }
-    void operator()(State& state, const char* buffer, size_t size, const T& right) const {
-        if (*right > state.value) {
-            AggDataTypeTraits<LT>::assign_value(state.value, right);
-            state.buffer_result.resize(size);
-            memcpy(state.buffer_result.data(), buffer, size);
+    void operator()(State& state, bool is_null, const char* buffer, size_t size, const T& right) const {
+        if (*right >= state.value) {
+            if constexpr (State::not_filter_nulls_flag) {
+                AggDataTypeTraits<LT>::assign_value(state.value, right);
+                if (is_null) {
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                } else {
+                    state.buffer_result.resize(size);
+                    memcpy(state.buffer_result.data(), buffer, size);
+                    state.null_result = false;
+                }
+            } else {
+                AggDataTypeTraits<LT>::assign_value(state.value, right);
+                state.buffer_result.resize(size);
+                memcpy(state.buffer_result.data(), buffer, size);
+                state.null_result = false;
+            }
         }
     }
 };
@@ -100,17 +152,41 @@ template <LogicalType LT, typename State, typename = guard::Guard>
 struct MinByElement {
     using T = RunTimeCppType<LT>;
     void operator()(State& state, Column* col, size_t row_num, const T& right) const {
-        if (right < state.value) {
-            state.value = right;
-            state.buffer_result.resize(col->serialize_size(row_num));
-            col->serialize(row_num, state.buffer_result.data());
+        if (right <= state.value) {
+            auto is_null = col->only_null() || col->is_null(row_num);
+            if (is_null) {
+                if constexpr (State::not_filter_nulls_flag) {
+                    state.value = right;
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                }
+            } else {
+                auto* data_col = ColumnHelper::get_data_column(col);
+                state.value = right;
+                state.buffer_result.resize(data_col->serialize_size(row_num));
+                data_col->serialize(row_num, state.buffer_result.data());
+                state.null_result = false;
+            }
         }
     }
-    void operator()(State& state, const char* buffer, size_t size, const T& right) const {
-        if (right < state.value) {
-            state.value = right;
-            state.buffer_result.resize(size);
-            memcpy(state.buffer_result.data(), buffer, size);
+    void operator()(State& state, bool is_null, const char* buffer, size_t size, const T& right) const {
+        if (right <= state.value) {
+            if constexpr (State::not_filter_nulls_flag) {
+                state.value = right;
+                if (is_null) {
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                } else {
+                    state.buffer_result.resize(size);
+                    memcpy(state.buffer_result.data(), buffer, size);
+                    state.null_result = false;
+                }
+            } else {
+                state.value = right;
+                state.buffer_result.resize(size);
+                memcpy(state.buffer_result.data(), buffer, size);
+                state.null_result = false;
+            }
         }
     }
 };
@@ -120,46 +196,76 @@ struct MinByElement<LT, State, JsonGuard<LT>> {
     using T = RunTimeCppType<LT>;
 
     void operator()(State& state, Column* col, size_t row_num, const T& right) const {
-        if (*right < state.value) {
-            AggDataTypeTraits<LT>::assign_value(state.value, right);
-            state.buffer_result.resize(col->serialize_size(row_num));
-            col->serialize(row_num, state.buffer_result.data());
+        if (*right <= state.value) {
+            auto is_null = col->only_null() || col->is_null(row_num);
+            if (is_null) {
+                if constexpr (State::not_filter_nulls_flag) {
+                    AggDataTypeTraits<LT>::assign_value(state.value, right);
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                }
+            } else {
+                AggDataTypeTraits<LT>::assign_value(state.value, right);
+                auto* data_col = ColumnHelper::get_data_column(col);
+                state.buffer_result.resize(data_col->serialize_size(row_num));
+                data_col->serialize(row_num, state.buffer_result.data());
+                state.null_result = false;
+            }
         }
     }
-    void operator()(State& state, const char* buffer, size_t size, const T& right) const {
-        if (*right < state.value) {
-            AggDataTypeTraits<LT>::assign_value(state.value, right);
-            state.buffer_result.resize(size);
-            memcpy(state.buffer_result.data(), buffer, size);
+    void operator()(State& state, bool is_null, const char* buffer, size_t size, const T& right) const {
+        if (*right <= state.value) {
+            if constexpr (State::not_filter_nulls_flag) {
+                AggDataTypeTraits<LT>::assign_value(state.value, right);
+                if (is_null) {
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                } else {
+                    state.buffer_result.resize(size);
+                    memcpy(state.buffer_result.data(), buffer, size);
+                    state.null_result = false;
+                }
+            } else {
+                AggDataTypeTraits<LT>::assign_value(state.value, right);
+                state.buffer_result.resize(size);
+                memcpy(state.buffer_result.data(), buffer, size);
+                state.null_result = false;
+            }
         }
     }
 };
 
-template <LogicalType LT>
-struct MaxByAggregateData<LT, StringLTGuard<LT>> {
+template <LogicalType LT, bool not_filter_nulls>
+struct MaxByAggregateData<LT, not_filter_nulls, StringLTGuard<LT>> {
+    static constexpr auto not_filter_nulls_flag = not_filter_nulls;
     raw::RawVector<uint8_t> buffer_result;
     raw::RawVector<uint8_t> buffer;
     int32_t size = -1;
+    bool null_result = true;
     bool has_value() const { return size > -1; }
     Slice slice_max() const { return {buffer.data(), buffer.size()}; }
     void reset() {
         buffer_result.clear();
         buffer.clear();
         size = -1;
+        null_result = true;
     }
 };
 
-template <LogicalType LT>
-struct MinByAggregateData<LT, StringLTGuard<LT>> {
+template <LogicalType LT, bool not_filter_nulls>
+struct MinByAggregateData<LT, not_filter_nulls, StringLTGuard<LT>> {
+    static constexpr auto not_filter_nulls_flag = not_filter_nulls;
     raw::RawVector<uint8_t> buffer_result;
     raw::RawVector<uint8_t> buffer;
     int32_t size = -1;
+    bool null_result = true;
     bool has_value() const { return size > -1; }
     Slice slice_min() const { return {buffer.data(), buffer.size()}; }
     void reset() {
         buffer_result.clear();
         buffer.clear();
         size = -1;
+        null_result = true;
     }
 };
 
@@ -167,21 +273,46 @@ template <LogicalType LT, typename State>
 struct MaxByElement<LT, State, StringLTGuard<LT>> {
     void operator()(State& state, Column* col, size_t row_num, const Slice& right) const {
         if (!state.has_value() || state.slice_max().compare(right) < 0) {
-            state.buffer_result.resize(col->serialize_size(row_num));
-            col->serialize(row_num, state.buffer_result.data());
-            state.buffer.resize(right.size);
-            memcpy(state.buffer.data(), right.data, right.size);
-            state.size = right.size;
+            bool is_null = col->only_null() || col->is_null(row_num);
+            if (is_null) {
+                if constexpr (State::not_filter_nulls_flag) {
+                    state.buffer.resize(right.size);
+                    memcpy(state.buffer.data(), right.data, right.size);
+                    state.size = right.size;
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                }
+            } else {
+                auto* data_col = ColumnHelper::get_data_column(col);
+                state.buffer_result.resize(data_col->serialize_size(row_num));
+                data_col->serialize(row_num, state.buffer_result.data());
+                state.null_result = false;
+                state.buffer.resize(right.size);
+                memcpy(state.buffer.data(), right.data, right.size);
+                state.size = right.size;
+            }
         }
     }
 
-    void operator()(State& state, const char* buffer, size_t size, const Slice& right) const {
+    void operator()(State& state, bool is_null, const char* buffer, size_t size, const Slice& right) const {
         if (!state.has_value() || state.slice_max().compare(right) < 0) {
-            state.buffer_result.resize(size);
-            memcpy(state.buffer_result.data(), buffer, size);
             state.buffer.resize(right.size);
             memcpy(state.buffer.data(), right.data, right.size);
             state.size = right.size;
+            if constexpr (State::not_filter_nulls_flag) {
+                if (is_null) {
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                } else {
+                    state.buffer_result.resize(size);
+                    memcpy(state.buffer_result.data(), buffer, size);
+                    state.null_result = false;
+                }
+            } else {
+                state.buffer_result.resize(size);
+                memcpy(state.buffer_result.data(), buffer, size);
+                state.null_result = false;
+            }
         }
     }
 };
@@ -190,21 +321,46 @@ template <LogicalType LT, typename State>
 struct MinByElement<LT, State, StringLTGuard<LT>> {
     void operator()(State& state, Column* col, size_t row_num, const Slice& right) const {
         if (!state.has_value() || state.slice_min().compare(right) > 0) {
-            state.buffer_result.resize(col->serialize_size(row_num));
-            col->serialize(row_num, state.buffer_result.data());
-            state.buffer.resize(right.size);
-            memcpy(state.buffer.data(), right.data, right.size);
-            state.size = right.size;
+            bool is_null = col->only_null() || col->is_null(row_num);
+            if (is_null) {
+                if constexpr (State::not_filter_nulls_flag) {
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                    state.buffer.resize(right.size);
+                    memcpy(state.buffer.data(), right.data, right.size);
+                    state.size = right.size;
+                }
+            } else {
+                auto* data_col = ColumnHelper::get_data_column(col);
+                state.buffer_result.resize(data_col->serialize_size(row_num));
+                data_col->serialize(row_num, state.buffer_result.data());
+                state.null_result = false;
+                state.buffer.resize(right.size);
+                memcpy(state.buffer.data(), right.data, right.size);
+                state.size = right.size;
+            }
         }
     }
 
-    void operator()(State& state, const char* buffer, size_t size, const Slice& right) const {
+    void operator()(State& state, bool is_null, const char* buffer, size_t size, const Slice& right) const {
         if (!state.has_value() || state.slice_min().compare(right) > 0) {
-            state.buffer_result.resize(size);
-            memcpy(state.buffer_result.data(), buffer, size);
             state.buffer.resize(right.size);
             memcpy(state.buffer.data(), right.data, right.size);
             state.size = right.size;
+            if constexpr (State::not_filter_nulls_flag) {
+                if (is_null) {
+                    state.buffer_result.clear();
+                    state.null_result = true;
+                } else {
+                    state.buffer_result.resize(size);
+                    memcpy(state.buffer_result.data(), buffer, size);
+                    state.null_result = false;
+                }
+            } else {
+                state.buffer_result.resize(size);
+                memcpy(state.buffer_result.data(), buffer, size);
+                state.null_result = false;
+            }
         }
     }
 };
@@ -221,15 +377,12 @@ public:
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
-        T column1_value;
-        if (columns[1]->is_nullable()) {
-            if (columns[1]->is_null(row_num)) {
-                return;
-            }
-            column1_value = down_cast<const NullableColumn*>(columns[1])->data_column()->get(row_num).get<T>();
-        } else {
-            column1_value = down_cast<const InputColumnType*>(columns[1])->get_data()[row_num];
+        if (columns[1]->only_null() || columns[1]->is_null(row_num)) {
+            return;
         }
+
+        auto* data_col1 = ColumnHelper::get_data_column(columns[1]);
+        auto column1_value = down_cast<const InputColumnType*>(data_col1)->get_data()[row_num];
         OP()(this->data(state), (Column*)columns[0], row_num, column1_value);
     }
 
@@ -243,25 +396,36 @@ public:
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         Slice src;
-        if (column->is_nullable()) {
-            if (column->is_null(row_num)) {
-                return;
-            }
-            const auto* nullable_column = down_cast<const NullableColumn*>(column);
-            src = nullable_column->data_column()->get(row_num).get_slice();
-        } else {
-            const auto* binary_column = down_cast<const BinaryColumn*>(column);
-            src = binary_column->get_slice(row_num);
+        if (column->only_null() || column->is_null(row_num)) {
+            return;
         }
+        auto* data_column = ColumnHelper::get_data_column(column);
+        const auto* binary_column = down_cast<const BinaryColumn*>(data_column);
+        src = binary_column->get_slice(row_num);
 
         if constexpr (LT != TYPE_JSON) {
             T value;
-            memcpy(&value, src.data, sizeof(T));
-            OP()(this->data(state), src.data + sizeof(T), src.size - sizeof(T), value);
+            auto p = src.data;
+            memcpy(&value, p, sizeof(T));
+            p += sizeof(T);
+            bool null_result = false;
+            if constexpr (State::not_filter_nulls_flag) {
+                null_result = (*p == 1);
+                p += 1;
+            }
+            OP()(this->data(state), null_result, p, src.size - (p - src.data), value);
         } else {
+            // it seems wrong, FE has forbidden max_by(t, JSON)
             JsonValue value(src);
             size_t value_size = value.serialize_size();
-            OP()(this->data(state), src.data + value_size, src.size - value_size, &value);
+            auto* p = src.data;
+            p += value_size;
+            bool null_result = false;
+            if constexpr (State::not_filter_nulls_flag) {
+                null_result = (*p == 1);
+                p += 1;
+            }
+            OP()(this->data(state), null_result, src.data + value_size, src.size - (p - src.data), &value);
         }
     }
 
@@ -269,20 +433,38 @@ public:
         raw::RawVector<uint8_t> buffer;
         if constexpr (LT != TYPE_JSON) {
             size_t value_size = sizeof(T);
-            buffer.resize(this->data(state).buffer_result.size() + value_size);
-            memcpy(buffer.data(), &(this->data(state).value), value_size);
-            memcpy(buffer.data() + value_size, this->data(state).buffer_result.data(),
-                   this->data(state).buffer_result.size());
+            size_t buffer_size = this->data(state).buffer_result.size() + value_size;
+            if constexpr (State::not_filter_nulls_flag) {
+                buffer_size += 1;
+            }
+            buffer.resize(buffer_size);
+            auto* p = buffer.data();
+            memcpy(p, &(this->data(state).value), value_size);
+            p += value_size;
+            if constexpr (State::not_filter_nulls_flag) {
+                *p = (this->data(state).null_result ? 1 : 0);
+                p += 1;
+            }
+            memcpy(p, this->data(state).buffer_result.data(), this->data(state).buffer_result.size());
         } else {
             size_t value_size = this->data(state).value.serialize_size();
-            buffer.resize(this->data(state).buffer_result.size() + value_size);
-            this->data(state).value.serialize(buffer.data());
-            memcpy(buffer.data() + value_size, this->data(state).buffer_result.data(),
-                   this->data(state).buffer_result.size());
+            size_t buffer_size = this->data(state).buffer_result.size() + value_size;
+            if constexpr (State::not_filter_nulls_flag) {
+                buffer_size += 1;
+            }
+            buffer.resize(buffer_size);
+            auto* p = buffer.data();
+            this->data(state).value.serialize(p);
+            p += value_size;
+            if constexpr (State::not_filter_nulls_flag) {
+                *p = (this->data(state).null_result ? 1 : 0);
+                p += 1;
+            }
+            memcpy(p, this->data(state).buffer_result.data(), this->data(state).buffer_result.size());
         }
         if (to->is_nullable()) {
             auto* column = down_cast<NullableColumn*>(to);
-            if (this->data(state).buffer_result.size() == 0) {
+            if (this->data(state).buffer_result.size() == 0 && !State::not_filter_nulls_flag) {
                 column->append_default();
             } else {
                 down_cast<BinaryColumn*>(column->data_column().get())->append(Slice(buffer.data(), buffer.size()));
@@ -296,25 +478,24 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      ColumnPtr* dst) const override {
-        const InputColumnType* col_maxmin = nullptr;
-        if (src[1]->is_nullable()) {
-            const auto* nullable_column = down_cast<const NullableColumn*>(src[1].get());
-            col_maxmin = down_cast<const InputColumnType*>(nullable_column->data_column().get());
-        } else {
-            col_maxmin = down_cast<const InputColumnType*>(src[1].get());
+        if (src[1]->only_null()) {
+            DCHECK((*dst)->is_nullable());
+            (*dst)->append_default(chunk_size);
+            return;
         }
 
+        const auto* col_maxmin = down_cast<const InputColumnType*>(ColumnHelper::get_data_column(src[1].get()));
         BinaryColumn* result = nullptr;
         if ((*dst)->is_nullable()) {
             auto* dst_nullable_column = down_cast<NullableColumn*>((*dst).get());
             result = down_cast<BinaryColumn*>(dst_nullable_column->data_column().get());
 
-            if (src[1]->is_nullable())
+            if (src[1]->is_nullable()) {
                 dst_nullable_column->null_column_data() =
                         down_cast<const NullableColumn*>(src[1].get())->immutable_null_column_data();
-            else
+            } else {
                 dst_nullable_column->null_column_data().resize(chunk_size, 0);
-
+            }
         } else {
             result = down_cast<BinaryColumn*>((*dst).get());
         }
@@ -323,26 +504,62 @@ public:
         result->get_offset().resize(chunk_size + 1);
 
         size_t old_size = bytes.size();
+        size_t new_size = old_size;
         for (size_t i = 0; i < chunk_size; ++i) {
             if (src[1]->is_null(i)) {
-                auto* dst_nullable_column = down_cast<NullableColumn*>((*dst).get());
-                dst_nullable_column->set_has_null(true);
                 result->get_offset()[i + 1] = old_size;
+                DCHECK((*dst)->is_nullable());
+                down_cast<NullableColumn*>((*dst).get())->set_has_null(true);
             } else {
-                size_t serde_size = src[0]->serialize_size(i);
+                auto is_null = src[0]->only_null() || src[0]->is_null(i);
                 T value = col_maxmin->get_data()[i];
-                size_t new_size;
-                if constexpr (LT != TYPE_JSON) {
-                    new_size = old_size + sizeof(T) + serde_size;
-                    bytes.resize(new_size);
-                    memcpy(bytes.data() + old_size, &value, sizeof(T));
-                    src[0]->serialize(i, bytes.data() + old_size + sizeof(T));
+                if (is_null) {
+                    if constexpr (State::not_filter_nulls_flag) {
+                        new_size = old_size + sizeof(T) + 1;
+                        bytes.resize(new_size);
+                        auto* p = bytes.data() + old_size;
+                        memcpy(p, &value, sizeof(T));
+                        p += sizeof(T);
+                        *p = 1;
+                    } else {
+                        auto* dst_nullable_column = down_cast<NullableColumn*>((*dst).get());
+                        auto& dst_nulls = dst_nullable_column->null_column_data();
+                        dst_nulls[i] = DATUM_NULL;
+                        dst_nullable_column->set_has_null(true);
+                    }
                 } else {
-                    size_t value_size = value->serialize_size();
-                    new_size = old_size + value_size + serde_size;
-                    bytes.resize(new_size);
-                    value->serialize(bytes.data() + old_size);
-                    src[0]->serialize(i, bytes.data() + old_size + value_size);
+                    auto* data_column = ColumnHelper::get_data_column(src[0].get());
+                    size_t serde_size = data_column->serialize_size(i);
+                    if constexpr (LT != TYPE_JSON) {
+                        new_size = old_size + sizeof(T) + serde_size;
+                        if constexpr (State::not_filter_nulls_flag) {
+                            new_size += 1;
+                        }
+                        bytes.resize(new_size);
+                        auto* p = bytes.data() + old_size;
+                        memcpy(p, &value, sizeof(T));
+                        p += sizeof(T);
+                        if constexpr (State::not_filter_nulls_flag) {
+                            *p = 0;
+                            p += 1;
+                        }
+                        data_column->serialize(i, p);
+                    } else {
+                        size_t value_size = value->serialize_size();
+                        new_size = old_size + value_size + serde_size;
+                        if constexpr (State::not_filter_nulls_flag) {
+                            new_size += 1;
+                        }
+                        bytes.resize(new_size);
+                        auto* p = bytes.data() + old_size;
+                        value->serialize(p);
+                        p += value_size;
+                        if constexpr (State::not_filter_nulls_flag) {
+                            *p = 0;
+                            p += 1;
+                        }
+                        data_column->serialize(i, p);
+                    }
                 }
                 result->get_offset()[i + 1] = new_size;
                 old_size = new_size;
@@ -351,10 +568,26 @@ public:
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        if (this->data(state).buffer_result.empty())
-            to->append_default();
-        else
-            to->deserialize_and_append(this->data(state).buffer_result.data());
+        if constexpr (State::not_filter_nulls_flag) {
+            if (this->data(state).null_result) {
+                DCHECK(to->is_nullable());
+                to->append_default();
+            } else {
+                if (to->is_nullable()) {
+                    down_cast<NullableColumn*>(to)->null_column()->append(DATUM_NOT_NULL);
+                }
+                ColumnHelper::get_data_column(to)->deserialize_and_append(this->data(state).buffer_result.data());
+            }
+        } else {
+            if (this->data(state).buffer_result.empty()) {
+                to->append_default();
+            } else {
+                if (to->is_nullable()) {
+                    down_cast<NullableColumn*>(to)->null_column()->append(DATUM_NOT_NULL);
+                }
+                ColumnHelper::get_data_column(to)->deserialize_and_append(this->data(state).buffer_result.data());
+            }
+        }
     }
 
     std::string get_name() const override { return "maxmin_by"; }
@@ -370,15 +603,10 @@ public:
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {
-        Slice column1_value;
-        if (columns[1]->is_nullable()) {
-            if (columns[1]->is_null(row_num)) {
-                return;
-            }
-            column1_value = down_cast<const NullableColumn*>(columns[1])->data_column()->get(row_num).get_slice();
-        } else {
-            column1_value = columns[1]->get(row_num).get_slice();
+        if (columns[1]->only_null() || columns[1]->is_null(row_num)) {
+            return;
         }
+        Slice column1_value = ColumnHelper::get_data_column(columns[1])->get(row_num).get_slice();
         OP()(this->data(state), (Column*)columns[0], row_num, column1_value);
     }
 
@@ -391,28 +619,29 @@ public:
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        Slice src;
-        if (column->is_nullable()) {
-            if (column->is_null(row_num)) {
-                return;
-            }
-            const auto* nullable_column = down_cast<const NullableColumn*>(column);
-            src = nullable_column->data_column()->get(row_num).get_slice();
-        } else {
-            const auto* binary_column = down_cast<const BinaryColumn*>(column);
-            src = binary_column->get_slice(row_num);
+        if (column->only_null() || column->is_null(row_num)) {
+            return;
         }
+        auto* data_column = ColumnHelper::get_data_column(column);
+        const auto* binary_column = down_cast<const BinaryColumn*>(data_column);
+        Slice src = binary_column->get_slice(row_num);
 
-        size_t size;
-        const char* c = src.get_data();
-        memcpy(&size, c, sizeof(size_t));
-        if (size == -1) return;
-        c += sizeof(size_t);
-        Slice value(c, size);
-        c += size;
-        memcpy(&size, c, sizeof(size_t));
-        c += sizeof(size_t);
-        OP()(this->data(state), c, size, value);
+        size_t value_size;
+        const char* p = src.get_data();
+        memcpy(&value_size, p, sizeof(size_t));
+        if (value_size == -1) return;
+        p += sizeof(size_t);
+        Slice value(p, value_size);
+        p += value_size;
+        bool null_result = false;
+        if constexpr (State::not_filter_nulls_flag) {
+            null_result = (*p == 1);
+            p += 1;
+        }
+        size_t state_size;
+        memcpy(&state_size, p, sizeof(size_t));
+        p += sizeof(size_t);
+        OP()(this->data(state), null_result, p, state_size, value);
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
@@ -425,15 +654,23 @@ public:
             buffer.resize(sizeof(size_t));
             memcpy(buffer.data(), &temp, sizeof(size_t));
         } else {
-            buffer.resize(result_size + value_size + 2 * sizeof(size_t));
-            unsigned char* c = buffer.data();
-            memcpy(c, &value_size, sizeof(size_t));
-            c += sizeof(size_t);
-            memcpy(c, this->data(state).buffer.data(), value_size);
-            c += value_size;
-            memcpy(c, &result_size, sizeof(size_t));
-            c += sizeof(size_t);
-            memcpy(c, this->data(state).buffer_result.data(), result_size);
+            auto buffer_size = result_size + value_size + 2 * sizeof(size_t);
+            if constexpr (State::not_filter_nulls_flag) {
+                buffer_size += 1;
+            }
+            buffer.resize(buffer_size);
+            unsigned char* p = buffer.data();
+            memcpy(p, &value_size, sizeof(size_t));
+            p += sizeof(size_t);
+            memcpy(p, this->data(state).buffer.data(), value_size);
+            p += value_size;
+            if constexpr (State::not_filter_nulls_flag) {
+                *p = (this->data(state).null_result ? 1 : 0);
+                p += 1;
+            }
+            memcpy(p, &result_size, sizeof(size_t));
+            p += sizeof(size_t);
+            memcpy(p, this->data(state).buffer_result.data(), result_size);
         }
 
         if (to->is_nullable()) {
@@ -452,25 +689,24 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      ColumnPtr* dst) const override {
-        const BinaryColumn* col_maxmin = nullptr;
-        if (src[1]->is_nullable()) {
-            const auto* nullable_column = down_cast<const NullableColumn*>(src[1].get());
-            col_maxmin = down_cast<const BinaryColumn*>(nullable_column->data_column().get());
-        } else {
-            col_maxmin = down_cast<const BinaryColumn*>(src[1].get());
+        if (src[1]->only_null()) {
+            DCHECK((*dst)->is_nullable());
+            (*dst)->append_default(chunk_size);
+            return;
         }
+        const BinaryColumn* col_maxmin = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(src[1].get()));
 
         BinaryColumn* result = nullptr;
         if ((*dst)->is_nullable()) {
             auto* dst_nullable_column = down_cast<NullableColumn*>((*dst).get());
             result = down_cast<BinaryColumn*>(dst_nullable_column->data_column().get());
 
-            if (src[1]->is_nullable())
+            if (src[1]->is_nullable()) {
                 dst_nullable_column->null_column_data() =
                         down_cast<const NullableColumn*>(src[1].get())->immutable_null_column_data();
-            else
+            } else {
                 dst_nullable_column->null_column_data().resize(chunk_size, 0);
-
+            }
         } else {
             result = down_cast<BinaryColumn*>((*dst).get());
         }
@@ -485,19 +721,49 @@ public:
                 dst_nullable_column->set_has_null(true);
                 result->get_offset()[i + 1] = old_size;
             } else {
-                Slice value = col_maxmin->get(i).get_slice();
-                size_t value_size = value.size;
-                size_t serde_size = src[0]->serialize_size(i);
-                size_t new_size = old_size + 2 * sizeof(size_t) + value_size + serde_size;
-                bytes.resize(new_size);
-                unsigned char* c = bytes.data() + old_size;
-                memcpy(c, &value_size, sizeof(size_t));
-                c += sizeof(size_t);
-                memcpy(c, value.data, value_size);
-                c += value_size;
-                memcpy(c, &serde_size, sizeof(size_t));
-                c += sizeof(size_t);
-                src[0]->serialize(i, c);
+                size_t new_size = old_size;
+                auto is_null = src[0]->only_null() || src[0]->is_null(i);
+                if (is_null) {
+                    if constexpr (State::not_filter_nulls_flag) {
+                        Slice value = col_maxmin->get(i).get_slice();
+                        size_t value_size = value.size;
+                        new_size = old_size + sizeof(size_t) + value_size + 1;
+                        bytes.resize(new_size);
+                        auto* p = bytes.data() + old_size;
+                        memcpy(p, &value_size, sizeof(size_t));
+                        p += sizeof(size_t);
+                        memcpy(p, value.get_data(), value_size);
+                        p += value_size;
+                        *p = 1;
+                    } else {
+                        auto* dst_nullable_column = down_cast<NullableColumn*>((*dst).get());
+                        auto& dst_nulls = dst_nullable_column->null_column_data();
+                        dst_nulls[i] = DATUM_NULL;
+                        dst_nullable_column->set_has_null(true);
+                    }
+                } else {
+                    Slice value = col_maxmin->get(i).get_slice();
+                    size_t value_size = value.size;
+                    auto* data_column = ColumnHelper::get_data_column(src[0].get());
+                    size_t serde_size = data_column->serialize_size(i);
+                    new_size = old_size + 2 * sizeof(size_t) + value_size + serde_size;
+                    if constexpr (State::not_filter_nulls_flag) {
+                        new_size += 1;
+                    }
+                    bytes.resize(new_size);
+                    unsigned char* p = bytes.data() + old_size;
+                    memcpy(p, &value_size, sizeof(size_t));
+                    p += sizeof(size_t);
+                    memcpy(p, value.data, value_size);
+                    p += value_size;
+                    if constexpr (State::not_filter_nulls_flag) {
+                        *p = 0;
+                        p += 1;
+                    }
+                    memcpy(p, &serde_size, sizeof(size_t));
+                    p += sizeof(size_t);
+                    data_column->serialize(i, p);
+                }
                 result->get_offset()[i + 1] = new_size;
                 old_size = new_size;
             }
@@ -505,10 +771,26 @@ public:
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        if (this->data(state).buffer_result.empty())
-            to->append_default();
-        else
-            to->deserialize_and_append(this->data(state).buffer_result.data());
+        if constexpr (State::not_filter_nulls_flag) {
+            if (this->data(state).null_result) {
+                DCHECK(to->is_nullable());
+                to->append_default();
+            } else {
+                if (to->is_nullable()) {
+                    down_cast<NullableColumn*>(to)->null_column()->append(DATUM_NOT_NULL);
+                }
+                ColumnHelper::get_data_column(to)->deserialize_and_append(this->data(state).buffer_result.data());
+            }
+        } else {
+            if (this->data(state).buffer_result.empty()) {
+                to->append_default();
+            } else {
+                if (to->is_nullable()) {
+                    down_cast<NullableColumn*>(to)->null_column()->append(DATUM_NOT_NULL);
+                }
+                ColumnHelper::get_data_column(to)->deserialize_and_append(this->data(state).buffer_result.data());
+            }
+        }
     }
 
     std::string get_name() const override { return "maxmin_by"; }

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -653,8 +653,8 @@ TEST_F(AggregateTest, test_stddev_samp) {
     }
 }
 
-TEST_F(AggregateTest, test_maxby) {
-    const AggregateFunction* func = get_aggregate_function("max_by", TYPE_VARCHAR, TYPE_INT, false);
+void test_max_by_helper(FunctionContext* ctx, const char* max_by_name) {
+    const AggregateFunction* func = get_aggregate_function(max_by_name, TYPE_VARCHAR, TYPE_INT, false);
     auto result_column = Int32Column::create();
     auto aggr_state = ManagedAggrState::create(ctx, func);
     auto int_column = Int32Column::create();
@@ -677,7 +677,7 @@ TEST_F(AggregateTest, test_maxby) {
     ASSERT_EQ(2, result_column->get_data()[0]);
 
     //test nullable column
-    func = get_aggregate_function("max_by", TYPE_DECIMALV2, TYPE_DOUBLE, false);
+    func = get_aggregate_function(max_by_name, TYPE_DECIMALV2, TYPE_DOUBLE, false);
     aggr_state = ManagedAggrState::create(ctx, func);
     auto data_column1 = DoubleColumn::create();
     auto null_column1 = NullColumn::create();
@@ -709,8 +709,16 @@ TEST_F(AggregateTest, test_maxby) {
     ASSERT_EQ(98.11, nullable_result_column->data_column()->get(0).get<double>());
 }
 
-TEST_F(AggregateTest, test_minby) {
-    const AggregateFunction* func = get_aggregate_function("min_by", TYPE_VARCHAR, TYPE_INT, false);
+TEST_F(AggregateTest, test_max_by) {
+    test_max_by_helper(ctx, "max_by");
+}
+
+TEST_F(AggregateTest, test_max_by_v2) {
+    test_max_by_helper(ctx, "max_by_v2");
+}
+
+void test_min_by_helper(FunctionContext* ctx, const char* min_by_name) {
+    const AggregateFunction* func = get_aggregate_function(min_by_name, TYPE_VARCHAR, TYPE_INT, false);
     auto result_column = Int32Column::create();
     auto aggr_state = ManagedAggrState::create(ctx, func);
     auto int_column = Int32Column::create();
@@ -733,7 +741,7 @@ TEST_F(AggregateTest, test_minby) {
     ASSERT_EQ(1, result_column->get_data()[0]);
 
     //test nullable column
-    func = get_aggregate_function("min_by", TYPE_DECIMALV2, TYPE_DOUBLE, false);
+    func = get_aggregate_function(min_by_name, TYPE_DECIMALV2, TYPE_DOUBLE, false);
     aggr_state = ManagedAggrState::create(ctx, func);
     auto data_column1 = DoubleColumn::create();
     auto null_column1 = NullColumn::create();
@@ -765,8 +773,16 @@ TEST_F(AggregateTest, test_minby) {
     ASSERT_EQ(1.11, nullable_result_column->data_column()->get(0).get<double>());
 }
 
-TEST_F(AggregateTest, test_maxby_with_nullable_aggregator) {
-    const AggregateFunction* func = get_aggregate_function("max_by", TYPE_VARCHAR, TYPE_INT, true);
+TEST_F(AggregateTest, test_min_by) {
+    test_min_by_helper(ctx, "min_by");
+}
+
+TEST_F(AggregateTest, test_min_by_v2) {
+    test_min_by_helper(ctx, "min_by_v2");
+}
+
+void test_max_by_with_nullable_aggregator_helper(FunctionContext* ctx, const char* max_by_name) {
+    const AggregateFunction* func = get_aggregate_function(max_by_name, TYPE_VARCHAR, TYPE_INT, true);
     auto* ctx_with_args0 = FunctionContext::create_test_context(
             {FunctionContext::TypeDesc{.type = TYPE_INT}, FunctionContext::TypeDesc{.type = TYPE_VARCHAR}},
             FunctionContext::TypeDesc{.type = TYPE_INT});
@@ -794,7 +810,7 @@ TEST_F(AggregateTest, test_maxby_with_nullable_aggregator) {
     ASSERT_EQ(2, result_column->get_data()[0]);
 
     //test nullable column
-    func = get_aggregate_function("max_by", TYPE_DECIMALV2, TYPE_DOUBLE, true);
+    func = get_aggregate_function(max_by_name, TYPE_DECIMALV2, TYPE_DOUBLE, true);
     auto* ctx_with_args1 = FunctionContext::create_test_context(
             {FunctionContext::TypeDesc{.type = TYPE_DOUBLE},
              FunctionContext::TypeDesc{.type = TYPE_DECIMALV2, .precision = 38, .scale = 9}},
@@ -831,9 +847,15 @@ TEST_F(AggregateTest, test_maxby_with_nullable_aggregator) {
     func->finalize_to_column(ctx_with_args1, aggr_state->state(), nullable_result_column.get());
     ASSERT_EQ(98.11, nullable_result_column->data_column()->get(0).get<double>());
 }
+TEST_F(AggregateTest, test_max_by_with_nullable_aggregator) {
+    test_max_by_with_nullable_aggregator_helper(ctx, "max_by");
+}
+TEST_F(AggregateTest, test_max_by_v2_with_nullable_aggregator) {
+    test_max_by_with_nullable_aggregator_helper(ctx, "max_by_v2");
+}
 
-TEST_F(AggregateTest, test_minby_with_nullable_aggregator) {
-    const AggregateFunction* func = get_aggregate_function("min_by", TYPE_VARCHAR, TYPE_INT, true);
+void test_min_by_with_nullable_aggregator_helper(FunctionContext* ctx, const char* min_by_name) {
+    const AggregateFunction* func = get_aggregate_function(min_by_name, TYPE_VARCHAR, TYPE_INT, true);
     auto* ctx_with_args0 = FunctionContext::create_test_context(
             {FunctionContext::TypeDesc{.type = TYPE_INT}, FunctionContext::TypeDesc{.type = TYPE_VARCHAR}},
             FunctionContext::TypeDesc{.type = TYPE_INT});
@@ -861,7 +883,7 @@ TEST_F(AggregateTest, test_minby_with_nullable_aggregator) {
     ASSERT_EQ(1, result_column->get_data()[0]);
 
     //test nullable column
-    func = get_aggregate_function("min_by", TYPE_DECIMALV2, TYPE_DOUBLE, true);
+    func = get_aggregate_function(min_by_name, TYPE_DECIMALV2, TYPE_DOUBLE, true);
     auto* ctx_with_args1 = FunctionContext::create_test_context(
             {FunctionContext::TypeDesc{.type = TYPE_DOUBLE},
              FunctionContext::TypeDesc{.type = TYPE_DECIMALV2, .precision = 38, .scale = 9}},
@@ -899,6 +921,12 @@ TEST_F(AggregateTest, test_minby_with_nullable_aggregator) {
     ASSERT_EQ(1.11, nullable_result_column->data_column()->get(0).get<double>());
 }
 
+TEST_F(AggregateTest, test_min_by_with_nullable_aggregator) {
+    test_min_by_with_nullable_aggregator_helper(ctx, "min_by");
+}
+TEST_F(AggregateTest, test_min_by_v2_with_nullable_aggregator) {
+    test_min_by_with_nullable_aggregator_helper(ctx, "min_by_v2");
+}
 TEST_F(AggregateTest, test_max) {
     const AggregateFunction* func = get_aggregate_function("max", TYPE_SMALLINT, TYPE_SMALLINT, false);
     test_agg_function<int16_t, int16_t>(ctx, func, 1023, 2999, 2999);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionName.java
@@ -16,6 +16,7 @@ package com.starrocks.analysis;
 
 import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Function;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
@@ -129,7 +130,7 @@ public class FunctionName implements Writable {
     public TFunctionName toThrift() {
         TFunctionName name = new TFunctionName(fn_);
         name.setDb_name(db_);
-        name.setFunction_name(fn_);
+        name.setFunction_name(Function.rectifyFunctionName(fn_));
         return name;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -37,6 +37,7 @@ package com.starrocks.catalog;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.FunctionName;
@@ -52,6 +53,8 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.starrocks.common.io.IOUtils.writeOptionString;
 
@@ -522,6 +525,15 @@ public class Function implements Writable {
             // Neither has var args and the lengths don't match
             return false;
         }
+    }
+
+    private static final Map<String, String> ACTUAL_NAMES = ImmutableMap.<String, String>builder()
+            .put(FunctionSet.MAX_BY, FunctionSet.MAX_BY_V2)
+            .put(FunctionSet.MIN_BY, FunctionSet.MIN_BY_V2)
+            .build();
+
+    public static String rectifyFunctionName(String s) {
+        return Optional.ofNullable(ACTUAL_NAMES.get(s)).orElse(s);
     }
 
     public TFunction toThrift() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -244,7 +244,9 @@ public class FunctionSet {
     public static final String HLL_UNION_AGG = "hll_union_agg";
     public static final String MAX = "max";
     public static final String MAX_BY = "max_by";
+    public static final String MAX_BY_V2 = "max_by_v2";
     public static final String MIN_BY = "min_by";
+    public static final String MIN_BY_V2 = "min_by_v2";
     public static final String MIN = "min";
     public static final String PERCENTILE_APPROX = "percentile_approx";
     public static final String PERCENTILE_CONT = "percentile_cont";

--- a/test/sql/test_max_min_by_not_filter_nulls_with_nulls/R/test_max_min_by_not_filter_nulls_with_nulls
+++ b/test/sql/test_max_min_by_not_filter_nulls_with_nulls/R/test_max_min_by_not_filter_nulls_with_nulls
@@ -1,0 +1,355 @@
+-- name: test_max_min_by_not_filter_nulls_with_nulls
+DROP TABLE if exists t0;
+-- result:
+-- !result
+CREATE TABLE if not exists t0
+(
+c0 INT  NULL,
+c1 INT  NULL,
+c2 DECIMAL128(7, 2)  NULL,
+c3 VARCHAR(10)  NULL 
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`, `c2` )
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1` ) BUCKETS 32
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default" 
+);
+-- result:
+-- !result
+INSERT INTO t0
+(c0, c1, c2, c3)
+VALUES
+('4', '8', NULL, NULL),
+(NULL, NULL, '55157.78', NULL),
+('9', '6', NULL, 'foo'),
+('8', NULL, '8.20', 'foobar'),
+('7', NULL, NULL, NULL),
+('2', NULL, '55157.78', NULL),
+('6', NULL, '29660.05', 'foo'),
+('4', NULL, NULL, NULL),
+(NULL, NULL, NULL, 'foobar'),
+(NULL, '6', NULL, NULL);
+-- result:
+-- !result
+SET new_planner_agg_stage=1;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-974664585
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+1687028600
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-6489867636
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+18698534208
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-9870420830
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+7689318910
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-3785801
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+3369616053
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-19258865877
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+25406211869
+-- !result
+SET new_planner_agg_stage=2;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_preaggregation;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-974664585
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+1687028600
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-6489867636
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+18698534208
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-9870420830
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+7689318910
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-3785801
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+3369616053
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-19258865877
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+25406211869
+-- !result
+SET new_planner_agg_stage=2;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_streaming;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-974664585
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+1687028600
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-6489867636
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+18698534208
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-9870420830
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+7689318910
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-3785801
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+3369616053
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-19258865877
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+25406211869
+-- !result
+SET new_planner_agg_stage=3;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_preaggregation;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-974664585
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+1687028600
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-6489867636
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+18698534208
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-9870420830
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+7689318910
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-3785801
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+3369616053
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-19258865877
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+25406211869
+-- !result
+SET new_planner_agg_stage=3;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_streaming;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-974664585
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+1687028600
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-6489867636
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+18698534208
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-9870420830
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+7689318910
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-3785801
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+3369616053
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-19258865877
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+25406211869
+-- !result
+SET new_planner_agg_stage=4;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_preaggregation;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-974664585
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+1687028600
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-6489867636
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+18698534208
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-9870420830
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+7689318910
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-3785801
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+3369616053
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-19258865877
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+25406211869
+-- !result
+SET new_planner_agg_stage=4;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_streaming;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-974664585
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+1687028600
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-6489867636
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+18698534208
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-9870420830
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+7689318910
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-3785801
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+3369616053
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-19258865877
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+25406211869
+-- !result

--- a/test/sql/test_max_min_by_not_filter_nulls_with_nulls/T/test_max_min_by_not_filter_nulls_with_nulls
+++ b/test/sql/test_max_min_by_not_filter_nulls_with_nulls/T/test_max_min_by_not_filter_nulls_with_nulls
@@ -1,0 +1,114 @@
+-- name: test_max_min_by_not_filter_nulls_with_nulls
+ DROP TABLE if exists t0;
+
+ CREATE TABLE if not exists t0
+ (
+ c0 INT  NULL,
+ c1 INT  NULL,
+ c2 DECIMAL128(7, 2)  NULL,
+ c3 VARCHAR(10)  NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`c0`, `c1`, `c2` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`c0`, `c1` ) BUCKETS 32
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+INSERT INTO t0
+(c0, c1, c2, c3)
+VALUES
+('4', '8', NULL, NULL),
+(NULL, NULL, '55157.78', NULL),
+('9', '6', NULL, 'foo'),
+('8', NULL, '8.20', 'foobar'),
+('7', NULL, NULL, NULL),
+('2', NULL, '55157.78', NULL),
+('6', NULL, '29660.05', 'foo'),
+('4', NULL, NULL, NULL),
+(NULL, NULL, NULL, 'foobar'),
+(NULL, '6', NULL, NULL);
+SET new_planner_agg_stage=1;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=2;
+SET streaming_preaggregation_mode = force_preaggregation;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=2;
+SET streaming_preaggregation_mode = force_streaming;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=3;
+SET streaming_preaggregation_mode = force_preaggregation;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=3;
+SET streaming_preaggregation_mode = force_streaming;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=4;
+SET streaming_preaggregation_mode = force_preaggregation;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=4;
+SET streaming_preaggregation_mode = force_streaming;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;

--- a/test/sql/test_max_min_by_not_filter_nulls_without_nulls/R/test_max_min_by_not_filter_nulls_without_nulls
+++ b/test/sql/test_max_min_by_not_filter_nulls_without_nulls/R/test_max_min_by_not_filter_nulls_without_nulls
@@ -1,0 +1,355 @@
+-- name: test_max_min_by_not_filter_nulls_without_nulls
+DROP TABLE if exists t0;
+-- result:
+-- !result
+CREATE TABLE if not exists t0
+(
+c0 INT NOT NULL,
+c1 INT NOT NULL,
+c2 DECIMAL128(7, 2) NOT NULL,
+c3 VARCHAR(10) NOT NULL 
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`, `c2` )
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1` ) BUCKETS 32
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default" 
+);
+-- result:
+-- !result
+INSERT INTO t0
+(c0, c1, c2, c3)
+VALUES
+('9', '8', '-23765.20', 'foo1'),
+('7', '1', '92426.92', 'foo6'),
+('2', '1', '-96540.02', 'foo10'),
+('7', '8', '-96540.02', 'foo1'),
+('5', '3', '70459.31', 'foo10'),
+('6', '1', '66032.48', 'foo9'),
+('4', '2', '-99763.42', 'foo2'),
+('1', '2', '92426.92', 'foo1'),
+('8', '9', '73215.84', 'foo10'),
+('5', '3', '45826.02', 'foo6');
+-- result:
+-- !result
+SET new_planner_agg_stage=1;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1457532312
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+372293362
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-4236324495
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-4391782332
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-11963166337
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-15649881085
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1321142242
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+-1190265313
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-30649812568
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+21366473853
+-- !result
+SET new_planner_agg_stage=2;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_preaggregation;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1457532312
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+372293362
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-4236324495
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-4391782332
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-11963166337
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-15649881085
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1321142242
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+-1190265313
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-30649812568
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+21366473853
+-- !result
+SET new_planner_agg_stage=2;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_streaming;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1457532312
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+372293362
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-4236324495
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-4391782332
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-11963166337
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-15649881085
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1321142242
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+-1190265313
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-30649812568
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+21366473853
+-- !result
+SET new_planner_agg_stage=3;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_preaggregation;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1457532312
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+372293362
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-4236324495
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-4391782332
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-11963166337
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-15649881085
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1321142242
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+-1190265313
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-30649812568
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+21366473853
+-- !result
+SET new_planner_agg_stage=3;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_streaming;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1457532312
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+372293362
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-4236324495
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-4391782332
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-11963166337
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-15649881085
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1321142242
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+-1190265313
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-30649812568
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+21366473853
+-- !result
+SET new_planner_agg_stage=4;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_preaggregation;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1457532312
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+372293362
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-4236324495
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-4391782332
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-11963166337
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-15649881085
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1321142242
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+-1190265313
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-30649812568
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+21366473853
+-- !result
+SET new_planner_agg_stage=4;
+-- result:
+-- !result
+SET streaming_preaggregation_mode = force_streaming;
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1457532312
+-- !result
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+372293362
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-4236324495
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-4391782332
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+-- result:
+-11963166337
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+-- result:
+-15649881085
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+-- result:
+-1321142242
+-- !result
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+-- result:
+-1190265313
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+-- result:
+-30649812568
+-- !result
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+-- result:
+21366473853
+-- !result

--- a/test/sql/test_max_min_by_not_filter_nulls_without_nulls/T/test_max_min_by_not_filter_nulls_without_nulls
+++ b/test/sql/test_max_min_by_not_filter_nulls_without_nulls/T/test_max_min_by_not_filter_nulls_without_nulls
@@ -1,0 +1,114 @@
+-- name: test_max_min_by_not_filter_nulls_without_nulls
+ DROP TABLE if exists t0;
+
+ CREATE TABLE if not exists t0
+ (
+ c0 INT NOT NULL,
+ c1 INT NOT NULL,
+ c2 DECIMAL128(7, 2) NOT NULL,
+ c3 VARCHAR(10) NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`c0`, `c1`, `c2` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`c0`, `c1` ) BUCKETS 32
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+INSERT INTO t0
+(c0, c1, c2, c3)
+VALUES
+('9', '8', '-23765.20', 'foo1'),
+('7', '1', '92426.92', 'foo6'),
+('2', '1', '-96540.02', 'foo10'),
+('7', '8', '-96540.02', 'foo1'),
+('5', '3', '70459.31', 'foo10'),
+('6', '1', '66032.48', 'foo9'),
+('4', '2', '-99763.42', 'foo2'),
+('1', '2', '92426.92', 'foo1'),
+('8', '9', '73215.84', 'foo10'),
+('5', '3', '45826.02', 'foo6');
+SET new_planner_agg_stage=1;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=2;
+SET streaming_preaggregation_mode = force_preaggregation;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=2;
+SET streaming_preaggregation_mode = force_streaming;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=3;
+SET streaming_preaggregation_mode = force_preaggregation;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=3;
+SET streaming_preaggregation_mode = force_streaming;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=4;
+SET streaming_preaggregation_mode = force_preaggregation;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;
+SET new_planner_agg_stage=4;
+SET streaming_preaggregation_mode = force_streaming;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,(count(DISTINCT c3)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0 group by c2) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,(count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0 group by c0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c2)) as __c_0 ,max_by(c0,coalesce(c0,0)*1000+c1) a,min_by(c0,coalesce(c0,0)*1000+c1) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(__c_0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select (count(DISTINCT c1)) as __c_0 ,max_by(c2,concat(coalesce(c2,'NULL'),c3)) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c2,max_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) a,min_by(c0,coalesce(c0,0)*1000+c1) over(partition by c2) b from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(a,0))+murmur_hash3_32(ifnull(b,0)))) as fingerprint from (select c0,max_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) a,min_by(c2,concat(coalesce(c2,'NULL'),c3)) over(partition by c1) b from t0) as t;


### PR DESCRIPTION
## Why I'm doing:

max_by/min_by should not filter nulls, for an example:

1. prepare data
```
create table test_table (
   `id` int NOT NULL,
   `name` varchar(10) DEFAULT NULL,
   `grade` int NOT NULL
) ENGINE=OLAP
PRIMARY KEY(`id`)
DISTRIBUTED BY HASH(`id`);

insert into test_table values (1,'john',90);
insert into test_table values (2,'jim',95);
insert into test_table values (3,NULL,100);

```

2. query Expected outcome 'null' actual outcome 'jim'
 
```
select max_by(name, grade) from test_table;
```

## What I'm doing:

1. max_by and min_by not filter nulls;
2. fix ancient bug: crash caused by window query like max_by(T, S) over window_def when S's type is not same to T's

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
<hr>This is an automatic backport of pull request #51354 done by [Mergify](https://mergify.com).
## Why I'm doing:

max_by/min_by should not filter nulls, for an example:

1. prepare data
```
create table test_table (
   `id` int NOT NULL,
   `name` varchar(10) DEFAULT NULL,
   `grade` int NOT NULL
) ENGINE=OLAP
PRIMARY KEY(`id`)
DISTRIBUTED BY HASH(`id`);

insert into test_table values (1,'john',90);
insert into test_table values (2,'jim',95);
insert into test_table values (3,NULL,100);

```

2. query Expected outcome 'null' actual outcome 'jim'
 
```
select max_by(name, grade) from test_table;
```

## What I'm doing:

1. max_by and min_by not filter nulls;
2. fix ancient bug: crash caused by window query like max_by(T, S) over window_def when S's type is not same to T's

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr


