### PR TITLE
[Enhancement] Support push down avg aggregate function in mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
@@ -14,27 +14,22 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
-import com.starrocks.catalog.ScalarType;
-import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
-import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
 
-import java.util.List;
 import java.util.Map;
 
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregateFunctionRollupUtils.getRollupAggregateFunc;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregatePushDownUtils.createAvgBySumCount;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregatePushDownUtils.createNewCallOperator;
 
 /**
  * `AggregateFunctionRewriter` will try to rewrite some agg functions to some transformations so can be
@@ -80,20 +75,6 @@ public class AggregateFunctionRewriter {
         }
     }
 
-    private Pair<ColumnRefOperator, CallOperator> createNewCallOperator(Function newFn,
-                                                                        List<ScalarOperator> args) {
-        Preconditions.checkState(newFn != null);
-        CallOperator newCallOp = new CallOperator(newFn.functionName(), newFn.getReturnType(), args, newFn);
-        ColumnRefOperator newColRef =
-                queryColumnRefFactory.create(newCallOp, newCallOp.getType(), newCallOp.isNullable());
-        for (Map.Entry<ColumnRefOperator, CallOperator> entry : oldAggregations.entrySet()) {
-            if (entry.getValue().equals(newCallOp)) {
-                return Pair.create(newColRef, newCallOp);
-            }
-        }
-        return Pair.create(newColRef, newCallOp);
-    }
-
     /**
      * For avg with rollup, return div(sum_col_ref, count_col_ref) and new sum/count call operator with newColumnRefToAggFuncMap.
      * For avg without rollup, return rewritten div(sum_call_op, count_call_op).
@@ -104,10 +85,11 @@ public class AggregateFunctionRewriter {
         // construct `sum` agg
         Function sumFn = ScalarOperatorUtil.findSumFn(aggFunc.getFunction().getArgs());
         Pair<ColumnRefOperator, CallOperator> sumCallOp =
-                createNewCallOperator(sumFn, aggFunc.getChildren());
+                createNewCallOperator(queryColumnRefFactory, oldAggregations, sumFn, aggFunc.getChildren());
 
         Function countFn = ScalarOperatorUtil.findArithmeticFunction(aggFunc.getFunction().getArgs(), FunctionSet.COUNT);
-        Pair<ColumnRefOperator, CallOperator> countCallOp = createNewCallOperator(countFn, aggFunc.getChildren());
+        Pair<ColumnRefOperator, CallOperator> countCallOp = createNewCallOperator(queryColumnRefFactory, oldAggregations,
+                countFn, aggFunc.getChildren());
 
         CallOperator newAvg = getNewAVGBySumCount(aggFunc, sumCallOp, countCallOp, isRollup);
         if (isRollup) {
@@ -132,24 +114,11 @@ public class AggregateFunctionRewriter {
                                              Pair<ColumnRefOperator, CallOperator> sumCallOp,
                                              Pair<ColumnRefOperator, CallOperator> countCallOp,
                                              boolean isRollup) {
-        CallOperator newAvg;
         if (isRollup) {
-            newAvg = new CallOperator(FunctionSet.DIVIDE, aggFunc.getType(),
-                    Lists.newArrayList(sumCallOp.first, countCallOp.first));
+            return createAvgBySumCount(aggFunc, sumCallOp.first, countCallOp.first);
         } else {
-            newAvg = new CallOperator(FunctionSet.DIVIDE, aggFunc.getType(),
-                    Lists.newArrayList(sumCallOp.second, countCallOp.second));
+            return createAvgBySumCount(aggFunc, sumCallOp.second, countCallOp.second);
         }
-        Type argType = aggFunc.getChild(0).getType();
-        if (argType.isDecimalV3()) {
-            // There is not need to apply ImplicitCastRule to divide operator of decimal types.
-            // but we should cast BIGINT-typed countColRef into DECIMAL(38,0).
-            ScalarType decimal128p38s0 = ScalarType.createDecimalV3NarrowestType(38, 0);
-            newAvg.getChildren().set(1, new CastOperator(decimal128p38s0, newAvg.getChild(1), true));
-        } else {
-            newAvg = (CallOperator) scalarRewriter.rewrite(newAvg, Lists.newArrayList(new ImplicitCastRule()));
-        }
-        return newAvg;
     }
 
     private ScalarOperator rewriteAggFunction(CallOperator aggFunc) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewPushDownRewriter.java
@@ -216,7 +216,7 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
             }
 
             context = new AggregatePushDownContext();
-            context.setAggregator(aggOp);
+            context.setAggregator(queryColumnRefFactory, aggOp);
             return context;
         }
 
@@ -484,6 +484,8 @@ public final class AggregatedMaterializedViewPushDownRewriter extends Materializ
 
                 if (uniqueAggregations.containsKey(aggCall)) {
                     ctx.aggColRefToPushDownAggMap.put(aggColRef, aggCall);
+                    // add into remapping even if it has existed.
+                    remapping.put(aggColRef, uniqueAggregations.get(aggCall));
                     continue;
                 }
                 // NOTE: This new aggregate type is final stage's type not the immediate/partial stage type.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
@@ -13,12 +13,16 @@
 // limitations under the License.
 package com.starrocks.sql.optimizer.rule.transformation.materialization.common;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -26,9 +30,12 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.AggregatedMaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
@@ -37,6 +44,7 @@ import com.starrocks.sql.optimizer.rule.tree.pdagg.AggregatePushDownContext;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.deriveLogicalProperty;
@@ -96,61 +104,36 @@ public class AggregatePushDownUtils {
 
         // TODO: use aggregate push down context to generate related push-down aggregation functions
         final Map<ColumnRefOperator, CallOperator> aggregations = origAggregate.getAggregations();
-        final ColumnRefFactory queryColumnRefFactory = mvRewriteContext.getMaterializationContext().getQueryRefFactory();
         for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregations.entrySet()) {
             ColumnRefOperator origAggColRef = entry.getKey();
             CallOperator aggCall = entry.getValue();
-            CallOperator newAggregate = getRollupFinalAggregate(mvRewriteContext, ctx, remapping, origAggColRef, aggCall);
-            if (newAggregate == null) {
-                return null;
-            }
-            // If rewritten function is not an aggregation function, it could be like ScalarFunc(AggregateFunc(...))
-            // We need to decompose it into Projection function and Aggregation function
-            // E.g. count(distinct x) => array_length(array_unique_agg(x))
-            // The array_length is a ScalarFunction and array_unique_agg is AggregateFunction
-            // So it's decomposed into 1: array_length(slot_2), 2: array_unique_agg(x)
-            CallOperator realAggregate = newAggregate;
-            int foundIndex = 0;
-            if (!newAggregate.isAggregate()) {
-                foundIndex = -1;
-                for (int i = 0; i < newAggregate.getChildren().size(); i++) {
-                    if (newAggregate.getChild(i) instanceof CallOperator) {
-                        CallOperator call = (CallOperator) newAggregate.getChild(i);
-                        if (call.isAggregate()) {
-                            foundIndex = i;
-                            realAggregate = call;
-                            break;
-                        }
-                    }
-                }
-                if (foundIndex == -1) {
-                    logMVRewrite(mvRewriteContext,
-                            "no aggregate functions found: " + newAggregate.getChildren());
+            if (ctx.avgToSumCountMapping.containsKey(aggCall)) {
+                // if it's an avg function, we need to rewrite it to sum and count function
+                Pair<ColumnRefOperator, ColumnRefOperator> newAggPair = ctx.avgToSumCountMapping.get(aggCall);
+                ColumnRefOperator sumColRef = newAggPair.first;
+                CallOperator sumAggCall = ctx.aggColRefToPushDownAggMap.get(sumColRef);
+                if (!getRollupFinalAggregate(mvRewriteContext, ctx, remapping, sumColRef, sumAggCall, newAggregations,
+                        aggColRefToAggMap)) {
                     return null;
                 }
-            }
-            // rewrite it with remapping and final aggregate should use the new input as its argument.
-            ScalarOperator newArg0 = remapping.get(origAggColRef);
-            realAggregate = replaceAggFuncArgument(mvRewriteContext, realAggregate, newArg0, foundIndex);
-
-            ColumnRefOperator newAggColRef = queryColumnRefFactory.create(realAggregate,
-                    realAggregate.getType(), realAggregate.isNullable());
-            newAggregations.put(newAggColRef, realAggregate);
-            if (!newAggregate.isAggregate()) {
-                CallOperator copyProject = (CallOperator) newAggregate.clone();
-                copyProject.setChild(foundIndex, newAggColRef);
-
-                ColumnRefOperator newProjColRef = queryColumnRefFactory
-                        .create(copyProject, copyProject.getType(), copyProject.isNullable());
-                // keeps original output column, otherwise upstream operators may be affected
-                aggProjection.put(newProjColRef, copyProject);
-                // replace original projection to newProjColRef.
-                aggColRefToAggMap.put(origAggColRef, copyProject);
+                ColumnRefOperator countColRef = newAggPair.second;
+                CallOperator countAggCall = ctx.aggColRefToPushDownAggMap.get(countColRef);
+                if (!getRollupFinalAggregate(mvRewriteContext, ctx, remapping, countColRef, countAggCall, newAggregations,
+                        aggColRefToAggMap)) {
+                    return null;
+                }
+                if (!aggColRefToAggMap.containsKey(sumColRef) || !aggColRefToAggMap.containsKey(countColRef)) {
+                    return null;
+                }
+                // after rewrite sum and count function(push-down), we need to rewrite avg function
+                ScalarOperator newAvg = createAvgBySumCount(aggCall, aggColRefToAggMap.get(sumColRef),
+                        aggColRefToAggMap.get(countColRef));
+                aggColRefToAggMap.put(origAggColRef, newAvg);
             } else {
-                // keeps original output column, otherwise upstream operators may be affected
-                aggProjection.put(newAggColRef, genRollupProject(aggCall, newAggColRef, true));
-                // replace original projection to newAggColRef or no need to change?
-                aggColRefToAggMap.put(origAggColRef, newAggColRef);
+                if (!getRollupFinalAggregate(mvRewriteContext, ctx, remapping, origAggColRef, aggCall, newAggregations,
+                        aggColRefToAggMap)) {
+                    return null;
+                }
             }
         }
 
@@ -186,6 +169,67 @@ public class AggregatePushDownUtils {
                 .build();
         OptExpression result = OptExpression.create(newAgg, newChildren);
         return result;
+    }
+
+    private static boolean getRollupFinalAggregate(MvRewriteContext mvRewriteContext,
+                                                   AggregatePushDownContext ctx,
+                                                   Map<ColumnRefOperator, ColumnRefOperator> remapping,
+                                                   ColumnRefOperator origAggColRef,
+                                                   CallOperator aggCall,
+                                                   Map<ColumnRefOperator, CallOperator> newAggregations,
+                                                   Map<ColumnRefOperator, ScalarOperator> aggColRefToAggMap) {
+        final ColumnRefFactory queryColumnRefFactory = mvRewriteContext.getMaterializationContext().getQueryRefFactory();
+        CallOperator newAggregate = getRollupFinalAggregate(mvRewriteContext, ctx, remapping, origAggColRef, aggCall);
+        if (newAggregate == null) {
+            return false;
+        }
+        // If rewritten function is not an aggregation function, it could be like ScalarFunc(AggregateFunc(...))
+        // We need to decompose it into Projection function and Aggregation function
+        // E.g. count(distinct x) => array_length(array_unique_agg(x))
+        // The array_length is a ScalarFunction and array_unique_agg is AggregateFunction
+        // So it's decomposed into 1: array_length(slot_2), 2: array_unique_agg(x)
+        CallOperator realAggregate = newAggregate;
+        // rewrite it with remapping and final aggregate should use the new input as its argument.
+        ScalarOperator newArg0 = remapping.get(origAggColRef);
+        Preconditions.checkArgument(newArg0 != null, "Aggregation's arg0 is null after " +
+                "remapping, aggColRef:{}, aggCall:{}", origAggColRef, aggCall);
+        if (!newAggregate.isAggregate()) {
+            int foundIndex = 0;
+            if (!newAggregate.isAggregate()) {
+                foundIndex = -1;
+                for (int i = 0; i < newAggregate.getChildren().size(); i++) {
+                    if (newAggregate.getChild(i) instanceof CallOperator) {
+                        CallOperator call = (CallOperator) newAggregate.getChild(i);
+                        if (call.isAggregate()) {
+                            foundIndex = i;
+                            realAggregate = call;
+                            break;
+                        }
+                    }
+                }
+                if (foundIndex == -1) {
+                    logMVRewrite(mvRewriteContext,
+                            "no aggregate functions found: " + newAggregate.getChildren());
+                    return false;
+                }
+            }
+            realAggregate = replaceAggFuncArgument(mvRewriteContext, realAggregate, newArg0, foundIndex);
+            ColumnRefOperator newAggColRef = queryColumnRefFactory.create(realAggregate,
+                    realAggregate.getType(), realAggregate.isNullable());
+            newAggregations.put(newAggColRef, realAggregate);
+            CallOperator copyProject = (CallOperator) newAggregate.clone();
+            copyProject.setChild(foundIndex, newAggColRef);
+            // replace original projection to newProjColRef.
+            aggColRefToAggMap.put(origAggColRef, copyProject);
+        } else {
+            realAggregate = replaceAggFuncArgument(mvRewriteContext, realAggregate, newArg0, 0);
+            ColumnRefOperator newAggColRef = queryColumnRefFactory.create(realAggregate,
+                    realAggregate.getType(), realAggregate.isNullable());
+            newAggregations.put(newAggColRef, realAggregate);
+            // replace original projection to newAggColRef or no need to change?
+            aggColRefToAggMap.put(origAggColRef, genRollupProject(aggCall, newAggColRef, true));
+        }
+        return true;
     }
 
     private static CallOperator getRollupFinalAggregate(MvRewriteContext mvRewriteContext,
@@ -279,5 +323,46 @@ public class AggregatePushDownUtils {
         }
         newAggCall.setChild(argIdx, newArg);
         return newAggCall;
+    }
+
+    /**
+     * Create new call operator with new function and arguments
+     */
+    public static Pair<ColumnRefOperator, CallOperator> createNewCallOperator(ColumnRefFactory columnRefFactory,
+                                                                              Map<ColumnRefOperator, CallOperator> aggregations,
+                                                                              Function newFn,
+                                                                              List<ScalarOperator> args) {
+        Preconditions.checkState(newFn != null);
+        CallOperator newCallOp = new CallOperator(newFn.functionName(), newFn.getReturnType(), args, newFn);
+        ColumnRefOperator newColRef =
+                columnRefFactory.create(newCallOp, newCallOp.getType(), newCallOp.isNullable());
+        // reuse old aggregation functions if it has existed
+        Optional<CallOperator> existedOpt = aggregations.values().stream().filter(newCallOp::equals).findFirst();
+        if (existedOpt.isPresent()) {
+            return Pair.create(newColRef, existedOpt.get());
+        } else {
+            return Pair.create(newColRef, newCallOp);
+        }
+    }
+
+    /**
+     * Create new avg function by sum and count function
+     */
+    public static CallOperator createAvgBySumCount(CallOperator avgFunc,
+                                                   ScalarOperator sumCallOp,
+                                                   ScalarOperator countCallOp) {
+        CallOperator newAvg = new CallOperator(FunctionSet.DIVIDE, avgFunc.getType(),
+                Lists.newArrayList(sumCallOp, countCallOp));
+        Type argType = avgFunc.getChild(0).getType();
+        if (argType.isDecimalV3()) {
+            // There is not need to apply ImplicitCastRule to divide operator of decimal types.
+            // but we should cast BIGINT-typed countColRef into DECIMAL(38,0).
+            ScalarType decimal128p38s0 = ScalarType.createDecimalV3NarrowestType(38, 0);
+            newAvg.getChildren().set(1, new CastOperator(decimal128p38s0, newAvg.getChild(1), true));
+        } else {
+            final ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
+            newAvg = (CallOperator) scalarRewriter.rewrite(newAvg, Lists.newArrayList(new ImplicitCastRule()));
+        }
+        return newAvg;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/AggregatePushDownContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/AggregatePushDownContext.java
@@ -17,13 +17,20 @@ package com.starrocks.sql.optimizer.rule.tree.pdagg;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 
 import java.util.List;
 import java.util.Map;
+
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.common.AggregatePushDownUtils.createNewCallOperator;
 
 public class AggregatePushDownContext {
     public static final AggregatePushDownContext EMPTY = new AggregatePushDownContext();
@@ -42,6 +49,9 @@ public class AggregatePushDownContext {
     // Query's aggregate call operator to push down aggregate call operator mapping,
     // those two operators are not the same so record it to be used later.
     public final Map<ColumnRefOperator, CallOperator> aggColRefToPushDownAggMap = Maps.newHashMap();
+    // For avg function, split it into sum and count function, this map records the mapping from avg function to sum and
+    // count's column ref operator.
+    public final Map<CallOperator, Pair<ColumnRefOperator, ColumnRefOperator>> avgToSumCountMapping = Maps.newHashMap();
 
     public boolean hasWindow = false;
 
@@ -59,6 +69,34 @@ public class AggregatePushDownContext {
     public void setAggregator(LogicalAggregationOperator aggregator) {
         this.origAggregator = aggregator;
         this.aggregations.putAll(aggregator.getAggregations());
+        aggregator.getGroupingKeys().forEach(c -> groupBys.put(c, c));
+        this.pushPaths.clear();
+    }
+
+    /**
+     * Set the aggregator and create new column ref operator for avg function.
+     */
+    public void setAggregator(ColumnRefFactory columnRefFactory,
+                              LogicalAggregationOperator aggregator) {
+        this.origAggregator = aggregator;
+        final Map<ColumnRefOperator, CallOperator> aggregations = aggregator.getAggregations();
+        for (Map.Entry<ColumnRefOperator, CallOperator> e : aggregations.entrySet()) {
+            if (e.getValue().getFunction().functionName().equalsIgnoreCase(FunctionSet.AVG)) {
+                CallOperator agg = e.getValue();
+                // for avg function, split it into sum and count function and push them down below join.
+                Function sumFn = ScalarOperatorUtil.findSumFn(agg.getFunction().getArgs());
+                Pair<ColumnRefOperator, CallOperator> sumCallOp =
+                        createNewCallOperator(columnRefFactory, aggregations, sumFn, agg.getChildren());
+                this.aggregations.put(sumCallOp.first, sumCallOp.second);
+                Function countFn = ScalarOperatorUtil.findArithmeticFunction(agg.getFunction().getArgs(), FunctionSet.COUNT);
+                Pair<ColumnRefOperator, CallOperator> countCallOp = createNewCallOperator(columnRefFactory, aggregations,
+                        countFn, agg.getChildren());
+                this.aggregations.put(countCallOp.first, countCallOp.second);
+                this.avgToSumCountMapping.put(e.getValue(), Pair.create(sumCallOp.first, countCallOp.first));
+            } else {
+                this.aggregations.put(e.getKey(), e.getValue());
+            }
+        }
         aggregator.getGroupingKeys().forEach(c -> groupBys.put(c, c));
         this.pushPaths.clear();
     }
@@ -88,6 +126,8 @@ public class AggregatePushDownContext {
     public void combine(AggregatePushDownContext ctx) {
         aggToFinalAggMap.putAll(ctx.aggToFinalAggMap);
         aggColRefToPushDownAggMap.putAll(ctx.aggColRefToPushDownAggMap);
+        aggToPartialAggMap.putAll(ctx.aggToPartialAggMap);
+        avgToSumCountMapping.putAll(ctx.avgToSumCountMapping);
     }
 
     public boolean isRewrittenByEquivalent(CallOperator aggCall) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewAggPushDownRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewAggPushDownRewriteTest.java
@@ -1050,4 +1050,45 @@ public class MaterializedViewAggPushDownRewriteTest extends MaterializedViewTest
             });
         }
     }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_Avg() {
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum, count(LO_REVENUE) as revenue_cnt \n" +
+                "from lineorder l group by LO_ORDERDATE");
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String query = String.format("select LO_ORDERDATE, avg(LO_REVENUE) as revenue_sum\n" +
+                    "   from lineorder l join dates d on l.LO_ORDERDATE = d.d_datekey\n" +
+                    "   group by LO_ORDERDATE");
+            sql(query).contains("mv0");
+        });
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_MultiAvgs1() {
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum, count(LO_REVENUE) as revenue_cnt \n" +
+                "from lineorder l group by LO_ORDERDATE");
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String query = String.format("select LO_ORDERDATE, avg(LO_REVENUE) as avg1, avg(LO_REVENUE) as avg2\n" +
+                    "   from lineorder l join dates d on l.LO_ORDERDATE = d.d_datekey\n" +
+                    "   group by LO_ORDERDATE");
+            sql(query).contains("mv0");
+        });
+    }
+
+    @Test
+    public void testAggPushDown_RollupFunctions_MultiAvgs2() {
+        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
+                "select LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum, count(LO_REVENUE) as revenue_cnt,\n" +
+                " sum(lo_custkey) as sum_lo_custkey, count(lo_custkey) as count_lo_custkey\n" +
+                "from lineorder l group by LO_ORDERDATE");
+        setTracLogModule("MV");
+        starRocksAssert.withMaterializedView(mv, () -> {
+            String query = String.format("select LO_ORDERDATE, sum(LO_REVENUE), avg(LO_REVENUE) as avg1, " +
+                    "avg(LO_REVENUE) as avg2, avg(lo_custkey) as avg3 from lineorder l \n" +
+                    "join dates d on l.LO_ORDERDATE = d.d_datekey group by LO_ORDERDATE");
+            sql(query).contains("mv0");
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewAggPushDownRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewAggPushDownRewriteTest.java
@@ -1083,7 +1083,6 @@ public class MaterializedViewAggPushDownRewriteTest extends MaterializedViewTest
                 "select LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum, count(LO_REVENUE) as revenue_cnt,\n" +
                 " sum(lo_custkey) as sum_lo_custkey, count(lo_custkey) as count_lo_custkey\n" +
                 "from lineorder l group by LO_ORDERDATE");
-        setTracLogModule("MV");
         starRocksAssert.withMaterializedView(mv, () -> {
             String query = String.format("select LO_ORDERDATE, sum(LO_REVENUE), avg(LO_REVENUE) as avg1, " +
                     "avg(LO_REVENUE) as avg2, avg(lo_custkey) as avg3 from lineorder l \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2814,7 +2814,6 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     @Test
     public void testCountDistinctToBitmapCount1() {
         String mv = "select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;";
-        setTracLogModule("MV");
         testRewriteOK(mv, "select user_id, bitmap_union(to_bitmap(tag_id)) x from user_tags group by user_id;")
                 .match("  |  <slot 2> : 6: user_id\n" +
                         "  |  <slot 5> : 7: bitmap_union(to_bitmap(tag_id))");
@@ -3297,7 +3296,6 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 ")");
 
         String mv = "SELECT time_slice(dt, interval 5 minute) as t, sum(c1) FROM t_time_slice GROUP BY t";
-        setTracLogModule("MV");
         testRewriteOK(mv, "SELECT time_slice(dt, interval 5 minute) as t FROM t_time_slice " +
                 "WHERE dt BETWEEN '2023-06-01' AND '2023-06-02' GROUP BY t");
         starRocksAssert.dropTable("t_time_slice");

--- a/test/sql/test_materialized_view/R/test_materialized_view_agg_pushdown_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_agg_pushdown_rewrite
@@ -71,14 +71,14 @@ COMMENT "OLAP"
 DISTRIBUTED BY HASH(`d_datekey`) BUCKETS 1;
 -- result:
 -- !result
- CREATE TABLE IF NOT EXISTS `supplier` (
-    `s_suppkey` int(11) NOT NULL COMMENT "",
-    `s_name` varchar(26) NOT NULL COMMENT "",
-    `s_address` varchar(26) NOT NULL COMMENT "",
-    `s_city` varchar(11) NOT NULL COMMENT "",
-    `s_nation` varchar(16) NOT NULL COMMENT "",
-    `s_region` varchar(13) NOT NULL COMMENT "",
-    `s_phone` varchar(16) NOT NULL COMMENT ""
+CREATE TABLE IF NOT EXISTS `supplier` (
+   `s_suppkey` int(11) NOT NULL COMMENT "",
+   `s_name` varchar(26) NOT NULL COMMENT "",
+   `s_address` varchar(26) NOT NULL COMMENT "",
+   `s_city` varchar(11) NOT NULL COMMENT "",
+   `s_nation` varchar(16) NOT NULL COMMENT "",
+   `s_region` varchar(13) NOT NULL COMMENT "",
+   `s_phone` varchar(16) NOT NULL COMMENT ""
 ) ENGINE=OLAP
 DUPLICATE KEY(`s_suppkey`)
 COMMENT "OLAP"
@@ -500,4 +500,46 @@ select d_year, LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE), 
 -- !result
 drop materialized view mv0;
 -- result:
+-- !result
+CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL AS
+select LO_ORDERDATE, sum(LO_REVENUE), count(LO_REVENUE), sum(lo_suppkey), count(lo_suppkey), max(LO_REVENUE), min(LO_REVENUE), bitmap_union(to_bitmap(LO_REVENUE)), hll_union(hll_hash(LO_REVENUE)), percentile_union(percentile_hash(LO_REVENUE)), any_value(LO_REVENUE), bitmap_agg(LO_REVENUE), array_agg_distinct(LO_REVENUE) 
+from lineorder l group by LO_ORDERDATE;
+-- result:
+-- !result
+refresh materialized view mv0 with sync mode;
+function: print_hit_materialized_view("select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE;", "mv0")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), sum(LO_REVENUE), max(LO_REVENUE) , sum(LO_REVENUE), max(LO_REVENUE), count(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE;", "mv0")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), min(LO_REVENUE), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE;", "mv0")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), min(LO_REVENUE), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE HAVING sum(LO_REVENUE) > 1;", "mv0")
+-- result:
+True
+-- !result
+select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE order by LO_ORDERDATE;
+-- result:
+1993-01-01	180	90	90.0
+1994-01-01	175	175	175.0
+-- !result
+select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), sum(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), max(LO_REVENUE) , sum(LO_REVENUE), max(LO_REVENUE), count(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE order by LO_ORDERDATE;
+-- result:
+1993-01-01	180	90	180	90.0	1.0	90	180	90	1	1
+1994-01-01	175	175	175	175.0	2.0	175	175	175	1	1
+-- !result
+select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE order by LO_ORDERDATE;
+-- result:
+1993-01-01	180	90	90	90.0	1.0	1	1	90.0	90.0	90	1
+1994-01-01	175	175	175	175.0	2.0	1	1	175.0	175.0	175	1
+-- !result
+select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE),  avg(LO_REVENUE), avg(lo_suppkey), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE HAVING sum(LO_REVENUE) > 1 order by LO_ORDERDATE;
+-- result:
+1993-01-01	180	90	90	90.0	1.0	1	1	90.0	90.0	90	1
+1994-01-01	175	175	175	175.0	2.0	1	1	175.0	175.0	175	1
 -- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_agg_pushdown_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_agg_pushdown_rewrite
@@ -254,3 +254,19 @@ select d_year, LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), sum(LO_REVENUE), 
 select d_year, LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date where l.LO_ORDERDATE >= '1993-01-01' group by d_year, LO_ORDERDATE order by LO_ORDERDATE;
 
 drop materialized view mv0;
+
+--- test simple case
+CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL AS
+select LO_ORDERDATE, sum(LO_REVENUE), count(LO_REVENUE), sum(lo_suppkey), count(lo_suppkey), max(LO_REVENUE), min(LO_REVENUE), bitmap_union(to_bitmap(LO_REVENUE)), hll_union(hll_hash(LO_REVENUE)), percentile_union(percentile_hash(LO_REVENUE)), any_value(LO_REVENUE), bitmap_agg(LO_REVENUE), array_agg_distinct(LO_REVENUE) 
+from lineorder l group by LO_ORDERDATE;
+refresh materialized view mv0 with sync mode;
+
+function: print_hit_materialized_view("select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE;", "mv0")
+function: print_hit_materialized_view("select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), sum(LO_REVENUE), max(LO_REVENUE) , sum(LO_REVENUE), max(LO_REVENUE), count(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE;", "mv0")
+function: print_hit_materialized_view("select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), min(LO_REVENUE), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE;", "mv0")
+function: print_hit_materialized_view("select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), min(LO_REVENUE), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE HAVING sum(LO_REVENUE) > 1;", "mv0")
+
+select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE order by LO_ORDERDATE;
+select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), sum(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), max(LO_REVENUE) , sum(LO_REVENUE), max(LO_REVENUE), count(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE order by LO_ORDERDATE;
+select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE order by LO_ORDERDATE;
+select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE),  avg(LO_REVENUE), avg(lo_suppkey), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE HAVING sum(LO_REVENUE) > 1 order by LO_ORDERDATE;


### PR DESCRIPTION
## Why I'm doing:
- If we have defined `sum/count` aggregate function for a table, we can also support `avg` function to push down below join since `avg` can be rewritten by `sum/count`.


But this case cannot work yet.
```
        String mv = String.format("CREATE MATERIALIZED VIEW mv0 REFRESH MANUAL as " +
                "select LO_ORDERDATE, sum(LO_REVENUE) as revenue_sum, count(LO_REVENUE) as revenue_cnt,\n" +
                " sum(lo_custkey) as sum_lo_custkey, count(lo_custkey) as count_lo_custkey\n" +
                "from lineorder l group by LO_ORDERDATE");
        starRocksAssert.withMaterializedView(mv, () -> {
            String query = String.format("select LO_ORDERDATE, sum(LO_REVENUE), avg(LO_REVENUE) as avg1, " +
                    "avg(LO_REVENUE) as avg2, avg(lo_custkey) as avg3 from lineorder l \n" +
                    "join dates d on l.LO_ORDERDATE = d.d_datekey group by LO_ORDERDATE");
            sql(query).contains("mv0");
        });
```
## What I'm doing:
- For `avg(col)` function, push down `sum(col)` and `count(col)` below join, and rewrite into`divide(sum, count) after rewrite.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
