### PR TITLE
[Enhancement] Loading task should abort transaction if fail because of timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -352,7 +352,9 @@ public class BrokerLoadJob extends BulkLoadJob {
                         .build());
                 return;
             }
-            if (retryTime <= 0 || !txnStatusChangeReason.contains("timeout") || !isTimeout()) {
+            boolean shouldRetry = retryTime > 0 && txnStatusChangeReason.contains("timeout")
+                    && (LoadErrorUtils.isTimeoutFromLoadingTaskExecution(txnStatusChangeReason) || isTimeout());
+            if (!shouldRetry) {
                 // record attachment in load job
                 unprotectUpdateLoadingStatus(txnState);
                 // cancel load job

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -45,6 +45,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.UserException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
@@ -250,6 +251,7 @@ public abstract class BulkLoadJob extends LoadJob {
 
     @Override
     public void onTaskFailed(long taskId, FailMsg failMsg) {
+        boolean timeoutFailure = false;
         writeLock();
         try {
             // check if job has been completed
@@ -264,9 +266,25 @@ public abstract class BulkLoadJob extends LoadJob {
             if (!failMsg.getMsg().contains("timeout") || failMsg.getCancelType() == FailMsg.CancelType.USER_CANCEL) {
                 unprotectedExecuteCancel(failMsg, true);
                 logFinalOperation();
+            } else {
+                timeoutFailure = true;
             }
         } finally {
             writeUnlock();
+        }
+
+        // For timeout failure, should abort the transaction and retry as soon as possible
+        if (timeoutFailure) {
+            try {
+                LOG.debug("Loading task with timeout failure try to abort transaction, " +
+                                "job_id: {}, task_id: {}, txn_id: {}, task fail message: {}",
+                        id, taskId, transactionId, failMsg.getMsg());
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
+                        dbId, transactionId, failMsg.getMsg());
+            } catch (UserException e) {
+                LOG.warn("Loading task failed to abort transaction, job_id: {}, task_id: {}, txn_id: {}, " +
+                        "task fail message: {}, abort exception:", id, taskId, transactionId, failMsg.getMsg(), e);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadErrorUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadErrorUtils.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.loadv2;
+
+public class LoadErrorUtils {
+
+    public static class ErrorMeta {
+        final String keywords;
+        final String description;
+
+        public ErrorMeta(String keywords, String description) {
+            this.keywords = keywords;
+            this.description = description;
+        }
+    }
+
+    public static final ErrorMeta BACKEND_BRPC_TIMEOUT =
+            new ErrorMeta("[E1008]Reached timeout", "Backend BRPC timeout");
+
+    private static final ErrorMeta[] LOADING_TASK_TIMEOUT_ERRORS = new ErrorMeta[] {BACKEND_BRPC_TIMEOUT};
+
+    public static boolean isTimeoutFromLoadingTaskExecution(String errorMsg) {
+        for (ErrorMeta errorMeta : LOADING_TASK_TIMEOUT_ERRORS) {
+            if (errorMsg.contains(errorMeta.keywords)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
In #38183, broker load will retry if loading task fails because of timeout. But currently the retry will be executed until transaction timeouts even if the loading task  has failed before transaction timeout. For example, the task fails because BE BRPC timeouts which is half of transaction timeout by default, and the load should retry immediately after the task fails.

## What I'm doing:
If the task fails because of timeout, abort the transaction so that it can try as soon as possible

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
