### PR TITLE
[Enhancement] adjust drop_tablet_worker_count to half of the core number by default

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -199,10 +199,11 @@ void AgentServer::Impl::init_or_die() {
                                        _thread_pool_publish_version);
         REGISTER_THREAD_POOL_METRICS(publish_version, _thread_pool_publish_version);
 #endif
-        int real_drop_tablet_worker_count = (config::drop_tablet_worker_count != 0) ? std::abs(config::drop_tablet_worker_count)
-                                                                                    : (int32_t)(CpuInfo::num_cores() / 2);
-        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, real_drop_tablet_worker_count,
-                                       std::numeric_limits<int>::max(), _thread_pool_drop);
+        int real_drop_tablet_worker_count = (config::drop_tablet_worker_count != 0)
+                                                    ? std::abs(config::drop_tablet_worker_count)
+                                                    : (int32_t)(CpuInfo::num_cores() / 2);
+        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, real_drop_tablet_worker_count, std::numeric_limits<int>::max(),
+                                       _thread_pool_drop);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("create_tablet", 1, config::create_tablet_worker_count,
                                        std::numeric_limits<int>::max(), _thread_pool_create_tablet);

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -199,8 +199,9 @@ void AgentServer::Impl::init_or_die() {
                                        _thread_pool_publish_version);
         REGISTER_THREAD_POOL_METRICS(publish_version, _thread_pool_publish_version);
 #endif
-        int real_drop_tablet_worker_count = (config::drop_tablet_worker_count > 0) ?
-                                             config::drop_tablet_worker_count : std::max((int)(CpuInfo::num_cores() / 2), (int)1);
+        int real_drop_tablet_worker_count = (config::drop_tablet_worker_count > 0)
+                                                    ? config::drop_tablet_worker_count
+                                                    : std::max((int)(CpuInfo::num_cores() / 2), (int)1);
         BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, real_drop_tablet_worker_count, std::numeric_limits<int>::max(),
                                        _thread_pool_drop);
 

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -199,8 +199,9 @@ void AgentServer::Impl::init_or_die() {
                                        _thread_pool_publish_version);
         REGISTER_THREAD_POOL_METRICS(publish_version, _thread_pool_publish_version);
 #endif
-
-        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, config::drop_tablet_worker_count, std::numeric_limits<int>::max(),
+        int32_t adjust_drop_tablet_worker_count = config::drop_tablet_worker_count;
+        adjust_drop_tablet_worker_count = (adjust_drop_tablet_worker_count < 0) ? -adjust_drop_tablet_worker_count : adjust_drop_tablet_worker_count;
+        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, (int32_t) (calc_real_num_threads(adjust_drop_tablet_worker_count) / 2), std::numeric_limits<int>::max(),
                                        _thread_pool_drop);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("create_tablet", 1, config::create_tablet_worker_count,

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -199,9 +199,8 @@ void AgentServer::Impl::init_or_die() {
                                        _thread_pool_publish_version);
         REGISTER_THREAD_POOL_METRICS(publish_version, _thread_pool_publish_version);
 #endif
-        int real_drop_tablet_worker_count = (config::drop_tablet_worker_count != 0)
-                                                    ? std::abs(config::drop_tablet_worker_count)
-                                                    : (int)(CpuInfo::num_cores() / 2);
+        int real_drop_tablet_worker_count = (config::drop_tablet_worker_count > 0) ?
+                                             config::drop_tablet_worker_count : std::max((int)(CpuInfo::num_cores() / 2), (int)1);
         BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, real_drop_tablet_worker_count, std::numeric_limits<int>::max(),
                                        _thread_pool_drop);
 

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -200,9 +200,10 @@ void AgentServer::Impl::init_or_die() {
         REGISTER_THREAD_POOL_METRICS(publish_version, _thread_pool_publish_version);
 #endif
         int32_t adjust_drop_tablet_worker_count = config::drop_tablet_worker_count;
-        adjust_drop_tablet_worker_count = (adjust_drop_tablet_worker_count < 0) ? -adjust_drop_tablet_worker_count : adjust_drop_tablet_worker_count;
-        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, (int32_t) (calc_real_num_threads(adjust_drop_tablet_worker_count) / 2), std::numeric_limits<int>::max(),
-                                       _thread_pool_drop);
+        adjust_drop_tablet_worker_count = (adjust_drop_tablet_worker_count < 0) ? -adjust_drop_tablet_worker_count
+                                                                                : adjust_drop_tablet_worker_count;
+        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, (int32_t) (calc_real_num_threads(adjust_drop_tablet_worker_count) / 2),
+                                       std::numeric_limits<int>::max(), _thread_pool_drop);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("create_tablet", 1, config::create_tablet_worker_count,
                                        std::numeric_limits<int>::max(), _thread_pool_create_tablet);

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -201,7 +201,7 @@ void AgentServer::Impl::init_or_die() {
 #endif
         int real_drop_tablet_worker_count = (config::drop_tablet_worker_count != 0)
                                                     ? std::abs(config::drop_tablet_worker_count)
-                                                    : (int32_t)(CpuInfo::num_cores() / 2);
+                                                    : (int)(CpuInfo::num_cores() / 2);
         BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, real_drop_tablet_worker_count, std::numeric_limits<int>::max(),
                                        _thread_pool_drop);
 

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -202,7 +202,7 @@ void AgentServer::Impl::init_or_die() {
         int32_t adjust_drop_tablet_worker_count = config::drop_tablet_worker_count;
         adjust_drop_tablet_worker_count = (adjust_drop_tablet_worker_count < 0) ? -adjust_drop_tablet_worker_count
                                                                                 : adjust_drop_tablet_worker_count;
-        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, (int32_t) (calc_real_num_threads(adjust_drop_tablet_worker_count) / 2),
+        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, (int32_t)(calc_real_num_threads(adjust_drop_tablet_worker_count) / 2),
                                        std::numeric_limits<int>::max(), _thread_pool_drop);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("create_tablet", 1, config::create_tablet_worker_count,

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -199,10 +199,9 @@ void AgentServer::Impl::init_or_die() {
                                        _thread_pool_publish_version);
         REGISTER_THREAD_POOL_METRICS(publish_version, _thread_pool_publish_version);
 #endif
-        int32_t adjust_drop_tablet_worker_count = config::drop_tablet_worker_count;
-        adjust_drop_tablet_worker_count = (adjust_drop_tablet_worker_count < 0) ? -adjust_drop_tablet_worker_count
-                                                                                : adjust_drop_tablet_worker_count;
-        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, (int32_t)(calc_real_num_threads(adjust_drop_tablet_worker_count) / 2),
+        int real_drop_tablet_worker_count = (config::drop_tablet_worker_count != 0) ? std::abs(config::drop_tablet_worker_count)
+                                                                                    : (int32_t)(CpuInfo::num_cores() / 2);
+        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, real_drop_tablet_worker_count,
                                        std::numeric_limits<int>::max(), _thread_pool_drop);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("create_tablet", 1, config::create_tablet_worker_count,

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -92,7 +92,7 @@ CONF_Int32(heartbeat_service_thread_count, "1");
 // The count of thread to create table.
 CONF_mInt32(create_tablet_worker_count, "3");
 // The count of thread to drop table.
-CONF_mInt32(drop_tablet_worker_count, "3");
+CONF_mInt32(drop_tablet_worker_count, "0");
 // The count of thread to batch load.
 CONF_Int32(push_worker_count_normal_priority, "3");
 // The count of thread to high priority batch load.

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -265,8 +265,12 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                     max_thread_cnt);
         });
         _config_callback.emplace("drop_tablet_worker_count", [&]() -> Status {
+            int max_thread_cnt = CpuInfo::num_cores() / 2;
+            if (config::drop_tablet_worker_count > 0) {
+                max_thread_cnt = config::drop_tablet_worker_count;
+            }
             auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::DROP);
-            return thread_pool->update_max_threads(config::drop_tablet_worker_count);
+            return thread_pool->update_max_threads(max_thread_cnt);
         });
         _config_callback.emplace("make_snapshot_worker_count", [&]() -> Status {
             auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::MAKE_SNAPSHOT);

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -265,7 +265,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                     max_thread_cnt);
         });
         _config_callback.emplace("drop_tablet_worker_count", [&]() -> Status {
-            int max_thread_cnt = CpuInfo::num_cores() / 2;
+            int max_thread_cnt = std::max((int)CpuInfo::num_cores() / 2, (int)1);
             if (config::drop_tablet_worker_count > 0) {
                 max_thread_cnt = config::drop_tablet_worker_count;
             }


### PR DESCRIPTION
## Why I'm doing:
In shared data mode, file gc relies on the efficiency of the delete file thread pool. The default thread pool size is too small, which causes the delete file task queue to accumulate easily under high ingestion concurrency or under large ingestion, resulting in slowing donw vacuum task.

## What I'm doing:
In the pr, we slightly increase the delete file thread pool size into half the cpu core (`config::drop_tablet_worker_count <= 0`) If user change the `config::drop_tablet_worker_count <= 0` at runtime, the thread pool size will also be modified as half the cpu core.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4 
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
