### PR TITLE
[BugFix] Fix partition column sequence is incorrect when delta lake with multi partition columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
@@ -61,7 +61,9 @@ public class DeltaConnectorScanRangeSource implements ConnectorScanRangeSource {
 
     private long addPartition(FileScanTask fileScanTask) throws AnalysisException {
         List<String> partitionValues = new ArrayList<>();
-        fileScanTask.getPartitionValues().forEach((key, value) -> partitionValues.add(value));
+        table.getPartitionColumnNames().forEach(column -> {
+            partitionValues.add(fileScanTask.getPartitionValues().get(column));
+        });
         PartitionKey partitionKey = PartitionUtil.createPartitionKey(partitionValues,
                 table.getPartitionColumns(), table);
         if (partitionKeys.containsKey(partitionKey)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/FileScanTask.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.delta;
 
 import io.delta.kernel.utils.FileStatus;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 
 import java.util.Map;
 
@@ -28,7 +29,7 @@ public class FileScanTask {
     public FileScanTask(FileStatus fileStatus, long records, Map<String, String> partitionValues) {
         this.fileStatus = fileStatus;
         this.records = records;
-        this.partitionValues = partitionValues;
+        this.partitionValues = new CaseInsensitiveMap<>(partitionValues);
     }
 
     public FileStatus getFileStatus() {

--- a/test/sql/test_deltalake/R/test_deltalake_catalog
+++ b/test/sql/test_deltalake/R/test_deltalake_catalog
@@ -277,6 +277,10 @@ select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type whe
 {"name":"Bob","sex":"male","age":25}
 {"name":"Diana","sex":"female","age":28}
 -- !result
+select task_id, request_id, parent_request_id from delta_test_${uuid0}.delta_oss_db.sample_multi_partitions where task_id = 'UW-33393' limit 1;
+-- result:
+UW-33393	111A893698524BD68886AD339701DAAA	111259989C2845BAAEF898D81951B6A1
+-- !result
 drop catalog delta_test_${uuid0}
 -- result:
 -- !result

--- a/test/sql/test_deltalake/T/test_deltalake_catalog
+++ b/test/sql/test_deltalake/T/test_deltalake_catalog
@@ -78,4 +78,7 @@ select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type whe
 select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct.sex='male' order by col_tinyint;
 select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type where col_struct.age<30 order by col_tinyint;
 
+-- test multi-partitions
+select task_id, request_id, parent_request_id from delta_test_${uuid0}.delta_oss_db.sample_multi_partitions where task_id = 'UW-33393' limit 1;
+
 drop catalog delta_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:
Fix #52361
## What I'm doing:
The result of `snapshot.getMetadata().getPartitionColNames()` is a set, can not keep sequence, use list instread of a set
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
