### PR TITLE
[BugFix] fix cloud native persistent index sst compaction when sst files contain same max_rss_rowid

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -51,13 +51,36 @@ Status KeyValueMerger::merge(const std::string& key, const std::string& value, u
             _max_rss_rowid = max_rss_rowid;
             _index_value_vers.emplace_front(version, index_value);
         } else if ((version > _index_value_vers.front().first) ||
-                   (version == _index_value_vers.front().first && max_rss_rowid > _max_rss_rowid)) {
+                   (version == _index_value_vers.front().first && max_rss_rowid > _max_rss_rowid) ||
+                   (version == _index_value_vers.front().first && max_rss_rowid == _max_rss_rowid &&
+                    index_value.get_value() == NullIndexValue)) {
             // NOTICE: we need both version and max_rss_rowid here to decide the order of keys.
-            // Consider the following two scenarios:
+            // Consider the following 3 scenarios:
             // 1. Same keys are from two different Rowsets, and we can decide their order by version recorded
             //    in Rowset.
+            //   | ------- ver1 --------- | + | -------- ver2 ----------|
+            //   | k1 k2 k3               |   | k3 k4                   |
+            //
+            //   k3 in ver2 will replace k3 in ver1, because it has a larger version.
+            //
             // 2. Same keys are from same Rowset, and they have same version. Now we use `max_rss_rowid` in sst to
             //    decide their order.
+            //   | ------- ver1 --------- | + | -------- ver1 ----------|
+            //   | k1 k2 k3               |   | k3 k4                   |
+            //   | max_rss_rowid = 2      |   | max_rss_rowid = 4       |
+            //
+            //   k3 with larger max_rss_rowid will replace previous one, because max_rss_rowid is incremental,
+            //   larger max_rss_rowid means it was generated later.
+            //
+            // 3. Same keys are from same Rowset, and they have same version. And they also have same `max_rss_rowid`
+            //    because one of them is delete flag.
+            //   | ------- ver1 --------- | + | -------- ver1 ----------|
+            //   | k1 k2 k3 k4(del)       |   | k3(del)      k4(del)    |
+            //   | max_rss_rowid = MAX    |   | max_rss_rowid = MAX     |
+            //
+            //   Because we use UINT32_TMAX as delete flag key's rowid, so two sst will have same
+            //   max_rss_rowid, when the second one is only contains delete flag keys.
+            //   k3 with delete flag will replace previous one.
             _max_rss_rowid = max_rss_rowid;
             std::list<std::pair<int64_t, IndexValue>> t;
             t.emplace_front(version, index_value);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -59,15 +59,22 @@ Status KeyValueMerger::merge(const std::string& key, const std::string& value, u
             // 1. Same keys are from two different Rowsets, and we can decide their order by version recorded
             //    in Rowset.
             //   | ------- ver1 --------- | + | -------- ver2 ----------|
-            //   | k1 k2 k3               |   | k3 k4                   |
+            //   | k1 k2 k3(1)            |   | k3(2) k4                |
             //
+            //   =
+            //   | ------- ver2 --------- |
+            //   | k1 k2 k3(2) k4         |
             //   k3 in ver2 will replace k3 in ver1, because it has a larger version.
             //
             // 2. Same keys are from same Rowset, and they have same version. Now we use `max_rss_rowid` in sst to
             //    decide their order.
             //   | ------- ver1 --------- | + | -------- ver1 ----------|
-            //   | k1 k2 k3               |   | k3 k4                   |
+            //   | k1 k2 k3(1)            |   | k3(2) k4                |
             //   | max_rss_rowid = 2      |   | max_rss_rowid = 4       |
+            //   =
+            //   | ------- ver1 --------- |
+            //   | k1 k2 k3(2) k4         |
+            //   | max_rss_rowid = 4      |
             //
             //   k3 with larger max_rss_rowid will replace previous one, because max_rss_rowid is incremental,
             //   larger max_rss_rowid means it was generated later.
@@ -77,6 +84,10 @@ Status KeyValueMerger::merge(const std::string& key, const std::string& value, u
             //   | ------- ver1 --------- | + | -------- ver1 ----------|
             //   | k1 k2 k3 k4(del)       |   | k3(del)      k4(del)    |
             //   | max_rss_rowid = MAX    |   | max_rss_rowid = MAX     |
+            //   =
+            //   | ------- ver1 --------- |
+            //   | k1 k2                  |
+            //   | max_rss_rowid = MAX    |
             //
             //   Because we use UINT32_TMAX as delete flag key's rowid, so two sst will have same
             //   max_rss_rowid, when the second one is only contains delete flag keys.

--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -399,6 +399,13 @@ public:
                     delta_writer->write(*(chunk_index.first), chunk_index.second.data(), chunk_index.second.size()));
             _replayer->upsert(chunk_index.first);
         }
+        size_t delete_size = _random_generator->random() % MaxUpsert;
+        for (int i = 0; i < delete_size; i++) {
+            auto chunk_index = gen_upsert_data(false);
+            RETURN_IF_ERROR(
+                    delta_writer->write(*(chunk_index.first), chunk_index.second.data(), chunk_index.second.size()));
+            _replayer->erase(chunk_index.first);
+        }
         RETURN_IF_ERROR(delta_writer->finish_with_txnlog());
         delta_writer->close();
         // Publish version
@@ -493,6 +500,13 @@ public:
                 RETURN_IF_ERROR(delta_writer->write(*(chunk_index.first), chunk_index.second.data(),
                                                     chunk_index.second.size()));
                 _replayer->upsert(chunk_index.first);
+            }
+            size_t delete_size = _random_generator->random() % MaxUpsert;
+            for (int i = 0; i < delete_size; i++) {
+                auto chunk_index = gen_upsert_data(false);
+                RETURN_IF_ERROR(delta_writer->write(*(chunk_index.first), chunk_index.second.data(),
+                                                    chunk_index.second.size()));
+                _replayer->erase(chunk_index.first);
             }
             RETURN_IF_ERROR(delta_writer->finish_with_txnlog());
             delta_writer->close();


### PR DESCRIPTION
## Why I'm doing:
Because we use `UINT32_TMAX` as delete flag key's rowid, so two sst files will have same `max_rss_rowid`, when the second one is only contains delete flag keys.
So when two sst files contain same version and `max_rss_rowid`, current implementation can't handle that, and it will cause error like:
```
E20241007 17:51:09.841304 140688967984704 meta_file.cpp:401] unexpected segment id: 55 tablet id: 2
W20241007 17:51:09.841645 140688967984704 transactions.cpp:328] Fail to apply txn log : Internal error: unexpected segment id: 55 tablet id: 2
be/src/storage/lake/update_manager.cpp:327 builder->update_num_del_stat(segment_id_to_add_dels)
be/src/storage/lake/txn_log_applier.cpp:119 check_and_recover([&]() { return apply_write_log(log.op_write(), log.txn_id()); }) tablet_id=2 txn=txn_id: 41
```

## What I'm doing:
E.g. there are two sst files with same version and `max_rss_rowid`. Because we use UINT32_TMAX as delete flag key's rowid, so two sst will have same `max_rss_rowid`, when the second one is only contains delete flag keys. 

k3 with delete flag will replace previous one.
```
 | ------- ver1 --------- | + | -------- ver1 ----------|
| k1 k2 k3 k4(del)       |   | k3(del)      k4(del)    |
| max_rss_rowid = MAX    |   | max_rss_rowid = MAX     |
=
| ------- ver1 --------- |
| k1 k2  k3(del)   k4(del)    |
| max_rss_rowid = MAX    |
```



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
