### PR TITLE
[BugFix] isLocalBucketShuffleJoin return wrong result

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
@@ -428,20 +428,20 @@ public class ExecutionFragment {
             return false;
         }
 
+        boolean hasBucketShuffle = false;
         if (root instanceof JoinNode) {
             JoinNode joinNode = (JoinNode) root;
             if (joinNode.isLocalHashBucket()) {
-                isRightOrFullBucketShuffle = joinNode.getJoinOp().isFullOuterJoin() || joinNode.getJoinOp().isRightJoin();
-                return true;
+                hasBucketShuffle = true;
+                isRightOrFullBucketShuffle |= joinNode.getJoinOp().isFullOuterJoin() || joinNode.getJoinOp().isRightJoin();
             }
         }
 
-        boolean childHasBucketShuffle = false;
         for (PlanNode child : root.getChildren()) {
-            childHasBucketShuffle |= isLocalBucketShuffleJoin(child);
+            hasBucketShuffle |= isLocalBucketShuffleJoin(child);
         }
 
-        return childHasBucketShuffle;
+        return hasBucketShuffle;
     }
 
     public boolean isScheduled() {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/TestBucketShuffleRightJoin.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/TestBucketShuffleRightJoin.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import com.starrocks.qe.scheduler.dag.ExecutionFragment;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static com.starrocks.sql.optimizer.statistics.CachedStatisticStorageTest.DEFAULT_CREATE_TABLE_TEMPLATE;
+
+public class TestBucketShuffleRightJoin {
+
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void setUp() {
+        UtFrameUtils.createMinStarRocksCluster();
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        FeConstants.runningUnitTest = true;
+        starRocksAssert = new StarRocksAssert(ctx);
+        try {
+            starRocksAssert.withDatabase(StatsConstants.STATISTICS_DB_NAME)
+                    .useDatabase(StatsConstants.STATISTICS_DB_NAME)
+                    .withTable(DEFAULT_CREATE_TABLE_TEMPLATE);
+
+            starRocksAssert.withDatabase("test").useDatabase("test");
+            String tableFmt = "CREATE TABLE `%s` (\n" +
+                    "  `c0` bigint(20) NOT NULL COMMENT \"\",\n" +
+                    "  `c1` bigint(20) NOT NULL COMMENT \"\",\n" +
+                    "  `c2` bigint(20) NOT NULL COMMENT \"\"\n" +
+                    ") ENGINE=OLAP \n" +
+                    "DUPLICATE KEY(`c0`)\n" +
+                    "COMMENT \"OLAP\"\n" +
+                    "DISTRIBUTED BY HASH(`c0`) BUCKETS 9 \n" +
+                    "PROPERTIES (\n" +
+                    "\"compression\" = \"LZ4\",\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ");";
+            for (String tableName : Arrays.asList("t0", "t1", "t2")) {
+                String createTblSql = String.format(tableFmt, tableName);
+                starRocksAssert.withTable(createTblSql);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Test
+    public void test() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String sql = "select t0.c0,t0.c1,t0.c2,t1.c2 as ab from " +
+                "(select * from t1 where c0 in (8)) t1 right outer join[bucket] " +
+                "(select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 " +
+                "left join[bucket] t2 on t2.c0 = t1.c0";
+        Pair<String, ExecPlan> explainAndExecPlan = UtFrameUtils.getPlanAndFragment(ctx, sql);
+        String plan = explainAndExecPlan.first;
+        ExecPlan execPlan = explainAndExecPlan.second;
+        DefaultCoordinator coord = new DefaultCoordinator.Factory().createQueryScheduler(
+                ctx, execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift());
+        coord.prepareExec();
+
+        boolean bucketShuffleRightJoinPresent = coord.getExecutionDAG().getFragmentsInPreorder()
+                .stream().anyMatch(ExecutionFragment::isRightOrFullBucketShuffle);
+        Assert.assertTrue(plan, bucketShuffleRightJoinPresent);
+    }
+}

--- a/test/sql/test_bucket_shuffle_right_join/R/test_bucket_shuffle_right_join
+++ b/test/sql/test_bucket_shuffle_right_join/R/test_bucket_shuffle_right_join
@@ -1,0 +1,270 @@
+-- name: test_bucket_shuffle_right_join
+ DROP TABLE if exists t0;
+-- result:
+-- !result
+ CREATE TABLE if not exists t0
+ (
+ c0 BIGINT NOT NULL,
+ c1 BIGINT NOT NULL,
+ c2 BIGINT NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`c0` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`c0` ) BUCKETS 9
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+-- result:
+-- !result
+ DROP TABLE if exists t1;
+-- result:
+-- !result
+ CREATE TABLE if not exists t1
+ (
+ c0 BIGINT NOT NULL,
+ c1 BIGINT NOT NULL,
+ c2 BIGINT NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`c0` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`c0` ) BUCKETS 9
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+-- result:
+-- !result
+ DROP TABLE if exists t2;
+-- result:
+-- !result
+ CREATE TABLE if not exists t2
+ (
+ c0 BIGINT NOT NULL,
+ c1 BIGINT NOT NULL,
+ c2 BIGINT NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`c0` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`c0` ) BUCKETS 9
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+-- result:
+-- !result
+INSERT INTO t0
+(c0, c1, c2)
+VALUES
+('0', '0', '0'),
+('1', '1', '1'),
+('2', '2', '2'),
+('3', '3', '3'),
+('4', '4', '4'),
+('5', '5', '5'),
+('6', '6', '6'),
+('7', '7', '7'),
+('8', '8', '8'),
+('9', '9', '9');
+-- result:
+-- !result
+INSERT INTO t1
+(c0, c1, c2)
+select * from t0;
+-- result:
+-- !result
+INSERT INTO t2
+(c0, c1, c2)
+select * from t0;
+-- result:
+-- !result
+ DROP TABLE if exists r;
+-- result:
+-- !result
+ CREATE TABLE if not exists r
+ (
+ fp BIGINT  NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`fp` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`fp` ) BUCKETS 1
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+-- result:
+-- !result
+truncate table r;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (0)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (0)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+-- result:
+1	1
+-- !result
+truncate table r;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (1)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (1)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+-- result:
+1	1
+-- !result
+truncate table r;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (2)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (2)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+-- result:
+1	1
+-- !result
+truncate table r;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (3)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (3)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+-- result:
+1	1
+-- !result
+truncate table r;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (4)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (4)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+-- result:
+1	1
+-- !result
+truncate table r;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (5)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (5)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+-- result:
+1	1
+-- !result
+truncate table r;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (6)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (6)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+-- result:
+1	1
+-- !result
+truncate table r;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (7)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (7)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+-- result:
+1	1
+-- !result
+truncate table r;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (8)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (8)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+-- result:
+1	1
+-- !result
+truncate table r;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (9)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (9)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+-- result:
+-- !result
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+-- result:
+1	1
+-- !result

--- a/test/sql/test_bucket_shuffle_right_join/T/test_bucket_shuffle_right_join
+++ b/test/sql/test_bucket_shuffle_right_join/T/test_bucket_shuffle_right_join
@@ -1,0 +1,165 @@
+-- name: test_bucket_shuffle_right_join
+ DROP TABLE if exists t0;
+
+ CREATE TABLE if not exists t0
+ (
+ c0 BIGINT NOT NULL,
+ c1 BIGINT NOT NULL,
+ c2 BIGINT NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`c0` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`c0` ) BUCKETS 9
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+ DROP TABLE if exists t1;
+
+ CREATE TABLE if not exists t1
+ (
+ c0 BIGINT NOT NULL,
+ c1 BIGINT NOT NULL,
+ c2 BIGINT NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`c0` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`c0` ) BUCKETS 9
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+ DROP TABLE if exists t2;
+
+ CREATE TABLE if not exists t2
+ (
+ c0 BIGINT NOT NULL,
+ c1 BIGINT NOT NULL,
+ c2 BIGINT NOT NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`c0` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`c0` ) BUCKETS 9
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+INSERT INTO t0
+(c0, c1, c2)
+VALUES
+('0', '0', '0'),
+('1', '1', '1'),
+('2', '2', '2'),
+('3', '3', '3'),
+('4', '4', '4'),
+('5', '5', '5'),
+('6', '6', '6'),
+('7', '7', '7'),
+('8', '8', '8'),
+('9', '9', '9');
+
+INSERT INTO t1
+(c0, c1, c2)
+select * from t0;
+
+INSERT INTO t2
+(c0, c1, c2)
+select * from t0;
+
+ DROP TABLE if exists r;
+
+ CREATE TABLE if not exists r
+ (
+ fp BIGINT  NULL 
+ ) ENGINE=OLAP
+ DUPLICATE KEY(`fp` )
+ COMMENT "OLAP"
+ DISTRIBUTED BY HASH(`fp` ) BUCKETS 1
+ PROPERTIES(
+ "replication_num" = "1",
+ "in_memory" = "false",
+ "storage_format" = "default" 
+ );
+truncate table r;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (0)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (0)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+truncate table r;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (1)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (1)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+truncate table r;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (2)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (2)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+truncate table r;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (3)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (3)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+truncate table r;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (4)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (4)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+truncate table r;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (5)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (5)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+truncate table r;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (6)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (6)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+truncate table r;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (7)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (7)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+truncate table r;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (8)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (8)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;
+truncate table r;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (9)) t1 right outer join[bucket] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[bucket] t2 on t2.c0 = t1.c0) as t;
+INSERT INTO r
+(fp)
+select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(c1,0))+murmur_hash3_32(ifnull(c2,0))+murmur_hash3_32(ifnull(ab,0)))) as fingerprint from (select t0.c0,t0.c1,t0.c2,t1.c2 as ab from (select * from t1 where c0 in (9)) t1 right outer join[shuffle] (select if(murmur_hash3_32(c0)=0,c0,NULL) as c0,c1,c2 from t0) t0 on t0.c0 = t1.c0 left join[shuffle] t2 on t2.c0 = t1.c0) as t;
+select assert_true(count(fp)=2), assert_true(count(distinct fp)=1) from r;


### PR DESCRIPTION
## Why I'm doing:

**No data sent from the right side of Bucket Shuffle Right Join Build (ExchangeSink)**

1. First, the Bucket seqs 3, 5, 7, 8, 9 of the left table in the Bucket shuffle join were pruned.

2. Generally, when bucket seqs are pruned, the instance id on the receiver side in the channel map is recorded as -1 to indicate no data is being sent. However, for right outer join, the NULL values from the build side need to be output, so for such cases, any valid instance id must be assigned to the pruned bucket seq.

```cpp
for (int32_t channel_id : _channel_indices) {
    if (_channels[channel_id]->get_fragment_instance_id().lo == -1) {
        // dest bucket is not used, continue
        continue;
    }

    for (int32_t i = 0; i < _num_shuffles_per_channel; ++i) {
        int shuffle_id = channel_id * _num_shuffles_per_channel + i;
        int driver_sequence = _driver_sequence_per_shuffle[shuffle_id];

        size_t from = _channel_row_idx_start_points[shuffle_id];
        size_t size = _channel_row_idx_start_points[shuffle_id + 1] - from;
        if (size == 0) {
            // no data for this channel, continue;
            continue;
        }

        RETURN_IF_ERROR(_channels[channel_id]->add_rows_selective(send_chunk, 
driver_sequence,
                                                                  
_row_indexes.data(), from, size, state));
    }
}
```

3. In practice, all the join column data on the right-hand side is NULL, and no valid instance id is assigned in the channel map, resulting in data being filtered.
![image](https://github.com/user-attachments/assets/1c19787d-6f64-411e-9653-2bea724fd2cb)


**2. The issue where NULL values on the HashJoin Build side need to be output, and assigning any instance id to the pruned bucketSeqs**

1. Cases where NULL values on the build side need to be output:

   a. Right join, full join, Right Anti JOIN

   b. Null-safe-eq join: `<=>`. It seems this is not currently considered in the logic, further confirmation is required.

2. Determine whether NULL values on the build side need to be output by `isRightOrFullBucketShuffleFragment`.

3. `isRightOrFullBucketShuffleFragment` is expected to be `true`, but is actually `false`.

```java
if (isRightOrFullBucketShuffleFragment && colocatedAssignment.isAllScanNodesAssigned()) {
    int bucketNum = colocatedAssignment.bucketNum;

    for (int bucketSeq = 0; bucketSeq < bucketNum; ++bucketSeq) {
        if (!bucketSeqToWorkerId.containsKey(bucketSeq)) {
            long workerId = workerProvider.selectNextWorker();
            bucketSeqToWorkerId.put(bucketSeq, workerId);
        }
        if (!bucketSeqToScanRange.containsKey(bucketSeq)) {
            bucketSeqToScanRange.put(bucketSeq, Maps.newHashMap());
            bucketSeqToScanRange.get(bucketSeq).put(scanNode.getId().asInt(), 
Lists.newArrayList());
        }
    }
}
```

**Top-Down Determination of `isRightOrFullBucketShuffle`: depends on first visited**

```java
private boolean isLocalBucketShuffleJoin(PlanNode root) {
    if (root instanceof ExchangeNode) {
        return false;
    }

    if (root instanceof JoinNode) {
        JoinNode joinNode = (JoinNode) root;
        if (joinNode.isLocalHashBucket()) {
            isRightOrFullBucketShuffle = 
joinNode.getJoinOp().isFullOuterJoin() || joinNode.getJoinOp().isRightJoin();
            return true;
        }
    }

    boolean childHasBucketShuffle = false;
    for (PlanNode child : root.getChildren()) {
        childHasBucketShuffle |= isLocalBucketShuffleJoin(child);
    }

    return childHasBucketShuffle;
}
```
![image](https://github.com/user-attachments/assets/fcd4c3f4-3ea6-4c5f-a4c3-5f81400042f9)

In the erroneous plan, there are three JOINS, and the above bucket shuffle left join is the first visited, directly determining `isRightOrFullBucketShuffle = false`.

## What I'm doing:

Fix function isLocalBucketShuffleJoin to return correct result.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
