### PR TITLE
[BugFix] Fix analyzer exception for generated column rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -195,19 +195,23 @@ public class QueryAnalyzer {
             }
 
             // 3. analyze generated column expression based on current scope
+            Map<Expr, SlotRef> analyzedGeneratedExprToColumnRef = new HashMap<>();
             for (Map.Entry<Expr, SlotRef> entry : generatedExprToColumnRef.entrySet()) {
                 entry.getKey().reset();
                 entry.getValue().reset();
-                
+
                 try {
                     ExpressionAnalyzer.analyzeExpression(entry.getKey(), new AnalyzeState(), scope, session);
                     ExpressionAnalyzer.analyzeExpression(entry.getValue(), new AnalyzeState(), scope, session);
                 } catch (Exception ignore) {
-                    // ignore generated column rewrite if hit any exception
-                    generatedExprToColumnRef.clear();
+                    // skip this generated column rewrite if hit any exception
+                    // some exception is reasonable because some of illegal generated column
+                    // rewrite will be rejected by ananlyzer exception.
+                    continue;
                 }
+                analyzedGeneratedExprToColumnRef.put(entry.getKey(), entry.getValue());
             }
-            resultGeneratedExprToColumnRef.putAll(generatedExprToColumnRef);
+            resultGeneratedExprToColumnRef.putAll(analyzedGeneratedExprToColumnRef);
         }
 
         @Override

--- a/test/sql/test_materialized_column/R/test_generated_column_rewrite
+++ b/test/sql/test_materialized_column/R/test_generated_column_rewrite
@@ -243,3 +243,51 @@ None
 DROP table t_generated_column_complex_rewrite_3;
 -- result:
 -- !result
+CREATE TABLE `t_generated_column_complex_rewrite_4` (
+  `pday` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`pday`)
+PARTITION BY (`pday`)
+DISTRIBUTED BY HASH(`pday`)
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t_generated_column_complex_rewrite_5` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `json_string` varchar(1048576) NOT NULL COMMENT "",
+  `col1` varchar(65533) NULL AS get_json_string(`json_string`, 'a') COMMENT "",
+  `col2` varchar(65533) NULL AS get_json_string(`json_string`, 'b') COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t_generated_column_complex_rewrite_4 values (1);
+-- result:
+-- !result
+INSERT INTO t_generated_column_complex_rewrite_5 values (1,"{\"a\" : \"b\"}");
+-- result:
+-- !result
+select * from (select t4.* from t_generated_column_complex_rewrite_4 as t4 left join t_generated_column_complex_rewrite_5 as t5 on t4.pday = t5.id) result;
+-- result:
+1
+-- !result
+DROP TABLE t_generated_column_complex_rewrite_4;
+-- result:
+-- !result
+DROP TABLE t_generated_column_complex_rewrite_5;
+-- result:
+-- !result

--- a/test/sql/test_materialized_column/T/test_generated_column_rewrite
+++ b/test/sql/test_materialized_column/T/test_generated_column_rewrite
@@ -110,3 +110,41 @@ PROPERTIES (
 INSERT INTO t_generated_column_complex_rewrite_3 VALUES (1);
 function: assert_explain_contains('SELECT COUNT(*) FROM t_generated_column_complex_rewrite_3 WHERE cast(id + 10 as string) IS NOT NULL', 'col')
 DROP table t_generated_column_complex_rewrite_3;
+
+CREATE TABLE `t_generated_column_complex_rewrite_4` (
+  `pday` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`pday`)
+PARTITION BY (`pday`)
+DISTRIBUTED BY HASH(`pday`)
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+CREATE TABLE `t_generated_column_complex_rewrite_5` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `json_string` varchar(1048576) NOT NULL COMMENT "",
+  `col1` varchar(65533) NULL AS get_json_string(`json_string`, 'a') COMMENT "",
+  `col2` varchar(65533) NULL AS get_json_string(`json_string`, 'b') COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"compression" = "LZ4",
+"enable_persistent_index" = "true",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+INSERT INTO t_generated_column_complex_rewrite_4 values (1);
+INSERT INTO t_generated_column_complex_rewrite_5 values (1,"{\"a\" : \"b\"}");
+
+select * from (select t4.* from t_generated_column_complex_rewrite_4 as t4 left join t_generated_column_complex_rewrite_5 as t5 on t4.pday = t5.id) result;
+
+DROP TABLE t_generated_column_complex_rewrite_4;
+DROP TABLE t_generated_column_complex_rewrite_5;


### PR DESCRIPTION
## Why I'm doing:
This problem is introduce by pr ##50398. When we re-analyze the generated expression in current scope for subquery, sometime we may meet an exception. In current implementation, a map will be clear but the iteration does not break cause ConcurrentModificationException.

## What I'm doing:
Remove the expression if re-analyze throw an exception instead of clear all generated column expression.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
