### PR TITLE
[BugFix] throw std::bad_alloc in allocate

### DIFF
--- a/be/src/exprs/agg/aggregate_state_allocator.h
+++ b/be/src/exprs/agg/aggregate_state_allocator.h
@@ -44,7 +44,7 @@ public:
 
     T* allocate(size_t n) {
         DCHECK(tls_agg_state_allocator != nullptr);
-        return static_cast<T*>(tls_agg_state_allocator->alloc(n * sizeof(T)));
+        return static_cast<T*>(tls_agg_state_allocator->checked_alloc(n * sizeof(T)));
     }
 
     void deallocate(T* ptr, size_t n) {

--- a/be/src/runtime/memory/column_allocator.h
+++ b/be/src/runtime/memory/column_allocator.h
@@ -16,8 +16,6 @@
 
 #include <glog/logging.h>
 
-#include <memory>
-
 #include "runtime/memory/mem_hook_allocator.h"
 
 namespace starrocks {
@@ -25,6 +23,7 @@ namespace starrocks {
 extern MemHookAllocator kDefaultColumnAllocator;
 inline thread_local Allocator* tls_column_allocator = &kDefaultColumnAllocator;
 
+// Implement the std::allocator: https://en.cppreference.com/w/cpp/memory/allocator
 template <class T>
 class ColumnAllocator {
 public:
@@ -44,9 +43,10 @@ public:
 
     ~ColumnAllocator() = default;
 
+    // Allocator n elements, throw std::bad_malloc if allocate failed
     T* allocate(size_t n) {
         DCHECK(tls_column_allocator != nullptr);
-        return static_cast<T*>(tls_column_allocator->alloc(n * sizeof(T)));
+        return static_cast<T*>(tls_column_allocator->checked_alloc(n * sizeof(T)));
     }
 
     void deallocate(T* ptr, size_t n) {

--- a/be/src/runtime/memory/counting_allocator.h
+++ b/be/src/runtime/memory/counting_allocator.h
@@ -135,6 +135,9 @@ public:
 #else
         *_counter += (result != nullptr) ? n * sizeof(T) : 0;
 #endif
+        if (UNLIKELY(result == nullptr)) {
+            throw std::bad_alloc();
+        }
 
         return result;
     }

--- a/be/src/runtime/memory/mem_hook_allocator.h
+++ b/be/src/runtime/memory/mem_hook_allocator.h
@@ -15,7 +15,6 @@
 
 #include <cstdlib>
 
-#include "common/compiler_util.h"
 #include "malloc.h"
 #include "runtime/memory/allocator.h"
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

https://github.com/StarRocks/starrocks/pull/49131

According to https://en.cppreference.com/w/cpp/memory/allocator, `std::allocator::allocate` should throw `std::bad_alloc` if fail to allocate memory, otherwise the returned nullptr may crash the process.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
