### PR TITLE
[Enhancement] Make some system tables query from leader fe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemTable.java
@@ -14,11 +14,27 @@
 
 package com.starrocks.catalog.system;
 
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.DescriptorTable.ReferencedPartitionInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
+import com.starrocks.catalog.system.information.BeConfigsSystemTable;
+import com.starrocks.catalog.system.information.BeTabletsSystemTable;
+import com.starrocks.catalog.system.information.FeTabletSchedulesSystemTable;
+import com.starrocks.catalog.system.information.LoadTrackingLogsSystemTable;
+import com.starrocks.catalog.system.information.LoadsSystemTable;
+import com.starrocks.catalog.system.information.MaterializedViewsSystemTable;
+import com.starrocks.catalog.system.information.PartitionsMetaSystemTable;
+import com.starrocks.catalog.system.information.PipesSystemTable;
+import com.starrocks.catalog.system.information.RoutineLoadJobsSystemTable;
+import com.starrocks.catalog.system.information.StreamLoadsSystemTable;
+import com.starrocks.catalog.system.information.TablesConfigSystemTable;
+import com.starrocks.catalog.system.information.TaskRunsSystemTable;
+import com.starrocks.catalog.system.information.TasksSystemTable;
+import com.starrocks.catalog.system.information.TemporaryTablesTable;
+import com.starrocks.catalog.system.information.ViewsSystemTable;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.thrift.TSchemaTable;
 import com.starrocks.thrift.TSchemaTableType;
@@ -41,11 +57,31 @@ public class SystemTable extends Table {
     public static final int NAME_CHAR_LEN = 2048;
     public static final int MAX_FIELD_VARCHAR_LENGTH = 65535;
 
+    // some metadata may be inaccurate in the follower fe, because they may be not persisted in leader fe,
+    // such as routine load job state changed from NEED_SCHEDULE to RUNNING.
+    private static final ImmutableSortedSet<String> QUERY_FROM_LEADER_TABLES =
+            ImmutableSortedSet.orderedBy(String.CASE_INSENSITIVE_ORDER)
+                    .add(FeTabletSchedulesSystemTable.NAME)
+                    .add(LoadTrackingLogsSystemTable.NAME)
+                    .add(LoadsSystemTable.NAME)
+                    .add(MaterializedViewsSystemTable.NAME)
+                    .add(PartitionsMetaSystemTable.NAME)
+                    .add(PipesSystemTable.NAME)
+                    .add(RoutineLoadJobsSystemTable.NAME)
+                    .add(StreamLoadsSystemTable.NAME)
+                    .add(TablesConfigSystemTable.NAME)
+                    .add(TaskRunsSystemTable.NAME)
+                    .add(TasksSystemTable.NAME)
+                    .add(TemporaryTablesTable.NAME)
+                    .add(ViewsSystemTable.NAME)
+                    .build();
+
     private final TSchemaTableType schemaTableType;
 
     private final String catalogName;
 
-    public SystemTable(long id, String name, TableType type, List<Column> baseSchema, TSchemaTableType schemaTableType) {
+    public SystemTable(long id, String name, TableType type, List<Column> baseSchema,
+                       TSchemaTableType schemaTableType) {
         this(DEFAULT_INTERNAL_CATALOG_NAME, id, name, type, baseSchema, schemaTableType);
     }
 
@@ -67,12 +103,12 @@ public class SystemTable extends Table {
 
     public boolean requireOperatePrivilege() {
         return (SystemTable.isBeSchemaTable(getName()) || SystemTable.isFeSchemaTable(getName())) &&
-                !getName().equals("be_tablets") && !getName().equals("fe_tablet_schedules");
+                !getName().equals(BeTabletsSystemTable.NAME) && !getName().equals(FeTabletSchedulesSystemTable.NAME);
     }
 
     @Override
     public boolean supportsUpdate() {
-        return name.equals("be_configs");
+        return name.equals(BeConfigsSystemTable.NAME);
     }
 
     @Override
@@ -139,10 +175,15 @@ public class SystemTable extends Table {
 
     /**
      * Evaluate the system table query with specified predicate
+     *
      * @param predicate can only be conjuncts
      * @return All columns and rows according to the schema of this table
      */
     public List<List<ScalarOperator>> evaluate(ScalarOperator predicate) {
         throw new NotImplementedException("not supported");
+    }
+
+    public static boolean needQueryFromLeader(String tableName) {
+        return QUERY_FROM_LEADER_TABLES.contains(tableName);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeBvarsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeBvarsSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class BeBvarsSystemTable {
+    private static final String NAME = "be_bvars";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.BE_BVARS_ID,
-                "be_bvars",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT), false)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
@@ -23,9 +23,11 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class BeCloudNativeCompactionsSystemTable {
+    private static final String NAME = "be_cloud_native_compactions";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.BE_CLOUD_NATIVE_COMPACTIONS,
-                "be_cloud_native_compactions",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCompactionsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCompactionsSystemTable.java
@@ -23,9 +23,11 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class BeCompactionsSystemTable {
+    private static final String NAME = "be_compactions";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.BE_COMPACTIONS_ID,
-                "be_compactions",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeConfigsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeConfigsSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class BeConfigsSystemTable {
+    public static final String NAME = "be_configs";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.BE_CONFIGS_ID,
-                "be_configs",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeDataCacheMetricsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeDataCacheMetricsTable.java
@@ -31,6 +31,7 @@ import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 
 public class BeDataCacheMetricsTable {
+    private static final String NAME = "be_datacache_metrics";
 
     public static SystemTable create() {
         ArrayList<StructField> dirSpacesFields = new ArrayList<>();
@@ -42,7 +43,7 @@ public class BeDataCacheMetricsTable {
         MapType usedBytesDetailType =
                 new MapType(ScalarType.createType(PrimitiveType.INT), ScalarType.createType(PrimitiveType.BIGINT));
 
-        return new SystemTable(SystemId.BE_DATACACHE_METRICS, "be_datacache_metrics", Table.TableType.SCHEMA,
+        return new SystemTable(SystemId.BE_DATACACHE_METRICS, NAME, Table.TableType.SCHEMA,
                 SystemTable.builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("STATUS", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeLogsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeLogsSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class BeLogsSystemTable {
+    private static final String NAME = "be_logs";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.BE_LOGS_ID,
-                "be_logs",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeMetricsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeMetricsSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class BeMetricsSystemTable {
+    private static final String NAME = "be_metrics";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.BE_METRICS_ID,
-                "be_metrics",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTabletsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTabletsSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class BeTabletsSystemTable {
+    public static final String NAME = "be_tablets";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.BE_TABLETS_ID,
-                "be_tablets",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeThreadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeThreadsSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class BeThreadsSystemTable {
+    private static final String NAME = "be_threads";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.BE_THREADS_ID,
-                "be_threads",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTxnsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTxnsSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class BeTxnsSystemTable {
+    private static final String NAME = "be_txns";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.BE_TXNS_ID,
-                "be_txns",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CharacterSetsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CharacterSetsSystemTable.java
@@ -23,11 +23,13 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class CharacterSetsSystemTable {
+    private static final String NAME = "character_sets";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.CHARACTER_SETS_ID,
-                "character_sets",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("CHARACTER_SET_NAME", ScalarType.createVarchar(512))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CollationsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CollationsSystemTable.java
@@ -23,11 +23,13 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class CollationsSystemTable {
+    private static final String NAME = "collations";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.COLLATIONS_ID,
-                "collations",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("COLLATION_NAME", ScalarType.createVarchar(512))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnPrivilegesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnPrivilegesSystemTable.java
@@ -23,11 +23,13 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class ColumnPrivilegesSystemTable {
+    private static final String NAME = "column_privileges";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.COLUMN_PRIVILEGES_ID,
-                "column_privileges",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("GRANTEE", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnsSystemTable.java
@@ -23,11 +23,13 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class ColumnsSystemTable {
+    private static final String NAME = "columns";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.COLUMNS_ID,
-                "columns",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("TABLE_CATALOG", ScalarType.createVarchar(512))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/EnginesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/EnginesSystemTable.java
@@ -22,11 +22,13 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class EnginesSystemTable {
+    private static final String NAME = "engines";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.ENGINES_ID,
-                "engines",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("ENGINE", ScalarType.createVarchar(64))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/EventsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/EventsSystemTable.java
@@ -24,11 +24,13 @@ import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class EventsSystemTable {
+    private static final String NAME = "events";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.EVENTS_ID,
-                "events",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("EVENT_CATALOG", ScalarType.createVarchar(64))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/FeMetricsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/FeMetricsSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class FeMetricsSystemTable {
+    public static final String NAME = "fe_metrics";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.FE_METRICS_ID,
-                "fe_metrics",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("FE_ID", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/FeTabletSchedulesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/FeTabletSchedulesSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class FeTabletSchedulesSystemTable {
+    public static final String NAME = "fe_tablet_schedules";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.FE_SCHEDULES_ID,
-                "fe_tablet_schedules",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("TABLE_ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/GlobalVariablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/GlobalVariablesSystemTable.java
@@ -22,9 +22,11 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class GlobalVariablesSystemTable {
+    private static final String NAME = "global_variables";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.GLOBAL_VARIABLES_ID,
-                "global_variables",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("VARIABLE_NAME", ScalarType.createVarchar(64))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/KeyColumnUsageSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/KeyColumnUsageSystemTable.java
@@ -24,11 +24,13 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class KeyColumnUsageSystemTable {
+    private static final String NAME = "key_column_usage";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.KEY_COLUMN_USAGE_ID,
-                "key_column_usage",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("CONSTRAINT_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadTrackingLogsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadTrackingLogsSystemTable.java
@@ -25,9 +25,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class LoadTrackingLogsSystemTable {
+    public static final String NAME = "load_tracking_logs";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.LOAD_TRACKING_LOGS_ID,
-                "load_tracking_logs",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class LoadsSystemTable {
+    public static final String NAME = "loads";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.LOADS_ID,
-                "loads",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -23,9 +23,11 @@ import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class MaterializedViewsSystemTable {
+    public static final String NAME = "materialized_views";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.MATERIALIZED_VIEWS_ID,
-                "materialized_views",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("MATERIALIZED_VIEW_ID", ScalarType.createVarchar(50))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
@@ -24,9 +24,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class PartitionsMetaSystemTable {
+    public static final String NAME = "partitions_meta";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.PARTITIONS_META_ID,
-                "partitions_meta",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("DB_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsSystemTableSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsSystemTableSystemTable.java
@@ -25,11 +25,13 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class PartitionsSystemTableSystemTable {
+    private static final String NAME = "partitions";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.PARTITIONS_ID,
-                "partitions",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("TABLE_CATALOG", ScalarType.createVarchar(FN_REFLEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PipeFileSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PipeFileSystemTable.java
@@ -22,7 +22,6 @@ import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 
 public class PipeFileSystemTable {
-
     public static final String NAME = "pipe_files";
 
     public static SystemTable create() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PipesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PipesSystemTable.java
@@ -21,7 +21,6 @@ import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 
 public class PipesSystemTable {
-
     public static final String NAME = "pipes";
 
     public static SystemTable create() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ReferentialConstraintsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ReferentialConstraintsSystemTable.java
@@ -23,11 +23,13 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class ReferentialConstraintsSystemTable {
+    private static final String NAME = "referential_constraints";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.REFERENTIAL_CONSTRAINTS_ID,
-                "referential_constraints",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("CONSTRAINT_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutineLoadJobsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutineLoadJobsSystemTable.java
@@ -25,9 +25,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class RoutineLoadJobsSystemTable {
+    public static final String NAME = "routine_load_jobs";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.ROUTINE_LOAD_JOBS_ID,
-                "routine_load_jobs",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("ID", ScalarType.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutinesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutinesSystemTable.java
@@ -24,11 +24,13 @@ import static com.starrocks.catalog.system.SystemTable.builder;
 import static com.starrocks.thrift.TSchemaTableType.SCH_PROCEDURES;
 
 public class RoutinesSystemTable {
+    private static final String NAME = "routines";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.ROUTINES_ID,
-                "routines",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("SPECIFIC_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SchemaPrivilegesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SchemaPrivilegesSystemTable.java
@@ -24,11 +24,13 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class SchemaPrivilegesSystemTable {
+    private static final String NAME = "schema_privileges";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.SCHEMA_PRIVILEGES_ID,
-                "schema_privileges",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("GRANTEE", ScalarType.createVarchar(81))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SchemataSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SchemataSystemTable.java
@@ -22,11 +22,13 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class SchemataSystemTable {
+    private static final String NAME = "schemata";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.SCHEMATA_ID,
-                "schemata",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("CATALOG_NAME", ScalarType.createVarchar(512))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SessionVariablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SessionVariablesSystemTable.java
@@ -22,9 +22,11 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class SessionVariablesSystemTable {
+    private static final String NAME = "session_variables";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.SESSION_VARIABLES_ID,
-                "session_variables",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("VARIABLE_NAME", ScalarType.createVarchar(64))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StatisticsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StatisticsSystemTable.java
@@ -23,11 +23,13 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class StatisticsSystemTable {
+    private static final String NAME = "statistics";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.STATISTICS_ID,
-                "statistics",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("TABLE_CATALOG", ScalarType.createVarchar(512))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StreamLoadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StreamLoadsSystemTable.java
@@ -25,9 +25,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class StreamLoadsSystemTable {
+    public static final String NAME = "stream_loads";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.STREAM_LOADS_ID,
-                "stream_loads",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("LABEL", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TableConstraintsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TableConstraintsSystemTable.java
@@ -22,11 +22,13 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class TableConstraintsSystemTable {
+    private static final String NAME = "table_constraints";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.TABLE_CONSTRAINTS_ID,
-                "table_constraints",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("CONSTRAINT_CATALOG", ScalarType.createVarchar(512))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablePrivilegesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablePrivilegesSystemTable.java
@@ -23,11 +23,13 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class TablePrivilegesSystemTable {
+    private static final String NAME = "table_privileges";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.TABLE_PRIVILEGES_ID,
-                "table_privileges",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("GRANTEE", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesConfigSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesConfigSystemTable.java
@@ -25,9 +25,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class TablesConfigSystemTable {
+    public static final String NAME = "tables_config";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.TABLES_CONFIG_ID,
-                "tables_config",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
@@ -26,9 +26,10 @@ import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class TablesSystemTable {
     public static final int MY_CS_NAME_SIZE = 32;
+    private static final String NAME = "tables";
 
     public static SystemTable create(String catalogName) {
-        return new SystemTable(catalogName, SystemId.TABLES_ID, "tables", Table.TableType.SCHEMA, builder()
+        return new SystemTable(catalogName, SystemId.TABLES_ID, NAME, Table.TableType.SCHEMA, builder()
                 .column("TABLE_CATALOG", ScalarType.createVarchar(FN_REFLEN))
                 .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
                 .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class TaskRunsSystemTable extends SystemTable {
-
     private static final Logger LOG = LogManager.getLogger(SystemTable.class);
 
     private static final SystemTable TABLE = new TaskRunsSystemTable();
@@ -68,13 +67,15 @@ public class TaskRunsSystemTable extends SystemTable {
                     .put(TType.BOOL, Type.BOOLEAN)
                     .build();
 
+    public static final String NAME = "task_runs";
+
     public static SystemTable getInstance() {
         return TABLE;
     }
 
     public TaskRunsSystemTable() {
         super(SystemId.TASK_RUNS_ID,
-                "task_runs",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("QUERY_ID", ScalarType.createVarchar(64))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
@@ -40,12 +40,13 @@ import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class TasksSystemTable {
-
     private static final Logger LOG = LogManager.getLogger(TasksSystemTable.class);
+
+    public static final String NAME = "tasks";
 
     public static SystemTable create() {
         return new SystemTable(SystemId.TASKS_ID,
-                "tasks",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("TASK_NAME", ScalarType.createVarchar(64))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TemporaryTablesTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TemporaryTablesTable.java
@@ -26,11 +26,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class TemporaryTablesTable {
-
     public static final int MY_CS_NAME_SIZE = 32;
+    public static final String NAME = "temp_tables";
 
     public static SystemTable create() {
-        return new SystemTable(SystemId.TEMP_TABLES_ID, "temp_tables", Table.TableType.SCHEMA, builder()
+        return new SystemTable(SystemId.TEMP_TABLES_ID, NAME, Table.TableType.SCHEMA, builder()
                 .column("TABLE_CATALOG", ScalarType.createVarchar(FN_REFLEN))
                 .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
                 .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TriggersSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TriggersSystemTable.java
@@ -24,11 +24,13 @@ import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class TriggersSystemTable {
+    private static final String NAME = "triggers";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.TRIGGERS_ID,
-                "triggers",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("TRIGGER_CATALOG", ScalarType.createVarchar(512))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/UserPrivilegesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/UserPrivilegesSystemTable.java
@@ -24,11 +24,13 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class UserPrivilegesSystemTable {
+    private static final String NAME = "user_privileges";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.USER_PRIVILEGES_ID,
-                "user_privileges",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("GRANTEE", ScalarType.createVarchar(81))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/VerboseSessionVariablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/VerboseSessionVariablesSystemTable.java
@@ -23,9 +23,11 @@ import com.starrocks.thrift.TSchemaTableType;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class VerboseSessionVariablesSystemTable {
+    private static final String NAME = "verbose_session_variables";
+
     public static SystemTable create() {
         return new SystemTable(SystemId.VERBOSE_SESSION_VARIABLES_ID,
-                "verbose_session_variables",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("VARIABLE_NAME", ScalarType.createVarchar(64))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -23,11 +23,13 @@ import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class ViewsSystemTable {
+    public static final String NAME = "views";
+
     public static SystemTable create(String catalogName) {
         return new SystemTable(
                 catalogName,
                 SystemId.VIEWS_ID,
-                "views",
+                NAME,
                 Table.TableType.SCHEMA,
                 builder()
                         .column("TABLE_CATALOG", ScalarType.createVarchar(512))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/GrantsTo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/GrantsTo.java
@@ -66,8 +66,11 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class GrantsTo {
+    private static final String GRANTS_TO_ROLES = "grants_to_roles";
+    private static final String GRANTS_TO_USERS = "grants_to_users";
+
     public static SystemTable createGrantsToRoles() {
-        return new SystemTable(SystemId.GRANTS_TO_ROLES_ID, "grants_to_roles", Table.TableType.SCHEMA,
+        return new SystemTable(SystemId.GRANTS_TO_ROLES_ID, GRANTS_TO_ROLES, Table.TableType.SCHEMA,
                 builder()
                         .column("GRANTEE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("OBJECT_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))
@@ -81,7 +84,7 @@ public class GrantsTo {
     }
 
     public static SystemTable createGrantsToUsers() {
-        return new SystemTable(SystemId.GRANTS_TO_USERS_ID, "grants_to_users", Table.TableType.SCHEMA,
+        return new SystemTable(SystemId.GRANTS_TO_USERS_ID, GRANTS_TO_USERS, Table.TableType.SCHEMA,
                 builder()
                         .column("GRANTEE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("OBJECT_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/RoleEdges.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/RoleEdges.java
@@ -34,8 +34,10 @@ import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class RoleEdges {
+    private static final String NAME = "role_edges";
+
     public static SystemTable create() {
-        return new SystemTable(SystemId.ROLE_EDGES_ID, "role_edges", Table.TableType.SCHEMA,
+        return new SystemTable(SystemId.ROLE_EDGES_ID, NAME, Table.TableType.SCHEMA,
                 builder()
                         .column("FROM_ROLE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("TO_ROLE", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
@@ -50,7 +50,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class SysFeLocks {
-
     public static final String NAME = "fe_locks";
 
     public static SystemTable create() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
@@ -33,8 +33,6 @@ import org.apache.thrift.TException;
 
 
 public class SysFeMemoryUsage {
-
-
     public static final String NAME = "fe_memory_usage";
 
     public static SystemTable create() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
@@ -42,11 +42,9 @@ import java.util.Collection;
 import java.util.Optional;
 
 public class SysObjectDependencies {
-
-    public static final String NAME = "object_dependencies";
-
     private static final Logger LOG = LogManager.getLogger(SysObjectDependencies.class);
 
+    public static final String NAME = "object_dependencies";
 
     public static SystemTable create() {
         return new SystemTable(SystemId.OBJECT_DEPENDENCIES, NAME, Table.TableType.SCHEMA,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -57,6 +57,9 @@ import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.Type;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.catalog.system.information.FeMetricsSystemTable;
+import com.starrocks.catalog.system.information.LoadTrackingLogsSystemTable;
+import com.starrocks.catalog.system.information.LoadsSystemTable;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -1644,8 +1647,8 @@ public class PlanFragmentBuilder {
                                 scanNode.setJobId(constantOperator.getBigint());
                                 break;
                             case "ID":
-                                if (scanNode.getTableName().equalsIgnoreCase("load_tracking_logs")
-                                        || scanNode.getTableName().equalsIgnoreCase("loads")) {
+                                if (scanNode.getTableName().equalsIgnoreCase(LoadTrackingLogsSystemTable.NAME)
+                                        || scanNode.getTableName().equalsIgnoreCase(LoadsSystemTable.NAME)) {
                                     scanNode.setJobId(constantOperator.getBigint());
                                 }
                                 break;
@@ -1697,19 +1700,18 @@ public class PlanFragmentBuilder {
                 }
             }
 
-            if (scanNode.getTableName().equalsIgnoreCase("load_tracking_logs") && scanNode.getLabel() == null
+            if (scanNode.getTableName().equalsIgnoreCase(LoadTrackingLogsSystemTable.NAME) && scanNode.getLabel() == null
                     && scanNode.getJobId() == null) {
                 throw UnsupportedException.unsupportedException("load_tracking_logs must specify label or job_id");
             }
 
-            if (scanNode.getTableName().equalsIgnoreCase("load_tracking_logs")
-                    || scanNode.getTableName().equalsIgnoreCase("loads")) {
+            if (SystemTable.needQueryFromLeader(scanNode.getTableName())) {
                 Pair<String, Integer> ipPort = GlobalStateMgr.getCurrentState().getNodeMgr().getLeaderIpAndRpcPort();
                 scanNode.setFrontendIP(ipPort.first);
                 scanNode.setFrontendPort(ipPort.second.intValue());
             }
 
-            if (scanNode.getTableName().equalsIgnoreCase("fe_metrics")) {
+            if (scanNode.getTableName().equalsIgnoreCase(FeMetricsSystemTable.NAME)) {
                 scanNode.computeFeNodes();
             }
 

--- a/test/sql/test_routine_load/R/test_commit_offset
+++ b/test/sql/test_routine_load/R/test_commit_offset
@@ -40,3 +40,8 @@ SHOW ROUTINE LOAD FOR rl_commit_offset;
 -- result:
 [REGEX].*{"0":"1713497961406"}.*
 -- !result
+
+select state from information_schema.routine_load_jobs where name = "rl_commit_offset" order by id desc limit 1;
+-- result:
+RUNNING
+-- !result

--- a/test/sql/test_routine_load/T/test_commit_offset
+++ b/test/sql/test_routine_load/T/test_commit_offset
@@ -26,3 +26,4 @@ FROM KAFKA (
 SELECT sleep(30);
 
 SHOW ROUTINE LOAD FOR rl_commit_offset;
+select state from information_schema.routine_load_jobs where name = "rl_commit_offset" order by id desc limit 1;


### PR DESCRIPTION
## Why I'm doing:
some metadata may be inaccurate in the follower fe, because they may be not persisted in leader fe,
such as routine load job state changed from NEED_SCHEDULE to RUNNING.

## What I'm doing:
these system tables should query from leader fe.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
