### PR TITLE
[BugFix] Fix split scan rule reuse column id

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -272,6 +272,7 @@ public class OptExpression {
         String childHeadlinePrefix = detailPrefix + "->  ";
         String childDetailPrefix = detailPrefix + "    ";
         for (OptExpression input : inputs) {
+            sb.append('\n');
             sb.append(input.debugString(childHeadlinePrefix, childDetailPrefix, limitLine));
         }
         return sb.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
@@ -233,6 +233,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
             builder.hintsReplicaIds = scanOperator.hintsReplicaIds;
             builder.prunedPartitionPredicates = scanOperator.prunedPartitionPredicates;
             builder.usePkIndex = scanOperator.usePkIndex;
+            builder.fromSplitOR = scanOperator.fromSplitOR;
             builder.vectorSearchOptions = scanOperator.vectorSearchOptions;
             return this;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FilterSelectivityEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FilterSelectivityEvaluator.java
@@ -47,15 +47,15 @@ public class FilterSelectivityEvaluator {
 
     public static final double NON_SELECTIVITY = 100;
 
-    public static final int IN_CHILDREN_THRESHOLD = 1024;
+    public static int IN_CHILDREN_THRESHOLD = 1024;
 
-    private int unionNumLimit;
+    private final int unionNumLimit;
 
-    private ScalarOperator predicate;
+    private final ScalarOperator predicate;
 
-    private Statistics statistics;
+    private final Statistics statistics;
 
-    private boolean isDecomposePhase;
+    private final boolean isDecomposePhase;
 
     public FilterSelectivityEvaluator(ScalarOperator predicate, Statistics statistics, boolean isDecomposePhase) {
         this.predicate = predicate;
@@ -90,23 +90,15 @@ public class FilterSelectivityEvaluator {
 
     private List<ColumnFilter> decomposeInPredicate(InPredicateOperator predicate) {
         List<ColumnFilter> inFilters = Lists.newArrayList();
-        Set<ScalarOperator> inSet = predicate.getChildren().stream().skip(1).collect(Collectors.toSet());
+        List<ScalarOperator> inList = predicate.getChildren().stream().skip(1).distinct().collect(Collectors.toList());
         ColumnRefOperator column = (ColumnRefOperator) predicate.getChild(0);
-        int totalSize = inSet.size();
+        int totalSize = inList.size();
         int numSubsets = (int) Math.ceil((double) totalSize / IN_CHILDREN_THRESHOLD);
-        List<List<ScalarOperator>> smallInSets = Lists.newArrayList();
         for (int i = 0; i < numSubsets; i++) {
-            smallInSets.add(Lists.newArrayList(column));
-        }
-
-        int currentIndex = 0;
-        for (ScalarOperator element : inSet) {
-            int subsetIndex = currentIndex / IN_CHILDREN_THRESHOLD;
-            smallInSets.get(subsetIndex).add(element);
-            currentIndex++;
-        }
-        for (int i = 0; i < numSubsets; i++) {
-            InPredicateOperator newInPredicate = new InPredicateOperator(false, smallInSets.get(i));
+            List<ScalarOperator> s = Lists.newArrayListWithExpectedSize(IN_CHILDREN_THRESHOLD + 2);
+            s.add(column);
+            s.addAll(inList.subList(i * IN_CHILDREN_THRESHOLD, Math.min((i + 1) * IN_CHILDREN_THRESHOLD, totalSize)));
+            InPredicateOperator newInPredicate = new InPredicateOperator(false, s);
             inFilters.add(evaluateScalarOperator(newInPredicate));
         }
 
@@ -315,13 +307,12 @@ public class FilterSelectivityEvaluator {
 
     public static class ColumnFilter implements Comparable<ColumnFilter> {
 
-        private Double selectRatio;
+        private final Double selectRatio;
 
         // TODO add index info
+        private final Optional<ColumnRefOperator> column;
 
-        private Optional<ColumnRefOperator> column;
-
-        private ScalarOperator filter;
+        private final ScalarOperator filter;
 
         public ColumnFilter(double selectRatio, ScalarOperator filter) {
             this.selectRatio = selectRatio;
@@ -341,6 +332,10 @@ public class FilterSelectivityEvaluator {
 
         public ScalarOperator getFilter() {
             return filter;
+        }
+
+        public Optional<ColumnRefOperator> getColumn() {
+            return column;
         }
 
         public boolean isUnknownSelectRatio() {
@@ -376,13 +371,7 @@ public class FilterSelectivityEvaluator {
 
         @Override
         public int compareTo(@NotNull ColumnFilter o) {
-            if (selectRatio < o.selectRatio) {
-                return -1;
-            } else if (selectRatio > o.selectRatio) {
-                return 1;
-            } else {
-                return 0;
-            }
+            return selectRatio.compareTo(o.selectRatio);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -700,15 +700,15 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
 
         // tbl_mock_015
         Assert.assertTrue(plan, plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 1, probe_expr = (1: mock_004)"));
+                "     - filter_id = 4, probe_expr = (80: mock_004)"));
         Assert.assertTrue(plan, plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 3, probe_expr = (24: mock_004)"));
+                "     - filter_id = 3, probe_expr = (62: mock_004)"));
 
         // table: tbl_mock_001, rollup: tbl_mock_001
         Assert.assertTrue(plan, plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (1: mock_004)"));
+                "     - filter_id = 1, probe_expr = (116: mock_004)"));
         Assert.assertTrue(plan, plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 4, probe_expr = (24: mock_004)"));
+                "     - filter_id = 0, probe_expr = (98: mock_004)\n"));
 
     }
 


### PR DESCRIPTION
## Why I'm doing:
Split scan rule:
* reuse column id, will take mistake in other rule
* doesn't handle projection

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
