### PR TITLE
[BugFix] Parameter validation for /api/show_meta_info api

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
@@ -35,6 +35,7 @@
 package com.starrocks.http.rest;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
@@ -51,6 +52,7 @@ import com.starrocks.http.IllegalArgException;
 import com.starrocks.persist.Storage;
 import com.starrocks.server.GlobalStateMgr;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -93,6 +95,12 @@ public class ShowMetaInfoAction extends RestBaseAction {
     @Override
     public void execute(BaseRequest request, BaseResponse response) {
         String action = request.getSingleParameter("action");
+        // check param empty
+        if (Strings.isNullOrEmpty(action)) {
+            response.appendContent("Missing parameter");
+            writeResponse(request, response, HttpResponseStatus.BAD_REQUEST);
+            return;
+        }
         Gson gson = new Gson();
         response.setContentType("application/json");
 
@@ -107,7 +115,11 @@ public class ShowMetaInfoAction extends RestBaseAction {
                 response.getContent().append(gson.toJson(getHaInfo()));
                 break;
             default:
-                break;
+                // clear content type set above
+                response.setContentType(null);
+                response.appendContent("Invalid parameter");
+                writeResponse(request, response, HttpResponseStatus.BAD_REQUEST);
+                return;
         }
         sendResult(request, response);
     }


### PR DESCRIPTION
## Why I'm doing:
/api/show_meta_info API in FE throwing  Nullpointer exception when required parameter is not passed. Need to add parameter validation and throw appropriate error message instead. 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
