### PR TITLE
[BugFix] Fix NullPointerException in getTabletsInHighLoadPath when select tablets to balance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -2086,7 +2086,12 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                 if (replica == null) {
                     continue;
                 }
-                int sortIndex = pathSortIndex.get(replica.getPathHash());
+                Integer sortIndex = pathSortIndex.get(replica.getPathHash());
+                if (sortIndex == null) {
+                    LOG.warn("Can not find path for tablet: {} on backend: {} by path hash: {}",
+                            tabletId, this.backendId, replica.getPathHash());
+                    continue;
+                }
                 if (sortIndex > lastHighLoadIndex) {
                     continue;
                 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes 
```
2024-10-08 21:22:34.695+05:00 ERROR (tablet scheduler|68) [Daemon.run():109] daemon thread got exception. name: tablet scheduler
java.lang.NullPointerException: null
        at com.starrocks.clone.DiskAndTabletLoadReBalancer$BackendBalanceState.getTabletsInHighLoadPath(DiskAndTabletLoadReBalancer.java:2077) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.DiskAndTabletLoadReBalancer.balanceClusterDisk(DiskAndTabletLoadReBalancer.java:530) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.DiskAndTabletLoadReBalancer.selectAlternativeTabletsForCluster(DiskAndTabletLoadReBalancer.java:98) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.Rebalancer.selectAlternativeTablets(Rebalancer.java:67) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.selectTabletsForBalance(TabletScheduler.java:1557) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.runAfterCatalogReady(TabletScheduler.java:457) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:107) ~[starrocks-fe.jar:?]
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
