### PR TITLE
[Enhancement] Reduce memory alloc in Locker

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockManager.java
@@ -373,7 +373,6 @@ public class LockManager {
             readerInfo.addProperty("name", owner.getLocker().getThreadName());
             readerInfo.addProperty("heldFor", nowMs - owner.getLockAcquireTimeMs());
             readerInfo.addProperty("waitTime", owner.getLockAcquireTimeMs() - locker.getLockRequestTimeMs());
-            readerInfo.addProperty("locker", locker.getLockerStackTrace());
             readerInfo.add("stack", LogUtil.getStackTraceToJsonArray(
                     locker.getLockerThread(), 0, DEFAULT_STACK_RESERVE_LEVELS));
             ownerArray.add(readerInfo);
@@ -390,7 +389,6 @@ public class LockManager {
             readerInfo.addProperty("name", locker.getThreadName());
             readerInfo.addProperty("heldFor", "");
             readerInfo.addProperty("waitTime", nowMs - locker.getLockRequestTimeMs());
-            readerInfo.addProperty("locker", locker.getLockerStackTrace());
             waiterArray.add(readerInfo);
         }
         ownerInfo.add("waiter", waiterArray);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/Locker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/Locker.java
@@ -49,9 +49,6 @@ public class Locker {
     /* The time when the current Locker starts to request for the lock. */
     private long lockRequestTimeMs;
 
-    /* The thread stack that created this locker. */
-    private final String lockerStackTrace;
-
     /* The thread that request lock. */
     private final Thread lockerThread;
 
@@ -60,7 +57,6 @@ public class Locker {
         this.waitingForType = null;
         /* Save the thread used to create the locker and thread stack. */
         this.lockerThread = Thread.currentThread();
-        this.lockerStackTrace = getStackTrace(this.lockerThread);
     }
 
     /**
@@ -79,9 +75,13 @@ public class Locker {
         }
 
         LockManager lockManager = GlobalStateMgr.getCurrentState().getLockManager();
-        LOG.debug(this + " | LockManager request lock : rid " + rid + ", lock type " + lockType);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{} | LockManager request lock : rid {}, lock type {}", this, rid, lockType);
+        }
         lockManager.lock(rid, this, lockType, timeout);
-        LOG.debug(this + " | LockManager acquire lock : rid " + rid + ", lock type " + lockType);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{} | LockManager acquire lock : rid {}, lock type {}", this, rid, lockType);
+        }
     }
 
     public void lock(long rid, LockType lockType) throws LockException {
@@ -96,7 +96,9 @@ public class Locker {
      */
     public void release(long rid, LockType lockType) {
         LockManager lockManager = GlobalStateMgr.getCurrentState().getLockManager();
-        LOG.debug(this + " | LockManager release lock : rid " + rid + ", lock type " + lockType);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{} | LockManager release lock : rid {}, lock type {}", this, rid, lockType);
+        }
         try {
             lockManager.release(rid, this, lockType);
         } catch (LockException e) {
@@ -543,10 +545,6 @@ public class Locker {
         return element.getClassName().substring(lastIdx + 1) + "." + element.getMethodName() + "():" + element.getLineNumber();
     }
 
-    public String getLockerStackTrace() {
-        return lockerStackTrace;
-    }
-
     public Thread getLockerThread() {
         return lockerThread;
     }
@@ -561,7 +559,7 @@ public class Locker {
 
     @Override
     public String toString() {
-        return ("(" + lockerThread.getName() + "|" + lockerThread.getId()) + ")" + " [" + lockerStackTrace + "]";
+        return ("(" + lockerThread.getName() + "|" + lockerThread.getId()) + ")";
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/MultiUserLock.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/MultiUserLock.java
@@ -105,10 +105,8 @@ public class MultiUserLock extends Lock {
                      */
 
                     if (lockOwnerLockType.isIntentionLock() && !lockRequestLockType.isIntentionLock()) {
-                        throw new NotSupportLockException("Can't request Database " + lockRequestLockType + " Lock ("
-                                + lockHolderRequest.getLocker().getLockerStackTrace() + ")"
-                                + " in the scope of Database " + lockOwnerLockType
-                                + " Lock (" + lockOwner.getLocker().getLockerStackTrace() + ")");
+                        throw new NotSupportLockException(String.format("Can't request Database %s Lock"
+                                + " in the scope of Database %s Lock", lockRequestLockType, lockOwnerLockType));
                     }
 
                     /*


### PR DESCRIPTION
## Why I'm doing:
Before optimization:
![image](https://github.com/user-attachments/assets/800ecb67-4cef-4831-8cd4-4d76d1ffd26a)

memory allocated (in 5min) in ReportHandler (locker accounts for the majority) is 1m * 17423 = 17G

After optimization:
![image](https://github.com/user-attachments/assets/096c8ee9-e3ed-4643-9f74-02034d73f544)
memory allocated (in 5min) in ReportHandler (locker accounts for the majority) is 1m * 4020 = 4G

the profile is generated by
```
./bin/profiler.sh -e alloc --alloc 1m -d 300 -f alloc-profile.html pid
```

## What I'm doing:

1. Remove the lockerStackTrace in Locker constructor.
2. Judge isDebugEnabled when logging debug log.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
