### PR TITLE
[BugFix] fix .net can not read sr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1460,6 +1460,10 @@ public class ExpressionAnalyzer {
                         node.getName().equalsIgnoreCase(SessionVariable.SQL_MODE)) {
                     node.setType(Type.VARCHAR);
                     node.setValue(SqlModeHelper.decode((long) node.getValue()));
+                } else if (!Strings.isNullOrEmpty(node.getName()) &&
+                        node.getName().equalsIgnoreCase(SessionVariable.AUTO_COMMIT)) {
+                    node.setType(Type.BIGINT);
+                    node.setValue(((boolean) node.getValue()) ? (long) (1) : (long) 0);
                 }
             } catch (DdlException e) {
                 throw new SemanticException(e.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -38,12 +38,15 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.VariableExpr;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.GlobalVarPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.SetStmtAnalyzer;
 import com.starrocks.sql.ast.SetStmt;
@@ -312,5 +315,15 @@ public class VariableMgrTest {
         mgr2.load(image.getMetaBlockReader());
 
         Assert.assertEquals(100, mgr2.getDefaultSessionVariable().getQueryTimeoutS());
+    }
+
+    @Test
+    public void testAutoCommit() throws Exception {
+        VariableExpr desc = new VariableExpr("autocommit");
+        ExpressionAnalyzer.analyzeExpressionIgnoreSlot(desc, UtFrameUtils.createDefaultCtx());
+
+        Assert.assertEquals("autocommit", desc.getName());
+        Assert.assertEquals(ScalarType.createType(PrimitiveType.BIGINT), desc.getType());
+        Assert.assertEquals((long) desc.getValue(), 1);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
fix https://github.com/StarRocks/starrocks/issues/44024
.net's mysql connector "MySQL.Data" will select @@autocommit to do some check when establish connection, but it assume select @@autocommit will return a Integer(Mysql return BigInt). But we return Boolean, which cause "MySQL.Data" thorw exception when establish connection. 

## What I'm doing:
change "select @@autocommit" 's return type from boolean to BigInt, which is same as Mysql's behavior. Test with jdbc and .net's mysql connector "MySQL.Data" , all work fine


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
