### PR TITLE
[BugFix] fix kudu timestamp data reading issue

### DIFF
--- a/java-extensions/kudu-reader/src/main/java/com/starrocks/kudu/reader/KuduColumnValue.java
+++ b/java-extensions/kudu-reader/src/main/java/com/starrocks/kudu/reader/KuduColumnValue.java
@@ -20,9 +20,12 @@ import com.starrocks.jni.connector.ColumnValue;
 import org.apache.kudu.client.RowResult;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static com.starrocks.kudu.reader.KuduScannerUtils.ZONE_UTC;
 
 public class KuduColumnValue implements ColumnValue {
     private final RowResult row;
@@ -78,7 +81,8 @@ public class KuduColumnValue implements ColumnValue {
 
     @Override
     public LocalDateTime getDateTime(TypeValue type) {
-        return row.getTimestamp(index).toLocalDateTime();
+        long millis = row.getLong(index) / 1000;
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZONE_UTC);
     }
 
     @Override

--- a/java-extensions/kudu-reader/src/main/java/com/starrocks/kudu/reader/KuduScannerUtils.java
+++ b/java-extensions/kudu-reader/src/main/java/com/starrocks/kudu/reader/KuduScannerUtils.java
@@ -16,6 +16,7 @@ package com.starrocks.kudu.reader;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 
@@ -23,6 +24,7 @@ public class KuduScannerUtils {
     private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final Base64.Decoder BASE64_DECODER = Base64.getUrlDecoder();
+    public static final ZoneId ZONE_UTC = ZoneId.of("UTC");
 
     public static String formatDateTime(LocalDateTime dateTime) {
         return dateTime.format(DATETIME_FORMATTER);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The timestamp type of Kudu stores nanoseconds, which adds 8 hours. Even if change the timezone of Kudu cluster to UTC, it still adds 8 hours. This will lead to two problems.
1. The return value will be more than 8 hours, for example: when saving is `2024-01-02 16:00:00`, before reading is `2024-01-03 00:00:00`.
2. As mentioned in the issue, jni's filter will filter more data.

Fixes #51918 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I did test it by deploying and it seems to do the trick
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
