### PR TITLE
[Refactor] refactor get updated partitions when create analyze job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -44,6 +44,7 @@ import org.apache.commons.lang.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -194,4 +195,21 @@ public abstract class ConnectorPartitionTraits {
      */
     public abstract Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
                                                          MaterializedView.AsyncRefreshContext context);
+
+    /**
+     * Get updated partitions based on updated time, return partition names if the partition is updated after the checkTime.
+     * For external table, we get partition update time from other system, there may be a time
+     * inconsistency between the two systems, so we add extraSeconds to make sure partition update
+     * time is later than check time
+     * @param checkTime the time to check
+     * @param extraSeconds partition updated time would add extraSeconds to check whether it is after checkTime
+     */
+    public abstract Set<String> getUpdatedPartitionNames(LocalDateTime checkTime, int extraSeconds);
+
+    /**
+     * Get the last update time of the table,
+     * For external table, we get partition update time from other system, there may be a time
+     * inconsistency between the two systems, so we add extraSeconds
+     */
+    public abstract LocalDateTime getTableLastUpdateTime(int extraSeconds);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionInfo.java
@@ -16,8 +16,14 @@ package com.starrocks.connector;
 
 import com.starrocks.connector.hive.RemoteFileInputFormat;
 
+import java.util.concurrent.TimeUnit;
+
 public interface PartitionInfo {
     long getModifiedTime();
+
+    default TimeUnit getModifiedTimeUnit()  {
+        return TimeUnit.SECONDS;
+    }
 
     default RemoteFileInputFormat getFileFormat() {
         throw new UnsupportedOperationException("");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/Partition.java
@@ -16,12 +16,19 @@ package com.starrocks.connector.iceberg;
 
 import com.starrocks.connector.PartitionInfo;
 
+import java.util.concurrent.TimeUnit;
+
 public class Partition implements PartitionInfo {
     private final long modifiedTime;
 
     @Override
     public long getModifiedTime() {
         return modifiedTime;
+    }
+
+    @Override
+    public TimeUnit getModifiedTimeUnit() {
+        return TimeUnit.MICROSECONDS;
     }
 
     public Partition(long modifiedTime) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -37,6 +37,9 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.PListCell;
 import org.apache.commons.lang.NotImplementedException;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -172,5 +175,46 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits  {
             }
         }
         return result;
+    }
+
+    @Override
+    public Set<String> getUpdatedPartitionNames(LocalDateTime checkTime, int extraSeconds) {
+        List<String> updatedPartitions = Lists.newArrayList();
+        try {
+            getPartitionNameWithPartitionInfo().
+                    forEach((partitionName, partitionInfo) -> {
+                        long partitionModifiedTimeMillis = partitionInfo.getModifiedTimeUnit().toMillis(
+                                partitionInfo.getModifiedTime());
+
+                        LocalDateTime partitionUpdateTime = LocalDateTime.ofInstant(
+                                Instant.ofEpochMilli(partitionModifiedTimeMillis).plusSeconds(extraSeconds),
+                                Clock.systemDefaultZone().getZone());
+                        if (partitionUpdateTime.isAfter(checkTime)) {
+                            updatedPartitions.add(partitionName);
+                        }
+                    });
+            return Sets.newHashSet(updatedPartitions);
+        } catch (Exception e) {
+            // some external table traits do not support getPartitionNameWithPartitionInfo, will throw exception,
+            // just return null
+            return null;
+        }
+    }
+
+    @Override
+    public LocalDateTime getTableLastUpdateTime(int extraSeconds) {
+        try {
+            long lastModifiedTimeMillis = getPartitionNameWithPartitionInfo().values().stream().
+                    map(partitionInfo -> partitionInfo.getModifiedTimeUnit().toMillis(partitionInfo.getModifiedTime())).
+                    max(Long::compareTo).orElse(0L);
+            if (lastModifiedTimeMillis != 0L) {
+                return LocalDateTime.ofInstant(Instant.ofEpochMilli(lastModifiedTimeMillis).plusSeconds(extraSeconds),
+                        Clock.systemDefaultZone().getZone());
+            }
+        } catch (Exception e) {
+            // some external table traits do not support getPartitionNameWithPartitionInfo, will throw exception,
+            // just return null
+        }
+        return null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/IcebergPartitionTraits.java
@@ -30,6 +30,9 @@ import com.starrocks.server.GlobalStateMgr;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Snapshot;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -129,6 +132,14 @@ public class IcebergPartitionTraits extends DefaultTraits {
             partitionKey.pushColumn(exprValue, column.getType().getPrimitiveType());
         }
         return partitionKey;
+    }
+
+    @Override
+    public LocalDateTime getTableLastUpdateTime(int extraSeconds) {
+        IcebergTable icebergTable = (IcebergTable) table;
+        Optional<Snapshot> snapshot = Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot());
+        return snapshot.map(value -> LocalDateTime.ofInstant(Instant.ofEpochMilli(value.timestampMillis()).
+                plusSeconds(extraSeconds), Clock.systemDefaultZone().getZone())).orElse(null);
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
there are some code in StatisticsCollectJobFactory and StatisticUtils about updated partitions and lastUpdateTime, move it to the ConnectorPartitionTraits, use ConnectorPartitionTraits to get UpdatedPartitionNames and TableLastUpdateTime
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
