### PR TITLE
[Refactor] Refactor AggregatedMaterializedViewPushDownRewriter to avoid cloning input opt expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
@@ -45,7 +45,6 @@ import com.starrocks.sql.optimizer.rule.tree.pdagg.AggregatePushDownContext;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,7 +52,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.deriveLogicalProperty;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregateFunctionRollupUtils.isSupportedAggFunctionPushDown;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregatePushDownUtils.doRewritePushDownAgg;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregatePushDownUtils.getPushDownRollupFinalAggregateOpt;
@@ -80,10 +78,7 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
     @Override
     public OptExpression doRewrite(MvRewriteContext mvContext) {
         OptExpression input = mvContext.getQueryExpression();
-
-        // try push down
-        OptExpression inputDuplicator = duplicateOptExpression(mvContext, input);
-        AggRewriteInfo rewriteInfo = process(inputDuplicator, AggregatePushDownContext.EMPTY);
+        AggRewriteInfo rewriteInfo = process(input, AggregatePushDownContext.EMPTY);
         if (rewriteInfo.hasRewritten()) {
             Optional<OptExpression> res = rewriteInfo.getOp();
             logMVRewrite(mvContext, "AggregateJoin pushdown rewrite success");
@@ -95,41 +90,6 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
             Utils.setOpBit(input, Operator.OP_PUSH_DOWN_BIT);
             return null;
         }
-    }
-
-    /**
-     * Since the aggregate pushdown rewriter may break original opt expression's structure, duplicate it first.
-     */
-    private static OptExpression duplicateOptExpression(MvRewriteContext mvRewriteContext,
-                                                        OptExpression input) {
-        Map<ColumnRefOperator, ScalarOperator> queryColumnRefMap =
-                MvUtils.getColumnRefMap(input, mvRewriteContext.getMaterializationContext().getQueryRefFactory());
-
-        OptExpressionDuplicator duplicator = new OptExpressionDuplicator(mvRewriteContext.getMaterializationContext());
-        OptExpression newQueryInput = duplicator.duplicate(input);
-
-        List<ColumnRefOperator> originalOutputColumns =
-                queryColumnRefMap.keySet().stream().collect(Collectors.toList());
-        List<ColumnRefOperator> newQueryOutputColumns = duplicator.getMappedColumns(originalOutputColumns);
-        Map<ColumnRefOperator, ScalarOperator> newProjectionMap = Maps.newHashMap();
-        for (int i = 0; i < originalOutputColumns.size(); i++) {
-            newProjectionMap.put(originalOutputColumns.get(i), newQueryOutputColumns.get(i));
-        }
-        Operator newOp = newQueryInput.getOp();
-        if (newOp.getProjection() == null) {
-            newOp.setProjection(new Projection(newProjectionMap));
-        } else {
-            // merge two projections
-            ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(newOp.getProjection().getColumnRefMap());
-            Map<ColumnRefOperator, ScalarOperator> resultMap = Maps.newHashMap();
-            for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : newProjectionMap.entrySet()) {
-                ScalarOperator result = rewriter.rewrite(entry.getValue());
-                resultMap.put(entry.getKey(), result);
-            }
-            newOp.setProjection(new Projection(resultMap));
-        }
-        deriveLogicalProperty(newQueryInput);
-        return newQueryInput;
     }
 
     @VisibleForTesting
@@ -304,10 +264,11 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
             if (!rewriteInfo.getRemappingUnChecked().isPresent()) {
                 return AggRewriteInfo.NOT_REWRITE;
             }
+            OptExpression childOpt = rewriteInfo.getOp().get();
 
             final Map<ColumnRefOperator, ColumnRefOperator> remapping = rewriteInfo.getRemappingUnChecked().get().getRemapping();
             optExpression = getPushDownRollupFinalAggregateOpt(mvRewriteContext, rewriteInfo.getCtx(),
-                    remapping, optExpression, optExpression.getInputs());
+                    remapping, optExpression, List.of(childOpt));
             if (!checkAggOpt(optExpression)) {
                 logMVRewrite(mvRewriteContext, "Rollup aggregate node is invalid after agg push down");
                 return AggRewriteInfo.NOT_REWRITE;
@@ -324,8 +285,10 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
                 return AggRewriteInfo.NOT_REWRITE;
             }
             // split aggregate to left/right child
-            LogicalJoinOperator joinOperator = (LogicalJoinOperator) optExpression.getOp();
-            Projection projection = joinOperator.getProjection();
+            LogicalJoinOperator newJoinOperator = new LogicalJoinOperator.Builder()
+                    .withOperator((LogicalJoinOperator) optExpression.getOp())
+                    .build();
+            Projection projection = newJoinOperator.getProjection();
             ReplaceColumnRefRewriter replacer = null;
             if (projection != null) {
                 replacer = new ReplaceColumnRefRewriter(projection.getColumnRefMap());
@@ -336,27 +299,30 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
             AggRewriteInfo aggRewriteInfo1 = process(optExpression.inputAt(1), rightContext);
 
             AggColumnRefRemapping combinedRemapping = new AggColumnRefRemapping();
+
+            OptExpression newChild0 = optExpression.inputAt(0);
+            OptExpression newChild1 = optExpression.inputAt(1);
             if (aggRewriteInfo0.hasRewritten()) {
-                optExpression.setChild(0, aggRewriteInfo0.getOp().get());
+                newChild0 = aggRewriteInfo0.getOp().get();
                 aggRewriteInfo0.output(combinedRemapping, context);
             }
             if (aggRewriteInfo1.hasRewritten()) {
-                optExpression.setChild(1, aggRewriteInfo1.getOp().get());
+                newChild1 = aggRewriteInfo1.getOp().get();
                 aggRewriteInfo1.output(combinedRemapping, context);
             }
             if (!combinedRemapping.isEmpty()) {
                 Map<ColumnRefOperator, ScalarOperator> newColRefMap = replaceColumnRefMap(context, combinedRemapping,
-                        joinOperator.getProjection().getColumnRefMap());
+                        newJoinOperator.getProjection().getColumnRefMap());
                 Projection newProjection = new Projection(newColRefMap);
-                joinOperator.setProjection(newProjection);
-
+                newJoinOperator.setProjection(newProjection);
             }
-            if (!checkJoinOpt(optExpression)) {
+            OptExpression newOptExpression = OptExpression.create(newJoinOperator, newChild0, newChild1);
+            if (!checkJoinOpt(newOptExpression)) {
                 logMVRewrite(mvRewriteContext, "Join node is invalid after agg push down");
                 return AggRewriteInfo.NOT_REWRITE;
             }
             return !aggRewriteInfo0.hasRewritten() && !aggRewriteInfo1.hasRewritten() ? AggRewriteInfo.NOT_REWRITE :
-                    new AggRewriteInfo(true, combinedRemapping, optExpression, context);
+                    new AggRewriteInfo(true, combinedRemapping, newOptExpression, context);
         }
 
         private Map<ColumnRefOperator, CallOperator> replaceAggregationExprs(
@@ -539,22 +505,28 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
 
         @Override
         public AggRewriteInfo visitLogicalProject(OptExpression optExpression, AggRewriteInfo rewriteInfo) {
-            if (!rewriteInfo.getRemappingUnChecked().isPresent()) {
+            if (rewriteInfo.getRemappingUnChecked().isEmpty()) {
                 return AggRewriteInfo.NOT_REWRITE;
             }
+            if (rewriteInfo.getOp().isEmpty()) {
+                return AggRewriteInfo.NOT_REWRITE;
+            }
+            AggColumnRefRemapping childRemapping = rewriteInfo.getRemappingUnChecked().get();
+            OptExpression childOpt = rewriteInfo.getOp().get();
+
             LogicalProjectOperator project = optExpression.getOp().cast();
             Map<ColumnRefOperator, ScalarOperator> columnRefMap = project.getColumnRefMap();
             ColumnRefSet columnRefSet = new ColumnRefSet();
             columnRefSet.union(columnRefMap.keySet());
             columnRefSet.union(getReferencedColumnRef(columnRefMap.values()));
             Map<ColumnRefOperator, ScalarOperator> newColumnRefMap =
-                    replaceColumnRefMap(rewriteInfo.getCtx(), rewriteInfo.getRemappingUnChecked().get(),
+                    replaceColumnRefMap(rewriteInfo.getCtx(), childRemapping,
                             columnRefMap);
             LogicalProjectOperator newProject = LogicalProjectOperator.builder()
                     .withOperator(project)
                     .setColumnRefMap(newColumnRefMap)
                     .build();
-            OptExpression newOpt = OptExpression.create(newProject, optExpression.getInputs());
+            OptExpression newOpt = OptExpression.create(newProject, childOpt);
             rewriteInfo.setOp(newOpt);
             return rewriteInfo;
         }
@@ -602,21 +574,10 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
         if (optExpression.getOp().getOpType() == OperatorType.LOGICAL_JOIN) {
             return new AggRewriteInfo(false, null, null, context);
         }
-
-        List<AggRewriteInfo> childAggRewriteInfoList = optExpression.getInputs().stream()
-                .map(input -> process(input, context))
-                .collect(Collectors.toList());
-        if (childAggRewriteInfoList.stream().noneMatch(AggRewriteInfo::hasRewritten)) {
-            return AggRewriteInfo.NOT_REWRITE;
+        if (optExpression.getInputs().size() > 1) {
+            return new AggRewriteInfo(false, null, null, context);
         }
-
-        // merge ColumnRefMapping generated by each child into a total one
-        Iterator<AggRewriteInfo> nextAggRewriteInfo = childAggRewriteInfoList.iterator();
-        optExpression.getInputs().replaceAll(input -> nextAggRewriteInfo.next().getOp().orElse(input));
-        AggColumnRefRemapping combinedRemapping = new AggColumnRefRemapping();
-        childAggRewriteInfoList.forEach(rewriteInfo -> rewriteInfo.getRemappingUnChecked().ifPresent(
-                combinedRemapping::combine));
-        return new AggRewriteInfo(true, combinedRemapping, optExpression, context);
+        return process(optExpression.inputAt(0), context);
     }
 
     // Check current opt to see whether push distinct agg down or not using PreVisitor

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1981,7 +1981,7 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
                 return null;
             }
 
-            // TODO(fixme): Push-down predicates will pollute the original input operators, if rewrite fail we should retrieve
+            // Push-down predicates will pollute the original input operators, if rewrite fail we should retrieve
             // push-down predicates.
             OptExpression newQueryExpr = pushdownPredicatesForJoin(queryExpression, queryCompensationPredicate);
             deriveLogicalProperty(newQueryExpr);
@@ -1991,7 +1991,6 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
                 deriveLogicalProperty(newQueryExpr);
             }
             return newQueryExpr;
-
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
@@ -106,7 +106,7 @@ public class AggregatePushDownUtils {
         final Map<ColumnRefOperator, CallOperator> aggregations = origAggregate.getAggregations();
         for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregations.entrySet()) {
             ColumnRefOperator origAggColRef = entry.getKey();
-            CallOperator aggCall = entry.getValue();
+            CallOperator aggCall = (CallOperator) entry.getValue().clone();
             if (ctx.avgToSumCountMapping.containsKey(aggCall)) {
                 // if it's an avg function, we need to rewrite it to sum and count function
                 Pair<ColumnRefOperator, ColumnRefOperator> newAggPair = ctx.avgToSumCountMapping.get(aggCall);


### PR DESCRIPTION
## Why I'm doing:
- Sometimes `OptExpressionDuplicator` is too heavy to clone a `OptExpression` which it will remapping all input columns to ensure column ref is not the same with the input.


## What I'm doing:
- Refactor AggregatedMaterializedViewPushDownRewriter to avoid cloning input opt expression 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
