### PR TITLE
[Enhancement] Support IS_DISTINCT_FROM in Trino dialect.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -234,6 +234,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
                     .put(ComparisonExpression.Operator.GREATER_THAN, BinaryType.GT)
                     .put(ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL, BinaryType.GE)
                     .put(ComparisonExpression.Operator.NOT_EQUAL, BinaryType.NE)
+                    .put(ComparisonExpression.Operator.IS_DISTINCT_FROM, BinaryType.EQ_FOR_NULL)
                     .build();
 
     private static final ImmutableMap<ArithmeticBinaryExpression.Operator, ArithmeticExpr.Operator> BINARY_OPERATOR_MAP =
@@ -1058,6 +1059,10 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         if (binaryOp == null) {
             throw unsupportedException(String.format("Trino parser on StarRocks does not support the comparison type %s",
                     node.getOperator()));
+        }
+        if (node.getOperator() == ComparisonExpression.Operator.IS_DISTINCT_FROM) {
+            return new CompoundPredicate(CompoundPredicate.Operator.NOT, new BinaryPredicate(binaryOp,
+                    (Expr) visit(node.getLeft(), context), (Expr) visit(node.getRight(), context)), null);
         }
         return new BinaryPredicate(binaryOp, (Expr) visit(node.getLeft(), context), (Expr) visit(node.getRight(),
                 context));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
@@ -52,13 +52,6 @@ public class TrinoParserNotSupportTest extends TrinoTestBase {
         analyzeFail(sql, "Unsupported expression [ALL]");
     }
 
-    // refer to https://trino.io/docs/current/functions/comparison.html#is-distinct-from-and-is-not-distinct-from
-    @Test
-    public void testDistinctFrom() {
-        String sql = "select NULL is distinct from NULL;";
-        analyzeFail(sql, "Trino parser on StarRocks does not support the comparison type IS_DISTINCT_FROM");
-    }
-
     // refer to https://trino.io/docs/current/language/types.html#interval-year-to-month
     @Test
     public void testIntervalDataType() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -1228,4 +1228,25 @@ public class TrinoQueryTest extends TrinoTestBase {
         String sql = "select cast(ARRAY[1] as array(int))";
         assertPlanContains(sql, "CAST([1] AS ARRAY<INT>)");
     }
+
+    @Test
+    public void testDistinctFrom() throws Exception {
+        String sql = "select 1 is distinct from 1";
+        analyzeSuccess(sql);
+
+        sql = "select 1 is distinct from null";
+        analyzeSuccess(sql);
+
+        sql = "select null is distinct from null";
+        analyzeSuccess(sql);
+
+        sql = "select 1 is not distinct from 1";
+        analyzeSuccess(sql);
+
+        sql = "select 1 is not distinct from null";
+        analyzeSuccess(sql);
+
+        sql = "select null is not distinct from null";
+        analyzeSuccess(sql);
+    }
 }

--- a/test/sql/test_trino_dialect/R/test_distinct_from
+++ b/test/sql/test_trino_dialect/R/test_distinct_from
@@ -1,0 +1,27 @@
+-- name: testDistinctFrom
+set sql_dialect='trino';
+-- result:
+-- !result
+select 1 is distinct from 1;
+-- result:
+0
+-- !result
+select 1 is distinct from null;
+-- result:
+1
+-- !result
+select null is distinct from null;
+-- result:
+0
+-- !result
+select 1 is not distinct from 1;
+-- result:
+1
+-- !result
+select 1 is not distinct from null;
+-- result:
+0
+-- !result
+select null is not distinct from null;
+-- result:
+1

--- a/test/sql/test_trino_dialect/T/test_distinct_from
+++ b/test/sql/test_trino_dialect/T/test_distinct_from
@@ -1,0 +1,10 @@
+-- name: testDistinctFrom
+
+set sql_dialect='trino';
+
+select 1 is distinct from 1;
+select 1 is distinct from null;
+select null is distinct from null;
+select 1 is not distinct from 1;
+select 1 is not distinct from null;
+select null is not distinct from null;


### PR DESCRIPTION
## Why I'm doing:
Starrocks's Trino dialect does not support IS_DISTINCT_FROM for now.

## What I'm doing:

Support IS_DISTINCT_FROM

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
