### PR TITLE
[Enhancement] support lz4/zstd compression algo for cloud native pk index files

### DIFF
--- a/be/src/storage/sstable/options.cpp
+++ b/be/src/storage/sstable/options.cpp
@@ -10,11 +10,14 @@ namespace starrocks::sstable {
 
 Options::Options() : comparator(BytewiseComparator()) {}
 
+// Set the compression type based on the input type.
 void Options::set_compression(CompressionTypePB type) {
     if (type == CompressionTypePB::LZ4_FRAME || type == CompressionTypePB::LZ4) {
         compression = kLz4FrameCompression;
     } else if (type == CompressionTypePB::ZSTD) {
         compression = kZstdCompression;
+    } else if (type == CompressionTypePB::NO_COMPRESSION) {
+        compression = kNoCompression;
     } else {
         // use default snappy.
     }

--- a/be/src/storage/sstable/options.cpp
+++ b/be/src/storage/sstable/options.cpp
@@ -10,4 +10,14 @@ namespace starrocks::sstable {
 
 Options::Options() : comparator(BytewiseComparator()) {}
 
+void Options::set_compression(CompressionTypePB type) {
+    if (type == CompressionTypePB::LZ4_FRAME || type == CompressionTypePB::LZ4) {
+        compression = kLz4FrameCompression;
+    } else if (type == CompressionTypePB::ZSTD) {
+        compression = kZstdCompression;
+    } else {
+        // use default snappy.
+    }
+}
+
 } // namespace starrocks::sstable

--- a/be/src/storage/sstable/options.h
+++ b/be/src/storage/sstable/options.h
@@ -7,6 +7,8 @@
 #include <cstdint>
 #include <string>
 
+#include "gen_cpp/types.pb.h"
+
 namespace starrocks {
 class Cache;
 
@@ -22,7 +24,9 @@ enum CompressionType {
     // NOTE: do not change the values of existing entries, as these are
     // part of the persistent format on disk.
     kNoCompression = 0x0,
-    kSnappyCompression = 0x1
+    kSnappyCompression = 0x1,
+    kLz4FrameCompression = 0x2,
+    kZstdCompression = 0x3
 };
 
 // Options to control the behavior of a database (passed to DB::Open)
@@ -93,6 +97,9 @@ struct Options {
     // Many applications will benefit from passing the result of
     // NewBloomFilterPolicy() here.
     const FilterPolicy* filter_policy = nullptr;
+
+    // set compression by CompressionTypePB from tablet schema.
+    void set_compression(CompressionTypePB type);
 };
 
 struct ReadIOStat {

--- a/be/src/storage/sstable/table_builder.cpp
+++ b/be/src/storage/sstable/table_builder.cpp
@@ -162,7 +162,7 @@ static Status CompressBlock(CompressionTypePB compression_type, const char* inpu
     size_t output_length = codec->max_compressed_len(length);
 
     // Resize the output string to accommodate the uncompressed length and the maximum compressed data length.
-    output->resize(sizeof(uint64_t) + output_length);
+    starrocks::raw::stl_string_resize_uninitialized(output, sizeof(uint64_t) + output_length);
 
     // Store the length of the uncompressed data in the first 64 bits of the output string.
     EncodeFixed64(output->data(), length);

--- a/be/src/storage/sstable/table_builder.cpp
+++ b/be/src/storage/sstable/table_builder.cpp
@@ -15,6 +15,7 @@
 #include "storage/sstable/filter_block.h"
 #include "storage/sstable/filter_policy.h"
 #include "storage/sstable/format.h"
+#include "util/compression/block_compression.h"
 #include "util/crc32c.h"
 #include "util/slice.h"
 
@@ -142,6 +143,43 @@ static bool Snappy_Compress(const char* input, size_t length, ::std::string* out
     return true;
 }
 
+/**
+ * Compresses the input data using the specified compression type.
+ *
+ * @param compression_type The type of compression to use.
+ * @param input The input data to compress.
+ * @param length The length of the input data.
+ * @param output The output string to store the compressed data.
+ * @return Status::OK() if the data was compressed successfully, otherwise an error status.
+ */
+static Status CompressBlock(CompressionTypePB compression_type, const char* input, uint64_t length,
+                            std::string* output) {
+    // Get the appropriate compression codec for the specified compression type.
+    const BlockCompressionCodec* codec = nullptr;
+    RETURN_IF_ERROR(get_block_compression_codec(compression_type, &codec));
+
+    // Calculate the maximum length of the compressed data.
+    size_t output_length = codec->max_compressed_len(length);
+
+    // Resize the output string to accommodate the uncompressed length and the maximum compressed data length.
+    output->resize(sizeof(uint64_t) + output_length);
+
+    // Store the length of the uncompressed data in the first 64 bits of the output string.
+    EncodeFixed64(output->data(), length);
+
+    // Create slices for the input and output data.
+    Slice output_slice(output->data() + sizeof(uint64_t), output_length);
+    Slice input_slice(input, length);
+
+    // Compress the input data and store it in the output slice.
+    RETURN_IF_ERROR(codec->compress(input_slice, &output_slice));
+
+    // Resize the output string to the actual size of the compressed data plus the size of the uncompressed length.
+    output->resize(sizeof(uint64_t) + output_slice.size);
+
+    return Status::OK();
+}
+
 void TableBuilder::WriteBlock(BlockBuilder* block, BlockHandle* handle) {
     // File format contains a sequence of blocks where each block has:
     //    block_data: uint8[n]
@@ -153,6 +191,7 @@ void TableBuilder::WriteBlock(BlockBuilder* block, BlockHandle* handle) {
 
     Slice block_contents;
     CompressionType type = r->options.compression;
+    std::string* compressed = &r->compressed_output;
     // TODO(postrelease): Support more compression options: zlib?
     switch (type) {
     case kNoCompression:
@@ -160,7 +199,6 @@ void TableBuilder::WriteBlock(BlockBuilder* block, BlockHandle* handle) {
         break;
 
     case kSnappyCompression: {
-        std::string* compressed = &r->compressed_output;
         if (Snappy_Compress(raw.get_data(), raw.get_size(), compressed) &&
             compressed->size() < raw.get_size() - (raw.get_size() / 8u)) {
             block_contents = *compressed;
@@ -170,6 +208,31 @@ void TableBuilder::WriteBlock(BlockBuilder* block, BlockHandle* handle) {
             block_contents = raw;
             type = kNoCompression;
         }
+        break;
+    }
+    case kLz4FrameCompression: {
+        auto st = CompressBlock(CompressionTypePB::LZ4_FRAME, raw.get_data(), raw.get_size(), compressed);
+        if (st.ok()) {
+            block_contents = *compressed;
+        } else {
+            LOG(ERROR) << "CompressByType fail, st : " << st.to_string();
+            block_contents = raw;
+            type = kNoCompression;
+        }
+        break;
+    }
+    case kZstdCompression: {
+        auto st = CompressBlock(CompressionTypePB::ZSTD, raw.get_data(), raw.get_size(), compressed);
+        if (st.ok()) {
+            block_contents = *compressed;
+        } else {
+            LOG(ERROR) << "CompressByType fail, st : " << st.to_string();
+            block_contents = raw;
+            type = kNoCompression;
+        }
+        break;
+    }
+    default: {
         break;
     }
     }

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -35,19 +35,21 @@
 
 namespace starrocks::lake {
 
-class PersistentIndexSstableTest : public ::testing::Test {
+class PersistentIndexSstableTest : public ::testing::Test,
+                                   ::testing::WithParamInterface<starrocks::sstable::CompressionType> {
 public:
-    static void SetUpTestCase() { CHECK_OK(fs::create_directories(kTestDir)); }
+    void SetUp() override { CHECK_OK(fs::create_directories(kTestDir)); }
 
-    static void TearDownTestCase() { (void)fs::remove_all(kTestDir); }
+    void TearDown() override { (void)fs::remove_all(kTestDir); }
 
 protected:
     constexpr static const char* const kTestDir = "./persistent_index_sstable_test";
 };
 
-TEST_F(PersistentIndexSstableTest, test_generate_sst_scan_and_check) {
+TEST_P(PersistentIndexSstableTest, test_generate_sst_scan_and_check) {
     const int N = 10000;
     sstable::Options options;
+    options.compression = GetParam();
     const std::string filename = "test1.sst";
     ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
     sstable::TableBuilder builder(options, file.get());
@@ -77,9 +79,10 @@ TEST_F(PersistentIndexSstableTest, test_generate_sst_scan_and_check) {
     delete sstable;
 }
 
-TEST_F(PersistentIndexSstableTest, test_generate_sst_seek_and_check) {
+TEST_P(PersistentIndexSstableTest, test_generate_sst_seek_and_check) {
     const int N = 10000;
     sstable::Options options;
+    options.compression = GetParam();
     const std::string filename = "test2.sst";
     ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
     sstable::TableBuilder builder(options, file.get());
@@ -109,7 +112,7 @@ TEST_F(PersistentIndexSstableTest, test_generate_sst_seek_and_check) {
     delete sstable;
 }
 
-TEST_F(PersistentIndexSstableTest, test_merge) {
+TEST_P(PersistentIndexSstableTest, test_merge) {
     std::vector<sstable::Iterator*> list;
     std::vector<std::unique_ptr<RandomAccessFile>> read_files;
     std::vector<uint64_t> fileszs;
@@ -118,6 +121,7 @@ TEST_F(PersistentIndexSstableTest, test_merge) {
     const int N = 10000;
     for (int i = 0; i < 3; ++i) {
         sstable::Options options;
+        options.compression = GetParam();
         const std::string filename = fmt::format("test_merge_{}.sst", i);
         ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
         sstable::TableBuilder builder(options, file.get());
@@ -132,6 +136,7 @@ TEST_F(PersistentIndexSstableTest, test_merge) {
         ASSIGN_OR_ABORT(read_files[i], fs::new_random_access_file(lake::join_path(kTestDir, filename)));
     }
     sstable::Options options;
+    options.compression = GetParam();
     sstable::ReadOptions read_options;
     std::vector<std::unique_ptr<sstable::Table>> sstable_ptrs(3);
     for (int i = 0; i < 3; ++i) {
@@ -145,6 +150,7 @@ TEST_F(PersistentIndexSstableTest, test_merge) {
     phmap::btree_map<std::string, std::string> map;
     {
         sstable::Options options;
+        options.compression = GetParam();
         sstable::Iterator* iter = sstable::NewMergingIterator(options.comparator, &list[0], list.size());
 
         iter->SeekToFirst();
@@ -194,7 +200,7 @@ TEST_F(PersistentIndexSstableTest, test_merge) {
     sstable_ptrs.clear();
 }
 
-TEST_F(PersistentIndexSstableTest, test_empty_iterator) {
+TEST_P(PersistentIndexSstableTest, test_empty_iterator) {
     std::unique_ptr<sstable::Iterator> iter;
     iter.reset(sstable::NewEmptyIterator());
     ASSERT_TRUE(!iter->Valid());
@@ -207,7 +213,7 @@ TEST_F(PersistentIndexSstableTest, test_empty_iterator) {
     ASSERT_ERROR(iter2->status());
 }
 
-TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
+TEST_P(PersistentIndexSstableTest, test_persistent_index_sstable) {
     const int N = 100;
     // 1. build sstable
     const std::string filename = "test_persistent_index_sstable_1.sst";
@@ -420,7 +426,7 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
     }
 }
 
-TEST_F(PersistentIndexSstableTest, test_index_value_protobuf) {
+TEST_P(PersistentIndexSstableTest, test_index_value_protobuf) {
     IndexValuesWithVerPB index_value_pb;
     for (int i = 0; i < 10; i++) {
         auto* value = index_value_pb.add_values();
@@ -435,5 +441,11 @@ TEST_F(PersistentIndexSstableTest, test_index_value_protobuf) {
         ASSERT_TRUE(val == IndexValue(((uint64_t)(i * 10 + i) << 32) | (i * 20 + i)));
     }
 }
+
+INSTANTIATE_TEST_SUITE_P(PersistentIndexSstableTest, PersistentIndexSstableTest,
+                         ::testing::Values(starrocks::sstable::CompressionType::kNoCompression,
+                                           starrocks::sstable::CompressionType::kSnappyCompression,
+                                           starrocks::sstable::CompressionType::kLz4FrameCompression,
+                                           starrocks::sstable::CompressionType::kZstdCompression));
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Support lz4/zstd compression algo for cloud native pk index files (.sst), setup specific compression algo by table schema will be in next PR.

And this is the result of TPCH100G table (lineitem):
  | snappy | LZ4 | ZSTD
-- | -- | -- | --
lineitem | 12.5G | 12.5G | 9.4G

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5