### PR TITLE
[BugFix]don't set NETWORK_CONNECTION error when received response from oss

### DIFF
--- a/be/src/fs/s3/poco_http_client.cpp
+++ b/be/src/fs/s3/poco_http_client.cpp
@@ -182,17 +182,8 @@ void PocoHttpClient::MakeRequestInternal(Aws::Http::HttpRequest& request,
                     // pass
                     // TODO, throttling
                 }
-                if (status_code >= ResponseCode::SUCCESS_RESPONSE_MIN &&
-                    status_code <= ResponseCode::SUCCESS_RESPONSE_MAX) {
-                    if (!poco_response.isBodyFilled()) {
-                        Poco::StreamCopier::copyStream(response_body_stream, response->GetResponseBody());
-                    }
-                } else {
-                    std::string error_message;
-                    Poco::StreamCopier::copyToString(response_body_stream, error_message);
-
-                    response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
-                    response->SetClientErrorMessage(error_message);
+                if (!poco_response.isBodyFilled()) {
+                    Poco::StreamCopier::copyStream(response_body_stream, response->GetResponseBody());
                 }
             }
 

--- a/be/test/io/s3_input_stream_test.cpp
+++ b/be/test/io/s3_input_stream_test.cpp
@@ -138,6 +138,15 @@ TEST_F(S3InputStreamTest, test_read) {
     ASSERT_EQ(10, *f->position());
 }
 
+TEST_F(S3InputStreamTest, test_not_found) {
+    auto f = std::make_unique<S3InputStream>(g_s3client, s_bucket_name, "key_not_found");
+    char buf[6];
+    auto r = f->read(buf, sizeof(buf));
+    EXPECT_TRUE(r.status().message().find("SdkResponseCode=404") != std::string::npos);
+    // ErrorCode 16 means RESOURCE_NOT_FOUND
+    EXPECT_TRUE(r.status().message().find("SdkErrorType=16") != std::string::npos);
+}
+
 TEST_F(S3InputStreamTest, test_skip) {
     auto f = new_random_access_file();
     char buf[6];


### PR DESCRIPTION
## Why I'm doing:
In some case, we use ErrorType to check if the resource exists, so we 
shouldn't set NETWORK_CONNECTION when we can get response.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
