### PR TITLE
[Enhancement] Support TCP Keep-Alive on MySQL connections

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -657,6 +657,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: Specifies whether asynchronous I/O is enabled for the FE node.
 - Introduced in: -
 
+##### mysql_service_nio_enable_keep_alive
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: Enable TCP Keep-Alive for MySQL connections. Useful for long-idled connections behind load balancers.
+- Introduced in: -
+
 ##### mysql_service_io_threads_num
 
 - Default: 4

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -850,6 +850,12 @@ public class Config extends ConfigBase {
     public static int mysql_service_io_threads_num = 4;
 
     /**
+     * Enable TCP Keep-Alive for MySQL connections. Useful for long-idled connections behind load balancers.
+     */
+    @ConfField
+    public static boolean mysql_service_nio_enable_keep_alive = true;
+
+    /**
      * max num of thread to handle task in mysql.
      */
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/nio/NMysqlServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/nio/NMysqlServer.java
@@ -82,9 +82,15 @@ public class NMysqlServer extends MysqlServer {
     @Override
     public boolean start() {
         try {
+            OptionMap optionMap = OptionMap.builder()
+                    .set(Options.TCP_NODELAY, true)
+                    .set(Options.BACKLOG, Config.mysql_nio_backlog_num)
+                    .set(Options.KEEP_ALIVE, Config.mysql_service_nio_enable_keep_alive)
+                    .getMap();
+
             server = xnioWorker.createStreamConnectionServer(NetUtils.getSockAddrBasedOnCurrIpVersion(port),
                     acceptListener,
-                    OptionMap.create(Options.TCP_NODELAY, true, Options.BACKLOG, Config.mysql_nio_backlog_num));
+                    optionMap);
             server.resumeAccepts();
             running = true;
             LOG.info("Open mysql server success on {}", port);


### PR DESCRIPTION
## Why I'm doing:

Issue: https://github.com/StarRocks/starrocks/issues/50153

AWS Network Load Balancers have a non configurable [idle timeout](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout) of 350 seconds, and long-running queries can easily take longer than this.

By default Linux emits a Keep-Alive packet every 7200 seconds when TCP Keep-Alive (`SO_KEEPALIVE`) is enabled on the socket. It is possible to change this interval using `ulimit` globally per host, or per pod when running on Kubernetes.

## What I'm doing:

I added a config for the FE to enable TCP Keep Alive on MySQL connections (default `false` to preserve old behavior).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [X] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [X] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [X] This pr needs user documentation (for new or modified features or behaviors)
  - [X] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
