### PR TITLE
[BugFix] Fix mysql jdbc incompatible bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -964,7 +964,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = TRANSACTION_ISOLATION)
     private String transactionIsolation = "REPEATABLE-READ";
     @VariableMgr.VarAttr(name = TRANSACTION_READ_ONLY, alias = TX_READ_ONLY)
-    private String transactionReadOnly = "OFF";
+    private boolean transactionReadOnly = false;
     // this is used to make c3p0 library happy
     @VariableMgr.VarAttr(name = CHARACTER_SET_CLIENT)
     private String charsetClient = "utf8";


### PR DESCRIPTION
## Why I'm doing:
If I change the velue of  `mysql_server_version`  from  5.1.0 to 8.0.33 to resolve the CVEs,  some springboot service which use `HikariPool` will not connect StarRocks:

BTW, I have test the two jdbc drivers, both  `mysql-connector-java-5.1.49` and `mysql-connector-java-8.0.33` can not work.

```
[2024-09-27 14:49:07,964] [main] ERROR com.zaxxer.hikari.pool.HikariPool (HikariPool.java:498) - OLAP-TEST - Error thrown while acquiring connection from data source
java.sql.SQLException: Could not retrieve transaction read-only status from server
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:965) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:898) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:887) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:861) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:878) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:874) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.ConnectionImpl.isReadOnly(ConnectionImpl.java:3523) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.ConnectionImpl.isReadOnly(ConnectionImpl.java:3490) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.zaxxer.hikari.pool.PoolBase.setupConnection(PoolBase.java:408) ~[HikariCP-4.0.3.jar:?]
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:369) ~[HikariCP-4.0.3.jar:?]
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:206) ~[HikariCP-4.0.3.jar:?]
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:476) ~[HikariCP-4.0.3.jar:?]
	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:561) ~[HikariCP-4.0.3.jar:?]
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:115) ~[HikariCP-4.0.3.jar:?]
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:112) ~[HikariCP-4.0.3.jar:?]
	at org.springframework.jdbc.datasource.DataSourceUtils.fetchConnection(DataSourceUtils.java:159) ~[spring-jdbc-5.3.27.jar:5.3.27]
	at org.springframework.jdbc.datasource.DataSourceUtils.doGetConnection(DataSourceUtils.java:117) ~[spring-jdbc-5.3.27.jar:5.3.27]
	at org.springframework.jdbc.datasource.DataSourceUtils.getConnection(DataSourceUtils.java:80) ~[spring-jdbc-5.3.27.jar:5.3.27]
	at org.springframework.jdbc.support.JdbcUtils.extractDatabaseMetaData(JdbcUtils.java:337) ~[spring-jdbc-5.3.27.jar:5.3.27]
	at org.springframework.boot.jdbc.AbstractDataSourceInitializer.getDatabaseName(AbstractDataSourceInitializer.java:96) ~[spring-boot-2.5.15.jar:2.5.15]
	at org.springframework.boot.autoconfigure.quartz.QuartzDataSourceInitializer.getDatabaseName(QuartzDataSourceInitializer.java:66) ~[spring-boot-autoconfigure-2.5.15.jar:2.5.15]
	at org.springframework.boot.jdbc.AbstractDataSourceInitializer.initialize(AbstractDataSourceInitializer.java:65) ~[spring-boot-2.5.15.jar:2.5.15]
	at org.springframework.boot.jdbc.AbstractDataSourceInitializer.afterPropertiesSet(AbstractDataSourceInitializer.java:55) ~[spring-boot-2.5.15.jar:2.5.15]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1863) ~[spring-beans-5.3.27.jar:5.3.27]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1800) ~[spring-beans-5.3.27.jar:5.3.27]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:620) ~[spring-beans-5.3.27.jar:5.3.27]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542) ~[spring-beans-5.3.27.jar:5.3.27]
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335) ~[spring-beans-5.3.27.jar:5.3.27]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) [spring-beans-5.3.27.jar:5.3.27]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333) [spring-beans-5.3.27.jar:5.3.27]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208) [spring-beans-5.3.27.jar:5.3.27]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:322) [spring-beans-5.3.27.jar:5.3.27]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208) [spring-beans-5.3.27.jar:5.3.27]
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1156) [spring-context-5.3.27.jar:5.3.27]
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:910) [spring-context-5.3.27.jar:5.3.27]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583) [spring-context-5.3.27.jar:5.3.27]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:145) [spring-boot-2.5.15.jar:2.5.15]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:780) [spring-boot-2.5.15.jar:2.5.15]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:453) [spring-boot-2.5.15.jar:2.5.15]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:343) [spring-boot-2.5.15.jar:2.5.15]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1370) [spring-boot-2.5.15.jar:2.5.15]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1359) [spring-boot-2.5.15.jar:2.5.15]
	at com.chinamobile.cmss.olap.server.OlapServerApp.main(OlapServerApp.java:26) [classes/:?]
Caused by: java.sql.SQLException: Invalid value for getInt() - 'OFF'
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:965) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:898) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:887) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:861) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.ResultSetImpl.getInt(ResultSetImpl.java:2504) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	at com.mysql.jdbc.ConnectionImpl.isReadOnly(ConnectionImpl.java:3519) ~[mysql-connector-java-5.1.49.jar:5.1.49]
	... 36 more
```

## What I'm doing:
Follow the Doris Fix:
https://github.com/apache/doris/blob/9b8e65b294c443d50e2745fdbc9f9a9aadef68ba/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java#L804-L805

Change `transactionReadOnly `to `boolean `Type & default value `false` can resolve this issue.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
