### PR TITLE
[BugFix] fix array_map's error result when inputs are constant

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -122,7 +122,7 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
         } else {
             if (result_null_column != nulltpr) {
                 data_column->empty_null_in_complex_column(result_null_column->get_data(),
-                                                      array_column->offsets().get_data());
+                                                          array_column->offsets().get_data());
             }
             elements_column = down_cast<const ArrayColumn*>(data_column.get())->elements_column();
         }

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -120,7 +120,7 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
                 }
             }
         } else {
-            if (result_null_column != nulltpr) {
+            if (result_null_column != nullptr) {
                 data_column->empty_null_in_complex_column(result_null_column->get_data(),
                                                           array_column->offsets().get_data());
             }

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -99,8 +99,12 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
         auto array_column = down_cast<const ArrayColumn*>(data_column.get());
         auto elements_column = array_column->elements_column();
         UInt32Column::Ptr offsets_column = array_column->offsets_column();
-        if constexpr (!all_const_input) {
-            if (input_elements[i]->is_constant()) {
+
+        if (input_elements[i]->is_constant()) {
+            if (!all_const_input || !capture_slot_ids.empty()) {
+                // if not all input columns are constant,
+                // or all input columns are constant but lambda expr depends on other capture columns(e.g. array_map(x->x+k,[1,2,3])),
+                // we should unpack the const column before evaluation
                 size_t elements_num = array_column->get_element_size(0);
                 elements_column = elements_column->clone();
                 offsets_column = UInt32Column::create();
@@ -114,13 +118,13 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
                     offset += elements_num;
                     offsets_column->append(offset);
                 }
-            } else {
-                if (result_null_column != nullptr) {
-                    data_column->empty_null_in_complex_column(result_null_column->get_data(),
-                                                              array_column->offsets().get_data());
-                }
-                elements_column = down_cast<const ArrayColumn*>(data_column.get())->elements_column();
             }
+        } else {
+            if (result_null_column != nulltpr) {
+                data_column->empty_null_in_complex_column(result_null_column->get_data(),
+                                                      array_column->offsets().get_data());
+            }
+            elements_column = down_cast<const ArrayColumn*>(data_column.get())->elements_column();
         }
 
         if (aligned_offsets == nullptr) {
@@ -173,8 +177,9 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
         column = tmp_col->replicate(aligned_offsets->get_data());
         column = ColumnHelper::align_return_type(column, type().children[0], column->size(), true);
     } else {
-        // if all input arguments are const,
-        if constexpr (all_const_input) {
+        // if all input arguments are constant and lambda expr doesn't rely on other capture columns,
+        // we can evaluate it based on const column
+        if (all_const_input && capture_slot_ids.empty()) {
             ASSIGN_OR_RETURN(auto tmp_col, context->evaluate(_children[0], cur_chunk.get()));
             tmp_col->check_or_die();
             // if result is a const column, we should unpack it first and make it to be the elements column of array column
@@ -200,8 +205,9 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
     DCHECK(column != nullptr);
     column = ColumnHelper::cast_to_nullable_column(column);
 
-    if constexpr (all_const_input) {
-        // if all input arguments are const, we can return a const column
+    if (all_const_input && capture_slot_ids.empty()) {
+        // if all input arguments are const and lambdaexpr doesn't depend on other capture columns,
+        // we can return a const column
         auto data_column = FunctionHelper::get_data_column_of_const(column);
 
         aligned_offsets = UInt32Column::create();

--- a/test/sql/test_array_fn/R/test_array_map_2
+++ b/test/sql/test_array_fn/R/test_array_map_2
@@ -130,9 +130,9 @@ None
 select array_map((x,y)->k, [1,2],[2,3]) from t order by k;
 -- result:
 [1,1]
-[1,1]
-[1,1]
-[1,1]
+[2,2]
+[3,3]
+[4,4]
 -- !result
 select array_map((x,y,z)->x+y+z, [1,2],[2,3],[3,4]) from t;
 -- result:


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8662

introduced by: #51244

for scenarios where all inputs are constant, we will directly evaluate lambda expr  based on the const column to avoid extra overhead. In this case, we will not unpack the const column or align the offset with capture columns. 
However, there is an exception, such as `array_map(x->array_length(x) > c1+1, [[1,2,3]])`, where the lambda expression depends on other capture columns. In this case, we cannot follow the above strategy and still need to unpack the const and follow the normal process, otherwise it will get a wrong result.
in this pr, I fixed it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
