### PR TITLE
[Enhancement] skip trigger analyze when table not update

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2110,10 +2110,10 @@ public class Config extends ConfigBase {
     public static long connector_table_query_trigger_analyze_small_table_rows = 10000000; // 10M
 
     @ConfField(mutable = true)
-    public static long connector_table_query_trigger_analyze_small_table_interval = 6 * 60 * 60; // unit: second, default 6h
+    public static long connector_table_query_trigger_analyze_small_table_interval = 2 * 3600; // unit: second, default 2h
 
     @ConfField(mutable = true)
-    public static long connector_table_query_trigger_analyze_large_table_interval = 24 * 60 * 60; // unit: second, default 24h
+    public static long connector_table_query_trigger_analyze_large_table_interval = 12 * 3600; // unit: second, default 12h
 
     @ConfField(mutable = true)
     public static int connector_table_query_trigger_analyze_max_running_task_num = 2;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -73,6 +73,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
@@ -223,6 +224,17 @@ public class StatisticUtils {
                 return null;
             }
         }
+    }
+
+    public static Set<String> getUpdatedPartitionNames(Table table, LocalDateTime checkTime) {
+        // get updated partitions
+        Set<String> updatedPartitions = null;
+        try {
+            updatedPartitions = ConnectorPartitionTraits.build(table).getUpdatedPartitionNames(checkTime, 60);
+        } catch (Exception e) {
+            // ConnectorPartitionTraits do not support all type of table, ignore exception
+        }
+        return updatedPartitions;
     }
 
     public static LocalDateTime getPartitionLastUpdateTime(Partition partition) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -23,7 +23,6 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
-import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
 import com.starrocks.monitor.unit.ByteSizeUnit;
 import com.starrocks.server.GlobalStateMgr;
@@ -310,12 +309,7 @@ public class StatisticsCollectJobFactory {
                                                    Database db, Table table, List<String> columnNames,
                                                    List<Type> columnTypes) {
         // get updated partitions
-        Set<String> updatedPartitions = null;
-        try {
-            updatedPartitions = ConnectorPartitionTraits.build(table).getUpdatedPartitionNames(statisticsUpdateTime, 60);
-        } catch (Exception e) {
-            // ConnectorPartitionTraits do not support all type of table, ignore exception
-        }
+        Set<String> updatedPartitions = StatisticUtils.getUpdatedPartitionNames(table, statisticsUpdateTime);
         LOG.info("create external full statistics job for table: {}, partitions: {}",
                 table.getName(), updatedPartitions);
         allTableJobMap.add(buildExternalStatisticsCollectJob(job.getCatalogName(), db, table,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskTest.java
@@ -22,19 +22,26 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.statistic.AnalyzeStatus;
+import com.starrocks.statistic.ColumnStatsMeta;
 import com.starrocks.statistic.ExternalAnalyzeStatus;
+import com.starrocks.statistic.ExternalBasicStatsMeta;
+import com.starrocks.statistic.ExternalFullStatisticsCollectJob;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.utframe.UtFrameUtils;
 import io.trino.hive.$internal.org.apache.commons.lang3.tuple.Triple;
 import mockit.Mock;
 import mockit.MockUp;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class ConnectorAnalyzeTaskTest {
     private static ConnectContext ctx;
@@ -44,6 +51,12 @@ public class ConnectorAnalyzeTaskTest {
         UtFrameUtils.createMinStarRocksCluster();
         ctx = UtFrameUtils.createDefaultCtx();
         ConnectorPlanTestBase.mockHiveCatalog(ctx);
+    }
+
+    @After
+    public void tearDown() {
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().getAnalyzeStatusMap().clear();
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().getExternalBasicStatsMetaMap().clear();
     }
 
     @Test
@@ -77,16 +90,86 @@ public class ConnectorAnalyzeTaskTest {
 
         new MockUp<ConnectorAnalyzeTask>() {
             @Mock
-            private AnalyzeStatus executeAnalyze(ConnectContext statsConnectCtx, AnalyzeStatus analyzeStatus) {
+            private AnalyzeStatus executeAnalyze(ConnectContext statsConnectCtx, AnalyzeStatus analyzeStatus,
+                                                 Set<String> updatedPartitions) {
+                analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FINISH);
                 return analyzeStatus;
+            }
+        };
+
+        new MockUp<StatisticUtils>() {
+            @Mock
+            public LocalDateTime getTableLastUpdateTime(Table table) {
+                return LocalDateTime.now().minusDays(1);
             }
         };
         // execute analyze when last analyze status is finish
         externalAnalyzeStatus.setStatus(StatsConstants.ScheduleStatus.FINISH);
+        // add ExternalBasicStatsMeta when analyze finish
+        ExternalBasicStatsMeta externalBasicStatsMeta = new ExternalBasicStatsMeta("hive0", "partitioned_db",
+                "orders", List.of("o_custkey", "o_orderstatus"), StatsConstants.AnalyzeType.FULL,
+                LocalDateTime.now(), Maps.newHashMap());
+        externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("o_custkey", StatsConstants.AnalyzeType.FULL,
+                LocalDateTime.now()));
+        externalBasicStatsMeta.addColumnStatsMeta(new ColumnStatsMeta("o_orderstatus", StatsConstants.AnalyzeType.FULL,
+                LocalDateTime.now()));
+
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().addExternalBasicStatsMeta(externalBasicStatsMeta);
+
         result = task1.run();
         Assert.assertTrue(result.isPresent());
         Assert.assertTrue(result.get() instanceof ExternalAnalyzeStatus);
         ExternalAnalyzeStatus externalAnalyzeStatusResult = (ExternalAnalyzeStatus) result.get();
         Assert.assertEquals(List.of("o_orderkey"), externalAnalyzeStatusResult.getColumns());
+    }
+
+    @Test
+    public void testTaskRunWithTableUpdate() {
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("hive0",
+                "partitioned_db", "orders");
+        String tableUUID = table.getUUID();
+
+        Triple<String, Database, Table> tableTriple = StatisticsUtils.getTableTripleByUUID(tableUUID);
+        ConnectorAnalyzeTask task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
+        new MockUp<ExternalFullStatisticsCollectJob>() {
+            @Mock
+            public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
+                // do nothing
+            }
+        };
+
+        Optional<AnalyzeStatus> result = task1.run();
+        Assert.assertTrue(result.isPresent());
+        Map<String, ColumnStatsMeta>  columnStatsMetaMap = GlobalStateMgr.getCurrentState().getAnalyzeMgr().
+                getExternalTableBasicStatsMeta("hive0", "partitioned_db", "orders").getColumnStatsMetaMap();
+        Assert.assertEquals(2, columnStatsMetaMap.size());
+        Assert.assertTrue(columnStatsMetaMap.containsKey("o_orderkey"));
+        Assert.assertTrue(columnStatsMetaMap.containsKey("o_custkey"));
+
+        new MockUp<StatisticUtils>() {
+            @Mock
+            public LocalDateTime getTableLastUpdateTime(Table table) {
+                return LocalDateTime.now().minusDays(1);
+            }
+        };
+        // table not update, skip analyze
+        task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
+        result = task1.run();
+        Assert.assertTrue(result.isEmpty());
+
+        // table update, analyze again
+        new MockUp<StatisticUtils>() {
+            @Mock
+            public LocalDateTime getTableLastUpdateTime(Table table) {
+                return LocalDateTime.now().plusMinutes(10);
+            }
+        };
+
+        task1 = new ConnectorAnalyzeTask(tableTriple, Sets.newHashSet("o_orderkey", "o_custkey"));
+        result = task1.run();
+        Assert.assertTrue(result.isPresent());
+        Assert.assertTrue(result.get() instanceof ExternalAnalyzeStatus);
+        ExternalAnalyzeStatus externalAnalyzeStatusResult = (ExternalAnalyzeStatus) result.get();
+        Assert.assertEquals(2, externalAnalyzeStatusResult.getColumns().size());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
We support trigger analyze when query connector table in #50747, but it only would analyze all partitions when the task run, we could skip unchanged partitions analyze task.
## What I'm doing:
1. when run analyze task, skip analyze when table not changed
2. skip analyze unchanged partitions
3. modify the connector_table_query_trigger_analyze_small_table_interval and connector_table_query_trigger_analyze_large_table_interval default value, because we could skip useless analyze task,  reduce the analyze interval
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
