### PR TITLE
[BugFix] fix memory leak of SegmentedColumn

### DIFF
--- a/be/src/column/vectorized_fwd.h
+++ b/be/src/column/vectorized_fwd.h
@@ -117,6 +117,7 @@ class SegmentedChunk;
 using SegmentedColumnPtr = std::shared_ptr<SegmentedColumn>;
 using SegmentedColumns = std::vector<SegmentedColumnPtr>;
 using SegmentedChunkPtr = std::shared_ptr<SegmentedChunk>;
+using SegmentedChunkWeakPtr = std::weak_ptr<SegmentedChunk>;
 
 using SchemaPtr = std::shared_ptr<Schema>;
 

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -156,7 +156,7 @@ private:
 
 class SegmentedColumn final : public std::enable_shared_from_this<SegmentedColumn> {
 public:
-    SegmentedColumn(SegmentedChunkPtr chunk, size_t column_index);
+    SegmentedColumn(const SegmentedChunkPtr& chunk, size_t column_index);
     SegmentedColumn(std::vector<ColumnPtr> columns, size_t segment_size);
     ~SegmentedColumn() = default;
 
@@ -171,8 +171,8 @@ public:
     std::vector<ColumnPtr> columns() const;
 
 private:
-    SegmentedChunkPtr _chunk; // The chunk it belongs to
-    size_t _column_index;     // The index in original chunk
+    SegmentedChunkWeakPtr _chunk; // The chunk it belongs to
+    size_t _column_index;         // The index in original chunk
     const size_t _segment_size;
 
     std::vector<ColumnPtr> _cached_columns; // Only used for SelectiveCopy


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

circular reference between `SegmentedColumn` and `SegmentedChunk` lead to memory leak.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
