### PR TITLE
[BugFix] Add null check for MV database into doTriggerToRefreshRelatedMVs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
@@ -141,6 +141,11 @@ public class LoadJobMVListener implements LoadJobListener {
         while (mvIdIterator.hasNext()) {
             MvId mvId = mvIdIterator.next();
             Database mvDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
+            if (mvDb == null) {
+                LOG.warn("materialized view's {} database does not exists.", mvId);
+                mvIdIterator.remove();
+                continue;
+            }
             MaterializedView materializedView = (MaterializedView) mvDb.getTable(mvId.getId());
             if (materializedView == null) {
                 LOG.warn("materialized view {} does not exists.", mvId.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -24,6 +24,7 @@ import com.starrocks.analysis.ParseNode;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.common.Config;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -127,7 +128,8 @@ public class CachingMvPlanContextBuilder {
         try {
             return MvPlanContextBuilder.getPlanContext(mv);
         } catch (Throwable e) {
-            LOG.warn("load mv plan cache failed: {}", mv.getName(), e);
+            LOG.warn("load mv plan cache failed: id:{}, name:{}, exception: {}",
+                    mv.getId(), mv.getName(), DebugUtil.getStackTrace(e));
             return Lists.newArrayList();
         }
     }


### PR DESCRIPTION
## Why I'm doing:
1. In our StarRocks setup we constantly see NullReferenceException error in logs that occurs after stream load task finish. Like this one:
```
[LoadJobMVListener.triggerToRefreshRelatedMVs():121] refresh mv after publish version failed: java.lang.NullPointerException
        at com.starrocks.listener.LoadJobMVListener.doTriggerToRefreshRelatedMVs(LoadJobMVListener.java:144)
        at com.starrocks.listener.LoadJobMVListener.triggerToRefreshRelatedMVs(LoadJobMVListener.java:119)
...
```

2. If the MV plan load cache fails displaying only the MV name is not enough because there could be multiple MVs with the same name in different databases.

## What I'm doing:

Add null check for MV database into doTriggerToRefreshRelatedMVs
Add MV id and exception stack to log on MV plan cache load failure

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

