### PR TITLE
[BugFix] Add task's defination into task run status

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
@@ -47,6 +47,7 @@ import com.starrocks.thrift.TUserIdentity;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.util.Strings;
 import org.apache.thrift.meta_data.FieldValueMetaData;
 import org.apache.thrift.protocol.TType;
 
@@ -211,14 +212,18 @@ public class TaskRunsSystemTable extends SystemTable {
             info.setState(status.getState().toString());
             info.setCatalog(status.getCatalogName());
             info.setDatabase(ClusterNamespace.getNameFromFullName(status.getDbName()));
-            try {
-                // NOTE: use task's definition to display task-run's definition here
-                Task task = taskManager.getTaskWithoutLock(taskName);
-                if (task != null) {
-                    info.setDefinition(task.getDefinition());
+            if (!Strings.isEmpty(status.getDefinition())) {
+                info.setDefinition(status.getDefinition());
+            } else {
+                try {
+                    // NOTE: use task's definition to display task-run's definition here
+                    Task task = taskManager.getTaskWithoutLock(taskName);
+                    if (task != null) {
+                        info.setDefinition(task.getDefinition());
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Get taskName {} definition failed: {}", taskName, e);
                 }
-            } catch (Exception e) {
-                LOG.warn("Get taskName {} definition failed: {}", taskName, e);
             }
             info.setError_code(status.getErrorCode());
             info.setError_message(status.getErrorMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -340,6 +340,10 @@ public class TaskRun implements Comparable<TaskRun> {
         status.setDbName(task.getDbName());
         status.setPostRun(task.getPostRun());
         status.setExpireTime(created + Config.task_runs_ttl_second * 1000L);
+        // NOTE: definition will cause a lot of repeats and cost a lot of metadata memory resources,
+        // since history task runs has been stored in sr's internal table, we can save it in the
+        // task run status.
+        status.setDefinition(task.getDefinition());
         status.getMvTaskRunExtraMessage().setExecuteOption(this.executeOption);
 
         LOG.info("init task status, task:{}, query_id:{}, create_time:{}", task.getName(), queryId, status.getCreateTime());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -425,6 +425,13 @@ public class TaskRunStatus implements Writable {
         return true;
     }
 
+    public String getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(String definition) {
+        this.definition = definition;
+    }
 
     public static TaskRunStatus read(DataInput in) throws IOException {
         String json = Text.readString(in);

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -510,7 +510,6 @@ public class RestoreJobMaterializedViewTest {
         assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
     }
 
-    @Test
     @Ignore
     public void testMVRestoreMVWithBaseTable3() {
         new MockUp<MetadataMgr>() {
@@ -530,7 +529,6 @@ public class RestoreJobMaterializedViewTest {
         assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
     }
 
-    @Test
     @Ignore
     public void testMVRestoreMVWithBaseTable4() {
         new MockUp<MetadataMgr>() {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -799,4 +799,21 @@ public class TaskManagerTest {
         taskRunManager.killTaskRun(1L, true);
         Assert.assertEquals(0, taskRunScheduler.getRunningTaskCount());
     }
+
+    @Test
+    public void testTaskRunDefinition() {
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        long taskId = 1;
+        TaskRun taskRun = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_MERGE_OPTION)
+                .build();
+        long now = System.currentTimeMillis();
+        taskRun.setTaskId(taskId);
+        taskRun.initStatus("1", now + 10);
+        taskRun.getStatus().setPriority(0);
+        TaskRunStatus taskRunStatus = taskRun.getStatus();
+        Assert.assertEquals(taskRunStatus.getDefinition(), "select 1");
+    }
 }

--- a/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite
+++ b/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite
@@ -176,7 +176,6 @@ select is_active, inactive_reason from information_schema.materialized_views
 -- result:
 true	
 -- !result
-  
 REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
 select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
 -- result:
@@ -202,7 +201,7 @@ FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
 -- !result
 REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
 select state from information_schema.task_runs
-  where `database`='db_${uuid0}' and `DEFINITION` like "%test_mv1%";
+  where `database`='db_${uuid0}' and `DEFINITION` like "%test_mv1%" ORDER BY CREATE_TIME DESC LIMIT 1;
 -- result:
 SUCCESS
 -- !result

--- a/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite
+++ b/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite
@@ -109,7 +109,7 @@ FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
 REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
 
 select state from information_schema.task_runs
-  where `database`='db_${uuid0}' and `DEFINITION` like "%test_mv1%";
+  where `database`='db_${uuid0}' and `DEFINITION` like "%test_mv1%" ORDER BY CREATE_TIME DESC LIMIT 1;
 
 drop materialized view default_catalog.db_${uuid0}.test_mv1;
 drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:
- Before v3.3, task run's definition is not stored in fe's metadata to avoid occupying too much memory but will cause missing definition if task has been dropped;

## What I'm doing:
- But since v3.3, history task runs has been stored in sr's internal table, we can save it in the  task run status.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
