### PR TITLE
[BugFix] fix asan crash in array_map

### DIFF
--- a/be/src/exprs/column_ref.cpp
+++ b/be/src/exprs/column_ref.cpp
@@ -30,6 +30,9 @@ int ColumnRef::get_slot_ids(std::vector<SlotId>* slot_ids) const {
     slot_ids->push_back(_column_id);
     return 1;
 }
+void ColumnRef::for_each_slot_id(std::function<void(SlotId)> cb) const {
+    cb(_column_id);
+}
 
 bool ColumnRef::is_bound(const std::vector<TupleId>& tuple_ids) const {
     for (int tuple_id : tuple_ids) {

--- a/be/src/exprs/column_ref.cpp
+++ b/be/src/exprs/column_ref.cpp
@@ -30,7 +30,7 @@ int ColumnRef::get_slot_ids(std::vector<SlotId>* slot_ids) const {
     slot_ids->push_back(_column_id);
     return 1;
 }
-void ColumnRef::for_each_slot_id(std::function<void(SlotId)> cb) const {
+void ColumnRef::for_each_slot_id(const std::function<void(SlotId)>& cb) const {
     cb(_column_id);
 }
 

--- a/be/src/exprs/column_ref.h
+++ b/be/src/exprs/column_ref.h
@@ -45,7 +45,7 @@ public:
     bool is_constant() const override { return false; }
 
     int get_slot_ids(std::vector<SlotId>* slot_ids) const override;
-    void for_each_slot_id(std::function<void(SlotId)> cb) const override;
+    void for_each_slot_id(const std::function<void(SlotId)>& cb) const override;
 
     std::string debug_string() const override;
 

--- a/be/src/exprs/column_ref.h
+++ b/be/src/exprs/column_ref.h
@@ -45,6 +45,7 @@ public:
     bool is_constant() const override { return false; }
 
     int get_slot_ids(std::vector<SlotId>* slot_ids) const override;
+    void for_each_slot_id(std::function<void(SlotId)> cb) const override;
 
     std::string debug_string() const override;
 

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -666,6 +666,12 @@ int Expr::get_slot_ids(std::vector<SlotId>* slot_ids) const {
     return n;
 }
 
+void Expr::for_each_slot_id(std::function<void(SlotId)> cb) const {
+    for (auto child : _children) {
+        child->for_each_slot_id(cb);
+    }
+}
+
 int Expr::get_subfields(std::vector<std::vector<std::string>>* subfields) const {
     int n = 0;
 

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -666,7 +666,7 @@ int Expr::get_slot_ids(std::vector<SlotId>* slot_ids) const {
     return n;
 }
 
-void Expr::for_each_slot_id(std::function<void(SlotId)> cb) const {
+void Expr::for_each_slot_id(const std::function<void(SlotId)>& cb) const {
     for (auto child : _children) {
         child->for_each_slot_id(cb);
     }

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -149,6 +149,8 @@ public:
 
     virtual int get_subfields(std::vector<std::vector<std::string>>* subfields) const;
 
+    virtual void for_each_slot_id(std::function<void(SlotId)> cb) const;
+
     /// Create expression tree from the list of nodes contained in texpr within 'pool'.
     /// Returns the root of expression tree in 'expr' and the corresponding ExprContext in
     /// 'ctx'.

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -149,7 +149,7 @@ public:
 
     virtual int get_subfields(std::vector<std::vector<std::string>>* subfields) const;
 
-    virtual void for_each_slot_id(std::function<void(SlotId)> cb) const;
+    virtual void for_each_slot_id(const std::function<void(SlotId)>& cb) const;
 
     /// Create expression tree from the list of nodes contained in texpr within 'pool'.
     /// Returns the root of expression tree in 'expr' and the corresponding ExprContext in

--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -111,9 +111,7 @@ Status LambdaFunction::collect_lambda_argument_ids() {
 
 SlotId LambdaFunction::max_used_slot_id() const {
     SlotId max_slot_id = 0;
-    for_each_slot_id([&max_slot_id](SlotId slot_id) {
-        max_slot_id = std::max(max_slot_id, slot_id);
-    });
+    for_each_slot_id([&max_slot_id](SlotId slot_id) { max_slot_id = std::max(max_slot_id, slot_id); });
     return max_slot_id;
 }
 

--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -110,12 +110,11 @@ Status LambdaFunction::collect_lambda_argument_ids() {
 }
 
 SlotId LambdaFunction::max_used_slot_id() const {
-    std::vector<SlotId> ids;
-    for (auto child : _children) {
-        child->get_slot_ids(&ids);
-    }
-    DCHECK(!ids.empty());
-    return *std::max_element(ids.begin(), ids.end());
+    SlotId max_slot_id = 0;
+    for_each_slot_id([&max_slot_id](SlotId slot_id) {
+        max_slot_id = std::max(max_slot_id, slot_id);
+    });
+    return max_slot_id;
 }
 
 Status LambdaFunction::collect_common_sub_exprs() {
@@ -216,12 +215,13 @@ StatusOr<ColumnPtr> LambdaFunction::evaluate_checked(ExprContext* context, Chunk
 }
 
 int LambdaFunction::get_slot_ids(std::vector<SlotId>* slot_ids) const {
+    // get_slot_ids only return capture slot ids,
+    // if expr is already prepared, we can get result from _captured_slot_ids, otherwise, get result from lambda expr
     if (_is_prepared) {
         slot_ids->insert(slot_ids->end(), _captured_slot_ids.begin(), _captured_slot_ids.end());
-        slot_ids->insert(slot_ids->end(), _arguments_ids.begin(), _arguments_ids.end());
-        return _captured_slot_ids.size() + _arguments_ids.size();
+        return _captured_slot_ids.size();
     } else {
-        return Expr::get_slot_ids(slot_ids);
+        return get_child(0)->get_slot_ids(slot_ids);
     }
 }
 

--- a/be/src/exprs/placeholder_ref.h
+++ b/be/src/exprs/placeholder_ref.h
@@ -32,6 +32,9 @@ public:
         slot_ids->emplace_back(_column_id);
         return 1;
     }
+    void for_each_slot_id(std::function<void(SlotId)> cb) const override {
+        cb(_column_id);
+    }
 
 private:
     SlotId _column_id;

--- a/be/src/exprs/placeholder_ref.h
+++ b/be/src/exprs/placeholder_ref.h
@@ -32,9 +32,7 @@ public:
         slot_ids->emplace_back(_column_id);
         return 1;
     }
-    void for_each_slot_id(std::function<void(SlotId)> cb) const override {
-        cb(_column_id);
-    }
+    void for_each_slot_id(std::function<void(SlotId)> cb) const override { cb(_column_id); }
 
 private:
     SlotId _column_id;

--- a/be/src/exprs/placeholder_ref.h
+++ b/be/src/exprs/placeholder_ref.h
@@ -32,7 +32,7 @@ public:
         slot_ids->emplace_back(_column_id);
         return 1;
     }
-    void for_each_slot_id(std::function<void(SlotId)> cb) const override { cb(_column_id); }
+    void for_each_slot_id(const std::function<void(SlotId)>& cb) const override { cb(_column_id); }
 
 private:
     SlotId _column_id;

--- a/test/sql/test_array_fn/R/test_array_map_2
+++ b/test/sql/test_array_fn/R/test_array_map_2
@@ -155,3 +155,15 @@ None
 None
 None
 -- !result
+select array_map(x->array_map(x->x+100,x), [[1,2,3]]);
+-- result:
+[[101,102,103]]
+-- !result
+select array_map(x->array_map(x->x+100,x), [[1,2,3], [null]]);
+-- result:
+[[101,102,103],[null]]
+-- !result
+select array_map(x->array_map(x->array_map(x->x+100,x),x), [[[1,2,3]]]);
+-- result:
+[[[101,102,103]]]
+-- !result

--- a/test/sql/test_array_fn/T/test_array_map_2
+++ b/test/sql/test_array_fn/T/test_array_map_2
@@ -60,3 +60,6 @@ select array_map((x,y,z)->x+y+z, [1,2],[2,3],[3,4]) from t;
 select array_map((x,y,z)->x+y+z, [1,2],[2,null],[3,4]) from t;
 select array_map((x,y,z)->x+y+z, [1,2],[2,null],null) from t;
 
+select array_map(x->array_map(x->x+100,x), [[1,2,3]]);
+select array_map(x->array_map(x->x+100,x), [[1,2,3], [null]]);
+select array_map(x->array_map(x->array_map(x->x+100,x),x), [[[1,2,3]]]);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8699

root cause

this crash is because we can't find the slot id in chunk and then can't pass the DCHECK inside it.
![image](https://github.com/user-attachments/assets/a59d590e-f96e-45c3-9210-f1a4a7ef2f09)

In fact, for `array_map(x -> array_map(x->x+100, x),[[1,23],[4,3,2]])`, the lambda expr `x->array_map(x->x+100,x)`
only depends on the lambda argument, not on other capture columns. `capture_slot_ids` should be empty here.
But the argument of the inner lambda expr `array_map(x->x+100,x)`is mistakenly regarded as the capture column and be added into the capture_slot_ids.

1. we use `LambdaFunction::get_slot_ids` to get the capture columns' slot id, and the result of this interface incorrectly includes the lambda argument id. this is the root cause of the above crash.
2. on the other hand, before executing `extract_outer_common_exprs` , we need to know the maximum slot_id used in the current `Expr` tree. The rewritten ColumnRef will allocate slot_id from the `max_used_slot_id + 1`. Here we need to consider the slot_id used by the lambda arguments. Currently, `LambdaFunction:get_slot_ids` is also used to get the result.

Obviously, these two places rely on `LambdaFunction::get_slot_ids` and there is a conflict. One needs to consider the lambda argument and the other does not.

To solve this problem
1. modify the behavior of `LambdaFunction::get_slot_ids`, and only include the capture columns' slot id in the return result
3. add a new interface `Expr::for_each_slot_id`  to traverse all slot ids in a certain Expr tree.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
