### PR TITLE
[BugFix] Fix insert into blackhole() analyze error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -325,7 +325,12 @@ public class InsertStmt extends DmlStmt {
     }
 
     public Table makeBlackHoleTable() {
-        return new BlackHoleTable(collectSelectedFieldsFromQueryStatement());
+        List<Column> columns = collectSelectedFieldsFromQueryStatement();
+        // rename each column's name, assign unique name
+        for (int i = 0; i < columns.size(); i++) {
+            columns.get(i).setName(columns.get(i).getName() + "_blackhole_" + i);
+        }
+        return new BlackHoleTable(columns);
     }
 
     public Table makeTableFunctionTable(SessionVariable sessionVariable) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DataCachePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DataCachePlanTest.java
@@ -168,7 +168,8 @@ public class DataCachePlanTest extends PlanTestBase {
                 "where l_shipdate>='1998-01-03'";
         assertPlanContains(sql, "BLACKHOLE TABLE SINK");
 
-        sql = "insert into blackhole() select * from hive0.datacache_db.multi_partition_table join hive0.datacache_db.multi_partition_table as t";
+        sql = "insert into blackhole() select * from hive0.datacache_db.multi_partition_table join " +
+                "hive0.datacache_db.multi_partition_table as t";
         assertPlanContains(sql, "BLACKHOLE TABLE SINK");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DataCachePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DataCachePlanTest.java
@@ -167,5 +167,8 @@ public class DataCachePlanTest extends PlanTestBase {
         String sql = "insert into blackhole() select * from hive0.datacache_db.multi_partition_table " +
                 "where l_shipdate>='1998-01-03'";
         assertPlanContains(sql, "BLACKHOLE TABLE SINK");
+
+        sql = "insert into blackhole() select * from hive0.datacache_db.multi_partition_table join hive0.datacache_db.multi_partition_table as t";
+        assertPlanContains(sql, "BLACKHOLE TABLE SINK");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Fix `insert into blackhole() select * from t1 join t1 as t` analyze error.

## What I'm doing:
fix it

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
