### PR TITLE
[Enhancement] increase query retry to 3

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1409,7 +1409,7 @@ public class Config extends ConfigBase {
      * You may reduce this number to avoid Avalanche disaster.
      */
     @ConfField(mutable = true)
-    public static int max_query_retry_time = 2;
+    public static int max_query_retry_time = 3;
 
     /**
      * In order not to wait too long for create table(index), set a max timeout.


### PR DESCRIPTION
* be favor to backen rpc failure.
* when a query delivered to backend and then the backend crash, the retry will be: 
  1) backend crash will be detected by the updateFragmentExecStatus with THRIFT_RPC_ERROR (first time)
  2) query will fail and retry without marking the backend as unusable (second time) 
  3) the query will fail in deploying phase, error with THRIFT_RPC_ERROR, and this time the backend will be marked as unusable, and will be blocked temporarily 
  4) query retry again, this time the bad backend is blocked temporarily, the exec plan is able to rebuild and deliver to a different backend and success.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
