### PR TITLE
[BugFix] Prevent crash if type mismatch in BinaryDictPageDecoder

### DIFF
--- a/be/src/storage/rowset/binary_dict_page.cpp
+++ b/be/src/storage/rowset/binary_dict_page.cpp
@@ -261,7 +261,9 @@ Status BinaryDictPageDecoder<Type>::next_batch(const SparseRange<>& range, Colum
         }
     }
 
-    CHECK(dst->append_strings_overflow(slices, _max_value_legth));
+    bool ok = dst->append_strings_overflow(slices, _max_value_legth);
+    DCHECK(ok) << "append_strings_overflow failed";
+    RETURN_IF(!ok, Status::InternalError("BinaryDictPageDecoder::next_batch failed"));
     return Status::OK();
 }
 


### PR DESCRIPTION
## Why I'm doing:

When in the process of schemachange, type may not match in execution, which may cause crash like this: 
```
*** Aborted at 1728954262 (unix time) try "date -d @1728954262" if you are using GNU date ***
PC: @     0x7f75d473d387 __GI_raise
*** SIGABRT (@0x3e800000800) received by PID 2048 (TID 0x7f7541f89700) from PID 2048; stack trace: ***
    @          0x6bc4c82 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f75d540c630 (unknown)
    @     0x7f75d473d387 __GI_raise
    @     0x7f75d473ea78 __GI_abort
    @          0x2d6e317 starrocks::failure_function()
    @          0x6bb865d google::LogMessage::Fail()
    @          0x6bbaacf google::LogMessage::SendToLog()
    @          0x6bb81ae google::LogMessage::Flush()
    @          0x6bbb0d9 google::LogMessageFatal::~LogMessageFatal()
    @          0x5a4ba6a starrocks::BinaryDictPageDecoder<>::next_batch()
    @          0x5a81840 starrocks::ParsedPageV2::read()
    @          0x5a333d4 starrocks::ScalarColumnIterator::next_batch()
    @          0x5455d10 starrocks::SegmentIterator::_read()
    @          0x544eb84 starrocks::SegmentIterator::_do_get_next()
    @          0x5450e40 starrocks::SegmentIterator::do_get_next()
    @          0x5a9a593 starrocks::TimedChunkIterator::do_get_next()
    @          0x55c720e starrocks::lake::TabletReader::do_get_next()
    @          0x5f1e48c starrocks::connector::LakeDataSource::get_next()
    @          0x39cbc5a starrocks::pipeline::ConnectorChunkSource::_read_chunk()
    @          0x3cee1ca starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @          0x39bdd9e _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlvE_clEv
    @          0x3acd011 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x305409c starrocks::ThreadPool::dispatch_thread()
    @          0x304d5aa starrocks::Thread::supervise_thread()
    @     0x7f75d5404ea5 start_thread
    @     0x7f75d4805b0d __clone
    @                0x0 (unknown)
```
## What I'm doing:

return status::error instead of crash.

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/8685)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
