### PR TITLE
[Enhancement] Make str_to_date and str2date function can parse format only with year and month

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -37,6 +37,7 @@ import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.WeekFields;
+import java.util.regex.Pattern;
 
 public class DateUtils {
     // These are marked as deprecated because they don't support year 0000 parsing
@@ -68,6 +69,9 @@ public class DateUtils {
     public static final DateTimeFormatter HOUR_FORMATTER_UNIX = unixDatetimeFormatter("%Y%m%d%H");
     public static final DateTimeFormatter YEAR_FORMATTER_UNIX = unixDatetimeFormatter("%Y");
     public static final DateTimeFormatter MONTH_FORMATTER_UNIX = unixDatetimeFormatter("%Y%m");
+    // A regular expressions that will support the dateTimeFormat pattern in year format or year month format
+    // For example '%y%m', '%y-%m'
+    public static final Pattern MONTH_YEAR_FORMATTER_PATTERN = Pattern.compile("%[yY](-)?(%c|%m)?");
 
     private static final JsonSerializer<LocalDateTime> LOCAL_DATETIME_PRINTER =
             (dateTime, type, cx) -> new JsonPrimitive(dateTime.format(DATE_TIME_FORMATTER_UNIX));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -425,10 +425,15 @@ public class ScalarOperatorFunctionsTest {
         assertEquals("1998-02-21 00:00:00",
                 ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("98-02-21"),
                         ConstantOperator.createVarchar("%y-%m-%d")).toString());
-
-        Assert.assertThrows(DateTimeException.class, () -> ScalarOperatorFunctions
-                .dateParse(ConstantOperator.createVarchar("201905"),
-                        ConstantOperator.createVarchar("%Y%m")).getDatetime());
+        assertEquals("2019-05-01 00:00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("201905"),
+                        ConstantOperator.createVarchar("%Y%m")).toString());
+        assertEquals("2019-05-01 00:00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2019-05"),
+                        ConstantOperator.createVarchar("%Y-%m")).toString());
+        assertEquals("2019-01-01 00:00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("2019"),
+                        ConstantOperator.createVarchar("%Y")).toString());
 
         Assert.assertThrows(DateTimeException.class, () -> ScalarOperatorFunctions
                 .dateParse(ConstantOperator.createVarchar("20190507"),


### PR DESCRIPTION
[Enhancement] Make str_to_date and str2date function can parse format only with year and month

## Why I'm doing:
StarRocks will not support select str_to_date('202410', '%Y%m') query but in trino it can work

## What I'm doing:
Set the parseDefaulting for MONTH_OF_YEAR and DAY_OF_MONTH in unixDatetimeFormatBuilder when the pattern is year or year month format pattern

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
