### PR TITLE
[Enhancement] Improve command SHOW PROC "/statistics" performance and some code refinements

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -941,12 +941,11 @@ public class TabletChecker extends FrontendDaemon {
             return createRedundantSchedCtx(TabletHealthStatus.FORCE_REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH,
                     stats.getNeedFurtherRepairReplica());
         } else {
-            List<Long> availableBEs = systemInfoService.getAvailableBackendIds();
             // We create `REPLICA_MISSING` type task only when there exists enough available BEs which
             // we can choose to clone data to, if not we should check if we can create `VERSION_INCOMPLETE` task,
             // so that repair of replica with incomplete version won't be blocked and hence version publish process
             // of load task won't be blocked either.
-            if (availableBEs.size() > stats.getAliveCnt()) {
+            if (aliveBackendsNum > stats.getAliveCnt()) {
                 if (stats.getAliveCnt() < (replicationNum / 2) + 1) {
                     return Pair.create(TabletHealthStatus.REPLICA_MISSING, TabletSchedCtx.Priority.HIGH);
                 } else if (stats.getAliveCnt() < replicationNum) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -852,57 +852,37 @@ public class SystemInfoService implements GsonPostProcessable {
     }
 
     public List<Long> getComputeNodeIds(boolean needAlive) {
-        List<Long> computeNodeIds = Lists.newArrayList(idToComputeNodeRef.keySet());
         if (needAlive) {
-            Iterator<Long> iter = computeNodeIds.iterator();
-            while (iter.hasNext()) {
-                ComputeNode computeNode = this.getComputeNode(iter.next());
-                if (computeNode == null || !computeNode.isAlive()) {
-                    iter.remove();
-                }
-            }
+            return idToComputeNodeRef.entrySet().stream()
+                    .filter(entry -> entry.getValue().isAlive())
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
+        } else {
+            return Lists.newArrayList(idToComputeNodeRef.keySet());
         }
-        return computeNodeIds;
     }
 
     public List<Long> getBackendIds(boolean needAlive) {
-        List<Long> backendIds = Lists.newArrayList(idToBackendRef.keySet());
         if (needAlive) {
-            Iterator<Long> iter = backendIds.iterator();
-            while (iter.hasNext()) {
-                Backend backend = this.getBackend(iter.next());
-                if (backend == null || !backend.isAlive()) {
-                    iter.remove();
-                }
-            }
+            return idToBackendRef.entrySet().stream()
+                    .filter(entry -> entry.getValue().isAlive())
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
+        } else {
+            return Lists.newArrayList(idToBackendRef.keySet());
         }
-        return backendIds;
     }
 
     public List<Long> getDecommissionedBackendIds() {
-        List<Long> backendIds = Lists.newArrayList(idToBackendRef.keySet());
-
-        Iterator<Long> iter = backendIds.iterator();
-        while (iter.hasNext()) {
-            Backend backend = this.getBackend(iter.next());
-            if (backend == null || !backend.isDecommissioned()) {
-                iter.remove();
-            }
-        }
-        return backendIds;
+        return idToBackendRef.entrySet().stream()
+                .filter(entry -> entry.getValue().isDecommissioned())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
     }
 
     public List<Long> getAvailableBackendIds() {
-        List<Long> backendIds = Lists.newArrayList(idToBackendRef.keySet());
-
-        Iterator<Long> iter = backendIds.iterator();
-        while (iter.hasNext()) {
-            Backend backend = this.getBackend(iter.next());
-            if (backend == null || !backend.isAvailable()) {
-                iter.remove();
-            }
-        }
-        return backendIds;
+        return idToBackendRef.entrySet().stream().filter(entry -> entry.getValue().isAvailable()).map(
+                Map.Entry::getKey).collect(Collectors.toList());
     }
 
     public List<Long> getAvailableComputeNodeIds() {

--- a/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
@@ -455,4 +455,15 @@ public class SystemInfoServiceTest {
         Assert.assertTrue(exception.getMessage().contains("No backend or compute node alive."));
     }
 
+    @Test
+    public void testGetDecommissionedBackends() throws Exception {
+        for (int i = 100; i < 200; i++) {
+            Backend be = new Backend(i, "decommissionedHost", 1000);
+            be.setStarletPort(i);
+            systemInfoService.addBackend(be);
+            be.setDecommissioned(true);
+        }
+        Assert.assertTrue(systemInfoService.getDecommissionedBackendIds().size() == 100);
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:
If there are many tablet in a single db, like hundreds of thousand, there would be millions replica. Then, command SHOW PROC '/statistic' may be very slow to finish, in the meanwhile, it will occupy the db lock during execution, which may slow down other query executions.

The performance bootle neck is that it calls method SystemInfoService.getBackendIds too many times (one call for each replica).
If there are 200 backends, each call may take hundred milliseconds:
![image](https://github.com/user-attachments/assets/11c56743-8a13-4077-bb7e-fb10a374e76f)


To improve command `SHOW PROC "/statistics" `performance, and other general operation which may call `SystemInfoService.getBackendIds`.
The main performance bottle neck of method `SystemInfoService.getBackendIds` is that it calls `this.getBackend(...)`, which is unnecessary.
<img width="576" alt="image" src="https://github.com/user-attachments/assets/1851dff7-ac28-44ff-899b-78254e47e5e1">

I made a micro benchmark for this improvement, if there are 200 backends, and 1000000 replicas, we can gain 5X performance improvement.
![image](https://github.com/user-attachments/assets/b0468bc5-f5b7-41f1-a92d-e9a60dc40146)
![image](https://github.com/user-attachments/assets/ef207e86-e06a-4637-be44-cac9707fc1c9)
![image](https://github.com/user-attachments/assets/52b0382b-bd58-4881-a447-bb32c532acad)

Fixes #51715



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
