### PR TITLE
[BugFix] fix issue when using placeholder in column position in prepare stmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Parameter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Parameter.java
@@ -83,4 +83,23 @@ public class Parameter extends Expr {
     protected String toSqlImpl() {
         return "?";
     }
+
+    @Override
+    public int hashCode() {
+        return slotId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (obj.getClass() != this.getClass()) {
+            return false;
+        }
+
+        Parameter parameter = (Parameter) obj;
+        return this.slotId == parameter.slotId;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/PreparedStmtTest.java
@@ -30,6 +30,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.HashSet;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -95,6 +97,22 @@ public class PreparedStmtTest{
         StatementBase statement = SqlParser.parse(prepareSql, ctx.getSessionVariable()).get(0);
         StmtExecutor executor = new StmtExecutor(ctx, statement);
         Assert.assertFalse(executor.isForwardToLeader());
+    }
+
+    @Test
+    public void testPrepareWithSelectConst() throws Exception {
+        String sql = "PREPARE stmt1 FROM select ?, ?, ?;";
+        PrepareStmt stmt = (PrepareStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        Assert.assertEquals(3, stmt.getParameters().size());
+
+        HashSet<Integer> idSet = new HashSet<Integer>();
+        for (Expr expr : stmt.getParameters()) {
+            Assert.assertEquals(true, idSet.add(expr.hashCode()));
+        }
+
+        Assert.assertEquals(false, stmt.getParameters().get(0).equals(stmt.getParameters().get(1)));
+        Assert.assertEquals(false, stmt.getParameters().get(1).equals(stmt.getParameters().get(2)));
+        Assert.assertEquals(false, stmt.getParameters().get(0).equals(stmt.getParameters().get(2)));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
fix issue when using placeholder in column position
```
starrocks> prepare pp from select ?, ?, ?;
Query OK, 0 rows affected (0.01 sec)

starrocks> set @a=1, @b=2, @c=3;
Query OK, 0 rows affected (0.00 sec)

starrocks> execute pp using @a, @b, @c;
+------+------+------+
| ?    | ?    | ?    |
+------+------+------+
|    3 |    3 |    3 |
+------+------+------+
1 row in set (0.02 sec)

```

## What I'm doing:
These column expressions are all '?' with the same hash code, so they are dentified as the same column when using put() and get() method of ExpressionMapping.
It can be solved by using slotId as the hashcode.

```
starrocks> prepare pp from select ?, ?, ?;
Query OK, 0 rows affected (0.01 sec)

starrocks> set @a=1, @b=2, @c=3;
Query OK, 0 rows affected (0.00 sec)

starrocks> execute pp using @a, @b, @c;
+------+------+------+
| ?    | ?    | ?    |
+------+------+------+
|    1 |    2 |    3 |
+------+------+------+
1 row in set (0.02 sec)

```

Fixes #50956

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
