### PR TITLE
[Enhancement] handle const column in array_length function

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -41,8 +41,8 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
     if (columns[0]->is_constant()) {
         auto col_result = Int32Column::create();
         col_result->append(col_array->offsets().get_data().data()[1]);
-        col_result->assign(num_rows, 0);
-        return col_result;
+        auto const_column = ConstColumn::create(col_result, num_rows);
+        return const_column;
     } else {
         Column* arg0 = columns[0].get();
         auto col_result = Int32Column::create();

--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -41,7 +41,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
     if (columns[0]->is_constant()) {
         auto col_result = Int32Column::create();
         col_result->append(col_array->offsets().get_data().data()[1]);
-        auto const_column = ConstColumn::create(col_result, num_rows);
+        auto const_column = ConstColumn::create(std::move(col_result), num_rows);
         return const_column;
     } else {
         Column* arg0 = columns[0].get();


### PR DESCRIPTION
## Why I'm doing:
This pr reduces memory usage. 
ConstColumn only contains one element and 4 bytes memory usage, 
but col_result contains num_rows elements after running code `col_result->assign(num_rows, 0)`  and num_rows * 4 bytes memory usage

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
