### PR TITLE
[BugFix] show create table displays Unicode encoding for default value of the field is entered in Chinese characters

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -61,6 +61,7 @@ import com.starrocks.sql.ast.IndexDef;
 import com.starrocks.thrift.TAggStateDesc;
 import com.starrocks.thrift.TColumn;
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.translate.UnicodeUnescaper;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -616,7 +617,8 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                 sb.append("DEFAULT ").append("(").append(defaultExpr.getExpr()).append(") ");
             }
         } else if (defaultValue != null && !type.isOnlyMetricType()) {
-            sb.append("DEFAULT \"").append(StringEscapeUtils.escapeJava(defaultValue)).append("\" ");
+            sb.append("DEFAULT \"").append(new UnicodeUnescaper().translate(StringEscapeUtils.escapeJava(defaultValue)))
+                    .append("\" ");
         } else if (isGeneratedColumn()) {
             String generatedColumnSql;
             if (idToColumn != null) {
@@ -733,7 +735,8 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                 sb.append("AUTO_INCREMENT ");
             }
             if (defaultValue != null && !type.isOnlyMetricType()) {
-                sb.append("DEFAULT \"").append(StringEscapeUtils.escapeJava(defaultValue)).append("\" ");
+                sb.append("DEFAULT \"").append(new UnicodeUnescaper().translate(StringEscapeUtils.escapeJava(defaultValue)))
+                        .append("\" ");
             }
         } else {
             if ("now()".equalsIgnoreCase(defaultExpr.getExpr())) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -2109,7 +2109,7 @@ public class CreateTableTest {
     public void testDefaultValueHasChineseChars() throws Exception {
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.useDatabase("test");
-        String sql1 = "CREATE TABLE `news_rt` (\n" +
+        String sql1 = "CREATE TABLE `news_rt1` (\n" +
                 "  `id` bigint(20) NOT NULL COMMENT \"pkid\",\n" +
                 "  `title` varchar(65533) NOT NULL DEFAULT \"撒\" COMMENT \"撒\"\n" +
                 ") ENGINE=OLAP \n" +
@@ -2120,8 +2120,8 @@ public class CreateTableTest {
                 "\"replication_num\" = \"1\"\n" +
                 ");";
         starRocksAssert.withTable(sql1);
-        String createTableSql = starRocksAssert.showCreateTable("show create table news_rt;");
-        starRocksAssert.dropTable("news_rt");
+        String createTableSql = starRocksAssert.showCreateTable("show create table news_rt1;");
+        starRocksAssert.dropTable("news_rt1");
         starRocksAssert.withTable(createTableSql);
     }
 
@@ -2129,7 +2129,7 @@ public class CreateTableTest {
     public void testDefaultValueHasChineseCharsNonPK() throws Exception {
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.useDatabase("test");
-        String sql1 = "CREATE TABLE `news_rt_non_pk` (\n" +
+        String sql1 = "CREATE TABLE `news_rt1_non_pk` (\n" +
                 "  `id` bigint(20) NOT NULL COMMENT \"pkid\",\n" +
                 "  `title` varchar(65533) NOT NULL DEFAULT \"撒\" COMMENT \"撒\"\n" +
                 ") ENGINE=OLAP \n" +
@@ -2140,8 +2140,8 @@ public class CreateTableTest {
                 "\"replication_num\" = \"1\"\n" +
                 ");";
         starRocksAssert.withTable(sql1);
-        String createTableSql = starRocksAssert.showCreateTable("show create table news_rt_non_pk;");
-        starRocksAssert.dropTable("news_rt_non_pk");
+        String createTableSql = starRocksAssert.showCreateTable("show create table news_rt1_non_pk;");
+        starRocksAssert.dropTable("news_rt1_non_pk");
         starRocksAssert.withTable(createTableSql);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -2106,6 +2106,46 @@ public class CreateTableTest {
     }
 
     @Test
+    public void testDefaultValueHasChineseChars() throws Exception {
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.useDatabase("test");
+        String sql1 = "CREATE TABLE `news_rt` (\n" +
+                "  `id` bigint(20) NOT NULL COMMENT \"pkid\",\n" +
+                "  `title` varchar(65533) NOT NULL DEFAULT \"撒\" COMMENT \"撒\"\n" +
+                ") ENGINE=OLAP \n" +
+                "PRIMARY KEY(`id`)\n" +
+                "COMMENT \"news\"\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 1 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");";
+        starRocksAssert.withTable(sql1);
+        String createTableSql = starRocksAssert.showCreateTable("show create table news_rt;");
+        starRocksAssert.dropTable("news_rt");
+        starRocksAssert.withTable(createTableSql);
+    }
+
+    @Test
+    public void testDefaultValueHasChineseCharsNonPK() throws Exception {
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.useDatabase("test");
+        String sql1 = "CREATE TABLE `news_rt_non_pk` (\n" +
+                "  `id` bigint(20) NOT NULL COMMENT \"pkid\",\n" +
+                "  `title` varchar(65533) NOT NULL DEFAULT \"撒\" COMMENT \"撒\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`id`)\n" +
+                "COMMENT \"news\"\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 1 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");";
+        starRocksAssert.withTable(sql1);
+        String createTableSql = starRocksAssert.showCreateTable("show create table news_rt_non_pk;");
+        starRocksAssert.dropTable("news_rt_non_pk");
+        starRocksAssert.withTable(createTableSql);
+    }
+
+    @Test
     public void testCreateTableWithNullableColumns1() throws Exception {
         String createSQL = "CREATE TABLE list_partition_tbl1 (\n" +
                 "      id BIGINT,\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -2123,6 +2123,7 @@ public class CreateTableTest {
         String createTableSql = starRocksAssert.showCreateTable("show create table news_rt1;");
         starRocksAssert.dropTable("news_rt1");
         starRocksAssert.withTable(createTableSql);
+        Assert.assertTrue(createTableSql, createTableSql.contains("撒"));
     }
 
     @Test
@@ -2143,6 +2144,7 @@ public class CreateTableTest {
         String createTableSql = starRocksAssert.showCreateTable("show create table news_rt1_non_pk;");
         starRocksAssert.dropTable("news_rt1_non_pk");
         starRocksAssert.withTable(createTableSql);
+        Assert.assertTrue(createTableSql, createTableSql.contains("撒"));
     }
 
     @Test


### PR DESCRIPTION
show create table displays Unicode encoding for default value of the field is entered in Chinese characters

## Why I'm doing:

## What I'm doing:

Fixes #51995 

```
mysql> show create table test111111;
+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table      | Create Table                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| test111111 | CREATE TABLE `test111111` (
  `test3` varchar(111) NULL DEFAULT "撒" COMMENT "撒",
  `test1` char(10) NULL DEFAULT "撒" COMMENT "撒",
  `test2` varchar(1) NULL DEFAULT "撒" COMMENT "撒",
  `test4` char(1) NULL DEFAULT "撒" COMMENT "撒",
  `test5` tinyint(4) NULL COMMENT "test1",
  `test6` varchar(1) NULL COMMENT "test2"
) ENGINE=OLAP 
DUPLICATE KEY(`test3`)
DISTRIBUTED BY HASH(`test3`)
PROPERTIES (
"compression" = "LZ4",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
);         |
+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
