### PR TITLE
[Enhancement] A build machine that supports the AVX2 instruction set compiles a package without the AVX2 instruction set.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -105,6 +105,7 @@ Usage: $0 <options>
                         build with compressing debug symbol. (default: $WITH_COMPRESS)
      --with-source-file-relative-path {ON|OFF}
                         build source file with relative path. (default: $WITH_RELATIVE_SRC_PATH)
+     --without-avx2     build Backend without avx2(instruction)    
      -h,--help          Show this help message
   Eg.
     $0                                           build all
@@ -141,6 +142,7 @@ OPTS=$(getopt \
   -l 'without-tenann' \
   -l 'with-compress-debug-symbol:' \
   -l 'with-source-file-relative-path:' \
+  -l 'without-avx2' \
   -l 'help' \
   -- "$@")
 
@@ -266,6 +268,7 @@ else
             --without-starcache) WITH_STARCACHE=OFF; shift ;;
             --output-compile-time) OUTPUT_COMPILE_TIME=ON; shift ;;
             --without-tenann) WITH_TENANN=OFF; shift ;;
+            --without-avx2) USE_AVX2=OFF; shift ;;
             --with-compress-debug-symbol) WITH_COMPRESS=$2 ; shift 2 ;;
             --with-source-file-relative-path) WITH_RELATIVE_SRC_PATH=$2 ; shift 2 ;;
             -h) HELP=1; shift ;;


### PR DESCRIPTION
## Why I'm doing:
In some virtual machines or containers, the AVX2 instruction set is not supported. However, whether the compiled package from the current build script includes AVX2 support depends on the CPU instruction set of the build machine. Therefore, if the build machine supports the AVX2 instruction set, it is not possible to compile a package that does not include AVX2 support.

## What I'm doing:
In the build.sh, add the --without-avx2 option to force the packaging of a product without the AVX2 instruction set. If this option is not added, the default strategy (detecting based on the build machine’s CPU) will be maintained.

## Fixes #issue
There is no corresponding issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
