### PR TITLE
[BugFix] Don't update datacache metrics after cache select

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectExecutor.java
@@ -84,8 +84,10 @@ public class DataCacheSelectExecutor {
         connectContext.setSessionVariable(sessionVariableBackup);
 
         Preconditions.checkNotNull(metrics, "Failed to retrieve cache select metrics");
+        // Don't update datacache metrics after cache select, because of datacache instance still not unified.
+        // Here update will display wrong metrics in show backends/compute nodes
         // update backend's datacache metrics after cache select
-        updateBackendDataCacheMetrics(metrics);
+        // updateBackendDataCacheMetrics(metrics);
         return metrics;
     }
 


### PR DESCRIPTION
## Why I'm doing:
fix datacache metrics error in `show backends`

## What I'm doing:
fix it

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
