### PR TITLE
[BugFix] Fix iceberg datacache auto populate failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DataCachePopulateRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DataCachePopulateRewriteRule.java
@@ -169,9 +169,10 @@ public class DataCachePopulateRewriteRule implements TreeRewriteRule {
             if (operatorType == OperatorType.PHYSICAL_ICEBERG_SCAN ||
                     operatorType == OperatorType.PHYSICAL_DELTALAKE_SCAN ||
                     operatorType == OperatorType.PHYSICAL_PAIMON_SCAN) {
-                // For iceberg/delta lake we can't infer total partitions, so don't check here.
-                // Paimon partition prune is after Optimizer (in PaimonScanNode#setupScanRangeLocations()),
-                // so here also don't check it
+                // For iceberg/delta lake is very expensive to get all partitions,
+                // so we didn't set the correct idToPartitionKey/selectedPartitionIds here.
+                // Paimon partition prune is after Optimizer (in PaimonScanNode#setupScanRangeLocations()).
+                // For the above cases, there is no need to check here.
                 return false;
             }
             if (scanOperatorPredicates.getIdToPartitionKey().size() <= 1) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DataCachePopulateRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/DataCachePopulateRewriteRule.java
@@ -166,8 +166,12 @@ public class DataCachePopulateRewriteRule implements TreeRewriteRule {
         }
 
         private boolean checkIsFullPartitionScan(ScanOperatorPredicates scanOperatorPredicates, OperatorType operatorType) {
-            if (operatorType == OperatorType.PHYSICAL_ICEBERG_SCAN || operatorType == OperatorType.PHYSICAL_DELTALAKE_SCAN) {
+            if (operatorType == OperatorType.PHYSICAL_ICEBERG_SCAN ||
+                    operatorType == OperatorType.PHYSICAL_DELTALAKE_SCAN ||
+                    operatorType == OperatorType.PHYSICAL_PAIMON_SCAN) {
                 // For iceberg/delta lake we can't infer total partitions, so don't check here.
+                // Paimon partition prune is after Optimizer (in PaimonScanNode#setupScanRangeLocations()),
+                // so here also don't check it
                 return false;
             }
             if (scanOperatorPredicates.getIdToPartitionKey().size() <= 1) {


### PR DESCRIPTION
## Why I'm doing:
Iceberg/Delta Lake/Paimon will not set correct partition numbers in ScanOperatorPredicates.

## What I'm doing:
Just don't check it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
