### PR TITLE
[Enhancement] support base manual compaction for cloud table

### DIFF
--- a/be/src/storage/lake/compaction_policy.h
+++ b/be/src/storage/lake/compaction_policy.h
@@ -41,17 +41,22 @@ public:
     virtual StatusOr<CompactionAlgorithm> choose_compaction_algorithm(const std::vector<RowsetPtr>& rowsets);
 
     static StatusOr<CompactionPolicyPtr> create(TabletManager* tablet_mgr,
-                                                std::shared_ptr<const TabletMetadataPB> tablet_metadata);
+                                                std::shared_ptr<const TabletMetadataPB> tablet_metadata,
+                                                bool force_base_compaction);
 
 protected:
-    explicit CompactionPolicy(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> tablet_metadata)
-            : _tablet_mgr(tablet_mgr), _tablet_metadata(std::move(tablet_metadata)) {
+    explicit CompactionPolicy(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> tablet_metadata,
+                              bool force_base_compaction)
+            : _tablet_mgr(tablet_mgr),
+              _tablet_metadata(std::move(tablet_metadata)),
+              _force_base_compaction(force_base_compaction) {
         CHECK(_tablet_mgr != nullptr) << "tablet_mgr is null";
         CHECK(_tablet_metadata != nullptr) << "tablet metadata is null";
     }
 
     TabletManager* _tablet_mgr;
     std::shared_ptr<const TabletMetadataPB> _tablet_metadata;
+    bool _force_base_compaction;
 };
 
 double compaction_score(TabletManager* tablet_mgr, const std::shared_ptr<const TabletMetadataPB>& metadata);

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -185,7 +185,7 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
     std::vector<std::unique_ptr<CompactionTaskContext>> contexts_vec;
     for (auto tablet_id : request->tablet_ids()) {
         auto context = std::make_unique<CompactionTaskContext>(request->txn_id(), tablet_id, request->version(),
-                                                               is_checker, cb);
+                                                               request->force_base_compaction(), is_checker, cb);
         {
             std::lock_guard l(_contexts_lock);
             _contexts.Append(context.get());

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -59,11 +59,12 @@ struct CompactionTaskStats {
 
 // Context of a single tablet compaction task.
 struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
-    explicit CompactionTaskContext(int64_t txn_id_, int64_t tablet_id_, int64_t version_, bool is_checker_,
-                                   std::shared_ptr<CompactionTaskCallback> cb_)
+    explicit CompactionTaskContext(int64_t txn_id_, int64_t tablet_id_, int64_t version_, bool force_base_compaction_,
+                                   bool is_checker_, std::shared_ptr<CompactionTaskCallback> cb_)
             : txn_id(txn_id_),
               tablet_id(tablet_id_),
               version(version_),
+              force_base_compaction(force_base_compaction_),
               is_checker(is_checker_),
               callback(std::move(cb_)) {}
 
@@ -76,6 +77,7 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     const int64_t txn_id;
     const int64_t tablet_id;
     const int64_t version;
+    const bool force_base_compaction;
     std::atomic<int64_t> start_time{0};
     std::atomic<int64_t> finish_time{0};
     std::atomic<bool> skipped{false};

--- a/be/src/storage/lake/primary_key_compaction_policy.h
+++ b/be/src/storage/lake/primary_key_compaction_policy.h
@@ -114,8 +114,9 @@ struct PKSizeTieredLevel {
 
 class PrimaryCompactionPolicy : public CompactionPolicy {
 public:
-    explicit PrimaryCompactionPolicy(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> tablet_metadata)
-            : CompactionPolicy(tablet_mgr, std::move(tablet_metadata)) {}
+    explicit PrimaryCompactionPolicy(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> tablet_metadata,
+                                     bool force_base_compaction)
+            : CompactionPolicy(tablet_mgr, std::move(tablet_metadata), force_base_compaction) {}
 
     ~PrimaryCompactionPolicy() override = default;
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -665,7 +665,8 @@ StatusOr<TabletSchemaPtr> TabletManager::get_output_rowset_schema(std::vector<ui
 StatusOr<CompactionTaskPtr> TabletManager::compact(CompactionTaskContext* context) {
     ASSIGN_OR_RETURN(auto tablet, get_tablet(context->tablet_id, context->version));
     auto tablet_metadata = tablet.metadata();
-    ASSIGN_OR_RETURN(auto compaction_policy, CompactionPolicy::create(this, tablet_metadata));
+    ASSIGN_OR_RETURN(auto compaction_policy,
+                     CompactionPolicy::create(this, tablet_metadata, context->force_base_compaction));
     ASSIGN_OR_RETURN(auto input_rowsets, compaction_policy->pick_rowsets());
     ASSIGN_OR_RETURN(auto algorithm, compaction_policy->choose_compaction_algorithm(input_rowsets));
     std::vector<uint32_t> input_rowsets_id;

--- a/be/test/storage/lake/compaction_policy_test.cpp
+++ b/be/test/storage/lake/compaction_policy_test.cpp
@@ -105,7 +105,8 @@ TEST_F(LakeCompactionPolicyTest, test_cumulative_by_segment_num) {
 
     ASSERT_EQ(7, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [4, 5, 6, 7, 8, 9, 10]
     ASSERT_EQ(7, input_rowsets.size());
@@ -136,7 +137,8 @@ TEST_F(LakeCompactionPolicyTest, test_base_by_segment_num) {
 
     ASSERT_EQ(6, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3, 4, 5, 6]
     ASSERT_EQ(6, input_rowsets.size());
@@ -162,7 +164,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_min_compaction) {
 
     ASSERT_EQ(2, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: []
     ASSERT_TRUE(input_rowsets.empty());
@@ -185,7 +188,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_max_compaction) {
 
     ASSERT_EQ(6, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3, 4, 5, 6]
     ASSERT_EQ(6, input_rowsets.size());
@@ -213,7 +217,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_max_compaction_by_max_singleto
 
     ASSERT_EQ(6, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3, 4, 5]
     ASSERT_EQ(5, input_rowsets.size());
@@ -240,7 +245,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_one_delete_middle) {
 
     ASSERT_EQ(4, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3]
     ASSERT_EQ(3, input_rowsets.size());
@@ -268,7 +274,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_two_delete_middle) {
 
     ASSERT_EQ(5, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3, 4]
     ASSERT_EQ(4, input_rowsets.size());
@@ -296,7 +303,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_two_delete_first) {
 
     ASSERT_EQ(5, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3, 4]
     ASSERT_EQ(4, input_rowsets.size());
@@ -328,7 +336,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_delete_limit_force_base_compac
 
     ASSERT_EQ(7, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3, 4, 5, 6, 7]
     ASSERT_EQ(7, input_rowsets.size());
@@ -355,7 +364,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_descending_order_level_size) {
 
     ASSERT_EQ(2, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: []
     ASSERT_TRUE(input_rowsets.empty());
@@ -385,7 +395,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_multi_descending_order_level_s
 
     ASSERT_EQ(7, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
 
     // compact 5 ~ 8
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
@@ -408,7 +419,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_multi_descending_order_level_s
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
     ASSERT_EQ(6, compaction_score(_tablet_mgr.get(), _tablet_metadata));
-    ASSIGN_OR_ABORT(compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
 
     // compact 2 ~ 4, 9
     ASSIGN_OR_ABORT(input_rowsets, compaction_policy->pick_rowsets());
@@ -435,7 +447,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_multi_descending_order_level_s
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
     ASSERT_EQ(3, compaction_score(_tablet_mgr.get(), _tablet_metadata));
-    ASSIGN_OR_ABORT(compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
 
     // compact 1, 10
     ASSIGN_OR_ABORT(input_rowsets, compaction_policy->pick_rowsets());
@@ -463,7 +476,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_order_level_size) {
 
     ASSERT_EQ(5, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3]
     ASSERT_EQ(3, input_rowsets.size());
@@ -490,7 +504,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_backtrace_base_compaction_dele
 
     ASSERT_EQ(3, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3]
     ASSERT_EQ(3, input_rowsets.size());
@@ -523,7 +538,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_backtrace_base_compaction_dele
 
     ASSERT_EQ(3, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     // compact 3 ~ 5
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [3, 4, 5]
@@ -545,7 +561,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_backtrace_base_compaction_dele
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
     ASSERT_EQ(5, compaction_score(_tablet_mgr.get(), _tablet_metadata));
-    ASSIGN_OR_ABORT(compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
 
     // compact 1, 2, 8, 6, 7
     ASSIGN_OR_ABORT(input_rowsets, compaction_policy->pick_rowsets());
@@ -579,7 +596,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_backtrace_base_compaction_mult
 
     ASSERT_EQ(5, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3, 4, 5]
     ASSERT_EQ(5, input_rowsets.size());
@@ -609,7 +627,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_backtrace_base_compaction_cont
 
     ASSERT_EQ(5, compaction_score(_tablet_mgr.get(), _tablet_metadata));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), _tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     // compaction input rowsets: [1, 2, 3, 4, 5]
     ASSERT_EQ(5, input_rowsets.size());

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -49,15 +49,17 @@ protected:
 
 TEST_F(LakeCompactionSchedulerTest, test_task_queue) {
     CompactionScheduler::WrapTaskQueues queue(10);
-    auto ctx = std::make_unique<CompactionTaskContext>(100 /* txn_id */, 101 /* tablet_id */, 1 /* version */,
-                                                       false /* is_checker */, nullptr);
+    auto ctx =
+            std::make_unique<CompactionTaskContext>(100 /* txn_id */, 101 /* tablet_id */, 1 /* version */,
+                                                    false /* force_base_compaction */, false /* is_checker */, nullptr);
     queue.set_target_size(5);
     ASSERT_EQ(5, queue.target_size());
     queue.put_by_txn_id(ctx->txn_id, ctx);
 
     std::vector<std::unique_ptr<CompactionTaskContext>> v;
-    auto ctx2 = std::make_unique<CompactionTaskContext>(101 /* txn_id */, 102 /* tablet_id */, 1 /* version */,
-                                                        false /* is_checker */, nullptr);
+    auto ctx2 =
+            std::make_unique<CompactionTaskContext>(101 /* txn_id */, 102 /* tablet_id */, 1 /* version */,
+                                                    false /* force_base_compaction */, false /* is_checker */, nullptr);
     v.push_back(std::move(ctx2));
     queue.put_by_txn_id(101 /* txn_id */, v);
 }
@@ -110,7 +112,8 @@ TEST_F(LakeCompactionSchedulerTest, test_compaction_cancel) {
     // has error
     {
         auto cb = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, nullptr);
-        CompactionTaskContext ctx(100 /* txn_id */, 101 /* tablet_id */, 1 /* version */, false /* is_checker */, cb);
+        CompactionTaskContext ctx(100 /* txn_id */, 101 /* tablet_id */, 1 /* version */,
+                                  false /* force_base_compaction */, false /* is_checker */, cb);
         cb->update_status(Status::Aborted("aborted for test"));
         EXPECT_FALSE(compaction_should_cancel(&ctx).ok());
     }
@@ -118,14 +121,16 @@ TEST_F(LakeCompactionSchedulerTest, test_compaction_cancel) {
     // not checker
     {
         auto cb = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, nullptr);
-        CompactionTaskContext ctx(100 /* txn_id */, 101 /* tablet_id */, 1 /* version */, false /* is_checker */, cb);
+        CompactionTaskContext ctx(100 /* txn_id */, 101 /* tablet_id */, 1 /* version */,
+                                  false /* force_base_compaction */, false /* is_checker */, cb);
         EXPECT_TRUE(compaction_should_cancel(&ctx).ok());
     }
 
     // is checker
     {
         auto cb = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, nullptr);
-        CompactionTaskContext ctx(100 /* txn_id */, 101 /* tablet_id */, 1 /* version */, true /* is_checker */, cb);
+        CompactionTaskContext ctx(100 /* txn_id */, 101 /* tablet_id */, 1 /* version */,
+                                  false /* force_base_compaction */, true /* is_checker */, cb);
         cb->set_last_check_time(0);
         EXPECT_TRUE(compaction_should_cancel(&ctx).ok());
     }

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -43,7 +43,7 @@ public:
 protected:
     // Implement a mock version of CompactionTaskCallback if needed
     std::shared_ptr<CompactionTaskCallback> callback;
-    CompactionTaskContext context{123, 456, 789, false, callback};
+    CompactionTaskContext context{123, 456, 789, false, false, callback};
 
     void SetUp() override {
         // Initialize your context or mock callback here if necessary

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -166,7 +166,7 @@ TEST_P(LakeDuplicateKeyCompactionTest, test1) {
     ASSERT_EQ(kChunkSize * 3, read(version));
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -203,7 +203,7 @@ TEST_P(LakeDuplicateKeyCompactionTest, test_empty_tablet) {
 
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());
@@ -309,7 +309,7 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
     // Cancelled compaction task
     {
         auto txn_id = next_id();
-        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         check_task(task);
         auto st = task->execute(CompactionTask::kCancelledFn);
@@ -319,7 +319,7 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
     // Completed compaction task without error
     {
         auto txn_id = next_id();
-        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         check_task(task);
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -463,7 +463,7 @@ TEST_P(LakeUniqueKeyCompactionTest, test1) {
     ASSERT_EQ(kChunkSize, read(version));
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -610,7 +610,7 @@ TEST_P(LakeUniqueKeyCompactionWithDeleteTest, test_base_compaction_with_delete) 
     }
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));

--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -544,8 +544,8 @@ public:
 
     Status compact_op() {
         auto txn_id = next_id();
-        auto task_context =
-                std::make_unique<CompactionTaskContext>(txn_id, _tablet_metadata->id(), _version, false, nullptr);
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, _tablet_metadata->id(), _version, false,
+                                                                    false, nullptr);
         ASSIGN_OR_RETURN(auto task, _tablet_mgr->compact(task_context.get()));
         RETURN_IF_ERROR(task->execute(CompactionTask::kNoCancelFn));
         RETURN_IF_ERROR(publish_single_version(_tablet_metadata->id(), _version + 1, txn_id));

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -218,7 +218,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     }
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -276,7 +276,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
     ASSERT_EQ(kChunkSize * 3, read(version));
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -343,7 +343,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
     ASSERT_EQ(kChunkSize * 2, read(version));
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -399,7 +399,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy) {
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
     ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata, false /* force_base_compaction */));
     config::lake_pk_compaction_max_input_rowsets = 1000;
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     EXPECT_EQ(3, input_rowsets.size());
@@ -469,7 +470,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
 
     config::lake_pk_compaction_max_input_rowsets = 4;
     ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     EXPECT_EQ(4, input_rowsets.size());
 
@@ -545,7 +547,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
 
     config::lake_pk_compaction_max_input_rowsets = 4;
     ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata, false /* force_base_compaction */));
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     EXPECT_EQ(4, input_rowsets.size());
     EXPECT_EQ(1, input_rowsets[0]->num_segments());
@@ -595,7 +598,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy_min_input) {
     }
     ASSERT_EQ(kChunkSize * 4, read(version));
     ASSIGN_OR_ABORT(auto tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), tablet_metadata, false /* force_base_compaction */));
     config::lake_pk_compaction_min_input_segments = 1;
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     EXPECT_EQ(4, input_rowsets.size());
@@ -614,7 +618,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy_min_input) {
     {
         // do compaction without input rowsets
         auto txn_id = next_id();
-        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, task_context->progress.value());
@@ -666,7 +670,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_score_by_policy) {
     ASSERT_EQ(kChunkSize * 3, read(version));
     ASSIGN_OR_ABORT(auto tablet_meta, _tablet_mgr->get_tablet_metadata(tablet_id, version));
 
-    ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create(_tablet_mgr.get(), tablet_meta));
+    ASSIGN_OR_ABORT(auto compaction_policy,
+                    CompactionPolicy::create(_tablet_mgr.get(), tablet_meta, false /* force_base_compaction */));
     config::lake_pk_compaction_max_input_rowsets = 1000;
     ASSIGN_OR_ABORT(auto input_rowsets, compaction_policy->pick_rowsets());
     EXPECT_EQ(3, input_rowsets.size());
@@ -720,7 +725,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
     ASSERT_EQ(kChunkSize * 3, read(version));
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -808,7 +813,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_remove_compaction_state) {
     }
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -891,7 +896,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_abort_txn) {
 
     auto txn_id = next_id();
     std::thread t1([&]() {
-        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         check_task(task);
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -952,7 +957,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_multi_output_seg) {
     // make sure compact can generate more than one segment in output rowset
     config::max_segment_file_size = 50;
     config::vector_chunk_size = 10;
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -1019,7 +1024,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_pk_recover_rowset_order_after_compact)
 
     config::lake_pk_compaction_max_input_rowsets = 2;
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -1211,7 +1216,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_rows_mapper) {
     ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -1303,7 +1308,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_data_load_conc) {
     // compact rowset 1 & 2 without publish
     auto compact_txn_id = next_id();
     {
-        auto task_context = std::make_unique<CompactionTaskContext>(compact_txn_id, tablet_id, version, false, nullptr);
+        auto task_context =
+                std::make_unique<CompactionTaskContext>(compact_txn_id, tablet_id, version, false, false, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         check_task(task);
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -1372,7 +1378,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), N);
 
     auto txn_id = next_id();
-    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -1435,7 +1441,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test_major_compaction_thread_safe) {
     workers.emplace_back([&]() {
         for (int i = 0; i < N; i++) {
             auto txn_id = next_id() + N * 10;
-            auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+            auto task_context =
+                    std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
             ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
             check_task(task);
             ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1207,7 +1207,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels) {
         auto old_val = config::lake_pk_compaction_min_input_segments;
         config::lake_pk_compaction_min_input_segments = 1;
         int64_t txn_id = next_id();
-        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, task_context->progress.value());
@@ -1373,7 +1373,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels3) {
         auto old_val = config::lake_pk_compaction_min_input_segments;
         config::lake_pk_compaction_min_input_segments = 1;
         int64_t txn_id = next_id();
-        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, task_context->progress.value());
@@ -1435,7 +1435,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels4) {
         auto old_val = config::lake_pk_compaction_min_input_segments;
         config::lake_pk_compaction_min_input_segments = 1;
         int64_t txn_id = next_id();
-        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, task_context->progress.value());
@@ -1536,7 +1536,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_individual_index_compaction) {
         config::lake_pk_compaction_min_input_segments = 1;
         config::lake_pk_index_sst_max_compaction_versions = 1;
         int64_t txn_id = next_id();
-        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, task_context->progress.value());
@@ -1554,7 +1554,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_individual_index_compaction) {
     // 4. compaction with sst
     {
         int64_t txn_id = next_id();
-        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, nullptr);
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, task_context->progress.value());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -124,16 +124,19 @@ public class CompactionMgr implements MemoryTrackable {
     }
 
     @NotNull
-    List<PartitionIdentifier> choosePartitionsToCompact(@NotNull Set<PartitionIdentifier> excludes,
+    List<PartitionStatisticsSnapshot> choosePartitionsToCompact(@NotNull Set<PartitionIdentifier> excludes,
             @NotNull Set<Long> excludeTables) {
-        return choosePartitionsToCompact(excludeTables).stream().filter(p -> !excludes.contains(p)).collect(Collectors.toList());
+        return choosePartitionsToCompact(excludeTables)
+                .stream()
+                .filter(p -> !excludes.contains(p.getPartition()))
+                .collect(Collectors.toList());
     }
 
     @NotNull
-    List<PartitionIdentifier> choosePartitionsToCompact(Set<Long> excludeTables) {
+    List<PartitionStatisticsSnapshot> choosePartitionsToCompact(Set<Long> excludeTables) {
         List<PartitionStatisticsSnapshot> selection = sorter.sort(
                 selector.select(partitionStatisticsHashMap.values(), excludeTables));
-        return selection.stream().map(PartitionStatisticsSnapshot::getPartition).collect(Collectors.toList());
+        return selection;
     }
 
     @NotNull

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionStatisticsSnapshot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/PartitionStatisticsSnapshot.java
@@ -42,4 +42,10 @@ public class PartitionStatisticsSnapshot {
     Quantiles getCompactionScore() {
         return compactionScore;
     }
+
+    @Override
+    public String toString() {
+        return String.format("partition=%s score=%s priority=%s",
+                partition.toString(), compactionScore.toString(), priority.toString());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/PartitionStatisticsSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/PartitionStatisticsSnapshotTest.java
@@ -35,5 +35,7 @@ public class PartitionStatisticsSnapshotTest {
         statistics.setPriority(PartitionStatistics.CompactionPriority.MANUAL_COMPACT);
         Assert.assertNotEquals(stat.getPriority(), statistics.getPriority());
         Assert.assertFalse(stat.getCompactionScore().compareTo(statistics.getCompactionScore()) == 0);
+
+        stat.toString();
     }
 }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -87,6 +87,7 @@ message CompactRequest {
     optional int64 timeout_ms = 4;
     optional bool allow_partial_success = 5;
     optional bytes encryption_meta = 6;
+    optional bool force_base_compaction = 7;
 }
 
 message CompactStat {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

lake table should align the behavior with native table when calling `alter table xxx compact`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
