### PR TITLE
[Enhancement] Set parse default for MONTH_OF_YEAR and DAY_OF_MONTH

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -346,4 +346,16 @@ public class DateUtils {
         }
         return builder;
     }
+
+    /**
+     * Get a unix datetime format builder with default MONTH_OF_YEAR and DAY_OF_MONTH
+     * @param pattern the date time pattern
+     * @param isOutputFormat true if the formatter is output format
+     * @return DateTimeFormatterBuilder
+     */
+    public static DateTimeFormatterBuilder unixDatetimeFormatBuilderWithDefault(String pattern, boolean isOutputFormat) {
+        return unixDatetimeFormatBuilder(pattern, isOutputFormat)
+            .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
+            .parseDefaulting(ChronoField.DAY_OF_MONTH, 1);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -396,7 +396,8 @@ public class ScalarOperatorFunctions {
 
     @ConstantFunction(name = "str_to_date", argTypes = {VARCHAR, VARCHAR}, returnType = DATETIME)
     public static ConstantOperator dateParse(ConstantOperator date, ConstantOperator fmtLiteral) {
-        DateTimeFormatter builder = DateUtils.unixDatetimeFormatter(fmtLiteral.getVarchar(), false);
+        DateTimeFormatter builder =
+                DateUtils.unixDatetimeFormatBuilderWithDefault(fmtLiteral.getVarchar(), false).toFormatter();
         String dateStr = StringUtils.strip(date.getVarchar(), "\r\n\t ");
         if (HAS_TIME_PART.matcher(fmtLiteral.getVarchar()).matches()) {
             LocalDateTime ldt;
@@ -418,7 +419,8 @@ public class ScalarOperatorFunctions {
 
     @ConstantFunction(name = "str2date", argTypes = {VARCHAR, VARCHAR}, returnType = DATE)
     public static ConstantOperator str2Date(ConstantOperator date, ConstantOperator fmtLiteral) {
-        DateTimeFormatterBuilder builder = DateUtils.unixDatetimeFormatBuilder(fmtLiteral.getVarchar(), false);
+        DateTimeFormatterBuilder builder =
+                DateUtils.unixDatetimeFormatBuilderWithDefault(fmtLiteral.getVarchar(), false);
         LocalDate ld = LocalDate.from(builder.toFormatter().withResolverStyle(ResolverStyle.STRICT).parse(
                 StringUtils.strip(date.getVarchar(), "\r\n\t ")));
         return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), Type.DATE);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -131,6 +131,15 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select date_parse('2014-12-21 12:34:56', '%Y-%m-%d %H:%i:%s');";
         assertPlanContains(sql, "2014-12-21 12:34:56");
 
+        sql = "select date_parse('202408', '%Y%m');";
+        assertPlanContains(sql, "2024-08-01");
+
+        sql = "select date_parse('2024-08', '%Y-%m');";
+        assertPlanContains(sql, "2024-08-01");
+
+        sql = "select date_parse('2024', '%Y');";
+        assertPlanContains(sql, "2024-01-01");
+
         sql = "select day_of_week(timestamp '2022-03-06 01:02:03');";
         assertPlanContains(sql, "dayofweek_iso('2022-03-06 01:02:03')");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -425,10 +425,15 @@ public class ScalarOperatorFunctionsTest {
         assertEquals("1998-02-21 00:00:00",
                 ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("98-02-21"),
                         ConstantOperator.createVarchar("%y-%m-%d")).toString());
-
-        Assert.assertThrows(DateTimeException.class, () -> ScalarOperatorFunctions
-                .dateParse(ConstantOperator.createVarchar("201905"),
+        assertEquals("2019-05-01 00:00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("201905"),
                         ConstantOperator.createVarchar("%Y%m")).getDatetime());
+        assertEquals("2019-05-01 00:00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2019-05"),
+                        ConstantOperator.createVarchar("%Y-%m")).getDatetime());
+        assertEquals("2019-01-01 00:00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2019"),
+                        ConstantOperator.createVarchar("%Y")).getDatetime());
 
         Assert.assertThrows(DateTimeException.class, () -> ScalarOperatorFunctions
                 .dateParse(ConstantOperator.createVarchar("20190507"),


### PR DESCRIPTION
## Why I'm doing:
StarRocks will not support select str_to_date('202410', '%Y%m') query but in trino it can work
## What I'm doing:
Set the parseDefaulting in `unixDatetimeFormatBuilder` in `DateUtils` for the MONTH_OF_YEAR and DAY_OF_MONTH as 1
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
