### PR TITLE
[Enhancement] improve shared-data cluster ingest slowdown display & strategy and also enable by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2708,12 +2708,9 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, comment =
             "The upper limit for compaction score, only takes effect when lake_enable_ingest_slowdown=true.\n" +
-                    "When the compaction score exceeds this value, data ingestion transactions will be prevented from\n" +
-                    "committing. This is a soft limit, the actual compaction score may exceed the configured bound.\n" +
-                    "The effective value will be set to the higher of the configured value here and " +
-                    "lake_compaction_score_selector_min_score.\n" +
+                    "When the compaction score exceeds this value, ingestion will be rejected.\n" +
                     "A value of 0 represents no limit.")
-    public static long lake_compaction_score_upper_bound = 1000;
+    public static long lake_compaction_score_upper_bound = 2000;
 
     @ConfField(mutable = true)
     public static boolean enable_new_publish_mechanism = false;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2691,7 +2691,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment =
             "Whether enable throttling ingestion speed when compaction score exceeds the threshold.\n" +
                     "Only takes effect for tables in clusters with run_mode=shared_data.")
-    public static boolean lake_enable_ingest_slowdown = false;
+    public static boolean lake_enable_ingest_slowdown = true;
 
     @ConfField(mutable = true, comment =
             "Compaction score threshold above which ingestion speed slowdown is applied.\n" +
@@ -2713,7 +2713,7 @@ public class Config extends ConfigBase {
                     "The effective value will be set to the higher of the configured value here and " +
                     "lake_compaction_score_selector_min_score.\n" +
                     "A value of 0 represents no limit.")
-    public static long lake_compaction_score_upper_bound = 0;
+    public static long lake_compaction_score_upper_bound = 1000;
 
     @ConfField(mutable = true)
     public static boolean enable_new_publish_mechanism = false;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CommitRateLimiterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CommitRateLimiterTest.java
@@ -229,13 +229,7 @@ public class CommitRateLimiterTest {
         compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 3, currentTimeMs,
                 Quantiles.compute(Lists.newArrayList(compactionScore)));
 
-        CommitRateExceededException e =
-                Assert.assertThrows(CommitRateExceededException.class, () -> limiter.check(partitions, currentTimeMs));
-        Assert.assertEquals(currentTimeMs + 1000, e.getAllowCommitTime());
-
-        CommitRateExceededException e2 =
-                Assert.assertThrows(CommitRateExceededException.class, () -> limiter.check(partitions, currentTimeMs));
-        Assert.assertEquals(currentTimeMs + 1000, e2.getAllowCommitTime());
+        Assert.assertThrows(CommitFailedException.class, () -> limiter.check(partitions, currentTimeMs));
     }
 
     @Test
@@ -275,8 +269,7 @@ public class CommitRateLimiterTest {
                 Quantiles.compute(Lists.newArrayList(compactionScore)));
 
         // This time commit should be denied by the lake_compaction_score_upper_bound
-        CommitRateExceededException e2 = Assert.assertThrows(CommitRateExceededException.class,
+        Assert.assertThrows(CommitFailedException.class,
                 () -> limiter.check(partitions, newCurrentTimeMs));
-        Assert.assertEquals(newCurrentTimeMs + 1000, e2.getAllowCommitTime());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
To keep the compaction score of partitions under a specific number is important, because it can introduce predictable query latency, which is important for a OLAP DB.
So we need to slow ingestion down, when compaction task can't catch up ingestion rate to prevent too large compaction score happen. And we also need a better display & strategy to tell our user that you can increase compaction worker to speed up both ingestion and query.

## What I'm doing:
1. When ingestion slow down happens, user can find the reason from this cmd:
```
mysql> show proc '/transactions/test_pri_load_c/running';
+---------------+----------------------------------------------+------------------+-------------------+--------------------+---------------------+------------+-------------+------------+----------------------------------------------------------------------------------------------------------------------------+--------------------+------------+-----------+--------+
| TransactionId | Label                                        | Coordinator      | TransactionStatus | LoadJobSourceType  | PrepareTime         | CommitTime | PublishTime | FinishTime | Reason                                                                                                                     | ErrorReplicasCount | ListenerId | TimeoutMs | ErrMsg |
+---------------+----------------------------------------------+------------------+-------------------+--------------------+---------------------+------------+-------------+------------+----------------------------------------------------------------------------------------------------------------------------+--------------------+------------+-----------+--------+
| 1034          | stream_load_d2753fbaa0b343acadd5f13de92d44c1 | FE: 172.26.94.39 | PREPARE           | FRONTEND_STREAMING | 2024-10-24 13:05:01 | NULL       | NULL        | NULL       | Partition's compaction score is larger than 100.0, delay commit for 6513ms. You can try to increase compaction concurrency, | 0                  | 11054      | 86400000  |        |
+---------------+----------------------------------------------+------------------+-------------------+--------------------+---------------------+------------+-------------+------------+----------------------------------------------------------------------------------------------------------------------------+--------------------+------------+-----------+--------+
```
User can find message `Partition's compaction score is larger than 100.0, delay commit for 6513ms. You can try to increase compaction concurrency` from Reason column.

2. When compaction score is larger than `lake_compaction_score_upper_bound` (default is 1000), then return error message and abort ingestion instead of keep slowdown.
```
{
    "TxnId": 1100,
    "Label": "stream_load_28369f71428e47b3a37f8a0d8da5d653",
    "Status": "Fail",
    "Message": "fail to execute commit task: Failed to load data into partition 11007, because of too large compaction score, current/limit: 1001.0/1000. You can reduce the loading job concurrency, or increase compaction concurrency",
    ...
```
3. enable slowdown ingestion by default.

## Result

```
lake_ingest_slowdown_threshold = 20
lake_ingest_slowdown_ratio = 0.5
lake_compaction_score_upper_bound = 50
```

![image](https://github.com/user-attachments/assets/1d60e5f5-083f-4050-a2b3-5327507f63cf)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
