### PR TITLE
[BugFix] Fix pipeline metrics after resource group

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -56,8 +56,8 @@ void GlobalDriverExecutor::initialize(int num_threads) {
 DriverExecutorMetrics GlobalDriverExecutor::metrics() const {
     return {.schedule_count = _schedule_count.load(),
             .driver_execution_ns = _driver_execution_ns.load(),
-            .driver_queue_len = _driver_queue->size(),
-            .driver_poller_block_queue_len = _blocked_driver_poller->num_drivers()};
+            .driver_queue_len = static_cast<int64_t>(_driver_queue->size()),
+            .driver_poller_block_queue_len = static_cast<int64_t>(_blocked_driver_poller->num_drivers())};
 }
 
 void GlobalDriverExecutor::change_num_threads(int32_t num_threads) {

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -37,13 +37,7 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
           _thread_pool(std::move(thread_pool)),
           _blocked_driver_poller(new PipelineDriverPoller(name, _driver_queue.get(), cpuids)),
           _exec_state_reporter(new ExecStateReporter(cpuids)),
-          _audit_statistics_reporter(new AuditStatisticsReporter()) {
-    REGISTER_GAUGE_STARROCKS_METRIC(pipe_driver_schedule_count, [this]() { return _schedule_count.load(); });
-    REGISTER_GAUGE_STARROCKS_METRIC(pipe_driver_execution_time, [this]() { return _driver_execution_ns.load(); });
-    REGISTER_GAUGE_STARROCKS_METRIC(pipe_driver_queue_len, [this]() { return _driver_queue->size(); });
-    REGISTER_GAUGE_STARROCKS_METRIC(pipe_poller_block_queue_len,
-                                    [this] { return _blocked_driver_poller->num_drivers(); });
-}
+          _audit_statistics_reporter(new AuditStatisticsReporter()) {}
 
 void GlobalDriverExecutor::close() {
     _driver_queue->close();
@@ -57,6 +51,13 @@ void GlobalDriverExecutor::initialize(int num_threads) {
     for (auto i = 0; i < num_threads; ++i) {
         (void)_thread_pool->submit_func([this]() { this->_worker_thread(); });
     }
+}
+
+DriverExecutorMetrics GlobalDriverExecutor::metrics() const {
+    return {.schedule_count = _schedule_count.load(),
+            .driver_execution_ns = _driver_execution_ns.load(),
+            .driver_queue_len = _driver_queue->size(),
+            .driver_poller_block_queue_len = _blocked_driver_poller->num_drivers()};
 }
 
 void GlobalDriverExecutor::change_num_threads(int32_t num_threads) {

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -34,6 +34,13 @@ namespace starrocks::pipeline {
 class DriverExecutor;
 using DriverExecutorPtr = std::shared_ptr<DriverExecutor>;
 
+struct DriverExecutorMetrics {
+    int64_t schedule_count;
+    int64_t driver_execution_ns;
+    int64_t driver_queue_len;
+    int64_t driver_poller_block_queue_len;
+};
+
 class DriverExecutor {
 public:
     DriverExecutor(std::string name) : _name(std::move(name)) {}
@@ -64,6 +71,8 @@ public:
     virtual size_t calculate_parked_driver(const ConstDriverPredicator& predicate_func) const = 0;
 
     virtual void bind_cpus(const CpuUtil::CpuIds& cpuids, const std::vector<CpuUtil::CpuIds>& borrowed_cpuids) = 0;
+
+    virtual DriverExecutorMetrics metrics() const = 0;
 
 protected:
     std::string _name;
@@ -101,6 +110,8 @@ private:
                                                    ObjectPool* obj_pool);
 
     void _finalize_epoch(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
+
+    DriverExecutorMetrics metrics() const override;
 
 private:
     // The maximum duration that a driver could stay in local_driver_queue

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -99,4 +99,8 @@ void ScanExecutor::bind_cpus(const CpuUtil::CpuIds& cpuids, const std::vector<Cp
     _thread_pool->bind_cpus(cpuids, borrowed_cpuids);
 }
 
+int64_t ScanExecutor::num_tasks() const {
+    return _task_queue->size();
+}
+
 } // namespace starrocks::workgroup

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -19,13 +19,8 @@
 
 namespace starrocks::workgroup {
 
-ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue,
-                           bool add_metrics)
-        : _task_queue(std::move(task_queue)), _thread_pool(std::move(thread_pool)) {
-    if (add_metrics) {
-        REGISTER_GAUGE_STARROCKS_METRIC(pipe_scan_executor_queuing, [this]() { return _task_queue->size(); });
-    }
-}
+ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue)
+        : _task_queue(std::move(task_queue)), _thread_pool(std::move(thread_pool)) {}
 
 void ScanExecutor::close() {
     _task_queue->close();

--- a/be/src/exec/workgroup/scan_executor.h
+++ b/be/src/exec/workgroup/scan_executor.h
@@ -41,6 +41,8 @@ public:
 
     void bind_cpus(const CpuUtil::CpuIds& cpuids, const std::vector<CpuUtil::CpuIds>& borrowed_cpuids);
 
+    int64_t num_tasks() const;
+
 private:
     void worker_thread();
 

--- a/be/src/exec/workgroup/scan_executor.h
+++ b/be/src/exec/workgroup/scan_executor.h
@@ -27,8 +27,7 @@ class ScanTaskQueue;
 
 class ScanExecutor {
 public:
-    explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue,
-                          bool add_metrics = true);
+    explicit ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue);
     virtual ~ScanExecutor() = default;
 
     void initialize(int32_t num_threads);

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -54,6 +54,12 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
     REGISTER_STARROCKS_METRIC(query_scan_bytes);
     REGISTER_STARROCKS_METRIC(query_scan_rows);
 
+    REGISTER_STARROCKS_METRIC(pipe_scan_executor_queuing);
+    REGISTER_STARROCKS_METRIC(pipe_driver_schedule_count);
+    REGISTER_STARROCKS_METRIC(pipe_driver_execution_time);
+    REGISTER_STARROCKS_METRIC(pipe_driver_queue_len);
+    REGISTER_STARROCKS_METRIC(pipe_poller_block_queue_len);
+
     REGISTER_STARROCKS_METRIC(load_channel_add_chunks_total);
     REGISTER_STARROCKS_METRIC(load_channel_add_chunks_duration_us);
     REGISTER_STARROCKS_METRIC(load_channel_add_chunks_wait_memtable_duration_us);

--- a/be/test/exec/workgroup/scan_task_queue_test.cpp
+++ b/be/test/exec/workgroup/scan_task_queue_test.cpp
@@ -39,7 +39,7 @@ PARALLEL_TEST(ScanExecutorTest, test_yield) {
                       .set_max_threads(4)
                       .set_max_queue_size(100)
                       .build(&thread_pool));
-    auto executor = std::make_unique<ScanExecutor>(std::move(thread_pool), std::move(queue), false);
+    auto executor = std::make_unique<ScanExecutor>(std::move(thread_pool), std::move(queue));
     DeferOp op([&]() { executor->close(); });
     executor->initialize(4);
 


### PR DESCRIPTION
## Why I'm doing:

After #50421, multiple DriverExecutor and ScanExecutor instances can exist within the same BE, and each instance registers metrics in its constructor. This results in two issues:

- When multiple DriverExecutor instances register and use metrics concurrently, it introduces race conditions.
- Additionally, these metrics do not accurately indicate the state of all DriverExecutor instances.


```
*** Aborted at 1730369805 (unix time) try "date -d @1730369805" if you are using GNU date ***
PC: @         0x10a44735 je_rtree_leaf_elm_lookup_hard
*** SIGSEGV (@0x0) received by PID 6547 (TID 0x7fcbfbaeb640) from PID 0; stack trace: ***
    @     0x7fcc5d8e9ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xf67d939 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fcc5e774916 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x7fcc5e77a60b JVM_handle_linux_signal
    @     0x7fcc5e76d46c signalHandler(int, siginfo_t*, void*)
    @     0x7fcc5d892520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @         0x10a44735 je_rtree_leaf_elm_lookup_hard
    @         0x109c1f23 jemalloc_usable_size
    @          0xae5a879 free
    @          0xb048555 starrocks::MetricRegistry::_deregister_locked(starrocks::Metric*)
    @          0xb048acc starrocks::MetricRegistry::register_metric(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, starrocks::MetricLabels const&, starrocks::Metric*)
    @          0x97659a9 starrocks::pipeline::GlobalDriverExecutor::GlobalDriverExecutor(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::unique_ptr<starrocks::ThreadPool, std::default_delete<starrocks::ThreadPool> >, bool, std::vector<uÑ,
    @          0x97594f6 starrocks::workgroup::PipelineExecutorSet::start()
    @          0x9751ea3 starrocks::workgroup::ExecutorsManager::maybe_create_exclusive_executors_unlocked(starrocks::workgroup::WorkGroup*, std::vector<unsigned long, std::allocator<unsigned long> > const&) const
    @          0x97490fa starrocks::workgroup::WorkGroupManager::create_workgroup_unlocked(std::shared_ptr<starrocks::workgroup::WorkGroup> const&, std::unique_lock<std::shared_mutex>&)
    @          0x974968c starrocks::workgroup::WorkGroupManager::add_workgroup(std::shared_ptr<starrocks::workgroup::WorkGroup> const&)
    @          0x9ad1a86 starrocks::pipeline::FragmentExecutor::_prepare_workgroup(starrocks::pipeline::UnifiedExecPlanFragmentParams const&)
    @          0x9ad721d starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0xae6fb48 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0xae7303e starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*)
    @          0xae8a901 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)
    @          0xae8ad6c std::_Function_handler<void (), starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::ClosurÓ,
    @          0x5c3742b starrocks::PriorityThreadPool::work_thread(int)
    @          0x5c2698f boost::detail::thread_data<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)> >::run()
    @          0xf62f25b thread_proxy
    @     0x7fcc5d8e4ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7fcc5d976850 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```


## What I'm doing:


To address this, move the metrics registration out of the DriverExecutor and ScanExecutor constructors and into `ExecEnv::init`, after the `esourceGroupManager` (which holds all executors) has been constructed.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
