### PR TITLE
[Enhancement] adjust async-profile queue strategy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -600,16 +600,12 @@ public class Config extends ConfigBase {
     @ConfField
     public static int heartbeat_mgr_blocking_queue_size = 1024;
 
-    /**
-     * num of thread to handle profile processing
-     */
-    @ConfField
+    @ConfField(comment = "[DEPRECATED] Number of thread to handle profile processing")
+    @Deprecated
     public static int profile_process_threads_num = 2;
 
-    /**
-     * blocking queue size to store profile process task
-     */
-    @ConfField
+    @ConfField(comment = "[DEPRECATED] Size of blocking queue to store profile process task")
+    @Deprecated
     public static int profile_process_blocking_queue_size = profile_process_threads_num * 128;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -79,7 +79,7 @@ public class ThreadPoolManager {
 
     private static Map<String, ThreadPoolExecutor> nameToThreadPoolMap = Maps.newConcurrentMap();
 
-    private static final String[] poolMerticTypes = {"pool_size", "active_thread_num", "task_in_queue",
+    private static final String[] POOL_METRIC_TYPES = {"pool_size", "active_thread_num", "task_in_queue",
             "completed_task_count"};
 
     private static final long KEEP_ALIVE_TIME = 60L;
@@ -92,7 +92,7 @@ public class ThreadPoolManager {
     }
 
     public static void registerThreadPoolMetric(String poolName, ThreadPoolExecutor threadPool) {
-        for (String poolMetricType : poolMerticTypes) {
+        for (String poolMetricType : POOL_METRIC_TYPES) {
             GaugeMetric<Integer> gauge =
                     new GaugeMetric<Integer>("thread_pool", MetricUnit.NOUNIT, "thread_pool statistics") {
                         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -79,7 +79,8 @@ public class ThreadPoolManager {
 
     private static Map<String, ThreadPoolExecutor> nameToThreadPoolMap = Maps.newConcurrentMap();
 
-    private static String[] poolMerticTypes = {"pool_size", "active_thread_num", "task_in_queue"};
+    private static final String[] poolMerticTypes = {"pool_size", "active_thread_num", "task_in_queue",
+            "completed_task_count"};
 
     private static final long KEEP_ALIVE_TIME = 60L;
 
@@ -104,6 +105,8 @@ public class ThreadPoolManager {
                                     return threadPool.getActiveCount();
                                 case "task_in_queue":
                                     return threadPool.getQueue().size();
+                                case "completed_task_count":
+                                    return (int) threadPool.getCompletedTaskCount();
                                 default:
                                     return 0;
                             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThreadPoolManager.java
@@ -251,5 +251,21 @@ public class ThreadPoolManager {
             executor.setMaximumPoolSize(poolSize);
         }
     }
+
+    /**
+     * Calculate the number of CPU cores available on the machine.
+     *
+     * @return The number of CPU cores available.
+     */
+    public static int cpuCores() {
+        return Runtime.getRuntime().availableProcessors();
+    }
+
+    /**
+     * Use at most 3/4 to execute cpu-intensive background tasks
+     */
+    public static int cpuIntensiveThreadPoolSize() {
+        return Integer.max(2, cpuCores() * 3 / 4);
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -954,8 +954,9 @@ public class RuntimeProfile {
             reorderedChildNames.addAll(minMaxChildNames);
             reorderedChildNames.addAll(otherChildNames);
 
+            Map<String, Counter> counterMap1 = profile.getCounterMap();
             for (String childName : reorderedChildNames) {
-                Counter childCounter = profile.getCounterMap().get(childName);
+                Counter childCounter = counterMap1.get(childName);
                 Preconditions.checkState(childCounter != null);
                 builder.append(prefix).append("   - ").append(childName).append(": ")
                         .append(printCounter(childCounter.getValue(), childCounter.getType())).append("\n");

--- a/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ThreadPoolManagerTest.java
@@ -38,7 +38,7 @@ public class ThreadPoolManagerTest {
 
         List<Metric> metricList = MetricRepo.getMetricsByName("thread_pool");
 
-        Assert.assertEquals(6, metricList.size());
+        Assert.assertEquals(8, metricList.size());
         Assert.assertEquals(ThreadPoolManager.LogDiscardPolicy.class,
                 testCachedPool.getRejectedExecutionHandler().getClass());
         Assert.assertEquals(ThreadPoolManager.BlockedPolicy.class,


### PR DESCRIPTION
## Why I'm doing:

`Async profile` uses a background threadpool to process profile, but it's configuration doesn't make sense for some intensive workload.
- `thread_num`: default is 2
- `queue_size`: `thread_num * 128`, too large
- The unmerged profile can be pretty large(2 digits MB), including the query-plan and a lot of counters in it

For a typical workload:
- Each profile task would take over 200ms, and the peak QPS is 100
- For this workload, it needs at least `100 / (1/0.2)=20` threads to catchup the query profile
- If the profile-worker is unable to catchup the queue, the query profile would be accumulated and take a lot of memory

## What I'm doing:

Change the threadpool of `profile-worker`:
1. `thread_num`: max as `cpu_cores*0.75`
2. `queue_size`: max as `thread_num*4` 

For the above workload:
1. If FE has 64 cpu_cores, the thread_num would be 48, which is enough


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
