### PR TITLE
[Feature] Support multi expression partition table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -1217,6 +1217,17 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return null;
     }
 
+    public List<SlotRef> collectAllSlotRefs() {
+        List<SlotRef> result = Lists.newArrayList();
+        if (this instanceof SlotRef) {
+            result.add((SlotRef) this);
+        }
+        for (Expr child : children) {
+            result.addAll(child.collectAllSlotRefs());
+        }
+        return result;
+    }
+
     /**
      * Returns the first child if this Expr is a CastExpr. Otherwise, returns 'this'.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -95,6 +95,8 @@ public class FeConstants {
     // the raw data of one tablet equals to 10GB approximately
     public static final long AUTO_DISTRIBUTION_UNIT = 3221225472L;
 
+    public static final String GENERATED_PARTITION_COLUMN_PREFIX = "__generated_partition_column_";
+
     // Max counter num of TOP K function
     public static final int MAX_COUNTER_NUM_OF_TOP_K = 100000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
@@ -222,7 +222,7 @@ public enum ScalarOperatorEvaluator {
 
         FunctionInvoker invoker = functions.get(signature);
 
-        return invoker != null && invoker.isMonotonic;
+        return invoker != null && isMonotonicFunc(invoker, call);
     }
 
     private boolean isMonotonicFunc(FunctionInvoker invoker, CallOperator operator) {
@@ -230,7 +230,9 @@ public enum ScalarOperatorEvaluator {
             return false;
         }
 
-        if (FunctionSet.DATE_FORMAT.equalsIgnoreCase(invoker.getSignature().getName())) {
+        if (FunctionSet.DATE_FORMAT.equalsIgnoreCase(invoker.getSignature().getName())
+                || (FunctionSet.FROM_UNIXTIME.equalsIgnoreCase(invoker.getSignature().getName())
+                && operator.getChildren().size() == 2)) {
             String pattern = operator.getChild(1).toString();
             if (pattern.isEmpty()) {
                 return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -577,8 +577,8 @@ public class ScalarOperatorFunctions {
     }
 
     @ConstantFunction.List(list = {
-            @ConstantFunction(name = "unix_timestamp", argTypes = {DATETIME}, returnType = BIGINT),
-            @ConstantFunction(name = "unix_timestamp", argTypes = {DATE}, returnType = BIGINT)
+            @ConstantFunction(name = "unix_timestamp", argTypes = {DATETIME}, returnType = BIGINT, isMonotonic = true),
+            @ConstantFunction(name = "unix_timestamp", argTypes = {DATE}, returnType = BIGINT, isMonotonic = true)
     })
     public static ConstantOperator unixTimestamp(ConstantOperator arg) {
         LocalDateTime dt = arg.getDatetime();
@@ -591,8 +591,8 @@ public class ScalarOperatorFunctions {
     }
 
     @ConstantFunction.List(list = {
-            @ConstantFunction(name = "from_unixtime", argTypes = {INT}, returnType = VARCHAR),
-            @ConstantFunction(name = "from_unixtime", argTypes = {BIGINT}, returnType = VARCHAR)
+            @ConstantFunction(name = "from_unixtime", argTypes = {INT}, returnType = VARCHAR, isMonotonic = true),
+            @ConstantFunction(name = "from_unixtime", argTypes = {BIGINT}, returnType = VARCHAR, isMonotonic = true)
     })
     public static ConstantOperator fromUnixTime(ConstantOperator unixTime) throws AnalysisException {
         long value = 0;
@@ -611,7 +611,7 @@ public class ScalarOperatorFunctions {
     }
 
     @ConstantFunction.List(list = {
-            @ConstantFunction(name = "from_unixtime_ms", argTypes = {BIGINT}, returnType = VARCHAR)
+            @ConstantFunction(name = "from_unixtime_ms", argTypes = {BIGINT}, returnType = VARCHAR, isMonotonic = true),
     })
     public static ConstantOperator fromUnixTimeMs(ConstantOperator unixTime) throws AnalysisException {
         long millisecond = unixTime.getBigint();
@@ -627,8 +627,8 @@ public class ScalarOperatorFunctions {
     }
 
     @ConstantFunction.List(list = {
-            @ConstantFunction(name = "from_unixtime", argTypes = {INT, VARCHAR}, returnType = VARCHAR),
-            @ConstantFunction(name = "from_unixtime", argTypes = {BIGINT, VARCHAR}, returnType = VARCHAR)
+            @ConstantFunction(name = "from_unixtime", argTypes = {INT, VARCHAR}, returnType = VARCHAR, isMonotonic = true),
+            @ConstantFunction(name = "from_unixtime", argTypes = {BIGINT, VARCHAR}, returnType = VARCHAR, isMonotonic = true)
     })
     public static ConstantOperator fromUnixTime(ConstantOperator unixTime, ConstantOperator fmtLiteral)
             throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -101,6 +101,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.CsvFormat;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Tracers;
@@ -115,9 +116,14 @@ import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.scheduler.persist.TaskSchedule;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ShowTemporaryTableStmt;
+import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.ExpressionAnalyzer;
+import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.FunctionAnalyzer;
+import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
+import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddBackendBlackListStmt;
 import com.starrocks.sql.ast.AddBackendClause;
@@ -777,7 +783,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                     context.charsetDesc() == null ? null :
                             ((Identifier) visit(context.charsetDesc().identifierOrString())).getValue(),
                     context.keyDesc() == null ? null : getKeysDesc(context.keyDesc()),
-                    context.partitionDesc() == null ? null : getPartitionDesc(context.partitionDesc(), columnDefs),
+                    context.partitionDesc() == null ? null : getPartitionDesc(context.partitionDesc(), columnDefs, tableName),
                     context.distributionDesc() == null ? null : (DistributionDesc) visit(context.distributionDesc()),
                     properties,
                     extProperties,
@@ -803,7 +809,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 context.charsetDesc() == null ? null :
                         ((Identifier) visit(context.charsetDesc().identifierOrString())).getValue(),
                 context.keyDesc() == null ? null : getKeysDesc(context.keyDesc()),
-                context.partitionDesc() == null ? null : getPartitionDesc(context.partitionDesc(), columnDefs),
+                context.partitionDesc() == null ? null : getPartitionDesc(context.partitionDesc(), columnDefs, tableName),
                 context.distributionDesc() == null ? null : (DistributionDesc) visit(context.distributionDesc()),
                 properties,
                 extProperties,
@@ -815,10 +821,66 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                                 .stream().map(Identifier::getValue).collect(toList()));
     }
 
-    private PartitionDesc getPartitionDesc(StarRocksParser.PartitionDescContext context, List<ColumnDef> columnDefs) {
+    private PartitionDesc generateMulitListPartitionDesc(StarRocksParser.PartitionDescContext context,
+                                                         List<ParseNode> multiDescList, List<ColumnDef> columnDefs,
+                                                         TableName tableName) {
+        List<String> columnList = Lists.newArrayList();
+        List<PartitionDesc> partitionDescList = Lists.newArrayList();
+        List<Expr> partitionExprs = Lists.newArrayList();
+        int placeHolderSlotId = 0;
+        for (ParseNode partitionExpr : multiDescList) {
+            if (partitionExpr instanceof Identifier) {
+                Identifier identifier = (Identifier) partitionExpr;
+                columnList.add(identifier.getValue());
+            }
+            if (partitionExpr instanceof FunctionCallExpr) {
+                FunctionCallExpr expr = (FunctionCallExpr) partitionExpr;
+                ExpressionAnalyzer.analyzeExpression(expr, new AnalyzeState(), new Scope(RelationId.anonymous(),
+                                new RelationFields(columnDefs.stream().map(col -> new Field(col.getName(),
+                                        col.getType(), tableName, null)).collect(Collectors.toList()))),
+                        new ConnectContext());
+                String columnName = FeConstants.GENERATED_PARTITION_COLUMN_PREFIX + placeHolderSlotId++;
+                columnList.add(columnName);
+                Type type = expr.getType();
+                if (type.isScalarType()) {
+                    ScalarType scalarType = (ScalarType) type;
+                    if (scalarType.isWildcardChar()) {
+                        type = ScalarType.createCharType(ScalarType.getOlapMaxVarcharLength());
+                    } else if (scalarType.isWildcardVarchar()) {
+                        type = ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
+                    }
+                }
+                TypeDef typeDef = new TypeDef(type);
+                try {
+                    typeDef.analyze();
+                } catch (Exception e) {
+                    throw new ParsingException("Generate partition column " + columnName
+                            + " for multi expression partition error: " + e.getMessage(), createPos(context));
+                }
+                ColumnDef generatedPartitionColumn = new ColumnDef(
+                        columnName, typeDef, null, false, null, null, true,
+                        ColumnDef.DefaultValueDef.NOT_SET, null, expr, "");
+                columnDefs.add(generatedPartitionColumn);
+                partitionExprs.add(expr);
+            }
+        }
+        ListPartitionDesc listPartitionDesc = new ListPartitionDesc(columnList, partitionDescList, partitionExprs);
+        listPartitionDesc.setAutoPartitionTable(true);
+        return listPartitionDesc;
+    }
+
+    private PartitionDesc getPartitionDesc(StarRocksParser.PartitionDescContext context,
+                                           List<ColumnDef> columnDefs, TableName tableName) {
         List<PartitionDesc> partitionDescList = new ArrayList<>();
         // for automatic partition
         if (context.functionCall() != null) {
+            FunctionCallExpr functionCallExpr = (FunctionCallExpr) visit(context.functionCall());
+            String functionName = functionCallExpr.getFnName().getFunction();
+            // except date_trunc, time_slice, str_to_date use generated column as partition column
+            if (!FunctionSet.DATE_TRUNC.equals(functionName) && !FunctionSet.TIME_SLICE.equals(functionName)
+                    && !FunctionSet.STR2DATE.equals(functionName)) {
+                return generateMulitListPartitionDesc(context, Lists.newArrayList(functionCallExpr), columnDefs, tableName);
+            }
             String currentGranularity = null;
             for (StarRocksParser.RangePartitionDescContext rangePartitionDescContext : context.rangePartitionDesc()) {
                 final PartitionDesc rangePartitionDesc = (PartitionDesc) visit(rangePartitionDescContext);
@@ -836,7 +898,6 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 }
                 partitionDescList.add(rangePartitionDesc);
             }
-            FunctionCallExpr functionCallExpr = (FunctionCallExpr) visit(context.functionCall());
             List<String> columnList = AnalyzerUtils.checkAndExtractPartitionCol(functionCallExpr, columnDefs);
             AnalyzerUtils.checkAutoPartitionTableLimit(functionCallExpr, currentGranularity);
             RangePartitionDesc rangePartitionDesc = new RangePartitionDesc(columnList, partitionDescList);
@@ -864,6 +925,23 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 }
             }
             return new ExpressionPartitionDesc(rangePartitionDesc, primaryExpression);
+        }
+        if (context.identifierList() == null) {
+            if (context.partitionExpr() != null) {
+                List<ParseNode> multiDescList = Lists.newArrayList(); 
+                for (StarRocksParser.PartitionExprContext partitionExpr : context.partitionExpr()) {
+                    if (partitionExpr.identifier() != null) {
+                        Identifier identifier = (Identifier) visit(partitionExpr.identifier());
+                        multiDescList.add(identifier);
+                    } else if (partitionExpr.functionCall() != null) {
+                        FunctionCallExpr expr = (FunctionCallExpr) visit(partitionExpr.functionCall());
+                        multiDescList.add(expr);
+                    } else {
+                        throw new ParsingException("Partition column list is empty", createPos(context));
+                    }
+                }
+                return generateMulitListPartitionDesc(context, multiDescList, columnDefs, tableName);
+            }
         }
         List<Identifier> identifierList = visit(context.identifierList().identifier(), Identifier.class);
         List<String> columnList = identifierList.stream().map(Identifier::getValue).collect(toList());
@@ -4274,7 +4352,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitOptimizeClause(StarRocksParser.OptimizeClauseContext context) {
         return new OptimizeClause(
                 context.keyDesc() == null ? null : getKeysDesc(context.keyDesc()),
-                context.partitionDesc() == null ? null : getPartitionDesc(context.partitionDesc(), null),
+                context.partitionDesc() == null ? null : getPartitionDesc(context.partitionDesc(), null, null),
                 context.distributionDesc() == null ? null : (DistributionDesc) visit(context.distributionDesc()),
                 context.orderByDesc() == null ? null :
                         visit(context.orderByDesc().identifierList().identifier(), Identifier.class)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2524,6 +2524,11 @@ optimizerTrace
     : TRACE (ALL | LOGS | TIMES | VALUES | REASON) identifier?
     ;
 
+partitionExpr
+    : identifier
+    | functionCall
+    ;
+
 partitionDesc
     : PARTITION BY RANGE identifierList '(' (rangePartitionDesc (',' rangePartitionDesc)*)? ')'
     | PARTITION BY RANGE primaryExpression '(' (rangePartitionDesc (',' rangePartitionDesc)*)? ')'
@@ -2531,6 +2536,7 @@ partitionDesc
     | PARTITION BY LIST? identifierList
     | PARTITION BY functionCall '(' (rangePartitionDesc (',' rangePartitionDesc)*)? ')'
     | PARTITION BY functionCall
+    | PARTITION BY partitionExpr (',' partitionExpr)*
     ;
 
 listPartitionDesc

--- a/test/sql/test_automatic_partition/R/test_multi_expr
+++ b/test/sql/test_automatic_partition/R/test_multi_expr
@@ -1,0 +1,244 @@
+-- name: test_multi_func_expr
+create table t(k1 datetime, k2 datetime, v int) partition by date_trunc('day', k1), date_trunc('month', k2);
+-- result:
+-- !result
+insert into t values('2020-01-01','2020-02-02', 1);
+-- result:
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*NORMAL	__generated_partition_column_0, __generated_partition_column_1.*
+-- !result
+select * from t;
+-- result:
+2020-01-01 00:00:00	2020-02-02 00:00:00	1	2020-01-01 00:00:00	2020-02-01 00:00:00
+-- !result
+
+
+
+
+
+
+
+
+
+
+
+
+-- name: test_multi_list_function
+create table t(k1 int, k2 datetime, v int) partition by k1,date_trunc('day', k2);
+-- result:
+-- !result
+insert into t values(1,'2020-01-01',1);
+-- result:
+-- !result
+insert into t values(1,'2020-01-02',1);
+-- result:
+-- !result
+insert into t values(2,'2020-01-01',1);
+-- result:
+-- !result
+insert into t values(3,'2020-01-01',1);
+-- result:
+-- !result
+insert into t values(3,'2020-01-03',1);
+-- result:
+-- !result
+explain select * from t where k1=1;
+-- result:
+[REGEX].*partitions=2/5.*
+-- !result
+explain select * from t where k1=1 and k2='2020-01-02';
+-- result:
+[REGEX].*partitions=1/5.*
+-- !result
+explain select * from t where k1=3 and k2='2020-01-01';
+-- result:
+[REGEX].*partitions=1/5.*
+-- !result
+explain select * from t where k1=2;
+-- result:
+[REGEX].*partitions=1/5.*
+-- !result
+explain select * from t where k2='2020-01-01';
+-- result:
+[REGEX].*partitions=3/5.*
+-- !result
+explain select * from t where k2='2020-01-02';
+-- result:
+[REGEX].*partitions=1/5.*
+-- !result
+explain select * from t where k2='2020-01-03';
+-- result:
+[REGEX].*partitions=1/5.*
+-- !result
+
+
+
+
+-- name: test_mulit_timestamp_function
+create table t(k1 int, k2 bigint, v int) partition by from_unixtime(k2),k1;
+-- result:
+-- !result
+insert into t values(1,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+-- result:
+-- !result
+insert into t values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+-- result:
+-- !result
+insert into t values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),1);
+-- result:
+-- !result
+select * from t;
+-- result:
+1	1577811661	1	2020-01-01 01:01:01
+2	1577811661	1	2020-01-01 01:01:01
+1	1196389819	1	2007-11-30 10:30:19
+-- !result
+explain select * from t where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+-- result:
+[REGEX].*partitions=1/3.*
+-- !result
+explain select * from t where k2=1196389819;
+-- result:
+[REGEX].*partitions=1/3.*
+-- !result
+explain select * from t where k1=1;
+-- result:
+[REGEX].*partitions=2/3.*
+-- !result
+create table t1(k1 int, k2 bigint, v int) partition by from_unixtime(k2, "%Y-%m-%d");
+-- result:
+-- !result
+insert into t1 values(1,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+-- result:
+-- !result
+insert into t1 values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+-- result:
+-- !result
+insert into t1 values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),1);
+-- result:
+-- !result
+explain select * from t1 where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+-- result:
+[REGEX].*partitions=1/2.*
+-- !result
+explain select * from t1 where k2=1196389819;
+-- result:
+[REGEX].*partitions=1/2.*
+-- !result
+
+
+
+-- name: test_single_column_partition
+create table t(k1 int, k2 bigint, v int) partition by from_unixtime(k2, '%Y-%m-%d');
+-- result:
+-- !result
+insert into t values(1,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+-- result:
+-- !result
+insert into t values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),1);
+-- result:
+-- !result
+select * from t;
+-- result:
+1	1577811661	1	2020-01-01
+1	1196389819	1	2007-11-30
+-- !result
+explain select * from t where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+-- result:
+[REGEX].*partitions=1/2.*
+-- !result
+
+
+
+-- name: test_primary_key_table
+create table t(k1 int, k2 bigint, v int) PRIMARY KEY(k1, k2) partition by from_unixtime(k2, '%Y-%m-%d');
+-- result:
+-- !result
+insert into t values(1,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+-- result:
+-- !result
+insert into t values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+-- result:
+-- !result
+insert into t values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),2);
+-- result:
+-- !result
+insert into t values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),1);
+-- result:
+-- !result
+insert into t values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),2);
+-- result:
+-- !result
+select * from t;
+-- result:
+1	1577811661	1	2020-01-01
+2	1577811661	2	2020-01-01
+1	1196389819	2	2007-11-30
+-- !result
+select * from t where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+-- result:
+1	1196389819	2	2007-11-30
+-- !result
+select * from t where k2=1196389819;
+-- result:
+1	1196389819	2	2007-11-30
+-- !result
+explain select * from t where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+-- result:
+[REGEX].*partitions=1/2.*
+-- !result
+explain select * from t where k2=1196389819;
+-- result:
+[REGEX].*partitions=1/2.*
+-- !result
+create table t1(k1 int, k2 bigint, v int) PRIMARY KEY(k1, k2) partition by from_unixtime(k2, '%Y-%m-%d'),k1;
+-- result:
+-- !result
+insert into t1 values(1,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+-- result:
+-- !result
+insert into t1 values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+-- result:
+-- !result
+insert into t1 values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),2);
+-- result:
+-- !result
+insert into t1 values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),1);
+-- result:
+-- !result
+insert into t1 values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),2);
+-- result:
+-- !result
+select * from t1;
+-- result:
+1	1577811661	1	2020-01-01
+1	1196389819	2	2007-11-30
+2	1577811661	2	2020-01-01
+-- !result
+select * from t1 where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+-- result:
+1	1196389819	2	2007-11-30
+-- !result
+select * from t1 where k2=1196389819;
+-- result:
+1	1196389819	2	2007-11-30
+-- !result
+explain select * from t1 where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+-- result:
+[REGEX].*partitions=1/3.*
+-- !result
+explain select * from t1 where k2=1196389819;
+-- result:
+[REGEX].*partitions=1/3.*
+-- !result
+-- name: test_create_error
+create table t(k1 int, k2 bigint, v int sum) AGGREGATE KEY(k1,k2) partition by from_unixtime(k2, '%Y-%m-%d');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: AGG_KEYS table should specify aggregate type for non-key column[__generated_partition_column_0].')
+-- !result
+create table t(k1 int, k2 bigint, v int) PRIMARY KEY(k1) partition by from_unixtime(k2, '%Y-%m-%d');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: The partition expr should base on key column.')
+-- !result

--- a/test/sql/test_automatic_partition/T/test_multi_expr
+++ b/test/sql/test_automatic_partition/T/test_multi_expr
@@ -1,0 +1,72 @@
+-- name: test_multi_func_expr
+create table t(k1 datetime, k2 datetime, v int) partition by date_trunc('day', k1), date_trunc('month', k2);
+insert into t values('2020-01-01','2020-02-02', 1);
+show partitions from t;
+select * from t;
+
+-- name: test_multi_list_function
+create table t(k1 int, k2 datetime, v int) partition by k1,date_trunc('day', k2);
+insert into t values(1,'2020-01-01',1);
+insert into t values(1,'2020-01-02',1);
+insert into t values(2,'2020-01-01',1);
+insert into t values(3,'2020-01-01',1);
+insert into t values(3,'2020-01-03',1);
+explain select * from t where k1=1;
+explain select * from t where k1=1 and k2='2020-01-02';
+explain select * from t where k1=3 and k2='2020-01-01';
+explain select * from t where k1=2;
+explain select * from t where k2='2020-01-01';
+explain select * from t where k2='2020-01-02';
+explain select * from t where k2='2020-01-03';
+
+-- name: test_mulit_timestamp_function
+create table t(k1 int, k2 bigint, v int) partition by from_unixtime(k2),k1;
+insert into t values(1,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+insert into t values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+insert into t values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),1);
+select * from t;
+explain select * from t where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+explain select * from t where k2=1196389819;
+explain select * from t where k1=1;
+create table t1(k1 int, k2 bigint, v int) partition by from_unixtime(k2, "%Y-%m-%d");
+insert into t1 values(1,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+insert into t1 values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+insert into t1 values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),1);
+explain select * from t1 where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+explain select * from t1 where k2=1196389819;
+
+-- name: test_single_column_partition
+create table t(k1 int, k2 bigint, v int) partition by from_unixtime(k2, '%Y-%m-%d');
+insert into t values(1,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+insert into t values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),1);
+select * from t;
+explain select * from t where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+explain select * from t where k2=1196389819;
+
+-- name: test_primary_key_table
+create table t(k1 int, k2 bigint, v int) PRIMARY KEY(k1, k2) partition by from_unixtime(k2, '%Y-%m-%d');
+insert into t values(1,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+insert into t values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+insert into t values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),2);
+insert into t values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),1);
+insert into t values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),2);
+select * from t;
+select * from t where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+select * from t where k2=1196389819;
+explain select * from t where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+explain select * from t where k2=1196389819;
+create table t1(k1 int, k2 bigint, v int) PRIMARY KEY(k1, k2) partition by from_unixtime(k2, '%Y-%m-%d'),k1;
+insert into t1 values(1,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+insert into t1 values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),1);
+insert into t1 values(2,UNIX_TIMESTAMP('2020-01-01 01:01:01'),2);
+insert into t1 values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),1);
+insert into t1 values(1,UNIX_TIMESTAMP('2007-11-30 10:30:19'),2);
+select * from t1;
+select * from t1 where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+select * from t1 where k2=1196389819;
+explain select * from t1 where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+explain select * from t1 where k2=1196389819;
+
+-- name: test_create_error
+create table t(k1 int, k2 bigint, v int sum) AGGREGATE KEY(k1,k2) partition by from_unixtime(k2, '%Y-%m-%d');
+create table t(k1 int, k2 bigint, v int) PRIMARY KEY(k1) partition by from_unixtime(k2, '%Y-%m-%d');

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -39,7 +39,7 @@ E: (1064, 'Getting analyzing error. Detail message: All generated columns must b
 -- !result
 CREATE TABLE t ( mc INT AS (1) ) PRIMARY KEY (mc) DISTRIBUTED BY HASH(mc) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Generated Column can not be KEY.')
+E: (1064, 'Getting analyzing error. Detail message: Generated Column mc can not be KEY.')
 -- !result
 CREATE TABLE t ( id BIGINT NOT NULL,  array_data ARRAY<int> NOT NULL, mc DOUBLE AS (array_avg(array_data)) ) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true", "fast_schema_evolution" = "true");
 -- result:


### PR DESCRIPTION
## Why I'm doing:
```
mysql> create table t(k1 int, k2 bigint, v int) PRIMARY KEY(k1, k2) partition by from_unixtime(k2, '%Y-%m-%d'),k1;
Query OK, 0 rows affected (0.02 sec)

mysql> show create table t;
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `k1` int(11) NOT NULL COMMENT "",
  `k2` bigint(20) NOT NULL COMMENT "",
  `v` int(11) NULL COMMENT "",
  `__generated_partition_column_0` varchar(1048576) NULL AS from_unixtime(`d`.`t`.`k2`, '%Y-%m-%d') COMMENT ""
) ENGINE=OLAP
PRIMARY KEY(`k1`, `k2`)
PARTITION BY (`__generated_partition_column_0`,`k1`)
DISTRIBUTED BY HASH(`k1`, `k2`)
PROPERTIES (
"compression" = "LZ4",
"enable_persistent_index" = "true",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "3"
); |
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> explain select * from t where k2=UNIX_TIMESTAMP('2007-11-30 10:30:19');
+------------------------------------------------------------------------+
| Explain String                                                         |
+------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                        |
|  OUTPUT EXPRS:1: k1 | 2: k2 | 3: v | 4: __generated_partition_column_0 |
|   PARTITION: UNPARTITIONED                                             |
|                                                                        |
|   RESULT SINK                                                          |
|                                                                        |
|   1:EXCHANGE                                                           |
|                                                                        |
| PLAN FRAGMENT 1                                                        |
|  OUTPUT EXPRS:                                                         |
|   PARTITION: RANDOM                                                    |
|                                                                        |
|   STREAM DATA SINK                                                     |
|     EXCHANGE ID: 01                                                    |
|     UNPARTITIONED                                                      |
|                                                                        |
|   0:OlapScanNode                                                       |
|      TABLE: t                                                          |
|      PREAGGREGATION: ON                                                |
|      PREDICATES: 2: k2 = 1196389819                                    |
|      partitions=1/3                                                    |
|      rollup: t                                                         |
|      tabletRatio=6/6                                                   |
|      tabletList=24092,24096,24100,24104,24108,24112                    |
|      cardinality=1                                                     |
|      avgRowSize=26.0                                                   |
+------------------------------------------------------------------------+
26 rows in set (0.01 sec)
```

## What I'm doing:

Fixes #52408

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
