### PR TITLE
[BugFix] least/greatest support date type and not return bigint

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -831,7 +831,9 @@ public class FunctionSet {
         if (functionName.equalsIgnoreCase(IFNULL) ||
                 functionName.equalsIgnoreCase(NULLIF) ||
                 functionName.equalsIgnoreCase(IF) ||
-                functionName.equalsIgnoreCase(COALESCE)) {
+                functionName.equalsIgnoreCase(COALESCE) ||
+                functionName.equalsIgnoreCase(LEAST) ||
+                functionName.equalsIgnoreCase(GREATEST)) {
             if (functionName.equalsIgnoreCase(IF)) {
                 arg_index = 1;
             }

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -155,6 +155,7 @@ vectorized_functions = [
     [102871, "least", True, False, "DECIMAL64", ["DECIMAL64", "..."], "MathFunctions::least<TYPE_DECIMAL64>"],
     [102872, "least", True, False, "DECIMAL128", ["DECIMAL128", "..."], "MathFunctions::least<TYPE_DECIMAL128>"],
     [10288, "least", True, False, "DATETIME", ["DATETIME", "..."], "MathFunctions::least<TYPE_DATETIME>"],
+    [102880, "least", True, False, "DATE", ["DATE", "..."], "MathFunctions::least<TYPE_DATE>"],
     [10289, "least", True, False, "VARCHAR", ["VARCHAR", "..."], "MathFunctions::least<TYPE_VARCHAR>"],
 
     [10290, "greatest", True, False, "TINYINT", ["TINYINT", "..."], "MathFunctions::greatest<TYPE_TINYINT>"],
@@ -169,6 +170,7 @@ vectorized_functions = [
     [102971, "greatest", True, False, "DECIMAL64", ["DECIMAL64", "..."], "MathFunctions::greatest<TYPE_DECIMAL64>"],
     [102972, "greatest", True, False, "DECIMAL128", ["DECIMAL128", "..."], "MathFunctions::greatest<TYPE_DECIMAL128>"],
     [10298, "greatest", True, False, "DATETIME", ["DATETIME", "..."], "MathFunctions::greatest<TYPE_DATETIME>"],
+    [102980, "greatest", True, False, "DATE", ["DATE", "..."], "MathFunctions::greatest<TYPE_DATE>"],
     [10299, "greatest", True, False, "VARCHAR", ["VARCHAR", "..."], "MathFunctions::greatest<TYPE_VARCHAR>"],
 
     [10300, "rand", True, False, "DOUBLE", [], "MathFunctions::rand", "MathFunctions::rand_prepare",


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes [#51904](https://github.com/StarRocks/starrocks/issues/51904)

```
mysql> select least(to_date('2024-09-28 00:00:00'), to_date('2024-10-12 00:00:00'));
+-----------------------------------------------------------------------+
| least(to_date('2024-09-28 00:00:00'), to_date('2024-10-12 00:00:00')) |
+-----------------------------------------------------------------------+
| 2024-09-28                                                            |
+-----------------------------------------------------------------------+
1 row in set (0.01 sec)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5