### PR TITLE
[BugFix]support disable ssl for poco_http_client for aws sdk

### DIFF
--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -223,6 +223,7 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const TCloudConfigurati
     } else {
         config.scheme = Aws::Http::Scheme::HTTP;
     }
+    config.verifySSL = aws_cloud_configuration.enable_ssl;
 
     if (!aws_cloud_credential.region.empty()) {
         config.region = aws_cloud_credential.region;

--- a/be/src/fs/s3/poco_http_client.cpp
+++ b/be/src/fs/s3/poco_http_client.cpp
@@ -38,7 +38,7 @@ PocoHttpClient::PocoHttpClient(const Aws::Client::ClientConfiguration& clientCon
                   Poco::Timespan(clientConfiguration.connectTimeoutMs * 1000),     // connection timeout.
                   Poco::Timespan(clientConfiguration.httpRequestTimeoutMs * 1000), // send timeout.
                   Poco::Timespan(clientConfiguration.httpRequestTimeoutMs * 1000)  // receive timeout.
-                  )) {}
+                  )), enable_ssl(clientConfiguration.verifySSL) {}
 
 std::shared_ptr<Aws::Http::HttpResponse> PocoHttpClient::MakeRequest(
         const std::shared_ptr<Aws::Http::HttpRequest>& request,
@@ -59,6 +59,9 @@ void PocoHttpClient::MakeRequestInternal(Aws::Http::HttpRequest& request,
     try {
         for (int attempt = 0; attempt < MAX_REDIRECT_ATTEMPTS; ++attempt) {
             Poco::URI poco_uri(uri);
+            if (!enable_ssl && poco_uri.getScheme() == "https") {
+                poco_uri.setScheme("http");
+            }
 
             // URI may changed, because of redirection
             auto session = makeHTTPSession(poco_uri, timeouts, false);

--- a/be/src/fs/s3/poco_http_client.cpp
+++ b/be/src/fs/s3/poco_http_client.cpp
@@ -38,7 +38,8 @@ PocoHttpClient::PocoHttpClient(const Aws::Client::ClientConfiguration& clientCon
                   Poco::Timespan(clientConfiguration.connectTimeoutMs * 1000),     // connection timeout.
                   Poco::Timespan(clientConfiguration.httpRequestTimeoutMs * 1000), // send timeout.
                   Poco::Timespan(clientConfiguration.httpRequestTimeoutMs * 1000)  // receive timeout.
-                  )), enable_ssl(clientConfiguration.verifySSL) {}
+                  )),
+          enable_ssl(clientConfiguration.verifySSL) {}
 
 std::shared_ptr<Aws::Http::HttpResponse> PocoHttpClient::MakeRequest(
         const std::shared_ptr<Aws::Http::HttpRequest>& request,

--- a/be/src/fs/s3/poco_http_client.h
+++ b/be/src/fs/s3/poco_http_client.h
@@ -47,6 +47,7 @@ private:
                              Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const;
 
     ConnectionTimeouts timeouts;
+    bool enable_ssl;
 };
 
 } // namespace starrocks::poco

--- a/be/test/fs/poco_http_client_test.cpp
+++ b/be/test/fs/poco_http_client_test.cpp
@@ -142,7 +142,6 @@ TEST_F(PocoHttpClientTest, TestDisableSSL) {
     // Create a client configuration object and set the custom retry strategy
     config.retryStrategy = retryStrategy;
 
-
     auto credentials = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(ak, sk);
 
     auto client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config),


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
every http client need support `disable ssl` seperately, so we need to support it in poco.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
