### PR TITLE
[BugFix] Fix wrong planner when writing into an external partitioned table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -1022,7 +1022,7 @@ public class InsertPlanner {
 
         List<String> targetColumnNames;
         if (insertStmt.getTargetColumnNames() == null) {
-            targetColumnNames = targetTable.getColumns().stream()
+            targetColumnNames = targetTable.getFullSchema().stream()
                     .map(Column::getName).collect(Collectors.toList());
         } else {
             targetColumnNames = Lists.newArrayList(insertStmt.getTargetColumnNames());


### PR DESCRIPTION
## Why I'm doing:

Reproduce:
```SQL
CREATE TABLE hive.`default`.`tablea` (
  `order_no` varchar(1048576),
  `branch_info` varchar(1048576),
  `branch_owership` varchar(1048576),
  `branch_create_time` varchar(1048576),
  `apply_date` varchar(1048576),
  `create_time` varchar(1048576),
  `dt` varchar(1048576)
)
PARTITION BY ( dt );

CREATE TABLE hive.`default`.`tableb` (
  `order_no` varchar(1048576),
  `branch_info` varchar(1048576),
  `branch_owership` varchar(1048576),
  `branch_create_time` varchar(1048576),
  `apply_date` varchar(1048576),
  `dt` varchar(1048576)
);

INSERT INTO hive.`default`.`tableb` VALUES
    ('1111', 'a,', '上海', '2024-10-14 00:28:34.0', '2024-10-14',  '2024-10-14'),
    ('1111', 'a,', '上海', '2024-10-14 00:34:41.0', '2024-10-14', '2024-10-12'),
    ('1111', 'b,', '上海', '2024-10-14 00:50:25.0', '2024-10-14',  '2024-10-13'),
    ('1111', 'b,', '上海', '2024-10-14 00:53:50.0', '2024-10-14',  '2024-10-14'),
    ('1111', 'f,', '上海', '2024-10-14 02:10:06.0', '2024-10-14',  '2024-10-14'),
    ('1111', 'c,', '上海', '2024-10-14 02:10:06.0', '2024-10-14',  '2024-10-16'),
    ('1111', 'q,', '上海', '2024-10-14 02:22:25.0', '2024-10-14',  '2024-10-11'),
    ('1111', 'd,', '上海', '2024-10-14 02:34:22.0', '2024-10-14', '2024-10-15'),
    ('1111', 'w,', '上海', '2024-10-14 02:38:42.0', '2024-10-14', '2024-10-17'),
    ('1111', 'b,', '北京', '2024-10-14 03:10:14.0', '2024-10-14', '2024-10-19');

INSERT INTO hive.`default`.`tablea`  select     order_no,
    branch_info,
    branch_owership,
    branch_create_time,
    apply_date,
    from_unixtime (unix_timestamp (), 'yyyy-MM-dd HH:mm:ss') as create_time,
    dt from hive.`default`.`tableb`;
```
You may find that data files are inserted into a wrong partition.

## What I'm doing:

Reason:

`getColumn` method uses `nameToColumn`, which is a TreeMap internally, meaning that the columns of target table are ordered by name, not the real order in the table. When comparing the columns of select items and target table, the position of partition key can be random. e.g. In the above SQL case, the partition key `dt` may appear in the 5th place(counting from zero), while the 5th select item is a function `from_unixtime`, the following `expr.isConstant()` check in code will pass. As a result, expected dynamical key partition insert is actual static key partiton insert.

Using `getFullSchema` can solve this problem.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
