### PR TITLE
[Enhancement] Enhance text base mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1872,7 +1872,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableMaterializedViewTextMatchRewrite = true;
 
     @VarAttr(name = MATERIALIZED_VIEW_SUBQUERY_TEXT_MATCH_MAX_COUNT)
-    private int materializedViewSubQueryTextMatchMaxCount = 4;
+    private int materializedViewSubQueryTextMatchMaxCount = 8;
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE)
     private boolean enableMaterializedViewViewDeltaRewrite = true;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1872,7 +1872,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableMaterializedViewTextMatchRewrite = true;
 
     @VarAttr(name = MATERIALIZED_VIEW_SUBQUERY_TEXT_MATCH_MAX_COUNT)
-    private int materializedViewSubQueryTextMatchMaxCount = 8;
+    private int materializedViewSubQueryTextMatchMaxCount = 4;
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE)
     private boolean enableMaterializedViewViewDeltaRewrite = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
@@ -29,6 +30,9 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -89,7 +93,6 @@ public class CachingMvPlanContextBuilder {
 
         /**
          * Create a AstKey with parseNode(sub parse node)
-         * @param parseNode
          */
         public AstKey(ParseNode parseNode) {
             this.sql = new AstToSQLBuilder.AST2SQLBuilderVisitor(true, false, true).visit(parseNode);
@@ -248,15 +251,16 @@ public class CachingMvPlanContextBuilder {
 
     public void invalidateAstFromCache(MaterializedView mv) {
         try {
-            ParseNode parseNode = mv.getDefineQueryParseNode();
-            if (parseNode == null) {
+            List<AstKey> astKeys = getAstKeysOfMV(mv);
+            if (CollectionUtils.isEmpty(astKeys)) {
                 return;
             }
-            AstKey astKey = new AstKey(parseNode);
-            if (!AST_TO_MV_MAP.containsKey(astKey)) {
-                return;
+            for (AstKey astKey : astKeys) {
+                if (!AST_TO_MV_MAP.containsKey(astKey)) {
+                    return;
+                }
+                AST_TO_MV_MAP.get(astKey).remove(mv);
             }
-            AST_TO_MV_MAP.get(astKey).remove(mv);
             LOG.info("Remove mv {} from ast cache", mv.getName());
         } catch (Exception e) {
             LOG.warn("invalidateAstFromCache failed: {}", mv.getName(), e);
@@ -272,18 +276,47 @@ public class CachingMvPlanContextBuilder {
         }
         try {
             // cache by ast
-            ParseNode parseNode = mv.getDefineQueryParseNode();
-            if (parseNode == null) {
+            List<AstKey> astKeys = getAstKeysOfMV(mv);
+            if (CollectionUtils.isEmpty(astKeys)) {
                 return;
             }
-            AST_TO_MV_MAP.computeIfAbsent(new AstKey(parseNode), ignored -> Sets.newHashSet())
-                    .add(mv);
+            for (AstKey astKey : astKeys) {
+                AST_TO_MV_MAP.computeIfAbsent(astKey, ignored -> Sets.newHashSet())
+                        .add(mv);
+            }
             LOG.info("Add mv {} input ast cache", mv.getName());
         } catch (Exception e) {
             LOG.warn("putAstIfAbsent failed: {}", mv.getName(), e);
         }
     }
 
+    private List<AstKey> getAstKeysOfMV(MaterializedView mv) {
+        List<AstKey> keys = Lists.newArrayList();
+        ParseNode parseNode = mv.getDefineQueryParseNode();
+        if (parseNode == null) {
+            return keys;
+        }
+        // add the complete ast tree
+        keys.add(new AstKey(parseNode));
+        if (!(parseNode instanceof QueryStatement)) {
+            return keys;
+        }
+
+        // add the ast tree without an order by clause
+        QueryStatement queryStatement = (QueryStatement) parseNode;
+        QueryRelation queryRelation = queryStatement.getQueryRelation();
+        if (!queryRelation.hasLimit() && queryRelation.hasOrderByClause()) {
+            // it's fine to change query relation directly since it's not used anymore.
+            List<OrderByElement> orderByElements = Lists.newArrayList(queryRelation.getOrderBy());
+            try {
+                queryRelation.clearOrder();
+                keys.add(new AstKey(parseNode));
+            } finally {
+                queryRelation.setOrderBy(orderByElements);
+            }
+        }
+        return keys;
+    }
     /**
      * @return: null if parseNode is null or astToMvsMap doesn't contain this ast, otherwise return the mvs
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -263,6 +263,7 @@ public class CachingMvPlanContextBuilder {
                     // remove mv from ast cache
                     Set<MaterializedView> relatedMVs = AST_TO_MV_MAP.get(astKey);
                     relatedMVs.remove(mv);
+
                     // remove ast key if no related mvs
                     if (relatedMVs.isEmpty()) {
                         AST_TO_MV_MAP.remove(astKey);
@@ -283,12 +284,12 @@ public class CachingMvPlanContextBuilder {
             return;
         }
         try {
+            // cache by ast
+            List<AstKey> astKeys = getAstKeysOfMV(mv);
+            if (CollectionUtils.isEmpty(astKeys)) {
+                return;
+            }
             synchronized (AST_TO_MV_MAP) {
-                // cache by ast
-                List<AstKey> astKeys = getAstKeysOfMV(mv);
-                if (CollectionUtils.isEmpty(astKeys)) {
-                    return;
-                }
                 for (AstKey astKey : astKeys) {
                     AST_TO_MV_MAP.computeIfAbsent(astKey, ignored -> Sets.newHashSet()).add(mv);
                 }


### PR DESCRIPTION
## Why I'm doing:

Query cannot be rewritten by mv-texted based rewrite if mv has `order by` and query has `order by` even if the defined query are exactly the same because subquery will eliminate `the order by ` in the subquery which cause text match failed:
```
MV: select user_id, time, bitmap_union(to_bitmap(tag_id)) as a from user_tags group by user_id, time order by user_id, time;

Query: select user_id, count(time) from (MV) as t group by user_id limit 3
```
## What I'm doing:
- Register an extra ast key if the mv's defined query has order by elements and without limit, so can be used to rewrite for the eliminated sorted-by input query.
- Correct the `materialized_view_subuqery_text_match_max_count` parameter which means the real sub query match count limit.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
