### PR TITLE
[Enhancement] Optimize upload and download for backup restore

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -132,6 +132,10 @@ CONF_Int32(update_schema_worker_count, "3");
 CONF_mInt32(upload_worker_count, "0");
 // The count of thread to download.
 CONF_mInt32(download_worker_count, "0");
+// The buffer size to upload.
+CONF_mInt32(upload_buffer_size, "4194304");
+// The buffer size to download.
+CONF_mInt32(download_buffer_size, "4194304");
 // The count of thread to make snapshot.
 CONF_mInt32(make_snapshot_worker_count, "5");
 // The count of thread to release snapshot.


### PR DESCRIPTION
## Why I'm doing:
Some code logic of upload and download is unreasonable.

## What I'm doing:
1. Remove the report rpc to FE at the beginning of upload and download, because it is useless in almost all situations. Keep the report rpc to FE during upload and download.
2. Add be config `upload_buffer_size` and `download_buffer_size` to config the buffer of upload and download.
3. Optimize some log.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
