### PR TITLE
[Bugfix] Fix incremental scan ranges when scan ranges are bound to pipeline drivers

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -407,10 +407,10 @@ static Status add_per_driver_scan_ranges_partition_values(RuntimeState* runtime_
     return Status::OK();
 }
 
-static bool has_more_per_driver_scan_ranges(const PerDriverScanRangesMap& map) {
+static bool has_more_per_driver_seq_scan_ranges(const PerDriverScanRangesMap& map) {
     bool has_more = false;
-    for (const auto& [_, sc] : map) {
-        has_more |= ScanMorsel::has_more_scan_ranges(sc);
+    for (const auto& [_, scan_ranges] : map) {
+        has_more |= ScanMorsel::has_more_scan_ranges(scan_ranges);
         if (has_more) return has_more;
     }
     return has_more;
@@ -544,7 +544,7 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
         RETURN_IF_ERROR(add_scan_ranges_partition_values(runtime_state, scan_ranges));
         RETURN_IF_ERROR(add_per_driver_scan_ranges_partition_values(runtime_state, scan_ranges_per_driver_seq));
         bool has_more_morsel = ScanMorsel::has_more_scan_ranges(scan_ranges) ||
-                               has_more_per_driver_scan_ranges(scan_ranges_per_driver_seq);
+                               has_more_per_driver_seq_scan_ranges(scan_ranges_per_driver_seq);
 
         ASSIGN_OR_RETURN(auto morsel_queue_factory,
                          scan_node->convert_scan_range_to_morsel_queue_factory(
@@ -954,7 +954,7 @@ Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const
                 continue;
             }
 
-            bool has_more_morsel = has_more_per_driver_scan_ranges(per_driver_scan_ranges);
+            bool has_more_morsel = has_more_per_driver_seq_scan_ranges(per_driver_scan_ranges);
             for (const auto& [driver_seq, scan_ranges] : per_driver_scan_ranges) {
                 if (scan_ranges.size() == 0) continue;
                 RETURN_IF_ERROR(add_scan_ranges_partition_values(runtime_state, scan_ranges));

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -54,6 +54,17 @@ void ScanMorsel::build_scan_morsels(int node_id, const std::vector<TScanRangePar
         morsels.emplace_back(std::make_unique<pipeline::ScanMorsel>(node_id, TScanRangeParams()));
     }
 }
+bool ScanMorsel::has_more_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {
+    bool has_more = false;
+    for (const auto& scan_range : scan_ranges) {
+        if (scan_range.__isset.empty && scan_range.empty) {
+            if (scan_range.__isset.has_more) {
+                has_more = scan_range.has_more;
+            }
+        }
+    }
+    return has_more;
+}
 
 void PhysicalSplitScanMorsel::init_tablet_reader_params(TabletReaderParams* params) {
     params->rowid_range_option = _rowid_range_option;
@@ -68,10 +79,13 @@ size_t SharedMorselQueueFactory::num_original_morsels() const {
     return _queue->num_original_morsels();
 }
 
-Status SharedMorselQueueFactory::append_morsels([[maybe_unused]] int driver_seq, Morsels&& morsels, bool has_more) {
+Status SharedMorselQueueFactory::append_morsels([[maybe_unused]] int driver_seq, Morsels&& morsels) {
     RETURN_IF_ERROR(_queue->append_morsels(std::move(morsels)));
-    _queue->set_has_more(has_more);
     return Status::OK();
+}
+
+void SharedMorselQueueFactory::set_has_more(bool v) {
+    _queue->set_has_more(v);
 }
 
 size_t IndividualMorselQueueFactory::num_original_morsels() const {
@@ -82,7 +96,7 @@ size_t IndividualMorselQueueFactory::num_original_morsels() const {
     return total;
 }
 
-Status MorselQueueFactory::append_morsels(int driver_seq, Morsels&& morsels, bool has_more) {
+Status MorselQueueFactory::append_morsels(int driver_seq, Morsels&& morsels) {
     return Status::NotSupported("MorselQueueFactory::append_morsels not supported");
 }
 
@@ -106,10 +120,25 @@ IndividualMorselQueueFactory::IndividualMorselQueueFactory(std::map<int, MorselQ
     }
 }
 
-Status IndividualMorselQueueFactory::append_morsels(int driver_seq, Morsels&& morsels, bool has_more) {
+static void ensure_size_of_queue_per_drive_seq(std::vector<MorselQueuePtr>& _queue_per_driver_seq, int driver_seq) {
+    int size = _queue_per_driver_seq.size();
+    if (driver_seq >= size) {
+        for (int i = 0; i < (driver_seq - size) + 1; i++) {
+            _queue_per_driver_seq.emplace_back(create_empty_morsel_queue());
+        }
+    }
+}
+
+Status IndividualMorselQueueFactory::append_morsels(int driver_seq, Morsels&& morsels) {
+    ensure_size_of_queue_per_drive_seq(_queue_per_driver_seq, driver_seq);
     RETURN_IF_ERROR(_queue_per_driver_seq[driver_seq]->append_morsels(std::move(morsels)));
-    _queue_per_driver_seq[driver_seq]->set_has_more(has_more);
     return Status::OK();
+}
+
+void IndividualMorselQueueFactory::set_has_more(bool v) {
+    for (auto& q : _queue_per_driver_seq) {
+        q->set_has_more(v);
+    }
 }
 
 BucketSequenceMorselQueueFactory::BucketSequenceMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq,
@@ -132,10 +161,16 @@ BucketSequenceMorselQueueFactory::BucketSequenceMorselQueueFactory(std::map<int,
     }
 }
 
-Status BucketSequenceMorselQueueFactory::append_morsels(int driver_seq, Morsels&& morsels, bool has_more) {
+Status BucketSequenceMorselQueueFactory::append_morsels(int driver_seq, Morsels&& morsels) {
+    ensure_size_of_queue_per_drive_seq(_queue_per_driver_seq, driver_seq);
     RETURN_IF_ERROR(_queue_per_driver_seq[driver_seq]->append_morsels(std::move(morsels)));
-    _queue_per_driver_seq[driver_seq]->set_has_more(has_more);
     return Status::OK();
+}
+
+void BucketSequenceMorselQueueFactory::set_has_more(bool v) {
+    for (auto& q : _queue_per_driver_seq) {
+        q->set_has_more(v);
+    }
 }
 
 size_t BucketSequenceMorselQueueFactory::num_original_morsels() const {
@@ -881,7 +916,10 @@ bool LogicalSplitMorselQueue::_is_last_split_of_current_morsel() {
 }
 
 MorselQueuePtr create_empty_morsel_queue() {
-    return std::make_unique<FixedMorselQueue>(std::vector<MorselPtr>{});
+    // instead of creating FixedMorselQueue, DynamicMorselQueue permits to add scan ranges dynamically
+    // because if we have incremental scan ranges delivery, some driver maybe does not have any scan ranges at first
+    // but in the next round, it will have scan ranges to process.
+    return std::make_unique<DynamicMorselQueue>(std::vector<MorselPtr>{}, true);
 }
 
 StatusOr<MorselPtr> DynamicMorselQueue::try_get() {

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -120,6 +120,9 @@ IndividualMorselQueueFactory::IndividualMorselQueueFactory(std::map<int, MorselQ
     }
 }
 
+// The reason why we want to expand size of this vector is support of incremental scan ranges delivery
+// Think about a case that in the initial round, there is 4 drivers assigned scan ranges, so vector size is 4
+// but in the next round, if there is 5 drivers assigned scan ranges, then we have to expane vector to 5.
 static void ensure_size_of_queue_per_drive_seq(std::vector<MorselQueuePtr>& _queue_per_driver_seq, int driver_seq) {
     int size = _queue_per_driver_seq.size();
     if (driver_seq >= size) {

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -248,7 +248,7 @@ public:
     virtual bool is_shared() const = 0;
     virtual bool could_local_shuffle() const = 0;
 
-    virtual Status append_morsels(Morsels&& morsels, bool has_more);
+    virtual Status append_morsels(int driver_seq, Morsels&& morsels, bool has_more);
 };
 
 class SharedMorselQueueFactory final : public MorselQueueFactory {
@@ -263,7 +263,7 @@ public:
     bool is_shared() const override { return true; }
     bool could_local_shuffle() const override { return true; }
 
-    Status append_morsels(Morsels&& morsels, bool has_more) override;
+    Status append_morsels(int driver_seq, Morsels&& morsels, bool has_more) override;
 
 private:
     MorselQueuePtr _queue;
@@ -287,6 +287,8 @@ public:
     bool is_shared() const override { return false; }
     bool could_local_shuffle() const override { return _could_local_shuffle; }
 
+    Status append_morsels(int driver_seq, Morsels&& morsels, bool has_more) override;
+
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;
     const bool _could_local_shuffle;
@@ -309,6 +311,8 @@ public:
     bool is_shared() const override { return false; }
 
     bool could_local_shuffle() const override { return _could_local_shuffle; }
+
+    Status append_morsels(int driver_seq, Morsels&& morsels, bool has_more) override;
 
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -183,6 +183,7 @@ public:
 
     static void build_scan_morsels(int node_id, const std::vector<TScanRangeParams>& scan_ranges,
                                    bool accept_empty_scan_ranges, pipeline::Morsels* morsels, bool* has_more_morsel);
+    static bool has_more_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges);
 
 private:
     std::unique_ptr<TScanRange> _scan_range;
@@ -248,7 +249,8 @@ public:
     virtual bool is_shared() const = 0;
     virtual bool could_local_shuffle() const = 0;
 
-    virtual Status append_morsels(int driver_seq, Morsels&& morsels, bool has_more);
+    virtual Status append_morsels(int driver_seq, Morsels&& morsels);
+    virtual void set_has_more(bool v) {}
 };
 
 class SharedMorselQueueFactory final : public MorselQueueFactory {
@@ -263,7 +265,8 @@ public:
     bool is_shared() const override { return true; }
     bool could_local_shuffle() const override { return true; }
 
-    Status append_morsels(int driver_seq, Morsels&& morsels, bool has_more) override;
+    Status append_morsels(int driver_seq, Morsels&& morsels) override;
+    void set_has_more(bool v) override;
 
 private:
     MorselQueuePtr _queue;
@@ -287,7 +290,8 @@ public:
     bool is_shared() const override { return false; }
     bool could_local_shuffle() const override { return _could_local_shuffle; }
 
-    Status append_morsels(int driver_seq, Morsels&& morsels, bool has_more) override;
+    Status append_morsels(int driver_seq, Morsels&& morsels) override;
+    void set_has_more(bool v) override;
 
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;
@@ -312,7 +316,8 @@ public:
 
     bool could_local_shuffle() const override { return _could_local_shuffle; }
 
-    Status append_morsels(int driver_seq, Morsels&& morsels, bool has_more) override;
+    Status append_morsels(int driver_seq, Morsels&& morsels) override;
+    void set_has_more(bool v) override;
 
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -99,6 +99,7 @@ public class TFragmentInstanceFactory {
         result.params.setQuery_id(jobSpec.getQueryId());
         result.params.setFragment_instance_id(instance.getInstanceId());
         result.params.setPer_node_scan_ranges(instance.getNode2ScanRanges());
+        result.params.setNode_to_per_driver_seq_scan_ranges(instance.getNode2DriverSeqToScanRanges());
         result.params.setPer_exch_num_senders(new HashMap<>());
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
@@ -324,6 +324,7 @@ public class FragmentInstance {
 
     public void resetAllScanRanges() {
         node2ScanRanges.clear();
+        node2DriverSeqToScanRanges.clear();
     }
 
     public void addScanRanges(Integer scanId, List<TScanRangeParams> scanRanges) {
@@ -332,6 +333,7 @@ public class FragmentInstance {
     }
 
     public void addScanRanges(Integer scanId, Integer driverSeq, List<TScanRangeParams> scanRanges) {
+        removeDuplicatedPartitionValues(scanId, scanRanges);
         node2DriverSeqToScanRanges.computeIfAbsent(scanId, k -> new HashMap<>())
                 .computeIfAbsent(driverSeq, k -> new ArrayList<>()).addAll(scanRanges);
     }

--- a/test/sql/test_deltalake/R/test_deltalake_scan_ranges
+++ b/test/sql/test_deltalake/R/test_deltalake_scan_ranges
@@ -234,10 +234,6 @@ select * from t_timestamp_ntz where col_timestamp_ntz >= '2024-01-02 01:02:01' a
 2	2024-01-03 04:05:06
 4	2024-01-04 01:02:03
 -- !result
-select * from delta_test_column_mapping;
--- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_33e83c7a4b264588b7f98b97ae9fe93a.delta_test_column_mapping'.")
--- !result
 select * from delta_lake_par_col_timestamp order by col_smallint;
 -- result:
 1	1	2024-01-01 01:01:01
@@ -281,10 +277,6 @@ select * from t_partition_timestamp_ntz where col_timestamp_ntz >= '2024-01-02 0
 1	2024-01-02 01:02:03
 2	2024-01-03 04:05:06
 4	2024-01-04 01:02:03
--- !result
-select * from delta_lake_par_col_double order by col_smallint;
--- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_33e83c7a4b264588b7f98b97ae9fe93a.delta_lake_par_col_double'.")
 -- !result
 select * from delta_lake_par_null order by col_smallint;
 -- result:

--- a/test/sql/test_deltalake/R/test_deltalake_scan_ranges
+++ b/test/sql/test_deltalake/R/test_deltalake_scan_ranges
@@ -34,7 +34,6 @@ create table t_timestamp_ntz as select * from delta_test_${uuid0}.delta_oss_db.t
 -- !result
 create table delta_test_column_mapping as select * from delta_test_${uuid0}.delta_oss_db.delta_test_column_mapping;
 -- result:
-E: (1064, "Unknown table 'Delta table feature [column mapping] is not supported'")
 -- !result
 create table delta_lake_par_col_timestamp as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp ;
 -- result:
@@ -233,6 +232,12 @@ select * from t_timestamp_ntz where col_timestamp_ntz >= '2024-01-02 01:02:01' a
 1	2024-01-02 01:02:03
 2	2024-01-03 04:05:06
 4	2024-01-04 01:02:03
+-- !result
+select * from delta_test_column_mapping;
+-- result:
+1	name1	sr
+2	name2	sr
+3	name3	sr
 -- !result
 select * from delta_lake_par_col_timestamp order by col_smallint;
 -- result:

--- a/test/sql/test_deltalake/R/test_deltalake_scan_ranges
+++ b/test/sql/test_deltalake/R/test_deltalake_scan_ranges
@@ -1,0 +1,323 @@
+-- name: testDeltaLakeScanRanges
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+-- result:
+-- !result
+set enable_connector_incremental_scan_ranges = true;
+-- result:
+-- !result
+set connector_incremental_scan_ranges_size = 1;
+-- result:
+-- !result
+create table string_col_dict_encode as select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode;
+-- result:
+-- !result
+create table delta_lake_data_type as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type;
+-- result:
+-- !result
+create table delta_lake_par_col_boolean as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean;
+-- result:
+-- !result
+create table delta_lake_par_col_date as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_date;
+-- result:
+-- !result
+create table delta_lake_par_col_string as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_string;
+-- result:
+-- !result
+create table t_timestamp_ntz as select * from delta_test_${uuid0}.delta_oss_db.t_timestamp_ntz;
+-- result:
+-- !result
+create table delta_test_column_mapping as select * from delta_test_${uuid0}.delta_oss_db.delta_test_column_mapping;
+-- result:
+E: (1064, "Unknown table 'Delta table feature [column mapping] is not supported'")
+-- !result
+create table delta_lake_par_col_timestamp as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp ;
+-- result:
+-- !result
+create table t_partition_timestamp_ntz as select * from delta_test_${uuid0}.delta_oss_db.t_partition_timestamp_ntz;
+-- result:
+-- !result
+create table delta_lake_par_col_double as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_double;
+-- result:
+E: (1064, 'Table partition by float/double/decimal datatype is not supported')
+-- !result
+create table delta_lake_par_null as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_null;
+-- result:
+-- !result
+select * from string_col_dict_encode where c3='a' order by c1;
+-- result:
+1	1	a
+6	2	a
+11	1	a
+16	2	a
+21	1	a
+26	2	a
+31	1	a
+36	2	a
+-- !result
+select * from delta_lake_data_type where col_struct is null;
+-- result:
+6	600	6000	60000	18.840000153	18.849560000	2024-04-29	2024-04-29 12:00:00	sixth_string	321.98	0	6	[16,17,18]	final_binary_data	None	None
+-- !result
+select col_struct from delta_lake_data_type where col_struct is not null order by col_tinyint;
+-- result:
+{"name":"Alice","sex":"female","age":30}
+{"name":"Bob","sex":"male","age":25}
+{"name":"Charlie","sex":"male","age":35}
+{"name":"Diana","sex":"female","age":28}
+{"name":"Edward","sex":"male","age":40}
+{"name":"Fiona","sex":"female","age":33}
+{"name":null,"sex":null,"age":null}
+-- !result
+select * from delta_lake_par_col_boolean where col_boolean = true;
+-- result:
+1	1	1
+2	2	1
+-- !result
+select * from delta_lake_par_col_boolean where col_boolean = false;
+-- result:
+3	3	0
+4	4	0
+-- !result
+select * from delta_lake_par_col_date where col_date = '2024-04-24' order by col_smallint;
+-- result:
+1	100	2024-04-24
+2	200	2024-04-24
+3	300	2024-04-24
+-- !result
+select * from delta_lake_par_col_date where col_date > '2024-04-24' order by col_smallint;
+-- result:
+4	400	2024-04-25
+5	500	2024-04-25
+6	600	2024-04-25
+7	700	2024-04-26
+8	800	2024-04-26
+9	900	2024-04-26
+10	1000	2024-04-27
+11	1100	2024-04-27
+12	1200	2024-04-27
+-- !result
+select * from delta_lake_par_col_date where col_date >= '2024-04-24' and col_date < '2024-04-26' order by col_smallint;
+-- result:
+1	100	2024-04-24
+2	200	2024-04-24
+3	300	2024-04-24
+4	400	2024-04-25
+5	500	2024-04-25
+6	600	2024-04-25
+-- !result
+select * from delta_lake_par_col_date where col_date = '2024-04-24' or col_date = '2024-04-26' order by col_smallint;
+-- result:
+1	100	2024-04-24
+2	200	2024-04-24
+3	300	2024-04-24
+7	700	2024-04-26
+8	800	2024-04-26
+9	900	2024-04-26
+-- !result
+select * from delta_lake_par_col_date where col_date != '2024-04-24' order by col_smallint;
+-- result:
+4	400	2024-04-25
+5	500	2024-04-25
+6	600	2024-04-25
+7	700	2024-04-26
+8	800	2024-04-26
+9	900	2024-04-26
+10	1000	2024-04-27
+11	1100	2024-04-27
+12	1200	2024-04-27
+-- !result
+select count(1) from delta_lake_par_col_date where col_date is NULL;
+-- result:
+0
+-- !result
+select count(1) from delta_lake_par_col_date where col_date is NOT NULL;
+-- result:
+12
+-- !result
+select * from delta_lake_par_col_date where col_date in ('2024-04-24', '2024-04-25') order by col_smallint;
+-- result:
+1	100	2024-04-24
+2	200	2024-04-24
+3	300	2024-04-24
+4	400	2024-04-25
+5	500	2024-04-25
+6	600	2024-04-25
+-- !result
+select * from delta_lake_par_col_date where col_date not in ('2024-04-24', '2024-04-25', '2024-04-26') order by col_smallint;
+-- result:
+10	1000	2024-04-27
+11	1100	2024-04-27
+12	1200	2024-04-27
+-- !result
+select * from delta_lake_par_col_string where col_string = 'value1' order by col_smallint;
+-- result:
+1	100	value1
+2	200	value1
+3	300	value1
+-- !result
+select * from delta_lake_par_col_string where col_string != 'value1' order by col_smallint;
+-- result:
+4	400	value2
+5	500	value2
+6	600	value2
+7	700	value3
+8	800	value3
+9	900	value3
+10	1000	value3
+-- !result
+select * from delta_lake_par_col_string where col_string in ('value1','value2') order by col_smallint;
+-- result:
+1	100	value1
+2	200	value1
+3	300	value1
+4	400	value2
+5	500	value2
+6	600	value2
+-- !result
+select * from delta_lake_par_col_string where col_string not in ('value1','value2') order by col_smallint;
+-- result:
+7	700	value3
+8	800	value3
+9	900	value3
+10	1000	value3
+-- !result
+select col_tinyint,col_array,col_map,col_struct from delta_lake_data_type where col_tinyint < 6 order by col_tinyint;
+-- result:
+1	[1,2,3]	{"key1":"value1","key2":"value2"}	{"name":"Alice","sex":"female","age":30}
+2	[4,5,6]	{"key3":"value3","key4":"value4"}	{"name":"Bob","sex":"male","age":25}
+3	[7,8,9]	{"key5":"value5","key6":"value6"}	{"name":"Charlie","sex":"male","age":35}
+4	[10,11,12]	{"key7":"value7","key8":"value8"}	{"name":"Diana","sex":"female","age":28}
+5	[13,14,15]	{"key9":"value9","key10":"value10"}	{"name":"Edward","sex":"male","age":40}
+-- !result
+select col_timestamp from delta_lake_data_type where col_timestamp = '2024-04-24 12:00:00';
+-- result:
+2024-04-24 12:00:00
+-- !result
+select col_timestamp from delta_lake_data_type where col_timestamp >= '2024-04-24 12:00:00' and col_timestamp < '2024-04-27 12:00:00';
+-- result:
+2024-04-24 12:00:00
+2024-04-25 12:00:00
+2024-04-26 12:00:00
+-- !result
+select * from t_timestamp_ntz order by col_int;
+-- result:
+1	2024-01-02 01:02:03
+2	2024-01-03 04:05:06
+3	None
+4	2024-01-04 01:02:03
+5	2024-01-05 04:05:06
+-- !result
+select * from t_timestamp_ntz where col_timestamp_ntz is null order by col_int;
+-- result:
+3	None
+-- !result
+select * from t_timestamp_ntz where col_timestamp_ntz is not null order by col_int;
+-- result:
+1	2024-01-02 01:02:03
+2	2024-01-03 04:05:06
+4	2024-01-04 01:02:03
+5	2024-01-05 04:05:06
+-- !result
+select * from t_timestamp_ntz where col_timestamp_ntz = '2024-01-02 01:02:03' order by col_int;
+-- result:
+1	2024-01-02 01:02:03
+-- !result
+select * from t_timestamp_ntz where col_timestamp_ntz >= '2024-01-02 01:02:01' and col_timestamp_ntz < '2024-01-04 01:02:04' order by col_int;
+-- result:
+1	2024-01-02 01:02:03
+2	2024-01-03 04:05:06
+4	2024-01-04 01:02:03
+-- !result
+select * from delta_test_column_mapping;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_33e83c7a4b264588b7f98b97ae9fe93a.delta_test_column_mapping'.")
+-- !result
+select * from delta_lake_par_col_timestamp order by col_smallint;
+-- result:
+1	1	2024-01-01 01:01:01
+2	2	2023-01-01 01:01:01
+3	3	2022-01-01 01:01:01
+-- !result
+select * from delta_lake_par_col_timestamp where col_timestamp > '2022-01-01 01:01:01' order by col_smallint;
+-- result:
+1	1	2024-01-01 01:01:01
+2	2	2023-01-01 01:01:01
+-- !result
+select * from delta_lake_par_col_timestamp where col_timestamp = '2023-01-01 01:01:01' order by col_smallint;
+-- result:
+2	2	2023-01-01 01:01:01
+-- !result
+select * from t_partition_timestamp_ntz order by col_int;
+-- result:
+1	2024-01-02 01:02:03
+2	2024-01-03 04:05:06
+3	None
+4	2024-01-04 01:02:03
+5	2024-01-05 04:05:06
+-- !result
+select * from t_partition_timestamp_ntz where col_timestamp_ntz is null order by col_int;
+-- result:
+3	None
+-- !result
+select * from t_partition_timestamp_ntz where col_timestamp_ntz is not null order by col_int;
+-- result:
+1	2024-01-02 01:02:03
+2	2024-01-03 04:05:06
+4	2024-01-04 01:02:03
+5	2024-01-05 04:05:06
+-- !result
+select * from t_partition_timestamp_ntz where col_timestamp_ntz = '2024-01-02 01:02:03' order by col_int;
+-- result:
+1	2024-01-02 01:02:03
+-- !result
+select * from t_partition_timestamp_ntz where col_timestamp_ntz >= '2024-01-02 01:02:01' and col_timestamp_ntz < '2024-01-04 01:02:04' order by col_int;
+-- result:
+1	2024-01-02 01:02:03
+2	2024-01-03 04:05:06
+4	2024-01-04 01:02:03
+-- !result
+select * from delta_lake_par_col_double order by col_smallint;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'test_db_33e83c7a4b264588b7f98b97ae9fe93a.delta_lake_par_col_double'.")
+-- !result
+select * from delta_lake_par_null order by col_smallint;
+-- result:
+1	1	2024-01-01 01:01:01
+2	2	2023-01-01 01:01:01
+3	3	2022-01-01 01:01:01
+4	44	None
+-- !result
+select * from delta_lake_par_null where col_timestamp is null order by col_smallint;
+-- result:
+4	44	None
+-- !result
+select * from delta_lake_par_null where col_timestamp is not null order by col_smallint;
+-- result:
+1	1	2024-01-01 01:01:01
+2	2	2023-01-01 01:01:01
+3	3	2022-01-01 01:01:01
+-- !result
+select col_struct from delta_lake_data_type where col_struct.age=30 order by col_tinyint;
+-- result:
+{"name":"Alice","sex":"female","age":30}
+-- !result
+select col_struct from delta_lake_data_type where col_struct.sex='male' order by col_tinyint;
+-- result:
+{"name":"Bob","sex":"male","age":25}
+{"name":"Charlie","sex":"male","age":35}
+{"name":"Edward","sex":"male","age":40}
+-- !result
+select col_struct from delta_lake_data_type where col_struct.age<30 order by col_tinyint;
+-- result:
+{"name":"Bob","sex":"male","age":25}
+{"name":"Diana","sex":"female","age":28}
+-- !result
+drop catalog delta_test_${uuid0}
+-- result:
+-- !result

--- a/test/sql/test_deltalake/T/test_deltalake_scan_ranges
+++ b/test/sql/test_deltalake/T/test_deltalake_scan_ranges
@@ -69,7 +69,7 @@ select * from t_timestamp_ntz where col_timestamp_ntz = '2024-01-02 01:02:03' or
 select * from t_timestamp_ntz where col_timestamp_ntz >= '2024-01-02 01:02:01' and col_timestamp_ntz < '2024-01-04 01:02:04' order by col_int;
 
 -- -- test column mapping
--- select * from delta_test_column_mapping;
+select * from delta_test_column_mapping;
 
 -- test timestamp as partition type
 select * from delta_lake_par_col_timestamp order by col_smallint;

--- a/test/sql/test_deltalake/T/test_deltalake_scan_ranges
+++ b/test/sql/test_deltalake/T/test_deltalake_scan_ranges
@@ -68,8 +68,8 @@ select * from t_timestamp_ntz where col_timestamp_ntz is not null order by col_i
 select * from t_timestamp_ntz where col_timestamp_ntz = '2024-01-02 01:02:03' order by col_int;
 select * from t_timestamp_ntz where col_timestamp_ntz >= '2024-01-02 01:02:01' and col_timestamp_ntz < '2024-01-04 01:02:04' order by col_int;
 
--- test column mapping
-select * from delta_test_column_mapping;
+-- -- test column mapping
+-- select * from delta_test_column_mapping;
 
 -- test timestamp as partition type
 select * from delta_lake_par_col_timestamp order by col_smallint;
@@ -83,8 +83,8 @@ select * from t_partition_timestamp_ntz where col_timestamp_ntz is not null orde
 select * from t_partition_timestamp_ntz where col_timestamp_ntz = '2024-01-02 01:02:03' order by col_int;
 select * from t_partition_timestamp_ntz where col_timestamp_ntz >= '2024-01-02 01:02:01' and col_timestamp_ntz < '2024-01-04 01:02:04' order by col_int;
 
--- test double as partition type
-select * from delta_lake_par_col_double order by col_smallint;
+-- -- test double as partition type
+-- select * from delta_lake_par_col_double order by col_smallint;
 
 -- test null partition
 select * from delta_lake_par_null order by col_smallint;

--- a/test/sql/test_deltalake/T/test_deltalake_scan_ranges
+++ b/test/sql/test_deltalake/T/test_deltalake_scan_ranges
@@ -1,0 +1,99 @@
+-- name: testDeltaLakeScanRanges
+
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+
+set enable_connector_incremental_scan_ranges = true;
+set connector_incremental_scan_ranges_size = 1;
+
+create table string_col_dict_encode as select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode;
+create table delta_lake_data_type as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type;
+create table delta_lake_par_col_boolean as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_boolean;
+create table delta_lake_par_col_date as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_date;
+create table delta_lake_par_col_string as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_string;
+create table t_timestamp_ntz as select * from delta_test_${uuid0}.delta_oss_db.t_timestamp_ntz;
+create table delta_test_column_mapping as select * from delta_test_${uuid0}.delta_oss_db.delta_test_column_mapping;
+create table delta_lake_par_col_timestamp as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_timestamp ;
+create table t_partition_timestamp_ntz as select * from delta_test_${uuid0}.delta_oss_db.t_partition_timestamp_ntz;
+create table delta_lake_par_col_double as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_col_double;
+create table delta_lake_par_null as select * from delta_test_${uuid0}.delta_oss_db.delta_lake_par_null;
+
+-- only partition column Predicate with runtime filter
+select * from string_col_dict_encode where c3='a' order by c1;
+
+-- test struct column is null
+
+select * from delta_lake_data_type where col_struct is null;
+
+-- test struct column is not null
+select col_struct from delta_lake_data_type where col_struct is not null order by col_tinyint;
+
+-- test partition prune with boolean type
+select * from delta_lake_par_col_boolean where col_boolean = true;
+select * from delta_lake_par_col_boolean where col_boolean = false;
+
+-- test predicate with date type
+select * from delta_lake_par_col_date where col_date = '2024-04-24' order by col_smallint;
+select * from delta_lake_par_col_date where col_date > '2024-04-24' order by col_smallint;
+select * from delta_lake_par_col_date where col_date >= '2024-04-24' and col_date < '2024-04-26' order by col_smallint;
+select * from delta_lake_par_col_date where col_date = '2024-04-24' or col_date = '2024-04-26' order by col_smallint;
+select * from delta_lake_par_col_date where col_date != '2024-04-24' order by col_smallint;
+select count(1) from delta_lake_par_col_date where col_date is NULL;
+select count(1) from delta_lake_par_col_date where col_date is NOT NULL;
+select * from delta_lake_par_col_date where col_date in ('2024-04-24', '2024-04-25') order by col_smallint;
+select * from delta_lake_par_col_date where col_date not in ('2024-04-24', '2024-04-25', '2024-04-26') order by col_smallint;
+
+-- test predicate with string type
+select * from delta_lake_par_col_string where col_string = 'value1' order by col_smallint;
+select * from delta_lake_par_col_string where col_string != 'value1' order by col_smallint;
+select * from delta_lake_par_col_string where col_string in ('value1','value2') order by col_smallint;
+select * from delta_lake_par_col_string where col_string not in ('value1','value2') order by col_smallint;
+
+-- test complex type
+select col_tinyint,col_array,col_map,col_struct from delta_lake_data_type where col_tinyint < 6 order by col_tinyint;
+
+-- test timestamp
+select col_timestamp from delta_lake_data_type where col_timestamp = '2024-04-24 12:00:00';
+select col_timestamp from delta_lake_data_type where col_timestamp >= '2024-04-24 12:00:00' and col_timestamp < '2024-04-27 12:00:00';
+
+-- test timestamp_ntz
+select * from t_timestamp_ntz order by col_int;
+select * from t_timestamp_ntz where col_timestamp_ntz is null order by col_int;
+select * from t_timestamp_ntz where col_timestamp_ntz is not null order by col_int;
+select * from t_timestamp_ntz where col_timestamp_ntz = '2024-01-02 01:02:03' order by col_int;
+select * from t_timestamp_ntz where col_timestamp_ntz >= '2024-01-02 01:02:01' and col_timestamp_ntz < '2024-01-04 01:02:04' order by col_int;
+
+-- test column mapping
+select * from delta_test_column_mapping;
+
+-- test timestamp as partition type
+select * from delta_lake_par_col_timestamp order by col_smallint;
+select * from delta_lake_par_col_timestamp where col_timestamp > '2022-01-01 01:01:01' order by col_smallint;
+select * from delta_lake_par_col_timestamp where col_timestamp = '2023-01-01 01:01:01' order by col_smallint;
+
+-- test timestamp_ntz as partition type
+select * from t_partition_timestamp_ntz order by col_int;
+select * from t_partition_timestamp_ntz where col_timestamp_ntz is null order by col_int;
+select * from t_partition_timestamp_ntz where col_timestamp_ntz is not null order by col_int;
+select * from t_partition_timestamp_ntz where col_timestamp_ntz = '2024-01-02 01:02:03' order by col_int;
+select * from t_partition_timestamp_ntz where col_timestamp_ntz >= '2024-01-02 01:02:01' and col_timestamp_ntz < '2024-01-04 01:02:04' order by col_int;
+
+-- test double as partition type
+select * from delta_lake_par_col_double order by col_smallint;
+
+-- test null partition
+select * from delta_lake_par_null order by col_smallint;
+select * from delta_lake_par_null where col_timestamp is null order by col_smallint;
+select * from delta_lake_par_null where col_timestamp is not null order by col_smallint;
+
+-- test predicate with struct subfield
+select col_struct from delta_lake_data_type where col_struct.age=30 order by col_tinyint;
+select col_struct from delta_lake_data_type where col_struct.sex='male' order by col_tinyint;
+select col_struct from delta_lake_data_type where col_struct.age<30 order by col_tinyint;
+
+drop catalog delta_test_${uuid0}

--- a/test/sql/test_hive/R/test_hive_scan_ranges
+++ b/test/sql/test_hive/R/test_hive_scan_ranges
@@ -32,6 +32,34 @@ select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_parquet or
 2	Bob	bj
 3	David	None
 -- !result
+create table t00 as select * from hive_sql_test_${uuid0}.hive_oss_db.hive_oss_par_parquet_snappy order by col_int, col_date;
+-- result:
+-- !result
+select * from t00 order by col_int, col_date;
+-- result:
+1	hello world	2021-01-01	1
+1	hello world	2022-01-01	1
+2	hello wrold	2021-01-01	1
+2	hello wrold	2022-01-01	1
+-- !result
+create table t01 as select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc order by id;
+-- result:
+-- !result
+select * from t01 order by id;
+-- result:
+1	Alice	bj
+2	Bob	bj
+3	David	None
+-- !result
+create table t02 as select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_parquet order by id;
+-- result:
+-- !result
+select * from t02 order by id;
+-- result:
+1	Alice	bj
+2	Bob	bj
+3	David	None
+-- !result
 drop catalog hive_sql_test_${uuid0}
 -- result:
 -- !result

--- a/test/sql/test_hive/T/test_hive_scan_ranges
+++ b/test/sql/test_hive/T/test_hive_scan_ranges
@@ -16,4 +16,16 @@ select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc order 
 
 select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_parquet order by id;
 
+create table t00 as select * from hive_sql_test_${uuid0}.hive_oss_db.hive_oss_par_parquet_snappy order by col_int, col_date;
+
+select * from t00 order by col_int, col_date;
+
+create table t01 as select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_orc order by id;
+
+select * from t01 order by id;
+
+create table t02 as select * from hive_sql_test_${uuid0}.hive_oss_db.string_par_with_null_parquet order by id;
+
+select * from t02 order by id;
+
 drop catalog hive_sql_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:

When running CTAS or insert into natibe table,  scan ranges are bound to driver seq, which is not supported yet.

## What I'm doing:

Support incremental scan ranges delivery when scan ranges are bound to driver sequence.

Fixes #https://github.com/StarRocks/StarRocksTest/issues/8711

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5