### PR TITLE
[Enhancement] use cloud native persistent index by default (backport #52209)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -93,6 +93,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     public static final String BINLOG_PROPERTY_PREFIX = "binlog";
     public static final String BINLOG_PARTITION = "binlog_partition_";
 
+    public static final String CLOUD_NATIVE_INDEX_TYPE = "CLOUD_NATIVE";
+    public static final String LOCAL_INDEX_TYPE = "LOCAL";
+
     public enum QueryRewriteConsistencyMode {
         DISABLE,    // 0: disable query rewrite
         LOOSE,      // 1: enable query rewrite, and skip the partition version check, still need to check mv partition exist
@@ -695,10 +698,11 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public TableProperty buildPersistentIndexType() {
-        String type = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, "LOCAL");
-        if (type.equals("LOCAL")) {
+        String defaultType = Config.enable_cloud_native_persistent_index_by_default ? CLOUD_NATIVE_INDEX_TYPE : LOCAL_INDEX_TYPE;
+        String type = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, defaultType);
+        if (type.equals(LOCAL_INDEX_TYPE)) {
             persistentIndexType = TPersistentIndexType.LOCAL;
-        } else if (type.equals("CLOUD_NATIVE")) {
+        } else if (type.equals(CLOUD_NATIVE_INDEX_TYPE)) {
             persistentIndexType = TPersistentIndexType.CLOUD_NATIVE;
         }
         return this;
@@ -707,9 +711,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     public static String persistentIndexTypeToString(TPersistentIndexType type) {
         switch (type) {
             case LOCAL:
-                return "LOCAL";
+                return LOCAL_INDEX_TYPE;
             case CLOUD_NATIVE:
-                return "CLOUD_NATIVE";
+                return CLOUD_NATIVE_INDEX_TYPE;
             default:
                 // shouldn't happen
                 // for it has been checked outside

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2962,7 +2962,7 @@ public class Config extends ConfigBase {
      * Using cloud native persistent index in primary key table by default when creating table.
      */
     @ConfField(mutable = true)
-    public static boolean enable_cloud_native_persistent_index_by_default = true;
+    public static boolean enable_cloud_native_persistent_index_by_default = false;
 
     /**
      * timeout for external table commit

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2958,6 +2958,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_persistent_index_by_default = true;
 
+    /*
+     * Using cloud native persistent index in primary key table by default when creating table.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_cloud_native_persistent_index_by_default = true;
+
     /**
      * timeout for external table commit
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1326,15 +1326,16 @@ public class PropertyAnalyzer {
         if (properties != null && properties.containsKey(PROPERTIES_PERSISTENT_INDEX_TYPE)) {
             String type = properties.get(PROPERTIES_PERSISTENT_INDEX_TYPE);
             properties.remove(PROPERTIES_PERSISTENT_INDEX_TYPE);
-            if (type.equalsIgnoreCase("LOCAL")) {
+            if (type.equalsIgnoreCase(TableProperty.LOCAL_INDEX_TYPE)) {
                 return TPersistentIndexType.LOCAL;
-            } else if (type.equalsIgnoreCase("CLOUD_NATIVE")) {
+            } else if (type.equalsIgnoreCase(TableProperty.CLOUD_NATIVE_INDEX_TYPE)) {
                 return TPersistentIndexType.CLOUD_NATIVE;
             } else {
                 throw new AnalysisException("Invalid persistent index type: " + type);
             }
         }
-        return TPersistentIndexType.LOCAL;
+        return Config.enable_cloud_native_persistent_index_by_default ? TPersistentIndexType.CLOUD_NATIVE
+                : TPersistentIndexType.LOCAL;
     }
 
     public static PeriodDuration analyzeStorageCoolDownTTL(Map<String, String> properties,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -439,7 +439,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD = "connector_sink_spill_mem_limit_threshold";
     public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
     public static final String ENABLE_ADAPTIVE_SINK_DOP = "enable_adaptive_sink_dop";
-    public static final String ENABLE_CLOUD_NATIVE_PERSISTENT_INDEX_BY_DEFAULT = "enable_cloud_native_persistent_index_by_default";
+    public static final String ENABLE_CLOUD_NATIVE_PERSISTENT_INDEX_BY_DEFAULT =
+            "enable_cloud_native_persistent_index_by_default";
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
     public static final String RUNTIME_FILTER_ON_EXCHANGE_NODE = "runtime_filter_on_exchange_node";
     public static final String ENABLE_MULTI_COLUMNS_ON_GLOBAL_RUNTIME_FILTER =

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -439,6 +439,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD = "connector_sink_spill_mem_limit_threshold";
     public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
     public static final String ENABLE_ADAPTIVE_SINK_DOP = "enable_adaptive_sink_dop";
+    public static final String ENABLE_CLOUD_NATIVE_PERSISTENT_INDEX_BY_DEFAULT = "enable_cloud_native_persistent_index_by_default";
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
     public static final String RUNTIME_FILTER_ON_EXCHANGE_NODE = "runtime_filter_on_exchange_node";
     public static final String ENABLE_MULTI_COLUMNS_ON_GLOBAL_RUNTIME_FILTER =
@@ -1393,6 +1394,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_ADAPTIVE_SINK_DOP)
     private boolean enableAdaptiveSinkDop = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_CLOUD_NATIVE_PERSISTENT_INDEX_BY_DEFAULT, flag = VariableMgr.INVISIBLE)
+    private boolean enableCloudNativePersistentIndexByDefault = false;
 
     @VariableMgr.VarAttr(name = JOIN_IMPLEMENTATION_MODE_V2, alias = JOIN_IMPLEMENTATION_MODE)
     private String joinImplementationMode = "auto"; // auto, merge, hash, nestloop
@@ -2447,6 +2451,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableAdaptiveSinkDop(boolean e) {
         this.enableAdaptiveSinkDop = e;
+    }
+
+    public boolean getEnableCloudNativePersistentIndexByDefault() {
+        return enableCloudNativePersistentIndexByDefault;
     }
 
     public long getMaxExecMemByte() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1298,6 +1298,15 @@ public class GlobalStateMgr {
                                         LiteralExpr.create("true", Type.BOOLEAN)),
                             false);
             }
+            if (nodeMgr.isFirstTimeStartUp()) {
+                // When the cluster is initially deployed, we use cloud native persistent index by default
+                VariableMgr.setSystemVariable(VariableMgr.getDefaultSessionVariable(), new SystemVariable(SetType.GLOBAL,
+                                SessionVariable.ENABLE_CLOUD_NATIVE_PERSISTENT_INDEX_BY_DEFAULT,
+                                LiteralExpr.create("true", Type.BOOLEAN)),
+                        false);
+            }
+            Config.enable_cloud_native_persistent_index_by_default = VariableMgr.getDefaultSessionVariable()
+                    .getEnableCloudNativePersistentIndexByDefault();
         } catch (UserException e) {
             LOG.warn("Failed to set ENABLE_ADAPTIVE_SINK_DOP", e);
         } catch (Throwable t) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1300,12 +1300,12 @@ public class GlobalStateMgr {
             }
             if (nodeMgr.isFirstTimeStartUp()) {
                 // When the cluster is initially deployed, we use cloud native persistent index by default
-                VariableMgr.setSystemVariable(VariableMgr.getDefaultSessionVariable(), new SystemVariable(SetType.GLOBAL,
-                                SessionVariable.ENABLE_CLOUD_NATIVE_PERSISTENT_INDEX_BY_DEFAULT,
-                                LiteralExpr.create("true", Type.BOOLEAN)),
+                variableMgr.setSystemVariable(variableMgr.getDefaultSessionVariable(), new SystemVariable(SetType.GLOBAL,
+                                        SessionVariable.ENABLE_CLOUD_NATIVE_PERSISTENT_INDEX_BY_DEFAULT,
+                                        LiteralExpr.create("true", Type.BOOLEAN)),
                         false);
             }
-            Config.enable_cloud_native_persistent_index_by_default = VariableMgr.getDefaultSessionVariable()
+            Config.enable_cloud_native_persistent_index_by_default = variableMgr.getDefaultSessionVariable()
                     .getEnableCloudNativePersistentIndexByDefault();
         } catch (UserException e) {
             LOG.warn("Failed to set ENABLE_ADAPTIVE_SINK_DOP", e);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4044,7 +4044,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         tableProperty.buildEnablePersistentIndex();
 
         if (table.isCloudNativeTable()) {
-            // now default to LOCAL
+            // now default to CLOUD_NATIVE
             tableProperty.buildPersistentIndexType();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -292,7 +292,7 @@ public class PropertyAnalyzerTest {
     public void testPersistentIndexType() throws AnalysisException {
         // empty property
         Map<String, String> property = new HashMap<>();
-        Assert.assertEquals(TPersistentIndexType.LOCAL, PropertyAnalyzer.analyzePersistentIndexType(property));
+        Assert.assertEquals(TPersistentIndexType.CLOUD_NATIVE, PropertyAnalyzer.analyzePersistentIndexType(property));
 
         Map<String, String> property2 = new HashMap<>();
         property2.put(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, "LOCAL");

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -292,7 +292,7 @@ public class PropertyAnalyzerTest {
     public void testPersistentIndexType() throws AnalysisException {
         // empty property
         Map<String, String> property = new HashMap<>();
-        Assert.assertEquals(TPersistentIndexType.CLOUD_NATIVE, PropertyAnalyzer.analyzePersistentIndexType(property));
+        Assert.assertEquals(TPersistentIndexType.LOCAL, PropertyAnalyzer.analyzePersistentIndexType(property));
 
         Map<String, String> property2 = new HashMap<>();
         property2.put(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, "LOCAL");

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -227,7 +227,7 @@ public class CreateLakeTableTest {
             Assert.assertTrue(enablePersistentIndex);
             // check table persistentIndexType
             String indexType = lakeTable.getPersistentIndexTypeString();
-            Assert.assertEquals(indexType, "LOCAL");
+            Assert.assertEquals(indexType, "CLOUD_NATIVE");
 
             String sql = "show create table lake_test.table_with_persistent_index";
             ShowCreateTableStmt showCreateTableStmt =
@@ -245,7 +245,7 @@ public class CreateLakeTableTest {
                         "(c0 int, c1 string, c2 int, c3 bigint)\n" +
                         "PRIMARY KEY(c0)\n" +
                         "distributed by hash(c0) buckets 2\n" +
-                        "properties('enable_persistent_index' = 'true');"));
+                        "properties('enable_persistent_index' = 'true', 'persistent_index_type' = 'LOCAL');"));
 
         ExceptionChecker.expectThrowsNoException(() -> createTable(
                 "create table lake_test.table_in_be_and_cn\n" +
@@ -256,7 +256,7 @@ public class CreateLakeTableTest {
             LakeTable lakeTable = getLakeTable("lake_test", "table_in_be_and_cn");
             // check table persistentIndex
             boolean enablePersistentIndex = lakeTable.enablePersistentIndex();
-            Assert.assertFalse(enablePersistentIndex);
+            Assert.assertTrue(enablePersistentIndex);
 
             String sql = "show create table lake_test.table_in_be_and_cn";
             ShowCreateTableStmt showCreateTableStmt =


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

backport #52209 , and also enable cloud native index when init bootstrap.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

