### PR TITLE
[BugFix] Fix Attempt to unlock lock, not locked by current locker in mv refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/Locker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/Locker.java
@@ -322,6 +322,9 @@ public class Locker {
         }
     }
 
+    /**
+     * No need to release lock explicitly, it will be released automatically when the locker failed.
+     */
     public boolean tryLockTablesWithIntensiveDbLock(Long dbId, List<Long> tableList, LockType lockType,
                                                     long timeout, TimeUnit unit) {
         Preconditions.checkState(lockType.equals(LockType.READ) || lockType.equals(LockType.WRITE));
@@ -457,28 +460,15 @@ public class Locker {
     }
 
     /**
-     * Try lock database and table id with intensive db lock.
-     *
+     * Try to lock a database and a table id with intensive db lock.
      * @return try if try lock success, false otherwise.
      */
     public boolean tryLockTableWithIntensiveDbLock(Long dbId, Long tableId, LockType lockType, long timeout, TimeUnit unit) {
-        boolean isLockSuccess = false;
-        try {
-            if (!tryLockTablesWithIntensiveDbLock(dbId, ImmutableList.of(tableId), lockType, timeout, unit)) {
-                return false;
-            }
-            isLockSuccess = true;
-        } finally {
-            if (!isLockSuccess) {
-                unLockTablesWithIntensiveDbLock(dbId, ImmutableList.of(tableId), lockType);
-            }
-        }
-        return true;
+        return tryLockTablesWithIntensiveDbLock(dbId, ImmutableList.of(tableId), lockType, timeout, unit);
     }
 
     /**
-     * Try lock database and tables with intensive db lock.
-     *
+     * Try to lock multi database and tables with intensive db lock.
      * @return try if try lock success, false otherwise.
      */
     public boolean tryLockTableWithIntensiveDbLock(LockParams lockParams, LockType lockType, long timeout, TimeUnit unit) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -72,7 +72,7 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
                                                  ScalarOperatorRewriteContext context) {
         // sort the children of compound predicate, but not use insensitive to compare which may cause wrong result:/
         // eg: a in ('a', 'A') will be normalized to a = 'a'
-        Map<String, ScalarOperator> sorted = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        Map<String, ScalarOperator> sorted = Maps.newTreeMap();
         if (predicate.isAnd()) {
             List<ScalarOperator> before = Utils.extractConjuncts(predicate);
             before.forEach(x -> sorted.put(x.toString(), x));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -70,23 +70,25 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
     @Override
     public ScalarOperator visitCompoundPredicate(CompoundPredicateOperator predicate,
                                                  ScalarOperatorRewriteContext context) {
+        // sort the children of compound predicate, but not use insensitive to compare which may cause wrong result:/
+        // eg: a in ('a', 'A') will be normalized to a = 'a'
         Map<String, ScalarOperator> sorted = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
         if (predicate.isAnd()) {
             List<ScalarOperator> before = Utils.extractConjuncts(predicate);
             before.forEach(x -> sorted.put(x.toString(), x));
             List<ScalarOperator> after = Lists.newArrayList(sorted.values());
-            if ((after).equals(before)) {
+            if (after.equals(before)) {
                 return predicate;
             }
-            return Utils.compoundAnd((after));
+            return Utils.compoundAnd(after);
         } else if (predicate.isOr()) {
             List<ScalarOperator> before = Utils.extractDisjunctive(predicate);
             before.forEach(x -> sorted.put(x.toString(), x));
             List<ScalarOperator> after = Lists.newArrayList(sorted.values());
-            if ((after).equals(before)) {
+            if (after.equals(before)) {
                 return predicate;
             }
-            return Utils.compoundOr((after));
+            return Utils.compoundOr(after);
         } else {
             // for not
             return predicate;


### PR DESCRIPTION
## Why I'm doing:

Fix two bugs in using mv:

1. refresh mvs may occur some exceptions below:
```
2024-10-14 12:32:08.193+08:00 WARN (starrocks-taskrun-pool-5|107576) [TaskRunExecutor.lambda$executeTaskRun$0():65] failed to execute TaskRun.
com.starrocks.sql.common.DmlException: Refresh materialized view hitted_mv_dw_bbzdb_bas_servicetype failed after retrying 1 times(try-lock 0 times), error-msg : java.lang.IllegalMonitorStateException: Attempt to unlock lock, not locked by current locker
	at com.starrocks.common.util.concurrent.lock.MultiUserLock.release(MultiUserLock.java:182)
	at com.starrocks.common.util.concurrent.lock.LockManager.release(LockManager.java:275)
	at com.starrocks.common.util.concurrent.lock.Locker.release(Locker.java:106)
	at com.starrocks.common.util.concurrent.lock.Locker.unLockTablesWithIntensiveDbLock(Locker.java:417)
	at com.starrocks.common.util.concurrent.lock.Locker.tryLockTableWithIntensiveDbLock(Locker.java:521)
	at com.starrocks.common.util.concurrent.lock.Locker.tryLockTableWithIntensiveDbLock(Locker.java:504)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.checkMvToRefreshedPartitions(PartitionBasedMvRefreshProcessor.java:280)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:412)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:366)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:325)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:199)
	at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:270)
	at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:58)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:387) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:325) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:199) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:270) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:58) ~[starrocks-fe.jar:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: java.lang.IllegalMonitorStateException: Attempt to unlock lock, not locked by current locker
	at com.starrocks.common.util.concurrent.lock.MultiUserLock.release(MultiUserLock.java:182) ~[starrocks-fe.jar:?]
	at com.starrocks.common.util.concurrent.lock.LockManager.release(LockManager.java:275) ~[starrocks-fe.jar:?]
	at com.starrocks.common.util.concurrent.lock.Locker.release(Locker.java:106) ~[starrocks-fe.jar:?]
	at com.starrocks.common.util.concurrent.lock.Locker.unLockTablesWithIntensiveDbLock(Locker.java:417) ~[starrocks-fe.jar:?]
	at com.starrocks.common.util.concurrent.lock.Locker.tryLockTableWithIntensiveDbLock(Locker.java:521) ~[starrocks-fe.jar:?]
	at com.starrocks.common.util.concurrent.lock.Locker.tryLockTableWithIntensiveDbLock(Locker.java:504) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.checkMvToRefreshedPartitions(PartitionBasedMvRefreshProcessor.java:280) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:412) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:366) ~[starrocks-fe.jar:?]
	... 8 more
```

2. query will be rewritten wrong if contains ` col in (upper('a'), lower('a')`;

## What I'm doing:
- 1. Unlock is not safe if batch locks fail, add try-catch to avoid this.
- 2. Using `Maps.newTreeMap()` instead of `CASE_INSENSITIVE_ORDER` to avoid this.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
