### PR TITLE
[Enhancement] Improve files() with wrong credentials error message

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/StorageAccessException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/StorageAccessException.java
@@ -16,6 +16,7 @@
 package com.starrocks.sql.analyzer;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 /**
@@ -37,8 +38,15 @@ public class StorageAccessException extends RuntimeException {
         Throwable rootCause = getRootCause();
         if (rootCause instanceof S3Exception) {
             S3Exception s3Exception = (S3Exception) rootCause;
-            builder.append("Error code: ").append(s3Exception.awsErrorDetails().errorCode()).append(". ");
-            builder.append("Error message: ").append(s3Exception.awsErrorDetails().errorMessage()).append(". ");
+            AwsErrorDetails awsErrorDetails = s3Exception.awsErrorDetails();
+            if (awsErrorDetails.errorCode() != null) {
+                builder.append("Error code: ").append(awsErrorDetails.errorCode()).append(". ");
+            }
+            if (awsErrorDetails.errorMessage() != null) {
+                builder.append("Error message: ").append(awsErrorDetails.errorMessage());
+            } else {
+                builder.append("Error message: ").append(s3Exception.getMessage());
+            }
         } else {
             builder.append("Error message: ").append(rootCause.getMessage());
         }

--- a/test/sql/test_files/R/test_error
+++ b/test/sql/test_files/R/test_error
@@ -11,6 +11,14 @@ select * from files("path" = "hdfs://hdfs://test/x", "format" = "parquet");
 -- result:
 E: (1064, 'Access storage error. Error message: java.net.UnknownHostException: hdfs')
 -- !result
+select * from files("path" = "s3://${oss_bucket}/x", "format" = "parquet");
+-- result:
+E: (1064, 'Access storage error. Error message: Unable to load credentials from system settings. Access key must be specified either via environment variable (AWS_ACCESS_KEY_ID) or system property (aws.accessKeyId).')
+-- !result
+select * from files("path" = "s3://${oss_bucket}/x", "format" = "parquet", "aws.s3.access_key" = "xxx", "aws.s3.secret_key" = "yyy", "aws.s3.region" = "us-west-2");
+-- result:
+[REGEX].*Status Code: 403.*
+-- !result
 
 
 shell: ossutil64 mkdir oss://${oss_bucket}/test_files/orc_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_files/T/test_error
+++ b/test/sql/test_files/T/test_error
@@ -6,6 +6,9 @@ use db_${uuid0};
 -- path error
 select * from files("path" = "xxx", "format" = "parquet");
 select * from files("path" = "hdfs://hdfs://test/x", "format" = "parquet");
+select * from files("path" = "s3://${oss_bucket}/x", "format" = "parquet");
+select * from files("path" = "s3://${oss_bucket}/x", "format" = "parquet", "aws.s3.access_key" = "xxx", "aws.s3.secret_key" = "yyy", "aws.s3.region" = "us-west-2");
+
 
 -- credential desensitization fail
 shell: ossutil64 mkdir oss://${oss_bucket}/test_files/orc_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
```
mysql> select * from files(     "path" = "s3://xxx",     "format" = "csv",     "aws.s3.access_key" = "xxx",     "aws.s3.secret_key" = "yyy",     "aws.s3.region" = "us-west-2" );
ERROR 1064 (HY000): Access storage error. Error code: null. Error message: null.
```

## What I'm doing:
```
mysql> select * from files(     "path" = "s3://xxx",     "format" = "csv",     "aws.s3.access_key" = "xxx",     "aws.s3.secret_key" = "yyy",     "aws.s3.region" = "us-west-2" );
ERROR 1064 (HY000): Access storage error. Error message: null (Service: S3, Status Code: 403, Request ID: K3CJ30H0FXXX, Extended Request ID: iSJrLAKZrEud8jyVET78KClqmpqH3n4t/JdcflMPQZ==)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
