### PR TITLE
[Enhancement] Transform count(distinct pk) into count(pk)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
@@ -52,11 +52,17 @@ import java.util.stream.Collectors;
  *
  * Rewrite count(distinct xx) group by x when distinct columns satisfy scan distribution
  *
+ * 1. If xx is not primary key:
  * e.g.
  * select count(distinct xx) from t group by x
  * ->
  * select count(xx) from (select x, xx from t group by x, xx) tt group by x;
  *
+ * 2. If xx is primary key:
+ * e.g.
+ * select count(distinct xx) from t group by x
+ * ->
+ * select count(xx) from t group by x;
  */
 public class GroupByCountDistinctRewriteRule extends TransformationRule {
     // multi-stage distinct function mapping

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
@@ -271,12 +271,8 @@ public class GroupByCountDistinctRewriteRule extends TransformationRule {
     private boolean isPrimaryKey(ColumnRefOperator column, LogicalOlapScanOperator scan) {
         OlapTable olapTable = (OlapTable) scan.getTable();
         if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
-            List<String> keyColumnNames = olapTable.getKeyColumns()
-                    .stream()
-                    .filter(Column::isKey)
-                    .map(Column::getName)
-                    .collect(Collectors.toList());
-            return keyColumnNames.size() == 1 && keyColumnNames.contains(column.getName());
+            List<Column> keyColumnNames = olapTable.getKeyColumns();
+            return keyColumnNames.size() == 1 && keyColumnNames.stream().anyMatch(c -> c.getName().equals(column.getName()));
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
@@ -19,8 +19,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -171,6 +174,21 @@ public class GroupByCountDistinctRewriteRule extends TransformationRule {
 
         List<ColumnRefOperator> firstGroupBy = Lists.newArrayList(aggregate.getGroupingKeys());
         Preconditions.checkState(distinctColumn.isPresent());
+
+        LogicalOlapScanOperator scan = (LogicalOlapScanOperator) input.getInputs().get(0).getOp();
+        if (isPrimaryKey(distinctColumn.get(), scan)) {
+            Map<ColumnRefOperator, CallOperator> newAggregations = Maps.newHashMap();
+            distinctMap.forEach((k, v) -> {
+                CallOperator newAgg = transformDistinctAgg(v);
+                newAggregations.put(k, newAgg);
+            });
+            LogicalAggregationOperator newAggregateOp = new LogicalAggregationOperator.Builder()
+                    .withOperator(aggregate)
+                    .setAggregations(newAggregations)
+                    .build();
+            return Lists.newArrayList(OptExpression.create(newAggregateOp, input.getInputs()));
+        }
+
         firstGroupBy.add(distinctColumn.get());
 
         Map<ColumnRefOperator, CallOperator> firstAggregations = Maps.newHashMap();
@@ -242,5 +260,18 @@ public class GroupByCountDistinctRewriteRule extends TransformationRule {
                 FunctionSet.MULTI_DISTINCT_SUM.equals(call.getFunction().functionName()) ||
                 FunctionSet.MULTI_DISTINCT_COUNT.equals(call.getFunction().functionName()) ||
                 FunctionSet.ARRAY_AGG_DISTINCT.equals(call.getFunction().functionName());
+    }
+
+    private boolean isPrimaryKey(ColumnRefOperator column, LogicalOlapScanOperator scan) {
+        OlapTable olapTable = (OlapTable) scan.getTable();
+        if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
+            List<String> keyColumnNames = olapTable.getKeyColumns()
+                    .stream()
+                    .filter(Column::isKey)
+                    .map(Column::getName)
+                    .collect(Collectors.toList());
+            return keyColumnNames.size() == 1 && keyColumnNames.contains(column.getName());
+        }
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctRewriteRule.java
@@ -272,7 +272,11 @@ public class GroupByCountDistinctRewriteRule extends TransformationRule {
         OlapTable olapTable = (OlapTable) scan.getTable();
         if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
             List<Column> keyColumnNames = olapTable.getKeyColumns();
-            return keyColumnNames.size() == 1 && keyColumnNames.stream().anyMatch(c -> c.getName().equals(column.getName()));
+            // The check() ensures there is only one DISTINCT column, so composite pk is not supported here
+            if (keyColumnNames.size() != 1) {
+                return false;
+            }
+            return keyColumnNames.get(0).getName().equals(column.getName());
         }
         return false;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -102,13 +102,21 @@ public class SelectStmtTest {
                 "\"replicated_storage\" = \"true\",\n" +
                 "\"compression\" = \"LZ4\"\n" +
                 "); ";
+
+        String createTableWithPrimaryKey = "CREATE TABLE db1.t_with_pk (" +
+                "user_id INT," +
+                "value INT) " +
+                "PRIMARY KEY (user_id) " +
+                "PROPERTIES('replication_num' = '1');";
+
         starRocksAssert = new StarRocksAssert();
         starRocksAssert.withDatabase("db1").useDatabase("db1");
         starRocksAssert.withTable(createTblStmtStr)
                 .withTable(createBaseAllStmtStr)
                 .withTable(createDateTblStmtStr)
                 .withTable(createPratitionTableStr)
-                .withTable(createTable1);
+                .withTable(createTable1)
+                .withTable(createTableWithPrimaryKey);
         FeConstants.enablePruneEmptyOutputScan = false;
     }
 
@@ -684,5 +692,26 @@ public class SelectStmtTest {
                 "         NULL\n" +
                 "     limit: 1\n" +
                 "     cardinality: 1\n"));
+    }
+
+    @Test
+    public void testDistinctCountOnPrimaryKey() throws Exception {
+        String insertData = "INSERT INTO t0 VALUES (1,0),(2,1),(3,0),(4,1);";
+        starRocksAssert.query(insertData);
+        String sql = "SELECT CASE WHEN(value = 1) THEN 'A' ELSE 'B' END as flag, COUNT(DISTINCT user_id) " +
+                "FROM db1.t_with_pk " +
+                "GROUP BY 1";
+
+        String plan = starRocksAssert.query(sql).explainQuery();
+
+        Assert.assertTrue(plan, plan.contains("2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(1: user_id)\n" +
+                "  |  group by: 3: case\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 1> : 1: user_id\n" +
+                "  |  <slot 3> : if(2: value = 1, 'A', 'B')\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -695,7 +695,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testDistinctCountOnPrimaryKey() throws Exception {
+    void testDistinctCountOnPrimaryKey() throws Exception {
         String insertData = "INSERT INTO t0 VALUES (1,0),(2,1),(3,0),(4,1);";
         starRocksAssert.query(insertData);
         String sql = "SELECT CASE WHEN(value = 1) THEN 'A' ELSE 'B' END as flag, COUNT(DISTINCT user_id) " +


### PR DESCRIPTION
## Why I'm doing:
In queries where COUNT(DISTINCT primary_key), the DISTINCT operation is redundant since the primary key guarantees uniqueness. We can optimize it by removing DISTINCT on aggregation(like count and sum) on primary key.

## What I'm doing:
This change is primarily within the `GroupByCountDistinctRewriteRule`. Additional logic has been added into this rule to detect cases where an aggregation (such as COUNT or SUM) is performed on a DISTINCT primary key. If the column is a primary key, the DISTINCT operation is automatically removed from the query. This optimization applies only when the aggregation is performed on a single primary key column, ensuring correctness by leveraging the uniqueness guarantee of primary keys.

Fixes #50974 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
