### PR TITLE
[BugFix] Add lock to committed_rs_map to prevent concurrency modification

### DIFF
--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -426,8 +426,8 @@ private:
 
     // Keep the rowsets committed but not publish which rowset meta without schema
     phmap::parallel_flat_hash_map<RowsetId, std::shared_ptr<Rowset>, HashOfRowsetId, std::equal_to<RowsetId>,
-                                  std::allocator<std::pair<const RowsetId, std::shared_ptr<Rowset>>>, 5,
-                                  std::mutex, true>
+                                  std::allocator<std::pair<const RowsetId, std::shared_ptr<Rowset>>>, 5, std::mutex,
+                                  true>
             _committed_rs_map;
 
     // gtid -> version

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -427,7 +427,7 @@ private:
     // Keep the rowsets committed but not publish which rowset meta without schema
     phmap::parallel_flat_hash_map<RowsetId, std::shared_ptr<Rowset>, HashOfRowsetId, std::equal_to<RowsetId>,
                                   std::allocator<std::pair<const RowsetId, std::shared_ptr<Rowset>>>, 5,
-                                  phmap::NullMutex, true>
+                                  std::mutex, true>
             _committed_rs_map;
 
     // gtid -> version


### PR DESCRIPTION
## Why I'm doing:
`_committed_rs_map` is defined as `phmap::parallel_flat_hash_map` but not hold lock, so concurrency modification may cause memory error.

## What I'm doing:
add `std::mutex` to `_committed_rs_map`.

Fixes https://github.com/StarRocks/StarRocksTest/issues/8684

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
