### PR TITLE
[Enhancement] add catalog properties to control get stats from metadata

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorProperties.java
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import java.util.Map;
+
+public class ConnectorProperties {
+    public static final String ENABLE_GET_STATS_FROM_METADATA = "enable_get_stats_from_metadata";
+
+    private final ConnectorType connectorType;
+    private final Map<String, String> properties;
+
+    public ConnectorProperties(String connectorType) {
+        this.connectorType = ConnectorType.from(connectorType);
+        this.properties = Map.of();
+    }
+
+    public ConnectorProperties(String connectorType, Map<String, String> properties) {
+        this.connectorType = ConnectorType.from(connectorType);
+        this.properties = properties;
+    }
+
+    public boolean enableGetTableStatsFromMetadata() {
+        if (properties.containsKey(ConnectorProperties.ENABLE_GET_STATS_FROM_METADATA)) {
+            return Boolean.parseBoolean(properties.get(ConnectorProperties.ENABLE_GET_STATS_FROM_METADATA));
+        }
+        // For Iceberg and DeltaLake, we don't get table stats from metadata by default.
+        if (connectorType == ConnectorType.ICEBERG || connectorType == ConnectorType.DELTALAKE) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorProperties.java
@@ -14,33 +14,30 @@
 
 package com.starrocks.connector;
 
+import org.apache.iceberg.util.PropertyUtil;
+
 import java.util.Map;
 
 public class ConnectorProperties {
-    public static final String ENABLE_GET_STATS_FROM_METADATA = "enable_get_stats_from_metadata";
+    public static final String ENABLE_GET_STATS_FROM_EXTERNAL_METADATA = "enable_get_stats_from_external_metadata";
 
     private final ConnectorType connectorType;
     private final Map<String, String> properties;
 
-    public ConnectorProperties(String connectorType) {
-        this.connectorType = ConnectorType.from(connectorType);
+    public ConnectorProperties(ConnectorType connectorType) {
+        this.connectorType = connectorType;
         this.properties = Map.of();
     }
 
-    public ConnectorProperties(String connectorType, Map<String, String> properties) {
-        this.connectorType = ConnectorType.from(connectorType);
+    public ConnectorProperties(ConnectorType connectorType, Map<String, String> properties) {
+        this.connectorType = connectorType;
         this.properties = properties;
     }
 
-    public boolean enableGetTableStatsFromMetadata() {
-        if (properties.containsKey(ConnectorProperties.ENABLE_GET_STATS_FROM_METADATA)) {
-            return Boolean.parseBoolean(properties.get(ConnectorProperties.ENABLE_GET_STATS_FROM_METADATA));
-        }
+    public boolean enableGetTableStatsFromExternalMetadata() {
         // For Iceberg and DeltaLake, we don't get table stats from metadata by default.
-        if (connectorType == ConnectorType.ICEBERG || connectorType == ConnectorType.DELTALAKE) {
-            return false;
-        } else {
-            return true;
-        }
+        boolean defaultValue = connectorType != ConnectorType.ICEBERG && connectorType != ConnectorType.DELTALAKE;
+        return PropertyUtil.propertyAsBoolean(properties, ConnectorProperties.ENABLE_GET_STATS_FROM_EXTERNAL_METADATA,
+                defaultValue);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -147,7 +147,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit,
                                          TableVersionRange versionRange) {
-        if (!properties.enableGetTableStatsFromMetadata()) {
+        if (!properties.enableGetTableStatsFromExternalMetadata()) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -26,6 +26,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
@@ -34,6 +35,7 @@ import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.common.ErrorType;
@@ -77,13 +79,15 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     private final Map<PredicateSearchKey, List<FileScanTask>> splitTasks = new ConcurrentHashMap<>();
     private final Set<PredicateSearchKey> scannedTables = new HashSet<>();
     private final DeltaStatisticProvider statisticProvider = new DeltaStatisticProvider();
+    private final ConnectorProperties properties;
 
     public DeltaLakeMetadata(HdfsEnvironment hdfsEnvironment, String catalogName, DeltaMetastoreOperations deltaOps,
-                             DeltaLakeCacheUpdateProcessor cacheUpdateProcessor) {
+                             DeltaLakeCacheUpdateProcessor cacheUpdateProcessor, ConnectorProperties properties) {
         this.hdfsEnvironment = hdfsEnvironment;
         this.catalogName = catalogName;
         this.deltaOps = deltaOps;
         this.cacheUpdateProcessor = cacheUpdateProcessor;
+        this.properties = properties;
     }
 
     public String getCatalogName() {
@@ -143,6 +147,10 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit,
                                          TableVersionRange versionRange) {
+        if (!properties.enableGetTableStatsFromMetadata()) {
+            return StatisticsUtils.buildDefaultStatistics(columns.keySet());
+        }
+
         DeltaLakeTable deltaLakeTable = (DeltaLakeTable) table;
         SnapshotImpl snapshot = (SnapshotImpl) deltaLakeTable.getDeltaSnapshot();
         String dbName = deltaLakeTable.getDbName();
@@ -161,12 +169,12 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
                     dbName, table, predicate);
         }
 
-        if (session.getSessionVariable().enableDeltaLakeColumnStatistics()) {
-            try (Timer ignored = Tracers.watchScope(EXTERNAL, "DELTA_LAKE.getTableStatistics" + key)) {
+        String traceLabel = session.getSessionVariable().enableDeltaLakeColumnStatistics() ?
+                "DELTA_LAKE.getTableStatistics" + key : "DELTA_LAKE.getCardinalityStats" + key;
+        try (Timer ignored = Tracers.watchScope(EXTERNAL, traceLabel)) {
+            if (session.getSessionVariable().enableDeltaLakeColumnStatistics()) {
                 return statisticProvider.getTableStatistics(schema, key, columns);
-            }
-        } else {
-            try (Timer ignored = Tracers.watchScope(EXTERNAL, "DELTA_LAKE.getCardinalityStats" + key)) {
+            } else {
                 return statisticProvider.getCardinalityStats(schema, key, columns);
             }
         }
@@ -310,22 +318,17 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
 
         List<FileScanTask> files = Lists.newArrayList();
         boolean enableCollectColumnStats = enableCollectColumnStatistics(connectContext);
+        String traceLabel = enableCollectColumnStats ? "DELTA_LAKE.updateDeltaLakeFileStats" :
+                "DELTA_LAKE.updateDeltaLakeCardinality";
+
         Iterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>> iterator =
                 buildFileScanTaskIterator(table, operator, enableCollectColumnStats);
         while (iterator.hasNext()) {
             Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> pair = iterator.next();
             files.add(pair.first);
-
-            if (enableCollectColumnStats) {
-                try (Timer ignored = Tracers.watchScope(EXTERNAL, "DELTA_LAKE.updateDeltaLakeFileStats")) {
-                    statisticProvider.updateFileStats(deltaLakeTable, key, pair.first, pair.second,
-                            nonPartitionPrimitiveColumns, partitionPrimitiveColumns);
-                }
-            } else {
-                try (Timer ignored = Tracers.watchScope(EXTERNAL, "DELTA_LAKE.updateDeltaLakeCardinality")) {
-                    statisticProvider.updateFileStats(deltaLakeTable, key, pair.first, pair.second,
-                            nonPartitionPrimitiveColumns, partitionPrimitiveColumns);
-                }
+            try (Timer ignored = Tracers.watchScope(EXTERNAL, traceLabel)) {
+                statisticProvider.updateFileStats(deltaLakeTable, key, pair.first, pair.second,
+                        nonPartitionPrimitiveColumns, partitionPrimitiveColumns);
             }
         }
         splitTasks.put(key, files);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.delta;
 
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.hive.CachingHiveMetastoreConf;
@@ -31,7 +32,7 @@ public class DeltaLakeMetadataFactory {
     protected final IDeltaLakeMetastore metastore;
     protected final long perQueryMetastoreMaxNum;
     private final HdfsEnvironment hdfsEnvironment;
-    protected final Map<String, String> properties;
+    protected final ConnectorProperties connectorProperties;
     protected final MetastoreType metastoreType;
 
     public DeltaLakeMetadataFactory(String catalogName, IDeltaLakeMetastore metastore, CachingHiveMetastoreConf hmsConf,
@@ -41,7 +42,7 @@ public class DeltaLakeMetadataFactory {
         this.metastore = metastore;
         this.perQueryMetastoreMaxNum = hmsConf.getPerQueryCacheMaxNum();
         this.hdfsEnvironment = hdfsEnvironment;
-        this.properties = properties;
+        this.connectorProperties = new ConnectorProperties(ConnectorType.DELTALAKE, properties);
         if (properties.containsKey(HIVE_METASTORE_URIS)) {
             this.hdfsEnvironment.getConfiguration().set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(),
                     properties.get(HIVE_METASTORE_URIS));
@@ -60,7 +61,7 @@ public class DeltaLakeMetadataFactory {
 
         Optional<DeltaLakeCacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
         return new DeltaLakeMetadata(hdfsEnvironment, catalogName, metastoreOperations,
-                cacheUpdateProcessor.orElse(null), new ConnectorProperties("deltalake", properties));
+                cacheUpdateProcessor.orElse(null), connectorProperties);
     }
 
     public synchronized Optional<DeltaLakeCacheUpdateProcessor> getCacheUpdateProcessor() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.delta;
 
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.hive.CachingHiveMetastoreConf;
@@ -30,6 +31,7 @@ public class DeltaLakeMetadataFactory {
     protected final IDeltaLakeMetastore metastore;
     protected final long perQueryMetastoreMaxNum;
     private final HdfsEnvironment hdfsEnvironment;
+    protected final Map<String, String> properties;
     protected final MetastoreType metastoreType;
 
     public DeltaLakeMetadataFactory(String catalogName, IDeltaLakeMetastore metastore, CachingHiveMetastoreConf hmsConf,
@@ -39,6 +41,7 @@ public class DeltaLakeMetadataFactory {
         this.metastore = metastore;
         this.perQueryMetastoreMaxNum = hmsConf.getPerQueryCacheMaxNum();
         this.hdfsEnvironment = hdfsEnvironment;
+        this.properties = properties;
         if (properties.containsKey(HIVE_METASTORE_URIS)) {
             this.hdfsEnvironment.getConfiguration().set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(),
                     properties.get(HIVE_METASTORE_URIS));
@@ -57,7 +60,7 @@ public class DeltaLakeMetadataFactory {
 
         Optional<DeltaLakeCacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
         return new DeltaLakeMetadata(hdfsEnvironment, catalogName, metastoreOperations,
-                cacheUpdateProcessor.orElse(null));
+                cacheUpdateProcessor.orElse(null), new ConnectorProperties("deltalake", properties));
     }
 
     public synchronized Optional<DeltaLakeCacheUpdateProcessor> getCacheUpdateProcessor() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
@@ -67,7 +67,8 @@ public class HiveConnector implements Connector {
                 internalMgr.isSearchRecursive(),
                 internalMgr.enableHmsEventsIncrementalSync(),
                 hdfsEnvironment,
-                internalMgr.getMetastoreType()
+                internalMgr.getMetastoreType(),
+                properties
         );
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -32,6 +32,7 @@ import com.starrocks.common.Version;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.PartitionInfo;
@@ -41,6 +42,7 @@ import com.starrocks.connector.RemoteFileOperations;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.PartitionUpdate.UpdateMode;
+import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -87,6 +89,7 @@ public class HiveMetadata implements ConnectorMetadata {
     private final Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor;
     private Executor updateExecutor;
     private Executor refreshOthersFeExecutor;
+    private final ConnectorProperties properties;
 
     public HiveMetadata(String catalogName,
                         HdfsEnvironment hdfsEnvironment,
@@ -95,7 +98,8 @@ public class HiveMetadata implements ConnectorMetadata {
                         HiveStatisticsProvider statisticsProvider,
                         Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor,
                         Executor updateExecutor,
-                        Executor refreshOthersFeExecutor) {
+                        Executor refreshOthersFeExecutor,
+                        ConnectorProperties properties) {
         this.catalogName = catalogName;
         this.hdfsEnvironment = hdfsEnvironment;
         this.hmsOps = hmsOps;
@@ -104,6 +108,7 @@ public class HiveMetadata implements ConnectorMetadata {
         this.cacheUpdateProcessor = cacheUpdateProcessor;
         this.updateExecutor = updateExecutor;
         this.refreshOthersFeExecutor = refreshOthersFeExecutor;
+        this.properties = properties;
     }
 
     @Override
@@ -314,6 +319,10 @@ public class HiveMetadata implements ConnectorMetadata {
                                          ScalarOperator predicate,
                                          long limit,
                                          TableVersionRange version) {
+        if (!properties.enableGetTableStatsFromMetadata()) {
+            return StatisticsUtils.buildDefaultStatistics(columns.keySet());
+        }
+
         Statistics statistics = null;
         List<ColumnRefOperator> columnRefOperators = Lists.newArrayList(columns.keySet());
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -319,7 +319,7 @@ public class HiveMetadata implements ConnectorMetadata {
                                          ScalarOperator predicate,
                                          long limit,
                                          TableVersionRange version) {
-        if (!properties.enableGetTableStatsFromMetadata()) {
+        if (!properties.enableGetTableStatsFromExternalMetadata()) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.hive;
 import com.starrocks.connector.CachingRemoteFileConf;
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.RemoteFileIO;
@@ -43,7 +44,7 @@ public class HiveMetadataFactory {
     private final boolean enableHmsEventsIncrementalSync;
     private final HdfsEnvironment hdfsEnvironment;
     private final MetastoreType metastoreType;
-    private final Map<String, String> properties;
+    private final ConnectorProperties connectorProperties;
 
     public HiveMetadataFactory(String catalogName,
                                IHiveMetastore metastore,
@@ -72,7 +73,7 @@ public class HiveMetadataFactory {
         this.enableHmsEventsIncrementalSync = enableHmsEventsIncrementalSync;
         this.hdfsEnvironment = hdfsEnvironment;
         this.metastoreType = metastoreType;
-        this.properties = properties;
+        this.connectorProperties = new ConnectorProperties(ConnectorType.HIVE, properties);
     }
 
     public HiveMetadata create() {
@@ -92,7 +93,7 @@ public class HiveMetadataFactory {
         Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
         return new HiveMetadata(catalogName, hdfsEnvironment, hiveMetastoreOperations, remoteFileOperations,
                 statisticsProvider, cacheUpdateProcessor, updateStatisticsExecutor, refreshOthersFeExecutor,
-                new ConnectorProperties("hive", properties));
+                connectorProperties);
     }
 
     public synchronized Optional<HiveCacheUpdateProcessor> getCacheUpdateProcessor() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
@@ -16,11 +16,13 @@ package com.starrocks.connector.hive;
 
 import com.starrocks.connector.CachingRemoteFileConf;
 import com.starrocks.connector.CachingRemoteFileIO;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.connector.RemoteFileOperations;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -41,6 +43,7 @@ public class HiveMetadataFactory {
     private final boolean enableHmsEventsIncrementalSync;
     private final HdfsEnvironment hdfsEnvironment;
     private final MetastoreType metastoreType;
+    private final Map<String, String> properties;
 
     public HiveMetadataFactory(String catalogName,
                                IHiveMetastore metastore,
@@ -54,7 +57,8 @@ public class HiveMetadataFactory {
                                boolean isRecursive,
                                boolean enableHmsEventsIncrementalSync,
                                HdfsEnvironment hdfsEnvironment,
-                               MetastoreType metastoreType) {
+                               MetastoreType metastoreType,
+                               Map<String, String> properties) {
         this.catalogName = catalogName;
         this.metastore = metastore;
         this.remoteFileIO = remoteFileIO;
@@ -68,6 +72,7 @@ public class HiveMetadataFactory {
         this.enableHmsEventsIncrementalSync = enableHmsEventsIncrementalSync;
         this.hdfsEnvironment = hdfsEnvironment;
         this.metastoreType = metastoreType;
+        this.properties = properties;
     }
 
     public HiveMetadata create() {
@@ -86,7 +91,8 @@ public class HiveMetadataFactory {
 
         Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
         return new HiveMetadata(catalogName, hdfsEnvironment, hiveMetastoreOperations, remoteFileOperations,
-                statisticsProvider, cacheUpdateProcessor, updateStatisticsExecutor, refreshOthersFeExecutor);
+                statisticsProvider, cacheUpdateProcessor, updateStatisticsExecutor, refreshOthersFeExecutor,
+                new ConnectorProperties("hive", properties));
     }
 
     public synchronized Optional<HiveCacheUpdateProcessor> getCacheUpdateProcessor() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
@@ -31,12 +31,13 @@ import java.util.Map;
 public class HudiConnector implements Connector {
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
     public static final List<String> SUPPORTED_METASTORE_TYPE = Lists.newArrayList("hive", "glue", "dlf");
+    private final Map<String, String> properties;
     private final String catalogName;
     private final HudiConnectorInternalMgr internalMgr;
     private final HudiMetadataFactory metadataFactory;
 
     public HudiConnector(ConnectorContext context) {
-        Map<String, String> properties = context.getProperties();
+        this.properties = context.getProperties();
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.catalogName = context.getCatalogName();
@@ -62,7 +63,8 @@ public class HudiConnector implements Connector {
                 internalMgr.getPullRemoteFileExecutor(),
                 internalMgr.isSearchRecursive(),
                 hdfsEnvironment,
-                internalMgr.getMetastoreType()
+                internalMgr.getMetastoreType(),
+                properties
         );
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -192,7 +192,7 @@ public class HudiMetadata implements ConnectorMetadata {
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate, long limit, TableVersionRange version) {
-        if (!properties.enableGetTableStatsFromMetadata()) {
+        if (!properties.enableGetTableStatsFromExternalMetadata()) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
@@ -35,6 +36,7 @@ import com.starrocks.connector.hive.HiveCacheUpdateProcessor;
 import com.starrocks.connector.hive.HiveMetastoreOperations;
 import com.starrocks.connector.hive.HiveStatisticsProvider;
 import com.starrocks.connector.hive.Partition;
+import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
@@ -64,19 +66,22 @@ public class HudiMetadata implements ConnectorMetadata {
     private final RemoteFileOperations fileOps;
     private final HiveStatisticsProvider statisticsProvider;
     private final Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor;
+    private final ConnectorProperties properties;
 
     public HudiMetadata(String catalogName,
                         HdfsEnvironment hdfsEnvironment,
                         HiveMetastoreOperations hmsOps,
                         RemoteFileOperations fileOperations,
                         HiveStatisticsProvider statisticsProvider,
-                        Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor) {
+                        Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor,
+                        ConnectorProperties properties) {
         this.catalogName = catalogName;
         this.hdfsEnvironment = hdfsEnvironment;
         this.hmsOps = hmsOps;
         this.fileOps = fileOperations;
         this.statisticsProvider = statisticsProvider;
         this.cacheUpdateProcessor = cacheUpdateProcessor;
+        this.properties = properties;
     }
 
     @Override
@@ -187,6 +192,10 @@ public class HudiMetadata implements ConnectorMetadata {
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate, long limit, TableVersionRange version) {
+        if (!properties.enableGetTableStatsFromMetadata()) {
+            return StatisticsUtils.buildDefaultStatistics(columns.keySet());
+        }
+
         Statistics statistics = null;
         List<ColumnRefOperator> columnRefOperators = Lists.newArrayList(columns.keySet());
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadataFactory.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.hudi;
 import com.starrocks.connector.CachingRemoteFileConf;
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.RemoteFileIO;
@@ -44,7 +45,7 @@ public class HudiMetadataFactory {
     private final boolean isRecursive;
     private final HdfsEnvironment hdfsEnvironment;
     private final MetastoreType metastoreType;
-    private final Map<String, String> properties;
+    private final ConnectorProperties connectorProperties;
 
     public HudiMetadataFactory(String catalogName,
                                IHiveMetastore metastore,
@@ -65,7 +66,7 @@ public class HudiMetadataFactory {
         this.isRecursive = isRecursive;
         this.hdfsEnvironment = hdfsEnvironment;
         this.metastoreType = metastoreType;
-        this.properties = properties;
+        this.connectorProperties = new ConnectorProperties(ConnectorType.HUDI, properties);
     }
 
     public HudiMetadata create() {
@@ -84,8 +85,7 @@ public class HudiMetadataFactory {
         Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
 
         return new HudiMetadata(catalogName, hdfsEnvironment, hiveMetastoreOperations,
-                remoteFileOperations, statisticsProvider, cacheUpdateProcessor,
-                new ConnectorProperties("hudi", properties));
+                remoteFileOperations, statisticsProvider, cacheUpdateProcessor, connectorProperties);
     }
 
     public synchronized Optional<HiveCacheUpdateProcessor> getCacheUpdateProcessor() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadataFactory.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.hudi;
 
 import com.starrocks.connector.CachingRemoteFileConf;
 import com.starrocks.connector.CachingRemoteFileIO;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.RemoteFileIO;
@@ -27,6 +28,7 @@ import com.starrocks.connector.hive.HiveMetastoreOperations;
 import com.starrocks.connector.hive.HiveStatisticsProvider;
 import com.starrocks.connector.hive.IHiveMetastore;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
@@ -42,6 +44,7 @@ public class HudiMetadataFactory {
     private final boolean isRecursive;
     private final HdfsEnvironment hdfsEnvironment;
     private final MetastoreType metastoreType;
+    private final Map<String, String> properties;
 
     public HudiMetadataFactory(String catalogName,
                                IHiveMetastore metastore,
@@ -51,7 +54,8 @@ public class HudiMetadataFactory {
                                ExecutorService pullRemoteFileExecutor,
                                boolean isRecursive,
                                HdfsEnvironment hdfsEnvironment,
-                               MetastoreType metastoreType) {
+                               MetastoreType metastoreType,
+                               Map<String, String> properties) {
         this.catalogName = catalogName;
         this.metastore = metastore;
         this.remoteFileIO = remoteFileIO;
@@ -61,6 +65,7 @@ public class HudiMetadataFactory {
         this.isRecursive = isRecursive;
         this.hdfsEnvironment = hdfsEnvironment;
         this.metastoreType = metastoreType;
+        this.properties = properties;
     }
 
     public HudiMetadata create() {
@@ -79,7 +84,8 @@ public class HudiMetadataFactory {
         Optional<HiveCacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
 
         return new HudiMetadata(catalogName, hdfsEnvironment, hiveMetastoreOperations,
-                remoteFileOperations, statisticsProvider, cacheUpdateProcessor);
+                remoteFileOperations, statisticsProvider, cacheUpdateProcessor,
+                new ConnectorProperties("hudi", properties));
     }
 
     public synchronized Optional<HiveCacheUpdateProcessor> getCacheUpdateProcessor() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -20,6 +20,7 @@ import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.glue.IcebergGlueCatalog;
@@ -52,6 +53,7 @@ public class IcebergConnector implements Connector {
     private ExecutorService icebergJobPlanningExecutor;
     private ExecutorService refreshOtherFeExecutor;
     private final IcebergCatalogProperties icebergCatalogProperties;
+    private final ConnectorProperties connectorProperties;
 
     public IcebergConnector(ConnectorContext context) {
         this.catalogName = context.getCatalogName();
@@ -59,6 +61,7 @@ public class IcebergConnector implements Connector {
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         this.hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.icebergCatalogProperties = new IcebergCatalogProperties(properties);
+        this.connectorProperties = new ConnectorProperties(ConnectorType.ICEBERG, properties);
     }
 
     private IcebergCatalog buildIcebergNativeCatalog() {
@@ -88,8 +91,7 @@ public class IcebergConnector implements Connector {
     @Override
     public ConnectorMetadata getMetadata() {
         return new IcebergMetadata(catalogName, hdfsEnvironment, getNativeCatalog(),
-                buildIcebergJobPlanningExecutor(), buildRefreshOtherFeExecutor(), icebergCatalogProperties,
-                new ConnectorProperties("iceberg", properties));
+                buildIcebergJobPlanningExecutor(), buildRefreshOtherFeExecutor(), icebergCatalogProperties, connectorProperties);
     }
 
     // In order to be compatible with the catalog created with the wrong configuration,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -19,6 +19,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.glue.IcebergGlueCatalog;
@@ -87,7 +88,8 @@ public class IcebergConnector implements Connector {
     @Override
     public ConnectorMetadata getMetadata() {
         return new IcebergMetadata(catalogName, hdfsEnvironment, getNativeCatalog(),
-                buildIcebergJobPlanningExecutor(), buildRefreshOtherFeExecutor(), icebergCatalogProperties);
+                buildIcebergJobPlanningExecutor(), buildRefreshOtherFeExecutor(), icebergCatalogProperties,
+                new ConnectorProperties("iceberg", properties));
     }
 
     // In order to be compatible with the catalog created with the wrong configuration,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -39,6 +39,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorTableVersion;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.ConnectorViewDefinition;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
@@ -192,7 +193,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                            ExecutorService jobPlanningExecutor, ExecutorService refreshOtherFeExecutor,
                            IcebergCatalogProperties catalogProperties) {
         this(catalogName, hdfsEnvironment, icebergCatalog, jobPlanningExecutor, refreshOtherFeExecutor,
-                catalogProperties, new ConnectorProperties("iceberg"));
+                catalogProperties, new ConnectorProperties(ConnectorType.ICEBERG));
     }
 
     public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog,
@@ -980,7 +981,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                                          ScalarOperator predicate,
                                          long limit,
                                          TableVersionRange version) {
-        if (!properties.enableGetTableStatsFromMetadata()) {
+        if (!properties.enableGetTableStatsFromExternalMetadata()) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
         IcebergTable icebergTable = (IcebergTable) table;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -18,6 +18,7 @@ import com.google.common.base.Strings;
 import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
@@ -50,9 +51,10 @@ public class PaimonConnector implements Connector {
     private Catalog paimonNativeCatalog;
     private final String catalogName;
     private final Options paimonOptions;
+    private final Map<String, String> properties;
 
     public PaimonConnector(ConnectorContext context) {
-        Map<String, String> properties = context.getProperties();
+        this.properties = context.getProperties();
         this.catalogName = context.getCatalogName();
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         this.hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
@@ -139,6 +141,7 @@ public class PaimonConnector implements Connector {
 
     @Override
     public ConnectorMetadata getMetadata() {
-        return new PaimonMetadata(catalogName, hdfsEnvironment, getPaimonNativeCatalog());
+        return new PaimonMetadata(catalogName, hdfsEnvironment, getPaimonNativeCatalog(),
+                new ConnectorProperties("paimon", properties));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -19,6 +19,7 @@ import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
@@ -51,10 +52,11 @@ public class PaimonConnector implements Connector {
     private Catalog paimonNativeCatalog;
     private final String catalogName;
     private final Options paimonOptions;
-    private final Map<String, String> properties;
+    private final ConnectorProperties connectorProperties;
 
     public PaimonConnector(ConnectorContext context) {
-        this.properties = context.getProperties();
+        Map<String, String> properties = context.getProperties();
+        this.connectorProperties = new ConnectorProperties(ConnectorType.PAIMON, properties);
         this.catalogName = context.getCatalogName();
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         this.hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
@@ -141,7 +143,6 @@ public class PaimonConnector implements Connector {
 
     @Override
     public ConnectorMetadata getMetadata() {
-        return new PaimonMetadata(catalogName, hdfsEnvironment, getPaimonNativeCatalog(),
-                new ConnectorProperties("paimon", properties));
+        return new PaimonMetadata(catalogName, hdfsEnvironment, getPaimonNativeCatalog(), connectorProperties);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -271,7 +271,7 @@ public class PaimonMetadata implements ConnectorMetadata {
                                          ScalarOperator predicate,
                                          long limit,
                                          TableVersionRange versionRange) {
-        if (!properties.enableGetTableStatsFromMetadata()) {
+        if (!properties.enableGetTableStatsFromExternalMetadata()) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.connector.ColumnTypeConverter;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.PartitionInfo;
@@ -31,6 +32,7 @@ import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -77,11 +79,14 @@ public class PaimonMetadata implements ConnectorMetadata {
     private final Map<String, Database> databases = new ConcurrentHashMap<>();
     private final Map<PaimonFilter, PaimonSplitsInfo> paimonSplits = new ConcurrentHashMap<>();
     private final Map<String, Long> partitionInfos = new ConcurrentHashMap<>();
+    private final ConnectorProperties properties;
 
-    public PaimonMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, Catalog paimonNativeCatalog) {
+    public PaimonMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, Catalog paimonNativeCatalog,
+                          ConnectorProperties properties) {
         this.paimonNativeCatalog = paimonNativeCatalog;
         this.hdfsEnvironment = hdfsEnvironment;
         this.catalogName = catalogName;
+        this.properties = properties;
     }
 
     @Override
@@ -266,6 +271,10 @@ public class PaimonMetadata implements ConnectorMetadata {
                                          ScalarOperator predicate,
                                          long limit,
                                          TableVersionRange versionRange) {
+        if (!properties.enableGetTableStatsFromMetadata()) {
+            return StatisticsUtils.buildDefaultStatistics(columns.keySet());
+        }
+
         Statistics.Builder builder = Statistics.builder();
         for (ColumnRefOperator columnRefOperator : columns.keySet()) {
             builder.addColumnStatistic(columnRefOperator, ColumnStatistic.unknown());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/StatisticsUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/StatisticsUtils.java
@@ -19,8 +19,14 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import io.trino.hive.$internal.org.apache.commons.lang3.tuple.ImmutableTriple;
 import io.trino.hive.$internal.org.apache.commons.lang3.tuple.Triple;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class StatisticsUtils {
     public static Table getTableByUUID(String tableUUID) {
@@ -56,5 +62,13 @@ public class StatisticsUtils {
         }
 
         return ImmutableTriple.of(splits[0], db, table);
+    }
+
+    public static Statistics buildDefaultStatistics(Set<ColumnRefOperator> columns) {
+        Statistics.Builder statisticsBuilder = Statistics.builder();
+        statisticsBuilder.setOutputRowCount(1);
+        statisticsBuilder.addColumnStatistics(
+                columns.stream().collect(Collectors.toMap(column -> column, column -> ColumnStatistic.unknown())));
+        return statisticsBuilder.build();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -27,6 +27,7 @@ import com.starrocks.connector.RemoteFileInfoDefaultSource;
 import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.delta.DeltaConnectorScanRangeSource;
+import com.starrocks.connector.delta.DeltaUtils;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -103,6 +104,7 @@ public class DeltaLakeScanNode extends ScanNode {
     public void setupScanRangeSource(ScalarOperator predicate, List<String> fieldNames, boolean enableIncrementalScanRanges)
             throws UserException {
         SnapshotImpl snapshot = (SnapshotImpl) deltaLakeTable.getDeltaSnapshot();
+        DeltaUtils.checkTableFeatureSupported(snapshot.getProtocol(), snapshot.getMetadata());
         Engine engine = deltaLakeTable.getDeltaEngine();
         long snapshotId = snapshot.getVersion(engine);
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.TableVersionRange;
@@ -72,7 +73,8 @@ public class DeltaLakeMetadataTest {
                 CachingDeltaLakeMetastore.createQueryLevelInstance(hmsBackedDeltaMetastore, 10000), false,
                 MetastoreType.HMS);
 
-        deltaLakeMetadata = new DeltaLakeMetadata(hdfsEnvironment, "delta0", deltaOps, null);
+        deltaLakeMetadata = new DeltaLakeMetadata(hdfsEnvironment, "delta0", deltaOps, null,
+                new ConnectorProperties("deltalake"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.TableVersionRange;
@@ -74,7 +75,7 @@ public class DeltaLakeMetadataTest {
                 MetastoreType.HMS);
 
         deltaLakeMetadata = new DeltaLakeMetadata(hdfsEnvironment, "delta0", deltaOps, null,
-                new ConnectorProperties("deltalake"));
+                new ConnectorProperties(ConnectorType.DELTALAKE));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -31,6 +31,7 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.CachingRemoteFileIO;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
@@ -131,7 +132,8 @@ public class HiveMetadataTest {
         columnRefFactory = new ColumnRefFactory();
         optimizerContext = new OptimizerContext(new Memo(), columnRefFactory, connectContext);
         hiveMetadata = new HiveMetadata("hive_catalog", new HdfsEnvironment(), hmsOps, fileOps, statisticsProvider,
-                Optional.empty(), executorForHmsRefresh, executorForHmsRefresh);
+                Optional.empty(), executorForHmsRefresh, executorForHmsRefresh,
+                new ConnectorProperties("hive"));
     }
 
     @After

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -32,6 +32,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
@@ -133,7 +134,7 @@ public class HiveMetadataTest {
         optimizerContext = new OptimizerContext(new Memo(), columnRefFactory, connectContext);
         hiveMetadata = new HiveMetadata("hive_catalog", new HdfsEnvironment(), hmsOps, fileOps, statisticsProvider,
                 Optional.empty(), executorForHmsRefresh, executorForHmsRefresh,
-                new ConnectorProperties("hive"));
+                new ConnectorProperties(ConnectorType.HIVE));
     }
 
     @After

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.HiveView;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -129,7 +130,7 @@ public class HiveViewTest extends PlanTestBase {
                 null, null, true, false);
         HiveMetadata hiveMetadata = new HiveMetadata("hive0", null, null, null, null,
                 Optional.of(hiveCacheUpdateProcessor), null, null,
-                new ConnectorProperties("hive"));
+                new ConnectorProperties(ConnectorType.HIVE));
 
         Table hiveView = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "tpch", "customer_view");
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveView;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -127,7 +128,8 @@ public class HiveViewTest extends PlanTestBase {
         HiveCacheUpdateProcessor hiveCacheUpdateProcessor = new HiveCacheUpdateProcessor("hive0", hiveMetastore,
                 null, null, true, false);
         HiveMetadata hiveMetadata = new HiveMetadata("hive0", null, null, null, null,
-                Optional.of(hiveCacheUpdateProcessor), null, null);
+                Optional.of(hiveCacheUpdateProcessor), null, null,
+                new ConnectorProperties("hive"));
 
         Table hiveView = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "tpch", "customer_view");
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.RemoteFileOperations;
@@ -88,7 +89,7 @@ public class HudiMetadataTest {
         columnRefFactory = new ColumnRefFactory();
         hudiMetadata =
                 new HudiMetadata("hive_catalog", new HdfsEnvironment(), hmsOps, fileOps, statisticsProvider,
-                        Optional.empty(), new ConnectorProperties("hudi"));
+                        Optional.empty(), new ConnectorProperties(ConnectorType.HUDI));
     }
 
     @After

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.CachingRemoteFileIO;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.RemoteFileOperations;
@@ -86,7 +87,8 @@ public class HudiMetadataTest {
         connectContext = UtFrameUtils.createDefaultCtx();
         columnRefFactory = new ColumnRefFactory();
         hudiMetadata =
-                new HudiMetadata("hive_catalog", new HdfsEnvironment(), hmsOps, fileOps, statisticsProvider, Optional.empty());
+                new HudiMetadata("hive_catalog", new HdfsEnvironment(), hmsOps, fileOps, statisticsProvider,
+                        Optional.empty(), new ConnectorProperties("hudi"));
     }
 
     @After

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -40,6 +40,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorTableVersion;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.PartitionInfo;
@@ -783,8 +784,8 @@ public class IcebergMetadataTest extends TableTestBase {
 
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
-                new ConnectorProperties("iceberg",
-                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_METADATA, "true")));
+                new ConnectorProperties(ConnectorType.ICEBERG,
+                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_EXTERNAL_METADATA, "true")));
         mockedNativeTableA.newFastAppend().appendFile(FILE_A).appendFile(FILE_A_1).commit();
         IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "db_name",
                 "table_name", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
@@ -812,8 +813,8 @@ public class IcebergMetadataTest extends TableTestBase {
         List<Column> columns = Lists.newArrayList(new Column("k1", INT), new Column("k2", INT));
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
-                new ConnectorProperties("iceberg",
-                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_METADATA, "true")));
+                new ConnectorProperties(ConnectorType.ICEBERG,
+                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_EXTERNAL_METADATA, "true")));
         mockedNativeTableB.newFastAppend().appendFile(FILE_B_3).commit();
         mockedNativeTableB.newFastAppend().appendFile(FILE_B_4).commit();
         mockedNativeTableB.refresh();
@@ -927,8 +928,8 @@ public class IcebergMetadataTest extends TableTestBase {
                 "table_name", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
-                new ConnectorProperties("iceberg",
-                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_METADATA, "true")));
+                new ConnectorProperties(ConnectorType.ICEBERG,
+                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_EXTERNAL_METADATA, "true")));
         Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<ColumnRefOperator, Column>();
         ColumnRefOperator columnRefOperator1 = new ColumnRefOperator(3, Type.INT, "id", true);
         ColumnRefOperator columnRefOperator2 = new ColumnRefOperator(4, Type.STRING, "data", true);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -38,6 +38,7 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
@@ -781,7 +782,9 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
 
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
+                new ConnectorProperties("iceberg",
+                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_METADATA, "true")));
         mockedNativeTableA.newFastAppend().appendFile(FILE_A).appendFile(FILE_A_1).commit();
         IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "db_name",
                 "table_name", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
@@ -808,7 +811,9 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         List<Column> columns = Lists.newArrayList(new Column("k1", INT), new Column("k2", INT));
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
+                new ConnectorProperties("iceberg",
+                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_METADATA, "true")));
         mockedNativeTableB.newFastAppend().appendFile(FILE_B_3).commit();
         mockedNativeTableB.newFastAppend().appendFile(FILE_B_4).commit();
         mockedNativeTableB.refresh();
@@ -921,7 +926,9 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "db_name",
                 "table_name", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
+                new ConnectorProperties("iceberg",
+                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_METADATA, "true")));
         Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<ColumnRefOperator, Column>();
         ColumnRefOperator columnRefOperator1 = new ColumnRefOperator(3, Type.INT, "id", true);
         ColumnRefOperator columnRefOperator2 = new ColumnRefOperator(4, Type.STRING, "data", true);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
@@ -97,7 +98,7 @@ public class PaimonMetadataTest {
     @Before
     public void setUp() {
         this.metadata = new PaimonMetadata("paimon_catalog", new HdfsEnvironment(), paimonNativeCatalog,
-                new ConnectorProperties("paimon"));
+                new ConnectorProperties(ConnectorType.PAIMON));
 
         BinaryRow row1 = new BinaryRow(2);
         BinaryRowWriter writer = new BinaryRowWriter(row1, 10);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
@@ -95,7 +96,8 @@ public class PaimonMetadataTest {
 
     @Before
     public void setUp() {
-        this.metadata = new PaimonMetadata("paimon_catalog", new HdfsEnvironment(), paimonNativeCatalog);
+        this.metadata = new PaimonMetadata("paimon_catalog", new HdfsEnvironment(), paimonNativeCatalog,
+                new ConnectorProperties("paimon"));
 
         BinaryRow row1 = new BinaryRow(2);
         BinaryRowWriter writer = new BinaryRowWriter(row1, 10);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MockedMetadataMgr;
 import com.starrocks.connector.delta.DeltaLakeMetadata;
@@ -253,7 +254,8 @@ public class ConnectorPlanTestBase extends PlanTestBase {
         GlobalStateMgr.getCurrentState().getCatalogMgr().createCatalog("paimon", MOCK_PAIMON_CATALOG_NAME, "", properties);
         //register paimon catalog
         PaimonMetadata paimonMetadata =
-                new PaimonMetadata(MOCK_PAIMON_CATALOG_NAME, new HdfsEnvironment(), paimonNativeCatalog);
+                new PaimonMetadata(MOCK_PAIMON_CATALOG_NAME, new HdfsEnvironment(), paimonNativeCatalog,
+                        new ConnectorProperties("paimon", properties));
         metadataMgr.registerMockedMetadata(MOCK_PAIMON_CATALOG_NAME, paimonMetadata);
     }
 
@@ -283,7 +285,8 @@ public class ConnectorPlanTestBase extends PlanTestBase {
                 MOCK_TABLE_MAP = new CaseInsensitiveMap<>();
 
         public MockedDeltaLakeMetadata() {
-            super(null, null, null, null);
+            super(null, null, null, null,
+                    new ConnectorProperties("deltalake"));
 
             long tableId = GlobalStateMgr.getCurrentState().getNextId();
             List<Column> columns = ImmutableList.<Column>builder()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -28,6 +28,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MockedMetadataMgr;
 import com.starrocks.connector.delta.DeltaLakeMetadata;
@@ -255,7 +256,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
         //register paimon catalog
         PaimonMetadata paimonMetadata =
                 new PaimonMetadata(MOCK_PAIMON_CATALOG_NAME, new HdfsEnvironment(), paimonNativeCatalog,
-                        new ConnectorProperties("paimon", properties));
+                        new ConnectorProperties(ConnectorType.PAIMON, properties));
         metadataMgr.registerMockedMetadata(MOCK_PAIMON_CATALOG_NAME, paimonMetadata);
     }
 
@@ -285,8 +286,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
                 MOCK_TABLE_MAP = new CaseInsensitiveMap<>();
 
         public MockedDeltaLakeMetadata() {
-            super(null, null, null, null,
-                    new ConnectorProperties("deltalake"));
+            super(null, null, null, null, new ConnectorProperties(ConnectorType.DELTALAKE));
 
             long tableId = GlobalStateMgr.getCurrentState().getNextId();
             List<Column> columns = ImmutableList.<Column>builder()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergEqualityDeletePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergEqualityDeletePlanTest.java
@@ -61,7 +61,7 @@ public class IcebergEqualityDeletePlanTest extends TableTestBase {
         AnalyzeTestUtil.init();
         String createCatalog = "CREATE EXTERNAL CATALOG iceberg_catalog PROPERTIES(\"type\"=\"iceberg\", " +
                 "\"iceberg.catalog.hive.metastore.uris\"=\"thrift://127.0.0.1:9083\", \"iceberg.catalog.type\"=\"hive\"," +
-                "\"enable_get_stats_from_metadata\"=\"true\")";
+                "\"enable_get_stats_from_external_metadata\"=\"true\")";
         starRocksAssert.withCatalog(createCatalog);
         new MockUp<IcebergMetadata>() {
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergEqualityDeletePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergEqualityDeletePlanTest.java
@@ -60,7 +60,8 @@ public class IcebergEqualityDeletePlanTest extends TableTestBase {
         UtFrameUtils.createMinStarRocksCluster();
         AnalyzeTestUtil.init();
         String createCatalog = "CREATE EXTERNAL CATALOG iceberg_catalog PROPERTIES(\"type\"=\"iceberg\", " +
-                "\"iceberg.catalog.hive.metastore.uris\"=\"thrift://127.0.0.1:9083\", \"iceberg.catalog.type\"=\"hive\")";
+                "\"iceberg.catalog.hive.metastore.uris\"=\"thrift://127.0.0.1:9083\", \"iceberg.catalog.type\"=\"hive\"," +
+                "\"enable_get_stats_from_metadata\"=\"true\")";
         starRocksAssert.withCatalog(createCatalog);
         new MockUp<IcebergMetadata>() {
             @Mock

--- a/test/sql/test_deltalake/R/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/R/test_deltalake_collect_stats
@@ -5,7 +5,7 @@ create external catalog delta_test_${uuid0} PROPERTIES (
     "aws.s3.access_key"="${oss_ak}",
     "aws.s3.secret_key"="${oss_sk}",
     "aws.s3.endpoint"="${oss_endpoint}",
-    "enable_get_stats_from_metadata"="true"
+    "enable_get_stats_from_external_metadata"="true"
 );
 -- result:
 -- !result

--- a/test/sql/test_deltalake/R/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/R/test_deltalake_collect_stats
@@ -4,7 +4,8 @@ create external catalog delta_test_${uuid0} PROPERTIES (
     "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
     "aws.s3.access_key"="${oss_ak}",
     "aws.s3.secret_key"="${oss_sk}",
-    "aws.s3.endpoint"="${oss_endpoint}"
+    "aws.s3.endpoint"="${oss_endpoint}",
+    "enable_get_stats_from_metadata"="true"
 );
 -- result:
 -- !result

--- a/test/sql/test_deltalake/T/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/T/test_deltalake_collect_stats
@@ -5,7 +5,8 @@ create external catalog delta_test_${uuid0} PROPERTIES (
     "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
     "aws.s3.access_key"="${oss_ak}",
     "aws.s3.secret_key"="${oss_sk}",
-    "aws.s3.endpoint"="${oss_endpoint}"
+    "aws.s3.endpoint"="${oss_endpoint}",
+    "enable_get_stats_from_metadata"="true"
 );
 
 set time_zone="Asia/Shanghai";

--- a/test/sql/test_deltalake/T/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/T/test_deltalake_collect_stats
@@ -6,7 +6,7 @@ create external catalog delta_test_${uuid0} PROPERTIES (
     "aws.s3.access_key"="${oss_ak}",
     "aws.s3.secret_key"="${oss_sk}",
     "aws.s3.endpoint"="${oss_endpoint}",
-    "enable_get_stats_from_metadata"="true"
+    "enable_get_stats_from_external_metadata"="true"
 );
 
 set time_zone="Asia/Shanghai";

--- a/test/sql/test_iceberg/R/test_iceberg_parallel_prepare_metadata
+++ b/test/sql/test_iceberg/R/test_iceberg_parallel_prepare_metadata
@@ -5,7 +5,7 @@ properties
     "type" = "iceberg",
     "iceberg.catalog.type" = "hive",
     "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}",
-    "enable_get_stats_from_metadata"="true"
+    "enable_get_stats_from_external_metadata"="true"
 );
 -- result:
 -- !result

--- a/test/sql/test_iceberg/R/test_iceberg_parallel_prepare_metadata
+++ b/test/sql/test_iceberg/R/test_iceberg_parallel_prepare_metadata
@@ -4,7 +4,8 @@ properties
 (
     "type" = "iceberg",
     "iceberg.catalog.type" = "hive",
-    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}",
+    "enable_get_stats_from_metadata"="true"
 );
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_parallel_prepare_metadata
+++ b/test/sql/test_iceberg/T/test_iceberg_parallel_prepare_metadata
@@ -4,7 +4,8 @@ properties
 (
     "type" = "iceberg",
     "iceberg.catalog.type" = "hive",
-    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}",
+    "enable_get_stats_from_metadata"="true"
 );
 
 create database ice_cat_${uuid0}.ice_db_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_parallel_prepare_metadata
+++ b/test/sql/test_iceberg/T/test_iceberg_parallel_prepare_metadata
@@ -5,7 +5,7 @@ properties
     "type" = "iceberg",
     "iceberg.catalog.type" = "hive",
     "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}",
-    "enable_get_stats_from_metadata"="true"
+    "enable_get_stats_from_external_metadata"="true"
 );
 
 create database ice_cat_${uuid0}.ice_db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
add catalog property "**enable_get_stats_from_metadata**" to control connector table whether to read stats from metadata

## What I'm doing:
enable_get_stats_from_metadata is true by default, delta lake and iceberg override this method and it's value is false by default

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
