### PR TITLE
[BugFix] fix from_unixtime return incorrenct results with some valid format string

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -1567,30 +1567,18 @@ StatusOr<ColumnPtr> TimeFunctions::from_unix_to_datetime_ms_64(FunctionContext* 
     return _t_from_unix_to_datetime_ms<TYPE_BIGINT>(context, columns);
 }
 
+const static std::unordered_map<std::string, std::string> format_conversion_map = {
+        {"yyyy", "%Y"}, {"MM", "%m"}, {"dd", "%d"}, {"HH", "%H"}, {"mm", "%i"}, {"ss", "%S"}};
+
 std::string TimeFunctions::convert_format(const Slice& format) {
-    switch (format.get_size()) {
-    case 8:
-        if (strncmp((const char*)format.get_data(), "yyyyMMdd", 8) == 0) {
-            std::string tmp("%Y%m%d");
-            return tmp;
+    std::string str = format.to_string();
+    for (const auto& it : format_conversion_map) {
+        if (str.find(it.first) == std::string::npos) {
+            continue;
         }
-        break;
-    case 10:
-        if (strncmp((const char*)format.get_data(), "yyyy-MM-dd", 10) == 0) {
-            std::string tmp("%Y-%m-%d");
-            return tmp;
-        }
-        break;
-    case 19:
-        if (strncmp((const char*)format.get_data(), "yyyy-MM-dd HH:mm:ss", 19) == 0) {
-            std::string tmp("%Y-%m-%d %H:%i:%s");
-            return tmp;
-        }
-        break;
-    default:
-        break;
+        str.replace(str.find(it.first), it.first.size(), it.second);
     }
-    return format.to_string();
+    return str;
 }
 
 // regex method

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -1319,6 +1319,62 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetimeWithConstFormat) {
                                                    FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
     }
+
+    // Test format string is "yyyy-MM-dd"
+    {
+        Columns columns;
+        auto tc1 = Int32Column::create();
+        tc1->append(24 * 60 * 60);
+        tc1->append(1565080737);
+        auto tc2 = ColumnHelper::create_const_column<TYPE_VARCHAR>("yyyy-MM-dd", 1);
+
+        columns.emplace_back(tc1);
+        columns.emplace_back(tc2);
+
+        _utils->get_fn_ctx()->set_constant_columns(columns);
+
+        ASSERT_TRUE(TimeFunctions::from_unix_prepare(_utils->get_fn_ctx(),
+                                                     FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                            .ok());
+
+        ColumnPtr result = TimeFunctions::from_unix_to_datetime_with_format_32(_utils->get_fn_ctx(), columns).value();
+
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ("1970-01-01", v->get_data()[0]);
+        ASSERT_EQ("2019-08-06", v->get_data()[1]);
+
+        ASSERT_TRUE(TimeFunctions::from_unix_close(_utils->get_fn_ctx(),
+                                                   FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                            .ok());
+    }
+
+    // Test format string is "yyyy-MM-dd HH:mm"
+    {
+        Columns columns;
+        auto tc1 = Int32Column::create();
+        tc1->append(24 * 60 * 60);
+        tc1->append(1565080737);
+        auto tc2 = ColumnHelper::create_const_column<TYPE_VARCHAR>("yyyy-MM-dd HH:mm", 1);
+
+        columns.emplace_back(tc1);
+        columns.emplace_back(tc2);
+
+        _utils->get_fn_ctx()->set_constant_columns(columns);
+
+        ASSERT_TRUE(TimeFunctions::from_unix_prepare(_utils->get_fn_ctx(),
+                                                     FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                            .ok());
+
+        ColumnPtr result = TimeFunctions::from_unix_to_datetime_with_format_32(_utils->get_fn_ctx(), columns).value();
+
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ("1970-01-01 16:00", v->get_data()[0]);
+        ASSERT_EQ("2019-08-06 01:38", v->get_data()[1]);
+
+        ASSERT_TRUE(TimeFunctions::from_unix_close(_utils->get_fn_ctx(),
+                                                   FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                            .ok());
+    }
 }
 
 TEST_F(TimeFunctionsTest, from_days) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -35,6 +35,7 @@
 package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.analysis.DecimalLiteral;
@@ -107,6 +108,8 @@ import static com.starrocks.sql.analyzer.FunctionAnalyzer.HAS_TIME_PART;
 public class ScalarOperatorFunctions {
     public static final Set<String> SUPPORT_JAVA_STYLE_DATETIME_FORMATTER =
             ImmutableSet.<String>builder().add("yyyy-MM-dd").add("yyyy-MM-dd HH:mm:ss").add("yyyyMMdd").build();
+    public static final List<String> JAVA_DATETIME_FORMATTER_LIST =
+            ImmutableList.of("yyyy", "MM", "dd", "HH", "mm", "ss"); 
 
     private static final int CONSTANT_128 = 128;
     private static final BigInteger INT_128_OPENER = BigInteger.ONE.shiftLeft(CONSTANT_128 + 1);
@@ -383,6 +386,15 @@ public class ScalarOperatorFunctions {
 
     }
 
+    private static boolean isJavaFormatter(String format) {
+        for (String str : JAVA_DATETIME_FORMATTER_LIST) {
+            if (format.contains((str))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @ConstantFunction.List(list = {
             @ConstantFunction(name = "date_format", argTypes = {DATETIME, VARCHAR}, returnType = VARCHAR, isMonotonic = true),
             @ConstantFunction(name = "date_format", argTypes = {DATE, VARCHAR}, returnType = VARCHAR, isMonotonic = true)
@@ -393,7 +405,7 @@ public class ScalarOperatorFunctions {
             return ConstantOperator.createNull(Type.VARCHAR);
         }
         // unix style
-        if (!SUPPORT_JAVA_STYLE_DATETIME_FORMATTER.contains(format.trim())) {
+        if (!isJavaFormatter(format)) {
             DateTimeFormatter builder = DateUtils.unixDatetimeFormatter(fmtLiteral.getVarchar());
             return ConstantOperator.createVarchar(builder.format(date.getDatetime()));
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -322,14 +322,14 @@ public class ScalarOperatorFunctionsTest {
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%4")).getVarchar());
         assertEquals("02",
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("%v")).getVarchar());
-        assertEquals("yyyy",
+        assertEquals("2001",
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("yyyy")).getVarchar());
         assertEquals("20010109",
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("yyyyMMdd")).getVarchar());
-        assertEquals("yyyyMMdd HH:mm:ss",
+        assertEquals("20010109 13:04:05",
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("yyyyMMdd HH:mm:ss"))
                         .getVarchar());
-        assertEquals("HH:mm:ss",
+        assertEquals("13:04:05",
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("HH:mm:ss")).getVarchar());
         assertEquals("2001-01-09",
                 ScalarOperatorFunctions.dateFormat(testDate, ConstantOperator.createVarchar("yyyy-MM-dd"))


### PR DESCRIPTION
## Why I'm doing:
When executing this query on StarRocks,
```sql
select from_unixtime(1727193600, 'yyyy-MM-dd HH:mm');
+-----------------------------------------------+
| from_unixtime(1727193600, 'yyyy-MM-dd HH:mm') |
+-----------------------------------------------+
| yyyy-MM-dd HH:mm                              |
+-----------------------------------------------+
```
We got incorrect results. Even though 'yyyy-MM-dd HH:mm' is also a valid format.

## What I'm doing:
Support more formats in function `from_unixtime`.

Fixes #issue #52148

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5