### PR TITLE
[Feature] (batch write part1) Implement the basic workflow on FE side

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3286,4 +3286,12 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = false)
     public static int lake_remove_table_thread_num = 4;
+
+    @ConfField(mutable = true)
+    public static int batch_write_gc_check_interval_ms = 60000;
+
+    @ConfField(mutable = true)
+    public static int batch_write_idle_ms = 3600000;
+
+    public static int batch_write_executor_threads_num = 4096;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/StatusOr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/StatusOr.java
@@ -1,18 +1,20 @@
-// Copyright 2021-present StarRocks, Inc. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package com.starrocks.load.batchwrite;
+package com.starrocks.common;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.thrift.TStatus;

--- a/fe/fe-core/src/main/java/com/starrocks/common/StatusOr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/StatusOr.java
@@ -1,18 +1,16 @@
-/*
- * Copyright 2021-present StarRocks, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package com.starrocks.common;
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -186,7 +186,7 @@ public class LoadAction extends RestBaseAction {
         int index = ThreadLocalRandom.current().nextInt(nodes.size());
         ComputeNode node = nodes.get(index);
         TNetworkAddress redirectAddr = new TNetworkAddress(node.getHost(), node.getHttpPort());
-        LOG.info("redirect batch write to destination={}, db: {}, tbl: {}", redirectAddr.toString(), dbName, tableName);
+        LOG.info("redirect batch write to destination={}, db: {}, tbl: {}", redirectAddr, dbName, tableName);
         redirectTo(request, response, redirectAddr);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -40,6 +40,10 @@ import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.load.batchwrite.RequestCoordinatorBackendResult;
+import com.starrocks.load.batchwrite.TableId;
+import com.starrocks.load.streamload.StreamLoadHttpHeader;
+import com.starrocks.load.streamload.StreamLoadKvParams;
 import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.qe.ConnectContext;
@@ -59,6 +63,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class LoadAction extends RestBaseAction {
     private static final Logger LOG = LogManager.getLogger(LoadAction.class);
@@ -95,6 +100,12 @@ public class LoadAction extends RestBaseAction {
             throw new DdlException("There is no 100-continue header");
         }
 
+        boolean enableBatchWrite = "true".equalsIgnoreCase(
+                request.getRequest().headers().get(StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE));
+        if (enableBatchWrite && redirectToLeader(request, response)) {
+            return;
+        }
+
         String dbName = request.getSingleParameter(DB_KEY);
         if (Strings.isNullOrEmpty(dbName)) {
             throw new DdlException("No database selected.");
@@ -105,10 +116,19 @@ public class LoadAction extends RestBaseAction {
             throw new DdlException("No table selected.");
         }
 
-        String label = request.getRequest().headers().get(LABEL_KEY);
-
         Authorizer.checkTableAction(ConnectContext.get().getCurrentUserIdentity(), ConnectContext.get().getCurrentRoleIds(),
                 dbName, tableName, PrivilegeType.INSERT);
+
+        if (!enableBatchWrite) {
+            processNormalStreamLoad(request, response, dbName, tableName);
+        } else {
+            processBatchWriteStreamLoad(request, response, dbName, tableName);
+        }
+    }
+
+    private void processNormalStreamLoad(
+            BaseRequest request, BaseResponse response, String dbName, String tableName) throws DdlException {
+        String label = request.getRequest().headers().get(LABEL_KEY);
 
         String warehouseName = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
         if (request.getRequest().headers().contains(WAREHOUSE_KEY)) {
@@ -146,6 +166,35 @@ public class LoadAction extends RestBaseAction {
         LOG.info("redirect load action to destination={}, db: {}, tbl: {}, label: {}, warehouse: {}",
                 redirectAddr.toString(), dbName, tableName, label, warehouseName);
         redirectTo(request, response, redirectAddr);
+    }
+
+    private void processBatchWriteStreamLoad(
+            BaseRequest request, BaseResponse response, String dbName, String tableName) throws DdlException {
+        TableId tableId = new TableId(dbName, tableName);
+        StreamLoadKvParams params = StreamLoadKvParams.fromHttpHeaders(request.getRequest().headers());
+        RequestCoordinatorBackendResult result = GlobalStateMgr.getCurrentState()
+                .getBatchWriteMgr().requestCoordinatorBackends(tableId, params);
+        if (!result.isOk()) {
+            BatchWriteResponseResult responseResult = new BatchWriteResponseResult(
+                    result.getStatus().status_code.name(), ActionStatus.FAILED,
+                    result.getStatus().error_msgs.get(0));
+            sendResult(request, response, responseResult);
+            return;
+        }
+
+        List<ComputeNode> nodes = result.getValue();
+        int index = ThreadLocalRandom.current().nextInt(nodes.size());
+        ComputeNode node = nodes.get(index);
+        TNetworkAddress redirectAddr = new TNetworkAddress(node.getHost(), node.getHttpPort());
+        LOG.info("redirect batch write to destination={}, db: {}, tbl: {}", redirectAddr.toString(), dbName, tableName);
+        redirectTo(request, response, redirectAddr);
+    }
+
+    public static class BatchWriteResponseResult extends RestBaseResult {
+
+        public BatchWriteResponseResult(String code, ActionStatus status, String msg) {
+            super(code, status, msg);
+        }
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseResult.java
@@ -84,6 +84,13 @@ public class RestBaseResult {
         this.message = msg;
     }
 
+    public RestBaseResult(String code, ActionStatus status, String msg) {
+        this.code = code;
+        this.status = status;
+        this.msg = msg;
+        this.message = msg;
+    }
+
     public static RestBaseResult getOk() {
         return OK;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteId.java
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.starrocks.load.streamload.StreamLoadKvParams;
+
+import java.util.Objects;
+
+/**
+ * Represents an identifier for a batch write.
+ */
+public class BatchWriteId {
+
+    /** The ID of the table associated with the batch write. */
+    private final TableId tableId;
+
+    /** The parameters for the stream load associated with the batch write. */
+    private final StreamLoadKvParams params;
+
+
+    public BatchWriteId(TableId tableId, StreamLoadKvParams params) {
+        this.tableId = tableId;
+        this.params = params;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BatchWriteId that = (BatchWriteId) o;
+        return Objects.equals(tableId, that.tableId) && Objects.equals(params, that.params);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableId, params);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
@@ -195,7 +195,7 @@ public class BatchWriteMgr extends FrontendDaemon {
             IsomorphicBatchWrite newLoad = new IsomorphicBatchWrite(
                     id, tableId, warehouseName, streamLoadInfo, batchWriteIntervalMs, batchWriteParallel,
                     params.toMap(), new ConnectContext(), coordinatorBackendAssigner, threadPoolExecutor);
-            coordinatorBackendAssigner.registerBatchWrite(id, newLoad.getWarehouse(), tableId, newLoad.getBatchWriteParallel());
+            coordinatorBackendAssigner.registerBatchWrite(id, newLoad.getWarehouseId(), tableId, newLoad.getBatchWriteParallel());
             return newLoad;
         });
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
@@ -72,7 +72,7 @@ public class BatchWriteMgr extends FrontendDaemon {
     }
 
     @Override
-    public void start() {
+    public synchronized void start() {
         super.start();
         this.coordinatorBackendAssigner.start();
         LOG.info("Start batch write manager");

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
@@ -1,0 +1,218 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
+import com.starrocks.common.ThreadPoolManager;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.load.streamload.StreamLoadInfo;
+import com.starrocks.load.streamload.StreamLoadKvParams;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import org.apache.arrow.util.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+import static com.starrocks.server.WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+
+/**
+ * Manages batch write operations.
+ */
+public class BatchWriteMgr extends FrontendDaemon {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BatchWriteMgr.class);
+
+    // An atomic counter used to generate unique ids for isomorphic batch writes.
+    private final AtomicLong idGenerator;
+
+    // A read-write lock to ensure thread-safe access to the loadMap.
+    private final ReentrantReadWriteLock lock;
+
+    // A concurrent map that stores IsomorphicBatchWrite instances, keyed by BatchWriteId.
+    private final ConcurrentHashMap<BatchWriteId, IsomorphicBatchWrite> isomorphicBatchWriteMap;
+
+    // An assigner that manages the assignment of coordinator backends.
+    private final CoordinatorBackendAssigner coordinatorBackendAssigner;
+
+    // A thread pool executor for executing batch write tasks.
+    private final ThreadPoolExecutor threadPoolExecutor;
+
+    public BatchWriteMgr() {
+        super("group-commit-mgr", Config.batch_write_gc_check_interval_ms);
+        this.idGenerator = new AtomicLong(0L);
+        this.isomorphicBatchWriteMap = new ConcurrentHashMap<>();
+        this.lock = new ReentrantReadWriteLock();
+        this.coordinatorBackendAssigner = new CoordinatorBackendAssignerImpl();
+        this.threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
+                        Config.batch_write_executor_threads_num, "group-commit-load", true);
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        this.coordinatorBackendAssigner.start();
+        LOG.info("Start batch write manager");
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        setInterval(Config.batch_write_gc_check_interval_ms);
+        cleanupInactiveBatchWrite();
+    }
+
+    /**
+     * Requests coordinator backends for the specified table and load parameters.
+     *
+     * @param tableId The ID of the table for which the coordinator backends are requested.
+     * @param params The parameters for the stream load.
+     * @return A RequestCoordinatorBackendResult containing the status of the operation and the coordinator backends.
+     */
+    public RequestCoordinatorBackendResult requestCoordinatorBackends(TableId tableId, StreamLoadKvParams params) {
+        lock.readLock().lock();
+        try {
+            Pair<TStatus, IsomorphicBatchWrite> result = getOrCreateTableBatchWrite(tableId, params);
+            if (result.first.getStatus_code() != TStatusCode.OK) {
+                return new RequestCoordinatorBackendResult(result.first, null);
+            }
+            return result.second.requestCoordinatorBackends();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Requests a load operation for the specified table and load parameters.
+     *
+     * @param tableId The ID of the table for which the load is requested.
+     * @param params The parameters for the stream load.
+     * @param backendId The id of the backend where the request is from.
+     * @param backendHost The host of the backend where the request is from.
+     * @return A RequestLoadResult containing the status of the operation and the load result.
+     */
+    public RequestLoadResult requestLoad(
+            TableId tableId, StreamLoadKvParams params, long backendId, String backendHost) {
+        lock.readLock().lock();
+        try {
+            Pair<TStatus, IsomorphicBatchWrite> result = getOrCreateTableBatchWrite(tableId, params);
+            if (result.first.getStatus_code() != TStatusCode.OK) {
+                return new RequestLoadResult(result.first, null);
+            }
+            return result.second.requestLoad(backendId, backendHost);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Cleans up inactive batch writes to release resources.
+     */
+    @VisibleForTesting
+    void cleanupInactiveBatchWrite() {
+        lock.writeLock().lock();
+        try {
+            List<Map.Entry<BatchWriteId, IsomorphicBatchWrite>> loads = isomorphicBatchWriteMap.entrySet().stream()
+                            .filter(entry -> !entry.getValue().isActive())
+                            .collect(Collectors.toList());
+            for (Map.Entry<BatchWriteId, IsomorphicBatchWrite> entry : loads) {
+                isomorphicBatchWriteMap.remove(entry.getKey());
+                coordinatorBackendAssigner.unregisterBatchWrite(entry.getValue().getId());
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Retrieves or creates an IsomorphicBatchWrite instance for the specified table and parameters.
+     *
+     * @param tableId The ID of the table for which the batch write is requested.
+     * @param params The parameters for the stream load.
+     * @return A Pair containing the status of the operation and the IsomorphicBatchWrite instance.
+     */
+    private Pair<TStatus, IsomorphicBatchWrite> getOrCreateTableBatchWrite(TableId tableId, StreamLoadKvParams params) {
+        BatchWriteId uniqueId = new BatchWriteId(tableId, params);
+        IsomorphicBatchWrite load = isomorphicBatchWriteMap.get(uniqueId);
+        if (load != null) {
+            return new Pair<>(new TStatus(TStatusCode.OK), load);
+        }
+
+        String warehouseName = params.getWarehouse().orElse(DEFAULT_WAREHOUSE_NAME);
+        StreamLoadInfo streamLoadInfo;
+        try {
+            streamLoadInfo = StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), params);
+        } catch (Exception e) {
+            TStatus status = new TStatus();
+            status.setStatus_code(TStatusCode.INVALID_ARGUMENT);
+            status.setError_msgs(Collections.singletonList(
+                    String.format("Failed to build stream load info, error: %s", e.getMessage())));
+            return new Pair<>(status, null);
+        }
+
+        Integer batchWriteIntervalMs = params.getBatchWriteIntervalMs().orElse(null);
+        if (batchWriteIntervalMs == null || batchWriteIntervalMs <= 0) {
+            TStatus status = new TStatus();
+            status.setStatus_code(TStatusCode.INVALID_ARGUMENT);
+            status.setError_msgs(Collections.singletonList(
+                    "Batch write interval must be set positive, but is " + batchWriteIntervalMs));
+            return new Pair<>(status, null);
+        }
+
+        Integer batchWriteParallel = params.getBatchWriteParallel().orElse(null);
+        if (batchWriteParallel == null || batchWriteParallel <= 0) {
+            TStatus status = new TStatus();
+            status.setStatus_code(TStatusCode.INVALID_ARGUMENT);
+            status.setError_msgs(Collections.singletonList(
+                    "Bathc load parallel must be set positive, but is " + batchWriteParallel));
+            return new Pair<>(status, null);
+        }
+
+        load = isomorphicBatchWriteMap.computeIfAbsent(uniqueId, uid -> {
+            long id = idGenerator.getAndIncrement();
+            IsomorphicBatchWrite newLoad = new IsomorphicBatchWrite(
+                    id, tableId, warehouseName, streamLoadInfo, batchWriteIntervalMs, batchWriteParallel,
+                    params.toMap(), new ConnectContext(), coordinatorBackendAssigner, threadPoolExecutor);
+            coordinatorBackendAssigner.registerBatchWrite(id, newLoad.getWarehouse(), tableId, newLoad.getBatchWriteParallel());
+            return newLoad;
+        });
+
+        return new Pair<>(new TStatus(TStatusCode.OK), load);
+    }
+
+    /**
+     * Returns the number of batch writes currently managed.
+     *
+     * @return The number of batch writes.
+     */
+    public int numBatchWrites() {
+        return isomorphicBatchWriteMap.size();
+    }
+
+    @VisibleForTesting
+    Map<BatchWriteId, IsomorphicBatchWrite> getIsomorphicBatchWriteMap() {
+        return isomorphicBatchWriteMap;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssigner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssigner.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.starrocks.system.ComputeNode;
+
+import java.util.List;
+
+/**
+ * Interface for assigning coordinator backends to loads.
+ */
+public interface CoordinatorBackendAssigner {
+
+    /**
+     * Starts the backend assigner.
+     */
+    void start();
+
+    /**
+     * Registers a batch write with the specified parameters.
+     *
+     * @param id The ID of the batch write operation.
+     * @param warehouseName The name of the warehouse.
+     * @param tableId The identifier of the table.
+     * @param expectParallel The expected parallelism.
+     */
+    void registerBatchWrite(long id, String warehouseName, TableId tableId, int expectParallel);
+
+    /**
+     * Unregisters a batch write.
+     *
+     * @param id The ID of the batch write to unregister.
+     */
+    void unregisterBatchWrite(long id);
+
+    /**
+     * Retrieves the list of compute nodes assigned to the batch write.
+     *
+     * @param id The ID of the batch write.
+     * @return A list of compute nodes assigned to the batch write.
+     */
+    List<ComputeNode> getBackends(long id);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssigner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssigner.java
@@ -32,11 +32,11 @@ public interface CoordinatorBackendAssigner {
      * Registers a batch write with the specified parameters.
      *
      * @param id The ID of the batch write operation.
-     * @param warehouseName The name of the warehouse.
+     * @param warehouseId The id of the warehouse.
      * @param tableId The identifier of the table.
      * @param expectParallel The expected parallelism.
      */
-    void registerBatchWrite(long id, String warehouseName, TableId tableId, int expectParallel);
+    void registerBatchWrite(long id, long warehouseId, TableId tableId, int expectParallel);
 
     /**
      * Unregisters a batch write.

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
@@ -23,6 +23,7 @@ public class CoordinatorBackendAssignerImpl implements CoordinatorBackendAssigne
 
     @Override
     public void start() {
+        // TODO implement this method
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
@@ -27,7 +27,7 @@ public class CoordinatorBackendAssignerImpl implements CoordinatorBackendAssigne
     }
 
     @Override
-    public void registerBatchWrite(long id, String warehouseName, TableId tableId, int expectParallel) {
+    public void registerBatchWrite(long id, long warehouseId, TableId tableId, int expectParallel) {
         throw new UnsupportedOperationException("Not implemented");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.starrocks.system.ComputeNode;
+
+import java.util.List;
+
+// TODO implement this class
+public class CoordinatorBackendAssignerImpl implements CoordinatorBackendAssigner {
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void registerBatchWrite(long id, String warehouseName, TableId tableId, int expectParallel) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public void unregisterBatchWrite(long id) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public List<ComputeNode> getBackends(long id) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/IsomorphicBatchWrite.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/IsomorphicBatchWrite.java
@@ -157,14 +157,14 @@ public class IsomorphicBatchWrite implements LoadExecuteCallback {
                 backends = null;
                 LOG.error(errMsg);
             }
-        } catch (Throwable throwable) {
+        } catch (Exception exception) {
             status.setStatus_code(TStatusCode.INTERNAL_ERROR);
             String msg = String.format("Unexpected exception happen when getting backends, db: %s, table: %s, " +
                         "warehouse: %s, load id: %s, error: %s", tableId.getDbName(), tableId.getTableName(),
-                                warehouseName, id, throwable.getMessage());
+                                warehouseName, id, exception.getMessage());
             status.setError_msgs(Collections.singletonList(msg));
             LOG.error("Failed to get backends, db: {}, table: {}, warehouse: {}, load id: {}",
-                    tableId.getDbName(), tableId.getTableName(), warehouseName, id, throwable);
+                    tableId.getDbName(), tableId.getTableName(), warehouseName, id, exception);
         }
         return new RequestCoordinatorBackendResult(status, backends);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/IsomorphicBatchWrite.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/IsomorphicBatchWrite.java
@@ -1,0 +1,268 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.load.streamload.StreamLoadInfo;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TUniqueId;
+import org.apache.arrow.util.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+/**
+ * Responsible for managing batch write operations with the isomorphic parameters.
+ * It will allocate a load for each write operation, and monitor the status of the load.
+ */
+public class IsomorphicBatchWrite implements LoadExecuteCallback {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IsomorphicBatchWrite.class);
+
+    private static final String LABEL_PREFIX = "batch_write_";
+
+    private final long id;
+    private final TableId tableId;
+    private final String warehouseName;
+    private final StreamLoadInfo streamLoadInfo;
+    private final int batchWriteIntervalMs;
+    private final int batchWriteParallel;
+    private final ImmutableMap<String, String> loadParameters;
+    private final ConnectContext connectContext;
+
+    /**
+     * The assigner for coordinator backends.
+     */
+    private final CoordinatorBackendAssigner coordinatorBackendAssigner;
+
+    /**
+     * The executor to run batch write tasks.
+     */
+    private final Executor executor;
+
+    /**
+     * The factory to create query coordinators.
+     */
+    private final Coordinator.Factory queryCoordinatorFactory;
+
+    /**
+     * The lock to manage concurrent access to the load executor map.
+     */
+    private final ReentrantReadWriteLock lock;
+
+    /**
+     * The map to store load executors, keyed by their labels.
+     */
+    private final ConcurrentHashMap<String, LoadExecutor> loadExecutorMap;
+
+    private final AtomicLong lastLoadCreateTimeMs;
+
+    public IsomorphicBatchWrite(
+            long id,
+            TableId tableId,
+            String warehouseName,
+            StreamLoadInfo streamLoadInfo,
+            int batchWriteIntervalMs,
+            int batchWriteParallel,
+            Map<String, String> loadParameters,
+            ConnectContext connectContext,
+            CoordinatorBackendAssigner coordinatorBackendAssigner,
+            Executor executor) {
+        this.id = id;
+        this.tableId = tableId;
+        this.warehouseName = warehouseName;
+        this.streamLoadInfo = streamLoadInfo;
+        this.batchWriteIntervalMs = batchWriteIntervalMs;
+        this.batchWriteParallel = batchWriteParallel;
+        this.loadParameters = ImmutableMap.<String, String>builder().putAll(loadParameters).build();
+        this.connectContext = connectContext;
+        this.coordinatorBackendAssigner = coordinatorBackendAssigner;
+        this.executor = executor;
+        this.queryCoordinatorFactory = new DefaultCoordinator.Factory();
+        this.loadExecutorMap = new ConcurrentHashMap<>();
+        this.lock = new ReentrantReadWriteLock();
+        this.lastLoadCreateTimeMs = new AtomicLong(System.currentTimeMillis());
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public TableId getTableId() {
+        return tableId;
+    }
+
+    public String getWarehouse() {
+        return warehouseName;
+    }
+
+    public int getBatchWriteParallel() {
+        return batchWriteParallel;
+    }
+
+    public int numRunningLoads() {
+        return loadExecutorMap.size();
+    }
+
+    /**
+     * Requests coordinator backends for the batch write operation.
+     * The backend can accept write operations for the specified table.
+     *
+     * @return The result of the request for coordinator backends.
+     */
+    public RequestCoordinatorBackendResult requestCoordinatorBackends() {
+        TStatus status = new TStatus();
+        List<ComputeNode> backends = null;
+        try {
+            backends = coordinatorBackendAssigner.getBackends(id);
+            if (!backends.isEmpty()) {
+                status.setStatus_code(TStatusCode.OK);
+            } else {
+                status.setStatus_code(TStatusCode.SERVICE_UNAVAILABLE);
+                String errMsg = String.format(
+                        "Can't find available backends, db: %s, table: %s, warehouse: %s, load id: %s",
+                        tableId.getDbName(), tableId.getTableName(), warehouseName, id);
+                status.setError_msgs(Collections.singletonList(errMsg));
+                backends = null;
+                LOG.error(errMsg);
+            }
+        } catch (Throwable throwable) {
+            status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+            String msg = String.format("Unexpected exception happen when getting backends, db: %s, table: %s, " +
+                        "warehouse: %s, load id: %s, error: %s", tableId.getDbName(), tableId.getTableName(),
+                                warehouseName, id, throwable.getMessage());
+            status.setError_msgs(Collections.singletonList(msg));
+            LOG.error("Failed to get backends, db: {}, table: {}, warehouse: {}, load id: {}",
+                    tableId.getDbName(), tableId.getTableName(), warehouseName, id, throwable);
+        }
+        return new RequestCoordinatorBackendResult(status, backends);
+    }
+
+    /**
+     * Requests a load for the write operation from the specified backend.
+     *
+     * @param backendId The id of the backend.
+     * @param backendHost The host of the backend.
+     * @return The result of the request for the load.
+     */
+    public RequestLoadResult requestLoad(long backendId, String backendHost) {
+        TStatus status = new TStatus();
+        lock.readLock().lock();
+        try {
+            for (LoadExecutor loadExecutor : loadExecutorMap.values()) {
+                if (loadExecutor.isActive() && loadExecutor.containCoordinatorBackend(backendId)) {
+                    status.setStatus_code(TStatusCode.OK);
+                    return new RequestLoadResult(status, loadExecutor.getLabel());
+                }
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        lock.writeLock().lock();
+        try {
+            for (LoadExecutor loadExecutor : loadExecutorMap.values()) {
+                if (loadExecutor.isActive() && loadExecutor.containCoordinatorBackend(backendId)) {
+                    status.setStatus_code(TStatusCode.OK);
+                    return new RequestLoadResult(status, loadExecutor.getLabel());
+                }
+            }
+
+            RequestCoordinatorBackendResult requestCoordinatorBackendResult = requestCoordinatorBackends();
+            if (!requestCoordinatorBackendResult.isOk()) {
+                return new RequestLoadResult(requestCoordinatorBackendResult.getStatus(), null);
+            }
+
+            Set<Long> backendIds = requestCoordinatorBackendResult.getValue().stream()
+                    .map(ComputeNode::getId).collect(Collectors.toSet());
+            if (!backendIds.contains(backendId)) {
+                ComputeNode backend = GlobalStateMgr.getCurrentState()
+                        .getNodeMgr().getClusterInfo().getBackendOrComputeNode(backendId);
+                if (backend == null || !backend.isAvailable()) {
+                    status.setStatus_code(TStatusCode.SERVICE_UNAVAILABLE);
+                    status.setError_msgs(Collections.singletonList(
+                            String.format("Backend [%s, %s] is not available", backendId, backendHost)));
+                    return new RequestLoadResult(status, null);
+                }
+                backendIds.add(backendId);
+            }
+
+            String label = LABEL_PREFIX + DebugUtil.printId(UUIDUtil.toTUniqueId(UUID.randomUUID()));
+            TUniqueId loadId = UUIDUtil.toTUniqueId(UUID.randomUUID());
+            LoadExecutor loadExecutor = new LoadExecutor(
+                    tableId, label, loadId, streamLoadInfo, batchWriteIntervalMs, loadParameters,
+                    connectContext, backendIds, queryCoordinatorFactory, this);
+            loadExecutorMap.put(label, loadExecutor);
+            try {
+                executor.execute(loadExecutor);
+            } catch (Exception e) {
+                loadExecutorMap.remove(label);
+                status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+                status.setError_msgs(Collections.singletonList(e.getMessage()));
+                return new RequestLoadResult(status, null);
+            }
+            status.setStatus_code(TStatusCode.OK);
+            lastLoadCreateTimeMs.set(System.currentTimeMillis());
+            return new RequestLoadResult(status, label);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Checks if the batch write operation is active.
+     *
+     * @return true if there are active load executors or the idle time is less than
+     *                  the configured threshold, false otherwise.
+     */
+    public boolean isActive() {
+        long idleTime = System.currentTimeMillis() - lastLoadCreateTimeMs.get();
+        return !loadExecutorMap.isEmpty() || idleTime < Config.batch_write_idle_ms;
+    }
+
+    @Override
+    public void finishLoad(String label) {
+        lock.writeLock().lock();
+        try {
+            loadExecutorMap.remove(label);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    @VisibleForTesting
+    LoadExecutor getLoadExecutor(String label) {
+        return loadExecutorMap.get(label);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/IsomorphicBatchWrite.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/IsomorphicBatchWrite.java
@@ -123,8 +123,8 @@ public class IsomorphicBatchWrite implements LoadExecuteCallback {
         return tableId;
     }
 
-    public String getWarehouse() {
-        return warehouseName;
+    public long getWarehouseId() {
+        return streamLoadInfo.getWarehouseId();
     }
 
     public int getBatchWriteParallel() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/LoadExecuteCallback.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/LoadExecuteCallback.java
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+/**
+ * Callback interface for load execution.
+ */
+public interface LoadExecuteCallback {
+
+    /**
+     * Called when the load operation is finished.
+     *
+     * @param label The label associated with the load operation.
+     */
+    void finishLoad(String label);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/LoadExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/LoadExecutor.java
@@ -23,8 +23,6 @@ import com.starrocks.common.LoadException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.DebugUtil;
-import com.starrocks.common.util.concurrent.lock.LockType;
-import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QeProcessorImpl;
@@ -227,15 +225,7 @@ public class LoadExecutor implements Runnable {
             throw new LoadException(String.format("Database %s does not exist", tableId.getDbName()));
         }
 
-        Table table;
-        Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
-        try {
-            table = GlobalStateMgr.getCurrentState()
-                    .getLocalMetastore().getTable(db.getFullName(), tableId.getTableName());
-        } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
-        }
+        Table table = db.getTable(tableId.getTableName());
         if (table == null) {
             throw new LoadException(String.format(
                     "Table [%s.%s] does not exist", tableId.getDbName(), tableId.getTableName()));

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/LoadExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/LoadExecutor.java
@@ -1,0 +1,276 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.LoadException;
+import com.starrocks.common.Pair;
+import com.starrocks.common.Status;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.load.streamload.StreamLoadInfo;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QeProcessorImpl;
+import com.starrocks.qe.scheduler.Coordinator;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.LoadPlanner;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
+import com.starrocks.transaction.TransactionState;
+import org.apache.arrow.util.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Responsible for executing a load.
+ */
+public class LoadExecutor implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LoadExecutor.class);
+
+    // Initialized in constructor ==================================
+    private final TableId tableId;
+    private final String label;
+    private final TUniqueId loadId;
+    private final StreamLoadInfo streamLoadInfo;
+    private final ImmutableMap<String, String> loadParameters;
+    private final ConnectContext connectContext;
+    private final Set<Long> coordinatorBackendIds;
+    private final int batchWriteIntervalMs;
+    private final Coordinator.Factory coordinatorFactory;
+    private final LoadExecuteCallback loadExecuteCallback;
+    private final TimeTrace timeTrace;
+    private final AtomicReference<Throwable> failure;
+
+    // Initialized in beginTxn() ==================================
+    private long txnId = -1;
+
+    // Initialized in executeLoad() ==================================
+    private Coordinator coordinator;
+    private List<TabletCommitInfo> tabletCommitInfo;
+    private List<TabletFailInfo> tabletFailInfo;
+
+    public LoadExecutor(
+            TableId tableId,
+            String label,
+            TUniqueId loadId,
+            StreamLoadInfo streamLoadInfo,
+            int batchWriteIntervalMs,
+            ImmutableMap<String, String> loadParameters,
+            ConnectContext connectContext,
+            Set<Long> coordinatorBackendIds,
+            Coordinator.Factory coordinatorFactory,
+            LoadExecuteCallback loadExecuteCallback) {
+        this.tableId = tableId;
+        this.label = label;
+        this.loadId = loadId;
+        this.streamLoadInfo = streamLoadInfo;
+        this.batchWriteIntervalMs = batchWriteIntervalMs;
+        this.loadParameters = loadParameters;
+        this.connectContext = connectContext;
+        this.coordinatorBackendIds = coordinatorBackendIds;
+        this.coordinatorFactory = coordinatorFactory;
+        this.loadExecuteCallback = loadExecuteCallback;
+        this.timeTrace = new TimeTrace();
+        this.failure = new AtomicReference<>();
+    }
+
+    @Override
+    public void run() {
+        timeTrace.startRunTsMs.set(System.currentTimeMillis());
+        try {
+            beginTxn();
+            executeLoad();
+            commitAndPublishTxn();
+        } catch (Throwable e) {
+            failure.set(e);
+            abortTxn(e);
+            LOG.error("Failed to execute load, label: {}, load id: {}, txn id: {}",
+                    label, DebugUtil.printId(loadId), txnId, e);
+        } finally {
+            loadExecuteCallback.finishLoad(label);
+            timeTrace.finishTimeMs.set(System.currentTimeMillis());
+        }
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Checks if the given backend id is contained in the coordinator backend IDs.
+     */
+    public boolean containCoordinatorBackend(long backendId) {
+        return coordinatorBackendIds.contains(backendId);
+    }
+
+    /**
+     * Checks if this batch is active and can accept new load requests.
+     */
+    public boolean isActive() {
+        if (failure.get() != null) {
+            return false;
+        }
+        long joinPlanTimeMs = timeTrace.joinPlanTimeMs.get();
+        return joinPlanTimeMs <= 0 || (System.currentTimeMillis() - joinPlanTimeMs < batchWriteIntervalMs);
+    }
+
+    public Throwable getFailure() {
+        return failure.get();
+    }
+
+    private void beginTxn() throws Exception {
+        timeTrace.beginTxnTsMs.set(System.currentTimeMillis());
+        Pair<Database, OlapTable> pair = getDbAndTable();
+        txnId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
+                pair.first.getId(), Lists.newArrayList(pair.second.getId()), label,
+                TransactionState.TxnCoordinator.fromThisFE(),
+                TransactionState.LoadJobSourceType.FRONTEND_STREAMING,
+                streamLoadInfo.getTimeout(), streamLoadInfo.getWarehouseId());
+    }
+
+    private void commitAndPublishTxn() throws Exception {
+        timeTrace.commitTxnTimeMs.set(System.currentTimeMillis());
+        Pair<Database, OlapTable> pair = getDbAndTable();
+        long publishTimeoutMs =
+                streamLoadInfo.getTimeout() * 1000L - (timeTrace.commitTxnTimeMs.get() - timeTrace.createTimeMs.get());
+        boolean publishSuccess = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().commitAndPublishTransaction(
+                pair.first, txnId, tabletCommitInfo, tabletFailInfo, publishTimeoutMs, null);
+        if (!publishSuccess) {
+            throw new LoadException(String.format(
+                    "Publish timeout, total timeout time: %s ms, publish timeout time: %s ms",
+                        streamLoadInfo.getTimeout() * 1000, publishTimeoutMs));
+        }
+    }
+
+    private void abortTxn(Throwable reason) {
+        if (txnId == -1) {
+            return;
+        }
+        try {
+            Pair<Database, OlapTable> pair = getDbAndTable();
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
+                    pair.first.getId(), txnId, reason == null ? "" : reason.getMessage());
+        } catch (Exception e) {
+            LOG.error("Failed to abort transaction {}", txnId, e);
+        }
+    }
+
+    private void executeLoad() throws Exception {
+        timeTrace.executePlanTimeMs.set(System.currentTimeMillis());
+        try {
+            Pair<Database, OlapTable> pair = getDbAndTable();
+            timeTrace.buildPlanTimeMs.set(System.currentTimeMillis());
+            LoadPlanner loadPlanner = new LoadPlanner(-1, loadId, txnId, pair.first.getId(),
+                    tableId.getDbName(), pair.second, streamLoadInfo.isStrictMode(), streamLoadInfo.getTimezone(),
+                    streamLoadInfo.isPartialUpdate(), connectContext, null,
+                    streamLoadInfo.getLoadMemLimit(), streamLoadInfo.getExecMemLimit(),
+                    streamLoadInfo.getNegative(), coordinatorBackendIds.size(), streamLoadInfo.getColumnExprDescs(),
+                    streamLoadInfo, label, streamLoadInfo.getTimeout());
+            loadPlanner.setWarehouseId(streamLoadInfo.getWarehouseId());
+            loadPlanner.setBatchWrite(batchWriteIntervalMs, loadParameters, coordinatorBackendIds);
+            loadPlanner.plan();
+
+            coordinator = coordinatorFactory.createStreamLoadScheduler(loadPlanner);
+            QeProcessorImpl.INSTANCE.registerQuery(loadId, coordinator);
+            timeTrace.executePlanTimeMs.set(System.currentTimeMillis());
+            coordinator.exec();
+
+            timeTrace.joinPlanTimeMs.set(System.currentTimeMillis());
+            int waitSecond = streamLoadInfo.getTimeout() -
+                    (int) (System.currentTimeMillis() - timeTrace.createTimeMs.get()) / 1000;
+            if (coordinator.join(waitSecond)) {
+                Status status = coordinator.getExecStatus();
+                if (!status.ok()) {
+                    throw new LoadException(
+                            String.format("Failed to execute load, status code: %s, error message: %s",
+                                    status.getErrorCodeString(), status.getErrorMsg()));
+                }
+                tabletCommitInfo = TabletCommitInfo.fromThrift(coordinator.getCommitInfos());
+                tabletFailInfo = TabletFailInfo.fromThrift(coordinator.getFailInfos());
+            } else {
+                throw new LoadException(
+                        String.format("Timeout to execute load after waiting for %s seconds", waitSecond));
+            }
+        } finally {
+            QeProcessorImpl.INSTANCE.unregisterQuery(loadId);
+        }
+    }
+
+    private Pair<Database, OlapTable> getDbAndTable() throws Exception {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        Database db = globalStateMgr.getLocalMetastore().getDb(tableId.getDbName());
+        if (db == null) {
+            throw new LoadException(String.format("Database %s does not exist", tableId.getDbName()));
+        }
+
+        Table table;
+        Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.READ);
+        try {
+            table = GlobalStateMgr.getCurrentState()
+                    .getLocalMetastore().getTable(db.getFullName(), tableId.getTableName());
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.READ);
+        }
+        if (table == null) {
+            throw new LoadException(String.format(
+                    "Table [%s.%s] does not exist", tableId.getDbName(), tableId.getTableName()));
+        }
+        return Pair.create(db, (OlapTable) table);
+    }
+
+    @VisibleForTesting
+    Set<Long> getCoordinatorBackendIds() {
+        return coordinatorBackendIds;
+    }
+
+    @VisibleForTesting
+    Coordinator getCoordinator() {
+        return coordinator;
+    }
+
+    @VisibleForTesting
+    TimeTrace getTimeTrace() {
+        return timeTrace;
+    }
+
+    // Trace the timing of various stages of the load operation.
+    static class TimeTrace {
+        AtomicLong createTimeMs;
+        AtomicLong startRunTsMs = new AtomicLong(-1);
+        AtomicLong beginTxnTsMs = new AtomicLong(-1);
+        AtomicLong buildPlanTimeMs = new AtomicLong(-1);
+        AtomicLong executePlanTimeMs = new AtomicLong(-1);
+        AtomicLong joinPlanTimeMs = new AtomicLong(-1);
+        AtomicLong commitTxnTimeMs = new AtomicLong(-1);
+        AtomicLong finishTimeMs = new AtomicLong(-1);
+
+        public TimeTrace() {
+            this.createTimeMs = new AtomicLong(System.currentTimeMillis());
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/LoadExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/LoadExecutor.java
@@ -105,7 +105,7 @@ public class LoadExecutor implements Runnable {
             beginTxn();
             executeLoad();
             commitAndPublishTxn();
-        } catch (Throwable e) {
+        } catch (Exception e) {
             failure.set(e);
             abortTxn(e);
             LOG.error("Failed to execute load, label: {}, load id: {}, txn id: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/RequestCoordinatorBackendResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/RequestCoordinatorBackendResult.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.load.batchwrite;
 
+import com.starrocks.common.StatusOr;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TStatus;
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/RequestCoordinatorBackendResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/RequestCoordinatorBackendResult.java
@@ -1,0 +1,31 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TStatus;
+
+import java.util.List;
+
+/**
+ * Represents the result of a request for coordinator backends.
+ * The value is a list of compute nodes that can accept write.
+ */
+public class RequestCoordinatorBackendResult extends StatusOr<List<ComputeNode>> {
+
+    public RequestCoordinatorBackendResult(TStatus status, List<ComputeNode> result) {
+        super(status, result);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/RequestLoadResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/RequestLoadResult.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.load.batchwrite;
 
+import com.starrocks.common.StatusOr;
 import com.starrocks.thrift.TStatus;
 
 /**

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/RequestLoadResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/RequestLoadResult.java
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.starrocks.thrift.TStatus;
+
+/**
+ * Represents the result of a load request. The value is a label
+ * that can be used to track the load.
+ */
+public class RequestLoadResult extends StatusOr<String> {
+
+    public RequestLoadResult(TStatus status, String label) {
+        super(status, label);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/StatusOr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/StatusOr.java
@@ -29,7 +29,7 @@ public abstract class StatusOr<T> {
     protected final TStatus status;
     protected final T value;
 
-    public StatusOr(TStatus status, T value) {
+    protected StatusOr(TStatus status, T value) {
         Preconditions.checkArgument((
                 status.status_code == TStatusCode.OK && value != null)
                 || (status.status_code != TStatusCode.OK && value == null));

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/StatusOr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/StatusOr.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+
+/**
+ * Abstract class representing a status or a value.
+ * The value is only present if the status is OK.
+ *
+ * @param <T> The type of the value.
+ */
+public abstract class StatusOr<T> {
+
+    protected final TStatus status;
+    protected final T value;
+
+    public StatusOr(TStatus status, T value) {
+        Preconditions.checkArgument((
+                status.status_code == TStatusCode.OK && value != null)
+                || (status.status_code != TStatusCode.OK && value == null));
+        this.status = status;
+        this.value = value;
+    }
+
+    public boolean isOk() {
+        return status.status_code.equals(TStatusCode.OK);
+    }
+
+    public TStatus getStatus() {
+        return status;
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/TableId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/TableId.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import java.util.Objects;
+
+/**
+ * Represents an identifier for a table in the database.
+ */
+public class TableId {
+
+    /** The name of the database. */
+    private final String dbName;
+
+    /** The name of the table. */
+    private final String tableName;
+
+    public TableId(String dbName, String tableName) {
+        this.dbName = dbName;
+        this.tableName = tableName;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TableId tableId = (TableId) o;
+        return Objects.equals(dbName, tableId.dbName) && Objects.equals(tableName, tableId.tableName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dbName, tableName);
+    }
+
+    @Override
+    public String toString() {
+        return "TableId{" +
+                "dbName='" + dbName + '\'' +
+                ", tableName='" + tableName + '\'' +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadHttpHeader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadHttpHeader.java
@@ -16,6 +16,8 @@ package com.starrocks.load.streamload;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.starrocks.http.rest.RestBaseAction.WAREHOUSE_KEY;
+
 /**
  * Http header names for stream load. They should be consistent
  * with those in http_common.h
@@ -41,6 +43,7 @@ public class StreamLoadHttpHeader {
     public static final String HTTP_MERGE_CONDITION = "merge_condition";
     public static final String HTTP_LOG_REJECTED_RECORD_NUM = "log_rejected_record_num";
     public static final String HTTP_COMPRESSION = "compression";
+    public static final String HTTP_WAREHOUSE = WAREHOUSE_KEY;
 
     // Headers for csv format ============================
     public static final String HTTP_COLUMN_SEPARATOR = "column_separator";
@@ -55,13 +58,20 @@ public class StreamLoadHttpHeader {
     public static final String HTTP_JSONROOT = "json_root";
     public static final String HTTP_STRIP_OUTER_ARRAY = "strip_outer_array";
 
+    // Headers for batch write ==========================
+    public static final String HTTP_ENABLE_BATCH_WRITE = "enable_batch_write";
+    public static final String HTTP_BATCH_WRITE_ASYNC = "batch_write_async";
+    public static final String HTTP_BATCH_WRITE_INTERVAL_MS = "batch_write_interval_ms";
+    public static final String HTTP_BATCH_WRITE_PARALLEL = "batch_write_parallel";
+
     // A list of all headers. If add a new header, should also add it to the list.
     public static final List<String> HTTP_HEADER_LIST = Arrays.asList(
-            HTTP_FORMAT, HTTP_COLUMNS, HTTP_WHERE, HTTP_COLUMN_SEPARATOR, HTTP_ROW_DELIMITER,
-            HTTP_SKIP_HEADER, HTTP_TRIM_SPACE, HTTP_ENCLOSE, HTTP_ESCAPE, HTTP_MAX_FILTER_RATIO,
-            HTTP_TIMEOUT, HTTP_PARTITIONS, HTTP_TEMP_PARTITIONS, HTTP_NEGATIVE, HTTP_STRICT_MODE,
-            HTTP_TIMEZONE, HTTP_LOAD_MEM_LIMIT, HTTP_JSONPATHS, HTTP_JSONROOT, HTTP_STRIP_OUTER_ARRAY,
-            HTTP_PARTIAL_UPDATE, HTTP_PARTIAL_UPDATE_MODE, HTTP_TRANSMISSION_COMPRESSION_TYPE, HTTP_LOAD_DOP,
-            HTTP_ENABLE_REPLICATED_STORAGE, HTTP_MERGE_CONDITION, HTTP_LOG_REJECTED_RECORD_NUM, HTTP_COMPRESSION
+            HTTP_FORMAT, HTTP_COLUMNS, HTTP_WHERE, HTTP_COLUMN_SEPARATOR, HTTP_ROW_DELIMITER, HTTP_SKIP_HEADER,
+            HTTP_TRIM_SPACE, HTTP_ENCLOSE, HTTP_ESCAPE, HTTP_MAX_FILTER_RATIO, HTTP_TIMEOUT, HTTP_PARTITIONS,
+            HTTP_TEMP_PARTITIONS, HTTP_NEGATIVE, HTTP_STRICT_MODE, HTTP_TIMEZONE, HTTP_LOAD_MEM_LIMIT,
+            HTTP_JSONPATHS, HTTP_JSONROOT, HTTP_STRIP_OUTER_ARRAY, HTTP_PARTIAL_UPDATE, HTTP_PARTIAL_UPDATE_MODE,
+            HTTP_TRANSMISSION_COMPRESSION_TYPE, HTTP_LOAD_DOP, HTTP_ENABLE_REPLICATED_STORAGE, HTTP_MERGE_CONDITION,
+            HTTP_LOG_REJECTED_RECORD_NUM, HTTP_COMPRESSION, HTTP_WAREHOUSE, HTTP_ENABLE_BATCH_WRITE,
+            HTTP_BATCH_WRITE_ASYNC, HTTP_BATCH_WRITE_INTERVAL_MS, HTTP_BATCH_WRITE_PARALLEL
     );
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -48,6 +48,8 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Optional;
 
+import static com.starrocks.server.WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+
 public class StreamLoadInfo {
 
     private static final Logger LOG = LogManager.getLogger(StreamLoadInfo.class);
@@ -100,7 +102,7 @@ public class StreamLoadInfo {
         this.stripOuterArray = false;
     }
 
-    public StreamLoadInfo(TUniqueId id, long txnId, TFileType fileType, TFileFormatType formatType, int timeout) {
+    public StreamLoadInfo(TUniqueId id, long txnId, TFileType fileType, TFileFormatType formatType, Optional<Integer> timeout) {
         this.id = id;
         this.txnId = txnId;
         this.fileType = fileType;
@@ -108,7 +110,7 @@ public class StreamLoadInfo {
         this.jsonPaths = "";
         this.jsonRoot = "";
         this.stripOuterArray = false;
-        this.timeout = timeout;
+        timeout.ifPresent(integer -> this.timeout = integer);
     }
 
     public String getConfluentSchemaRegistryUrl() {
@@ -271,12 +273,19 @@ public class StreamLoadInfo {
         return warehouseId;
     }
 
-    public static StreamLoadInfo fromHttpStreamLoadRequest(TUniqueId id, long txnId, int timeout, StreamLoadKvParams params)
+    public static StreamLoadInfo fromHttpStreamLoadRequest(
+            TUniqueId id, long txnId, Optional<Integer> timeout, StreamLoadKvParams params)
             throws UserException {
         StreamLoadInfo streamLoadInfo = new StreamLoadInfo(id, txnId,
                 params.getFileType().orElse(TFileType.FILE_STREAM),
                 params.getFileFormatType().orElse(TFileFormatType.FORMAT_CSV_PLAIN), timeout);
         streamLoadInfo.setOptionalFromStreamLoad(params);
+        String warehouseName = params.getWarehouse().orElse(DEFAULT_WAREHOUSE_NAME);
+        Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(warehouseName);
+        if (warehouse == null) {
+            throw new UserException(String.format("Warehouse [%s] does not exist", warehouseName));
+        }
+        streamLoadInfo.setWarehouseId(warehouse.getId());
         return streamLoadInfo;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -79,6 +79,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -767,7 +768,8 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
 
     public void unprotectedExecute(HttpHeaders headers) throws UserException {
         streamLoadParams = StreamLoadKvParams.fromHttpHeaders(headers);
-        streamLoadInfo = StreamLoadInfo.fromHttpStreamLoadRequest(loadId, txnId, (int) timeoutMs / 1000, streamLoadParams);
+        streamLoadInfo = StreamLoadInfo.fromHttpStreamLoadRequest(
+                loadId, txnId, Optional.of((int) timeoutMs / 1000), streamLoadParams);
         if (table == null) {
             getTable();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -141,6 +141,7 @@ import com.starrocks.load.ExportChecker;
 import com.starrocks.load.ExportMgr;
 import com.starrocks.load.InsertOverwriteJobMgr;
 import com.starrocks.load.Load;
+import com.starrocks.load.batchwrite.BatchWriteMgr;
 import com.starrocks.load.loadv2.LoadEtlChecker;
 import com.starrocks.load.loadv2.LoadJobScheduler;
 import com.starrocks.load.loadv2.LoadLoadingChecker;
@@ -299,6 +300,7 @@ public class GlobalStateMgr {
     private final LoadMgr loadMgr;
     private final RoutineLoadMgr routineLoadMgr;
     private final StreamLoadMgr streamLoadMgr;
+    private final BatchWriteMgr batchWriteMgr;
     private final ExportMgr exportMgr;
     private final MaterializedViewMgr materializedViewMgr;
 
@@ -631,6 +633,7 @@ public class GlobalStateMgr {
         this.load = new Load();
         this.streamLoadMgr = new StreamLoadMgr();
         this.routineLoadMgr = new RoutineLoadMgr();
+        this.batchWriteMgr = new BatchWriteMgr();
         this.exportMgr = new ExportMgr();
         this.materializedViewMgr = new MaterializedViewMgr();
 
@@ -1369,6 +1372,7 @@ public class GlobalStateMgr {
         // start routine load scheduler
         routineLoadScheduler.start();
         routineLoadTaskScheduler.start();
+        batchWriteMgr.start();
         // start dynamic partition task
         dynamicPartitionScheduler.start();
         // start daemon thread to update db used data quota for db txn manager periodically
@@ -2125,6 +2129,10 @@ public class GlobalStateMgr {
 
     public StreamLoadMgr getStreamLoadMgr() {
         return streamLoadMgr;
+    }
+
+    public BatchWriteMgr getBatchWriteMgr() {
+        return batchWriteMgr;
     }
 
     public RoutineLoadTaskScheduler getRoutineLoadTaskScheduler() {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1722,10 +1722,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             status.setStatus_code(TStatusCode.NOT_AUTHORIZED);
             status.addToError_msgs(authenticationException.getMessage());
             result.setStatus(status);
-        } catch (Throwable throwable) {
+        } catch (Exception exception) {
             TStatus status = new TStatus();
             status.setStatus_code(TStatusCode.INTERNAL_ERROR);
-            status.addToError_msgs(throwable.getMessage());
+            status.addToError_msgs(exception.getMessage());
             result.setStatus(status);
         }
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -104,6 +104,8 @@ import com.starrocks.lake.Utils;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.leader.LeaderImpl;
 import com.starrocks.load.EtlJobType;
+import com.starrocks.load.batchwrite.RequestLoadResult;
+import com.starrocks.load.batchwrite.TableId;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.load.loadv2.LoadMgr;
 import com.starrocks.load.loadv2.ManualLoadTxnCommitAttachment;
@@ -116,6 +118,7 @@ import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
 import com.starrocks.load.routineload.RoutineLoadJob;
 import com.starrocks.load.routineload.RoutineLoadMgr;
 import com.starrocks.load.streamload.StreamLoadInfo;
+import com.starrocks.load.streamload.StreamLoadKvParams;
 import com.starrocks.load.streamload.StreamLoadMgr;
 import com.starrocks.load.streamload.StreamLoadTask;
 import com.starrocks.metric.MetricRepo;
@@ -168,6 +171,8 @@ import com.starrocks.thrift.TAllocateAutoIncrementIdResult;
 import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
+import com.starrocks.thrift.TBatchWriteRequest;
+import com.starrocks.thrift.TBatchWriteResult;
 import com.starrocks.thrift.TBeginRemoteTxnRequest;
 import com.starrocks.thrift.TBeginRemoteTxnResponse;
 import com.starrocks.thrift.TColumnDef;
@@ -1696,6 +1701,34 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         }
+    }
+
+    @Override
+    public TBatchWriteResult requestBatchWrite(TBatchWriteRequest request) throws TException {
+        TBatchWriteResult result = new TBatchWriteResult();
+        try {
+            checkPasswordAndLoadPriv(request.getUser(), request.getPasswd(), request.getDb(),
+                    request.getTbl(), request.getUser_ip());
+            TableId tableId = new TableId(request.getDb(), request.getTbl());
+            StreamLoadKvParams params = new StreamLoadKvParams(request.getParams());
+            RequestLoadResult loadResult = GlobalStateMgr.getCurrentState()
+                    .getBatchWriteMgr().requestLoad(tableId, params, request.getBackend_id(), request.getBackend_host());
+            result.setStatus(loadResult.getStatus());
+            if (loadResult.isOk()) {
+                result.setLabel(loadResult.getValue());
+            }
+        } catch (AuthenticationException authenticationException) {
+            TStatus status = new TStatus();
+            status.setStatus_code(TStatusCode.NOT_AUTHORIZED);
+            status.addToError_msgs(authenticationException.getMessage());
+            result.setStatus(status);
+        } catch (Throwable throwable) {
+            TStatus status = new TStatus();
+            status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs(throwable.getMessage());
+            result.setStatus(status);
+        }
+        return result;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Analyzer;
@@ -74,6 +75,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -135,12 +137,19 @@ public class LoadPlanner {
     private TPartialUpdateMode partialUpdateMode = TPartialUpdateMode.ROW_MODE;
 
     private long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+    private Set<Long> candidateBackendIds = new HashSet<>();
 
     private LoadJob.JSONOptions jsonOptions = new LoadJob.JSONOptions();
 
     private Boolean missAutoIncrementColumn = Boolean.FALSE;
 
     private String mergeConditionStr;
+
+    // Only valid for stream load
+    private boolean enableBatchWrite = false;
+    private int batchWriteIntervalMs;
+    private ImmutableMap<String, String> batchWriteParameters;
+    private Set<Long> batchWriteBackendIds;
 
     public LoadPlanner(long loadJobId, TUniqueId loadId, long txnId, long dbId, OlapTable destTable,
                        boolean strictMode, String timezone, long timeoutS,
@@ -237,6 +246,14 @@ public class LoadPlanner {
 
     public long getWarehouseId() {
         return warehouseId;
+    }
+
+    public void setBatchWrite(
+            int batchWriteIntervalMs, ImmutableMap<String, String> loadParameters, Set<Long> batchWriteBackendIds) {
+        this.enableBatchWrite = true;
+        this.batchWriteIntervalMs = batchWriteIntervalMs;
+        this.batchWriteParameters = loadParameters;
+        this.batchWriteBackendIds = new HashSet<>(batchWriteBackendIds);
     }
 
     public void setPartialUpdateMode(TPartialUpdateMode mode) {
@@ -417,6 +434,9 @@ public class LoadPlanner {
             StreamLoadScanNode streamScanNode = new StreamLoadScanNode(loadId, new PlanNodeId(0), tupleDesc,
                     destTable, streamLoadInfo, dbName, label, parallelInstanceNum, txnId, warehouseId);
             streamScanNode.setNeedAssignBE(true);
+            if (enableBatchWrite) {
+                streamScanNode.setBatchWrite(batchWriteIntervalMs, batchWriteParameters, batchWriteBackendIds);
+            }
             streamScanNode.setUseVectorizedLoad(true);
             streamScanNode.init(analyzer);
             streamScanNode.finalizeStats(analyzer);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -137,7 +137,6 @@ public class LoadPlanner {
     private TPartialUpdateMode partialUpdateMode = TPartialUpdateMode.ROW_MODE;
 
     private long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-    private Set<Long> candidateBackendIds = new HashSet<>();
 
     private LoadJob.JSONOptions jsonOptions = new LoadJob.JSONOptions();
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -1,0 +1,130 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.starrocks.load.batchwrite.BatchWriteMgr;
+import com.starrocks.load.batchwrite.RequestCoordinatorBackendResult;
+import com.starrocks.load.batchwrite.TableId;
+import com.starrocks.load.streamload.StreamLoadKvParams;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import mockit.Mock;
+import mockit.MockUp;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class LoadActionTest extends StarRocksHttpTestCase {
+
+    private OkHttpClient noRedirectClient = new OkHttpClient.Builder()
+            .readTimeout(100, TimeUnit.SECONDS)
+            .followRedirects(false)
+            .build();
+
+    @Test
+    public void testBatchWriteStreamLoadSuccess() throws Exception {
+        Map<String, String> map = new HashMap<>();
+        map.put(HTTP_ENABLE_BATCH_WRITE, "true");
+        Request request = buildRequest(map);
+        List<ComputeNode> computeNodes = new ArrayList<>();
+        List<String> redirectLocations = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            String host = "192.0.0." + i;
+            int httpPort = 8040;
+            computeNodes.add(new ComputeNode(i, host, 9050));
+            computeNodes.get(i - 1).setHttpPort(httpPort);
+            redirectLocations.add(getLoadUrl(host, httpPort));
+        }
+
+        new MockUp<BatchWriteMgr>() {
+            @Mock
+            public RequestCoordinatorBackendResult requestCoordinatorBackends(TableId tableId, StreamLoadKvParams params) {
+                return new RequestCoordinatorBackendResult(new TStatus(TStatusCode.OK), computeNodes);
+            }
+        };
+
+        try (Response response = noRedirectClient.newCall(request).execute()) {
+            assertEquals(307, response.code());
+            String location = response.header("Location");
+            assertTrue(redirectLocations.contains(location));
+        }
+    }
+
+    @Test
+    public void testBatchWriteStreamLoadFailure() throws Exception {
+        Map<String, String> map = new HashMap<>();
+        map.put(HTTP_ENABLE_BATCH_WRITE, "true");
+        Request request = buildRequest(map);
+
+        new MockUp<BatchWriteMgr>() {
+            @Mock
+            public RequestCoordinatorBackendResult requestCoordinatorBackends(TableId tableId, StreamLoadKvParams params) {
+                TStatus status = new TStatus();
+                status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+                status.addToError_msgs("artificial failure");
+                return new RequestCoordinatorBackendResult(status, null);
+            }
+        };
+
+        try (Response response = noRedirectClient.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            Map<String, Object> result = parseResponseBody(response);
+            assertEquals("INTERNAL_ERROR", result.get("code"));
+            assertEquals("FAILED", result.get("status"));
+            assertEquals("artificial failure", result.get("message"));
+            assertEquals("artificial failure", result.get("msg"));
+        }
+    }
+
+    private Request buildRequest(Map<String, String> headers) {
+        Request.Builder builder = new Request.Builder();
+        builder.addHeader("Authorization", rootAuth);
+        builder.addHeader("Expect", "100-continue");
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            builder.addHeader(entry.getKey(), entry.getValue());
+        }
+        builder.put(RequestBody.create(new byte[0]));
+        builder.url(String.format(BASE_URL + "/api/%s/%s/_stream_load", DB_NAME, TABLE_NAME));
+        return builder.build();
+    }
+
+    private String getLoadUrl(String host, int port) {
+        return String.format("http://%s:%d/api/%s/%s/_stream_load", host, port, DB_NAME, TABLE_NAME);
+    }
+
+    private static Map<String, Object> parseResponseBody(Response response) throws IOException {
+        ResponseBody body = response.body();
+        assertNotNull(body);
+        String bodyStr = body.string();
+        return objectMapper.readValue(bodyStr, new TypeReference<>() {});
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -113,7 +113,7 @@ public class LoadActionTest extends StarRocksHttpTestCase {
             builder.addHeader(entry.getKey(), entry.getValue());
         }
         builder.put(RequestBody.create(new byte[0]));
-        builder.url(String.format(BASE_URL + "/api/%s/%s/_stream_load", DB_NAME, TABLE_NAME));
+        builder.url(String.format("%s/api/%s/%s/_stream_load", BASE_URL, DB_NAME, TABLE_NAME));
         return builder.build();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
@@ -188,7 +188,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
         new MockUp<CoordinatorBackendAssignerImpl>() {
 
             @Mock
-            public void registerBatchWrite(long id, String warehouseName, TableId tableId, int expectParallel) {
+            public void registerBatchWrite(long id, long warehouseId, TableId tableId, int expectParallel) {
             }
 
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
@@ -1,0 +1,204 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.starrocks.load.streamload.StreamLoadKvParams;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TStatusCode;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_INTERVAL_MS;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_PARALLEL;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_FORMAT;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_WAREHOUSE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class BatchWriteMgrTest extends BatchWriteTestBase {
+
+    private BatchWriteMgr batchWriteMgr;
+
+    private TableId tableId1;
+    private TableId tableId2;
+    private TableId tableId3;
+    private TableId tableId4;
+
+    @Before
+    public void setup() {
+        batchWriteMgr = new BatchWriteMgr();
+        batchWriteMgr.start();
+
+        tableId1 = new TableId(DB_NAME_1, TABLE_NAME_1_1);
+        tableId2 = new TableId(DB_NAME_1, TABLE_NAME_1_2);
+        tableId3 = new TableId(DB_NAME_2, TABLE_NAME_2_1);
+        tableId4 = new TableId(DB_NAME_2, TABLE_NAME_2_2);
+    }
+
+    @Test
+    public void testRequestBackends() {
+        StreamLoadKvParams params1 = new StreamLoadKvParams(new HashMap<>() {{
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "1000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "1");
+            }});
+        mockCoordinatorBackendAssignerImpl(1);
+        RequestCoordinatorBackendResult result1 =
+                batchWriteMgr.requestCoordinatorBackends(tableId1, params1);
+        assertTrue(result1.isOk());
+        assertEquals(1, result1.getValue().size());
+        assertEquals(1, batchWriteMgr.numBatchWrites());
+
+        StreamLoadKvParams params2 = new StreamLoadKvParams(new HashMap<>() {{
+                put(HTTP_FORMAT, "json");
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "1000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "1");
+            }});
+        RequestCoordinatorBackendResult result2 =
+                batchWriteMgr.requestCoordinatorBackends(tableId1, params2);
+        mockCoordinatorBackendAssignerImpl(1);
+        assertTrue(result2.isOk());
+        assertEquals(1, result2.getValue().size());
+        assertEquals(2, batchWriteMgr.numBatchWrites());
+
+        StreamLoadKvParams params3 = new StreamLoadKvParams(new HashMap<>() {{
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "10000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "4");
+            }});
+        mockCoordinatorBackendAssignerImpl(4);
+        RequestCoordinatorBackendResult result3 =
+                batchWriteMgr.requestCoordinatorBackends(tableId2, params3);
+        assertTrue(result3.isOk());
+        assertEquals(4, result3.getValue().size());
+        assertEquals(3, batchWriteMgr.numBatchWrites());
+
+        StreamLoadKvParams params4 = new StreamLoadKvParams(new HashMap<>() {{
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "10000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "4");
+            }});
+        mockCoordinatorBackendAssignerImpl(4);
+        RequestCoordinatorBackendResult result4 =
+                batchWriteMgr.requestCoordinatorBackends(tableId3, params4);
+        assertTrue(result4.isOk());
+        assertEquals(4, result4.getValue().size());
+        assertEquals(4, batchWriteMgr.numBatchWrites());
+    }
+
+    @Test
+    public void testRequestLoad() {
+        mockCoordinatorBackendAssignerImpl(4);
+        StreamLoadKvParams params = new StreamLoadKvParams(new HashMap<>() {{
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "100000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "4");
+            }});
+        RequestLoadResult result1 = batchWriteMgr.requestLoad(
+                tableId4, params, allNodes.get(0).getId(), allNodes.get(0).getHost());
+        assertTrue(result1.isOk());
+        assertNotNull(result1.getValue());
+        assertEquals(1, batchWriteMgr.numBatchWrites());
+
+        RequestLoadResult result2 = batchWriteMgr.requestLoad(
+                tableId4, params, allNodes.get(0).getId(), allNodes.get(0).getHost());
+        assertTrue(result2.isOk());
+        assertEquals(result1.getValue(), result2.getValue());
+        assertEquals(1, batchWriteMgr.numBatchWrites());
+    }
+
+    @Test
+    public void testCheckParameters() {
+        StreamLoadKvParams params1 = new StreamLoadKvParams(new HashMap<>());
+        RequestCoordinatorBackendResult result1 =
+                batchWriteMgr.requestCoordinatorBackends(tableId1, params1);
+        assertFalse(result1.isOk());
+        assertEquals(TStatusCode.INVALID_ARGUMENT, result1.getStatus().getStatus_code());
+        assertEquals(0, batchWriteMgr.numBatchWrites());
+
+        StreamLoadKvParams params2 = new StreamLoadKvParams(new HashMap<>() {{
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "10000");
+            }});
+        RequestCoordinatorBackendResult result2 =
+                batchWriteMgr.requestCoordinatorBackends(tableId2, params2);
+        assertFalse(result2.isOk());
+        assertEquals(TStatusCode.INVALID_ARGUMENT, result2.getStatus().getStatus_code());
+        assertEquals(0, batchWriteMgr.numBatchWrites());
+
+        StreamLoadKvParams params3 = new StreamLoadKvParams(new HashMap<>() {{
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "10000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "4");
+                put(HTTP_WAREHOUSE, "no_exist");
+            }});
+        RequestCoordinatorBackendResult result3 =
+                batchWriteMgr.requestCoordinatorBackends(tableId3, params3);
+        assertFalse(result3.isOk());
+        assertEquals(TStatusCode.INVALID_ARGUMENT, result3.getStatus().getStatus_code());
+        assertEquals(0, batchWriteMgr.numBatchWrites());
+    }
+
+    @Test
+    public void testCleanupInactiveBatchWrite() {
+        mockCoordinatorBackendAssignerImpl(4);
+        StreamLoadKvParams params1 = new StreamLoadKvParams(new HashMap<>() {{
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "10000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "4");
+            }});
+        RequestCoordinatorBackendResult result1 = batchWriteMgr.requestCoordinatorBackends(tableId1, params1);
+        assertTrue(result1.isOk());
+        assertEquals(1, batchWriteMgr.numBatchWrites());
+
+        StreamLoadKvParams params2 = new StreamLoadKvParams(new HashMap<>() {{
+                put(HTTP_BATCH_WRITE_INTERVAL_MS, "100000");
+                put(HTTP_BATCH_WRITE_PARALLEL, "4");
+            }});
+        RequestLoadResult result2 = batchWriteMgr.requestLoad(
+                tableId4, params2, allNodes.get(0).getId(), allNodes.get(0).getHost());
+        assertTrue(result2.isOk());
+        assertEquals(2, batchWriteMgr.numBatchWrites());
+
+        new MockUp<IsomorphicBatchWrite>() {
+
+            @Mock
+            public boolean isActive() {
+                return false;
+            }
+        };
+        batchWriteMgr.cleanupInactiveBatchWrite();
+        assertEquals(0, batchWriteMgr.numBatchWrites());
+    }
+
+    // TODO remove this mock after CoordinatorBackendAssignerImpl is implemented
+    private void mockCoordinatorBackendAssignerImpl(int numBackends) {
+        new MockUp<CoordinatorBackendAssignerImpl>() {
+
+            @Mock
+            public void registerBatchWrite(long id, String warehouseName, TableId tableId, int expectParallel) {
+            }
+
+            @Mock
+            public void unregisterBatchWrite(long id) {
+            }
+
+            @Mock
+            public List<ComputeNode> getBackends(long id) {
+                return allNodes.subList(0, numBackends);
+            }
+        };
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteTestBase.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.schema.MTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TTabletCommitInfo;
+import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class BatchWriteTestBase {
+
+    protected static final String DB_NAME_1 = "batch_write_load_db_1";
+    protected static final String TABLE_NAME_1_1 = "batch_write_load_tbl_1_1";
+    protected static final String TABLE_NAME_1_2 = "batch_write_load_tbl_1_2";
+    protected static final String DB_NAME_2 = "batch_write_load_db_2";
+    protected static final String TABLE_NAME_2_1 = "batch_write_load_tbl_2_1";
+    protected static final String TABLE_NAME_2_2 = "batch_write_load_tbl_2_2";
+
+    protected static ConnectContext connectContext;
+    protected static StarRocksAssert starRocksAssert;
+    protected static Database DATABASE_1;
+    protected static OlapTable TABLE_1_1;
+    protected static OlapTable TABLE_1_2;
+    protected static Database DATABASE_2;
+    protected static OlapTable TABLE_2_1;
+    protected static OlapTable TABLE_2_2;
+
+    protected static List<ComputeNode> allNodes;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+        UtFrameUtils.addMockBackend(10004);
+        UtFrameUtils.addMockBackend(10005);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase(DB_NAME_1)
+                .useDatabase(DB_NAME_1)
+                .withTable(new MTable(TABLE_NAME_1_1, Arrays.asList("c0 INT", "c1 STRING")))
+                .withTable(new MTable(TABLE_NAME_1_2, Arrays.asList("c0 INT")));
+        starRocksAssert.withDatabase(DB_NAME_2)
+                .useDatabase(DB_NAME_2)
+                .withTable(new MTable(TABLE_NAME_2_1, Arrays.asList("c0 INT", "c1 STRING")))
+                .withTable(new MTable(TABLE_NAME_2_2, Arrays.asList("c0 INT")));
+
+        DATABASE_1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME_1);
+        TABLE_1_1 = (OlapTable) DATABASE_1.getTable(TABLE_NAME_1_1);
+        TABLE_1_2 = (OlapTable) DATABASE_1.getTable(TABLE_NAME_1_2);
+
+        DATABASE_2 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME_2);
+        TABLE_2_1 = (OlapTable) DATABASE_2.getTable(TABLE_NAME_2_1);
+        TABLE_2_2 = (OlapTable) DATABASE_2.getTable(TABLE_NAME_2_2);
+
+        allNodes = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableBackends()
+                .stream().map(node -> (ComputeNode) node).collect(Collectors.toList());
+        Collections.shuffle(allNodes);
+    }
+
+    protected List<TTabletCommitInfo> buildCommitInfos() {
+        List<TTabletCommitInfo> commitInfos = new ArrayList<>();
+        for (Partition partition : TABLE_1_1.getPartitions()) {
+            List<MaterializedIndex> materializedIndices =
+                    partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+            for (MaterializedIndex index : materializedIndices) {
+                for (Tablet tablet : index.getTablets()) {
+                    for (long backendId : tablet.getBackendIds()) {
+                        commitInfos.add(new TTabletCommitInfo(tablet.getId(), backendId));
+                    }
+                }
+            }
+        }
+        return commitInfos;
+    }
+
+    protected TransactionStatus getTxnStatus(String label) {
+        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getLabelStatus(DATABASE_1.getId(), label);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/IsomorphicBatchWriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/IsomorphicBatchWriteTest.java
@@ -274,7 +274,11 @@ public class IsomorphicBatchWriteTest extends BatchWriteTestBase {
             LoadExecutor loadExecutor = (LoadExecutor) runnable;
             Thread thread = new Thread(loadExecutor);
             thread.start();
+            long endTime = System.currentTimeMillis() + 120000;
             while (loadExecutor.getTimeTrace().joinPlanTimeMs.get() <= 0) {
+                if (System.currentTimeMillis() > endTime) {
+                    throw new Exception("Load executor execute plan timeout");
+                }
                 Thread.sleep(10);
             }
             DefaultCoordinator coordinator = (DefaultCoordinator) loadExecutor.getCoordinator();

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/IsomorphicBatchWriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/IsomorphicBatchWriteTest.java
@@ -1,0 +1,304 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.load.loadv2.LoadJob;
+import com.starrocks.load.streamload.StreamLoadHttpHeader;
+import com.starrocks.load.streamload.StreamLoadInfo;
+import com.starrocks.load.streamload.StreamLoadKvParams;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.task.LoadEtlTask;
+import com.starrocks.thrift.FrontendServiceVersion;
+import com.starrocks.thrift.TReportExecStatusParams;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TTabletFailInfo;
+import com.starrocks.transaction.TransactionStatus;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class IsomorphicBatchWriteTest extends BatchWriteTestBase {
+
+    @Mocked
+    private CoordinatorBackendAssigner assigner;
+    private TestThreadPoolExecutor executor;
+    private int parallel;
+
+    private IsomorphicBatchWrite load;
+
+    @Before
+    public void setup() throws Exception {
+        executor = new TestThreadPoolExecutor();
+        parallel = 4;
+        assertTrue("Number nodes " + allNodes.size(), parallel < allNodes.size());
+        Map<String, String> map = new HashMap<>();
+        map.put(StreamLoadHttpHeader.HTTP_FORMAT, "json");
+        map.put(StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE, "true");
+        map.put(StreamLoadHttpHeader.HTTP_BATCH_WRITE_ASYNC, "true");
+        StreamLoadKvParams params = new StreamLoadKvParams(map);
+        StreamLoadInfo streamLoadInfo =
+                StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), params);
+        load = new IsomorphicBatchWrite(
+                1,
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                WarehouseManager.DEFAULT_WAREHOUSE_NAME,
+                streamLoadInfo,
+                1000,
+                parallel,
+                params.toMap(),
+                connectContext,
+                assigner,
+                executor);
+    }
+
+    @Test
+    public void testRequestBackendsSuccess() {
+        List<ComputeNode> nodes = allNodes.subList(0, parallel);
+        new Expectations() {
+            {
+                assigner.getBackends(1);
+                result = nodes;
+            }
+        };
+        RequestCoordinatorBackendResult requestResult = load.requestCoordinatorBackends();
+        assertTrue(requestResult.isOk());
+        assertSame(nodes, requestResult.getValue());
+    }
+
+    @Test
+    public void testRequestBackendsWithEmptyResult() {
+        new Expectations() {
+            {
+                assigner.getBackends(1);
+                result = Collections.emptyList();
+            }
+        };
+        RequestCoordinatorBackendResult requestResult = load.requestCoordinatorBackends();
+        assertFalse(requestResult.isOk());
+        assertEquals(TStatusCode.SERVICE_UNAVAILABLE, requestResult.getStatus().getStatus_code());
+    }
+
+    @Test
+    public void testRequestBackendsWithException() {
+        new Expectations() {
+            {
+                assigner.getBackends(1);
+                result = new Exception("artificial failure");
+            }
+        };
+        RequestCoordinatorBackendResult requestResult = load.requestCoordinatorBackends();
+        assertFalse(requestResult.isOk());
+        assertEquals(TStatusCode.INTERNAL_ERROR, requestResult.getStatus().getStatus_code());
+    }
+
+    @Test
+    public void testRequestLoadFromCoordinatorBackend() throws Exception {
+        List<ComputeNode> nodes = allNodes.subList(0, parallel);
+        new Expectations() {
+            {
+                assigner.getBackends(1);
+                result = nodes;
+            }
+        };
+        RequestLoadResult result1 = load.requestLoad(nodes.get(0).getId(), nodes.get(0).getHost());
+        assertTrue(result1.isOk());
+        String label = result1.getValue();
+        assertNotNull(label);
+        assertEquals(1, load.numRunningLoads());
+        LoadExecutor loadExecutor = load.getLoadExecutor(label);
+        assertNotNull(loadExecutor);
+        assertEquals(nodes.stream().map(ComputeNode::getId).collect(Collectors.toSet()),
+                loadExecutor.getCoordinatorBackendIds());
+
+        RequestLoadResult result2 = load.requestLoad(nodes.get(1).getId(), nodes.get(1).getHost());
+        assertTrue(result2.isOk());
+        assertEquals(label, result2.getValue());
+
+        executor.manualRun(loadExecutor);
+
+        assertEquals(TransactionStatus.VISIBLE, getTxnStatus(label));
+        assertNull(load.getLoadExecutor(label));
+        assertEquals(0, load.numRunningLoads());
+    }
+
+    @Test
+    public void testRequestLoadFromNoneCoordinatorBackend() throws Exception {
+        List<ComputeNode> nodes = allNodes.subList(0, parallel);
+        new Expectations() {
+            {
+                assigner.getBackends(1);
+                result = nodes;
+            }
+        };
+
+        // Request from coordinator backend
+        RequestLoadResult result1 = load.requestLoad(nodes.get(0).getId(), nodes.get(0).getHost());
+        assertTrue(result1.isOk());
+        String label1 = result1.getValue();
+        assertNotNull(label1);
+        assertEquals(1, load.numRunningLoads());
+        LoadExecutor loadExecutor1 = load.getLoadExecutor(label1);
+        assertNotNull(loadExecutor1);
+        assertEquals(nodes.stream().map(ComputeNode::getId).collect(Collectors.toSet()),
+                loadExecutor1.getCoordinatorBackendIds());
+
+        RequestLoadResult result2 = load.requestLoad(allNodes.get(parallel).getId(), allNodes.get(parallel).getHost());
+        assertTrue(result2.isOk());
+        String label2 = result2.getValue();
+        assertNotNull(label2);
+        assertEquals(2, load.numRunningLoads());
+        assertNotEquals(label1, label2);
+        LoadExecutor loadExecutor2 = load.getLoadExecutor(label2);
+        assertNotNull(loadExecutor2);
+        assertNotSame(loadExecutor1, loadExecutor2);
+        Set<Long> expectNodeIds = nodes.stream().map(ComputeNode::getId).collect(Collectors.toSet());
+        expectNodeIds.add(allNodes.get(parallel).getId());
+        assertEquals(expectNodeIds, loadExecutor2.getCoordinatorBackendIds());
+
+        executor.manualRun(loadExecutor1);
+        executor.manualRun(loadExecutor2);
+
+        assertEquals(TransactionStatus.VISIBLE, getTxnStatus(label1));
+        assertEquals(TransactionStatus.VISIBLE, getTxnStatus(label2));
+        assertEquals(0, load.numRunningLoads());
+    }
+
+    @Test
+    public void testRequestLoadFromUnavailableBackend() {
+        List<ComputeNode> nodes = allNodes.subList(0, parallel);
+        new Expectations() {
+            {
+                assigner.getBackends(1);
+                result = nodes;
+            }
+        };
+
+        RequestLoadResult result = load.requestLoad(Integer.MAX_VALUE, "127.0.0.1");
+        assertFalse(result.isOk());
+        assertEquals(TStatusCode.SERVICE_UNAVAILABLE, result.getStatus().getStatus_code());
+    }
+
+    @Test
+    public void testExecuteLoadFail() {
+        List<ComputeNode> nodes = allNodes.subList(0, parallel);
+        new Expectations() {
+            {
+                assigner.getBackends(1);
+                result = nodes;
+            }
+        };
+
+        executor.setThrowException(true);
+        RequestLoadResult result = load.requestLoad(nodes.get(0).getId(), nodes.get(0).getHost());
+        assertFalse(result.isOk());
+        assertEquals(TStatusCode.INTERNAL_ERROR, result.getStatus().getStatus_code());
+        assertEquals(0, load.numRunningLoads());
+    }
+
+    private class TestThreadPoolExecutor implements Executor {
+
+        private final Set<Runnable> pendingRunnable;
+        private boolean throwException;
+
+        public TestThreadPoolExecutor() {
+            this.pendingRunnable = new HashSet<>();
+            this.throwException = false;
+        }
+
+        public boolean isThrowException() {
+            return throwException;
+        }
+
+        public void setThrowException(boolean throwException) {
+            this.throwException = throwException;
+        }
+
+        @Override
+        public void execute(@NotNull Runnable command) {
+            if (throwException) {
+                throw new RejectedExecutionException("artificial failure");
+            }
+
+            pendingRunnable.add(command);
+        }
+
+        public void manualRun(Runnable runnable) throws Exception {
+            boolean exist = pendingRunnable.remove(runnable);
+            if (!exist) {
+                return;
+            }
+
+            if (!(runnable instanceof LoadExecutor)) {
+                runnable.run();
+                return;
+            }
+
+            LoadExecutor loadExecutor = (LoadExecutor) runnable;
+            Thread thread = new Thread(loadExecutor);
+            thread.start();
+            while (loadExecutor.getTimeTrace().joinPlanTimeMs.get() <= 0) {
+                Thread.sleep(10);
+            }
+            DefaultCoordinator coordinator = (DefaultCoordinator) loadExecutor.getCoordinator();
+            assertNotNull(coordinator);
+            coordinator.getExecutionDAG().getExecutions().forEach(execution -> {
+                int indexInJob = execution.getIndexInJob();
+                TReportExecStatusParams request = new TReportExecStatusParams(FrontendServiceVersion.V1);
+                request.setBackend_num(indexInJob)
+                        .setDone(true)
+                        .setStatus(new TStatus(TStatusCode.OK))
+                        .setFragment_instance_id(execution.getInstanceId());
+                request.setCommitInfos(buildCommitInfos());
+                TTabletFailInfo failInfo = new TTabletFailInfo();
+                request.setFailInfos(Collections.singletonList(failInfo));
+                Map<String, String> currLoadCounters = ImmutableMap.of(
+                        LoadEtlTask.DPP_NORMAL_ALL, String.valueOf(10),
+                        LoadEtlTask.DPP_ABNORMAL_ALL, String.valueOf(0),
+                        LoadJob.UNSELECTED_ROWS, String.valueOf(0),
+                        LoadJob.LOADED_BYTES, String.valueOf(40)
+                );
+                request.setLoad_counters(currLoadCounters);
+                coordinator.updateFragmentExecStatus(request);
+            });
+            thread.join();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/LoadExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/LoadExecutorTest.java
@@ -1,0 +1,358 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.batchwrite;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.analysis.DescriptorTable;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.LoadException;
+import com.starrocks.common.Status;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.load.streamload.StreamLoadHttpHeader;
+import com.starrocks.load.streamload.StreamLoadInfo;
+import com.starrocks.load.streamload.StreamLoadKvParams;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.StreamLoadPlanner;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.scheduler.Coordinator;
+import com.starrocks.schema.MTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.LoadPlanner;
+import com.starrocks.thrift.TDescriptorTable;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class LoadExecutorTest extends BatchWriteTestBase {
+
+    private String label;
+    private TUniqueId loadId;
+    StreamLoadKvParams kvParams;
+    private StreamLoadInfo streamLoadInfo;
+    private TestLoadExecuteCallback loadExecuteCallback;
+
+    @Mocked
+    private Coordinator coordinator;
+    private TestCoordinatorFactor coordinatorFactory;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+        UtFrameUtils.addMockBackend(10004);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase(DB_NAME_1)
+                .useDatabase(DB_NAME_1)
+                .withTable(new MTable(TABLE_NAME_1_1, Arrays.asList("c0 INT", "c1 STRING")));
+        DATABASE_1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME_1);
+        TABLE_1_1 = (OlapTable) DATABASE_1.getTable(TABLE_NAME_1_1);
+    }
+
+    @Before
+    public void setup() throws Exception {
+        label = "batch_write_" + DebugUtil.printId(UUIDUtil.toTUniqueId(UUID.randomUUID()));
+        loadId = UUIDUtil.toTUniqueId(UUID.randomUUID());
+
+        Map<String, String> map = new HashMap<>();
+        map.put(StreamLoadHttpHeader.HTTP_FORMAT, "json");
+        map.put(StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE, "true");
+        map.put(StreamLoadHttpHeader.HTTP_BATCH_WRITE_ASYNC, "true");
+        kvParams = new StreamLoadKvParams(map);
+        streamLoadInfo = StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), kvParams);
+        loadExecuteCallback = new TestLoadExecuteCallback();
+        coordinatorFactory = new TestCoordinatorFactor(coordinator);
+    }
+
+    @Test
+    public void testLoadSuccess() throws Exception {
+        LoadExecutor executor = new LoadExecutor(
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                ImmutableMap.<String, String>builder().putAll(kvParams.toMap()).build(),
+                connectContext,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback
+            );
+
+        new Expectations() {
+            {
+                coordinator.join((anyInt));
+                result = true;
+                coordinator.getExecStatus();
+                result = new Status();
+                coordinator.getCommitInfos();
+                result = buildCommitInfos();
+            }
+        };
+
+        executor.run();
+        assertNull(executor.getFailure());
+        assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
+        assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
+        TransactionStatus txnStatus =
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getLabelStatus(DATABASE_1.getId(), label);
+        assertEquals(TransactionStatus.VISIBLE, txnStatus);
+    }
+
+    @Test
+    public void testPlanExecuteFail() {
+        LoadExecutor executor = new LoadExecutor(
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                ImmutableMap.<String, String>builder().putAll(kvParams.toMap()).build(),
+                connectContext,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback
+        );
+
+        Status status = new Status(TStatusCode.INTERNAL_ERROR, "artificial failure");
+        new Expectations() {
+            {
+                coordinator.join((anyInt));
+                result = true;
+                coordinator.getExecStatus();
+                result = status;
+            }
+        };
+
+        Exception expectException = new LoadException(
+                String.format("Failed to execute load, status code: %s, error message: %s",
+                        status.getErrorCodeString(), status.getErrorMsg()));
+        testLoadFailBase(executor, expectException, TransactionStatus.ABORTED);
+    }
+
+    @Test
+    public void testPlanExecuteTimeout() {
+        LoadExecutor executor = new LoadExecutor(
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                ImmutableMap.<String, String>builder().putAll(kvParams.toMap()).build(),
+                connectContext,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback
+        );
+
+        new Expectations() {
+            {
+                coordinator.join((anyInt));
+                result = false;
+            }
+        };
+
+        Exception expectException = new LoadException("Timeout to execute load");
+        testLoadFailBase(executor, expectException, TransactionStatus.ABORTED);
+    }
+
+    @Test
+    public void testTableDoesNotExist() {
+        String fakeTableName = TABLE_NAME_1_1 + "_fake";
+        LoadExecutor executor = new LoadExecutor(
+                new TableId(DB_NAME_1, fakeTableName),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                ImmutableMap.<String, String>builder().putAll(kvParams.toMap()).build(),
+                connectContext,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback
+        );
+
+        Exception expectException = new LoadException(
+                String.format("Table [%s.%s] does not exist", DB_NAME_1, fakeTableName));
+        testLoadFailBase(executor, expectException, TransactionStatus.UNKNOWN);
+    }
+
+
+    private void testLoadFailBase(
+            LoadExecutor executor, Exception expectedException, TransactionStatus expectedTxnStatus) {
+        executor.run();
+        Throwable throwable = executor.getFailure();
+        assertNotNull(throwable);
+        assertSame(expectedException.getClass(), throwable.getClass());
+        assertTrue(throwable.getMessage().contains(expectedException.getMessage()));
+        assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
+        assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
+        TransactionStatus txnStatus =
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getLabelStatus(DATABASE_1.getId(), label);
+        assertEquals(expectedTxnStatus, txnStatus);
+    }
+
+    @Test
+    public void testIsActive() {
+        LoadExecutor executor = new LoadExecutor(
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                ImmutableMap.<String, String>builder().putAll(kvParams.toMap()).build(),
+                connectContext,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback
+        );
+
+        assertTrue(executor.isActive());
+
+        new Expectations() {
+            {
+                coordinator.join((anyInt));
+                result = true;
+                coordinator.getExecStatus();
+                result = new Status(TStatusCode.INTERNAL_ERROR, "artificial failure");
+            }
+        };
+        executor.run();
+        assertFalse(executor.isActive());
+    }
+
+    @Test
+    public void testContainCoordinatorBackend() {
+        LoadExecutor executor = new LoadExecutor(
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                ImmutableMap.<String, String>builder().putAll(kvParams.toMap()).build(),
+                connectContext,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback
+        );
+        assertFalse(executor.containCoordinatorBackend(10001L));
+        assertTrue(executor.containCoordinatorBackend(10002L));
+    }
+
+    private static class TestLoadExecuteCallback implements LoadExecuteCallback {
+
+        private final List<String> finishedLoads = new ArrayList<>();
+
+        public List<String> getFinishedLoads() {
+            return finishedLoads;
+        }
+
+        @Override
+        public void finishLoad(String label) {
+            finishedLoads.add(label);
+        }
+    }
+    
+    private static class TestCoordinatorFactor implements Coordinator.Factory {
+
+        private final Coordinator coordinator;
+        
+        public TestCoordinatorFactor(Coordinator coordinator) {
+            this.coordinator = coordinator;
+        }
+
+        @Override
+        public Coordinator createStreamLoadScheduler(LoadPlanner loadPlanner) {
+            return coordinator;
+        }
+        
+        @Override
+        public Coordinator createQueryScheduler(ConnectContext context, List<PlanFragment> fragments,
+                                                List<ScanNode> scanNodes, TDescriptorTable descTable) {
+            return coordinator;
+        }
+
+        @Override
+        public Coordinator createInsertScheduler(ConnectContext context, List<PlanFragment> fragments,
+                                                 List<ScanNode> scanNodes, TDescriptorTable descTable) {
+            return coordinator;
+        }
+
+        @Override
+        public Coordinator createBrokerLoadScheduler(LoadPlanner loadPlanner) {
+            return coordinator;
+        }
+
+
+        @Override
+        public Coordinator createSyncStreamLoadScheduler(StreamLoadPlanner planner, TNetworkAddress address) {
+            return coordinator;
+        }
+
+        @Override
+        public Coordinator createNonPipelineBrokerLoadScheduler(Long jobId, TUniqueId queryId,
+                                                                DescriptorTable descTable, List<PlanFragment> fragments,
+                                                                List<ScanNode> scanNodes, String timezone,
+                                                                long startTime, Map<String, String> sessionVariables,
+                                                                ConnectContext context, long execMemLimit,
+                                                                long warehouseId) {
+            return coordinator;
+        }
+
+        @Override
+        public Coordinator createBrokerExportScheduler(Long jobId, TUniqueId queryId, DescriptorTable descTable,
+                                                       List<PlanFragment> fragments, List<ScanNode> scanNodes,
+                                                       String timezone, long startTime,
+                                                       Map<String, String> sessionVariables, long execMemLimit,
+                                                       long warehouseId) {
+            return coordinator;
+        }
+
+        @Override
+        public Coordinator createRefreshDictionaryCacheScheduler(ConnectContext context, TUniqueId queryId,
+                                                                 DescriptorTable descTable,
+                                                                 List<PlanFragment> fragments,
+                                                                 List<ScanNode> scanNodes) {
+            return coordinator;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/LoadExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/LoadExecutorTest.java
@@ -104,7 +104,7 @@ public class LoadExecutorTest extends BatchWriteTestBase {
     }
 
     @Test
-    public void testLoadSuccess() throws Exception {
+    public void testLoadSuccess() {
         LoadExecutor executor = new LoadExecutor(
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadKvParamsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadKvParamsTest.java
@@ -24,9 +24,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.starrocks.http.rest.RestBaseAction.WAREHOUSE_KEY;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_ASYNC;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_INTERVAL_MS;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_PARALLEL;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_COLUMNS;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_COLUMN_SEPARATOR;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_COMPRESSION;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENABLE_REPLICATED_STORAGE;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENCLOSE;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ESCAPE;
@@ -298,6 +302,30 @@ public class StreamLoadKvParamsTest extends StreamLoadParamsTestBase {
             return new StreamLoadKvParams(Collections.emptyMap());
         }
         return new StreamLoadKvParams(Collections.singletonMap(key, value));
+    }
+
+    @Test
+    public void testBatchWrite() {
+        {
+            StreamLoadKvParams params = new StreamLoadKvParams(new HashMap<>());
+            assertFalse(params.getEnableBatchWrite().isPresent());
+            assertFalse(params.getBatchWriteAsync().isPresent());
+            assertFalse(params.getBatchWriteIntervalMs().isPresent());
+            assertFalse(params.getBatchWriteParallel().isPresent());
+        }
+
+        {
+            Map<String, String> map = new HashMap<>();
+            map.put(HTTP_ENABLE_BATCH_WRITE, "true");
+            map.put(HTTP_BATCH_WRITE_ASYNC, "true");
+            map.put(HTTP_BATCH_WRITE_INTERVAL_MS, "1000");
+            map.put(HTTP_BATCH_WRITE_PARALLEL, "4");
+            StreamLoadKvParams params = new StreamLoadKvParams(map);
+            assertEquals(true, params.getEnableBatchWrite().orElse(null));
+            assertEquals(true, params.getBatchWriteAsync().orElse(null));
+            assertEquals(Integer.valueOf(1000), params.getBatchWriteIntervalMs().orElse(null));
+            assertEquals(Integer.valueOf(4), params.getBatchWriteParallel().orElse(null));
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
@@ -73,6 +73,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_PARTIAL_UPDATE_MODE;
@@ -215,7 +216,7 @@ public class StreamLoadPlannerTest {
                 Collections.singletonMap(HTTP_PARTIAL_UPDATE_MODE, "column"));
         UUID uuid = UUID.randomUUID();
         TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
-        StreamLoadInfo streamLoadInfo2 = StreamLoadInfo.fromHttpStreamLoadRequest(loadId, 100, 100, param);
+        StreamLoadInfo streamLoadInfo2 = StreamLoadInfo.fromHttpStreamLoadRequest(loadId, 100, Optional.of(100), param);
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         StreamLoadInfo streamLoadInfo3 = StreamLoadInfo.fromRoutineLoadJob(routineLoadJob);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
@@ -216,9 +216,9 @@ public class StreamLoadPlannerTest {
                 Collections.singletonMap(HTTP_PARTIAL_UPDATE_MODE, "column"));
         UUID uuid = UUID.randomUUID();
         TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
-        StreamLoadInfo streamLoadInfo2 = StreamLoadInfo.fromHttpStreamLoadRequest(loadId, 100, Optional.of(100), param);
+        StreamLoadInfo.fromHttpStreamLoadRequest(loadId, 100, Optional.of(100), param);
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        StreamLoadInfo streamLoadInfo3 = StreamLoadInfo.fromRoutineLoadJob(routineLoadJob);
+        StreamLoadInfo.fromRoutineLoadJob(routineLoadJob);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -41,6 +41,8 @@ import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
 import com.starrocks.thrift.TAuthInfo;
+import com.starrocks.thrift.TBatchWriteRequest;
+import com.starrocks.thrift.TBatchWriteResult;
 import com.starrocks.thrift.TColumnDef;
 import com.starrocks.thrift.TCreatePartitionRequest;
 import com.starrocks.thrift.TCreatePartitionResult;
@@ -100,6 +102,12 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_ASYNC;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_INTERVAL_MS;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_PARALLEL;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -1194,6 +1202,26 @@ public class FrontendServiceImplTest {
         doThrow(new LockTimeoutException("get database read lock timeout")).when(impl).streamLoadPutImpl(any());
         TStreamLoadPutResult result = impl.streamLoadPut(request);
         Assert.assertEquals(TStatusCode.TIMEOUT, result.status.status_code);
+    }
+
+    @Test
+    public void testRequestBatchWrite() throws Exception {
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TBatchWriteRequest request = new TBatchWriteRequest();
+        request.setDb("test");
+        request.setTbl("site_access_hour");
+        request.setUser("root");
+        request.setPasswd("");
+        request.setBackend_id(10001);
+        request.setBackend_host("127.0.0.1");
+        request.putToParams(HTTP_ENABLE_BATCH_WRITE, "true");
+        request.putToParams(HTTP_BATCH_WRITE_ASYNC, "true");
+        request.putToParams(HTTP_BATCH_WRITE_INTERVAL_MS, "1000");
+        request.putToParams(HTTP_BATCH_WRITE_PARALLEL, "4");
+
+        TBatchWriteResult result = impl.requestBatchWrite(request);
+        assertEquals(TStatusCode.OK, result.getStatus().getStatus_code());
+        assertNotNull(result.getLabel());
     }
 
     @Test

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -963,6 +963,23 @@ struct TStreamLoadPutResult {
     2: optional InternalService.TExecPlanFragmentParams params
 }
 
+struct TBatchWriteRequest {
+    1: optional string db
+    2: optional string tbl
+    3: optional string user
+    4: optional string passwd
+    5: optional string user_ip
+    6: optional i64 backend_id
+    7: optional string backend_host;
+    8: optional map<string, string> params;
+}
+
+struct TBatchWriteResult {
+    1: optional Status.TStatus status;
+    // only valid for success
+    2: optional string label;
+}
+
 struct TKafkaRLTaskProgress {
     1: required map<i32,i64> partitionCmtOffset
     2: optional map<i32,i64> partitionCmtOffsetTimestamp
@@ -1903,6 +1920,8 @@ service FrontendService {
     TLoadTxnCommitResult loadTxnPrepare(1: TLoadTxnCommitRequest request)
 
     TStreamLoadPutResult streamLoadPut(1: TStreamLoadPutRequest request)
+
+    TBatchWriteResult requestBatchWrite(1: TBatchWriteRequest request)
 
     Status.TStatus snapshotLoaderReport(1: TSnapshotLoaderReportRequest request)
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -280,6 +280,10 @@ struct TBrokerScanRange {
     3: required list<Types.TNetworkAddress> broker_addresses
     // used for channel stream load only
     4: optional i32 channel_id
+    // available when this is a stream load in batch write mode
+    5: optional bool enable_batch_write
+    6: optional i32 batch_write_interval_ms
+    7: optional map<string, string> batch_write_parameters;
 }
 
 // Es scan range


### PR DESCRIPTION
## Why I'm doing:
The first PR to support batching stream load on the server side. This pr mainly implements the basic workflow on the FE side. 

## What I'm doing:
The core logic
* http client sends http request to FE, and FE will redirect it a coordinator BE. This process is similar to the normal stream load, but there is difference for how to choose the BE. stream load will carry headers `enable_batch_write` to enable batching on the server side
```
curl --location-trusted -u <username>:<password> \
    -H "Expect:100-continue" \
    -H "format:json" \
    -H "enable_batch_write:true" \
    -H "batch_write_async:true" \
    -H "batch_write_interval_ms:1000" \
    -H "batch_write_parallel:4" \
    -T example1.json -XPUT \
    http://<fe_host>:<fe_http_port>/api/mydatabase/table1/_stream_load
```
* coordinator BE sends thrift request to FE to execute a load. This process is also similar to the normal stream load, but there is difference for how to execute the load plan
* FE will maintain a set of coordinator backends for isomorphic stream loads which is implemented by `CoordinatorBackendAssigner`. `isomorphic` means those stream loads have the same parameters. FE will randomly redirect each stream load to one of those BE so that these stream loads can be batched. The number of backends is controlled by parameter `batch_write_parallel`
* For the load plan, it's almost the same as that of [parallel transaction stream load](https://github.com/StarRocks/starrocks/pull/12182). It uses pipeline engine and can have multiple parallelisms. The main change is that we need deploy it to the coordinator backends assigned by `CoordinatorBackendAssigner`

There will be other PRs to implement the following functions
* complete the logic of coordinator assigner
* the logic on the BE side
* enhance observability

Fixes [#51085](https://github.com/StarRocks/starrocks/issues/51085)

## What type of PR is this:

- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
