### PR TITLE
[Enhancement] table level stats meta support incremental column stats for external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
@@ -101,7 +101,7 @@ public class ShowBasicStatsMetaStmt extends ShowStmt {
 
     public static List<String> showExternalBasicStatsMeta(ConnectContext context,
                                                           ExternalBasicStatsMeta basicStatsMeta) throws MetaNotFoundException {
-        List<String> row = Lists.newArrayList("", "", "ALL", "", "", "", "");
+        List<String> row = Lists.newArrayList("", "", "ALL", "", "", "", "", "", "");
         String catalogName = basicStatsMeta.getCatalogName();
         String dbName = basicStatsMeta.getDbName();
         String tableName = basicStatsMeta.getTableName();
@@ -135,6 +135,7 @@ public class ShowBasicStatsMetaStmt extends ShowStmt {
         row.set(3, basicStatsMeta.getType().name());
         row.set(4, basicStatsMeta.getUpdateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
         row.set(5, basicStatsMeta.getProperties() == null ? "{}" : basicStatsMeta.getProperties().toString());
+        row.set(7, basicStatsMeta.getColumnStatsString());
 
         return row;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -332,6 +332,10 @@ public class AnalyzeMgr implements Writable {
         return externalBasicStatsMetaMap;
     }
 
+    public ExternalBasicStatsMeta getExternalTableBasicStatsMeta(String catalogName, String dbName, String tableName) {
+        return externalBasicStatsMetaMap.get(new StatsMetaKey(catalogName, dbName, tableName));
+    }
+
     public HistogramStatsMeta getHistogramMeta(long tableId, String column) {
         return histogramStatsMetaMap.get(Pair.create(tableId, column));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalBasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalBasicStatsMeta.java
@@ -14,10 +14,12 @@
 
 package com.starrocks.statistic;
 
+import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
+import org.apache.commons.collections4.MapUtils;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -25,6 +27,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ExternalBasicStatsMeta implements Writable {
     @SerializedName("catalogName")
@@ -35,6 +38,8 @@ public class ExternalBasicStatsMeta implements Writable {
     @SerializedName("tableName")
     private String tableName;
 
+    // Deprecated by columnStatsMetaMap
+    @Deprecated
     @SerializedName("columns")
     private List<String> columns;
 
@@ -46,6 +51,9 @@ public class ExternalBasicStatsMeta implements Writable {
 
     @SerializedName("properties")
     private Map<String, String> properties;
+
+    @SerializedName("columnStats")
+    private Map<String, ColumnStatsMeta> columnStatsMetaMap = Maps.newConcurrentMap();
 
     public ExternalBasicStatsMeta() {}
 
@@ -99,5 +107,38 @@ public class ExternalBasicStatsMeta implements Writable {
     public static ExternalBasicStatsMeta read(DataInput in) throws IOException {
         String s = Text.readString(in);
         return GsonUtils.GSON.fromJson(s, ExternalBasicStatsMeta.class);
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    public void setUpdateTime(LocalDateTime updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public void setAnalyzeType(StatsConstants.AnalyzeType analyzeType) {
+        this.type = analyzeType;
+    }
+
+    public void addColumnStatsMeta(ColumnStatsMeta columnStatsMeta) {
+        this.columnStatsMetaMap.put(columnStatsMeta.getColumnName(), columnStatsMeta);
+    }
+
+    public Map<String, ColumnStatsMeta> getColumnStatsMetaMap() {
+        return columnStatsMetaMap;
+    }
+
+    public String getColumnStatsString() {
+        if (MapUtils.isEmpty(columnStatsMetaMap)) {
+            return "";
+        }
+        return columnStatsMetaMap.values().stream()
+                .map(ColumnStatsMeta::simpleString).collect(Collectors.joining(","));
+    }
+
+    public ExternalBasicStatsMeta clone() {
+        String json = GsonUtils.GSON.toJson(this);
+        return GsonUtils.GSON.fromJson(json, ExternalBasicStatsMeta.class);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
```
analyze full table tbl(col1);
analyze full table tbl(col2);
```
the second analyze statement 's **stats meta** would override the first statement
use **`show stats meta`**  will only show the second stats meta

## What I'm doing:
add column stats map inside the ExternalBasicStatsMeta to record the incremental analyzed columns

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
