### PR TITLE
[BugFix] Fix the problem that arrow read parquet file query memory is negative

### DIFF
--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -18,6 +18,7 @@
 #include <arrow/status.h>
 #include <gutil/strings/substitute.h>
 
+#include <memory>
 #include <utility>
 
 #include "common/config.h"
@@ -27,6 +28,7 @@
 #include "parquet/schema.h"
 #include "parquet_schema_builder.h"
 #include "runtime/descriptors.h"
+#include "util/byte_buffer.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks {
@@ -419,16 +421,22 @@ arrow::Result<int64_t> ParquetChunkFile::Tell() const {
 }
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> ParquetChunkFile::Read(int64_t nbytes) {
-    auto buffer_res = arrow::AllocateBuffer(nbytes, arrow::default_memory_pool());
-    ARROW_RETURN_NOT_OK(buffer_res);
-    std::shared_ptr<arrow::Buffer> read_buf = std::move(buffer_res.ValueOrDie());
-    arrow::Result<int64_t> bytes_read_res = ReadAt(_pos, nbytes, read_buf->mutable_data());
-    ARROW_RETURN_NOT_OK(bytes_read_res);
+    auto tracker = CurrentThread::mem_tracker();
+    if (tracker == nullptr) {
+        return arrow::Status::ExecutionError("current thread memory tracker Not Found when allocate arrow Buffer");
+    }
+    std::unique_ptr<arrow::Buffer> buffer_res;
+    ARROW_RETURN_NOT_OK(arrow::AllocateBuffer(nbytes, arrow::default_memory_pool()).Value(&buffer_res));
+    std::shared_ptr<arrow::Buffer> read_buf(buffer_res.release(), MemTrackerDeleter(tracker));
+    int64_t bytes_read_res = 0;
+    ARROW_RETURN_NOT_OK(ReadAt(_pos, nbytes, read_buf->mutable_data()).Value(&bytes_read_res));
     // If bytes_read is equal with read_buf's capacity, we just assign
-    if (bytes_read_res.ValueOrDie() == nbytes) {
+    if (bytes_read_res == nbytes) {
         return std::move(read_buf);
     } else {
-        return arrow::SliceBuffer(read_buf, 0, bytes_read_res.ValueOrDie());
+        std::shared_ptr<arrow::Buffer> slice_buf(new arrow::Buffer(read_buf, 0, bytes_read_res),
+                                                 MemTrackerDeleter(tracker));
+        return slice_buf;
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
arrow buffer allocate from process. but release it in pipeline threads
```
 @          0x9c56be1  arrow::PoolBuffer::Reserve(long)
    @          0x9c56cb0  arrow::PoolBuffer::Resize(long, bool)
    @          0x9c554ba  arrow::AllocateBuffer(long, long, arrow::MemoryPool*) [clone .localalias]
    @          0x9c55a8d  arrow::AllocateBuffer(long, arrow::MemoryPool*)
    @          0x4bbb99b  starrocks::ParquetChunkFile::Read(long)
    @          0x9bcabb2  arrow::io::RandomAccessFile::ReadAt(long, long) [clone .localalias]
    @          0x9bcbc51  arrow::internal::FnOnce<void ()>::FnImpl<std::_Bind<arrow::detail::ContinueFuture (arrow::Future<std::shared_ptr<arrow::Buffer> >, arrow::io::RandomAccessFile::ReadAsync(arrow::io::IOContext const&, long, long)::{lambda()#1})> >::invoke()
    @          0x9cd0549  std::thread::_State_impl<std::thread::_Invoker<std::tuple<arrow::internal::ThreadPool::LaunchWorkersUnlocked(int)::{lambda()#1}> > >::_M_run()
    @          0xc5b6854  execute_native_thread_routine
```

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8363

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
