### PR TITLE
[BugFix] Fix http sql oom issue

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,6 @@
 # ignore protobuf cve temporary
 CVE-2024-7254
-# ignore commons-io-2.11.0.jar introduced by iceberg-metadata-reader
+# ignore commons-io-2.11.0.jar introduced by odps-reader
 CVE-2024-47554
 # ignore avro-1.11.3.jar introduced by iceberg-core-1.6.0
 CVE-2024-47561

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,6 @@
 # ignore protobuf cve temporary
 CVE-2024-7254
+# ignore commons-io-2.11.0.jar introduced by iceberg-metadata-reader
+CVE-2024-47554
+# ignore avro-1.11.3.jar introduced by iceberg-core-1.6.0
+CVE-2024-47561

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -423,6 +423,7 @@ under the License.
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
+            <version>4.1.114.Final</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -423,7 +423,6 @@ under the License.
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.114.Final</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpResultSender.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpResultSender.java
@@ -117,33 +117,29 @@ public class HttpResultSender {
     }
 
     // BE already transferred results into json format, FE just need to Forward json objects to the client
-    private void writeResultBatch(TResultBatch resultBatch, ChannelHandlerContext channel, Coordinator coord)
-            throws InterruptedException {
+    private void writeResultBatch(TResultBatch resultBatch, ChannelHandlerContext channel, Coordinator coord) {
         int rowsSize = resultBatch.getRowsSize();
-        int unWritableCount = 0;
+        int count = 0;
         for (ByteBuffer row : resultBatch.getRows()) {
             // when channel is not writeable, sleep a while to balance read/write speed to avoid oom
             while (!channel.channel().isWritable()) {
-                //                LOG.warn("http sql:channel is not writable when sending result");
                 // if channel is closed, cancel query
                 if (!channel.channel().isActive()) {
                     coord.cancel("channel is closed, cancel query");
-                    //                    LOG.warn("http query:channel is closed, cancel query");
+                    LOG.warn("http query:channel is closed, cancel query");
                     return;
                 }
-                unWritableCount++;
-                if (unWritableCount == 10) {
-                    //                    LOG.warn("http sql:sleep");
-                    Thread.sleep(1);
-                    unWritableCount = 0;
-                } else {
-                    Thread.onSpinWait();
+                count++;
+                Thread.yield();
+                if (count == 100) {
+                    // maybe stuck, so flush to clear ChannelOutboundBuffer
+                    channel.flush();
+                    count = 0;
                 }
             }
             if (row != resultBatch.getRows().get(rowsSize - 1)) {
                 channel.write(Unpooled.wrappedBuffer(row));
                 if (!channel.channel().isWritable()) {
-                    //                    LOG.warn("http sql:channel is not writable so flush!");
                     channel.flush();
                 }
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpResultSender.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpResultSender.java
@@ -67,7 +67,7 @@ public class HttpResultSender {
     }
 
     // for select
-    public RowBatch sendQueryResult(Coordinator coord, ExecPlan execPlan) throws Exception {
+    public RowBatch sendQueryResult(Coordinator coord, ExecPlan execPlan, String sql) throws Exception {
         RowBatch batch;
         ChannelHandlerContext nettyChannel = context.getNettyChannel();
         // if some data already sent to client, when exception occurs,we just close the channel
@@ -84,7 +84,7 @@ public class HttpResultSender {
         while (true) {
             batch = coord.getNext();
             if (batch.getBatch() != null) {
-                writeResultBatch(batch.getBatch(), nettyChannel, coord);
+                writeResultBatch(batch.getBatch(), nettyChannel, coord, sql);
                 context.updateReturnRows(batch.getBatch().getRows().size());
             }
             if (batch.isEos()) {
@@ -117,7 +117,8 @@ public class HttpResultSender {
     }
 
     // BE already transferred results into json format, FE just need to Forward json objects to the client
-    private void writeResultBatch(TResultBatch resultBatch, ChannelHandlerContext channel, Coordinator coord) {
+    private void writeResultBatch(TResultBatch resultBatch, ChannelHandlerContext channel, Coordinator coord,
+                                  String sql) {
         int rowsSize = resultBatch.getRowsSize();
         int count = 0;
         for (ByteBuffer row : resultBatch.getRows()) {
@@ -126,7 +127,8 @@ public class HttpResultSender {
                 // if channel is closed, cancel query
                 if (!channel.channel().isActive()) {
                     coord.cancel("channel is closed, cancel query");
-                    LOG.warn("http query:channel is closed, cancel query");
+                    LOG.warn("http query:channel is closed, cancel query, query id:{}, query:{}", coord.getQueryId(),
+                            sql);
                     return;
                 }
                 count++;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
@@ -290,6 +290,7 @@ public class ExecuteSqlAction extends RestBaseAction {
             // for queryStatement, if some data already sent, we just close the channel
             if (parsedStmt instanceof QueryStatement && context.getSendDate()) {
                 context.getNettyChannel().close();
+                LOG.warn("http sql:Netty channel is closed because: " + context.getState().getErrorMessage());
                 return;
             }
             // send error message

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
@@ -290,7 +290,8 @@ public class ExecuteSqlAction extends RestBaseAction {
             // for queryStatement, if some data already sent, we just close the channel
             if (parsedStmt instanceof QueryStatement && context.getSendDate()) {
                 context.getNettyChannel().close();
-                LOG.warn("http sql:Netty channel is closed because: " + context.getState().getErrorMessage());
+                LOG.warn("http sql:Netty channel is closed, query id:{}, query:{}, reason:{}", context.getQueryId(),
+                        parsedStmt.getOrigStmt().getOrigStmt(), context.getState().getErrorMessage());
                 return;
             }
             // send error message

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1200,7 +1200,7 @@ public class StmtExecutor {
 
         RowBatch batch;
         if (context instanceof HttpConnectContext) {
-            batch = httpResultSender.sendQueryResult(coord, execPlan);
+            batch = httpResultSender.sendQueryResult(coord, execPlan, parsedStmt.getOrigStmt().getOrigStmt());
         } else {
             boolean needSendResult = !isPlanAdvisorAnalyze && !isExplainAnalyze
                     && !context.getSessionVariable().isEnableExecutionOnly();


### PR DESCRIPTION
## Why I'm doing:
1. for large result set, http sql may cause FE oom, which is because ChunkedWriteHandler will buffer data in queue when call ChannelHandlerContext.write, this queue can be super large(observed be dump file) when network is slow or client consumes slow, ChannelHandlerContext.flush will call ChunkedWriteHandler.flush, but ChunkedWriteHandler.flush won't promise "queue's element will be out of queue and continue to be flushed into socket"

2. for large result set, http sql may stuck in while loop if doesn't call ChannelHandlerContext.flush


## What I'm doing:
1. upgrade netty to 4.1.114.Final, in this version, ChunkedWriteHandler won't buffer data which is not ChunkInput type
2.when channel is not writable, we count to 100, and call ChannelHandlerContext.flush to avoid stuck


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
