### PR TITLE
[Enhancement] Refactor CachingMvPlanContextBuilder to support timeout in loading mv's plan cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -293,7 +293,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             materializedView.getTableProperty().setMvQueryRewriteSwitch(queryRewriteSwitch);
             if (!materializedView.isEnableRewrite()) {
                 // invalidate caches for mv rewrite when disable mv rewrite.
-                CachingMvPlanContextBuilder.getInstance().invalidateFromCache(materializedView, false);
+                CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(materializedView, false);
             } else {
                 CachingMvPlanContextBuilder.getInstance().putAstIfAbsent(materializedView);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -578,7 +578,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     public void setActive() {
         LOG.info("set {} to active", name);
         // reset mv rewrite cache when it is active again
-        CachingMvPlanContextBuilder.getInstance().invalidateFromCache(this, true);
+        CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(this, true);
         this.active = true;
         this.inactiveReason = null;
     }
@@ -589,7 +589,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         this.inactiveReason = reason;
         // reset cached variables
         resetMetadataCache();
-        CachingMvPlanContextBuilder.getInstance().invalidateFromCache(this, false);
+        CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(this, false);
     }
 
     /**
@@ -937,7 +937,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
         // 1. Remove from plan cache
         MvId mvId = new MvId(db.getId(), getId());
-        CachingMvPlanContextBuilder.getInstance().invalidateFromCache(this, false);
+        CachingMvPlanContextBuilder.getInstance().updateMvPlanContextCache(this, false);
 
         // 2. Remove from base tables
         List<BaseTableInfo> baseTableInfos = getBaseTableInfos();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -761,7 +761,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             return Sets.newHashSet();
         }
 
-        return ConnectorPartitionTraits.build(baseTable).getUpdatedPartitionNames(
+        return ConnectorPartitionTraits.build(this, baseTable).getUpdatedPartitionNames(
                 this.getBaseTableInfos(),
                 this.getRefreshScheme().getAsyncRefreshContext());
     }
@@ -783,7 +783,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     return Optional.empty();
                 }
             }
-            Optional<Long> baseTableTs = ConnectorPartitionTraits.build(baseTable).maxPartitionRefreshTs();
+            Optional<Long> baseTableTs = ConnectorPartitionTraits.build(this, baseTable).maxPartitionRefreshTs();
             if (!baseTableTs.isPresent()) {
                 return Optional.empty();
             }
@@ -863,7 +863,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             return result;
         }
 
-        return ConnectorPartitionTraits.build(baseTable).getUpdatedPartitionNames(
+        return ConnectorPartitionTraits.build(this, baseTable).getUpdatedPartitionNames(
                 this.getBaseTableInfos(),
                 this.refreshScheme.getAsyncRefreshContext());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3118,8 +3118,12 @@ public class Config extends ConfigBase {
     /**
      * mv plan cache expire interval in seconds
      */
+    @Deprecated
     @ConfField(mutable = true)
     public static long mv_plan_cache_expire_interval_sec = 24L * 60L * 60L;
+
+    @ConfField(mutable = true, comment = "The default thread pool size of mv plan cache")
+    public static int mv_plan_cache_thread_pool_size = 3;
 
     /**
      * mv plan cache expire interval in seconds

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -101,12 +101,12 @@ public abstract class ConnectorPartitionTraits {
      * @param table the table to build partition traits
      * @return the partition traits
      */
-    public static ConnectorPartitionTraits buildWithCache(ConnectContext ctx, Table table) {
+    public static ConnectorPartitionTraits buildWithCache(ConnectContext ctx, MaterializedView mv, Table table) {
         ConnectorPartitionTraits delegate = buildWithoutCache(table);
         if (Config.enable_mv_query_context_cache && ctx != null && ctx.getQueryMVContext() != null) {
             QueryMaterializationContext queryMVContext = ctx.getQueryMVContext();
             Cache<Object, Object> cache = queryMVContext.getMvQueryContextCache();
-            return new CachedPartitionTraits(cache, delegate, queryMVContext.getQueryCacheStats());
+            return new CachedPartitionTraits(cache, delegate, queryMVContext.getQueryCacheStats(), mv);
         } else {
             return delegate;
         }
@@ -117,9 +117,14 @@ public abstract class ConnectorPartitionTraits {
      * @param table the table to build partition traits
      * @return the partition traits
      */
+    public static ConnectorPartitionTraits build(MaterializedView mv, Table table) {
+        ConnectContext ctx = ConnectContext.get();
+        return buildWithCache(ctx, mv, table);
+    }
+
     public static ConnectorPartitionTraits build(Table table) {
         ConnectContext ctx = ConnectContext.get();
-        return buildWithCache(ctx, table);
+        return buildWithCache(ctx, null, table);
     }
 
     private static ConnectorPartitionTraits buildWithoutCache(Table table) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
@@ -51,10 +51,12 @@ public class CachedPartitionTraits extends DefaultTraits {
     private final Cache<Object, Object> cache;
     private final ConnectorPartitionTraits delegate;
     private final QueryMaterializationContext.QueryCacheStats stats;
+    private final MaterializedView mv;
 
     public CachedPartitionTraits(Cache<Object, Object> cache,
                                  ConnectorPartitionTraits delegate,
-                                 QueryMaterializationContext.QueryCacheStats stats) {
+                                 QueryMaterializationContext.QueryCacheStats stats,
+                                 MaterializedView mv) {
         Objects.requireNonNull(cache);
         Objects.requireNonNull(delegate);
         Objects.requireNonNull(stats);
@@ -62,6 +64,7 @@ public class CachedPartitionTraits extends DefaultTraits {
         this.delegate = delegate;
         this.table = delegate.getTable();
         this.stats = stats;
+        this.mv = mv;
     }
 
     /**
@@ -70,7 +73,7 @@ public class CachedPartitionTraits extends DefaultTraits {
      * @return the cache key
      */
     private String buildCacheKey(String prefix) {
-        return String.format("cache_%s_%s", prefix, table.getId());
+        return String.format("cache_%s_%s_%s", prefix, (mv == null) ? "0" : mv.getId(), table.getId());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -160,6 +161,9 @@ public class CachingMvPlanContextBuilder {
     public List<MvPlanContext> getPlanContextIfPresent(SessionVariable sessionVariable,
                                                        MaterializedView mv) {
         CompletableFuture<List<MvPlanContext>> future = MV_PLAN_CONTEXT_CACHE.getIfPresent(mv);
+        if (future == null) {
+            return Lists.newArrayList();
+        }
         return getMvPlanCacheFromFuture(sessionVariable, mv, future);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -27,7 +27,6 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import org.apache.logging.log4j.LogManager;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -104,7 +104,8 @@ public class MvRewritePreprocessor {
         this.queryColumnRefFactory = queryColumnRefFactory;
         this.context = context;
         this.requiredColumns = requiredColumns;
-        this.queryMaterializationContext = context.getQueryMaterializationContext();
+        this.queryMaterializationContext = context.getQueryMaterializationContext() == null ?
+                new QueryMaterializationContext() : context.getQueryMaterializationContext();
     }
 
     @VisibleForTesting
@@ -231,13 +232,16 @@ public class MvRewritePreprocessor {
             try {
                 // 1. get related mvs for all input tables
                 Set<MaterializedView> relatedMVs = getRelatedMVs(queryTables, context.getOptimizerConfig().isRuleBased());
+
+                // filter mvs which is set by config: including/excluding mvs
+                Set<MaterializedView> selectedRelatedMVs = getRelatedMVsByConfig(relatedMVs);
+                logMVPrepare(connectContext, "Choose {}/{} mvs after user config", selectedRelatedMVs.size(), relatedMVs.size());
                 // add into queryMaterializationContext for later use
-                this.queryMaterializationContext.addRelatedMVs(relatedMVs);
+                this.queryMaterializationContext.addRelatedMVs(selectedRelatedMVs);
 
                 // 2. choose best related mvs by user's config or related mv limit
-                Set<MaterializedView> selectedRelatedMVs;
                 try (Timer t1 = Tracers.watchScope("MVChooseCandidates")) {
-                    selectedRelatedMVs = chooseBestRelatedMVs(queryTables, relatedMVs, queryOptExpression);
+                    selectedRelatedMVs = chooseBestRelatedMVs(queryTables, selectedRelatedMVs, queryOptExpression);
                 }
 
                 // 3. convert to mv with planContext, skip if mv has no valid plan(not SPJG)
@@ -259,7 +263,7 @@ public class MvRewritePreprocessor {
 
                 // To avoid disturbing queries without mv, only initialize materialized view context
                 // when there are candidate mvs.
-                if (context.getCandidateMvs() != null && !context.getCandidateMvs().isEmpty()) {
+                if (CollectionUtils.isNotEmpty(context.getCandidateMvs())) {
                     // it's safe used in the optimize context here since the query mv context is not shared across the
                     // connect-context.
                     connectContext.setQueryMVContext(queryMaterializationContext);
@@ -525,15 +529,14 @@ public class MvRewritePreprocessor {
             OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "MV contains extra tables besides FK-PK");
             return Pair.create(false, "MV contains extra tables besides FK-PK");
         }
-        if (connectContext == null) {
-            return Pair.create(true, null);
-        }
+        SessionVariable sessionVariable  = connectContext == null ? SessionVariable.DEFAULT_SESSION_VARIABLE
+                : connectContext.getSessionVariable();
         // if mv is in plan cache(avoid building plan), check whether it's valid
         List<MvPlanContext> planContexts = force ?
                 CachingMvPlanContextBuilder.getInstance()
-                        .getOrLoadPlanContext(connectContext.getSessionVariable(), mv) :
+                        .getOrLoadPlanContext(sessionVariable, mv) :
                 CachingMvPlanContextBuilder.getInstance()
-                        .getPlanContextIfPresent(connectContext.getSessionVariable(), mv);
+                        .getPlanContextIfPresent(sessionVariable, mv);
         if (CollectionUtils.isNotEmpty(planContexts) &&
                 planContexts.stream().noneMatch(MvPlanContext::isValidMvPlan)) {
             logMVPrepare(connectContext, "MV {} has no valid plan from {} plan contexts",
@@ -580,18 +583,14 @@ public class MvRewritePreprocessor {
     public Set<MaterializedView> chooseBestRelatedMVs(Set<Table> queryTables,
                                                       Set<MaterializedView> relatedMVs,
                                                       OptExpression queryOptExpression) {
-        // 1. filter mvs which is set by config: including/excluding mvs
-        Set<MaterializedView> validMVs = getRelatedMVsByConfig(relatedMVs);
-        logMVPrepare(connectContext, "Choose {}/{} mvs after user config", validMVs.size(), relatedMVs.size());
-
-        // 2. choose all valid mvs and filter mvs that cannot be rewritten for the query
-        validMVs = validMVs.stream()
+        // choose all valid mvs and filter mvs that cannot be rewritten for the query
+        Set<MaterializedView> validMVs = relatedMVs.stream()
                 .filter(mv -> isMVValidToRewriteQuery(connectContext, mv, false, queryTables).first)
                 .collect(Collectors.toSet());
         logMVPrepare(connectContext, "Choose {}/{} valid mvs after checking valid",
                 validMVs.size(), relatedMVs.size());
 
-        // 3. choose max config related mvs for mv rewrite to avoid too much optimize time
+        // choose max config related mvs for mv rewrite to avoid too much optimize time
         int maxRelatedMVsLimit = connectContext.getSessionVariable().getCboMaterializedViewRewriteRelatedMVsLimit();
         if (validMVs.size() <= maxRelatedMVsLimit) {
             return validMVs;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -345,8 +345,12 @@ public class MetaFunctions {
         try {
             MaterializedView mv = (MaterializedView) table;
             String plans = "";
+            ConnectContext connectContext = ConnectContext.get() == null ? new ConnectContext() : ConnectContext.get();
+            boolean defaultUseCacheValue = connectContext.getSessionVariable().isEnableMaterializedViewPlanCache();
+            connectContext.getSessionVariable().setEnableMaterializedViewPlanCache(useCache.getBoolean());
             List<MvPlanContext> planContexts =
-                    CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, useCache.getBoolean());
+                    CachingMvPlanContextBuilder.getInstance().getPlanContext(connectContext.getSessionVariable(), mv);
+            connectContext.getSessionVariable().setEnableMaterializedViewPlanCache(defaultUseCacheValue);
             int size = planContexts.size();
             for (int i = 0; i < size; i++) {
                 MvPlanContext context = planContexts.get(i);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
@@ -226,7 +226,7 @@ public class BestMvSelector {
                         expression.getStatistics(), scanOperator.getTable().getBaseSchema().size(), sortScore);
                 if (isAggregate) {
                     List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(
-                            mv, optimizerContext.getSessionVariable().isEnableMaterializedViewPlanCache());
+                            optimizerContext.getSessionVariable(), mv);
                     for (MvPlanContext planContext : planContexts) {
                         if (planContext.getLogicalPlan().getOp() instanceof LogicalAggregationOperator) {
                             LogicalAggregationOperator aggregationOperator = planContext.getLogicalPlan().getOp().cast();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1324,7 +1324,7 @@ public class MvUtils {
                                                  boolean isInlineView) {
         // step1: get from mv plan cache
         List<MvPlanContext> mvPlanContexts = CachingMvPlanContextBuilder.getInstance()
-                .getPlanContext(mv, connectContext.getSessionVariable().isEnableMaterializedViewPlanCache());
+                .getPlanContext(connectContext.getSessionVariable(), mv);
         if (mvPlanContexts != null && !mvPlanContexts.isEmpty() && mvPlanContexts.get(0).getLogicalPlan() != null) {
             // TODO: distinguish normal mv plan and view rewrite plan
             return mvPlanContexts.get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/SingleTableRewriteBaseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/SingleTableRewriteBaseRule.java
@@ -169,7 +169,7 @@ public abstract class SingleTableRewriteBaseRule extends BaseMaterializedViewRew
                 if (isAggregate) {
                     MaterializedView mv = (MaterializedView) scanOperator.getTable();
                     List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(
-                            mv, optimizerContext.getSessionVariable().isEnableMaterializedViewPlanCache());
+                            optimizerContext.getSessionVariable(), mv);
                     for (MvPlanContext planContext : planContexts) {
                         if (planContext.getLogicalPlan().getOp() instanceof LogicalAggregationOperator) {
                             LogicalAggregationOperator aggregationOperator = planContext.getLogicalPlan().getOp().cast();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -262,7 +262,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                     {
                         RuntimeProfile runtimeProfile = processor.getRuntimeProfile();
                         QueryMaterializationContext.QueryCacheStats queryCacheStats = getQueryCacheStats(runtimeProfile);
-                        String key = String.format("cache_getUpdatedPartitionNames_%s", table.getId());
+                        String key = String.format("cache_getUpdatedPartitionNames_%s_%s", mv.getId(), table.getId());
                         Assert.assertTrue(queryCacheStats != null);
                         Assert.assertTrue(queryCacheStats.getCounter().containsKey(key));
                         Assert.assertTrue(queryCacheStats.getCounter().get(key) == 1);
@@ -288,7 +288,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                         processor = refreshMV("test", mv);
                         RuntimeProfile runtimeProfile = processor.getRuntimeProfile();
                         QueryMaterializationContext.QueryCacheStats queryCacheStats = getQueryCacheStats(runtimeProfile);
-                        String key = String.format("cache_getUpdatedPartitionNames_%s", table.getId());
+                        String key = String.format("cache_getUpdatedPartitionNames_%s_%s", mv.getId(), table.getId());
                         Assert.assertTrue(queryCacheStats != null);
                         Assert.assertTrue(queryCacheStats.getCounter().containsKey(key));
                         Assert.assertTrue(queryCacheStats.getCounter().get(key) >= 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -353,7 +353,7 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
 
                 // if mv_3 is in the plan cache
                 MaterializedView mv3 = getMv("test", "mv_3");
-                CachingMvPlanContextBuilder.getInstance().getPlanContext(mv3, true);
+                CachingMvPlanContextBuilder.getInstance().getPlanContext(connectContext.getSessionVariable(), mv3);
                 validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
                 Assert.assertEquals(1, validMVs.size());
                 Assert.assertTrue(containsMV(validMVs, "mv_1"));
@@ -434,7 +434,7 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
                 // if mv_3 is in the plan cache
                 connectContext.getSessionVariable().setCboMaterializedViewRewriteRelatedMVsLimit(2);
                 MaterializedView mv3 = getMv("test", "mv_3");
-                CachingMvPlanContextBuilder.getInstance().getPlanContext(mv3, true);
+                CachingMvPlanContextBuilder.getInstance().getPlanContext(connectContext.getSessionVariable(), mv3);
                 validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
                 Assert.assertEquals(1, validMVs.size());
                 Assert.assertTrue(containsMV(validMVs, "mv_1"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1747,6 +1747,15 @@ public class MvRewriteTest extends MvRewriteTestBase {
         starRocksAssert.dropMaterializedView("test_partition_tbl_mv3");
     }
 
+    private List<MvPlanContext> getPlanContext(MaterializedView mv, boolean useCache) {
+        boolean prev = connectContext.getSessionVariable().isEnableMaterializedViewPlanCache();
+        connectContext.getSessionVariable().setEnableMaterializedViewPlanCache(useCache);
+        List<MvPlanContext> result = CachingMvPlanContextBuilder.getInstance().getPlanContext(
+                connectContext.getSessionVariable(), mv);
+        connectContext.getSessionVariable().setEnableMaterializedViewPlanCache(prev);
+        return result;
+    }
+
     @Test
     public void testPlanCache() throws Exception {
         {
@@ -1759,15 +1768,15 @@ public class MvRewriteTest extends MvRewriteTestBase {
             starRocksAssert.withMaterializedView(mvSql);
 
             MaterializedView mv = getMv("test", "agg_join_mv_1");
-            List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, false);
+            List<MvPlanContext> planContexts = getPlanContext(mv, false);
             Assert.assertNotNull(planContexts);
             Assert.assertNotNull(planContexts.size() == 1);
             Assert.assertFalse(CachingMvPlanContextBuilder.getInstance().contains(mv));
-            planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+            planContexts = getPlanContext(mv, true);
             Assert.assertNotNull(planContexts);
             Assert.assertNotNull(planContexts.size() == 1);
             Assert.assertTrue(CachingMvPlanContextBuilder.getInstance().contains(mv));
-            planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, false);
+            planContexts = getPlanContext(mv, false);
             Assert.assertNotNull(planContexts);
             Assert.assertNotNull(planContexts.size() == 1);
             starRocksAssert.dropMaterializedView("agg_join_mv_1");
@@ -1781,7 +1790,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
             starRocksAssert.withMaterializedView(mvSql);
 
             MaterializedView mv = getMv("test", "mv_with_window");
-            List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+            List<MvPlanContext> planContexts = getPlanContext(mv, true);
             Assert.assertNotNull(planContexts);
             Assert.assertNotNull(planContexts.size() == 1);
             Assert.assertTrue(CachingMvPlanContextBuilder.getInstance().contains(mv));
@@ -1801,7 +1810,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 starRocksAssert.withMaterializedView(mvSql);
 
                 MaterializedView mv = getMv("test", mvName);
-                List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+                List<MvPlanContext> planContexts = getPlanContext(mv, true);
                 Assert.assertNotNull(planContexts);
                 Assert.assertNotNull(planContexts.size() == 1);
             }
@@ -1829,10 +1838,10 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 }
             };
             // build cache
-            List<MvPlanContext> planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+            List<MvPlanContext> planContexts = getPlanContext(mv, true);
             Assert.assertEquals(Lists.newArrayList(), planContexts);
             // hit cache
-            planContexts = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+            planContexts = getPlanContext(mv, true);
             Assert.assertEquals(Lists.newArrayList(), planContexts);
         }
     }

--- a/test/sql/test_materialized_view/R/test_mv_reasoning
+++ b/test/sql/test_materialized_view/R/test_mv_reasoning
@@ -143,5 +143,5 @@ TRACE REASON MV
     FROM t1
     ORDER BY c1;
 -- result:
-    MV rewrite fail for mv1: MV contains non-SPJG operators(no view rewrite): LOGICAL_TOPN
+    MV rewrite fail for mv1: MV contains non-SPJG operators(no view rewrite): LOGICAL_TOPN 
 -- !result

--- a/test/sql/test_materialized_view/R/test_mv_reasoning
+++ b/test/sql/test_materialized_view/R/test_mv_reasoning
@@ -143,5 +143,5 @@ TRACE REASON MV
     FROM t1
     ORDER BY c1;
 -- result:
-    MV rewrite fail for mv1: invalid query plan 0/1: MV contains non-SPJG operators(no view rewrite): LOGICAL_TOPN 
+    MV rewrite fail for mv1: MV contains non-SPJG operators(no view rewrite): LOGICAL_TOPN
 -- !result


### PR DESCRIPTION
## Why I'm doing:
`CachingMvPlanContextBuilder#getPlanContext` may block user's query's process or even stuck/hang.

## What I'm doing:
- Move `getOrLoadPlanContext` by using a backgroud thread pool(Config.mv_plan_cache_thread_pool_size, default 3 thread)
- Remove `expireAfterAccess`'s refresh of the mv plan context cache since mv's plan should not be changed
- Load MV Plan Context async automatically when mv is on load to avoid optimization time in cold run. 
- Add `timeout` for loading mv's plan cache to avoid hanging user's query.
- Fix a bug in testing: `CachedPartitionTraits` should take care `mv` either beside the base table.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
