### PR TITLE
[Enhancement] staros agent listShard does not need replica info

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -501,7 +501,8 @@ public class StarOSAgent {
 
         List<List<ShardInfo>> shardInfo;
         try {
-            shardInfo = client.listShard(serviceId, Arrays.asList(groupId));
+            shardInfo = client.listShard(serviceId, Arrays.asList(groupId), DEFAULT_WORKER_GROUP_ID,
+                                         true /* withoutReplicaInfo */);
         } catch (StarClientException e) {
             throw new DdlException(String.format("Failed to list shards in group %d. error:%s", groupId, e.getMessage()));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -731,4 +731,23 @@ public class StarOSAgentTest {
     private Set<Long> getBackendIdsByShard(long shardId, long workerGroupId) throws UserException {
         return starosAgent.getAllNodeIdsByShard(shardId, workerGroupId, false);
     }
+
+    @Test
+    public void testListShard() throws StarClientException, DdlException {
+        ShardInfo shardInfo = ShardInfo.newBuilder().setShardId(1000L).build();
+        List<List<ShardInfo>> infos = new ArrayList<>();
+        infos.add(Lists.newArrayList(shardInfo));
+        new Expectations() {
+            {
+                client.listShard("1", Lists.newArrayList(999L), StarOSAgent.DEFAULT_WORKER_GROUP_ID, true);
+                result = infos;
+                minTimes = 1;
+                maxTimes = 1;
+            }
+        };
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+        List<Long> ids = starosAgent.listShard(999L);
+        Assert.assertEquals(1, ids.size());
+        Assert.assertEquals((Long) 1000L, (Long) ids.get(0));
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
list shard only provides shard id, replica info is not needed, this helps star mgr meta sync do less work

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
