### PR TITLE
[UT] Remove unstable drop task test

### DIFF
--- a/test/sql/test_task/R/test_drop
+++ b/test/sql/test_task/R/test_drop
@@ -31,10 +31,6 @@ select sleep(2);
 select TASK_NAME, SCHEDULE from information_schema.tasks where `DATABASE`='test_drop_task_${uuid0}';
 -- result:
 -- !result
-select TASK_NAME, STATE, ERROR_MESSAGE from information_schema.task_runs where `DATABASE`='test_drop_task_${uuid0}';
--- result:
-test_kill	FAILED	kill TaskRun
--- !result
 drop task not_exist_task;
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: Task not_exist_task is not exist.')


### PR DESCRIPTION
## Why I'm doing:
The result of information_schema.task_runs depends on the execute time, delete it.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
