### PR TITLE
[BugFix] Fix local file rename in broker

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/broker-core/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/broker-core/src/main/java/com/starrocks/broker/hdfs/FileSystemManager.java
@@ -983,8 +983,12 @@ public class FileSystemManager {
 
     public void renamePath(String srcPath, String destPath, Map<String, String> properties) {
         WildcardURI srcPathUri = new WildcardURI(srcPath);
+        String srcAuthority = srcPathUri.getAuthority();
         WildcardURI destPathUri = new WildcardURI(destPath);
-        if (!srcPathUri.getAuthority().trim().equals(destPathUri.getAuthority().trim())) {
+        String destAuthority = destPathUri.getAuthority();
+        // the authority of local file path is null, like file:///xxx.
+        // skip check when the authority is null.
+        if (srcAuthority != null && destAuthority != null && !srcAuthority.trim().equals(destAuthority.trim())) {
             throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     "only allow rename in same file system");
         }


### PR DESCRIPTION
## Why I'm doing:
the authority of local file path is null, like file:///xxx.
broker rename will throw NPE.

## What I'm doing:
skip check when the authority is null.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
