### PR TITLE
[BugFix] fix array_map crash

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -116,8 +116,10 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
                     offsets_column->append(offset);
                 }
             } else {
-                data_column->empty_null_in_complex_column(result_null_column->get_data(),
-                                                          array_column->offsets().get_data());
+                if (result_null_column != nullptr) {
+                    data_column->empty_null_in_complex_column(result_null_column->get_data(),
+                                                            array_column->offsets().get_data());
+                }
                 elements_column = down_cast<const ArrayColumn*>(data_column.get())->elements_column();
             }
         }

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -118,7 +118,7 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
             } else {
                 if (result_null_column != nullptr) {
                     data_column->empty_null_in_complex_column(result_null_column->get_data(),
-                                                            array_column->offsets().get_data());
+                                                              array_column->offsets().get_data());
                 }
                 elements_column = down_cast<const ArrayColumn*>(data_column.get())->elements_column();
             }

--- a/test/sql/test_array_fn/R/test_array_map_2
+++ b/test/sql/test_array_fn/R/test_array_map_2
@@ -99,6 +99,13 @@ select array_map((x,y,z,d)->x+y+z+d, arr_0, arr_1, arr_2, [1]) from t order by k
 -- result:
 [REGEX].*Input array element's size is not equal in array_map().*
 -- !result
+select array_map((x)->x*x, arr_0) from t order by k;
+-- result:
+[1,4]
+[1,4]
+[1,4]
+[1,4]
+-- !result
 select array_map(x->x, arr_0) from t order by k;
 -- result:
 [1,2]

--- a/test/sql/test_array_fn/T/test_array_map_2
+++ b/test/sql/test_array_fn/T/test_array_map_2
@@ -44,6 +44,8 @@ delete from t where k = 5;
 select array_map((x,y,z)->x+y+z, arr_0, arr_1, arr_2) from t order by k;
 select array_map((x,y,z,d)->x+y+z+d, arr_0, arr_1, arr_2, [1,2]) from t order by k;
 select array_map((x,y,z,d)->x+y+z+d, arr_0, arr_1, arr_2, [1]) from t order by k;
+select array_map((x)->x*x, arr_0) from t order by k;
+
 
 select array_map(x->x, arr_0) from t order by k;
 -- independent expr


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8652
introduced by https://github.com/StarRocks/starrocks/pull/51244

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
