### PR TITLE
[Enhancement] ConsolidateLikesRule yields non-optimized predicates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
@@ -84,4 +84,10 @@ public class ScalarOperatorUtil {
                         likeOp.getChild(1).isConstantRef())
                 .orElse(false);
     }
+
+    public static boolean isSimpleNotLike(ScalarOperator op) {
+        return Utils.downcast(op, CompoundPredicateOperator.class)
+                .map(compOp -> compOp.isNot() && isSimpleLike(compOp.getChild(0)))
+                .orElse(false);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithMultiLikeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithMultiLikeTest.java
@@ -73,6 +73,14 @@ public class SelectStmtWithMultiLikeTest {
     private static Stream<Arguments> multiLikeTestCases() {
         String sqlFormat = "select count(1) from t0 where %s";
         String[][] testCases = new String[][] {
+                {"order_date > '2024-01-1' and site = 'ABC' and income = 10.0 and ship_mode = 3 and " +
+                        "ship_code = 3 and region not like '%ABC%' and region not like '%DEF%'",
+                        "Predicates: [2: order_date, DATE, false] > '2024-01-01', " +
+                                "[3: site, VARCHAR, false] = 'ABC', " +
+                                "cast([4: income, DECIMAL64(7,0), false] as DECIMAL64(8,1)) = 10.0, " +
+                                "[5: ship_mode, INT, false] = 3, [6: ship_code, INT, true] = 3, " +
+                                "NOT (1: region REGEXP '^((.*ABC.*)|(.*DEF.*))$')"
+                },
                 {"region like '%ABC' or region like 'DEF_G'",
                         "Predicates: " +
                                 "1: region REGEXP '^((.*ABC)|(DEF.G))$'"},


### PR DESCRIPTION
## Why I'm doing:

predicates as follows: 
```
p and a not like "%a%" and a not like "%b%"  
```
is converted by ConsolidateLikesRules into
```
p and a not regex "^.*(a|b).*$"  or  (p and a not regex "^.*(a|b).*$") is NULL
```

the result is can not be used to prune partitions.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
