### PR TITLE
[Enhancement] support alter persistent index type in shared-data pk table

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -486,13 +486,43 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
     return Status::OK();
 }
 
+// This function cleans up the SSTable metadata after an alter operation that changes the persistent index type.
+void MetaFileBuilder::_sstable_meta_clean_after_alter_type() {
+    // Check if the persistent index type is LOCAL or if the persistent index is disabled,
+    // and there are SSTables present.
+    if ((_tablet_meta->persistent_index_type() == PersistentIndexTypePB::LOCAL ||
+         !_tablet_meta->enable_persistent_index()) &&
+        _tablet_meta->sstable_meta().sstables_size() > 0) {
+        // Iterate through all SSTables and move them to orphan files.
+        for (const auto& sstable : _tablet_meta->sstable_meta().sstables()) {
+            FileMetaPB file_meta;
+            file_meta.set_name(sstable.filename());
+            file_meta.set_size(sstable.filesize());
+            _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
+        }
+        // Clear the SSTable metadata.
+        _tablet_meta->clear_sstable_meta();
+    }
+}
+
 Status MetaFileBuilder::finalize(int64_t txn_id) {
     auto version = _tablet_meta->version();
-    // finalize delvec
+
+    // Finalize delete vectors by updating their metadata and writing them to disk
     RETURN_IF_ERROR(_finalize_delvec(version, txn_id));
+
+    // Clean up SSTable metadata after an alter operation that changes the persistent index type
+    _sstable_meta_clean_after_alter_type();
+
+    // Persist the updated tablet metadata
     RETURN_IF_ERROR(_tablet.put_metadata(_tablet_meta));
+
+    // Update the primary index data version in the update manager
     _update_mgr->update_primary_index_data_version(_tablet, version);
+
+    // Fill the delete vector cache with the newly finalized delete vectors
     _fill_delvec_cache();
+
     return Status::OK();
 }
 

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -75,6 +75,8 @@ private:
     // collect del files which are above cloud native index's rebuild point
     void _collect_del_files_above_rebuild_point(RowsetMetadataPB* rowset,
                                                 std::vector<DelfileWithRowsetId>* collect_del_files);
+    // clean sstable meta after alter type
+    void _sstable_meta_clean_after_alter_type();
 
 private:
     Tablet _tablet;

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -391,6 +391,12 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
     if (tablet_meta_info.__isset.enable_persistent_index) {
         metadata_update_info->set_enable_persistent_index(tablet_meta_info.enable_persistent_index);
     }
+    if (tablet_meta_info.__isset.persistent_index_type) {
+        PersistentIndexTypePB index_type = tablet_meta_info.persistent_index_type == TPersistentIndexType::LOCAL
+                                                   ? PersistentIndexTypePB::LOCAL
+                                                   : PersistentIndexTypePB::CLOUD_NATIVE;
+        metadata_update_info->set_persistent_index_type(index_type);
+    }
     if (tablet_meta_info.__isset.tablet_schema) {
         // FIXME: pass compression type
         auto compression_type = TCompressionType::LZ4_FRAME;

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -31,6 +31,7 @@
 namespace starrocks::lake {
 
 namespace {
+
 Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMetadata& op_alter_metas,
                             TabletManager* tablet_mgr) {
     for (const auto& alter_meta : op_alter_metas.metadata_update_infos()) {
@@ -42,6 +43,21 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
             // If tablet is doing apply rowset right now, remove primary index from index cache may be failed
             // because the primary index is available in cache
             // But it will be remove from index cache after apply is finished
+            (void)update_mgr->index_cache().try_remove_by_key(metadata->id());
+        }
+        // Check if the alter_meta has a persistent index type change
+        if (alter_meta.has_persistent_index_type()) {
+            // Get the previous and new persistent index types
+            PersistentIndexTypePB prev_type = metadata->persistent_index_type();
+            PersistentIndexTypePB new_type = alter_meta.persistent_index_type();
+            // Apply the changes to the persistent index type
+            metadata->set_persistent_index_type(new_type);
+            LOG(INFO) << fmt::format("alter persistent index type from {} to {} for tablet id: {}",
+                                     PersistentIndexTypePB_Name(prev_type), PersistentIndexTypePB_Name(new_type),
+                                     metadata->id());
+            // Get the update manager
+            auto update_mgr = tablet_mgr->update_mgr();
+            // Try to remove the index from the index cache
             (void)update_mgr->index_cache().try_remove_by_key(metadata->id());
         }
         // update tablet meta

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -500,7 +500,6 @@ TEST_F(AlterTabletMetaTest, test_alter_persistent_index_type) {
 
     auto write_data_fn = [&]() {
         int64_t txn_id = next_id();
-        auto tablet_id = _tablet_metadata->id();
         std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
         std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
         auto c0 = Int32Column::create();

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -473,76 +473,93 @@ TEST_F(AlterTabletMetaTest, test_alter_pk_update_tablet_schema) {
 
 TEST_F(AlterTabletMetaTest, test_alter_persistent_index_type) {
     lake::SchemaChangeHandler handler(_tablet_mgr.get());
-    TUpdateTabletMetaInfoReq update_tablet_meta_req;
-    int64_t txn_id = next_id();
-    update_tablet_meta_req.__set_txn_id(txn_id);
+    int version = 2;
 
-    TTabletMetaInfo tablet_meta_info;
-    auto tablet_id = _tablet_metadata->id();
-    tablet_meta_info.__set_tablet_id(tablet_id);
-    tablet_meta_info.__set_meta_type(TTabletMetaType::ENABLE_PERSISTENT_INDEX);
-    tablet_meta_info.__set_enable_persistent_index(true);
+    auto change_index_fn = [&](bool enable_persistent_index, TPersistentIndexType::type type) {
+        TUpdateTabletMetaInfoReq update_tablet_meta_req;
+        int64_t txn_id = next_id();
+        update_tablet_meta_req.__set_txn_id(txn_id);
 
-    update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
-    ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
+        TTabletMetaInfo tablet_meta_info;
+        auto tablet_id = _tablet_metadata->id();
+        tablet_meta_info.__set_tablet_id(tablet_id);
+        tablet_meta_info.__set_meta_type(TTabletMetaType::ENABLE_PERSISTENT_INDEX);
+        tablet_meta_info.__set_enable_persistent_index(enable_persistent_index);
+        tablet_meta_info.__set_persistent_index_type(type);
 
-    auto new_tablet_meta = publish_single_version(tablet_id, 2, txn_id);
-    ASSERT_OK(new_tablet_meta.status());
-    ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
-    ASSERT_TRUE(new_tablet_meta.value()->persistent_index_type() == PersistentIndexTypePB::LOCAL);
+        update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
+        ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
 
-    txn_id = next_id();
-    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
-    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
-    auto c0 = Int32Column::create();
-    auto c1 = Int32Column::create();
-    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
-    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
-    Chunk chunk0({c0, c1}, _schema);
-    auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
-    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-    std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;
-    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
-    ASSERT_OK(writer->open());
-    // write segment #1
-    ASSERT_OK(writer->write(chunk0));
-    ASSERT_OK(writer->finish());
-    // write txnlog
-    auto txn_log = std::make_shared<TxnLog>();
-    txn_log->set_tablet_id(_tablet_metadata->id());
-    txn_log->set_txn_id(txn_id);
-    auto op_write = txn_log->mutable_op_write();
-    for (auto& f : writer->files()) {
-        op_write->mutable_rowset()->add_segments(std::move(f.path));
+        auto new_tablet_meta = publish_single_version(tablet_id, version++, txn_id);
+        ASSERT_OK(new_tablet_meta.status());
+        ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
+        ASSERT_TRUE(new_tablet_meta.value()->persistent_index_type() == (type == TPersistentIndexType::LOCAL)
+                            ? PersistentIndexTypePB::LOCAL
+                            : PersistentIndexTypePB::CLOUD_NATIVE);
+    };
+
+    auto write_data_fn = [&]() {
+        int64_t txn_id = next_id();
+        auto tablet_id = _tablet_metadata->id();
+        std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+        std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+        c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+        Chunk chunk0({c0, c1}, _schema);
+        auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+        std::shared_ptr<const TabletSchema> const_schema = _tablet_schema;
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+        // write segment #1
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->finish());
+        // write txnlog
+        auto txn_log = std::make_shared<TxnLog>();
+        txn_log->set_tablet_id(_tablet_metadata->id());
+        txn_log->set_txn_id(txn_id);
+        auto op_write = txn_log->mutable_op_write();
+        for (auto& f : writer->files()) {
+            op_write->mutable_rowset()->add_segments(std::move(f.path));
+        }
+        op_write->mutable_rowset()->set_num_rows(writer->num_rows());
+        op_write->mutable_rowset()->set_data_size(writer->data_size());
+        op_write->mutable_rowset()->set_overlapped(false);
+        ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+        writer->close();
+        ASSERT_OK(publish_single_version(_tablet_metadata->id(), version++, txn_id).status());
+    };
+
+    // 1. change to local index
+    change_index_fn(true, TPersistentIndexType::LOCAL);
+    ASSIGN_OR_ABORT(auto tablet_meta, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version - 1));
+    ASSERT_EQ(true, tablet_meta->enable_persistent_index());
+    ASSERT_TRUE(tablet_meta->persistent_index_type() == PersistentIndexTypePB::LOCAL);
+    // 2. write data
+    write_data_fn();
+    // 3. change to cloud native index
+    change_index_fn(true, TPersistentIndexType::CLOUD_NATIVE);
+    ASSIGN_OR_ABORT(auto tablet_meta2, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version - 1));
+    ASSERT_EQ(true, tablet_meta2->enable_persistent_index());
+    ASSERT_TRUE(tablet_meta2->persistent_index_type() == PersistentIndexTypePB::CLOUD_NATIVE);
+    // 4. generate sst files
+    int64_t old_val = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 1;
+    for (int i = 0; i < 10; i++) {
+        write_data_fn();
     }
-    op_write->mutable_rowset()->set_num_rows(writer->num_rows());
-    op_write->mutable_rowset()->set_data_size(writer->data_size());
-    op_write->mutable_rowset()->set_overlapped(false);
-    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
-    writer->close();
-    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 3, txn_id).status());
-    auto data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);
-    ASSERT_TRUE(data_dir != nullptr);
-    ASSERT_OK(FileSystem::Default()->path_exists(data_dir->get_persistent_index_path() + "/" +
-                                                 std::to_string(tablet_id)));
-
-    int64_t txn_id2 = next_id();
-    TUpdateTabletMetaInfoReq update_tablet_meta_req2;
-    update_tablet_meta_req2.__set_txn_id(txn_id2);
-
-    TTabletMetaInfo tablet_meta_info2;
-    tablet_meta_info2.__set_tablet_id(tablet_id);
-    tablet_meta_info2.__set_meta_type(TTabletMetaType::ENABLE_PERSISTENT_INDEX);
-    tablet_meta_info2.__set_enable_persistent_index(true);
-    tablet_meta_info2.__set_persistent_index_type(TPersistentIndexType::CLOUD_NATIVE);
-
-    update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
-    ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
-
-    auto new_tablet_meta2 = publish_single_version(tablet_id, 4, txn_id2);
-    ASSERT_OK(new_tablet_meta2.status());
-    ASSERT_EQ(true, new_tablet_meta2.value()->enable_persistent_index());
-    ASSERT_TRUE(new_tablet_meta2.value()->persistent_index_type() == PersistentIndexTypePB::CLOUD_NATIVE);
+    config::l0_max_mem_usage = old_val;
+    ASSIGN_OR_ABORT(auto tablet_meta3, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version - 1));
+    ASSERT_TRUE(tablet_meta3->sstable_meta().sstables_size() > 0);
+    // 4. change back to local
+    change_index_fn(true, TPersistentIndexType::LOCAL);
+    ASSIGN_OR_ABORT(auto tablet_meta4, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version - 1));
+    ASSERT_EQ(true, tablet_meta4->enable_persistent_index());
+    ASSERT_TRUE(tablet_meta4->persistent_index_type() == PersistentIndexTypePB::LOCAL);
+    ASSERT_TRUE(tablet_meta4->sstable_meta().sstables_size() == 0);
+    ASSERT_TRUE(tablet_meta4->orphan_files_size() > 0);
 }
 
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -362,6 +362,9 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
 
                     isSynchronous = false;
                 } else {
+                    if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)) {
+                        throw new DdlException("StarRocks doesn't support alter persistent_index_type under shared-nothing mode");
+                    }
                     schemaChangeHandler.updateTableMeta(db, tableName.getTbl(), properties,
                             TTabletMetaType.ENABLE_PERSISTENT_INDEX);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -349,7 +349,8 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC)) {
                 schemaChangeHandler.updateTableMeta(db, tableName.getTbl(), properties,
                         TTabletMetaType.PRIMARY_INDEX_CACHE_EXPIRE_SEC);
-            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
+            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)) {
                 if (table.isCloudNativeTable()) {
                     Locker locker = new Locker();
                     locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -38,31 +38,39 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
     @SerializedName(value = "metaValue")
     private boolean metaValue;
 
+    @SerializedName(value = "persistentIndexType")
+    private String persistentIndexType;
+
     // for deserialization
     public LakeTableAlterMetaJob() {
         super(JobType.SCHEMA_CHANGE);
     }
 
     public LakeTableAlterMetaJob(long jobId, long dbId, long tableId, String tableName,
-                                 long timeoutMs, TTabletMetaType metaType, boolean metaValue) {
+                                 long timeoutMs, TTabletMetaType metaType, boolean metaValue,
+                                 String persistentIndexType) {
         super(jobId, JobType.SCHEMA_CHANGE, dbId, tableId, tableName, timeoutMs);
         this.metaType = metaType;
         this.metaValue = metaValue;
+        this.persistentIndexType = persistentIndexType;
     }
 
     @Override
     protected TabletMetadataUpdateAgentTask createTask(PhysicalPartition partition,
             MaterializedIndex index, long nodeId, Set<Long> tablets) {
-        return TabletMetadataUpdateAgentTaskFactory.createGenericBooleanPropertyUpdateTask(nodeId, tablets,
-                metaValue, metaType);
+        return TabletMetadataUpdateAgentTaskFactory.createLakePersistentIndexUpdateTask(nodeId, tablets,
+                metaValue, persistentIndexType);
     }
 
     @Override
     protected void updateCatalog(Database db, LakeTable table) {
         if (metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX) {
+            // re-use ENABLE_PERSISTENT_INDEX for both enable index and index's type.
             table.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
                     String.valueOf(metaValue));
             table.getTableProperty().buildEnablePersistentIndex();
+            table.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE,
+                    String.valueOf(persistentIndexType));
             table.getTableProperty().buildPersistentIndexType();
         }
     }
@@ -72,6 +80,7 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         LakeTableAlterMetaJob other = (LakeTableAlterMetaJob) job;
         this.metaType = other.metaType;
         this.metaValue = other.metaValue;
+        this.persistentIndexType = other.persistentIndexType;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2017,14 +2017,17 @@ public class SchemaChangeHandler extends AlterHandler {
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
                 enablePersistentIndex = PropertyAnalyzer.analyzeBooleanProp(properties,
                         PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, false);
-                boolean oldEnablePersistentIndex = olapTable.enablePersistentIndex();
-                if (oldEnablePersistentIndex == enablePersistentIndex) {
-                    LOG.info(String.format("table: %s enable_persistent_index is %s, nothing need to do",
-                            olapTable.getName(), enablePersistentIndex));
-                    return null;
-                }
                 persistentIndexType = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE,
                         TableProperty.CLOUD_NATIVE_INDEX_TYPE);
+                boolean oldEnablePersistentIndex = olapTable.enablePersistentIndex();
+                String oldPersistentIndexType = olapTable.getPersistentIndexType() == TPersistentIndexType.LOCAL ?
+                        TableProperty.LOCAL_INDEX_TYPE : TableProperty.CLOUD_NATIVE_INDEX_TYPE;
+                if (oldEnablePersistentIndex == enablePersistentIndex
+                        && persistentIndexType == oldPersistentIndexType) {
+                    LOG.info(String.format("table: %s enable_persistent_index is %s persistent_index_type is %s, "
+                            +  "nothing need to do", olapTable.getName(), enablePersistentIndex, persistentIndexType));
+                    return null;
+                }
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)) {
                 // only support set persistent_index_type when enable_persistent_index is true
                 enablePersistentIndex = olapTable.enablePersistentIndex();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2028,6 +2028,10 @@ public class SchemaChangeHandler extends AlterHandler {
                             +  "nothing need to do", olapTable.getName(), enablePersistentIndex, persistentIndexType));
                     return null;
                 }
+                if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)
+                        && !enablePersistentIndex) {
+                    throw new DdlException("enable_persistent_index is false, can not set persistent_index_type");
+                }
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)) {
                 // only support set persistent_index_type when enable_persistent_index is true
                 enablePersistentIndex = olapTable.enablePersistentIndex();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -117,6 +117,7 @@ import com.starrocks.task.AgentTaskExecutor;
 import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.task.TabletMetadataUpdateAgentTask;
 import com.starrocks.task.TabletMetadataUpdateAgentTaskFactory;
+import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.thrift.TWriteQuorumType;
@@ -2012,6 +2013,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
 
             boolean enablePersistentIndex = false;
+            String persistentIndexType = "";
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
                 enablePersistentIndex = PropertyAnalyzer.analyzeBooleanProp(properties,
                         PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, false);
@@ -2019,6 +2021,23 @@ public class SchemaChangeHandler extends AlterHandler {
                 if (oldEnablePersistentIndex == enablePersistentIndex) {
                     LOG.info(String.format("table: %s enable_persistent_index is %s, nothing need to do",
                             olapTable.getName(), enablePersistentIndex));
+                    return null;
+                }
+                persistentIndexType = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE,
+                        TableProperty.CLOUD_NATIVE_INDEX_TYPE);
+            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)) {
+                // only support set persistent_index_type when enable_persistent_index is true
+                enablePersistentIndex = olapTable.enablePersistentIndex();
+                if (!enablePersistentIndex) {
+                    throw new DdlException("enable_persistent_index is false, can not set persistent_index_type");
+                }
+                String oldPersistentIndexType = olapTable.getPersistentIndexType() == TPersistentIndexType.LOCAL ?
+                        TableProperty.LOCAL_INDEX_TYPE : TableProperty.CLOUD_NATIVE_INDEX_TYPE;
+                persistentIndexType = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE,
+                        TableProperty.CLOUD_NATIVE_INDEX_TYPE);
+                if (oldPersistentIndexType.equals(persistentIndexType)) {
+                    LOG.info(String.format("table: %s persistent_index_type is %s, nothing need to do",
+                            olapTable.getName(), persistentIndexType));
                     return null;
                 }
             } else {
@@ -2030,7 +2049,7 @@ public class SchemaChangeHandler extends AlterHandler {
             alterMetaJob = new LakeTableAlterMetaJob(GlobalStateMgr.getCurrentState().getNextId(),
                     db.getId(),
                     olapTable.getId(), olapTable.getName(), timeoutSecond,
-                    TTabletMetaType.ENABLE_PERSISTENT_INDEX, enablePersistentIndex);
+                    TTabletMetaType.ENABLE_PERSISTENT_INDEX, enablePersistentIndex, persistentIndexType);
         } else {
             // shouldn't happen
             throw new DdlException("only support alter enable_persistent_index in shared_data mode");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -250,6 +250,13 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
                         "Property " + PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX +
                                 " must be bool type(false/true)");
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE).equalsIgnoreCase("CLOUD_NATIVE") &&
+                    !properties.get(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE).equalsIgnoreCase("LOCAL")) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE +
+                                " must be CLOUD_NATIVE or LOCAL");
+            }
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE).equalsIgnoreCase("true") &&
                     !properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE).equalsIgnoreCase("false")) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -354,6 +354,21 @@ public class LakeTableAlterMetaJobTest {
         // success
         AlterJobV2 job2 = schemaChangeHandler.createAlterMetaJob(modify, db, table2);
         Assert.assertNotNull(job2);
-        db.dropTable(table2.getName());
+    }
+
+    @Test
+    public void testModifyPropertyWithIndexTypeFailure() throws Exception {
+        LakeTable table2 = createTable(connectContext,
+                    "CREATE TABLE t11(c0 INT) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                                "PROPERTIES('enable_persistent_index'='true', 'persistent_index_type'='LOCAL')");
+        Map<String, String> properties = new HashMap<>();
+        properties.put("enable_persistent_index", "false");
+        properties.put("persistent_index_type", "CLOUD_NATIVE");
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+        // should throw exception
+        ExceptionChecker.expectThrows(DdlException.class,
+                () -> schemaChangeHandler.createAlterMetaJob(modify, db, table2));
+
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -84,7 +84,7 @@ public class LakeTableAlterMetaJobTest {
                                 "PROPERTIES('enable_persistent_index'='false')");
         Assert.assertFalse(table.enablePersistentIndex());
         job = new LakeTableAlterMetaJob(GlobalStateMgr.getCurrentState().getNextId(), db.getId(), table.getId(),
-                    table.getName(), 60 * 1000, TTabletMetaType.ENABLE_PERSISTENT_INDEX, true);
+                    table.getName(), 60 * 1000, TTabletMetaType.ENABLE_PERSISTENT_INDEX, true, "CLOUD_NATIVE");
     }
 
     @After
@@ -228,7 +228,7 @@ public class LakeTableAlterMetaJobTest {
 
         LakeTableAlterMetaJob replayAlterMetaJob = new LakeTableAlterMetaJob(job.jobId,
                     job.dbId, job.tableId, job.tableName,
-                    job.timeoutMs, TTabletMetaType.ENABLE_PERSISTENT_INDEX, true);
+                    job.timeoutMs, TTabletMetaType.ENABLE_PERSISTENT_INDEX, true, "CLOUD_NATIVE");
 
         Table<Long, Long, MaterializedIndex> partitionIndexMap = job.getPartitionIndexMap();
         Map<Long, Long> commitVersionMap = job.getCommitVersionMap();

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -159,6 +159,7 @@ message MetadataUpdateInfoPB {
     // enable persistent index in primary key table
     optional bool enable_persistent_index = 1;
     optional TabletSchemaPB tablet_schema = 2;
+    optional PersistentIndexTypePB persistent_index_type = 3;
 }
 
 message TxnLogPB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -435,6 +435,7 @@ struct TTabletMetaInfo {
     9: optional TTabletSchema tablet_schema;
     // |create_schema_file| only used when |tablet_schema| exists
     10: optional bool create_schema_file;
+    11: optional TPersistentIndexType persistent_index_type;
 }
 
 struct TUpdateTabletMetaInfoReq {


### PR DESCRIPTION
## Why I'm doing:
This pull request introduces several changes to support altering the persistent index type in the metadata of SSTables. Key changes include adding a new function to clean up SSTable metadata, updating the metadata handling to accommodate the new persistent index type, and adding tests to validate these changes.

Now we can achieve SQL like this:
```
alter table a set("persistent_index_type" = "LOCAL");
alter table a set("persistent_index_type" = "CLOUD_NATIVE");
```

## What I'm doing:

### Metadata Handling Improvements:
* [`be/src/storage/lake/meta_file.cpp`](diffhunk://#diff-8da1a78cf605cdb609488453fb2de6df00421063acf7c75a05bc227a91e4271cR489-R525): Added `_sstable_meta_clean_after_alter_type` function to clean up SSTable metadata after an alter operation that changes the persistent index type.
* [`be/src/storage/lake/meta_file.h`](diffhunk://#diff-db3a0688438f74dac5a51a65a8bce51740e6a54b74767275b2fd092f75bca8e1R78-R79): Declared the `_sstable_meta_clean_after_alter_type` function.
* [`be/src/storage/lake/schema_change.cpp`](diffhunk://#diff-891eba0b56724b4dd5fac0e3c0090cfe0150022f235929eee032e7b2f23705d6R394-R399): Updated `do_process_update_tablet_meta` to handle the `persistent_index_type` field.
* [`be/src/storage/lake/txn_log_applier.cpp`](diffhunk://#diff-55a0699dbbae209fd69966dfd871c674b6a39ba196f16864d436c52d7ba34e45R48-R62): Modified `apply_alter_meta_log` to apply changes to the persistent index type and update the index cache accordingly.

### Testing Enhancements:
* [`be/test/storage/lake/alter_tablet_meta_test.cpp`](diffhunk://#diff-1b639a6a902213ad0233b71ff6cdc924d4be56a22ae215c06b06a50c561cc1b1R474-R564): Added a new test `test_alter_persistent_index_type` to validate the changes in persistent index type and the corresponding metadata updates.

### Java Code Changes:
* [`fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java`](diffhunk://#diff-7c1e0e870ab8fbd8e7536ab2c6077355ce358cf3316bbd078f37c8d083eb0583L352-R353): Updated properties handling to include `PROPERTIES_PERSISTENT_INDEX_TYPE`.
* [`fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java`](diffhunk://#diff-0c6c730a0868d875ba7284e1534852c2a0cda312141074be4c43bdbb3ab8a1efR41-R73): Added handling for `persistentIndexType` in `LakeTableAlterMetaJob`. [[1]](diffhunk://#diff-0c6c730a0868d875ba7284e1534852c2a0cda312141074be4c43bdbb3ab8a1efR41-R73) [[2]](diffhunk://#diff-0c6c730a0868d875ba7284e1534852c2a0cda312141074be4c43bdbb3ab8a1efR83)
* [`fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java`](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cR120): Updated `SchemaChangeHandler` to handle `persistentIndexType` and create appropriate alter meta jobs. [[1]](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cR120) [[2]](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cR2016) [[3]](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cR2026-R2042) [[4]](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cL2033-R2052)
* [`fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java`](diffhunk://#diff-d823bc00d682d8a36f2257a3ddcfa045cd2f248ef768d7f9fb0c9a53b039d82cR253-R259): Added validation for `PROPERTIES_PERSISTENT_INDEX_TYPE`.
* [`fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java`](diffhunk://#diff-eb263ed7ab717dfd98fc68dd4663042de8cc42e19044bb5490cb1180531159c0R23): Added a new factory method `createLakePersistentIndexUpdateTask` for creating tasks to update the persistent index type. [[1]](diffhunk://#diff-eb263ed7ab717dfd98fc68dd4663042de8cc42e19044bb5490cb1180531159c0R23) [[2]](diffhunk://#diff-eb263ed7ab717dfd98fc68dd4663042de8cc42e19044bb5490cb1180531159c0R68-R77)

These changes collectively enhance the system's ability to handle persistent index type alterations and ensure that metadata is correctly updated and validated.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
