### PR TITLE
[BugFix] Fix mv refresh with multi partition columns ref base tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateCombinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateCombinator.java
@@ -63,7 +63,6 @@ public final class AggStateCombinator extends ScalarFunction  {
             intermediateType.setAggStateDesc(aggStateDesc);
             // use agg state desc's nullable as `agg_state` function's nullable
             aggStateFunc.setIsNullable(aggStateDesc.getResultNullable());
-            LOG.info("Register agg state function: {}", aggStateFunc.functionName());
             return Optional.of(aggStateFunc);
         } catch (Exception e) {
             LOG.warn("Failed to create AggStateCombinator for function: {}", aggFunc.functionName(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateMergeCombinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateMergeCombinator.java
@@ -65,7 +65,6 @@ public final class AggStateMergeCombinator extends AggregateFunction {
             aggStateMergeFunc.setAggStateDesc(aggStateDesc);
             // use agg state desc's nullable as `agg_state` function's nullable
             aggStateMergeFunc.setIsNullable(aggStateDesc.getResultNullable());
-            LOG.info("Register agg state function: {}", aggStateMergeFunc.functionName());
             return Optional.of(aggStateMergeFunc);
         } catch (Exception e) {
             LOG.warn("Failed to create AggStateMergeCombinator for function: {}", aggFunc.functionName(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUnionCombinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUnionCombinator.java
@@ -65,7 +65,6 @@ public final class AggStateUnionCombinator extends AggregateFunction {
             aggStateUnionFunc.setAggStateDesc(aggStateDesc);
             // use agg state desc's nullable as `agg_state` function's nullable
             aggStateUnionFunc.setIsNullable(aggStateDesc.getResultNullable());
-            LOG.info("Register agg state function: {}", aggStateUnionFunc.functionName());
             return Optional.of(aggStateUnionFunc);
         } catch (Exception e) {
             LOG.warn("Failed to create AggStateUnionCombinator for function: {}", aggFunc.functionName(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -62,7 +62,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -403,32 +402,6 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                 mvContext.setNextPartitionEnd(null);
             }
         }
-    }
-
-    /**
-     * @param mvPartitionNames : the need to refresh materialized view partition names
-     * @return : the corresponding ref base table partition names to the materialized view partition names
-     */
-    protected Map<Table, Set<String>> getBasePartitionNamesByMVPartitionNames(Set<String> mvPartitionNames) {
-        Map<Table, Set<String>> result = new HashMap<>();
-        Map<String, Map<Table, Set<String>>> mvRefBaseTablePartitionMaps =
-                mvContext.getMvRefBaseTableIntersectedPartitions();
-        for (String mvPartitionName : mvPartitionNames) {
-            if (mvRefBaseTablePartitionMaps == null || !mvRefBaseTablePartitionMaps.containsKey(mvPartitionName)) {
-                LOG.warn("Cannot find need refreshed mv table partition from synced partition info: {}",
-                        mvPartitionName);
-                continue;
-            }
-            Map<Table, Set<String>> mvRefBaseTablePartitionMap = mvRefBaseTablePartitionMaps.get(mvPartitionName);
-            for (Map.Entry<Table, Set<String>> entry : mvRefBaseTablePartitionMap.entrySet()) {
-                Table baseTable = entry.getKey();
-                Set<String> baseTablePartitions = entry.getValue();
-                // If the result already contains the base table name, add all new partitions to the existing set
-                // If the result doesn't contain the base table name, put the new set into the map
-                result.computeIfAbsent(baseTable, k -> Sets.newHashSet()).addAll(baseTablePartitions);
-            }
-        }
-        return result;
     }
 
     private void addRangePartitions(Database database, MaterializedView materializedView,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCell.java
@@ -21,4 +21,6 @@ package com.starrocks.sql.common;
  * For list partition, it can be {@code List<List<String>>} to represent the list values of the partition.
  */
 public abstract class PCell {
+
+    public abstract  boolean isIntersected(PCell o);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
@@ -65,6 +65,15 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
         return partitionItems;
     }
 
+    @Override
+    public boolean isIntersected(PCell o) {
+        if (!(o instanceof PListCell)) {
+            return false;
+        }
+        PListCell other = (PListCell) o;
+        return CollectionUtils.containsAny(partitionItems, other.partitionItems);
+    }
+
     public int getItemSize() {
         if (partitionItems == null) {
             return 0;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCell.java
@@ -57,9 +57,14 @@ public final class PRangeCell extends PCell implements Comparable<PRangeCell> {
      *         && other.lowerBound.compareTo(upperBound) <= 0;
      *   }
      */
-    public boolean isIntersected(PRangeCell o) {
-        return this.range.upperEndpoint().compareTo(o.range.lowerEndpoint()) > 0 &&
-                this.range.lowerEndpoint().compareTo(o.range.upperEndpoint()) < 0;
+    @Override
+    public boolean isIntersected(PCell o) {
+        if (!(o instanceof PRangeCell)) {
+            return false;
+        }
+        PRangeCell other = (PRangeCell) o;
+        return this.range.upperEndpoint().compareTo(other.range.lowerEndpoint()) > 0 &&
+                this.range.lowerEndpoint().compareTo(other.range.upperEndpoint()) < 0;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -1278,6 +1278,18 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
             MVTaskRunExtraMessage message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
             Assert.assertEquals("p1,p2,p3", message.getMvPartitionsToRefreshString());
             Assert.assertEquals("{t1=[p1, p2, p3]}", message.getBasePartitionsToRefreshMapString());
+
+            // update new partitions of base table
+            addListPartition("t1", "p4", "2020-07-02", "shenzhen");
+            addListPartition("t1", "p5", "2020-07-05", "shenzhen");
+            executeInsertSql("INSERT INTO t1 partition(p4) VALUES  (\"2020-07-02\", \"shenzhen\", 3);");
+            executeInsertSql("INSERT INTO t1 partition(p5) VALUES  (\"2020-07-05\", \"shenzhen\", 4);");
+            processor = getProcessor(taskRun);
+            mvTaskRunContext = processor.getMvContext();
+            Assert.assertNull(mvTaskRunContext.getNextPartitionValues());
+            message = mvTaskRunContext.status.getMvTaskRunExtraMessage();
+            Assert.assertEquals("p1,p2,p3,p5", message.getMvPartitionsToRefreshString());
+            Assert.assertEquals("{t1=[p1, p2, p3, p4, p5]}", message.getBasePartitionsToRefreshMapString());
             starRocksAssert.dropTable("t1");
             starRocksAssert.dropMaterializedView("mv1");
         } catch (Exception e) {

--- a/test/test_sql_cases.py
+++ b/test/test_sql_cases.py
@@ -94,7 +94,7 @@ class TestSQLCases(sr_sql_lib.StarrocksSQLApiLib):
         Configs that are not ready for production but it can be used for testing.
         """
         default_configs = [
-            "'enable_mv_refresh_insert_strict' = 'true'",
+            "'mv_refresh_fail_on_filter_data' = 'true'",
             "'enable_mv_refresh_query_rewrite' = 'true'",
             # enlarge task run concurrency to speed up mv's refresh and find more potential bugs
             "'task_runs_concurrency' = '16'",


### PR DESCRIPTION
## Why I'm doing:

When partitions p4 and p5 in the base table t1 change, cascading will cause the refresh of p1 and p5 in the materialized view mv1. However, p1 includes two partitions, 2020-07-01 and 2020-07-02, and the partition 2020-07-02 does not only come from the partition p4. Therefore, other partitions it depends on must also be taken into account.

![image](https://github.com/user-attachments/assets/9a0c75c4-451e-4c06-b003-ceb5d0fd24a1)

Since p1 contains two partitions, 2020-07-01 and 2020-07-02, and the partition 2020-07-02 is not solely derived from the p4 partition, other partitions it depends on must also be considered when cascading the refresh. Therefore, during the cascaded refresh, it is necessary to include partitions p1, p2, and p3 that have not changed:

![image](https://github.com/user-attachments/assets/bd21cb9b-a7b4-44b5-8b47-b8359f09f872)

## What I'm doing:
- Fix mv refresh with multi partition columns ref base tables

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
