### PR TITLE
[BugFix] fix show create table when enable persistent index is false

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -720,6 +720,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public static String persistentIndexTypeToString(TPersistentIndexType type) {
+        if (type == null) {
+            return "";
+        }
         switch (type) {
             case LOCAL:
                 return LOCAL_INDEX_TYPE;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -720,9 +720,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public static String persistentIndexTypeToString(TPersistentIndexType type) {
-        if (type == null) {
-            return "";
-        }
         switch (type) {
             case LOCAL:
                 return LOCAL_INDEX_TYPE;
@@ -933,6 +930,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public String getPersistentIndexTypeString() {
+        if (persistentIndexType == null) {
+            return "";
+        }
         return persistentIndexTypeToString(persistentIndexType);
     }
 


### PR DESCRIPTION
## Why I'm doing:
When create table using `enable_persistent_index = false` in shared-data mode, and then show create table will return error:
```
[StmtExecutor.execute():758] execute Exception, sql show create table haha4
java.lang.NullPointerException: null
        at com.starrocks.catalog.TableProperty.persistentIndexTypeToString(TableProperty.java:723) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.TableProperty.getPersistentIndexTypeString(TableProperty.java:933) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.OlapTable.getPersistentIndexTypeString(OlapTable.java:2402) ~[starrocks-fe.jar:?]
        at com.starrocks.lake.LakeTable.getUniqueProperties(LakeTable.java:166) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.OlapTable.getProperties(OlapTable.java:3319) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder.getDdlStmt(AstToStringBuilder.java:1600) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder.getDdlStmt(AstToStringBuilder.java:1472) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.showCreateInternalCatalogTable(ShowExecutor.java:739) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.visitShowCreateTableStatement(ShowExecutor.java:694) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.visitShowCreateTableStatement(ShowExecutor.java:286) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.ShowCreateTableStmt.accept(ShowCreateTableStmt.java:115) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:75) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ShowExecutor.execute(ShowExecutor.java:283) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleShow(StmtExecutor.java:1746) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:696) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:363) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:562) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:897) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

Introduced by #42626

It will cause NULL pointer failure in this line : https://github.com/StarRocks/starrocks/blob/8faf4961cb4a7d955acfb4782e6c03848f2bef33/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java#L166

## What I'm doing:
Fix it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
