### PR TITLE
[BugFix] view is not supported by cache select

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DataCacheStmtAnalyzer.java
@@ -132,6 +132,9 @@ public class DataCacheStmtAnalyzer {
             Analyzer.analyze(queryStatement, context);
 
             SelectRelation selectRelation = (SelectRelation) queryStatement.getQueryRelation();
+            if (!(selectRelation.getRelation() instanceof TableRelation)) {
+                throw new SemanticException("Cache select only support olap table, external table or materialized view.");
+            }
             TableRelation tableRelation = (TableRelation) selectRelation.getRelation();
             TableName tableName = tableRelation.getResolveTableName();
             if (CatalogMgr.isInternalCatalog(tableName.getCatalog()) && RunMode.isSharedNothingMode()) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DataCacheStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DataCacheStmtAnalyzerTest.java
@@ -16,11 +16,14 @@ package com.starrocks.analysis;
 
 import com.starrocks.datacache.DataCacheMgr;
 import com.starrocks.datacache.DataCacheRule;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.CreateDataCacheRuleStmt;
 import com.starrocks.sql.ast.DataCacheSelectStatement;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -112,7 +115,7 @@ public class DataCacheStmtAnalyzerTest {
     }
 
     @Test
-    public void testCacheSelect() {
+    public void testCacheSelect() throws Exception {
         DataCacheSelectStatement stmt = (DataCacheSelectStatement) analyzeSuccess(
                 "cache select * from hive0.datacache_db.multi_partition_table");
         Assert.assertEquals("black_hole_catalog.black_hole_db.black_hole_table",
@@ -121,6 +124,11 @@ public class DataCacheStmtAnalyzerTest {
         analyzeFail("cache select * from hive0.datacache_db.not_existed");
         analyzeFail("cache select * from default_catalog.test.t0",
                 "Currently cache select is not supported in local olap table");
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test").useDatabase("test").withView("create view aaa as select 1;");
+        analyzeFail("cache select * from test.aaa",
+                "Cache select only support olap table, external table or materialized view.");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
view sql can be very complicated, cache select can only handle simple sql.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
