### PR TITLE
[BugFix] Consider CN number in HashJoinCostModel.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/HashJoinCostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/HashJoinCostModel.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.cost;
 
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
@@ -87,7 +88,8 @@ public class HashJoinCostModel {
         double probeCost;
         double leftOutput = leftStatistics.getOutputSize(context.getChildOutputColumns(0));
         double rightOutput = rightStatistics.getOutputSize(context.getChildOutputColumns(1));
-        int parallelFactor = Math.max(ConnectContext.get().getAliveBackendNumber(),
+        int parallelFactor = Math.max(ConnectContext.get().getAliveBackendNumber() +
+                ConnectContext.get().getGlobalStateMgr().getNodeMgr().getClusterInfo().getAliveComputeNodeNumber(),
                 ConnectContext.get().getSessionVariable().getDegreeOfParallelism());
         switch (execMode) {
             case BROADCAST:
@@ -112,7 +114,12 @@ public class HashJoinCostModel {
         JoinExecMode execMode = deriveJoinExecMode();
         double rightOutput = rightStatistics.getOutputSize(context.getChildOutputColumns(1));
         double memCost;
-        int beNum = Math.max(1, ConnectContext.get().getAliveBackendNumber());
+
+        // TODO: It may not be accurate in shared-data cluster using all alive compute nodes to
+        //  estimate the cost, ideally it should be warehouse awareness.
+        int beNum = Math.max(1, ConnectContext.get().getAliveBackendNumber() +
+                (RunMode.isSharedDataMode() ?
+                ConnectContext.get().getGlobalStateMgr().getNodeMgr().getClusterInfo().getAliveComputeNodeNumber() : 0));
 
         if (JoinExecMode.BROADCAST == execMode) {
             memCost = rightOutput * beNum;
@@ -127,7 +134,8 @@ public class HashJoinCostModel {
         double keySize = calculateKeySize();
 
         double cachePenaltyFactor;
-        int parallelFactor = Math.max(ConnectContext.get().getAliveBackendNumber(),
+        int parallelFactor = Math.max(ConnectContext.get().getAliveBackendNumber() +
+                ConnectContext.get().getGlobalStateMgr().getNodeMgr().getClusterInfo().getAliveComputeNodeNumber(),
                 ConnectContext.get().getSessionVariable().getDegreeOfParallelism()) * 2;
         double mapSize = Math.min(1, keySize) * rightStatistics.getOutputRowCount();
 

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q21.sql
@@ -1,10 +1,10 @@
 [fragment statistics]
-PLAN FRAGMENT 0(F11)
+PLAN FRAGMENT 0(F10)
 Output Exprs:2: S_NAME | 77: count
 Input Partition: UNPARTITIONED
 RESULT SINK
 
-28:MERGING-EXCHANGE
+27:MERGING-EXCHANGE
 distribution type: GATHER
 limit: 100
 cardinality: 100
@@ -12,13 +12,13 @@ column statistics:
 * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
 * count-->[0.0, 2334116.9317591335, 0.0, 8.0, 40000.0] ESTIMATE
 
-PLAN FRAGMENT 1(F10)
+PLAN FRAGMENT 1(F09)
 
 Input Partition: HASH_PARTITIONED: 2: S_NAME
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 28
+OutPut Exchange Id: 27
 
-27:TOP-N
+26:TOP-N
 |  order by: [77, BIGINT, false] DESC, [2, VARCHAR, false] ASC
 |  offset: 0
 |  limit: 100
@@ -27,7 +27,7 @@ OutPut Exchange Id: 28
 |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
 |  * count-->[0.0, 2334116.9317591335, 0.0, 8.0, 40000.0] ESTIMATE
 |
-26:AGGREGATE (merge finalize)
+25:AGGREGATE (merge finalize)
 |  aggregate: count[([77: count, BIGINT, false]); args: ; result: BIGINT; args nullable: true; result nullable: false]
 |  group by: [2: S_NAME, VARCHAR, false]
 |  cardinality: 40000
@@ -35,7 +35,7 @@ OutPut Exchange Id: 28
 |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
 |  * count-->[0.0, 2334116.9317591335, 0.0, 8.0, 40000.0] ESTIMATE
 |
-25:EXCHANGE
+24:EXCHANGE
 distribution type: SHUFFLE
 partition exprs: [2: S_NAME, VARCHAR, false]
 cardinality: 40000
@@ -44,9 +44,9 @@ PLAN FRAGMENT 2(F00)
 
 Input Partition: RANDOM
 OutPut Partition: HASH_PARTITIONED: 2: S_NAME
-OutPut Exchange Id: 25
+OutPut Exchange Id: 24
 
-24:AGGREGATE (update serialize)
+23:AGGREGATE (update serialize)
 |  STREAMING
 |  aggregate: count[(*); args: ; result: BIGINT; args nullable: false; result nullable: false]
 |  group by: [2: S_NAME, VARCHAR, false]
@@ -55,17 +55,16 @@ OutPut Exchange Id: 25
 |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
 |  * count-->[0.0, 2334116.9317591335, 0.0, 8.0, 40000.0] ESTIMATE
 |
-23:Project
+22:Project
 |  output columns:
 |  2 <-> [2: S_NAME, VARCHAR, false]
 |  cardinality: 2334117
 |  column statistics:
 |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
 |
-22:HASH JOIN
-|  join op: RIGHT SEMI JOIN (BUCKET_SHUFFLE)
-|  equal join conjunct: [41: L_ORDERKEY, INT, false] = [9: L_ORDERKEY, INT, false]
-|  other join predicates: [43: L_SUPPKEY, INT, false] != [11: L_SUPPKEY, INT, false]
+21:HASH JOIN
+|  join op: INNER JOIN (BUCKET_SHUFFLE)
+|  equal join conjunct: [26: O_ORDERKEY, INT, false] = [9: L_ORDERKEY, INT, false]
 |  build runtime filters:
 |  - filter_id = 4, build_expr = (9: L_ORDERKEY), remote = false
 |  output columns: 2
@@ -75,66 +74,19 @@ OutPut Exchange Id: 25
 |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
 |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
 |
-|----21:EXCHANGE
+|----20:EXCHANGE
 |       distribution type: SHUFFLE
 |       partition exprs: [9: L_ORDERKEY, INT, false]
-|       cardinality: 2334119
+|       cardinality: 4799990
 |
-0:OlapScanNode
-table: lineitem, rollup: lineitem
-preAggregation: on
-partitionsRatio=1/1, tabletsRatio=20/20
-actualRows=0, avgRowSize=12.0
-cardinality: 600000000
-probe runtime filters:
-- filter_id = 4, probe_expr = (41: L_ORDERKEY)
-column statistics:
-* L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
-* L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-
-PLAN FRAGMENT 3(F01)
-
-Input Partition: RANDOM
-OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 9: L_ORDERKEY
-OutPut Exchange Id: 21
-
-20:Project
-|  output columns:
-|  2 <-> [2: S_NAME, VARCHAR, false]
-|  9 <-> [9: L_ORDERKEY, INT, false]
-|  11 <-> [11: L_SUPPKEY, INT, false]
-|  cardinality: 2334119
-|  column statistics:
-|  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
-|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2334119.2658784] ESTIMATE
-|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
-|
-19:HASH JOIN
-|  join op: INNER JOIN (BUCKET_SHUFFLE)
-|  equal join conjunct: [26: O_ORDERKEY, INT, false] = [9: L_ORDERKEY, INT, false]
-|  build runtime filters:
-|  - filter_id = 3, build_expr = (9: L_ORDERKEY), remote = false
-|  output columns: 2, 9, 11
-|  cardinality: 2334119
-|  column statistics:
-|  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
-|  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
-|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 2334119.2658784] ESTIMATE
-|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
-|
-|----18:EXCHANGE
-|       distribution type: SHUFFLE
-|       partition exprs: [9: L_ORDERKEY, INT, false]
-|       cardinality: 4799995
-|
-2:Project
+1:Project
 |  output columns:
 |  26 <-> [26: O_ORDERKEY, INT, false]
 |  cardinality: 72941300
 |  column statistics:
 |  * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 7.29413E7] ESTIMATE
 |
-1:OlapScanNode
+0:OlapScanNode
 table: orders, rollup: orders
 preAggregation: on
 Predicates: [28: O_ORDERSTATUS, CHAR, false] = 'F'
@@ -142,120 +94,156 @@ partitionsRatio=1/1, tabletsRatio=10/10
 actualRows=0, avgRowSize=9.0
 cardinality: 72941300
 probe runtime filters:
-- filter_id = 3, probe_expr = (26: O_ORDERKEY)
+- filter_id = 4, probe_expr = (26: O_ORDERKEY)
 column statistics:
 * O_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 7.29413E7] ESTIMATE
 * O_ORDERSTATUS-->[-Infinity, Infinity, 0.0, 1.0, 1.0] MCV: [[O:73204400][F:72941300][P:3854300]] ESTIMATE
 
-PLAN FRAGMENT 4(F02)
+PLAN FRAGMENT 3(F01)
 
 Input Partition: RANDOM
 OutPut Partition: BUCKET_SHUFFLE_HASH_PARTITIONED: 9: L_ORDERKEY
-OutPut Exchange Id: 18
+OutPut Exchange Id: 20
 
-17:Project
+19:Project
 |  output columns:
 |  2 <-> [2: S_NAME, VARCHAR, false]
 |  9 <-> [9: L_ORDERKEY, INT, false]
-|  11 <-> [11: L_SUPPKEY, INT, false]
-|  cardinality: 4799995
+|  cardinality: 4799990
 |  column statistics:
 |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
-|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 4799995.2] ESTIMATE
-|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 4799990.4000047995] ESTIMATE
 |
-16:HASH JOIN
-|  join op: RIGHT ANTI JOIN (COLOCATE)
+18:HASH JOIN
+|  join op: RIGHT SEMI JOIN (COLOCATE)
 |  colocate: true
-|  equal join conjunct: [59: L_ORDERKEY, INT, false] = [9: L_ORDERKEY, INT, false]
-|  other join predicates: [61: L_SUPPKEY, INT, false] != [11: L_SUPPKEY, INT, false]
+|  equal join conjunct: [41: L_ORDERKEY, INT, false] = [9: L_ORDERKEY, INT, false]
+|  other join predicates: [43: L_SUPPKEY, INT, false] != [11: L_SUPPKEY, INT, false]
 |  build runtime filters:
-|  - filter_id = 2, build_expr = (9: L_ORDERKEY), remote = false
-|  output columns: 2, 9, 11
-|  cardinality: 4799995
+|  - filter_id = 3, build_expr = (9: L_ORDERKEY), remote = false
+|  output columns: 2, 9
+|  cardinality: 4799990
 |  column statistics:
 |  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
 |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
-|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 4799995.2] ESTIMATE
+|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 4799990.4000047995] ESTIMATE
 |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
 |
-|----15:Project
+|----17:Project
 |    |  output columns:
 |    |  2 <-> [2: S_NAME, VARCHAR, false]
 |    |  9 <-> [9: L_ORDERKEY, INT, false]
 |    |  11 <-> [11: L_SUPPKEY, INT, false]
-|    |  cardinality: 12000000
+|    |  cardinality: 4799995
 |    |  column statistics:
 |    |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
-|    |  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E7] ESTIMATE
+|    |  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 4799995.2] ESTIMATE
 |    |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
 |    |
-|    14:HASH JOIN
-|    |  join op: INNER JOIN (BROADCAST)
-|    |  equal join conjunct: [11: L_SUPPKEY, INT, false] = [1: S_SUPPKEY, INT, false]
+|    16:HASH JOIN
+|    |  join op: RIGHT ANTI JOIN (COLOCATE)
+|    |  colocate: true
+|    |  equal join conjunct: [59: L_ORDERKEY, INT, false] = [9: L_ORDERKEY, INT, false]
+|    |  other join predicates: [61: L_SUPPKEY, INT, false] != [11: L_SUPPKEY, INT, false]
 |    |  build runtime filters:
-|    |  - filter_id = 1, build_expr = (1: S_SUPPKEY), remote = false
+|    |  - filter_id = 2, build_expr = (9: L_ORDERKEY), remote = false
 |    |  output columns: 2, 9, 11
-|    |  cardinality: 12000000
+|    |  cardinality: 4799995
 |    |  column statistics:
 |    |  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
 |    |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
-|    |  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E7] ESTIMATE
+|    |  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 4799995.2] ESTIMATE
 |    |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
 |    |
-|    |----13:EXCHANGE
-|    |       distribution type: BROADCAST
-|    |       cardinality: 40000
+|    |----15:Project
+|    |    |  output columns:
+|    |    |  2 <-> [2: S_NAME, VARCHAR, false]
+|    |    |  9 <-> [9: L_ORDERKEY, INT, false]
+|    |    |  11 <-> [11: L_SUPPKEY, INT, false]
+|    |    |  cardinality: 12000000
+|    |    |  column statistics:
+|    |    |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
+|    |    |  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E7] ESTIMATE
+|    |    |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
+|    |    |
+|    |    14:HASH JOIN
+|    |    |  join op: INNER JOIN (BROADCAST)
+|    |    |  equal join conjunct: [11: L_SUPPKEY, INT, false] = [1: S_SUPPKEY, INT, false]
+|    |    |  build runtime filters:
+|    |    |  - filter_id = 1, build_expr = (1: S_SUPPKEY), remote = false
+|    |    |  output columns: 2, 9, 11
+|    |    |  cardinality: 12000000
+|    |    |  column statistics:
+|    |    |  * S_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
+|    |    |  * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 40000.0] ESTIMATE
+|    |    |  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.2E7] ESTIMATE
+|    |    |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 40000.0] ESTIMATE
+|    |    |
+|    |    |----13:EXCHANGE
+|    |    |       distribution type: BROADCAST
+|    |    |       cardinality: 40000
+|    |    |
+|    |    6:Project
+|    |    |  output columns:
+|    |    |  9 <-> [9: L_ORDERKEY, INT, false]
+|    |    |  11 <-> [11: L_SUPPKEY, INT, false]
+|    |    |  cardinality: 300000000
+|    |    |  column statistics:
+|    |    |  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
+|    |    |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+|    |    |
+|    |    5:OlapScanNode
+|    |       table: lineitem, rollup: lineitem
+|    |       preAggregation: on
+|    |       Predicates: [21: L_RECEIPTDATE, DATE, false] > [20: L_COMMITDATE, DATE, false]
+|    |       partitionsRatio=1/1, tabletsRatio=20/20
+|    |       actualRows=0, avgRowSize=20.0
+|    |       cardinality: 300000000
+|    |       probe runtime filters:
+|    |       - filter_id = 1, probe_expr = (11: L_SUPPKEY)
+|    |       column statistics:
+|    |       * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
+|    |       * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+|    |       * L_COMMITDATE-->[6.967872E8, 9.097632E8, 0.0, 4.0, 2466.0] ESTIMATE
+|    |       * L_RECEIPTDATE-->[6.94368E8, 9.150336E8, 0.0, 4.0, 2554.0] MCV: [[1995-10-08:269400][1997-08-08:266100][1997-06-05:266000][1998-07-26:265100][1994-12-03:264500]] ESTIMATE
 |    |
-|    6:Project
+|    4:Project
 |    |  output columns:
-|    |  9 <-> [9: L_ORDERKEY, INT, false]
-|    |  11 <-> [11: L_SUPPKEY, INT, false]
+|    |  59 <-> [59: L_ORDERKEY, INT, false]
+|    |  61 <-> [61: L_SUPPKEY, INT, false]
 |    |  cardinality: 300000000
 |    |  column statistics:
 |    |  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 |    |  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 |    |
-|    5:OlapScanNode
+|    3:OlapScanNode
 |       table: lineitem, rollup: lineitem
 |       preAggregation: on
-|       Predicates: [21: L_RECEIPTDATE, DATE, false] > [20: L_COMMITDATE, DATE, false]
+|       Predicates: [71: L_RECEIPTDATE, DATE, false] > [70: L_COMMITDATE, DATE, false]
 |       partitionsRatio=1/1, tabletsRatio=20/20
 |       actualRows=0, avgRowSize=20.0
 |       cardinality: 300000000
 |       probe runtime filters:
-|       - filter_id = 1, probe_expr = (11: L_SUPPKEY)
+|       - filter_id = 2, probe_expr = (59: L_ORDERKEY)
 |       column statistics:
 |       * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 |       * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 |       * L_COMMITDATE-->[6.967872E8, 9.097632E8, 0.0, 4.0, 2466.0] ESTIMATE
 |       * L_RECEIPTDATE-->[6.94368E8, 9.150336E8, 0.0, 4.0, 2554.0] MCV: [[1995-10-08:269400][1997-08-08:266100][1997-06-05:266000][1998-07-26:265100][1994-12-03:264500]] ESTIMATE
 |
-4:Project
-|  output columns:
-|  59 <-> [59: L_ORDERKEY, INT, false]
-|  61 <-> [61: L_SUPPKEY, INT, false]
-|  cardinality: 300000000
-|  column statistics:
-|  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
-|  * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-|
-3:OlapScanNode
+2:OlapScanNode
 table: lineitem, rollup: lineitem
 preAggregation: on
-Predicates: [71: L_RECEIPTDATE, DATE, false] > [70: L_COMMITDATE, DATE, false]
 partitionsRatio=1/1, tabletsRatio=20/20
-actualRows=0, avgRowSize=20.0
-cardinality: 300000000
+actualRows=0, avgRowSize=12.0
+cardinality: 600000000
 probe runtime filters:
-- filter_id = 2, probe_expr = (59: L_ORDERKEY)
+- filter_id = 3, probe_expr = (41: L_ORDERKEY)
 column statistics:
 * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 * L_SUPPKEY-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-* L_COMMITDATE-->[6.967872E8, 9.097632E8, 0.0, 4.0, 2466.0] ESTIMATE
-* L_RECEIPTDATE-->[6.94368E8, 9.150336E8, 0.0, 4.0, 2554.0] MCV: [[1995-10-08:269400][1997-08-08:266100][1997-06-05:266000][1998-07-26:265100][1994-12-03:264500]] ESTIMATE
 
-PLAN FRAGMENT 5(F04)
+PLAN FRAGMENT 4(F04)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
@@ -300,7 +288,7 @@ column statistics:
 * S_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1000000.0] ESTIMATE
 * S_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 6(F05)
+PLAN FRAGMENT 5(F05)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED


### PR DESCRIPTION
## Why I'm doing:
Sometimes FE choose the wrong join mode while cluster is running in share-data mode because of the following code
of HashJoinCostModel
```
public double getMemCost() {
        JoinExecMode execMode = deriveJoinExecMode();
        double rightOutput = rightStatistics.getOutputSize(context.getChildOutputColumns(1));
        double memCost;
        int beNum = Math.max(1, ConnectContext.get().getAliveBackendNumber());

        if (JoinExecMode.BROADCAST == execMode) {
            memCost = rightOutput * beNum;
        } else {
            memCost = rightOutput;
        }
        return memCost;
    }
```
The broadcast cost should be rightOutput * (beNum + cnNum)

## What I'm doing:

Fix the bug.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
