### PR TITLE
[BugFix] Fix AggStateUnionCombinator's result type with agg state desc

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUnionCombinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUnionCombinator.java
@@ -50,10 +50,9 @@ public final class AggStateUnionCombinator extends AggregateFunction {
 
     public static Optional<AggStateUnionCombinator> of(AggregateFunction aggFunc) {
         try {
-            Type intermediateType = aggFunc.getIntermediateTypeOrReturnType();
+            Type intermediateType = aggFunc.getIntermediateTypeOrReturnType().clone();
             FunctionName functionName = new FunctionName(aggFunc.functionName() + FunctionSet.AGG_STATE_UNION_SUFFIX);
-            AggStateUnionCombinator aggStateUnionFunc =
-                    new AggStateUnionCombinator(functionName, intermediateType);
+            AggStateUnionCombinator aggStateUnionFunc = new AggStateUnionCombinator(functionName, intermediateType);
             aggStateUnionFunc.setBinaryType(TFunctionBinaryType.BUILTIN);
             aggStateUnionFunc.setPolymorphic(aggFunc.isPolymorphic());
             AggStateDesc aggStateDesc;
@@ -63,6 +62,8 @@ public final class AggStateUnionCombinator extends AggregateFunction {
                 aggStateDesc = new AggStateDesc(aggFunc);
             }
             aggStateUnionFunc.setAggStateDesc(aggStateDesc);
+            // set agg state desc for the function's result type so can be used as the later agg state functions.
+            intermediateType.setAggStateDesc(aggStateDesc);
             // use agg state desc's nullable as `agg_state` function's nullable
             aggStateUnionFunc.setIsNullable(aggStateDesc.getResultNullable());
             return Optional.of(aggStateUnionFunc);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.FunctionAnalyzer;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -166,13 +167,13 @@ public class AggStateUtils {
                 result = AggStateCombinator.of(aggFunc);
             }
         } else if (func instanceof AggStateUnionCombinator) {
-            AggregateFunction argFn = getAggStateFunction(session, argumentTypes, pos);
+            AggregateFunction argFn = getAggStateFunction(session, func, argumentTypes, pos);
             if (argFn == null) {
                 return null;
             }
             result = AggStateUnionCombinator.of(argFn);
         } else if (func instanceof AggStateMergeCombinator) {
-            AggregateFunction argFn = getAggStateFunction(session, argumentTypes, pos);
+            AggregateFunction argFn = getAggStateFunction(session, func, argumentTypes, pos);
             if (argFn == null) {
                 return null;
             }
@@ -186,14 +187,16 @@ public class AggStateUtils {
     }
 
     private static AggregateFunction getAggStateFunction(ConnectContext session,
+                                                         Function inputFunc,
                                                          Type[] argumentTypes,
                                                          NodePosition pos) {
         Preconditions.checkArgument(argumentTypes.length == 1,
                 "AggState's AggFunc should have only one argument");
         Type arg0Type = argumentTypes[0];
-        Preconditions.checkArgument(arg0Type.getAggStateDesc() != null,
-                String.format("AggState's agg state desc is null"));
-
+        if (arg0Type.getAggStateDesc() == null) {
+            throw new SemanticException(String.format("AggState's AggFunc should have AggStateDesc: %s",
+                    inputFunc), pos);
+        }
         AggStateDesc aggStateDesc = arg0Type.getAggStateDesc();
         List<Type> argTypes = aggStateDesc.getArgTypes();
         String argFnName = aggStateDesc.getFunctionName();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -5774,6 +5774,25 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "as \n" +
                 "SELECT k1, k2, avg_union(avg_state(k3 * 4)) as v1 from s1 where k1 != 'a' group by k1, k2;");
         {
+            String query = "select k1, k2, avg_merge(v1) from (" +
+                    "SELECT k1, k2, avg_union(avg_state(k3 * 4)) as v1 from s1 where k1 != 'a' group by k1,k2) t " +
+                    "group by k1, k2;";
+            String plan = UtFrameUtils.getFragmentPlan(connectContext, query);
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
+        {
+            String query = "select k1, k2, avg_merge(v1) from (" +
+                    " SELECT k1, k2, avg_union(avg_state(k3 * 4)) as v1 from s1 where k1 != 'a' group by k1,k2 " +
+                    " UNION ALL" +
+                    " SELECT k1, k2, avg_union(avg_state(k3 * 4)) as v1 from s1 where k1 != 'a' group by k1,k2 " +
+                    ") t " +
+                    "group by k1, k2;";
+            String plan = UtFrameUtils.getFragmentPlan(connectContext, query);
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
+
+
+        {
             String query = "SELECT k1, k2, avg_union(avg_state(k3 * 4)) as v1 from s1 where k1 != 'a' group by k1, k2;";
             String plan = UtFrameUtils.getFragmentPlan(connectContext, query);
             PlanTestBase.assertContains(plan, "test_mv1");


### PR DESCRIPTION
## Why I'm doing:
This query will be failed because we can not deduce  `avg_union`'s agg state desc:
```
select k1, k2, avg_merge(v1) from (" +
                    " SELECT k1, k2, avg_union(avg_state(k3 * 4)) as v1 from s1 where k1 != 'a' group by k1,k2 " +
                    " UNION ALL" +
                    " SELECT k1, k2, avg_union(avg_state(k3 * 4)) as v1 from s1 where k1 != 'a' group by k1,k2 " +
                    ") t " +
                    "group by k1, k2;
```
## What I'm doing:
- `AggStateUnionCombinator` should return type with `agg state desc` for later use.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
