### PR TITLE
[BugFix] cast bigint to string return wrong result

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -158,7 +158,7 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
 
         // cascaded cast cannot be reduced if middle type's size is smaller than two sides
         // e.g. cast(cast(smallint as tinyint) as int)
-        if (parentSlotSize > childSlotSize && childSlotSize <= grandChildSlotSize) {
+        if (parentSlotSize >= childSlotSize && childSlotSize <= grandChildSlotSize) {
             return false;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -158,7 +158,7 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
 
         // cascaded cast cannot be reduced if middle type's size is smaller than two sides
         // e.g. cast(cast(smallint as tinyint) as int)
-        if (parentSlotSize > childSlotSize && childSlotSize < grandChildSlotSize) {
+        if (parentSlotSize > childSlotSize && childSlotSize <= grandChildSlotSize) {
             return false;
         }
 

--- a/test/sql/test_cast/R/test_cast_string_to_int
+++ b/test/sql/test_cast/R/test_cast_string_to_int
@@ -46,5 +46,5 @@ select cast(cast((9-1)/3+1 as bigint) as string);
 -- !result
 select cast(cast((9-1)/3+1 as bigint) as double);
 -- result:
-3
+3.0
 -- !result

--- a/test/sql/test_cast/R/test_cast_string_to_int
+++ b/test/sql/test_cast/R/test_cast_string_to_int
@@ -44,3 +44,7 @@ select cast(cast((9-1)/3+1 as bigint) as string);
 -- result:
 3
 -- !result
+select cast(cast((9-1)/3+1 as bigint) as double);
+-- result:
+3
+-- !result

--- a/test/sql/test_cast/R/test_cast_string_to_int
+++ b/test/sql/test_cast/R/test_cast_string_to_int
@@ -39,3 +39,8 @@ select cast('+' as largeint);
 -- result:
 None
 -- !result
+-- name: test_cast_bigint_to_string
+select cast(cast((9-1)/3+1 as bigint) as string);
+-- result:
+3
+-- !result

--- a/test/sql/test_cast/T/test_cast_string_to_int
+++ b/test/sql/test_cast/T/test_cast_string_to_int
@@ -11,3 +11,4 @@ select cast('-' as largeint);
 select cast('+' as largeint);
 -- name: test_cast_bigint_to_string
 select cast(cast((9-1)/3+1 as bigint) as string);
+select cast(cast((9-1)/3+1 as bigint) as double);

--- a/test/sql/test_cast/T/test_cast_string_to_int
+++ b/test/sql/test_cast/T/test_cast_string_to_int
@@ -9,3 +9,5 @@ select cast('-' as bigint);
 select cast('+' as bigint);
 select cast('-' as largeint);
 select cast('+' as largeint);
+-- name: test_cast_bigint_to_string
+select cast(cast((9-1)/3+1 as bigint) as string);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #51545 
```
mysql> select cast(cast((9-1)/3+1 as bigint) as string);
+---------------------------------------------------------------+
| CAST((CAST((((9 - 1) / 3) + 1) AS BIGINT)) AS VARCHAR(65533)) |
+---------------------------------------------------------------+
| 3                                                             |
+---------------------------------------------------------------+
1 row in set (0.01 sec)
```
## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3