### PR TITLE
[BugFix] informationschema.task_runs timezone fix

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
@@ -51,6 +51,7 @@ import org.apache.logging.log4j.util.Strings;
 import org.apache.thrift.meta_data.FieldValueMetaData;
 import org.apache.thrift.protocol.TType;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -162,7 +163,7 @@ public class TaskRunsSystemTable extends SystemTable {
         }
         // From timestamp to DATETIME
         if (value.getType().isBigint() && schemaType.isDatetime()) {
-            return ConstantOperator.createDatetime(DateUtils.fromEpochMillis(value.getBigint() * 1000));
+            return ConstantOperator.createDatetime(DateUtils.fromEpochMillis(value.getBigint() * 1000, ZoneId.systemDefault()));
         }
         return value.castTo(schemaType)
                 .orElseThrow(() -> new NotImplementedException(String.format("unsupported type cast from %s to %s",

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -28,7 +28,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -118,8 +117,8 @@ public class DateUtils {
         return dateTime.format(DATE_TIME_FORMATTER_UNIX);
     }
 
-    public static LocalDateTime fromEpochMillis(long epochMilli) {
-        return LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMilli), ZoneOffset.UTC);
+    public static LocalDateTime fromEpochMillis(long epochMilli, ZoneId zoneId) {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMilli), zoneId);
     }
 
     public static LocalDateTime parseUnixDateTime(String str) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeFileRecord.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeFileRecord.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.util.Strings;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -96,7 +97,7 @@ public class PipeFileRecord {
         } else {
             record.fileVersion = String.valueOf(file.getModificationTime());
         }
-        record.lastModified = DateUtils.fromEpochMillis(file.getModificationTime());
+        record.lastModified = DateUtils.fromEpochMillis(file.getModificationTime(), ZoneOffset.UTC);
         record.stagedTime = LocalDateTime.now();
         record.loadState = FileListRepo.PipeFileState.UNLOADED;
         return record;

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -43,9 +43,12 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 public class InformationSchemaDataSourceTest {
 
@@ -296,6 +299,14 @@ public class InformationSchemaDataSourceTest {
         Assert.assertEquals("1", props.get("replication_num"));
     }
 
+    public static ZoneOffset offset(ZoneId id) {
+        return ZoneOffset.ofTotalSeconds((int) 
+            TimeUnit.MILLISECONDS.toSeconds(
+                TimeZone.getTimeZone(id).getRawOffset()        // Returns offset in milliseconds 
+            )
+        );
+    }
+
     @Test
     public void testTaskRunsEvaluation() throws Exception {
         starRocksAssert.withDatabase("d1").useDatabase("d1");
@@ -306,10 +317,12 @@ public class InformationSchemaDataSourceTest {
         taskRun.setTaskName("t_1024");
         taskRun.setState(Constants.TaskRunState.SUCCESS);
         taskRun.setDbName("d1");
-        taskRun.setCreateTime(DateUtils.parseDatTimeString("2024-01-02 03:04:05").toEpochSecond(ZoneOffset.UTC) * 1000);
-        taskRun.setProcessStartTime(
-                DateUtils.parseDatTimeString("2024-01-02 03:04:05").toEpochSecond(ZoneOffset.UTC) * 1000);
-        taskRun.setFinishTime(DateUtils.parseDatTimeString("2024-01-02 03:04:05").toEpochSecond(ZoneOffset.UTC) * 1000);
+        taskRun.setCreateTime(DateUtils.parseDatTimeString("2024-01-02 03:04:05")
+                .toEpochSecond(offset(ZoneId.systemDefault())) * 1000);
+        taskRun.setFinishTime(DateUtils.parseDatTimeString("2024-01-02 03:04:05")
+                .toEpochSecond(offset(ZoneId.systemDefault())) * 1000);
+        taskRun.setExpireTime(DateUtils.parseDatTimeString("2024-01-02 03:04:05")
+                .toEpochSecond(offset(ZoneId.systemDefault())) * 1000);
         new MockUp<TaskManager>() {
             @Mock
             public List<TaskRunStatus> getMatchedTaskRunStatus(TGetTasksParams params) {
@@ -320,7 +333,7 @@ public class InformationSchemaDataSourceTest {
         starRocksAssert.query("select * from information_schema.task_runs where task_name = 't_1024' ")
                 .explainContains("     constant exprs: ",
                         "NULL | 't_1024' | '2024-01-02 03:04:05' | '2024-01-02 03:04:05' | 'SUCCESS' | " +
-                                "NULL | 'd1' | 'insert into t1 select * from t1' | '1970-01-01 00:00:00' | 0 | " +
+                                "NULL | 'd1' | 'insert into t1 select * from t1' | '2024-01-02 03:04:05' | 0 | " +
                                 "NULL | '0%' | '' | NULL");
         starRocksAssert.query("select state, error_message" +
                         " from information_schema.task_runs where task_name = 't_1024' ")


### PR DESCRIPTION
## Why I'm doing:
informationschema.task_runs timezone fix

## What I'm doing:

Fixes #52121 

mysql> SELECT TASK_NAME,CREATE_TIME FROM `information_schema`.`task_runs` WHERE `TASK_NAME` = 'mv-54287' ORDER BY `CREATE_TIME` DESC LIMIT 0,10;
+-----------+---------------------+
| TASK_NAME | CREATE_TIME         |
+-----------+---------------------+
| mv-54287  | 2024-10-20 12:27:10 |
+-----------+---------------------+
1 row in set (0.03 sec)

mysql> SELECT TASK_NAME,CREATE_TIME FROM `information_schema`.`task_runs` WHERE `TASK_NAME` = 'mv-54287' AND `CREATE_TIME` >= '2024-10-19 00:00:00' ORDER BY `CREATE_TIME` DESC LIMIT 0,10;
+-----------+---------------------+
| TASK_NAME | CREATE_TIME         |
+-----------+---------------------+
| mv-54287  | 2024-10-20 12:27:10 |
+-----------+---------------------+
1 row in set (0.04 sec)

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [X] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
