### PR TITLE
[Enhancement] optimize SegmentedColumnSelectiveCopy

### DIFF
--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -296,7 +296,7 @@ struct HashTableParam {
     bool mor_reader_mode = false;
 
     // TODO: optimize this according to chunk width
-    size_t build_chunk_segment_size = 1 << 16;
+    size_t build_chunk_segment_size = 1 << 20;
 };
 
 template <class T>

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -647,8 +647,9 @@ public:
 
         ContainerT& output_items = output->get_data();
         output_items.resize(_size);
-        for (uint32_t i = 0; i < _size; i++) {
-            uint32_t idx = _indexes[_from + i];
+        size_t from = _from;
+        for (size_t i = 0; i < _size; i++) {
+            size_t idx = _indexes[from + i];
             auto [segment_id, segment_offset] = _segment_address(idx, segment_size);
             DCHECK_LT(segment_id, columns.size());
             DCHECK_LT(segment_offset, columns[segment_id]->size());
@@ -691,8 +692,9 @@ public:
         // assign offsets
         output_offsets.resize(_size + 1);
         size_t num_bytes = 0;
+        size_t from = _from;
         for (size_t i = 0; i < _size; i++) {
-            uint32_t idx = _indexes[_from + i];
+            size_t idx = _indexes[from + i];
             auto [segment_id, segment_offset] = _segment_address(idx, segment_size);
             DCHECK_LT(segment_id, columns.size());
             DCHECK_LT(segment_offset, columns[segment_id]->size());
@@ -708,7 +710,7 @@ public:
         // copy bytes
         Byte* dest_bytes = output_bytes.data();
         for (size_t i = 0; i < _size; i++) {
-            uint32_t idx = _indexes[_from + i];
+            size_t idx = _indexes[from + i];
             auto [segment_id, segment_offset] = _segment_address(idx, segment_size);
             Bytes& src_bytes = *input_bytes[segment_id];
             Offsets& src_offsets = *input_offsets[segment_id];
@@ -734,8 +736,9 @@ public:
         output->reserve(_size);
 
         auto columns = _segment_column->columns();
-        for (uint32_t i = 0; i < _size; i++) {
-            uint32_t idx = _indexes[_from + i];
+        size_t from = _from;
+        for (size_t i = 0; i < _size; i++) {
+            size_t idx = _indexes[from + i];
             auto [segment_id, segment_offset] = _segment_address(idx, segment_size);
             output->append(*columns[segment_id], segment_offset, 1);
         }
@@ -766,9 +769,9 @@ public:
     ColumnPtr result() { return _result; }
 
 private:
-    inline std::pair<int, int> _segment_address(uint32 idx, size_t segment_size) {
-        int segment_id = idx / segment_size;
-        int segment_offset = idx % segment_size;
+    __attribute__((always_inline)) std::pair<size_t, size_t> _segment_address(size_t idx, size_t segment_size) {
+        size_t segment_id = idx / segment_size;
+        size_t segment_offset = idx % segment_size;
         return {segment_id, segment_offset};
     }
 

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -168,6 +168,7 @@ public:
     size_t size() const;
     void upgrade_to_nullable();
     size_t segment_size() const;
+    size_t num_segments() const;
     std::vector<ColumnPtr> columns() const;
 
 private:


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

optimization 0: add fastpath for 1 segment, use `Column::append_selective`

optimization 1: change segment_size from `1<<16` to `1<<20`.

optimization 2: Improve generated instructions of selective copy:
1. use `size_t` instead of `uint32_t` to avoid `cltq` instruction
2. correctly inline the `_segment_address` function

instructions after the change(with clang-16 compiler), current bottleneck is memory copy:
```
       │     starrocks::Status starrocks::SegmentedColumnSelectiveCopy::do_visit<int>(starrocks::FixedLengthColumnBase<int> const&):
       │     be/build_RELEASE/be/src/storage/chunk_helper.cpp:657
  0.36 │519:   mov     (%r9,%rcx,8),%rcx
       │     std::vector<int, starrocks::ColumnAllocator<int> >::operator[](unsigned long):
  1.36 │       mov     (%rcx),%rcx
       │     starrocks::Status starrocks::SegmentedColumnSelectiveCopy::do_visit<int>(starrocks::FixedLengthColumnBase<int> const&):
       │     be/build_RELEASE/be/src/storage/chunk_helper.cpp:657
  1.93 │       mov     (%rcx,%rax,4),%eax
 84.87 │       mov     %eax,(%rdi,%r8,4)
       │     be/build_RELEASE/be/src/storage/chunk_helper.cpp:651
  1.84 │       inc     %r8
  0.45 │       mov     0x3c(%rbx),%eax
  0.46 │       cmp     %rax,%r8
       │     ↓ jae     53f
       │     be/build_RELEASE/be/src/storage/chunk_helper.cpp:652
  0.39 │532:   mov     (%rsi,%r8,4),%eax
       │     starrocks::SegmentedColumnSelectiveCopy::_segment_address(unsigned long, unsigned long):
       │     be/build_RELEASE/be/src/storage/chunk_helper.cpp:771
  0.95 │       cmp     %r10,%rax
       │     ↑ jae     510
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
