### PR TITLE
[Enhancement] change default value of statistic_auto_collect_small_table_interval

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2049,10 +2049,10 @@ public class Config extends ConfigBase {
     public static long statistic_auto_collect_small_table_size = 5L * 1024 * 1024 * 1024; // 5G
 
     @ConfField(mutable = true)
-    public static long statistic_auto_collect_small_table_rows = 10000000; // 10M
+    public static long statistic_auto_collect_small_table_rows = 10_000_000; // 10M
 
-    @ConfField(mutable = true)
-    public static long statistic_auto_collect_small_table_interval = 0; // unit: second, default 0
+    @ConfField(mutable = true, comment = "The interval of auto statistics for small tables in seconds")
+    public static long statistic_auto_collect_small_table_interval = 60L;
 
     @ConfField(mutable = true, comment = "The interval of auto collecting histogram statistics")
     public static long statistic_auto_collect_histogram_interval = 3600L * 1; // 1h


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Change the default value of `statistic_auto_collect_small_table_interval` from `0` to `60`, to make it reasonable.

Affect: not too much, because the `AutoCollector` is scheduled every 5mins

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
