### PR TITLE
[BugFix] Fix several problem for logical view restore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -707,11 +707,9 @@ public class BackupJob extends AbstractJob {
             localMetaInfoFilePath = metaInfoFile.getAbsolutePath();
 
             // 3. save job info file
-            // save table info into BackupJobInfo only for OlapTable or MV
-            List<Table> olapTbls = backupMeta.getTables().values().stream()
-                                   .filter(Table::isOlapTableOrMaterializedView).collect(Collectors.toList());
-            jobInfo = BackupJobInfo.fromCatalog(createTime, label, dbName, dbId, olapTbls, snapshotInfos);
-            LOG.warn("job info: {}. {}", jobInfo, this);
+            jobInfo = BackupJobInfo.fromCatalog(createTime, label, dbName, dbId, backupMeta.getTables().values(),
+                    snapshotInfos);
+            LOG.debug("job info: {}. {}", jobInfo, this);
             File jobInfoFile = new File(jobDir, Repository.PREFIX_JOB_INFO + createTimeStr);
             if (!jobInfoFile.createNewFile()) {
                 status = new Status(ErrCode.COMMON_ERROR, "Failed to create job info file: " + jobInfoFile.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
@@ -304,11 +304,16 @@ public class BackupJobInfo implements Writable {
 
         // tbls
         for (Table tbl : tbls) {
-            OlapTable olapTbl = (OlapTable) tbl;
             BackupTableInfo tableInfo = new BackupTableInfo();
             tableInfo.id = tbl.getId();
             tableInfo.name = tbl.getName();
             jobInfo.tables.put(tableInfo.name, tableInfo);
+
+            if (tbl.isOlapView()) {
+                continue;
+            }
+
+            OlapTable olapTbl = (OlapTable) tbl;
             // partitions
             for (Partition partition : olapTbl.getPartitions()) {
                 BackupPartitionInfo partitionInfo = new BackupPartitionInfo();
@@ -451,6 +456,11 @@ public class BackupJobInfo implements Writable {
             }
             JSONObject parts = tbl.getJSONObject("partitions");
             String[] partsNames = JSONObject.getNames(parts);
+            if (partsNames == null) {
+                // skip logical view
+                jobInfo.tables.put(tblName, tblInfo);
+                continue;
+            }
             for (String partName : partsNames) {
                 BackupPartitionInfo partInfo = new BackupPartitionInfo();
                 partInfo.name = partName;

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -47,7 +47,6 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.Table.Cell;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.BrokerDesc;
-import com.starrocks.analysis.TableName;
 import com.starrocks.backup.BackupJobInfo.BackupIndexInfo;
 import com.starrocks.backup.BackupJobInfo.BackupPartitionInfo;
 import com.starrocks.backup.BackupJobInfo.BackupPhysicalPartitionInfo;
@@ -79,9 +78,7 @@ import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
-import com.starrocks.catalog.View;
 import com.starrocks.common.Config;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.Text;
@@ -93,11 +90,8 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.fs.HdfsUtil;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.ColocatePersistInfo;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.ast.CreateViewStmt;
-import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
 import com.starrocks.task.AgentTaskExecutor;
@@ -538,6 +532,18 @@ public class RestoreJob extends AbstractJob {
                 Preconditions.checkNotNull(remoteTbl);
                 Table localTbl = globalStateMgr.getLocalMetastore()
                             .getTable(db.getFullName(), jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
+
+                if (localTbl != null && remoteTbl.isOlapView() && !localTbl.isOlapView()) {
+                    status = new Status(ErrCode.BAD_REPLACE,
+                                        "Table: " + localTbl.getName() + " has existed and it is not a View");
+                    return;
+                }
+
+                if (remoteTbl.isOlapView()) {
+                    restoredTbls.add(remoteTbl);
+                    continue;
+                }
+
                 if (localTbl != null) {
                     if (localTbl instanceof OlapTable && localTbl.hasAutoIncrementColumn()) {
                         // it must be !isReplay == true
@@ -768,7 +774,7 @@ public class RestoreJob extends AbstractJob {
                             backupTableInfo.getPartInfo(restorePart.getName()), true);
                 }
                 // set restored table's new name after all 'genFileMapping'
-                ((OlapTable) restoreTbl).setName(jobInfo.getAliasByOriginNameIfSet(restoreTbl.getName()));
+                restoreTbl.setName(jobInfo.getAliasByOriginNameIfSet(restoreTbl.getName()));
             }
 
             LOG.debug("finished to generate create replica tasks. {}", this);
@@ -784,14 +790,6 @@ public class RestoreJob extends AbstractJob {
 
         // add all restored partition and tbls to globalStateMgr
         addRestorePartitionsAndTables(db);
-        if (!status.ok()) {
-            return;
-        }
-
-        // add all restored olap view into globalStateMgr
-        List<View> restoredOlapViews = backupMeta.getTables().values().stream().filter(Table::isOlapView)
-                                       .map(x -> (View) x).collect(Collectors.toList());
-        addRestoreOlapView(restoredOlapViews);
         if (!status.ok()) {
             return;
         }
@@ -853,38 +851,6 @@ public class RestoreJob extends AbstractJob {
         }
     }
 
-    protected void addRestoreOlapView(List<View> restoredOlapViews) {
-        Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
-
-        ConnectContext context = new ConnectContext();
-        context.setDatabase(db.getFullName());
-        context.setGlobalStateMgr(globalStateMgr);
-        context.setStartTime();
-        context.setThreadLocalInfo();
-
-        for (View restoredOlapView : restoredOlapViews) {
-            Table localTbl = db.getTable(restoredOlapView.getId());
-            if (localTbl != null && !localTbl.isOlapView()) {
-                status = new Status(ErrCode.BAD_REPLACE,
-                                    "Table: " + localTbl.getName() + " has existed and it is not a View");
-                return;
-            }
-
-            CreateViewStmt stmt = new CreateViewStmt(false, true, new TableName(db.getFullName(), restoredOlapView.getName()),
-                    Lists.newArrayList(), restoredOlapView.getComment(), restoredOlapView.getQueryStatement(), NodePosition.ZERO);
-            stmt.setColumns(restoredOlapView.getColumns());
-            stmt.setInlineViewDef(restoredOlapView.getInlineViewDef());
-            context.getSessionVariable().setSqlMode(restoredOlapView.getSqlMode());
-            try {
-                GlobalStateMgr.getCurrentState().getMetadataMgr().createView(stmt);
-            } catch (DdlException e) {
-                status = new Status(ErrCode.COMMON_ERROR,
-                                    "Failed to create view for restore. err message: " + e.getMessage());
-                return;
-            }
-        }
-    }
-
     protected void addRestorePartitionsAndTables(Database db) {
         Locker locker = new Locker();
         locker.lockDatabase(db.getId(), LockType.WRITE);
@@ -896,6 +862,10 @@ public class RestoreJob extends AbstractJob {
 
             // add restored tables
             for (Table tbl : restoredTbls) {
+                if (tbl.isOlapView()) {
+                    // for logical view, force drop and replace
+                    db.dropTable(tbl.getName());
+                }
                 if (!db.registerTableUnlocked(tbl)) {
                     status = new Status(ErrCode.COMMON_ERROR, "Table " + tbl.getName()
                             + " already exist in db: " + db.getOriginName());
@@ -1152,7 +1122,7 @@ public class RestoreJob extends AbstractJob {
             for (BackupTableInfo tblInfo : jobInfo.tables.values()) {
                 Table tbl = globalStateMgr.getLocalMetastore()
                             .getTable(db.getFullName(), jobInfo.getAliasByOriginNameIfSet(tblInfo.name));
-                if (tbl == null) {
+                if (tbl == null || tbl.isOlapView()) {
                     continue;
                 }
                 OlapTable olapTbl = (OlapTable) tbl;
@@ -1174,9 +1144,8 @@ public class RestoreJob extends AbstractJob {
             locker.unLockDatabase(db.getId(), LockType.WRITE);
         }
 
-        List<View> restoredOlapViews = backupMeta.getTables().values().stream().filter(Table::isOlapView)
-                                       .map(x -> (View) x).collect(Collectors.toList());
-        addRestoreOlapView(restoredOlapViews);
+        // restored view need not to be added again here, because
+        // another edit log created by createView will done.
 
         LOG.info("replay check and prepare meta. {}", this);
     }
@@ -1493,7 +1462,7 @@ public class RestoreJob extends AbstractJob {
 
             for (long tblId : restoredVersionInfo.rowKeySet()) {
                 Table tbl = globalStateMgr.getLocalMetastore().getTable(db.getId(), tblId);
-                if (tbl == null) {
+                if (tbl == null || tbl.isOlapView()) {
                     continue;
                 }
                 OlapTable olapTbl = (OlapTable) tbl;

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -540,6 +540,7 @@ public class RestoreJob extends AbstractJob {
                 }
 
                 if (remoteTbl.isOlapView()) {
+                    remoteTbl.setId(globalStateMgr.getNextId());
                     restoredTbls.add(remoteTbl);
                     continue;
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -839,6 +839,11 @@ public class RestoreJobTest {
 
         View restoredView = (View) db.getTable(CatalogMocker.TEST_TBL6_ID);
 
+        BackupTableInfo tblInfo = new BackupTableInfo();
+        tblInfo.id = CatalogMocker.TEST_TBL6_ID;
+        tblInfo.name = CatalogMocker.TEST_TBL6_NAME;
+        jobInfo.tables.put(tblInfo.name, tblInfo);
+
         new MockUp<LocalMetastore>() {
             @Mock
             public Database getDb(String dbName) {


### PR DESCRIPTION
This pr fix several problem:

1. analyze exception will be throw if we specify view name after ON clause. Becase view is not in BackupJobInfo
2. can not set alias for logical view when doing restore
3. can not choice part of view to be restored, we must restored all view, this pr also fix this problem.
4. Forget to remove metadata for View if restore is failed.
5. do not add restore view again when replay log for restorejob.

In this pr, we refactor the code mainly in:
1. use both backupMeta and BackupJobInfo to save the View backup info.
2. remove addRestoreOlapView function and register view into db directly, just like OlapTable.

after refactor the code, all problem have been fixed.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
