### PR TITLE
[BugFix] Fix BE crash when schema scan rpc failed

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -449,8 +449,11 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
                            << print_id(state->fragment_instance_id()) << ", error=" << start_status.to_string();
                 _set_scan_status(start_status);
             }
+            Status status;
 
-            auto status = chunk_source->buffer_next_batch_chunks_blocking(state, kIOTaskBatchSize, _workgroup.get());
+            if (start_status.ok()) {
+                status = chunk_source->buffer_next_batch_chunks_blocking(state, kIOTaskBatchSize, _workgroup.get());
+            }
 
             if (!status.ok() && !status.is_end_of_file()) {
                 LOG(ERROR) << "scan fragment " << print_id(state->fragment_instance_id()) << " driver "

--- a/be/src/exec/schema_scanner/schema_variables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_variables_scanner.cpp
@@ -18,8 +18,10 @@
 #include "runtime/runtime_state.h"
 #include "runtime/string_value.h"
 #include "types/logical_type.h"
+#include "util/failpoint/fail_point.h"
 
 namespace starrocks {
+DEFINE_FAIL_POINT(schema_scan_rpc_failed);
 
 SchemaScanner::ColumnDesc SchemaVariablesScanner::_s_vars_columns[] = {
         //   name,       type,          size
@@ -57,6 +59,7 @@ Status SchemaVariablesScanner::start(RuntimeState* state) {
     var_params.__set_threadId(_param->thread_id);
 
     // init schema scanner state
+    FAIL_POINT_TRIGGER_RETURN_ERROR(schema_scan_rpc_failed);
     RETURN_IF_ERROR(SchemaScanner::init_schema_scanner_state(state));
     RETURN_IF_ERROR(SchemaHelper::show_variables(_ss_state, var_params, &_var_result));
 

--- a/test/sql/test_scan/R/test_schema_scan_rpc_failed
+++ b/test/sql/test_scan/R/test_schema_scan_rpc_failed
@@ -1,0 +1,10 @@
+-- name: test_schema_scan_rpc_failed
+admin enable failpoint 'schema_scan_rpc_failed';
+-- result:
+-- !result
+[UC] SHOW VARIABLES WHERE Variable_name ='language';
+-- result:
+-- !result
+admin disable failpoint 'schema_scan_rpc_failed';
+-- result:
+-- !result

--- a/test/sql/test_scan/T/test_schema_scan_rpc_failed
+++ b/test/sql/test_scan/T/test_schema_scan_rpc_failed
@@ -1,0 +1,5 @@
+-- name: test_schema_scan_rpc_failed
+
+admin enable failpoint 'schema_scan_rpc_failed';
+[UC] SHOW VARIABLES WHERE Variable_name ='language';
+admin disable failpoint 'schema_scan_rpc_failed';


### PR DESCRIPTION
## Why I'm doing:


in #49318 add a start interface for chunksource. but not check return status.

## What I'm doing:

```
*** Aborted at 1728909404 (unix time) try "date -d @1728909404" if you are using GNU date ***
PC: @          0x6bbdd8b starrocks::SchemaVariablesScanner::fill_chunk(std::shared_ptr<starrocks::Chunk>*)
*** SIGSEGV (@0x28) received by PID 1854307 (TID 0x7f0b1bbff640) from PID 40; stack trace: ***
    @     0x7f0cb7d89ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0x8f2bb29 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f0cb7d32520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x6bbdd8b starrocks::SchemaVariablesScanner::fill_chunk(std::shared_ptr<starrocks::Chunk>*)
    @          0x6bbdf4c starrocks::SchemaVariablesScanner::get_next(std::shared_ptr<starrocks::Chunk>*, bool*)
    @          0x6bb8d39 starrocks::pipeline::SchemaChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @          0x4dd429f starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @          0x4d1967f auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const [clone .constprop.0]
    @          0x4663b9e starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x7bb93b2 starrocks::ThreadPool::dispatch_thread()
    @          0x7bb16a9 starrocks::Thread::supervise_thread(void*)
    @     0x7f0cb7d84ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f0cb7e16850 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
