### PR TITLE
[BugFix] Fix incorrect materialized index row count

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -116,7 +117,7 @@ public class TabletStatMgr extends FrontendDaemon {
 
                 // NOTE: calculate the row first with read lock, then update the stats with write lock
                 locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
-                Map<Long, Long> indexRowCountMap = Maps.newHashMap();
+                Map<Pair<Long, Long>, Long> indexRowCountMap = Maps.newHashMap();
                 try {
                     OlapTable olapTable = (OlapTable) table;
                     for (Partition partition : olapTable.getAllPartitions()) {
@@ -129,7 +130,8 @@ public class TabletStatMgr extends FrontendDaemon {
                                 for (Tablet tablet : index.getTablets()) {
                                     indexRowCount += tablet.getRowCount(version);
                                 } // end for tablets
-                                indexRowCountMap.put(index.getId(), indexRowCount);
+                                indexRowCountMap.put(Pair.create(physicalPartition.getId(), index.getId()),
+                                        indexRowCount);
                                 if (!olapTable.isTempPartition(partition.getId())) {
                                     totalRowCount += indexRowCount;
                                 }
@@ -150,7 +152,8 @@ public class TabletStatMgr extends FrontendDaemon {
                         for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                             for (MaterializedIndex index :
                                     physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
-                                Long indexRowCount = indexRowCountMap.get(index.getId());
+                                Long indexRowCount =
+                                        indexRowCountMap.get(Pair.create(physicalPartition.getId(), index.getId()));
                                 if (indexRowCount != null) {
                                     index.setRowCount(indexRowCount);
                                 }


### PR DESCRIPTION
## Why I'm doing:
Fix incorrect mv row count which introduced in #50668
## What I'm doing:

The `MaterializedIndex` object is different in every `physicalPartition`, but with the same `index.getId()`, so the `indexRowCountMap.put(index.getId(), indexRowCount)` will overwrite previous mv partition's row count with the later partition's row count

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
