### PR TITLE
[Feature][fe][mdc] add srid to log message

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -270,6 +270,7 @@ public class Log4jConfig extends XmlConfiguration {
                             "'file':{'$resolver':'source','field':'fileName'}," +
                             "'method':{'$resolver':'source','field':'methodName'}," +
                             "'message':{'$resolver':'message','stringfield':'true'}," +
+                            "'srid':{'$resolver':'ctx','field':'srid'}," +
                             "'exception':{'$resolver':'exception','field':'stackTrace','stackTrace':{'stringified':true,'full':true}}}";
             jsonConfig = jsonConfig.replace("'", "\"");
             String jsonLayoutFormatter = "<JsonTemplateLayout maxStringLength=\"%d\" locationInfoEnabled=\"true\">\n" +
@@ -285,17 +286,17 @@ public class Log4jConfig extends XmlConfiguration {
         } else {
             // fallback to plaintext logging
             properties.put("syslog_default_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m%n\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m -srid=%X{srid}%n\"/>");
             properties.put("syslog_warning_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m%n %ex\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m -srid=%X{srid}%n %ex\"/>");
             properties.put("syslog_audit_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m%n\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m -srid=%X{srid}%n\"/>");
             properties.put("syslog_dump_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m%n\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m -srid=%X{srid}%n\"/>");
             properties.put("syslog_bigquery_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m%n\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m -srid=%X{srid}%n\"/>");
             properties.put("syslog_profile_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m%n\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m -srid=%X{srid}%n\"/>");
         }
 
         String xmlConfTemplate = generateXmlConfTemplate();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -85,6 +85,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.slf4j.MDC;
 
 import java.io.IOException;
 import java.nio.channels.SocketChannel;
@@ -677,6 +678,7 @@ public class ConnectContext {
 
     public void setQueryId(UUID queryId) {
         this.queryId = queryId;
+        MDC.put("srid", String.valueOf(queryId));
     }
 
     public UUID getLastQueryId() {


### PR DESCRIPTION
## Why I'm doing:
Find the log events for one specific query is important for troubleshooting, currently it's hard if not impossible in FE. 

## What I'm doing:
By adding `srid`field to MDC context and appending it to each log message, now it's able to find all the messages of one query, see below for example:
```
todo
``` 

Fixes [#issue](https://github.com/StarRocks/starrocks/issues/50646)

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5