### PR TITLE
[Feature] Support db level UDF for backup restore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -48,6 +48,7 @@ import com.starrocks.analysis.TableRef;
 import com.starrocks.backup.Status.ErrCode;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FsBroker;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
@@ -155,6 +156,9 @@ public class BackupJob extends AbstractJob {
 
     private boolean testPrimaryKey = false;
 
+    @SerializedName(value = "backupFunctions")
+    private List<Function> backupFunctions = Lists.newArrayList();
+
     public BackupJob() {
         super(JobType.BACKUP);
     }
@@ -196,6 +200,10 @@ public class BackupJob extends AbstractJob {
 
     public List<TableRef> getTableRef() {
         return tableRefs;
+    }
+
+    public void setBackupFunctions(List<Function> functions) {
+        this.backupFunctions = functions;
     }
 
     public synchronized boolean finishTabletSnapshotTask(SnapshotTask task, TFinishTaskRequest request) {
@@ -541,6 +549,7 @@ public class BackupJob extends AbstractJob {
                 copiedTables.add(copiedTbl);
             }
             backupMeta = new BackupMeta(copiedTables);
+            backupMeta.setFunctions(backupFunctions);
         } finally {
             locker.unLockDatabase(db.getId(), LockType.READ);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
@@ -444,6 +444,16 @@ public class BackupJobInfo implements Writable {
 
         JSONObject backupObjs = root.getJSONObject("backup_objects");
         String[] tblNames = JSONObject.getNames(backupObjs);
+        if (tblNames == null) {
+            // means that pure snapshot for functions
+            String result = root.getString("backup_result");
+            if (result.equals("succeed")) {
+                jobInfo.success = true;
+            } else {
+                jobInfo.success = false;
+            }
+            return;
+        }
         for (String tblName : tblNames) {
             BackupTableInfo tblInfo = new BackupTableInfo();
             tblInfo.name = tblName;

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupMeta.java
@@ -34,8 +34,10 @@
 
 package com.starrocks.backup;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -63,6 +65,8 @@ public class BackupMeta implements Writable, GsonPostProcessable {
     private Map<String, Table> tblNameMap = Maps.newHashMap();
     // tbl id -> tbl
     private Map<Long, Table> tblIdMap = Maps.newHashMap();
+    @SerializedName(value = "functions")
+    private List<Function> functions = Lists.newArrayList();
 
     private BackupMeta() {
 
@@ -85,6 +89,14 @@ public class BackupMeta implements Writable, GsonPostProcessable {
 
     public Table getTable(Long tblId) {
         return tblIdMap.get(tblId);
+    }
+
+    public void setFunctions(List<Function> functions) {
+        this.functions = functions;
+    }
+
+    public List<Function> getFunctions() {
+        return functions;
     }
 
     public static BackupMeta fromFile(String filePath, int starrocksMetaVersion) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -651,6 +651,15 @@ public class Database extends MetaObject implements Writable {
         GlobalStateMgr.getCurrentState().getEditLog().logDropFunction(function);
     }
 
+    public synchronized void dropFunctionForRestore(Function function) {
+        FunctionSearchDesc fnDesc = new FunctionSearchDesc(function.getFunctionName(), function.getArgs(),
+                                                           function.hasVarArgs());
+        try {
+            dropFunctionImpl(fnDesc, true);
+        } catch (UserException ignore) {
+        }
+    }
+
     public synchronized void replayDropFunction(FunctionSearchDesc functionSearchDesc) {
         try {
             dropFunctionImpl(functionSearchDesc, false);
@@ -731,6 +740,10 @@ public class Database extends MetaObject implements Writable {
             functions.addAll(entry.getValue());
         }
         return functions;
+    }
+
+    public synchronized List<Function> getFunctionsByName(String functionName) {
+        return name2Function.getOrDefault(functionName, ImmutableList.of());
     }
 
     public boolean isSystemDatabase() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -443,6 +443,10 @@ public class Function implements Writable {
         this.aggStateDesc = aggStateDesc;
     }
 
+    public void setFunctionName(FunctionName name) {
+        this.name = name;
+    }
+
     // Compares this to 'other' for mode.
     public boolean compare(Function other, CompareMode mode) {
         switch (mode) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2111,7 +2111,7 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
                     PrivilegeType.REPOSITORY.name(), ObjectType.SYSTEM.name(), null);
         }
         List<TableRef> tableRefs = statement.getTableRefs();
-        if (statement.withOnClause() && tableRefs.size() == 0 && statement.getFnRefs().size() == 0) {
+        if (statement.withOnClause() && tableRefs.isEmpty() && statement.getFnRefs().isEmpty()) {
             String dBName = statement.getDbName();
             throw new SemanticException("Database: %s is empty", dBName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2111,7 +2111,7 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
                     PrivilegeType.REPOSITORY.name(), ObjectType.SYSTEM.name(), null);
         }
         List<TableRef> tableRefs = statement.getTableRefs();
-        if (tableRefs.size() == 0) {
+        if (statement.withOnClause() && tableRefs.size() == 0 && statement.getFnRefs().size() == 0) {
             String dBName = statement.getDbName();
             throw new SemanticException("Database: %s is empty", dBName);
         }
@@ -2200,7 +2200,7 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
 
         List<TableRef> tableRefs = statement.getTableRefs();
         // check create_database on current catalog if we're going to restore the whole database
-        if (tableRefs == null || tableRefs.isEmpty()) {
+        if (!statement.withOnClause() && (tableRefs == null || tableRefs.isEmpty())) {
             try {
                 Authorizer.checkCatalogAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                         context.getCurrentCatalog(), PrivilegeType.CREATE_DATABASE);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
@@ -35,6 +35,7 @@ import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.BackupStmt;
 import com.starrocks.sql.ast.CancelBackupStmt;
+import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.RestoreStmt;
 import com.starrocks.sql.ast.ShowBackupStmt;
@@ -78,11 +79,12 @@ public class BackupRestoreAnalyzer {
             String dbName = getDbName(backupStmt.getDbName(), context);
             Database database = getDatabase(dbName, context);
             analyzeLabelAndRepo(backupStmt.getLabel(), backupStmt.getRepoName());
+            boolean withOnClause = backupStmt.withOnClause();
             Map<String, TableRef> tblPartsMap = Maps.newTreeMap();
             List<TableRef> tableRefs = backupStmt.getTableRefs();
-            // If TableRefs is empty, it means that we do not specify any table in Backup stmt.
+            // If TableRefs is empty and withOnClause is not true, it means that we do not specify any table in Backup stmt.
             // We should backup all table in current database.
-            if (tableRefs.size() == 0) {
+            if (!withOnClause && tableRefs.size() == 0) {
                 for (Table tbl : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(database.getId())) {
                     if (!Config.enable_backup_materialized_view && tbl.isMaterializedView()) {
                         LOG.info("Skip backup materialized view: {} because " +
@@ -130,6 +132,14 @@ public class BackupRestoreAnalyzer {
             } else {
                 tableRefs.clear();
                 tableRefs.addAll(tblPartsMap.values());
+            }
+
+            // analyze and get Function for stmt
+            List<FunctionRef> fnRefs = backupStmt.getFnRefs();
+            if (!withOnClause) {
+                fnRefs.add(new FunctionRef(database.getFunctions()));
+            } else {
+                backupStmt.getFnRefs().stream().forEach(x -> x.analyzeForBackup(database));
             }
 
             Map<String, String> properties = backupStmt.getProperties();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/BackupRestoreAnalyzer.java
@@ -84,7 +84,7 @@ public class BackupRestoreAnalyzer {
             List<TableRef> tableRefs = backupStmt.getTableRefs();
             // If TableRefs is empty and withOnClause is not true, it means that we do not specify any table in Backup stmt.
             // We should backup all table in current database.
-            if (!withOnClause && tableRefs.size() == 0) {
+            if (!withOnClause && tableRefs.isEmpty()) {
                 for (Table tbl : GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(database.getId())) {
                     if (!Config.enable_backup_materialized_view && tbl.isMaterializedView()) {
                         LOG.info("Skip backup materialized view: {} because " +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AbstractBackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AbstractBackupStmt.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.LabelName;
 import com.starrocks.analysis.TableRef;
+import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -28,12 +29,14 @@ public class AbstractBackupStmt extends DdlStmt {
     protected LabelName labelName;
     protected String repoName;
     protected List<TableRef> tblRefs;
+    protected List<FunctionRef> fnRefs;
+    protected boolean withOnClause;
     protected Map<String, String> properties;
 
     protected long timeoutMs;
 
     public AbstractBackupStmt(LabelName labelName, String repoName, List<TableRef> tableRefs,
-                              Map<String, String> properties, NodePosition pos) {
+                              List<FunctionRef> fnRefs, Map<String, String> properties, NodePosition pos) {
         super(pos);
         this.labelName = labelName;
         this.repoName = repoName;
@@ -41,7 +44,12 @@ public class AbstractBackupStmt extends DdlStmt {
         if (this.tblRefs == null) {
             this.tblRefs = Lists.newArrayList();
         }
+        this.fnRefs = fnRefs;
+        if (this.fnRefs == null) {
+            this.fnRefs = Lists.newArrayList();
+        }
 
+        this.withOnClause = !(this.tblRefs.isEmpty() && this.fnRefs.isEmpty());
         this.properties = properties == null ? Maps.newHashMap() : properties;
     }
 
@@ -65,8 +73,16 @@ public class AbstractBackupStmt extends DdlStmt {
         return tblRefs;
     }
 
+    public List<FunctionRef> getFnRefs() {
+        return fnRefs;
+    }
+
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public boolean withOnClause() {
+        return withOnClause;
     }
 
     public long getTimeoutMs() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/BackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/BackupStmt.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.LabelName;
 import com.starrocks.analysis.TableRef;
+import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -29,13 +30,14 @@ public class BackupStmt extends AbstractBackupStmt {
 
     private BackupType type = BackupType.FULL;
 
-    public BackupStmt(LabelName labelName, String repoName, List<TableRef> tblRefs, Map<String, String> properties) {
-        super(labelName, repoName, tblRefs, properties, NodePosition.ZERO);
+    public BackupStmt(LabelName labelName, String repoName, List<TableRef> tblRefs, List<FunctionRef> fnRefs,
+                      Map<String, String> properties) {
+        super(labelName, repoName, tblRefs, fnRefs, properties, NodePosition.ZERO);
     }
 
-    public BackupStmt(LabelName labelName, String repoName, List<TableRef> tblRefs,
+    public BackupStmt(LabelName labelName, String repoName, List<TableRef> tblRefs, List<FunctionRef> fnRefs,
                       Map<String, String> properties, NodePosition pos) {
-        super(labelName, repoName, tblRefs, properties, pos);
+        super(labelName, repoName, tblRefs, fnRefs, properties, pos);
     }
 
     public long getTimeoutMs() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/FunctionRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/FunctionRef.java
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.ast;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.FunctionName;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Function;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.List;
+
+/**
+ * FunctionRef is used to represent all Functions (UDF) with same FunctionName.
+ * This description for Function is maked when creating AST with unanalyzed state and maked with
+ * analyzed state if given a Function Object.
+ */
+public class FunctionRef implements ParseNode {
+    private final NodePosition pos;
+    private FunctionName fnName;
+    private String alias;
+    // set after analyzed
+    private List<Function> fn;
+    private boolean analyzed;
+
+    public FunctionRef(List<Function> fn) {
+        this.fn = fn;
+        this.analyzed = true;
+        this.pos = NodePosition.ZERO;
+    }
+
+    public FunctionRef(FunctionName fnName, String alias, NodePosition pos) {
+        this.fnName = fnName;
+        this.pos = pos;
+        this.fn = Lists.newArrayList();
+        this.alias = alias;
+        this.analyzed = false;
+    }
+
+    public FunctionName getFnName() {
+        return fnName;
+    }
+
+    public void analyzeForBackup(Database db) {
+        fnName.analyze(db.getFullName());
+
+        this.fn = db.getFunctionsByName(fnName.getFunction());
+        
+        if (this.fn.isEmpty()) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                    "Invalid backup function(s), function name: " + fnName.toString());
+        }
+        this.analyzed = true;
+    }
+
+    public boolean checkSameFunctionNameForRestore(Function func) {
+        return this.fnName.getFunction().equalsIgnoreCase(func.functionName());
+    }
+
+    public List<Function> getFunctions() {
+        Preconditions.checkState(this.analyzed);
+        return this.fn;
+    }
+
+    public String getAlias() {
+        return this.alias;
+    }
+
+    @Override
+    public NodePosition getPos() {
+        return pos;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RestoreStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RestoreStmt.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.LabelName;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -31,13 +32,14 @@ public class RestoreStmt extends AbstractBackupStmt {
     private int starrocksMetaVersion = -1;
 
     public RestoreStmt(LabelName labelName, String repoName, List<TableRef> tblRefs,
-                       Map<String, String> properties) {
-        this(labelName, repoName, tblRefs, properties, NodePosition.ZERO);
+                       List<FunctionRef> fnRefs, Map<String, String> properties) {
+        this(labelName, repoName, tblRefs, fnRefs, properties, NodePosition.ZERO);
     }
 
     public RestoreStmt(LabelName labelName, String repoName, List<TableRef> tblRefs,
-                       Map<String, String> properties, NodePosition pos) {
-        super(labelName, repoName, tblRefs, properties, pos);
+                       List<FunctionRef> fnRefs, Map<String, String> properties,
+                       NodePosition pos) {
+        super(labelName, repoName, tblRefs, fnRefs, properties, pos);
     }
 
     public boolean allowLoad() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1728,7 +1728,7 @@ privObjectTypePlural
 backupStatement
     : BACKUP SNAPSHOT qualifiedName
     TO identifier
-    (ON '(' tableDesc (',' tableDesc) * ')')?
+    (ON '(' backupObjectDesc (',' backupObjectDesc) * ')')?
     (PROPERTIES propertyList)?
     ;
 
@@ -1743,7 +1743,7 @@ showBackupStatement
 restoreStatement
     : RESTORE SNAPSHOT qualifiedName
     FROM identifier
-    (ON '(' restoreTableDesc (',' restoreTableDesc) * ')')?
+    (ON '(' restoreObjectDesc (',' restoreObjectDesc) * ')')?
     (PROPERTIES propertyList)?
     ;
 
@@ -2508,8 +2508,16 @@ frameBound
 
 // ------------------------------------------- COMMON AST --------------------------------------------------------------
 
+backupObjectDesc
+    : tableDesc | FUNCTION qualifiedName
+    ;
+
 tableDesc
     : qualifiedName partitionNames?
+    ;
+
+restoreObjectDesc
+    : restoreTableDesc | FUNCTION qualifiedName (AS identifier)?
     ;
 
 restoreTableDesc

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -37,6 +37,7 @@ package com.starrocks.backup;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.starrocks.analysis.FunctionName;
 import com.starrocks.backup.BackupJobInfo.BackupIndexInfo;
 import com.starrocks.backup.BackupJobInfo.BackupPartitionInfo;
 import com.starrocks.backup.BackupJobInfo.BackupPhysicalPartitionInfo;
@@ -45,6 +46,7 @@ import com.starrocks.backup.BackupJobInfo.BackupTabletInfo;
 import com.starrocks.backup.RestoreJob.RestoreJobState;
 import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
@@ -53,6 +55,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.Type;
 import com.starrocks.catalog.View;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
@@ -956,5 +959,19 @@ public class RestoreJobTest {
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(RestoreJobState.FINISHED, job.getState());
+    }
+
+    @Test
+    public void testRestoreAddFunction() {
+        backupMeta = new BackupMeta(Lists.newArrayList());
+        Function f1 = new Function(new FunctionName(db.getFullName(), "test_function"),
+                                   new Type[] {Type.INT}, new String[] {"argName"}, Type.INT, false);
+
+        backupMeta.setFunctions(Lists.newArrayList(f1));
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
+                             new BackupJobInfo(), false, 3, 100000,
+                             globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        
+        job.addRestoredFunctions(db);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DatabaseTest.java
@@ -204,4 +204,15 @@ public class DatabaseTest {
         Assert.assertEquals(functions.size(), 1);
         Assert.assertTrue(functions.get(0).compare(f, Function.CompareMode.IS_IDENTICAL));
     }
+
+    @Test
+    public void testAddAndDropFunctionForRestore() {
+        Function f1 = new Function(new FunctionName(db.getFullName(), "test_function"),
+                                   new Type[] {Type.INT}, new String[] {"argName"}, Type.INT, false);
+        try {
+            db.addFunction(f1);
+        } catch (Exception e) {
+        }
+        db.dropFunctionForRestore(f1);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
@@ -55,6 +55,9 @@ public class AnalyzeBackupRestoreTest {
         Repository repo = new Repository(10000, "repo", false, location, storage);
         repo.initRepository();
         GlobalStateMgr.getCurrentState().getBackupHandler().getRepoMgr().addAndInitRepoIfNotExist(repo, false);
+
+        AnalyzeTestUtil.getStarRocksAssert().withFunction("CREATE FUNCTION Echostring(string) RETURNS string properties" +
+                        "(\"symbol\" = \"Echostring\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");
     }
 
     @Test
@@ -68,6 +71,8 @@ public class AnalyzeBackupRestoreTest {
         analyzeSuccess("BACKUP SNAPSHOT snapshot_pk_label TO `repo` ON ( tprimary ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( t3, T3 ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( FUNCTION Echostring ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( t0, t0 ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
@@ -104,6 +109,10 @@ public class AnalyzeBackupRestoreTest {
                 "\"replication_num\"=\"1\",\"meta_version\"=\"10\"," +
                 "\"starrocks_meta_version\"=\"10\",\"timeout\"=\"3600\" );");
         analyzeSuccess("RESTORE SNAPSHOT test.`snapshot_2` FROM `repo` " +
+                "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"allow_load\"=\"true\"," +
+                "\"replication_num\"=\"1\",\"meta_version\"=\"10\"," +
+                "\"starrocks_meta_version\"=\"10\",\"timeout\"=\"3600\" );");
+        analyzeSuccess("RESTORE SNAPSHOT test.`snapshot_pk_label` FROM `repo` ON ( FUNCTION Echostring )" +
                 "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"allow_load\"=\"true\"," +
                 "\"replication_num\"=\"1\",\"meta_version\"=\"10\"," +
                 "\"starrocks_meta_version\"=\"10\",\"timeout\"=\"3600\" );");

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -39,9 +39,12 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.TypeDef;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -50,6 +53,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.ScalarFunction;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AlreadyExistsException;
@@ -87,6 +91,7 @@ import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateFunctionStmt;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
@@ -104,6 +109,7 @@ import com.starrocks.sql.ast.DropDbStmt;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.DropTemporaryTableStmt;
+import com.starrocks.sql.ast.FunctionArgsDef;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
@@ -119,6 +125,7 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.system.BackendResourceStat;
+import com.starrocks.thrift.TFunctionBinaryType;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.lang.StringUtils;
@@ -332,6 +339,24 @@ public class StarRocksAssert {
         }
     }
 
+    public static void utCreateFunctionMock(CreateFunctionStmt createFunctionStmt, ConnectContext ctx) throws Exception {
+        FunctionName functionName = createFunctionStmt.getFunctionName();
+        functionName.analyze(ctx.getDatabase());
+        FunctionArgsDef argsDef = createFunctionStmt.getArgsDef();
+        TypeDef returnType = createFunctionStmt.getReturnType();
+        // check argument
+        argsDef.analyze();
+        returnType.analyze();
+
+        Function function = ScalarFunction.createUdf(
+                functionName, argsDef.getArgTypes(),
+                returnType.getType(), argsDef.isVariadic(), TFunctionBinaryType.SRJAR,
+                "", "", "", "", !"shared".equalsIgnoreCase(""));
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(ctx.getDatabase());
+        db.addFunction(function, true, false);
+    }
+
     public static void utCreateTableWithRetry(CreateTableStmt createTableStmt, ConnectContext ctx) throws Exception {
         executeWithRetry((retryTime) -> {
             CreateTableStmt createTableStmtCopied = createTableStmt;
@@ -352,6 +377,15 @@ public class StarRocksAssert {
             }
             GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmtCopied);
         }, "Drop Table", 3);
+    }
+
+    public StarRocksAssert withFunction(String sql) throws Exception {
+        Config.enable_udf = true;
+        CreateFunctionStmt createFunctionStmt =
+                    (CreateFunctionStmt) UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, ctx);
+        Config.enable_udf = false;
+        utCreateFunctionMock(createFunctionStmt, ctx);
+        return this;
     }
 
     public StarRocksAssert withTable(String sql) throws Exception {


### PR DESCRIPTION
In this pr, we implement backup restore for UDFs for database level (not global UDF).

`Implementation:`
To support backup the UDFs, we reuse the backupMeta and simply save the UDFs
metadata into backupMeta to finish the backup process.
To support restore the UDFs, we recover all UDFs metadata info from backupMeta
and add into the coressponding Database to finish restore process.

`Usage:`
In this pr, we introduce a new grammer for users to specify whether we need to
backup/restore for a UDF. We use keyword `FUNCTION` to specify a object name is
a function but not a table object (says, `TABLE`/`MV`/`VIEW`)
`Example:`
```
BACKUP SNAPSHOT dbname.snapshotName TO `repo_name` ON (FUNCTION myUDF PROPERTIES(...);
RESTORE SNAPSHOT dbname.snapshotName FROM `repo_name` ON (FUNCTION myUDF AS newName) PROPERTIES(...);
```

Here’s a summary of the behavior changes in backup restore after supporting UDFs.
1. Use keyword `FUNCTION` to specify backup/restore object type.
2. Support use alias in restore stmt to rename a restored UDF.
3. If there is no `ON` clause in backup/restore stmt, means that backup/restore all of table object and UDF
   for the specfied db.
4. If restore the UDF(s) when the db already has function(s) with same name, the old one(s) will be replaced.

Fixes #52427 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
