### PR TITLE
[Enhancement] avoid to extract constant expr as common expr in array_map

### DIFF
--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -67,7 +67,7 @@ Status LambdaFunction::extract_outer_common_exprs(RuntimeState* state, Expr* exp
 
         RETURN_IF_ERROR(extract_outer_common_exprs(state, child, ctx));
         // if child is a slotref or a lambda function or a literal, we can't replace it.
-        if (child->is_slotref() || child->is_lambda_function() || child->is_literal()) {
+        if (child->is_slotref() || child->is_lambda_function() || child->is_literal() || child->is_constant()) {
             continue;
         }
 

--- a/test/sql/test_array_fn/R/test_array_map_2
+++ b/test/sql/test_array_fn/R/test_array_map_2
@@ -183,3 +183,10 @@ select array_map(arg0 -> array_map(arg1 -> array_map(arg2 -> array_map(arg3 -> a
 -- result:
 [[[[[2,3]]]]]
 -- !result
+set @arr=array_generate(1,10000);
+-- result:
+-- !result
+select /*+ SET_VAR(query_mem_limit=104857600)*/array_sum(array_map(x->array_contains(@arr,x), array_generate(1,100000)));
+-- result:
+10000
+-- !result

--- a/test/sql/test_array_fn/T/test_array_map_2
+++ b/test/sql/test_array_fn/T/test_array_map_2
@@ -69,3 +69,5 @@ select array_map(arg0 -> array_map(arg1 -> array_map(arg2 -> array_map(arg3 -> a
 select array_map(arg0 -> array_map(arg1 -> array_map(arg2 -> array_map(arg3 -> array_length(arg2) + arg3, arg2), arg1), arg0), [[[[1,2]]]]);
 select array_map(arg0 -> array_map(arg1 -> array_map(arg2 -> array_map(arg3 -> array_map(arg4->array_length(arg2) + arg4, arg3), arg2), arg1), arg0), [[[[[1,2]]]]] );
 
+set @arr=array_generate(1,10000);
+select /*+ SET_VAR(query_mem_limit=104857600)*/array_sum(array_map(x->array_contains(@arr,x), array_generate(1,100000)));


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

In the `array_map` prepare phase, we will try to extract independent expressions from lambda expr as common expressions to avoid repeated calculations. At this time, the common expressions will be replaced with `ColumnRef`s.

However, there was a place that was not considered before, If the expression itself is a constant, we should not replace it with a `ColumnRef`, otherwise we will lose some opportunities for const optimization of the function.

Take the following query as an example, `@arr` was mistakenly replaced with `ColumnRef`, making it impossible for `array_contains` and `array_map` to apply optimization for const columns.
```sql
set @arr=array_generate(1,10000);
select array_map(x->array_contains(@arr,x), array_generate(1,100000));
```

|    | QueryTime | 
|  ----  | ----  |
| baseline  | 3.6s |
| after optimization  | 0.04s |


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
