### PR TITLE
[BugFix] Fix spill cost too much memory when enable group execution

### DIFF
--- a/be/src/exec/spill/mem_table.cpp
+++ b/be/src/exec/spill/mem_table.cpp
@@ -187,6 +187,8 @@ void OrderedMemTable::reset() {
     SpillableMemTable::reset();
     _chunk_slice.reset(nullptr);
     _chunk.reset();
+    _permutation.clear();
+    _permutation.shrink_to_fit();
 }
 
 StatusOr<ChunkPtr> OrderedMemTable::_do_sort(const ChunkPtr& chunk) {


### PR DESCRIPTION
## Why I'm doing:
SSB100G
```
set pipeline_dop=1;
set enable_spill=true;
set spill_mode="force";
set enable_spill_buffer_read=false;
select count(*) from (select count(*) from lineorder group by lo_orderkey)t;
```

baseline:
```
     - QueryExecutionWallTime: 23s409ms
     - QueryPeakMemoryUsagePerNode: 1.182 GB
     - QueryPeakScheduleTime: 21.029ms
     - QuerySpillBytes: 1.124 GB
     - QuerySumMemoryUsage: 2.363 GB
```
fixed:
```
     - QueryExecutionWallTime: 22s812ms
     - QueryPeakMemoryUsagePerNode: 82.066 MB
     - QueryPeakScheduleTime: 21.634ms
     - QuerySpillBytes: 1.124 GB
     - QuerySumMemoryUsage: 164.131 MB
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
