### PR TITLE
[UT] remove execute_script in UT

### DIFF
--- a/be/test/fs/key_cache_test.cpp
+++ b/be/test/fs/key_cache_test.cpp
@@ -89,8 +89,6 @@ TEST_F(KeyCacheTest, AddKey) {
     key->set_id(2);
     cache.add_key(key);
     ASSERT_EQ(2, cache.size());
-    std::string result;
-    ASSERT_TRUE(execute_script("System.print(ExecEnv.key_cache_info())", result).ok());
 }
 
 static void wrap_unwrap_test(int num_level) {

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -345,11 +345,6 @@ void TabletUpdatesTest::test_writeread(bool enable_persistent_index) {
     ASSERT_TRUE(_tablet->rowset_commit(2, rs0).ok());
     ASSERT_EQ(2, _tablet->updates()->max_version());
 
-    string o;
-    ASSERT_TRUE(execute_script(fmt::format("StorageEngine.reset_delvec({}, {}, 2)", _tablet->tablet_id(), 0), o).ok());
-    ASSERT_TRUE(execute_script("System.print(ExecEnv.grep_log_as_string(0,0,\"I\",\"tablet_manager\",1))", o).ok());
-    LOG(INFO) << "grep log: " << o;
-
     auto rs1 = create_rowset(_tablet, keys);
     ASSERT_TRUE(_tablet->rowset_commit(3, rs1).ok());
     ASSERT_EQ(3, _tablet->updates()->max_version());


### PR DESCRIPTION
## Why I'm doing:
`execute_script` will cause memory leak, like:
```
Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x11796128 in __interceptor_realloc (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x11796128)
    #1 0x1e1addf4 in wrenbind17::VM::VM(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, unsigned long, unsigned long, int)::{lambda(void*, unsigned long, void*)#3}::operator()(void*, unsigned long, void*) const (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e1addf4)
    #2 0x1e1ade27 in wrenbind17::VM::VM(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, unsigned long, unsigned long, int)::{lambda(void*, unsigned long, void*)#3}::_FUN(void*, unsigned long, void*) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e1ade27)
    #3 0x1e2e5c45 in wrenReallocate (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e2e5c45)
    #4 0x1e2da152 in resizeMap (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e2da152)
    #5 0x1e2da24e in wrenMapSet (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e2da24e)
    #6 0x1e2efaaa in wrenInitializeCore (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e2efaaa)
    #7 0x1e2e5904 in wrenNewVM (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e2e5904)
    #8 0x1e1b0285 in wrenbind17::VM::VM(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, unsigned long, unsigned long, int) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e1b0285)
    #9 0x1e1a30f8 in starrocks::execute_script(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1e1a30f8)
    #10 0x1193abb5 in starrocks::KeyCacheTest_AddKey_Test::TestBody() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x1193abb5)
    #11 0x24fce403 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x24fce403)
    #12 0x24fbdc1d in testing::Test::Run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x24fbdc1d)
    #13 0x24fbdd84 in testing::TestInfo::Run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x24fbdd84)
    #14 0x24fbde74 in testing::TestSuite::Run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x24fbde74)
    #15 0x24fbe435 in testing::internal::UnitTestImpl::RunAllTests() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x24fbe435)
    #16 0x24fbe670 in testing::UnitTest::Run() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x24fbe670)
    #17 0x117f48a3 in RUN_ALL_TESTS() (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x117f48a3)
    #18 0x117dda8e in starrocks::init_test_env(int, char**) (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x117dda8e)
    #19 0x117de4db in main (/root/starrocks/be/ut_build_ASAN/test/starrocks_test+0x117de4db)
    #20 0x7f1d8bd77d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
```

## What I'm doing:
Remove them in UT.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
