### PR TITLE
[Enhancement] auto change replication_num of system tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -23,6 +23,7 @@ import com.starrocks.common.util.AutoInferUtil;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -68,7 +69,7 @@ public class LoadsHistorySyncer extends FrontendDaemon {
             "properties('replication_num' = '%d') ";
 
     private static final String CORRECT_LOADS_HISTORY_REPLICATION_NUM =
-            "ALTER TABLE %s SET ('default.replication_num'='3')";
+            "ALTER TABLE %s SET ('default.replication_num'='%d')";
 
     private static final String LOADS_HISTORY_SYNC =
             "INSERT INTO %s " +
@@ -78,10 +79,9 @@ public class LoadsHistorySyncer extends FrontendDaemon {
             "AND load_finish_time > ( " +
             "SELECT COALESCE(MAX(load_finish_time), '0001-01-01 00:00:00') " +
             "FROM %s);";
-    
+
     private boolean databaseExists = false;
     private boolean tableExists = false;
-    private boolean tableCorrected = false;
 
     public LoadsHistorySyncer() {
         super("Load history syncer", Config.loads_history_sync_interval_second * 1000L);
@@ -97,18 +97,22 @@ public class LoadsHistorySyncer extends FrontendDaemon {
     }
 
     public static boolean correctTable() {
-        int numBackends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber();
+        if (RunMode.isSharedDataMode()) {
+            return true;
+        }
+        int numBackends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getRetainedBackendNumber();
+        int expectedReplication = Integer.max(1, Integer.min(Config.default_replication_num, numBackends));
         int replica = GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .mayGetTable(LOADS_HISTORY_DB_NAME, LOADS_HISTORY_TABLE_NAME)
                 .map(tbl -> ((OlapTable) tbl).getPartitionInfo().getMinReplicationNum())
                 .orElse((short) 1);
-        if (numBackends < 3) {
-            LOG.info("not enough backends in the cluster, expected 3 but got {}", numBackends);
-            return false;
-        }
-        if (replica < 3) {
-            String sql = SQLBuilder.buildAlterTableSql();
+        // For scale-out, we may need to extend it to more replicas
+        // For scale-in, we may need to drop replicas
+        if (replica != expectedReplication) {
+            String sql = SQLBuilder.buildAlterTableSql(expectedReplication);
             RepoExecutor.getInstance().executeDDL(sql);
+            LOG.info("changed table {} replication_num from {} to {}",
+                    LOADS_HISTORY_TABLE_NAME, replica, expectedReplication);
         } else {
             LOG.info("table {} already has {} replicas, no need to alter replication_num",
                     LOADS_HISTORY_TABLE_NAME, replica);
@@ -129,10 +133,8 @@ public class LoadsHistorySyncer extends FrontendDaemon {
             LOG.info("table created: " + LOADS_HISTORY_TABLE_NAME);
             tableExists = true;
         }
-        if (!tableCorrected && correctTable()) {
-            LOG.info("table corrected: " + LOADS_HISTORY_TABLE_NAME);
-            tableCorrected = true;
-        }
+
+        correctTable();
 
         if (getInterval() != Config.loads_history_sync_interval_second * 1000L) {
             setInterval(Config.loads_history_sync_interval_second * 1000L);
@@ -171,9 +173,9 @@ public class LoadsHistorySyncer extends FrontendDaemon {
                     CatalogUtils.normalizeTableName(LOADS_HISTORY_DB_NAME, LOADS_HISTORY_TABLE_NAME), replica);
         }
 
-        public static String buildAlterTableSql() {
+        public static String buildAlterTableSql(int replica) {
             return String.format(CORRECT_LOADS_HISTORY_REPLICATION_NUM,
-                    CatalogUtils.normalizeTableName(LOADS_HISTORY_DB_NAME, LOADS_HISTORY_TABLE_NAME));
+                    CatalogUtils.normalizeTableName(LOADS_HISTORY_DB_NAME, LOADS_HISTORY_TABLE_NAME), replica);
         }
 
         public static String buildSyncSql() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/FileListTableRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/FileListTableRepo.java
@@ -16,7 +16,6 @@ package com.starrocks.load.pipe.filelist;
 
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.common.UserException;
-import com.starrocks.common.util.AutoInferUtil;
 import com.starrocks.load.pipe.PipeFileRecord;
 import com.starrocks.statistic.StatsConstants;
 import org.apache.commons.collections.CollectionUtils;
@@ -64,7 +63,7 @@ public class FileListTableRepo extends FileListRepo {
                     "properties('replication_num' = '%d') ";
 
     protected static final String CORRECT_FILE_LIST_REPLICATION_NUM =
-            "ALTER TABLE %s SET ('replication_num'='3')";
+            "ALTER TABLE %s SET ('replication_num'='%d')";
 
     protected static final String ALL_COLUMNS =
             "`pipe_id`, `file_name`, `file_version`, `file_size`, `state`, `last_modified`, `staged_time`," +
@@ -155,15 +154,14 @@ public class FileListTableRepo extends FileListRepo {
      */
     static class SQLBuilder {
 
-        public static String buildCreateTableSql() throws UserException {
-            int replica = AutoInferUtil.calDefaultReplicationNum();
+        public static String buildCreateTableSql(int replicationNum) throws UserException {
             return String.format(FILE_LIST_TABLE_CREATE,
-                    CatalogUtils.normalizeTableName(FILE_LIST_DB_NAME, FILE_LIST_TABLE_NAME), replica);
+                    CatalogUtils.normalizeTableName(FILE_LIST_DB_NAME, FILE_LIST_TABLE_NAME), replicationNum);
         }
 
-        public static String buildAlterTableSql() {
+        public static String buildAlterTableSql(int replicationNum) {
             return String.format(CORRECT_FILE_LIST_REPLICATION_NUM,
-                    CatalogUtils.normalizeTableName(FILE_LIST_DB_NAME, FILE_LIST_TABLE_NAME));
+                    CatalogUtils.normalizeTableName(FILE_LIST_DB_NAME, FILE_LIST_TABLE_NAME), replicationNum);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -52,7 +52,6 @@ public class TaskRunHistoryTable {
     public static final String DATABASE_NAME = StatsConstants.STATISTICS_DB_NAME;
     public static final String TABLE_NAME = "task_run_history";
     public static final String TABLE_FULL_NAME = DATABASE_NAME + "." + TABLE_NAME;
-    public static final int TABLE_REPLICAS = 3;
     public static final String CREATE_TABLE =
             String.format("CREATE TABLE IF NOT EXISTS %s (" +
                     // identifiers
@@ -93,7 +92,7 @@ public class TaskRunHistoryTable {
             "SELECT history_content_json " + "FROM " + TABLE_FULL_NAME + " WHERE ";
 
     private static final TableKeeper KEEPER =
-            new TableKeeper(DATABASE_NAME, TABLE_NAME, CREATE_TABLE, TABLE_REPLICAS,
+            new TableKeeper(DATABASE_NAME, TABLE_NAME, CREATE_TABLE,
                     () -> Math.max(1, Config.task_runs_ttl_second / 3600 / 24));
 
     public static TableKeeper createKeeper() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -46,6 +46,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.load.EtlStatus;
 import com.starrocks.load.loadv2.LoadJobFinalOperation;
+import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.load.streamload.StreamLoadTxnCommitAttachment;
 import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.qe.ConnectContext;
@@ -61,6 +62,7 @@ import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TxnCommitAttachment;
 import com.starrocks.warehouse.Warehouse;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -473,6 +475,30 @@ public class StatisticUtils {
 
         List<String> columns = table.getBaseSchema().stream().map(Column::getName).collect(Collectors.toList());
         GlobalStateMgr.getCurrentState().getStatisticStorage().expireConnectorTableColumnStatistics(table, columns);
+    }
+
+    /**
+     * Change the replication_num of system table according to cluster status
+     * 1. When scale-out to greater than 3 nodes, change the replication_num to 3
+     * 3. When scale-in to less than 3 node, change it to retainedBackendNum
+     */
+    public static void alterSystemTableReplicationNumIfNecessary(String tableName) {
+        int expectedReplicationNum =
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getSystemTableExpectedReplicationNum();
+        int replica = GlobalStateMgr.getCurrentState()
+                .getLocalMetastore().mayGetTable(StatsConstants.STATISTICS_DB_NAME, tableName)
+                .map(tbl -> ((OlapTable) tbl).getPartitionInfo().getMinReplicationNum())
+                .orElse((short) 1);
+
+        if (replica != expectedReplicationNum) {
+            String sql = String.format("ALTER TABLE %s.%s SET ('replication_num'='%d')",
+                    StatsConstants.STATISTICS_DB_NAME, tableName, expectedReplicationNum);
+            if (StringUtils.isNotEmpty(sql)) {
+                RepoExecutor.getInstance().executeDDL(sql);
+            }
+            LOG.info("changed replication_number of table {} from {} to {}",
+                    tableName, replica, expectedReplicationNum);
+        }
     }
 
     // only support collect statistics for slotRef and subfield expr

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -482,7 +482,7 @@ public class StatisticUtils {
      * 1. When scale-out to greater than 3 nodes, change the replication_num to 3
      * 3. When scale-in to less than 3 node, change it to retainedBackendNum
      */
-    public static void alterSystemTableReplicationNumIfNecessary(String tableName) {
+    public static boolean alterSystemTableReplicationNumIfNecessary(String tableName) {
         int expectedReplicationNum =
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getSystemTableExpectedReplicationNum();
         int replica = GlobalStateMgr.getCurrentState()
@@ -498,7 +498,9 @@ public class StatisticUtils {
             }
             LOG.info("changed replication_number of table {} from {} to {}",
                     tableName, replica, expectedReplicationNum);
+            return true;
         }
+        return false;
     }
 
     // only support collect statistics for slotRef and subfield expr

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -20,11 +20,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
-import com.starrocks.catalog.LocalTablet;
-import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.Partition;
 import com.starrocks.common.Config;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.AutoInferUtil;
@@ -37,7 +33,6 @@ import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
-import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.KeysDesc;
 import com.starrocks.sql.common.EngineType;
@@ -52,9 +47,6 @@ import java.util.Map;
 
 public class StatisticsMetaManager extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(StatisticsMetaManager.class);
-
-    // If all replicas are lost more than 3 times in a row, rebuild the statistics table
-    private int lossTableCount = 0;
 
     public StatisticsMetaManager() {
         super("statistics meta manager", 60L * 1000L);
@@ -81,42 +73,6 @@ public class StatisticsMetaManager extends FrontendDaemon {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(StatsConstants.STATISTICS_DB_NAME);
         Preconditions.checkState(db != null);
         return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName) != null;
-    }
-
-    private boolean checkReplicateNormal(String tableName) {
-        int aliveSize = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAliveBackendNumber();
-        int total = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber();
-        // maybe cluster just shutdown, ignore
-        if (aliveSize <= total / 2) {
-            lossTableCount = 0;
-            return true;
-        }
-
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(StatsConstants.STATISTICS_DB_NAME);
-        Preconditions.checkState(db != null);
-        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
-        Preconditions.checkState(table != null);
-        if (table.isCloudNativeTableOrMaterializedView()) {
-            return true;
-        }
-
-        boolean check = true;
-        for (Partition partition : table.getPartitions()) {
-            // check replicate miss
-            if (partition.getBaseIndex().getTablets().stream()
-                    .anyMatch(t -> ((LocalTablet) t).getNormalReplicaBackendIds().isEmpty())) {
-                check = false;
-                break;
-            }
-        }
-
-        if (!check) {
-            lossTableCount++;
-        } else {
-            lossTableCount = 0;
-        }
-
-        return lossTableCount < 3;
     }
 
     private static final List<String> KEY_COLUMN_NAMES = ImmutableList.of(
@@ -322,21 +278,6 @@ public class StatisticsMetaManager extends FrontendDaemon {
         }
     }
 
-    private boolean dropTable(String tableName) {
-        LOG.info("drop statistics table start");
-        DropTableStmt stmt = new DropTableStmt(true,
-                new TableName(StatsConstants.STATISTICS_DB_NAME, tableName), true);
-
-        try {
-            GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(stmt);
-        } catch (DdlException e) {
-            LOG.warn("Failed to drop table", e);
-            return false;
-        }
-        LOG.info("drop statistics table done");
-        return !checkTableExist(tableName);
-    }
-
     private void trySleep(long millis) {
         try {
             Thread.sleep(millis);
@@ -347,39 +288,33 @@ public class StatisticsMetaManager extends FrontendDaemon {
 
     private boolean createTable(String tableName) {
         ConnectContext context = StatisticUtils.buildConnectContext();
-        context.setThreadLocalInfo();
-
-        if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
-            return createSampleStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.FULL_STATISTICS_TABLE_NAME)) {
-            return createFullStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
-            return createHistogramStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
-            return createExternalFullStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME)) {
-            return createExternalHistogramStatisticsTable(context);
-        } else {
-            throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
+        try (ConnectContext.ScopeGuard guard = context.bindScope()) {
+            if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
+                return createSampleStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.FULL_STATISTICS_TABLE_NAME)) {
+                return createFullStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
+                return createHistogramStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
+                return createExternalFullStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME)) {
+                return createExternalHistogramStatisticsTable(context);
+            } else {
+                throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
+            }
         }
     }
 
     private void refreshStatisticsTable(String tableName) {
-        while (checkTableExist(tableName) && !checkReplicateNormal(tableName)) {
-            LOG.info("statistics table " + tableName + " replicate is not normal, will drop table and rebuild");
-            if (dropTable(tableName)) {
-                break;
-            }
-            LOG.warn("drop statistics table " + tableName + " failed");
-            trySleep(10000);
-        }
-
         while (!checkTableExist(tableName)) {
             if (createTable(tableName)) {
                 break;
             }
             LOG.warn("create statistics table " + tableName + " failed");
             trySleep(10000);
+        }
+        if (checkTableExist(tableName)) {
+            StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -154,7 +154,6 @@ public class TaskRunHistoryTest {
         assertEquals(StatsConstants.STATISTICS_DB_NAME, keeper.getDatabaseName());
         assertEquals(TaskRunHistoryTable.TABLE_NAME, keeper.getTableName());
         assertEquals(TaskRunHistoryTable.CREATE_TABLE, keeper.getCreateTableSql());
-        assertEquals(TaskRunHistoryTable.TABLE_REPLICAS, keeper.getTableReplicas());
 
         // database not exists
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticUtilsTest.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import com.starrocks.common.Config;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class StatisticUtilsTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        UtFrameUtils.createMinStarRocksCluster();
+        if (!starRocksAssert.databaseExist("_statistics_")) {
+            StatisticsMetaManager m = new StatisticsMetaManager();
+            m.createStatisticsTablesForTest();
+        }
+        UtFrameUtils.addMockBackend(123);
+        UtFrameUtils.addMockBackend(124);
+    }
+
+    @Test
+    void alterSystemTableReplicationNumIfNecessary() {
+        // 1. Has sufficient backends
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public int getRetainedBackendNumber() {
+                return 100;
+            }
+        };
+        final String tableName = "column_statistics";
+        Assert.assertTrue(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertFalse(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertEquals("3",
+                starRocksAssert.getTable(StatsConstants.STATISTICS_DB_NAME, tableName).getProperties().get(
+                        "replication_num"));
+
+        // 2. change default_replication_num
+        Config.default_replication_num = 1;
+        Assert.assertTrue(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertFalse(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertEquals("1",
+                starRocksAssert.getTable(StatsConstants.STATISTICS_DB_NAME, tableName).getProperties().get(
+                        "replication_num"));
+        Config.default_replication_num = 3;
+        Assert.assertTrue(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+
+        // 3. Has no sufficient backends
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public int getRetainedBackendNumber() {
+                return 1;
+            }
+        };
+        Assert.assertTrue(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertFalse(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertEquals("1",
+                starRocksAssert.getTable(StatsConstants.STATISTICS_DB_NAME, tableName).getProperties().get(
+                        "replication_num"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When scale-in the cluster from 3 nodes to 1 node:
- Since the system tables in `_statistics_` database will have 3 replicas, they would stop the scale-in
- The current solution is to drop this database and recreate it, but which is not safe actually

## What I'm doing:

Auto change replication_num of several system tables
- When scaling out to more than 3 nodes, change the replication_num to 3
- When scaling in to 1 node, change the replication_num to 1, otherwise scale-in would never succeed

Affected system tables:
- `column_statistics`             
- `histogram_statistics`        
- `table_statistic_v1`            
- `external_column_statistics`    
- `external_histogram_statistics`
- 3.2: `pipe_file_list`                
- 3.3: `loads_history`                 
- 3.3: `task_run_history`              

Behavior change:
- before: the replication_num will only be increased but not decreased
- now: the replication_num will be increased when scale-out, and decreased when scale-in

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
