### PR TITLE
[BugFix] When the reserved keyword uses backquotes as input, deserialization causes  parseSqlToExpr syntax error, which results in log edit failure.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -283,7 +283,8 @@ public class SlotRef extends Expr {
         if (tblName != null && !isFromLambda()) {
             return tblName.toSql() + "." + "`" + colName + "`";
         } else if (label != null) {
-            return label;
+            sb.append("`").append(label).append("`");
+            return sb.toString();
         } else if (desc.getSourceExprs() != null) {
             sb.append("<slot ").append(desc.getId().asInt()).append(">");
             for (Expr expr : desc.getSourceExprs()) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -65,8 +65,9 @@ public class SlotRef extends Expr {
     private TableName tblName;
     private String colName;
     private ColumnId columnId;
-    // Used in toSql
+    //label/isBackQuoted used in toSql
     private String label;
+    private boolean isBackQuoted = false;
 
     private QualifiedName qualifiedName;
 
@@ -170,6 +171,10 @@ public class SlotRef extends Expr {
 
     public SlotRef(SlotId slotId) {
         this(new SlotDescriptor(slotId, "", Type.INVALID, false));
+    }
+
+    public void setBackQuoted(boolean isBackQuoted) {
+        this.isBackQuoted = isBackQuoted;
     }
 
     public QualifiedName getQualifiedName() {
@@ -283,8 +288,12 @@ public class SlotRef extends Expr {
         if (tblName != null && !isFromLambda()) {
             return tblName.toSql() + "." + "`" + colName + "`";
         } else if (label != null) {
-            sb.append("`").append(label).append("`");
-            return sb.toString();
+            if (isBackQuoted) {
+                sb.append("`").append(label).append("`");
+                return sb.toString();
+            } else {
+                return label;
+            }
         } else if (desc.getSourceExprs() != null) {
             sb.append("<slot ").append(desc.getId().asInt()).append(">");
             for (Expr expr : desc.getSourceExprs()) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -177,6 +177,10 @@ public class SlotRef extends Expr {
         this.isBackQuoted = isBackQuoted;
     }
 
+    public boolean isBackQuoted() {
+        return isBackQuoted;
+    }
+
     public QualifiedName getQualifiedName() {
         return qualifiedName;
     }
@@ -288,7 +292,7 @@ public class SlotRef extends Expr {
         if (tblName != null && !isFromLambda()) {
             return tblName.toSql() + "." + "`" + colName + "`";
         } else if (label != null) {
-            if (isBackQuoted) {
+            if (isBackQuoted && !(label.startsWith("`") && label.endsWith("`"))) {
                 sb.append("`").append(label).append("`");
                 return sb.toString();
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnId.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 
 import com.starrocks.common.util.ParseUtil;
+
 import java.util.Comparator;
 import java.util.Objects;
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnId.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog;
 
 
+import com.starrocks.common.util.ParseUtil;
 import java.util.Comparator;
 import java.util.Objects;
 
@@ -71,6 +72,13 @@ public class ColumnId {
     @Override
     public String toString() {
         return getId();
+    }
+
+    public String toSql(boolean isBackQuoted) {
+        if (isBackQuoted) {
+            return ParseUtil.backquote(id);
+        }
+        return id;
     }
 
     public static final Comparator<ColumnId> CASE_INSENSITIVE_ORDER =

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -167,6 +168,11 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
         this.partitionExprs = partitionExprs;
         this.isMultiColumnPartition = partitionExprs.size() > 0;
         this.type = type;
+    }
+
+    @VisibleForTesting
+    public List<ColumnIdExpr> getPartitionExprs() {
+        return partitionExprs;
     }
 
     public List<Expr> getPartitionExprs(Map<ColumnId, Column> idToColumn) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ColumnIdExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ColumnIdExpr.java
@@ -137,6 +137,9 @@ public class ColumnIdExpr {
             if (node.getTblNameWithoutAnalyzed() != null) {
                 return node.getTblNameWithoutAnalyzed().toString() + "." + node.getColumnId().getId();
             } else {
+                if (node.isBackQuoted()) {
+                    return "`" + node.getColumnId().getId() + "`";
+                }
                 return node.getColumnId().getId();
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ColumnIdExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ColumnIdExpr.java
@@ -18,6 +18,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
+import com.starrocks.common.util.ParseUtil;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -135,12 +136,9 @@ public class ColumnIdExpr {
         @Override
         public String visitSlot(SlotRef node, Void context) {
             if (node.getTblNameWithoutAnalyzed() != null) {
-                return node.getTblNameWithoutAnalyzed().toString() + "." + node.getColumnId().getId();
+                return node.getTblNameWithoutAnalyzed().toSql() + "." + ParseUtil.backquote(node.getColumnId().getId());
             } else {
-                if (node.isBackQuoted()) {
-                    return "`" + node.getColumnId().getId() + "`";
-                }
-                return node.getColumnId().getId();
+                return node.getColumnId().toSql(node.isBackQuoted());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/Identifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/Identifier.java
@@ -22,6 +22,8 @@ public class Identifier implements ParseNode {
 
     private final NodePosition pos;
 
+    private boolean isBackQuoted = false;
+
     public Identifier(String value) {
         this(value, NodePosition.ZERO);
     }
@@ -38,6 +40,14 @@ public class Identifier implements ParseNode {
     @Override
     public NodePosition getPos() {
         return pos;
+    }
+
+    public void setBackQuoted(boolean isBackQuoted) {
+        this.isBackQuoted = isBackQuoted;
+    }
+
+    public boolean isBackQuoted() {
+        return isBackQuoted;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -7076,7 +7076,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         List<String> parts = new ArrayList<>();
         parts.add(identifier.getValue());
         QualifiedName qualifiedName = QualifiedName.of(parts, createPos(context));
-        return new SlotRef(qualifiedName);
+        SlotRef slotRef = new SlotRef(qualifiedName);
+        if (identifier.isBackQuoted()) {
+            slotRef.setBackQuoted(true);
+        }
+        return slotRef;
     }
 
     @Override
@@ -7155,7 +7159,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitBackQuotedIdentifier(StarRocksParser.BackQuotedIdentifierContext context) {
-        return new Identifier(context.getText().replace("`", ""), createPos(context));
+        Identifier backQuotedIdentifier = new Identifier(context.getText().replace("`", ""), createPos(context));
+        backQuotedIdentifier.setBackQuoted(true);
+        return backQuotedIdentifier;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
@@ -691,6 +691,13 @@ public class ExpressionRangePartitionInfoTest {
             Assert.assertTrue(e.getMessage().contains("Getting syntax error at line 1, column 10. " +
                     "Detail message: Unexpected input '(', the most similar input is {<EOF>}."));
         }
-    }
 
+        //the table still create successfully.
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = db.getTable("table_reserverd_keyword_partition1");
+        ExpressionRangePartitionInfo expressionRangePartitionInfo =
+                (ExpressionRangePartitionInfo) ((OlapTable) table).getPartitionInfo();
+        String exprToSql = expressionRangePartitionInfo.getPartitionExprs().get(0).toSql();
+        Assert.assertEquals("date_trunc('day', partition)", exprToSql);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
@@ -28,6 +28,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc.PartitionRangeType;
 import com.starrocks.sql.ast.PartitionValue;
@@ -590,6 +591,106 @@ public class ExpressionRangePartitionInfoTest {
         String json = GsonUtils.GSON.toJson(olapTable);
         // deserialize
         OlapTable readTable = GsonUtils.GSON.fromJson(json, OlapTable.class);
+    }
+
+    @Test
+    public void testExpressionRangePartitionInfoWithReservedKeywordSerialized() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE table_reserverd_keyword_partition (\n" +
+                "databaseName varchar(200) NULL COMMENT \"\",\n" +
+                "tableName varchar(200) NULL COMMENT \"\",\n" +
+                "queryTime varchar(50) NULL COMMENT \"\",\n" +
+                "queryId varchar(50) NULL COMMENT \"\",\n" +
+                "partitionHitSum int(11) NULL COMMENT \"\",\n" +
+                "partitionSum int(11) NULL COMMENT \"\",\n" +
+                "tabletHitNum int(11) NULL COMMENT \"\",\n" +
+                "tabletSum int(11) NULL COMMENT \"\",\n" +
+                "startHitPartition varchar(20) NULL COMMENT \"\",\n" +
+                "`partition` date NULL COMMENT \"\",\n" +
+                "clusterAddress varchar(50) NULL COMMENT \"\",\n" +
+                "costTime int(11) NULL COMMENT \"\",\n" +
+                "tableQueryCount int(11) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(databaseName, tableName)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "PARTITION BY date_trunc('day', `partition`)\n" +
+                "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"enable_persistent_index\" = \"false\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                ");";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        ExpressionPartitionDesc exprPartitiondesc = (ExpressionPartitionDesc) createTableStmt.getPartitionDesc();
+        FunctionCallExpr funExpr = (FunctionCallExpr) exprPartitiondesc.getExpr();
+        SlotRef slotRef = (SlotRef) funExpr.getChild(1);
+        Assert.assertTrue(slotRef.isBackQuoted());
+
+
+        StarRocksAssert.utCreateTableWithRetry(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = db.getTable("table_reserverd_keyword_partition");
+        ExpressionRangePartitionInfo expressionRangePartitionInfo =
+                (ExpressionRangePartitionInfo) ((OlapTable) table).getPartitionInfo();
+        String exprToSql = expressionRangePartitionInfo.getPartitionExprs().get(0).toSql();
+        Assert.assertEquals("date_trunc('day', `partition`)", exprToSql);
+        // serialize
+        String json = GsonUtils.GSON.toJson(table);
+        // deserialize
+        OlapTable readTable = GsonUtils.GSON.fromJson(json, OlapTable.class);
+        expressionRangePartitionInfo = (ExpressionRangePartitionInfo) readTable.getPartitionInfo();
+        List<ColumnIdExpr> readPartitionExprs = expressionRangePartitionInfo.getPartitionExprs();
+        Function fn = readPartitionExprs.get(0).getExpr().getFn();
+        Assert.assertNotNull(fn);
+    }
+
+    @Test
+    public void testExpressionRangePartitionInfoWithReservedKeywordSerializedWrong() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE table_reserverd_keyword_partition1 (\n" +
+                "databaseName varchar(200) NULL COMMENT \"\",\n" +
+                "tableName varchar(200) NULL COMMENT \"\",\n" +
+                "queryTime varchar(50) NULL COMMENT \"\",\n" +
+                "queryId varchar(50) NULL COMMENT \"\",\n" +
+                "partitionHitSum int(11) NULL COMMENT \"\",\n" +
+                "partitionSum int(11) NULL COMMENT \"\",\n" +
+                "tabletHitNum int(11) NULL COMMENT \"\",\n" +
+                "tabletSum int(11) NULL COMMENT \"\",\n" +
+                "startHitPartition varchar(20) NULL COMMENT \"\",\n" +
+                "`partition` date NULL COMMENT \"\",\n" +
+                "clusterAddress varchar(50) NULL COMMENT \"\",\n" +
+                "costTime int(11) NULL COMMENT \"\",\n" +
+                "tableQueryCount int(11) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(databaseName, tableName)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "PARTITION BY date_trunc('day', `partition`)\n" +
+                "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"enable_persistent_index\" = \"false\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                ");";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        ExpressionPartitionDesc exprPartitiondesc = (ExpressionPartitionDesc) createTableStmt.getPartitionDesc();
+        FunctionCallExpr funExpr = (FunctionCallExpr) exprPartitiondesc.getExpr();
+        SlotRef slotRef = (SlotRef) funExpr.getChild(1);
+        Assert.assertTrue(slotRef.isBackQuoted());
+        slotRef.setBackQuoted(false);
+
+        try {
+            // serialize in OnCrete Function will throw err,because of "date_trunc('day', partition)".
+            GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+            Assert.fail();
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertTrue(e.getMessage().contains("Getting syntax error at line 1, column 10. " +
+                    "Detail message: Unexpected input '(', the most similar input is {<EOF>}."));
+        }
     }
 
 }

--- a/test/sql/test_automatic_bucket/R/test_automatic_partition
+++ b/test/sql/test_automatic_bucket/R/test_automatic_partition
@@ -517,7 +517,7 @@ t	CREATE TABLE `t` (
   `v` int(11) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`k`, `v`)
-PARTITION BY date_trunc('DAY', k)
+PARTITION BY date_trunc('DAY', `k`)
 DISTRIBUTED BY RANDOM
 PROPERTIES (
 "bucket_size" = "1",
@@ -549,7 +549,7 @@ t	CREATE TABLE `t` (
   `v` int(11) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`k`, `v`)
-PARTITION BY date_trunc('DAY', `k`)
+PARTITION BY date_trunc('DAY', k)
 DISTRIBUTED BY RANDOM
 PROPERTIES (
 "bucket_size" = "1",

--- a/test/sql/test_automatic_bucket/R/test_automatic_partition
+++ b/test/sql/test_automatic_bucket/R/test_automatic_partition
@@ -549,7 +549,7 @@ t	CREATE TABLE `t` (
   `v` int(11) NULL COMMENT ""
 ) ENGINE=OLAP 
 DUPLICATE KEY(`k`, `v`)
-PARTITION BY date_trunc('DAY', k)
+PARTITION BY date_trunc('DAY', `k`)
 DISTRIBUTED BY RANDOM
 PROPERTIES (
 "bucket_size" = "1",


### PR DESCRIPTION
## Why I'm doing:
There is a difference between that the pr and [51781](https://github.com/StarRocks/starrocks/pull/51781).
Error scenario encountered with the create sql in version3.3:
1 create tablet succeeds
2 getEditLog().logCreateTable reported error
3 Restart FE, table is missing.
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/a8e20aec-5259-4b4d-94a0-9f4583815450">


## What I'm doing:
Fixes #51678

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
