### PR TITLE
[Enhancement] Support gc for cloud native persistent index files

### DIFF
--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -69,6 +69,10 @@ inline bool is_tablet_metadata_lock(std::string_view file_name) {
     return HasSuffixString(file_name, ".lock");
 }
 
+inline bool is_sst(std::string_view file_name) {
+    return HasSuffixString(file_name, ".sst");
+}
+
 inline std::string tablet_metadata_filename(int64_t tablet_id, int64_t version) {
     return fmt::format("{:016X}_{:016X}.meta", tablet_id, version);
 }

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -68,7 +68,7 @@ protected:
             full_path = join_path(join_path(kTestDir, kMetadataDirectoryName), name);
         } else if (is_txn_log(name) || is_txn_slog(name) || is_txn_vlog(name) || is_combined_txn_log(name)) {
             full_path = join_path(join_path(kTestDir, kTxnLogDirectoryName), name);
-        } else if (is_segment(name) || is_delvec(name) || is_del(name)) {
+        } else if (is_segment(name) || is_delvec(name) || is_del(name) || is_sst(name)) {
             full_path = join_path(join_path(kTestDir, kSegmentDirectoryName), name);
         } else {
             CHECK(false) << name;

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -697,6 +697,7 @@ TEST_P(LakeVacuumTest, test_delete_tablets_02) {
     create_data_file("00000000000359e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
     create_data_file("00000000000459e4_3d9c9edb-a69d-4a06-9093-a9f557e4c3b0.dat");
     create_data_file("00000000000459e3_9ae981b3-7d4b-49e9-9723-d7f752686154.delvec");
+    create_data_file("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686154.sst");
 
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {
@@ -776,6 +777,13 @@ TEST_P(LakeVacuumTest, test_delete_tablets_02) {
                 }
             ]
         },
+        "sstable_meta": {
+            "sstables": [
+                {
+                    "filename": "0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686154.sst"
+                }
+            ]
+        },
         "prev_garbage_version": 3
         }
         )DEL")));
@@ -796,6 +804,7 @@ TEST_P(LakeVacuumTest, test_delete_tablets_02) {
         EXPECT_FALSE(file_exist("00000000000359e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
         EXPECT_FALSE(file_exist("00000000000459e4_3d9c9edb-a69d-4a06-9093-a9f557e4c3b0.dat"));
         EXPECT_FALSE(file_exist("00000000000459e3_9ae981b3-7d4b-49e9-9723-d7f752686154.delvec"));
+        EXPECT_FALSE(file_exist("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686154.sst"));
     }
     {
         DeleteTabletRequest request;
@@ -1243,6 +1252,8 @@ TEST_P(LakeVacuumTest, test_datafile_gc) {
 
     create_data_file("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat");
     create_data_file("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat");
+    create_data_file("0000000000011111_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst");
+    create_data_file("0000000000022222_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst");
 
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {
@@ -1263,17 +1274,28 @@ TEST_P(LakeVacuumTest, test_datafile_gc) {
                 ],
                 "data_size": 4096
             }
-        ]
+        ],
+        "sstable_meta": {
+            "sstables": [
+                {
+                    "filename": "0000000000022222_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"
+                }
+            ]
+        }
         }
         )DEL")));
 
     ASSERT_OK(datafile_gc(kTestDir, join_path(kTestDir, "audit.log"), 0, false));
     EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
     EXPECT_TRUE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+    EXPECT_TRUE(file_exist("0000000000011111_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"));
+    EXPECT_TRUE(file_exist("0000000000022222_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"));
 
     ASSERT_OK(datafile_gc(kTestDir, "", 0, true));
     EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
     EXPECT_FALSE(file_exist("00000000000259e4_a542395a-bff5-48a7-a3a7-2ed05691b58c.dat"));
+    EXPECT_FALSE(file_exist("0000000000011111_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"));
+    EXPECT_TRUE(file_exist("0000000000022222_a542395a-bff5-48a7-a3a7-2ed05691b58c.sst"));
 }
 
 TEST_P(LakeVacuumTest, test_vacuum_combined_txn_log) {


### PR DESCRIPTION
## Why I'm doing:
In the current implementation, there are two scenarios where cloud native persistent index files cannot be reclaimed:
1. Performing a full garbage collection on files using the meta tool.
2. When executing a tablet drop.

## What I'm doing:
Support gc for cloud native persistent index files in these two scenarios.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
