### PR TITLE
[Refactor] Chop too large hyperscan regex pattern when logging it on an error

### DIFF
--- a/be/src/exprs/like_predicate.cpp
+++ b/be/src/exprs/like_predicate.cpp
@@ -49,7 +49,9 @@ bool LikePredicate::hs_compile_and_alloc_scratch(const std::string& pattern, Lik
     if (hs_compile(pattern.c_str(), HS_FLAG_ALLOWEMPTY | HS_FLAG_DOTALL | HS_FLAG_UTF8 | HS_FLAG_SINGLEMATCH,
                    HS_MODE_BLOCK, nullptr, &state->database, &state->compile_err) != HS_SUCCESS) {
         std::stringstream error;
-        error << "Invalid hyperscan expression: " << std::string(slice.data, slice.size) << ": "
+        auto chopped_size = std::min<size_t>(slice.size, 64);
+        auto ellipsis = (chopped_size < slice.size) ? "..." : "";
+        error << "Invalid hyperscan expression: " << std::string(slice.data, chopped_size) << ellipsis << ": "
               << state->compile_err->message << PROMPT_INFO;
         LOG(WARNING) << error.str().c_str();
         hs_free_compile_error(state->compile_err);


### PR DESCRIPTION
## Why I'm doing:
When hypercan patten exceeds some threshold(30KB+), hyperscan compilation report error and log the error, the size of be log would grow crazily. 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
