### PR TITLE
[BugFix] set persistent index type when alter enable persistent index

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -63,6 +63,7 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
             table.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
                     String.valueOf(metaValue));
             table.getTableProperty().buildEnablePersistentIndex();
+            table.getTableProperty().buildPersistentIndexType();
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
When alter table and set enable persistent index from false to true, we forgot to set `persistent_index_type`. And it will cause null pointer when execute show create table like:
```
[StmtExecutor.execute():758] execute Exception, sql show create table haha4
java.lang.NullPointerException: null
        at com.starrocks.catalog.TableProperty.persistentIndexTypeToString(TableProperty.java:723) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.TableProperty.getPersistentIndexTypeString(TableProperty.java:933) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.OlapTable.getPersistentIndexTypeString(OlapTable.java:2402) ~[starrocks-fe.jar:?]
        at com.starrocks.lake.LakeTable.getUniqueProperties(LakeTable.java:166) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.OlapTable.getProperties(OlapTable.java:3319) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder.getDdlStmt(AstToStringBuilder.java:1600) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder.getDdlStmt(AstToStringBuilder.java:1472) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.showCreateInternalCatalogTable(ShowExecutor.java:739) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.visitShowCreateTableStatement(ShowExecutor.java:694) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ShowExecutor$ShowExecutorVisitor.visitShowCreateTableStatement(ShowExecutor.java:286) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.ShowCreateTableStmt.accept(ShowCreateTableStmt.java:115) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:75) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ShowExecutor.execute(ShowExecutor.java:283) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleShow(StmtExecutor.java:1746) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:696) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:363) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:562) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:897) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

## What I'm doing:
Fix it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
