### PR TITLE
[Enhancement] Add count_distinct_implementation/enable_count_distinct_rewrite_by_hll_bitmap to control count distinct's implmentation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -730,6 +730,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // binary, json, compact
     public static final String THRIFT_PLAN_PROTOCOL = "thrift_plan_protocol";
 
+    public static final String COUNT_DISTINCT_IMPLEMENTATION = "count_distinct_implementation";
+
+    public static final String ENABLE_COUNT_DISTINCT_REWRITE_BY_HLL_BITMAP = "enable_count_distinct_rewrite_by_hll_bitmap";
+
     // 0 means disable interleaving, positive value sets the group size, but adaptively enable interleaving,
     // negative value means force interleaving under the group size of abs(interleaving_group_size)
     public static final String INTERLEAVING_GROUP_SIZE = "interleaving_group_size";
@@ -1574,6 +1578,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_PLAN_ADVISOR)
     private boolean enablePlanAdvisor = true;
 
+    @VarAttr(name = COUNT_DISTINCT_IMPLEMENTATION)
+    private String countDistinctImplementation = "default";
+
+    // By default, we always use the created mv's bitmap/hll to rewrite count distinct, but result is not
+    // exactly matched with the original result.
+    // If we want to get the exactly matched result, we can disable this.
+    @VarAttr(name = ENABLE_COUNT_DISTINCT_REWRITE_BY_HLL_BITMAP)
+    private boolean enableCountDistinctRewriteByHllBitmap = true;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -4254,6 +4266,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnablePlanAdvisor(boolean enablePlanAdvisor) {
         this.enablePlanAdvisor = enablePlanAdvisor;
+    }
+
+    public void setCountDistinctImplementation(String countDistinctImplementation) {
+        this.countDistinctImplementation = countDistinctImplementation;
+    }
+
+    public SessionVariableConstants.CountDistinctImplMode getCountDistinctImplementation() {
+        return SessionVariableConstants.CountDistinctImplMode.parse(countDistinctImplementation);
+    }
+
+    public boolean isEnableCountDistinctRewriteByHllBitmap() {
+        return enableCountDistinctRewriteByHllBitmap;
+    }
+
+    public void setEnableCountDistinctRewriteByHllBitmap(boolean enableCountDistinctRewriteByHllBitmap) {
+        this.enableCountDistinctRewriteByHllBitmap = enableCountDistinctRewriteByHllBitmap;
     }
 
     public int getConnectorIncrementalScanRangeNumber() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.qe;
 
+import org.apache.commons.lang3.EnumUtils;
+
 public class SessionVariableConstants {
 
     private SessionVariableConstants() {}
@@ -74,5 +76,16 @@ public class SessionVariableConstants {
         TWO_STAGE,
         THREE_STAGE,
         FOUR_STAGE
+    }
+
+    // default, ndv, rewrite_by_hll_bitmap
+    public enum CountDistinctImplMode {
+        DEFAULT,                // default, keeps the original count distinct implementation
+        NDV,                    // ndv, uses HyperLogLog to estimate the count distinct
+        MULTI_COUNT_DISTINCT;
+        public static String MODE_DEFAULT = DEFAULT.toString();
+        public static CountDistinctImplMode parse(String str) {
+            return EnumUtils.getEnumIgnoreCase(CountDistinctImplMode.class, str);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -787,7 +787,7 @@ public class FunctionAnalyzer {
                     }
                 }
             }
-        } else if (FunctionSet.COUNT.equalsIgnoreCase(fnName) && node.isDistinct()) {
+        } else if (FunctionSet.COUNT.equalsIgnoreCase(fnName) && node.isDistinct() && node.getChildren().size() == 1) {
             SessionVariableConstants.CountDistinctImplMode countDistinctImplementation =
                     session.getSessionVariable().getCountDistinctImplementation();
             if (countDistinctImplementation != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -45,6 +45,7 @@ import com.starrocks.catalog.combinator.AggStateUtils;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariableConstants;
 import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -784,6 +785,25 @@ public class FunctionAnalyzer {
                         fn = Expr.getBuiltinFunction(FunctionSet.BITMAP_AGG, argumentTypes,
                                 Function.CompareMode.IS_IDENTICAL);
                     }
+                }
+            }
+        } else if (FunctionSet.COUNT.equalsIgnoreCase(fnName) && node.isDistinct()) {
+            SessionVariableConstants.CountDistinctImplMode countDistinctImplementation =
+                    session.getSessionVariable().getCountDistinctImplementation();
+            if (countDistinctImplementation != null) {
+                switch (countDistinctImplementation) {
+                    case NDV:
+                        node.resetFnName("", FunctionSet.NDV);
+                        node.getParams().setIsDistinct(false);
+                        fn = Expr.getBuiltinFunction(FunctionSet.NDV, argumentTypes,
+                                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                        break;
+                    case MULTI_COUNT_DISTINCT:
+                        node.resetFnName("", FunctionSet.MULTI_DISTINCT_COUNT);
+                        node.getParams().setIsDistinct(false);
+                        fn = Expr.getBuiltinFunction(FunctionSet.MULTI_DISTINCT_COUNT, argumentTypes,
+                                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                        break;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -317,6 +317,17 @@ public class SetStmtAnalyzer {
             DataCachePopulateMode.fromName(resolvedExpression.getStringValue());
         }
 
+        // count_distinct_implementation
+        if (variable.equalsIgnoreCase(SessionVariable.COUNT_DISTINCT_IMPLEMENTATION)) {
+            String rewriteModeName = resolvedExpression.getStringValue();
+            if (!EnumUtils.isValidEnumIgnoreCase(SessionVariableConstants.CountDistinctImplMode.class, rewriteModeName)) {
+                String supportedList = StringUtils.join(
+                        EnumUtils.getEnumList(SessionVariableConstants.CountDistinctImplMode.class), ",");
+                throw new SemanticException(String.format("Unsupported count distinct implementation mode: %s, " +
+                        "supported list is %s", rewriteModeName, supportedList));
+            }
+        }
+
         var.setResolvedExpression(resolvedExpression);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -732,7 +732,8 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         final RewriteContext rewriteContext = new RewriteContext(
                 queryExpression, queryPredicateSplit, queryEc, queryRelationIdToColumns, queryColumnRefFactory,
                 mvRewriteContext.getQueryColumnRefRewriter(), mvExpression, mvPredicateSplit, mvRelationIdToColumns,
-                mvColumnRefFactory, mvColumnRefRewriter, materializationContext.getOutputMapping(), queryColumnSet);
+                mvColumnRefFactory, mvColumnRefRewriter, materializationContext.getOutputMapping(), queryColumnSet,
+                optimizerContext);
         // add agg push down rewrite info
         rewriteContext.setAggregatePushDownContext(mvRewriteContext.getAggregatePushDownContext());
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RewriteContext.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.google.common.collect.BiMap;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.EquivalenceClasses;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -44,6 +45,7 @@ public class RewriteContext {
     private final ReplaceColumnRefRewriter mvColumnRefRewriter;
     private final Map<ColumnRefOperator, ColumnRefOperator> outputMapping;
     private final Set<ColumnRefOperator> queryColumnSet;
+    private final OptimizerContext optimizerContext;
     private BiMap<Integer, Integer> queryToMvRelationIdMapping;
     private ScalarOperator unionRewriteQueryExtraPredicate;
     private AggregatePushDownContext aggregatePushDownContext;
@@ -62,7 +64,8 @@ public class RewriteContext {
                           ColumnRefFactory mvRefFactory,
                           ReplaceColumnRefRewriter mvColumnRefRewriter,
                           Map<ColumnRefOperator, ColumnRefOperator> outputMapping,
-                          Set<ColumnRefOperator> queryColumnSet) {
+                          Set<ColumnRefOperator> queryColumnSet,
+                          OptimizerContext optimizerContext) {
         this.queryExpression = queryExpression;
         this.queryPredicateSplit = queryPredicateSplit;
         this.queryEquivalenceClasses = queryEquivalenceClasses;
@@ -76,6 +79,7 @@ public class RewriteContext {
         this.mvColumnRefRewriter = mvColumnRefRewriter;
         this.outputMapping = outputMapping;
         this.queryColumnSet = queryColumnSet;
+        this.optimizerContext = optimizerContext;
     }
 
     public BiMap<Integer, Integer> getQueryToMvRelationIdMapping() {
@@ -180,5 +184,9 @@ public class RewriteContext {
 
     public void setRollup(boolean rollup) {
         isRollup = rollup;
+    }
+
+    public OptimizerContext getOptimizerContext() {
+        return optimizerContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/BitmapRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/BitmapRewriteEquivalent.java
@@ -18,6 +18,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -129,6 +130,10 @@ public class BitmapRewriteEquivalent extends IAggregateRewriteEquivalent {
         boolean isRollup = shuttleContext.isRollup();
         if (aggFuncName.equals(FunctionSet.COUNT) && aggFunc.isDistinct() ||
                 aggFuncName.equals(MULTI_DISTINCT_COUNT)) {
+            SessionVariable sessionVariable = shuttleContext.getRewriteContext().getOptimizerContext().getSessionVariable();
+            if (!sessionVariable.isEnableCountDistinctRewriteByHllBitmap()) {
+                return null;
+            }
             ScalarOperator arg0 = aggFunc.getChild(0);
             if (!arg0.equals(eqChild)) {
                 return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/BitmapRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/BitmapRewriteEquivalent.java
@@ -128,7 +128,7 @@ public class BitmapRewriteEquivalent extends IAggregateRewriteEquivalent {
         CallOperator aggFunc = (CallOperator) newInput;
         String aggFuncName = aggFunc.getFnName();
         boolean isRollup = shuttleContext.isRollup();
-        if (aggFuncName.equals(FunctionSet.COUNT) && aggFunc.isDistinct() ||
+        if ((aggFuncName.equals(FunctionSet.COUNT) && aggFunc.isDistinct() && aggFunc.getChildren().size() == 1) ||
                 aggFuncName.equals(MULTI_DISTINCT_COUNT)) {
             SessionVariable sessionVariable = shuttleContext.getRewriteContext().getOptimizerContext().getSessionVariable();
             if (!sessionVariable.isEnableCountDistinctRewriteByHllBitmap()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/HLLRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/HLLRewriteEquivalent.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -33,6 +34,7 @@ import static com.starrocks.catalog.FunctionSet.HLL_CARDINALITY;
 import static com.starrocks.catalog.FunctionSet.HLL_HASH;
 import static com.starrocks.catalog.FunctionSet.HLL_UNION;
 import static com.starrocks.catalog.FunctionSet.HLL_UNION_AGG;
+import static com.starrocks.catalog.FunctionSet.MULTI_DISTINCT_COUNT;
 import static com.starrocks.catalog.FunctionSet.NDV;
 
 public class HLLRewriteEquivalent extends IAggregateRewriteEquivalent {
@@ -78,7 +80,12 @@ public class HLLRewriteEquivalent extends IAggregateRewriteEquivalent {
         return null;
     }
 
-    public static ImmutableSet<String> SUPPORT_AGG_FUNC = ImmutableSet.of(APPROX_COUNT_DISTINCT, NDV, HLL_UNION_AGG);
+    public static ImmutableSet<String> SUPPORT_AGG_FUNC = ImmutableSet.of(
+            APPROX_COUNT_DISTINCT,
+            NDV,
+            HLL_UNION_AGG,
+            MULTI_DISTINCT_COUNT
+    );
 
     @Override
     public boolean isSupportPushDownRewrite(CallOperator aggFunc) {
@@ -88,6 +95,10 @@ public class HLLRewriteEquivalent extends IAggregateRewriteEquivalent {
 
         String aggFuncName = aggFunc.getFnName();
         if (SUPPORT_AGG_FUNC.contains(aggFuncName)) {
+            return true;
+        }
+        // count distinct
+        if (aggFuncName.equals(FunctionSet.COUNT) && aggFunc.isDistinct()) {
             return true;
         }
         return false;
@@ -105,6 +116,7 @@ public class HLLRewriteEquivalent extends IAggregateRewriteEquivalent {
         CallOperator aggFunc = (CallOperator) newInput;
         String aggFuncName = aggFunc.getFnName();
         boolean isRollup = shuttleContext.isRollup();
+
         if (aggFuncName.equals(APPROX_COUNT_DISTINCT) || aggFuncName.equals(NDV)) {
             ScalarOperator arg0 = aggFunc.getChild(0);
             if (!arg0.equals(eqChild)) {
@@ -130,7 +142,17 @@ public class HLLRewriteEquivalent extends IAggregateRewriteEquivalent {
                     eqArg = arg0;
                 }
             }
-
+            if (!eqArg.equals(eqChild)) {
+                return null;
+            }
+            return rewriteImpl(shuttleContext, aggFunc, replace, isRollup);
+        } else if ((aggFuncName.equalsIgnoreCase(FunctionSet.COUNT) && aggFunc.isDistinct()) ||
+                aggFuncName.equalsIgnoreCase(MULTI_DISTINCT_COUNT)) {
+            SessionVariable sessionVariable = shuttleContext.getRewriteContext().getOptimizerContext().getSessionVariable();
+            if (!sessionVariable.isEnableCountDistinctRewriteByHllBitmap()) {
+                return null;
+            }
+            ScalarOperator eqArg = aggFunc.getChild(0);
             if (!eqArg.equals(eqChild)) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/HLLRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/HLLRewriteEquivalent.java
@@ -146,8 +146,8 @@ public class HLLRewriteEquivalent extends IAggregateRewriteEquivalent {
                 return null;
             }
             return rewriteImpl(shuttleContext, aggFunc, replace, isRollup);
-        } else if ((aggFuncName.equalsIgnoreCase(FunctionSet.COUNT) && aggFunc.isDistinct()) ||
-                aggFuncName.equalsIgnoreCase(MULTI_DISTINCT_COUNT)) {
+        } else if ((aggFuncName.equalsIgnoreCase(FunctionSet.COUNT) && aggFunc.isDistinct()
+                && aggFunc.getChildren().size() == 1) || aggFuncName.equalsIgnoreCase(MULTI_DISTINCT_COUNT)) {
             SessionVariable sessionVariable = shuttleContext.getRewriteContext().getOptimizerContext().getSessionVariable();
             if (!sessionVariable.isEnableCountDistinctRewriteByHllBitmap()) {
                 return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -275,7 +275,7 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
         }
         try {
             CompletableFuture<Optional<ColumnStatistic>> result =
-                    columnStatistics.get(new ColumnStatsCacheKey(table.getId(), column));
+                        columnStatistics.get(new ColumnStatsCacheKey(table.getId(), column));
             if (result.isDone()) {
                 Optional<ColumnStatistic> realResult;
                 realResult = result.get();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -3025,6 +3025,8 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         connectContext.getSessionVariable().setEnableCountDistinctRewriteByHllBitmap(true);
         testRewriteOK(mv, "select user_id, count(distinct tag_id) x, count(distinct tag_id) y " +
                 "from user_tags group by user_id;");
+        testRewriteFail(mv, "select user_id, count(distinct tag_id, user_id) y " +
+                "from user_tags group by user_id;");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2954,6 +2954,32 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     }
 
     @Test
+    public void testStrColumnCountDistinctToBitmapCount3() {
+        String mv = "select user_id, time, bitmap_union(bitmap_hash(user_name)), " +
+                "bitmap_union(bitmap_hash(concat(user_name, \"a\"))), " +
+                "bitmap_union(bitmap_hash(concat(user_name, \"b\"))), " +
+                "bitmap_union(bitmap_hash(concat(user_name, \"c\"))) from user_tags group by user_id, time;";
+        connectContext.getSessionVariable().setEnableCountDistinctRewriteByHllBitmap(false);
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        connectContext.getSessionVariable().setCboCteReuse(false);
+        testRewriteOK(mv, "select user_id, bitmap_union(bitmap_hash(user_name)) x from user_tags group by user_id;");
+        testRewriteOK(mv, "select user_id, bitmap_count(bitmap_union(bitmap_hash(user_name))) x " +
+                "from user_tags group by user_id;");
+        testRewriteFail(mv, "select user_id, count(distinct user_name), " +
+                " count(distinct concat(user_name, \"a\")), count(distinct concat(user_name, \"b\"))," +
+                " count(distinct concat(user_name, \"c\"))  from user_tags group by user_id;");
+        testRewriteFail(mv, "select user_id, count(distinct user_name), " +
+                " count(distinct concat(user_name, \"a\")), count(distinct concat(user_name, \"b\"))," +
+                " count(distinct concat(user_name, \"c\"))  from user_tags group by user_id, time;");
+        testRewriteFail(mv, "select user_id, time, count(distinct user_name), " +
+                " count(distinct concat(user_name, \"a\")), count(distinct concat(user_name, \"b\"))," +
+                " count(distinct concat(user_name, \"c\"))  from user_tags group by user_id, time;");
+        connectContext.getSessionVariable().setCboCteReuse(true);
+        connectContext.getSessionVariable().setEnableCountDistinctRewriteByHllBitmap(true);
+    }
+
+
+    @Test
     public void testBitmapUnionCountToBitmapCount1() {
         String mv = "select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;";
         testRewriteOK(mv, "select user_id, bitmap_union_count(to_bitmap(tag_id)) x from user_tags group by user_id;");
@@ -2979,6 +3005,26 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteOK(mv, "select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id;");
         testRewriteOK(mv, "select user_id, ndv(tag_id) x from user_tags group by user_id;");
         testRewriteOK(mv, "select user_id, hll_union(hll_hash(tag_id)) x from user_tags group by user_id;");
+    }
+
+    @Test
+    public void testApproxCountToHLL3() {
+        connectContext.getSessionVariable().setCountDistinctImplementation("ndv");
+        String mv = "select user_id, time, hll_union(hll_hash(tag_id)) from user_tags group by user_id, time;";
+        testRewriteOK(mv, "select user_id, count(distinct tag_id) x, count(distinct tag_id) y " +
+                "from user_tags group by user_id;");
+        connectContext.getSessionVariable().setCountDistinctImplementation("default");
+    }
+
+    @Test
+    public void testApproxCountToHLL4() {
+        connectContext.getSessionVariable().setEnableCountDistinctRewriteByHllBitmap(false);
+        String mv = "select user_id, time, hll_union(hll_hash(tag_id)) from user_tags group by user_id, time;";
+        testRewriteFail(mv, "select user_id, count(distinct tag_id) x, count(distinct tag_id) y " +
+                "from user_tags group by user_id;");
+        connectContext.getSessionVariable().setEnableCountDistinctRewriteByHllBitmap(true);
+        testRewriteOK(mv, "select user_id, count(distinct tag_id) x, count(distinct tag_id) y " +
+                "from user_tags group by user_id;");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2002,6 +2002,12 @@ public class AggregateTest extends PlanTestBase {
         assertContains(plan, " |  output: ndv(if(9: expr, 2: v2, -999)), " +
                 "ndv(if(9: expr, 3: v3, -999))\n" +
                 "  |  group by: ");
+
+        sql = "select count(distinct v1, v2) from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                        "  |  STREAMING\n" +
+                        "  |  group by: 1: v1, 2: v2");
         connectContext.getSessionVariable().setCountDistinctImplementation("default");
     }
 
@@ -2038,6 +2044,11 @@ public class AggregateTest extends PlanTestBase {
                 "  |  output: multi_distinct_count(if(9: expr, 2: v2, -999)), " +
                 "multi_distinct_count(if(9: expr, 3: v3, -999))\n" +
                 "  |  group by: ");
+        sql = "select count(distinct v1, v2) from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: 1: v1, 2: v2");
         connectContext.getSessionVariable().setCountDistinctImplementation("default");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1973,6 +1973,75 @@ public class AggregateTest extends PlanTestBase {
     }
 
     @Test
+    public void testCountDistinctImplementation1() throws Exception {
+        // normal case
+        String sql = "select " +
+                "count(distinct t1a)," + // varchar
+                "count(distinct t1b)," + // smallint
+                "count(distinct t1c)," + // int
+                "count(distinct t1d)," + // bigint
+                "count(distinct t1e)," + // float
+                "count(distinct t1f)," + //double
+                "count(distinct t1g)," + // bigint
+                "count(distinct id_datetime)," + // datetime
+                "count(distinct id_date)," + // date
+                "count(distinct id_decimal)" + //decimal
+                "from test_all_type_not_null";
+        connectContext.getSessionVariable().setCountDistinctImplementation("ndv");
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  |  output: ndv(7: t1g), ndv(8: id_datetime), " +
+                "ndv(9: id_date), ndv(10: id_decimal), ndv(1: t1a), ndv(2: t1b), " +
+                "ndv(3: t1c), ndv(4: t1d), ndv(5: t1e), ndv(6: t1f)\n" +
+                "  |  group by: ");
+        sql = "select count(distinct if(v1 = 1, v2, -999)) as c1, \n" +
+                "count(distinct if(v1 = 1, v3, -999)) as c2,\n" +
+                "count(distinct if(v1 = 1, v2, -999)) - " +
+                "count(distinct if(v1 = 1, v3, -999))\n" +
+                "from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, " |  output: ndv(if(9: expr, 2: v2, -999)), " +
+                "ndv(if(9: expr, 3: v3, -999))\n" +
+                "  |  group by: ");
+        connectContext.getSessionVariable().setCountDistinctImplementation("default");
+    }
+
+    @Test
+    public void testCountDistinctImplementation2() throws Exception {
+        // normal case
+        String sql = "select " +
+                "count(distinct t1a)," + // varchar
+                "count(distinct t1b)," + // smallint
+                "count(distinct t1c)," + // int
+                "count(distinct t1d)," + // bigint
+                "count(distinct t1e)," + // float
+                "count(distinct t1f)," + //double
+                "count(distinct t1g)," + // bigint
+                "count(distinct id_datetime)," + // datetime
+                "count(distinct id_date)," + // date
+                "count(distinct id_decimal)" + //decimal
+                "from test_all_type_not_null";
+        connectContext.getSessionVariable().setCountDistinctImplementation("multi_count_distinct");
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  |  output: multi_distinct_count(7: t1g), multi_distinct_count(8: id_datetime), " +
+                "multi_distinct_count(9: id_date), multi_distinct_count(10: id_decimal), " +
+                "multi_distinct_count(1: t1a), multi_distinct_count(2: t1b), " +
+                "multi_distinct_count(3: t1c), multi_distinct_count(4: t1d), " +
+                "multi_distinct_count(5: t1e), multi_distinct_count(6: t1f)\n" +
+                "  |  group by: ");
+        sql = "select count(distinct if(v1 = 1, v2, -999)) as c1, \n" +
+                "count(distinct if(v1 = 1, v3, -999)) as c2,\n" +
+                "count(distinct if(v1 = 1, v2, -999)) - " +
+                "count(distinct if(v1 = 1, v3, -999))\n" +
+                "from t0;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: multi_distinct_count(if(9: expr, 2: v2, -999)), " +
+                "multi_distinct_count(if(9: expr, 3: v3, -999))\n" +
+                "  |  group by: ");
+        connectContext.getSessionVariable().setCountDistinctImplementation("default");
+    }
+
+    @Test
     public void testGroupByLiteral() throws Exception {
         String sql = "select -9223372036854775808 group by TRUE;";
         String plan = getFragmentPlan(sql);

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1975,6 +1975,33 @@ class StarrocksSQLApiLib(object):
             if plan.find(expect) > 0:
                 return True
         return False
+    
+    def print_hit_materialized_views(self, query) -> str:
+        """
+        print all mv_names hit in query
+        """
+        time.sleep(1)
+        sql = "explain %s" % (query)
+        res = self.execute_sql(sql, True)
+        if not res["status"]:
+            print(res)
+            return ""
+        plan = res["result"]
+        if not plan:
+            return ""
+        mv_name = None
+        ans = []
+        for line in plan:
+            if len(line) != 1:
+                continue
+            content = line[0]
+            if content.find("MaterializedView: true") > 0:
+                if mv_name:
+                    ans.append(mv_name)
+                mv_name = None
+            if content.find("TABLE:") > 0:
+                mv_name = content.split("TABLE:")[1].strip()
+        return ",".join(ans)
 
     def assert_equal_result(self, *sqls):
         if len(sqls) < 2:

--- a/test/sql/test_materialized_view/R/test_materialized_view_rewrite_count_distinct
+++ b/test/sql/test_materialized_view/R/test_materialized_view_rewrite_count_distinct
@@ -1,0 +1,153 @@
+-- name: test_materialized_view_rewrite_count_distinct
+create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'a', 1);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'b', 2);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'c', 3);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'd', 4);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 1, 'e', 5);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 2, 'e', 5);
+-- result:
+-- !result
+insert into user_tags values('2023-04-13', 3, 'e', 6);
+-- result:
+-- !result
+set count_distinct_implementation='ndv';
+-- result:
+-- !result
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+-- result:
+1	5	5
+2	1	1
+3	1	1
+-- !result
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+-- result:
+6	5
+-- !result
+set count_distinct_implementation='multi_count_distinct';
+-- result:
+-- !result
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+-- result:
+1	5	5
+2	1	1
+3	1	1
+-- !result
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+-- result:
+6	5
+-- !result
+set count_distinct_implementation='default';
+-- result:
+-- !result
+create materialized view test_mv1 
+distributed by hash(user_id) 
+as select user_id, bitmap_union(to_bitmap(tag_id)), bitmap_union(to_bitmap(user_name)) from user_tags group by user_id;
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+set enable_count_distinct_rewrite_by_hll_bitmap=true;
+-- result:
+-- !result
+function: print_hit_materialized_views("select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("select count(distinct tag_id), count(distinct user_name) from user_tags;")
+-- result:
+test_mv1
+-- !result
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+-- result:
+1	5	0
+2	1	0
+3	1	0
+-- !result
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+-- result:
+6	0
+-- !result
+set enable_count_distinct_rewrite_by_hll_bitmap=false;
+-- result:
+-- !result
+function: print_hit_materialized_views("select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("select count(distinct tag_id), count(distinct user_name) from user_tags;")
+-- result:
+
+-- !result
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+-- result:
+1	5	5
+2	1	1
+3	1	1
+-- !result
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+-- result:
+6	5
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1 
+distributed by hash(user_id) 
+as select user_id, time, hll_union(hll_hash(tag_id)) as agg1, hll_union(hll_hash(user_name)) as agg2  from user_tags group by user_id, time;
+-- result:
+-- !result
+refresh materialized view test_mv1 with sync mode;
+set enable_count_distinct_rewrite_by_hll_bitmap=true;
+-- result:
+-- !result
+function: print_hit_materialized_views("select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;")
+-- result:
+test_mv1
+-- !result
+function: print_hit_materialized_views("select count(distinct tag_id), count(distinct user_name) from user_tags;")
+-- result:
+test_mv1
+-- !result
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+-- result:
+1	5	5
+2	1	1
+3	1	1
+-- !result
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+-- result:
+6	5
+-- !result
+set enable_count_distinct_rewrite_by_hll_bitmap=false;
+-- result:
+-- !result
+function: print_hit_materialized_views("select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("select count(distinct tag_id), count(distinct user_name) from user_tags;")
+-- result:
+
+-- !result
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+-- result:
+1	5	5
+2	1	1
+3	1	1
+-- !result
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+-- result:
+6	5
+-- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite_count_distinct
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite_count_distinct
@@ -1,0 +1,58 @@
+-- name: test_materialized_view_rewrite_count_distinct
+create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
+insert into user_tags values('2023-04-13', 1, 'a', 1);
+insert into user_tags values('2023-04-13', 1, 'b', 2);
+insert into user_tags values('2023-04-13', 1, 'c', 3);
+insert into user_tags values('2023-04-13', 1, 'd', 4);
+insert into user_tags values('2023-04-13', 1, 'e', 5);
+insert into user_tags values('2023-04-13', 2, 'e', 5);
+insert into user_tags values('2023-04-13', 3, 'e', 6);
+
+
+set count_distinct_implementation='ndv';
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+
+set count_distinct_implementation='multi_count_distinct';
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+
+set count_distinct_implementation='default';
+
+create materialized view test_mv1 
+distributed by hash(user_id) 
+as select user_id, bitmap_union(to_bitmap(tag_id)), bitmap_union(to_bitmap(user_name)) from user_tags group by user_id;
+
+refresh materialized view test_mv1 with sync mode;
+
+set enable_count_distinct_rewrite_by_hll_bitmap=true;
+function: print_hit_materialized_views("select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;")
+function: print_hit_materialized_views("select count(distinct tag_id), count(distinct user_name) from user_tags;")
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+
+set enable_count_distinct_rewrite_by_hll_bitmap=false;
+function: print_hit_materialized_views("select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;")
+function: print_hit_materialized_views("select count(distinct tag_id), count(distinct user_name) from user_tags;")
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+
+drop materialized view test_mv1;
+
+create materialized view test_mv1 
+distributed by hash(user_id) 
+as select user_id, time, hll_union(hll_hash(tag_id)) as agg1, hll_union(hll_hash(user_name)) as agg2  from user_tags group by user_id, time;
+
+refresh materialized view test_mv1 with sync mode;
+
+set enable_count_distinct_rewrite_by_hll_bitmap=true;
+function: print_hit_materialized_views("select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;")
+function: print_hit_materialized_views("select count(distinct tag_id), count(distinct user_name) from user_tags;")
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+select count(distinct tag_id), count(distinct user_name) from user_tags;
+
+set enable_count_distinct_rewrite_by_hll_bitmap=false;
+function: print_hit_materialized_views("select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;")
+function: print_hit_materialized_views("select count(distinct tag_id), count(distinct user_name) from user_tags;")
+select user_id, count(distinct tag_id), count(distinct user_name) from user_tags group by user_id order by user_id;
+select count(distinct tag_id), count(distinct user_name) from user_tags;


### PR DESCRIPTION
## Why I'm doing:
By default, user's mv with `hll_union(hll_hash(x))` cannot be rewritten by mv.


## What I'm doing:
- Add `count_distinct_implementation(supports default/ndv/mulit_count_distinct)` to rewrite `count (distinc x)) ` to `ndv(x)` or `multi_count_distinct(x)`;
- Add `enable_count_distinct_rewrite_by_hll_bitmap` to control whether to use mv with `hll/bitmap` to rewrite `count distinct`, default:true.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
