### PR TITLE
[BugFix] FunctionHelper::union_nullable_column will return nullptr if all the input columns is not nullable

### DIFF
--- a/be/src/exprs/function_helper.cpp
+++ b/be/src/exprs/function_helper.cpp
@@ -38,7 +38,6 @@ NullColumnPtr FunctionHelper::union_nullable_column(const ColumnPtr& v1, const C
     } else if (v2->is_nullable()) {
         result = ColumnHelper::as_raw_column<NullableColumn>(v2)->null_column()->clone();
     } else {
-        DCHECK(false);
         return nullptr;
     }
 

--- a/be/src/exprs/function_helper.h
+++ b/be/src/exprs/function_helper.h
@@ -69,7 +69,7 @@ public:
      * if v1 is NullableColumn and v2 is NullableColumn, union
      * if v1 is NullableColumn and v2 is not NullableColumn, return v1.nullColumn
      * if v1 is not NullableColumn and v2 is NullableColumn, return v2.nullColumn
-     * if v1 is not NullableColumn and v2 is not NullableColumn, impossible
+     * if v1 is not NullableColumn and v2 is not NullableColumn, return nullptr
      * 
      * @param v1 
      * @param v2 


### PR DESCRIPTION
## Why I'm doing:

```
  *** Aborted at 1727663414 (unix time) try "date -d @1727663414" if you are using GNU date ***
  PC: @     0x7f923fe969fc pthread_kill
  *** SIGABRT (@0x68cc5) received by PID 429253 (TID 0x7f92400f4840) from PID 429253; stack trace: ***
      @     0x7f923fe99ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
      @         0x1b5a6049 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
      @     0x7f923fe42520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
      @     0x7f923fe969fc pthread_kill
      @     0x7f923fe42476 raise
      @     0x7f923fe287f3 abort
      @         0x14ad8969 starrocks::failure_function()
      @         0x1b5997de google::LogMessage::Fail()
      @         0x1b59aa59 google::LogMessageFatal::~LogMessageFatal()
      @         0x1816d0b7 starrocks::FunctionHelper::union_nullable_column(std::shared_ptr<starrocks::Column> const&, std::shared_ptr<starrocks::Column> const&)
      @         0x12ce12fc starrocks::ArrayOverlap<(starrocks::LogicalType)17>::_array_overlap(std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > > const&)
      @         0x12cbbde7 starrocks::ArrayOverlap<(starrocks::LogicalType)17>::process(starrocks::FunctionContext*, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > > const&)
      @         0x12c42043 starrocks::ArrayFunctionsTest_array_overlap_varchar_Test::TestBody()
      @         0x1fe39c54 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
      @         0x1fe2b23e testing::Test::Run()
      @         0x1fe2b3a5 testing::TestInfo::Run()
      @         0x1fe2b495 testing::TestSuite::Run()
      @         0x1fe2ba56 testing::internal::UnitTestImpl::RunAllTests()
      @         0x1fe2bc91 testing::UnitTest::Run()
      @         0x120413c2 RUN_ALL_TESTS()
      @         0x12036cf3 starrocks::init_test_env(int, char**)
      @         0x12037212 main
      @     0x7f923fe29d90 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
      @     0x7f923fe29e40 __libc_start_main
      @         0x12036025 _start
```

## What I'm doing:

FunctionHelper::union_nullable_column will return nullptr if all the input columns is not nullable.

This way, we can write fewer if-else statements to check input arguments.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
