### PR TITLE
[BugFix] Fix unknown error when delta lake query's predicate has struct subfield

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScalarOperationToDeltaLakeExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScalarOperationToDeltaLakeExpr.java
@@ -153,6 +153,10 @@ public class ScalarOperationToDeltaLakeExpr {
                 return null;
             }
             Column column = context.getColumn(columnName);
+            // For struct subfield, cannot get the column for now, just return null
+            if (column == null) {
+                return null;
+            }
 
             DeltaDataType resultType = getResultType(columnName, context);
             Literal literal = getLiteral(operator.getChild(1), resultType, context.isPartitionColumn(columnName));

--- a/test/sql/test_deltalake/R/test_deltalake_catalog
+++ b/test/sql/test_deltalake/R/test_deltalake_catalog
@@ -262,6 +262,21 @@ select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_null where col_tim
 2	2	2023-01-01 01:01:01
 3	3	2022-01-01 01:01:01
 -- !result
+select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct.age=30 order by col_tinyint;
+-- result:
+{"name":"Alice","sex":"female","age":30}
+-- !result
+select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct.sex='male' order by col_tinyint;
+-- result:
+{"name":"Bob","sex":"male","age":25}
+{"name":"Charlie","sex":"male","age":35}
+{"name":"Edward","sex":"male","age":40}
+-- !result
+select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct.age<30 order by col_tinyint;
+-- result:
+{"name":"Bob","sex":"male","age":25}
+{"name":"Diana","sex":"female","age":28}
+-- !result
 drop catalog delta_test_${uuid0}
 -- result:
 -- !result

--- a/test/sql/test_deltalake/T/test_deltalake_catalog
+++ b/test/sql/test_deltalake/T/test_deltalake_catalog
@@ -75,4 +75,9 @@ select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_null order by col_
 select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_null where col_timestamp is null order by col_smallint;
 select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_null where col_timestamp is not null order by col_smallint;
 
+-- test predicate with struct subfield
+select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct.age=30 order by col_tinyint;
+select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct.sex='male' order by col_tinyint;
+select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct.age<30 order by col_tinyint;
+
 drop catalog delta_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:
query will throw unknow error when query has predicate with struct subfield
## What I'm doing:

Fixes #51903

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
