### PR TITLE
[BugFix] Disable execution group for partial support colocate join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExecGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExecGroup.java
@@ -55,7 +55,9 @@ public class ExecGroup {
     }
 
     public void disableColocateGroup(PlanNode root) {
-        clearRuntimeFilterExecGroupInfo(root);
+        if (isColocateExecGroup()) {
+            clearRuntimeFilterExecGroupInfo(root);
+        }
         this.disableColocateGroup = true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExecGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExecGroup.java
@@ -49,7 +49,9 @@ public class ExecGroup {
 
     public void add(PlanNode node, boolean disableColocateGroup) {
         add(node);
-        this.disableColocateGroup = this.disableColocateGroup || disableColocateGroup;
+        if (!this.disableColocateGroup && disableColocateGroup) {
+            disableColocateGroup(node);
+        }
     }
 
     public void disableColocateGroup(PlanNode root) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExecGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExecGroup.java
@@ -64,9 +64,9 @@ public class ExecGroup {
 
         root.getProbeRuntimeFilters().forEach(RuntimeFilterDescription::clearExecGroupInfo);
 
-        if (root instanceof JoinNode) {
-            JoinNode joinNode = (JoinNode) root;
-            joinNode.buildRuntimeFilters.forEach(RuntimeFilterDescription::clearExecGroupInfo);
+        if (root instanceof RuntimeFilterBuildNode) {
+            RuntimeFilterBuildNode rfBuildNode = (RuntimeFilterBuildNode) root;
+            rfBuildNode.getBuildRuntimeFilters().forEach(RuntimeFilterDescription::clearExecGroupInfo);
         }
 
         root.getChildren().forEach(this::clearRuntimeFilterExecGroupInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExecGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExecGroup.java
@@ -63,7 +63,6 @@ public class ExecGroup {
         }
 
         root.getProbeRuntimeFilters().forEach(RuntimeFilterDescription::clearExecGroupInfo);
-
         if (root instanceof RuntimeFilterBuildNode) {
             RuntimeFilterBuildNode rfBuildNode = (RuntimeFilterBuildNode) root;
             rfBuildNode.getBuildRuntimeFilters().forEach(RuntimeFilterDescription::clearExecGroupInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -350,6 +350,11 @@ public class RuntimeFilterDescription {
         this.execGroupId = buildExecGroupId;
     }
 
+    public void clearExecGroupInfo() {
+        this.isBuildFromColocateGroup = false;
+        this.execGroupId = -1;
+    }
+
     public boolean canPushAcrossExchangeNode() {
         if (onlyLocal) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2813,7 +2813,10 @@ public class PlanFragmentBuilder {
                     // do nothing
                 } else {
                     // we don't support group execution for other join
-                    currentExecGroup.setDisableColocateGroup();
+                    currentExecGroup.disableColocateGroup(leftFragmentPlanRoot);
+                    rightExecGroup.disableColocateGroup(rightFragmentPlanRoot);
+                    currentExecGroup.merge(rightExecGroup);
+                    execGroups.remove(rightExecGroup);
                 }
             }
             currentExecGroup.add(joinNode);


### PR DESCRIPTION
## Why I'm doing:

BE crashed.
```
*** Aborted at 1728368458 (unix time) try "date -d @1728368458" if you are using GNU date ***
PC: @          0x49068b4 starrocks::pipeline::HashJoinerFactory::get_builder(int, int)
*** SIGFPE (@0x49068b4) received by PID 20231 (TID 0x7fb68ea42700) from PID 76572852; stack trace: ***
    @     0x7fb6fb82f20b __pthread_once_slow
    @          0xb0b3754 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fb6fb838630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x49068b4 starrocks::pipeline::HashJoinerFactory::get_builder(int, int)
    @          0x4904f5e starrocks::pipeline::HashJoinProbeOperatorFactory::create(int, int)
    @          0x4930803 starrocks::pipeline::Pipeline::instantiate_drivers(starrocks::RuntimeState*)
    @          0x48b9210 starrocks::pipeline::FragmentContext::iterate_pipeline(std::function<void (starrocks::pipeline::Pipeline*)> const&)
    @          0x47f9652 starrocks::pipeline::FragmentExecutor::_prepare_pipeline_driver(starrocks::ExecEnv*, starrocks::pipeline::UnifiedExecPlanFragmentParams const&)
    @          0x47fe7ed starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0x7714203 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0x771ea43 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*)
    @          0x7726f7b starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)
    @          0x3a50b18 starrocks::PriorityThreadPool::work_thread(int)
    @          0xb070ac7 thread_proxy
    @     0x7fb6fb830ea5 start_thread
    @     0x7fb6faa1bb0d __clone
```

---

So far, we do not support cases where one side of the join is in a normal execution group while the other side is in a colocate execution group. This can result in the `HashJoinBuildOperator` and `HashJoinProbeOperator` being placed in two different execution groups. 

However, sometimes this scenario is not handled correctly. For instance, in the following case, the right table's One-Phase Aggregation will be processed by the colocate execution group, while the left table's Bucket Shuffle Join will be processed by the normal execution group.
```
                        Colocate Join
                        /          \
Bucket Shuffle Join (right join)    One-Phase Agg
```


```
| PLAN FRAGMENT 1(F00)                                                                                                                                                                                                                           |
|   Fragment Cost: 2951.5111111111114                                                                                                                                                                                                            |
|   colocate exec groups: ExecGroup{groupId=4, nodeIds=[5, 8, 9, 10]}                                                                                                                                                                            |
|                                                                                                                                                                                                                                                |
|   Input Partition: RANDOM                                                                                                                                                                                                                      |
|   OutPut Partition: UNPARTITIONED                                                                                                                                                                                                              |
|   OutPut Exchange Id: 14                                                                                                                                                                                                                       |
|                                                                                                                                                                                                                                                |
|   13:AGGREGATE (update serialize)                                                                                                                                                                                                              |
|   |  aggregate: count[([53: avg, DOUBLE, true]); args: DOUBLE; result: BIGINT; args nullable: true; result nullable: false], count[([1: case, BIGINT, true]); args: BIGINT; result: BIGINT; args nullable: true; result nullable: false]       |
|   |  hasNullableGenerateChild: true                                                                                                                                                                                                            |
|   |  cardinality: 1                                                                                                                                                                                                                            |
|   |                                                                                                                                                                                                                                            |
|   12:Project                                                                                                                                                                                                                                   |
|   |  output columns:                                                                                                                                                                                                                           |
|   |  1 <-> [1: case, BIGINT, true]                                                                                                                                                                                                             |
|   |  53 <-> [53: avg, DOUBLE, true]                                                                                                                                                                                                            |
|   |  hasNullableGenerateChild: true                                                                                                                                                                                                            |
|   |  cardinality: 31                                                                                                                                                                                                                           |
|   |                                                                                                                                                                                                                                            |
|   11:HASH JOIN                                                                                                                                                                                                                                 |
|   |  join op: LEFT OUTER JOIN (COLOCATE)                                                                                                                                                                                                       |
|   |  colocate: true                                                                                                                                                                                                                            |
|   |  equal join conjunct: [1: case, BIGINT, true] = [27: case, BIGINT, true]                                                                                                                                                                   |
|   |  output columns: 1, 53                                                                                                                                                                                                                     |
|   |  can local shuffle: true                                                                                                                                                                                                                   |
|   |  cardinality: 31                                                                                                                                                                                                                           |
|   |                                                                                                                                                                                                                                            |
|   |----10:AGGREGATE (update finalize)                                                                                                                                                                                                          |
|   |    |  aggregate: avg[([27: case, BIGINT, true]); args: BIGINT; result: DOUBLE; args nullable: true; result nullable: true]                                                                                                                 |
|   |    |  group by: [27: case, BIGINT, true]                                                                                                                                                                                                   |
|   |    |  hasNullableGenerateChild: true                                                                                                                                                                                                       |
|   |    |  cardinality: 8                                                                                                                                                                                                                       |
|   |    |                                                                                                                                                                                                                                       |
|   |    9:Project                                                                                                                                                                                                                               |
|   |    |  output columns:                                                                                                                                                                                                                      |
|   |    |  27 <-> [27: case, BIGINT, false]                                                                                                                                                                                                     |
|   |    |  hasNullableGenerateChild: true                                                                                                                                                                                                       |
|   |    |  cardinality: 31                                                                                                                                                                                                                      |
|   |    |                                                                                                                                                                                                                                       |
|   |    8:HASH JOIN                                                                                                                                                                                                                             |
|   |    |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE)                                                                                                                                                                                            |
|   |    |  equal join conjunct: [27: case, BIGINT, false] = [39: case, BIGINT, true]                                                                                                                                                            |
|   |    |  output columns: 27                                                                                                                                                                                                                   |
|   |    |  can local shuffle: false                                                                                                                                                                                                             |
|   |    |  cardinality: 31                                                                                                                                                                                                                      |
|   |    |                                                                                                                                                                                                                                       |
|   |    |----7:EXCHANGE                                                                                                                                                                                                                         |
|   |    |       distribution type: SHUFFLE                                                                                                                                                                                                      |
|   |    |       partition exprs: [39: case, BIGINT, true]                                                                                                                                                                                       |
|   |    |       cardinality: 9                                                                                                                                                                                                                  |
|   |    |                                                                                                                                                                                                                                       |
|   |    5:OlapScanNode                                                                                                                                                                                                                          |
|   |       table: ACTIVITY, rollup: ACTIVITY                                                                                                                                                                                                    |
|   |       preAggregation: on                                                                                                                                                                                                                   |
|   |       partitionsRatio=1/1, tabletsRatio=16/16                                                                                                                                                                                              |
|   |       tabletList=10418,10420,10422,10424,10426,10428,10430,10432,10434,10436 ...                                                                                                                                                           |
|   |       actualRows=31, avgRowSize=8.0                                                                                                                                                                                                        |
|   |       cardinality: 31                                                                                                                                                                                                                      |
|   |                                                                                                                                                                                                                                            |
|   4:Project                                                                                                                                                                                                                                    |
|   |  output columns:                                                                                                                                                                                                                           |
|   |  1 <-> [1: case, BIGINT, true]                                                                                                                                                                                                             |
|   |  hasNullableGenerateChild: true                                                                                                                                                                                                            |
|   |  cardinality: 31                                                                                                                                                                                                                           |
|   |                                                                                                                                                                                                                                            |
|   3:HASH JOIN                                                                                                                                                                                                                                  |
|   |  join op: RIGHT OUTER JOIN (BUCKET_SHUFFLE)                                                                                                                                                                                                |
|   |  equal join conjunct: [1: case, BIGINT, true] = [13: case, BIGINT, true]                                                                                                                                                                   |
|   |  build runtime filters:                                                                                                                                                                                                                    |
|   |  - filter_id = 0, build_expr = (13: case), remote = false                                                                                                                                                                                  |
|   |  output columns: 1                                                                                                                                                                                                                         |
|   |  can local shuffle: false                                                                                                                                                                                                                  |
|   |  cardinality: 31                                                                                                                                                                                                                           |
|   |                                                                                                                                                                                                                                            |
|   |----2:EXCHANGE                                                                                                                                                                                                                              |
|   |       distribution type: SHUFFLE                                                                                                                                                                                                           |
|   |       partition exprs: [13: case, BIGINT, true]                                                                                                                                                                                            |
|   |       cardinality: 9                                                                                                                                                                                                                       |
|   |                                                                                                                                                                                                                                            |
|   0:OlapScanNode                                                                                                                                                                                                                               |
|      table: ACTIVITY, rollup: ACTIVITY                                                                                                                                                                                                         |
|      preAggregation: on                                                                                                                                                                                                                        |
|      partitionsRatio=1/1, tabletsRatio=16/16                                                                                                                                                                                                   |
|      tabletList=10418,10420,10422,10424,10426,10428,10430,10432,10434,10436 ...                                                                                                                                                                |
|      actualRows=31, avgRowSize=8.0                                                                                                                                                                                                             |
|      cardinality: 31                                                                                                                                                                                                                           |
|      probe runtime filters:                                                                                                                                                                                                                    |
|      - filter_id = 0, probe_expr = (1: case)                              
```

## What I'm doing:


If the `JoinNode` does not support colocate execution groups on any side, we should:
1. Clear the execution group information from the Runtime Filter on both sides.
2. Disable the colocate execution group.
3. Move all nodes from the right execution group to the left execution group.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
