### PR TITLE
[BugFix] fix setDouble issue in jdbc with prepare stmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FloatLiteral.java
@@ -76,6 +76,11 @@ public class FloatLiteral extends LiteralExpr {
         this(value, NodePosition.ZERO);
     }
 
+    public FloatLiteral(String value, Type type) throws AnalysisException {
+        this(value, NodePosition.ZERO);
+        this.type = type;
+    }
+
     public FloatLiteral(String value, NodePosition pos) throws AnalysisException {
         super(pos);
         Double floatValue = null;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/LiteralExpr.java
@@ -87,7 +87,7 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
                 break;
             case FLOAT:
             case DOUBLE:
-                literalExpr = new FloatLiteral(value);
+                literalExpr = new FloatLiteral(value, type);
                 break;
             case DECIMALV2:
             case DECIMAL32:

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/LiteralExprCompareTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/LiteralExprCompareTest.java
@@ -19,6 +19,7 @@ package com.starrocks.analysis;
 
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -181,6 +182,14 @@ public class LiteralExprCompareTest {
         Assert.assertTrue(0 == double1.compareLiteral(double2));
         // self equal
         Assert.assertTrue(0 == double1.compareLiteral(double1));
+
+        LiteralExpr floatType = LiteralExpr.create("3.14", Type.FLOAT);
+        Assert.assertEquals(PrimitiveType.FLOAT, floatType.getType().getPrimitiveType());
+        Assert.assertEquals(true, floatType.equals(new FloatLiteral(3.14, Type.FLOAT)));
+
+        LiteralExpr doubleType = LiteralExpr.create("3.14", Type.DOUBLE);
+        Assert.assertEquals(PrimitiveType.DOUBLE, doubleType.getType().getPrimitiveType());
+        Assert.assertEquals(true, doubleType.equals(new FloatLiteral(3.14, Type.DOUBLE)));
     }
 
     private void intTestInternal(ScalarType type) throws AnalysisException {


### PR DESCRIPTION
## Why I'm doing:
fix setDouble issue in jdbc with prepare stmt:
![image](https://github.com/user-attachments/assets/2fd49aac-4353-4e03-a8fe-3a43a4b990ab)

the result is wrong:
![image](https://github.com/user-attachments/assets/4ceefa7c-0e87-44d4-8f76-b5bc6bb0f7b8)

the reason is wrong type processing in FloatLiteral::parseMysqlParam. 
For example, the data is of double type, but the getFloat method is used to obtain the data, result in wrong value.

## What I'm doing:
When a new floatLiteral object is created, its type should be specified explicitly, not based on its numeric size.
Otherwise, when the data is small, it will be processed as the float type, even if the value is assigned by setDouble method in JDBC.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/8c5875a8-4889-4a7d-b6ff-3e37f531f29c">

ths result is right:
![image](https://github.com/user-attachments/assets/50ebdc51-1134-4e9a-9e6f-b19d2568ddb1)


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
