### PR TITLE
[Enhancement] Enhance AggregatedTimeSeriesRewriter to support rewrite with multi mvs

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithHiveTest.java
@@ -47,9 +47,11 @@ public class MvTimeSeriesRewriteWithHiveTest extends MvRewriteTestBase {
                     "     PREDICATES: 26: dt >= '1998-01-02'\n" +
                     "     partitions=1/2");
             PlanTestBase.assertContains(plan, "     TABLE: lineitem_par\n" +
-                    "     PARTITION PREDICATES: NOT (date_trunc('month', 35: l_shipdate) >= '1998-01-02'), " +
+                    "     PARTITION PREDICATES: (NOT (date_trunc('month', 35: l_shipdate) >= '1998-01-02')) OR " +
+                    "(NOT (date_trunc('month', 35: l_shipdate) >= '1998-01-02')), 35: l_shipdate >= '1998-01-02', " +
                     "35: l_shipdate >= '1998-01-02'\n" +
-                    "     NO EVAL-PARTITION PREDICATES: NOT (date_trunc('month', 35: l_shipdate) >= '1998-01-02')\n" +
+                    "     NO EVAL-PARTITION PREDICATES: (NOT (date_trunc('month', 35: l_shipdate) >= '1998-01-02')) OR " +
+                    "(NOT (date_trunc('month', 35: l_shipdate) >= '1998-01-02'))\n" +
                     "     partitions=4/6");
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithOlapTest.java
@@ -129,7 +129,7 @@ public class MvTimeSeriesRewriteWithOlapTest extends MvRewriteTestBase {
         PlanTestBase.assertContains(plan, "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: date_trunc('day', 22: k1) < '2024-01-01 01:00:00', 22: k1 >= '2024-01-01 01:00:00'\n" +
-                "     partitions=1/5");
+                "     partitions=4/5");
         starRocksAssert.dropMaterializedView("test_mv1");
     }
 
@@ -155,7 +155,7 @@ public class MvTimeSeriesRewriteWithOlapTest extends MvRewriteTestBase {
             PlanTestBase.assertContains(plan, "     TABLE: t0\n" +
                     "     PREAGGREGATION: ON\n" +
                     "     PREDICATES: date_trunc('day', 24: k1) < '2024-01-01 01:00:00', 24: k1 >= '2024-01-01 01:00:00'\n" +
-                    "     partitions=1/5");
+                    "     partitions=4/5");
         }
         {
             // date column should be the same with date_trunc('day', ct)
@@ -184,7 +184,7 @@ public class MvTimeSeriesRewriteWithOlapTest extends MvRewriteTestBase {
                     "     PREDICATES: (date_trunc('day', 24: k1) > '2024-01-31 01:00:00') OR " +
                     "(date_trunc('day', 24: k1) < '2024-01-01 01:00:00'), 24: k1 <= '2024-02-01 01:00:00', " +
                     "24: k1 >= '2024-01-01 01:00:00'\n" +
-                    "     partitions=2/5");
+                    "     partitions=3/5");
         }
         starRocksAssert.dropMaterializedView("test_mv1");
     }
@@ -212,17 +212,57 @@ public class MvTimeSeriesRewriteWithOlapTest extends MvRewriteTestBase {
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: 36: dt >= '2024-01-01 01:00:00'\n" +
                 "     partitions=3/4");
-        PlanTestBase.assertContains(plan, "  8:OlapScanNode\n" +
-                "     TABLE: test_mv1\n" +
+        PlanTestBase.assertContains(plan, "     TABLE: test_mv1\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: date_trunc('month', 45: dt) < '2024-01-01 01:00:00', 45: dt >= '2024-01-01 01:00:00'\n" +
-                "     partitions=31/63");
+                "     partitions=62/63");
         PlanTestBase.assertContains(plan, "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: date_trunc('day', 25: k1) < '2024-01-01 01:00:00', 25: k1 >= '2024-01-01 01:00:00'\n" +
-                "     partitions=1/5");
+                "     partitions=4/5");
         starRocksAssert.dropMaterializedView("test_mv1");
         starRocksAssert.dropMaterializedView("test_mv2");
+    }
+
+    @Test
+    public void testAggregateTimeSeriesRollupWithMultiMVs() throws Exception {
+        starRocksAssert.withRefreshedMaterializedView("CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1\n" +
+                "PARTITION BY (dt)\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") as select date_trunc('hour', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2\n" +
+                "from t2 group by date_trunc('hour', ts);");
+        starRocksAssert.withRefreshedMaterializedView("CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv2\n" +
+                "PARTITION BY (dt)\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") as select date_trunc('day', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2\n" +
+                "from t2 group by date_trunc('day', ts);");
+        starRocksAssert.withRefreshedMaterializedView("CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv3\n" +
+                "PARTITION BY (dt)\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") as select date_trunc('month', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2\n" +
+                "from t2 group by date_trunc('month', ts);");
+
+        // date column should be the same with date_trunc('day', ct)
+        String query = "select sum(v1), sum(v2) from t2 where ts >= '2020-03-23 12:12:00' order by 1;";
+        UtFrameUtils.mockLogicalScanIsEmptyOutputRows(false);
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "     TABLE: test_mv3\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 19: dt >= '2020-03-23 12:12:00'");
+        PlanTestBase.assertContains(plan, "     TABLE: test_mv2\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 43: dt >= '2020-03-23 12:12:00', date_trunc('month', 43: dt) < '2020-03-22 12:12:00'\n");
+        PlanTestBase.assertContains(plan, "     TABLE: t2\n" +
+                "     PREAGGREGATION: ON");
+        starRocksAssert.dropMaterializedView("test_mv1");
+        starRocksAssert.dropMaterializedView("test_mv2");
+        starRocksAssert.dropMaterializedView("test_mv3");
     }
 
     @Test
@@ -246,7 +286,7 @@ public class MvTimeSeriesRewriteWithOlapTest extends MvRewriteTestBase {
         PlanTestBase.assertContains(plan, "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: date_trunc('day', 14: k1) < '2024-01-01 01:00:00', 14: k1 >= '2024-01-01 01:00:00'\n" +
-                "     partitions=1/5");
+                "     partitions=4/5");
         PlanTestBase.assertContains(plan, "  16:AGGREGATE (update serialize)\n" +
                 "  |  output: array_unique_agg(18: count)\n" +
                 "  |  group by: \n" +

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_time_series
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_time_series
@@ -84,7 +84,7 @@ True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where k2 > '2020-10-23 12:12:00' and k2 <= '2020-10-25 12:12:00'  group by k1 order by 1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where (k2 > '2020-10-23 12:12:00' or k2 <= '2020-10-24 12:12:00') and k8 > 2  group by k1 order by 1;", "test_mv1")
 -- result:
@@ -193,7 +193,7 @@ True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where k2 > '2020-10-23 12:12:00' and k2 <= '2020-10-25 12:12:00'  group by k1 order by 1;", "test_mv1")
 -- result:
-False
+True
 -- !result
 function: print_hit_materialized_view("select k1, sum(k6), sum(k7), sum(k8), count(1) as cnt from t1  where (k2 > '2020-10-23 12:12:00' or k2 <= '2020-10-24 12:12:00') and k8 > 2  group by k1 order by 1;", "test_mv1")
 -- result:

--- a/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_time_series_multi_mvs
+++ b/test/sql/test_materialized_view_rewrite/R/test_mv_rewrite_with_time_series_multi_mvs
@@ -1,0 +1,246 @@
+-- name: test_mv_rewrite_with_time_series_multi_mvs
+CREATE TABLE t0(
+ ts datetime,
+ v1 INT,
+ v2 INT)
+ DUPLICATE KEY(ts)
+ PARTITION BY date_trunc('day', ts)
+DISTRIBUTED BY HASH(ts);
+-- result:
+-- !result
+INSERT INTO t0 VALUES 
+  ('2020-01-22 12:12:12', 0,1),
+  ('2020-02-23 12:12:12',1,1),
+  ('2020-03-24 12:12:12',1,2),
+  ('2020-04-25 12:12:12',3,3),
+  ('2020-05-22 12:12:12', 0,1),
+  ('2020-06-23 12:12:12',1,1),
+  ('2020-07-24 12:12:12',1,2),
+  ('2020-08-24 12:12:12',1,2),
+  ('2020-09-24 12:12:12',1,2),
+  ('2020-10-25 12:12:12',3,3);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('hour', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2
+from t0 group by date_trunc('hour', ts);
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv2
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('day', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2
+from t0 group by date_trunc('day', ts);
+-- result:
+-- !result
+refresh materialized view test_mv2 with sync mode;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv3
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('month', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2
+from t0 group by date_trunc('month', ts);
+-- result:
+-- !result
+refresh materialized view test_mv3 with sync mode;
+set enable_materialized_view_rewrite=true;
+-- result:
+-- !result
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;")
+-- result:
+test_mv2,test_mv3
+-- !result
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;")
+-- result:
+test_mv2,test_mv3
+-- !result
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts < '2020-04-23 12:12:00'  order by 1;")
+-- result:
+test_mv3
+-- !result
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts <= '2020-05-23 12:12:00' and ts > '2020-10-22' order by 1;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-01-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;")
+-- result:
+test_mv2
+-- !result
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-10-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where (ts > '2020-06-23 12:12:00' or ts <= '2020-10-24 12:12:00') group by date_trunc('day', ts) order by 1;")
+-- result:
+test_mv1
+-- !result
+select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;
+-- result:
+12	17
+-- !result
+select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;
+-- result:
+11	16
+-- !result
+select sum(v1), sum(v2) from t0 where ts < '2020-04-23 12:12:00'  order by 1;
+-- result:
+2	4
+-- !result
+select sum(v1), sum(v2) from t0 where ts <= '2020-05-23 12:12:00' and ts > '2020-10-22' order by 1;
+-- result:
+None	None
+-- !result
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-01-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;
+-- result:
+2020-02-23 00:00:00	1	1
+2020-03-24 00:00:00	1	2
+2020-04-25 00:00:00	3	3
+2020-05-22 00:00:00	0	1
+2020-06-23 00:00:00	1	1
+2020-07-24 00:00:00	1	2
+2020-08-24 00:00:00	1	2
+2020-09-24 00:00:00	1	2
+-- !result
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-10-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;
+-- result:
+-- !result
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where (ts > '2020-06-23 12:12:00' or ts <= '2020-10-24 12:12:00') group by date_trunc('day', ts) order by 1;
+-- result:
+2020-01-22 00:00:00	0	1
+2020-02-23 00:00:00	1	1
+2020-03-24 00:00:00	1	2
+2020-04-25 00:00:00	3	3
+2020-05-22 00:00:00	0	1
+2020-06-23 00:00:00	1	1
+2020-07-24 00:00:00	1	2
+2020-08-24 00:00:00	1	2
+2020-09-24 00:00:00	1	2
+2020-10-25 00:00:00	3	3
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop materialized view test_mv2;
+-- result:
+-- !result
+drop materialized view test_mv3;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('hour', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2
+from t0 group by date_trunc('hour', ts);
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv2
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('day', dt) as dt, sum(sum_v1) as sum_v1, sum(sum_v2) as sum_v2
+from test_mv1 group by date_trunc('day', dt);
+-- result:
+-- !result
+refresh materialized view test_mv2 with sync mode;
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv3
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('month', dt) as dt, sum(sum_v1) as sum_v1, sum(sum_v2) as sum_v2
+from test_mv2 group by date_trunc('month', dt);
+-- result:
+-- !result
+refresh materialized view test_mv3 with sync mode;
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;")
+-- result:
+test_mv1,test_mv2,test_mv3
+-- !result
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;")
+-- result:
+test_mv1,test_mv2,test_mv3
+-- !result
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts < '2020-04-23 12:12:00'  order by 1;")
+-- result:
+test_mv1,test_mv2,test_mv3
+-- !result
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts <= '2020-05-23 12:12:00' and ts > '2020-10-22' order by 1;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-01-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;")
+-- result:
+test_mv1,test_mv2
+-- !result
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-10-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where (ts > '2020-06-23 12:12:00' or ts <= '2020-10-24 12:12:00') group by date_trunc('day', ts) order by 1;")
+-- result:
+test_mv2
+-- !result
+select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;
+-- result:
+12	17
+-- !result
+select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;
+-- result:
+11	16
+-- !result
+select sum(v1), sum(v2) from t0 where ts < '2020-04-23 12:12:00'  order by 1;
+-- result:
+2	4
+-- !result
+select sum(v1), sum(v2) from t0 where ts <= '2020-05-23 12:12:00' and ts > '2020-10-22' order by 1;
+-- result:
+None	None
+-- !result
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-01-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;
+-- result:
+2020-02-23 00:00:00	1	1
+2020-03-24 00:00:00	1	2
+2020-04-25 00:00:00	3	3
+2020-05-22 00:00:00	0	1
+2020-06-23 00:00:00	1	1
+2020-07-24 00:00:00	1	2
+2020-08-24 00:00:00	1	2
+2020-09-24 00:00:00	1	2
+-- !result
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-10-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;
+-- result:
+-- !result
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where (ts > '2020-06-23 12:12:00' or ts <= '2020-10-24 12:12:00') group by date_trunc('day', ts) order by 1;
+-- result:
+2020-01-22 00:00:00	0	1
+2020-02-23 00:00:00	1	1
+2020-03-24 00:00:00	1	2
+2020-04-25 00:00:00	3	3
+2020-05-22 00:00:00	0	1
+2020-06-23 00:00:00	1	1
+2020-07-24 00:00:00	1	2
+2020-08-24 00:00:00	1	2
+2020-09-24 00:00:00	1	2
+2020-10-25 00:00:00	3	3
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop materialized view test_mv2;
+-- result:
+-- !result
+drop materialized view test_mv3;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_with_time_series_multi_mvs
+++ b/test/sql/test_materialized_view_rewrite/T/test_mv_rewrite_with_time_series_multi_mvs
@@ -1,0 +1,119 @@
+-- name: test_mv_rewrite_with_time_series_multi_mvs
+CREATE TABLE t0(
+ ts datetime,
+ v1 INT,
+ v2 INT)
+ DUPLICATE KEY(ts)
+ PARTITION BY date_trunc('day', ts)
+DISTRIBUTED BY HASH(ts);
+
+INSERT INTO t0 VALUES 
+  ('2020-01-22 12:12:12', 0,1),
+  ('2020-02-23 12:12:12',1,1),
+  ('2020-03-24 12:12:12',1,2),
+  ('2020-04-25 12:12:12',3,3),
+  ('2020-05-22 12:12:12', 0,1),
+  ('2020-06-23 12:12:12',1,1),
+  ('2020-07-24 12:12:12',1,2),
+  ('2020-08-24 12:12:12',1,2),
+  ('2020-09-24 12:12:12',1,2),
+  ('2020-10-25 12:12:12',3,3);
+
+-- test for time series with multi mvs
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('hour', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2
+from t0 group by date_trunc('hour', ts);
+refresh materialized view test_mv1 with sync mode;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv2
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('day', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2
+from t0 group by date_trunc('day', ts);
+refresh materialized view test_mv2 with sync mode;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv3
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('month', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2
+from t0 group by date_trunc('month', ts);
+refresh materialized view test_mv3 with sync mode;
+
+set enable_materialized_view_rewrite=true;
+
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;")
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;")
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts < '2020-04-23 12:12:00'  order by 1;")
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts <= '2020-05-23 12:12:00' and ts > '2020-10-22' order by 1;")
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-01-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;")
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-10-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;")
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where (ts > '2020-06-23 12:12:00' or ts <= '2020-10-24 12:12:00') group by date_trunc('day', ts) order by 1;")
+
+select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;
+select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;
+select sum(v1), sum(v2) from t0 where ts < '2020-04-23 12:12:00'  order by 1;
+select sum(v1), sum(v2) from t0 where ts <= '2020-05-23 12:12:00' and ts > '2020-10-22' order by 1;
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-01-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-10-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where (ts > '2020-06-23 12:12:00' or ts <= '2020-10-24 12:12:00') group by date_trunc('day', ts) order by 1;
+
+drop materialized view test_mv1;
+drop materialized view test_mv2;
+drop materialized view test_mv3;
+
+-- test for time series with nested mvs
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('hour', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2
+from t0 group by date_trunc('hour', ts);
+refresh materialized view test_mv1 with sync mode;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv2
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('day', dt) as dt, sum(sum_v1) as sum_v1, sum(sum_v2) as sum_v2
+from test_mv1 group by date_trunc('day', dt);
+refresh materialized view test_mv2 with sync mode;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv3
+PARTITION BY (dt)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+"replication_num" = "1"
+) as select date_trunc('month', dt) as dt, sum(sum_v1) as sum_v1, sum(sum_v2) as sum_v2
+from test_mv2 group by date_trunc('month', dt);
+
+refresh materialized view test_mv3 with sync mode;
+
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;")
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;")
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts < '2020-04-23 12:12:00'  order by 1;")
+function: print_hit_materialized_views("select sum(v1), sum(v2) from t0 where ts <= '2020-05-23 12:12:00' and ts > '2020-10-22' order by 1;")
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-01-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;")
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-10-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;")
+function: print_hit_materialized_views("select date_trunc('day', ts), sum(v1), sum(v2) from t0 where (ts > '2020-06-23 12:12:00' or ts <= '2020-10-24 12:12:00') group by date_trunc('day', ts) order by 1;")
+
+select sum(v1), sum(v2) from t0 where ts > '2020-02-23 12:12:00' order by 1;
+select sum(v1), sum(v2) from t0 where ts >= '2020-03-23 12:12:00' order by 1;
+select sum(v1), sum(v2) from t0 where ts < '2020-04-23 12:12:00'  order by 1;
+select sum(v1), sum(v2) from t0 where ts <= '2020-05-23 12:12:00' and ts > '2020-10-22' order by 1;
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-01-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where ts > '2020-10-23 12:12:00' and ts <= '2020-10-25 12:12:00' group by date_trunc('day', ts) order by 1;
+select date_trunc('day', ts), sum(v1), sum(v2) from t0 where (ts > '2020-06-23 12:12:00' or ts <= '2020-10-24 12:12:00') group by date_trunc('day', ts) order by 1;
+
+drop materialized view test_mv1;
+drop materialized view test_mv2;
+drop materialized view test_mv3;


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/issues/51446 use nested mvs to resolve time-series rewrite problem.

If users create mvs without using nested mvs, it cannot be rewritten by this feature, eg:
```
CREATE TABLE t0(
 ts datetime,
 v1 INT,
 v2 INT)
 DUPLICATE KEY(ts)
 PARTITION BY RANGE(ts)
 (
   PARTITION p1 VALUES LESS THAN ('2024-01-01'),
   PARTITION p2 VALUES LESS THAN ('2024-01-02'),
   PARTITION p3 VALUES LESS THAN ('2024-01-03'),
   PARTITION p4 VALUES LESS THAN ('2024-02-03'),
   PARTITION p5 VALUES LESS THAN ('2024-03-03')
)
DISTRIBUTED BY HASH(k1);

create MATERIALIZED VIEW test_hourly_mv
PARTITION BY (dt)
DISTRIBUTED BY RANDOM
PROPERTIES (
"replication_num" = "1"
) as select date_trunc('hour', ts) as dt, sum(v1) as sum_v1, sum(v2) as sum_v2
from t0 group by date_trunc('hour', k1);

create MATERIALIZED VIEW test_daily_mv
PARTITION BY (dt)
DISTRIBUTED BY RANDOM
PROPERTIES (
"replication_num" = "1"
) as select date_trunc('day', dt) as dt, sum(sum_v1) as sum_v1, sum(sum_v2) as sum_v2
from t0 group by date_trunc('day', dt);

create MATERIALIZED VIEW test_monthly_mv
PARTITION BY (dt)
DISTRIBUTED BY RANDOM
PROPERTIES (
"replication_num" = "1"
) as select date_trunc('month', dt) as dt, sum(sum_v1) as sum_v1, sum(sum_v2) as sum_v2
from t0 group by date_trunc('month', dt);

-- query
SELECT SUM(v1) FROM t0
WHERE dt BETWEEN '2024-08-01 01:00' AND '2024-10-25 01:00';
```
## What I'm doing:
- Add more tests about this case and Enhance AggregatedTimeSeriesRewriter to support rewrite with multi mvs   

Fixes https://github.com/StarRocks/starrocks/issues/51446

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
