### PR TITLE
[Feature] (Part 1) Support to create materialized views with multi partition columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -18,7 +18,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -101,6 +100,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -113,7 +113,19 @@ import static com.starrocks.backup.mv.MVRestoreUpdater.restoreBaseTableInfoIfNoR
 import static com.starrocks.backup.mv.MVRestoreUpdater.restoreBaseTableInfoIfRestored;
 
 /**
- * meta structure for materialized view
+ * A Materialized View is a database object that contains the results of a query.
+ * - Base tables are the tables that are referenced in the view definition.
+ * - Ref base tables are some special base tables of a materialized view that are referenced by mv's partition expression.
+ * </p>
+ * In our partition-change-tracking mechanism, we need to track the partition change of ref base tables to refresh the associated
+ * partitions of the materialized view.
+ * </p>
+ * NOTE:
+ * - A Materialized View can have multi base-tables which are tables that are referenced in the view definition.
+ * - A Materialized View can have multi ref-base-tables which are tables that are referenced by mv's partition expression.
+ * - A Materialized View's partition expressions can be range partitioned or list partitioned:
+ *      - If mv is range partitioned, it must only have one partition column.
+ *      - If mv is list partitioned, it can have multi partition columns.
  */
 public class MaterializedView extends OlapTable implements GsonPreProcessable, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(MaterializedView.class);
@@ -479,15 +491,16 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     // Multi ref base table partition expression and ref slot ref map.
     @SerializedName(value = "partitionExprMaps")
     private Map<ExpressionSerializedObject, ExpressionSerializedObject> serializedPartitionExprMaps;
-    private Map<Expr, SlotRef> partitionExprMaps;
+    // Use LinedHashMap to keep the order of partition exprs by the user's defined order which can be used when mv contains multi
+    // partition columns.
+    private LinkedHashMap<Expr, SlotRef> partitionExprMaps;
+
     // ref base table to partition expression
-    private transient volatile Optional<Map<Table, Expr>> refBaseTablePartitionExprsOpt = Optional.empty();
+    private Optional<Map<Table, List<Expr>>> refBaseTablePartitionExprsOpt = Optional.empty();
     // ref bae table to partition column slot ref
-    private transient volatile Optional<Map<Table, SlotRef>> refBaseTablePartitionSlotsOpt = Optional.empty();
+    private Optional<Map<Table, List<SlotRef>>> refBaseTablePartitionSlotsOpt = Optional.empty();
     // ref bae table to partition column
-    private transient volatile Optional<Map<Table, Column>> refBaseTablePartitionColumnsOpt = Optional.empty();
-    // cache table to base table info's mapping to refresh table
-    private transient volatile Map<Table, BaseTableInfo> tableToBaseTableInfoCache = Maps.newConcurrentMap();
+    private Optional<Map<Table, List<Column>>> refBaseTablePartitionColumnsOpt = Optional.empty();
 
     // Materialized view's output columns may be different from defined query's output columns.
     // Record the indexes based on materialized view's column output.
@@ -599,7 +612,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         refBaseTablePartitionExprsOpt = Optional.empty();
         refBaseTablePartitionSlotsOpt = Optional.empty();
         refBaseTablePartitionColumnsOpt = Optional.empty();
-        tableToBaseTableInfoCache.clear();
     }
 
     public String getInactiveReason() {
@@ -688,7 +700,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return partitionExprMaps;
     }
 
-    public void setPartitionExprMaps(Map<Expr, SlotRef> partitionExprMaps) {
+    public void setPartitionExprMaps(LinkedHashMap<Expr, SlotRef> partitionExprMaps) {
         this.partitionExprMaps = partitionExprMaps;
     }
 
@@ -705,11 +717,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * NOTE: Only one column is supported for now, support more columns in the future.
      * @return the partition column of the materialized view
      */
-    public Optional<Column> getPartitionColumn() {
+    public Optional<Column> getRangePartitionColumn() {
         List<Column> partitionCols = partitionInfo.getPartitionColumns(this.idToColumn);
-        if (partitionCols == null || partitionCols.isEmpty()) {
+        if (CollectionUtils.isEmpty(partitionCols)) {
             return Optional.empty();
         }
+        Preconditions.checkState(partitionInfo.isRangePartition(), "Only range partition is supported now");
         return Optional.of(partitionCols.get(0));
     }
 
@@ -718,17 +731,17 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * NOTE: only one partition expr is supported for now.
      * @return the partition expr of the range partitioned materialized view
      */
-    public Expr getPartitionExpr() {
+    public Expr getRangePartitionExpr() {
         if (partitionRefTableExprs == null) {
             return null;
         }
-
+        Preconditions.checkState(partitionInfo.isRangePartition(), "Only range partition is supported now");
         Expr partitionExpr = partitionRefTableExprs.get(0);
         if (partitionExpr == null) {
             return null;
         }
         if (partitionExpr.getType() == Type.INVALID) {
-            Optional<Column> partitionColOpt = getPartitionColumn();
+            Optional<Column> partitionColOpt = getRangePartitionColumn();
             if (partitionColOpt.isEmpty()) {
                 return null;
             }
@@ -736,18 +749,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             partitionExpr.setType(partitionColType);
         }
         return partitionExpr;
-    }
-
-    public static Expr getPartitionExpr(MaterializedView materializedView) {
-        // TODO: only range partition expr is supported now
-        if (!materializedView.getPartitionInfo().isExprRangePartitioned()) {
-            return null;
-        }
-        ExpressionRangePartitionInfo expressionRangePartitionInfo =
-                ((ExpressionRangePartitionInfo) materializedView.getPartitionInfo());
-        // currently, mv only supports one expression
-        Preconditions.checkState(expressionRangePartitionInfo.getPartitionExprsSize() == 1);
-        return materializedView.getPartitionExpr();
     }
 
     /**
@@ -896,12 +897,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             mv.setQueryOutputIndices(Lists.newArrayList(queryOutputIndices));
         }
         if (this.partitionExprMaps != null) {
-            mv.partitionExprMaps = ImmutableMap.copyOf(this.partitionExprMaps);
+            mv.partitionExprMaps = this.partitionExprMaps;
         }
         mv.refBaseTablePartitionExprsOpt = this.refBaseTablePartitionExprsOpt;
         mv.refBaseTablePartitionSlotsOpt = this.refBaseTablePartitionSlotsOpt;
         mv.refBaseTablePartitionColumnsOpt = this.refBaseTablePartitionColumnsOpt;
-        mv.tableToBaseTableInfoCache = this.tableToBaseTableInfoCache;
     }
 
     @Override
@@ -1083,11 +1083,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     private void analyzePartitionInfo() {
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
-
         if (partitionInfo.isUnPartitioned()) {
             return;
         }
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         // analyze expression, because it converts to sql for serialize
         ConnectContext connectContext = new ConnectContext();
         connectContext.setDatabase(db.getFullName());
@@ -1462,62 +1461,23 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     /**
-     * Get table to the partition expr map of the materialized view.
+     * NOTE: The ref-base-table partition expressions' order is guaranteed as the order of mv's defined partition columns' order.
      * @return table to the partition expr map, multi values if mv contains multi ref base tables, empty if it's un-partitioned
      */
-    public Map<Table, Expr> getRefBaseTablePartitionExprs() {
-        if (refBaseTablePartitionExprsOpt.isEmpty()) {
-            Map<Table, Expr> refBaseTablePartitionExprMap = Maps.newHashMap();
-            for (BaseTableInfo tableInfo : baseTableInfos) {
-                Table table = MvUtils.getTableChecked(tableInfo);
-                Optional<MVPartitionExpr> mvPartitionExpr = MvUtils.getMvPartitionExpr(partitionExprMaps, table);
-                if (mvPartitionExpr.isEmpty()) {
-                    LOG.info("Base table {} contains no partition expr, skip", table.getName());
-                    continue;
-                }
-                tableToBaseTableInfoCache.put(table, tableInfo);
-                refBaseTablePartitionExprMap.put(table, mvPartitionExpr.get().getExpr());
-            }
-            LOG.info("The refBaseTablePartitionExprMap of mv {} is {}", getName(), refBaseTablePartitionExprMap);
-            synchronized (this) {
-                if (refBaseTablePartitionExprsOpt.isEmpty()) {
-                    refBaseTablePartitionExprsOpt = Optional.of(refBaseTablePartitionExprMap);
-                    return refBaseTablePartitionExprMap;
-                }
-            }
-        }
-        Preconditions.checkState(refBaseTablePartitionExprsOpt.isPresent());
-        return refBaseTablePartitionExprsOpt.map(this::refreshBaseTable).get();
+    public Map<Table, List<Expr>> getRefBaseTablePartitionExprs() {
+        return refBaseTablePartitionExprsOpt.orElse(Maps.newHashMap());
     }
 
     /**
      * Get table to the partition slot ref map of the materialized view.
+     * </p>
+     * NOTE: The ref-base-table slot refs' order is guaranteed as the order of mv's defined partition columns' order.
+     * </p>
      * @return table to the partition slot ref map, multi values if mv contains multi ref base tables, empty if it's
      * un-partitioned
      */
-    public Map<Table, SlotRef> getRefBaseTablePartitionSlots() {
-        if (refBaseTablePartitionSlotsOpt.isEmpty()) {
-            Map<Table, SlotRef> refBaseTablePartitionSlotMap = new HashMap<>();
-            for (BaseTableInfo tableInfo : baseTableInfos) {
-                Table table = MvUtils.getTableChecked(tableInfo);
-                Optional<MVPartitionExpr> mvPartitionExpr = MvUtils.getMvPartitionExpr(partitionExprMaps, table);
-                if (mvPartitionExpr.isEmpty()) {
-                    LOG.info("Base table {} contains no partition expr, skip", table.getName());
-                    continue;
-                }
-                tableToBaseTableInfoCache.put(table, tableInfo);
-                refBaseTablePartitionSlotMap.put(table, mvPartitionExpr.get().getSlotRef());
-            }
-            LOG.info("The refBaseTablePartitionSlotMap of mv {} is {}", getName(), refBaseTablePartitionSlotMap);
-            synchronized (this) {
-                if (refBaseTablePartitionSlotsOpt.isEmpty()) {
-                    refBaseTablePartitionSlotsOpt = Optional.of(refBaseTablePartitionSlotMap);
-                    return refBaseTablePartitionSlotMap;
-                }
-            }
-        }
-        Preconditions.checkState(refBaseTablePartitionSlotsOpt.isPresent());
-        return refBaseTablePartitionSlotsOpt.map(this::refreshBaseTable).get();
+    public Map<Table, List<SlotRef>> getRefBaseTablePartitionSlots() {
+        return refBaseTablePartitionSlotsOpt.orElse(Maps.newHashMap());
     }
 
     /**
@@ -1600,65 +1560,47 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     /**
      * Get the related partition table and column of the materialized view since one mv can contain multi ref base tables.
-     * @return The related partition table and its partition column referred by the materialized view.
+     * NOTE: The ref-base-table columns' order is guaranteed as the order of mv's defined partition columns' order.
      */
-    public Map<Table, Column> getRefBaseTablePartitionColumns() {
-        if (refBaseTablePartitionColumnsOpt.isEmpty()) {
-            Map<Table, Column> result = getBaseTablePartitionColumnMapImpl();
-            synchronized (this) {
-                if (refBaseTablePartitionColumnsOpt.isEmpty()) {
-                    refBaseTablePartitionColumnsOpt = Optional.of(result);
-                    return result;
-                }
-            }
-        }
-        Preconditions.checkState(refBaseTablePartitionColumnsOpt.isPresent());
-        return refBaseTablePartitionColumnsOpt.map(this::refreshBaseTable).get();
+    public Map<Table, List<Column>> getRefBaseTablePartitionColumns() {
+        return refBaseTablePartitionColumnsOpt.orElse(Maps.newLinkedHashMap());
     }
 
-    /**
-     * Since the table is cached in the Optional, needs to refresh it again for each query.
-     * TODO: optimize cases which not care table's refresh-ness.
-     */
-    private <K> Map<Table, K> refreshBaseTable(Map<Table, K> cached) {
-        Map<Table, K> result = Maps.newHashMap();
-        for (Map.Entry<Table, K> e : cached.entrySet()) {
-            Preconditions.checkState(tableToBaseTableInfoCache.containsKey(e.getKey()));
-            Table refreshedTable = MvUtils.getTableChecked(tableToBaseTableInfoCache.get(e.getKey()));
-            result.put(refreshedTable, e.getValue());
-        }
-        return result;
-    }
-
-    private Map<Table, Column> getBaseTablePartitionColumnMapImpl() {
-        Map<Table, Column> result = Maps.newHashMap();
+    private Map<Table, List<Column>> getBaseTablePartitionColumnMapImpl() {
+        Map<Table, List<Column>> result = Maps.newHashMap();
         if (partitionExprMaps == null || partitionExprMaps.isEmpty()) {
             return result;
         }
 
         // find the partition column for each base table
-        Map<Table, SlotRef> baseTablePartitionSlotMap = getRefBaseTablePartitionSlots();
+        Preconditions.checkArgument(refBaseTablePartitionSlotsOpt.isPresent());
+        Map<Table, List<SlotRef>> baseTablePartitionSlotMap = refBaseTablePartitionSlotsOpt.get();
         for (BaseTableInfo baseTableInfo : baseTableInfos) {
-            Table table = MvUtils.getTableChecked(baseTableInfo);
-            if (!baseTablePartitionSlotMap.containsKey(table)) {
+            Table baseTable = MvUtils.getTableChecked(baseTableInfo);
+            if (!baseTablePartitionSlotMap.containsKey(baseTable)) {
                 continue;
             }
-
-            List<Column> partitionColumns = PartitionUtil.getPartitionColumns(table);
-            if (partitionColumns.isEmpty()) {
+            // ref table's partition columns
+            List<Column> basePartitionColumns = PartitionUtil.getPartitionColumns(baseTable);
+            if (basePartitionColumns.isEmpty()) {
                 continue;
             }
-
-            // if the partition column is the same with the slot ref, put it into the result.
-            SlotRef slotRef = baseTablePartitionSlotMap.get(table);
-            Optional<Column> partitionColumnOpt = MvUtils.getColumnBySlotRef(partitionColumns, slotRef);
-            if (partitionColumnOpt.isEmpty()) {
-                LOG.warn("Partition slot ref {} is not in the base table {}, baseTablePartitionSlotMap:{}", slotRef,
-                        table.getName(), baseTablePartitionSlotMap);
-                continue;
+            // If the partition column is the same with the slot ref, put it into the result.
+            // We can guarantee that output column orders are same with ref-base table's columns.
+            List<SlotRef> baseSlotRefs = baseTablePartitionSlotMap.get(baseTable);
+            List<Column> refPartitionColumns = Lists.newArrayList();
+            for (SlotRef slotRef : baseSlotRefs) {
+                Optional<Column> partitionColumnOpt = MvUtils.getColumnBySlotRef(basePartitionColumns, slotRef);
+                if (partitionColumnOpt.isEmpty()) {
+                    LOG.warn("Partition slot ref {} is not in the base table {}, baseTablePartitionSlotMap:{}", slotRef,
+                            baseTable.getName(), baseTablePartitionSlotMap);
+                    continue;
+                }
+                refPartitionColumns.add(partitionColumnOpt.get());
             }
-            tableToBaseTableInfoCache.put(table, baseTableInfo);
-            result.put(table, partitionColumnOpt.get());
+            if (!refPartitionColumns.isEmpty()) {
+                result.put(baseTable, refPartitionColumns);
+            }
         }
         if (result.isEmpty()) {
             throw new RuntimeException(String.format("Can not find partition column map for mv:%s on base tables:%s", name,
@@ -1751,7 +1693,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 }
             }
         }
-        this.serializedPartitionExprMaps = Maps.newHashMap();
+        this.serializedPartitionExprMaps = Maps.newLinkedHashMap();
         if (partitionExprMaps != null) {
             for (Map.Entry<Expr, SlotRef> entry : partitionExprMaps.entrySet()) {
                 if (entry.getKey() != null && entry.getValue() != null) {
@@ -1767,19 +1709,17 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     @Override
     public void gsonPostProcess() throws IOException {
         super.gsonPostProcess();
-        // only partition materialized view need to recover partitionRefTableExprs
-        Optional<Column> partitionColOpt = getPartitionColumn();
-        if (partitionColOpt.isEmpty()) {
+        List<Column> partitionCols = getPartitionColumns();
+        if (CollectionUtils.isEmpty(partitionCols)) {
             return;
         }
-        Column partitionCol = partitionColOpt.get();
 
         // for single ref base table, recover from serializedPartitionRefTableExprs
         partitionRefTableExprs = new ArrayList<>();
-        partitionExprMaps = Maps.newHashMap();
+        partitionExprMaps = Maps.newLinkedHashMap();
         if (serializedPartitionRefTableExprs != null) {
             for (ExpressionSerializedObject expressionSql : serializedPartitionRefTableExprs) {
-                Expr partitionExpr = parsePartitionExpr(expressionSql.getExpressionSql(), partitionCol);
+                Expr partitionExpr = parsePartitionExpr(expressionSql.getExpressionSql());
                 if (partitionExpr == null) {
                     LOG.warn("parse partition expr failed, sql: {}", expressionSql.getExpressionSql());
                     continue;
@@ -1796,7 +1736,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             for (Map.Entry<ExpressionSerializedObject, ExpressionSerializedObject> entry :
                     serializedPartitionExprMaps.entrySet()) {
                 if (entry.getKey() != null && entry.getValue() != null) {
-                    Expr partitionExpr = parsePartitionExpr(entry.getKey().getExpressionSql(), partitionCol);
+                    Expr partitionExpr = parsePartitionExpr(entry.getKey().getExpressionSql());
                     if (partitionExpr == null) {
                         LOG.warn("parse partition expr failed, sql: {}", entry.getKey().getExpressionSql());
                         continue;
@@ -1810,7 +1750,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     private void analyzePartitionExprs() {
         try {
-            Map<Table, Expr> refBaseTablePartitionExprs = getRefBaseTablePartitionExprs();
+            // analyze partition exprs for ref base tables
+            analyzeRefBaseTablePartitionExprs();
+            // analyze partition exprs
+            Map<Table, List<Expr>> refBaseTablePartitionExprs = getRefBaseTablePartitionExprs();
             ConnectContext connectContext = new ConnectContext();
             if (refBaseTablePartitionExprs != null) {
                 for (BaseTableInfo baseTableInfo : baseTableInfos) {
@@ -1822,15 +1765,62 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     if (!refBaseTablePartitionExprs.containsKey(refBaseTable)) {
                         continue;
                     }
-                    Expr partitionExpr = refBaseTablePartitionExprs.get(refBaseTable);
+                    List<Expr> partitionExprs = refBaseTablePartitionExprs.get(refBaseTable);
                     TableName tableName = new TableName(baseTableInfo.getCatalogName(),
                             baseTableInfo.getDbName(), baseTableInfo.getTableName());
-                    analyzePartitionExpr(connectContext, refBaseTable, tableName, partitionExpr);
+                    for (Expr partitionExpr : partitionExprs) {
+                        analyzePartitionExpr(connectContext, refBaseTable, tableName, partitionExpr);
+                    }
                 }
             }
+            // analyze partition slots for ref base tables
+            analyzeRefBaseTablePartitionSlots();
+            // analyze partition columns for ref base tables
+            analyzeRefBaseTablePartitionColumns();
         } catch (Exception e) {
             LOG.warn("Analyze partition exprs failed", e);
         }
+    }
+
+    private void analyzeRefBaseTablePartitionExprs() {
+        Map<Table, List<Expr>> refBaseTablePartitionExprMap = Maps.newHashMap();
+        for (BaseTableInfo tableInfo : baseTableInfos) {
+            Table table = MvUtils.getTableChecked(tableInfo);
+            List<MVPartitionExpr> mvPartitionExprs = MvUtils.getMvPartitionExpr(partitionExprMaps, table);
+            if (CollectionUtils.isEmpty(mvPartitionExprs)) {
+                LOG.info("Base table {} contains no partition expr, skip", table.getName());
+                continue;
+            }
+
+            List<Expr> exprs = mvPartitionExprs.stream().map(MVPartitionExpr::getExpr).collect(Collectors.toList());
+            refBaseTablePartitionExprMap.put(table, exprs);
+        }
+        LOG.info("The refBaseTablePartitionExprMap of mv {} is {}", getName(), refBaseTablePartitionExprMap);
+        refBaseTablePartitionExprsOpt = Optional.of(refBaseTablePartitionExprMap);
+    }
+
+    public void analyzeRefBaseTablePartitionSlots() {
+        Map<Table, List<SlotRef>> refBaseTablePartitionSlotMap = Maps.newHashMap();
+        for (BaseTableInfo tableInfo : baseTableInfos) {
+            Table table = MvUtils.getTableChecked(tableInfo);
+            List<MVPartitionExpr> mvPartitionExprs = MvUtils.getMvPartitionExpr(partitionExprMaps, table);
+            if (CollectionUtils.isEmpty(mvPartitionExprs)) {
+                LOG.info("Base table {} contains no partition expr, skip", table.getName());
+                continue;
+            }
+            List<SlotRef> slotRefs = mvPartitionExprs
+                    .stream()
+                    .map(MVPartitionExpr::getSlotRef)
+                    .collect(Collectors.toList());
+            refBaseTablePartitionSlotMap.put(table, slotRefs);
+        }
+        LOG.info("The refBaseTablePartitionSlotMap of mv {} is {}", getName(), refBaseTablePartitionSlotMap);
+        refBaseTablePartitionSlotsOpt = Optional.of(refBaseTablePartitionSlotMap);
+    }
+
+    private void analyzeRefBaseTablePartitionColumns() {
+        Map<Table, List<Column>> result = getBaseTablePartitionColumnMapImpl();
+        refBaseTablePartitionColumnsOpt = Optional.of(result);
     }
 
     private void analyzePartitionExpr(ConnectContext connectContext,
@@ -1858,18 +1848,13 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     /**
      * Parse partition expr from sql
      * @param sql serialized partition expr sql
-     * @param partitionCol materialized view's partition column
      * @return parsed and unanalyzed partition expr
      */
-    private Expr parsePartitionExpr(String sql, Column partitionCol) {
+    private Expr parsePartitionExpr(String sql) {
         if (Strings.isNullOrEmpty(sql)) {
             return null;
         }
-        Expr partitionExpr = SqlParser.parseSqlToExpr(sql, SqlModeHelper.MODE_DEFAULT);
-        if (partitionExpr.getType() == Type.INVALID) {
-            partitionExpr.setType(partitionCol.getType());
-        }
-        return partitionExpr;
+        return SqlParser.parseSqlToExpr(sql, SqlModeHelper.MODE_DEFAULT);
     }
 
     public String inspectMeta() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -203,12 +203,14 @@ public class MvRefreshArbiter {
                     baseTableUpdateInfo.addListPartitionKeys(partitionNameWithRange);
                     baseTableUpdateInfo.addToRefreshPartitionNames(partitionNameWithRange.keySet());
                 } else if (mvPartitionInfo.isRangePartition()) {
-                    Expr partitionExpr = mv.getRangePartitionExpr();
                     Preconditions.checkArgument(refPartitionColumns.size() == 1,
                             "Range partition column size must be 1");
                     Column partitionColumn = refPartitionColumns.get(0);
+                    Optional<Expr> partitionExprOpt = mv.getRangePartitionFirstExpr();
+                    Preconditions.checkArgument(partitionExprOpt.isPresent(),
+                            "Range partition expr must be present");
                     Map<String, Range<PartitionKey>> partitionNameWithRange = getMVPartitionNameWithRange(baseTable,
-                            partitionColumn, updatedPartitionNamesList, partitionExpr);
+                            partitionColumn, updatedPartitionNamesList, partitionExprOpt.get());
                     for (Map.Entry<String, Range<PartitionKey>> e : partitionNameWithRange.entrySet()) {
                         baseTableUpdateInfo.addRangePartitionKeys(e.getKey(), e.getValue());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.starrocks.analysis.Expr;
@@ -186,23 +187,26 @@ public class MvRefreshArbiter {
             if (baseUpdatedPartitionNames == null) {
                 return null;
             }
-            Map<Table, Column> partitionTableAndColumns = mv.getRefBaseTablePartitionColumns();
-            if (!partitionTableAndColumns.containsKey(baseTable)) {
+            Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
+            if (!refBaseTablePartitionColumns.containsKey(baseTable)) {
                 baseTableUpdateInfo.addToRefreshPartitionNames(baseUpdatedPartitionNames);
                 return baseTableUpdateInfo;
             }
 
             try {
                 List<String> updatedPartitionNamesList = Lists.newArrayList(baseUpdatedPartitionNames);
-                Column partitionColumn = partitionTableAndColumns.get(baseTable);
+                List<Column> refPartitionColumns = refBaseTablePartitionColumns.get(baseTable);
                 PartitionInfo mvPartitionInfo = mv.getPartitionInfo();
                 if (mvPartitionInfo.isListPartition()) {
                     Map<String, PListCell> partitionNameWithRange = getMVPartitionNameWithList(baseTable,
-                            partitionColumn, updatedPartitionNamesList);
+                            refPartitionColumns, updatedPartitionNamesList);
                     baseTableUpdateInfo.addListPartitionKeys(partitionNameWithRange);
                     baseTableUpdateInfo.addToRefreshPartitionNames(partitionNameWithRange.keySet());
                 } else if (mvPartitionInfo.isRangePartition()) {
-                    Expr partitionExpr = MaterializedView.getPartitionExpr(mv);
+                    Expr partitionExpr = mv.getRangePartitionExpr();
+                    Preconditions.checkArgument(refPartitionColumns.size() == 1,
+                            "Range partition column size must be 1");
+                    Column partitionColumn = refPartitionColumns.get(0);
                     Map<String, Range<PartitionKey>> partitionNameWithRange = getMVPartitionNameWithRange(baseTable,
                             partitionColumn, updatedPartitionNamesList, partitionExpr);
                     for (Map.Entry<String, Range<PartitionKey>> e : partitionNameWithRange.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1215,14 +1215,37 @@ public class OlapTable extends Table {
     }
 
     /**
-     * @return : table's partition name to list partition names.
+     * NOTE: Only list partitioned olap table can call this method.
+     * @return : table's partition name to all list partition cells.
      * eg:
      *  partition columns   : (a, b, c)
      *  values              : [[1, 2, 3], [4, 5, 6]]
      */
     public Map<String, PListCell> getListPartitionItems() {
-        Preconditions.checkState(partitionInfo instanceof ListPartitionInfo);
+        return getListPartitionItems(Optional.empty());
+    }
+
+    /**
+     * Return the partition items of the selected partition columns if selectedPartitionCols is not null, otherwise return
+     * all partition items.
+     */
+    public Map<String, PListCell> getListPartitionItems(Optional<List<Column>> selectedPartitionCols) {
+        Preconditions.checkState(partitionInfo instanceof ListPartitionInfo, "partition info is not list partition");
         ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
+        List<Column> partitionCols = listPartitionInfo.getPartitionColumns(this.idToColumn);
+        List<Integer> colIdxes = Lists.newArrayList();
+        if (selectedPartitionCols.isPresent()) {
+            Preconditions.checkState(!selectedPartitionCols.isEmpty(), "selected partition columns is empty");
+            Preconditions.checkState(partitionCols.size() >= selectedPartitionCols.get().size(),
+                    "selected partition columns size is larger than partition columns size");
+            for (Column select : selectedPartitionCols.get()) {
+                int idx = partitionCols.indexOf(select);
+                if (idx == -1) {
+                    throw new SemanticException("column " + select.getName() + " is not partition column");
+                }
+                colIdxes.add(idx);
+            }
+        }
         Map<String, PListCell> partitionItems = Maps.newHashMap();
         for (Map.Entry<Long, Partition> partitionEntry : idToPartition.entrySet()) {
             Long partitionId = partitionEntry.getKey();
@@ -1233,7 +1256,7 @@ public class OlapTable extends Table {
             }
             // one item
             List<String> singleValues = listPartitionInfo.getIdToValues().get(partitionId);
-            if (singleValues != null) {
+            if (CollectionUtils.isNotEmpty(singleValues)) {
                 List<List<String>> cellValue = Lists.newArrayList();
                 // for one item(single value), treat it as multi values.
                 for (String val : singleValues) {
@@ -1244,8 +1267,20 @@ public class OlapTable extends Table {
 
             // multi items
             List<List<String>> multiValues = listPartitionInfo.getIdToMultiValues().get(partitionId);
-            if (multiValues != null) {
-                partitionItems.put(partitionName, new PListCell(multiValues));
+            if (CollectionUtils.isNotEmpty(multiValues)) {
+                if (CollectionUtils.isEmpty(colIdxes)) {
+                    partitionItems.put(partitionName, new PListCell(multiValues));
+                } else {
+                    List<List<String>> cellValue = Lists.newArrayList();
+                    for (List<String> multiValue : multiValues) {
+                        List<String> selectedValues = Lists.newArrayList();
+                        for (int idx : colIdxes) {
+                            selectedValues.add(multiValue.get(idx));
+                        }
+                        cellValue.add(selectedValues);
+                    }
+                    partitionItems.put(partitionName, new PListCell(cellValue));
+                }
             }
         }
         return partitionItems;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -60,16 +60,16 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         Preconditions.checkState(partitionInfo.isExprRangePartitioned());
         // If non-partition-by table has changed, should refresh all mv partitions
-        Expr partitionExpr = mv.getPartitionExpr();
-        Map<Table, Column> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
-        if (refBaseTableAndColumns.isEmpty()) {
+        Expr partitionExpr = mv.getRangePartitionExpr();
+        Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
+        if (refBaseTablePartitionColumns.isEmpty()) {
             mv.setInactiveAndReason("partition configuration changed");
             LOG.warn("mark mv:{} inactive for get partition info failed", mv.getName());
             throw new RuntimeException(String.format("getting partition info failed for mv: %s", mv.getName()));
         }
 
         // if it needs to refresh based on non-ref base tables, return full refresh directly.
-        boolean isRefreshBasedOnNonRefTables = needsRefreshOnNonRefBaseTables(refBaseTableAndColumns);
+        boolean isRefreshBasedOnNonRefTables = needsRefreshOnNonRefBaseTables(refBaseTablePartitionColumns);
         logMVPrepare(mv, "MV refresh based on non-ref base table:{}", isRefreshBasedOnNonRefTables);
         if (isRefreshBasedOnNonRefTables) {
             return new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.FULL);
@@ -78,7 +78,7 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         // record the relation of partitions between materialized view and base partition table
         MvUpdateInfo mvTimelinessInfo = new MvUpdateInfo(MvUpdateInfo.MvToRefreshType.PARTIAL);
         // collect & update mv's to refresh partitions based on base table's partition changes
-        Map<Table, Set<String>> baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTableAndColumns,
+        Map<Table, Set<String>> baseChangedPartitionNames = collectBaseTableUpdatePartitionNames(refBaseTablePartitionColumns,
                 mvTimelinessInfo);
 
         // collect all ref base table's partition range map
@@ -120,11 +120,11 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
                 .collect(Collectors.toMap(e -> e.getKey(), e -> new PRangeCell(e.getValue())));
         mvTimelinessInfo.addMVPartitionNameToCellMap(mvPartitionNameToCell);
 
-        Map<Table, Expr> baseTableToPartitionExprs = mv.getRefBaseTablePartitionExprs();
+        Map<Table, List<Expr>> refBaseTablePartitionExprs = mv.getRefBaseTablePartitionExprs();
         Map<Table, Map<String, Set<String>>> baseToMvNameRef = RangePartitionDiffer
-                .generateBaseRefMap(basePartitionNameToRangeMap, baseTableToPartitionExprs, mvPartitionNameToRangeMap);
+                .generateBaseRefMap(basePartitionNameToRangeMap, refBaseTablePartitionExprs, mvPartitionNameToRangeMap);
         Map<String, Map<Table, Set<String>>> mvToBaseNameRef = RangePartitionDiffer
-                .generateMvRefMap(mvPartitionNameToRangeMap, baseTableToPartitionExprs, basePartitionNameToRangeMap);
+                .generateMvRefMap(mvPartitionNameToRangeMap, refBaseTablePartitionExprs, basePartitionNameToRangeMap);
         mvTimelinessInfo.getBasePartToMvPartNames().putAll(baseToMvNameRef);
         mvTimelinessInfo.getMvPartToBasePartNames().putAll(mvToBaseNameRef);
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -737,7 +737,7 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
         // Update scheduler interval.
         setInterval(Config.dynamic_partition_check_interval_seconds * 1000L);
 
-        // Schedule tables with dynamic partition enabled(only works for base table).
+        // Schedule tables with dynamic partition enabled (only works for base table).
         if (Config.dynamic_partition_enable) {
             scheduleDynamicPartition();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -180,7 +180,7 @@ public abstract class ConnectorPartitionTraits {
      *
      * @apiNote it must be a list-partitioned table
      */
-    public abstract Map<String, PListCell> getPartitionList(Column partitionColumn) throws AnalysisException;
+    public abstract Map<String, PListCell> getPartitionList(List<Column> partitionColumns) throws AnalysisException;
 
     public abstract Map<String, PartitionInfo> getPartitionNameWithPartitionInfo();
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/CachedPartitionTraits.java
@@ -156,9 +156,9 @@ public class CachedPartitionTraits extends DefaultTraits {
     }
 
     @Override
-    public Map<String, PListCell> getPartitionList(Column partitionColumn) throws AnalysisException {
+    public Map<String, PListCell> getPartitionList(List<Column> partitionColumns) throws AnalysisException {
         return getCacheWithException("getPartitionList",
-                () -> delegate.getPartitionList(partitionColumn), () -> Maps.newHashMap());
+                () -> delegate.getPartitionList(partitionColumns), () -> Maps.newHashMap());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -105,8 +105,8 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits  {
     }
 
     @Override
-    public Map<String, PListCell> getPartitionList(Column partitionColumn) throws AnalysisException {
-        return PartitionUtil.getMVPartitionNameWithList(table, partitionColumn, getPartitionNames());
+    public Map<String, PListCell> getPartitionList(List<Column> partitionColumns) throws AnalysisException {
+        return PartitionUtil.getMVPartitionNameWithList(table, partitionColumns, getPartitionNames());
     }
 
     @Override
@@ -161,7 +161,7 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits  {
             for (Map.Entry<String, MaterializedView.BasePartitionInfo> versionEntry : versionMap.entrySet()) {
                 String basePartitionName = versionEntry.getKey();
                 if (!latestPartitionInfo.containsKey(basePartitionName)) {
-                    // partitions deleted
+                    // TODO: If one partition has been dropped, refresh all existed partitions again.
                     return latestPartitionInfo.keySet();
                 }
                 long basePartitionVersion = latestPartitionInfo.get(basePartitionName).getModifiedTime();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
@@ -62,9 +62,8 @@ public class OlapPartitionTraits extends DefaultTraits {
     }
 
     @Override
-    public Map<String, PListCell> getPartitionList(Column partitionColumn) {
-        // TODO: check partition type
-        return ((OlapTable) table).getListPartitionItems();
+    public Map<String, PListCell> getPartitionList(List<Column> partitionColumns) {
+        return ((OlapTable) table).getListPartitionItems(Optional.of(partitionColumns));
     }
 
     @Override
@@ -106,7 +105,7 @@ public class OlapPartitionTraits extends DefaultTraits {
             String basePartitionName = versionEntry.getKey();
             Partition basePartition = baseTable.getPartition(basePartitionName);
             if (basePartition == null) {
-                // Once there is a partition deleted, refresh all partitions.
+                // TODO: Once there is a partition deleted, refresh all partitions.
                 return baseTable.getVisiblePartitionNames();
             }
             MaterializedView.BasePartitionInfo mvRefreshedPartitionInfo = versionEntry.getValue();

--- a/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionExprResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionExprResolver.java
@@ -26,7 +26,6 @@ import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.BaseTableInfo;
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.SRStringUtils;
@@ -49,6 +48,8 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -543,45 +544,45 @@ public class MVPartitionExprResolver {
     }
 
     /**
-     * This is the single ref base table partition expr method, we use it as the default method.
+     * 1. Ensure the result `partitionExprMaps` is valid, otherwise use the original partition expr.
+     * 2. Ensure the result is ordered by mv's defined partition expression orders.
      */
-    private static Pair<Expr, SlotRef> getMVPartitionExpr(Expr partitionExpr, QueryStatement stmt) {
-        Expr resolved = MVPartitionSlotRefResolver.resolveExpr(partitionExpr, stmt);
-        SlotRef slotRef = MaterializedView.getMvPartitionSlotRef(resolved);
-        return Pair.create(resolved, slotRef);
-    }
-
-    /**
-     * Ensure the result `partitionExprMaps` is valid, otherwise use the original partition expr.
-     */
-    public static Map<Expr, SlotRef> getMVPartitionExprsChecked(Expr mvRefPartitionExpr,
-                                                                QueryStatement stmt,
-                                                                List<BaseTableInfo> baseTableInfos) {
-        Map<Expr, SlotRef> partitionExprMaps = getMVPartitionExprs(mvRefPartitionExpr, stmt);
-        if (partitionExprMaps == null) {
-            LOG.warn("The partition expr maps slot ref should be from the base table, eqExprs:{}", partitionExprMaps);
-            partitionExprMaps = Maps.newHashMap();
-        }
-        if (partitionExprMaps.isEmpty()) {
-            // TODO: should we use the original partition expr? remove this later.
-            LOG.warn("Failed to build mv partition expr from base table: " + stmt.getOrigStmt());
-            Pair<Expr, SlotRef> pair = getMVPartitionExpr(mvRefPartitionExpr, stmt);
-            partitionExprMaps.put(pair.first, pair.second);
+    public static LinkedHashMap<Expr, SlotRef> getMVPartitionExprsChecked(List<Expr> mvRefPartitionExprs,
+                                                                          QueryStatement stmt,
+                                                                          List<BaseTableInfo> baseTableInfos) {
+        LinkedHashMap<Expr, SlotRef> mvPartitionExprMaps = Maps.newLinkedHashMap();
+        int refBaseTableCols = -1;
+        for (Expr mvRefPartitionExpr : mvRefPartitionExprs) {
+            List<MVPartitionExpr> partitionExprMaps = getMVPartitionExprs(mvRefPartitionExpr, stmt);
+            if (partitionExprMaps == null) {
+                LOG.warn("The partition expr maps slot ref should be from the base table, eqExprs:{}",
+                        partitionExprMaps);
+                throw new SemanticException("Failed to build mv partition expr from base table: " + stmt.getOrigStmt());
+            }
+            // If mv contains multi partition columns, needs to ensure each partition column refers the same base tables' count.
+            if (refBaseTableCols == -1) {
+                refBaseTableCols = partitionExprMaps.size();
+            } else if (refBaseTableCols != partitionExprMaps.size()) {
+                throw new SemanticException(String.format("The current partition expr maps size %s should be equal to " +
+                        "the size of the first partition expr maps: %s", partitionExprMaps.size(), refBaseTableCols));
+            }
+            partitionExprMaps.stream()
+                            .forEach(eq -> mvPartitionExprMaps.put(eq.getExpr(), eq.getSlotRef()));
         }
         if (baseTableInfos != null) {
-            Set<MVPartitionExpr> mvPartitionExprs = Sets.newHashSet();
+            Set<List<MVPartitionExpr>> mvPartitionExprs = Sets.newHashSet();
             for (BaseTableInfo baseTableInfo : baseTableInfos) {
                 Table table = MvUtils.getTableChecked(baseTableInfo);
-                Optional<MVPartitionExpr> mvPartitionExpr = MvUtils.getMvPartitionExpr(partitionExprMaps, table);
-                if (mvPartitionExpr.isPresent()) {
-                    mvPartitionExprs.add(mvPartitionExpr.get());
+                List<MVPartitionExpr> refPartitionExprs = MvUtils.getMvPartitionExpr(mvPartitionExprMaps, table);
+                if (!refPartitionExprs.isEmpty()) {
+                    mvPartitionExprs.add(refPartitionExprs);
                 }
             }
-            Preconditions.checkState(mvPartitionExprs.size() <= partitionExprMaps.size(),
+            Preconditions.checkState(mvPartitionExprs.size() <= mvPartitionExprMaps.size(),
                     String.format("The size of mv partition exprs %s should be less or equal to the size of " +
-                                    "partition expr maps: %s", mvPartitionExprs, partitionExprMaps));
+                                    "partition expr maps: %s", mvPartitionExprs, mvPartitionExprMaps));
         }
-        return partitionExprMaps;
+        return mvPartitionExprMaps;
     }
 
     /**
@@ -589,9 +590,9 @@ public class MVPartitionExprResolver {
      * which it comes from.
      * Constructs a mapping of partitioned expressions to slot references for join operations in a materialized view.
      */
-    private static Map<Expr, SlotRef> getMVPartitionExprs(Expr partitionExpr,
-                                                          QueryStatement statement) {
-        Map<Expr, SlotRef> eqExprs = Maps.newHashMap();
+    private static List<MVPartitionExpr> getMVPartitionExprs(Expr partitionExpr,
+                                                             QueryStatement statement) {
+        List<MVPartitionExpr> eqExprs = Lists.newArrayList();
         Exprs mvEquivalentExprs = resolveMVPartitionExpr(partitionExpr, statement);
         if (mvEquivalentExprs == null || mvEquivalentExprs.isEmpty()) {
             // no join predicate
@@ -602,9 +603,9 @@ public class MVPartitionExprResolver {
         Map<TableName, EqTableInfo> eqTableInfos = Maps.newHashMap();
         List<MVPartitionExpr> mvEquivalentPartitionExprs = getMVEquivalentPartExpr(mvEquivalentExprs);
         for (MVPartitionExpr eq : mvEquivalentPartitionExprs) {
-            Expr eqExpr = eq.getExpr();
             SlotRef slotRef = eq.getSlotRef();
-            eqExprs.put(eqExpr, slotRef);
+            Expr eqExpr = eq.getExpr();
+            eqExprs.add(eq);
             eqTableInfos.computeIfAbsent(slotRef.getTblNameWithoutAnalyzed(), (ignored) -> new EqTableInfo())
                     .addEqExprs(eqExpr);
         }
@@ -616,18 +617,21 @@ public class MVPartitionExprResolver {
         // t1 join a on t1.k1 = a.k1 join a on t1.k1 = date_trunc(a.k1)
         // t1 join a on t1.k1 = a.k1 join a on t1.k1 = a.k2
         // at least the partition expr should be in mvEquivalentExprsMap
-        eqExprs.entrySet().removeIf(entry -> {
-            TableName tableName = entry.getValue().getTblNameWithoutAnalyzed();
+        for (Iterator<MVPartitionExpr> iter = eqExprs.iterator(); iter.hasNext();) {
+            MVPartitionExpr eq = iter.next();
+            TableName tableName = eq.getSlotRef().getTblNameWithoutAnalyzed();
             EqTableInfo eqTableInfo = eqTableInfos.get(tableName);
             if (eqTableInfo == null) {
-                return false;
+                continue;
             }
             if (eqTableInfo.eqExprs.size() == 0) {
-                return true;
+                iter.remove();
             }
             // only keeps the first one
-            return !eqTableInfo.eqExprs.get(0).equals(entry.getKey());
-        });
+            if (!eqTableInfo.eqExprs.get(0).equals(eq.getExpr())) {
+                iter.remove();
+            }
+        }
         return eqExprs;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionSlotRefResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/analyzer/MVPartitionSlotRefResolver.java
@@ -220,15 +220,15 @@ public class MVPartitionSlotRefResolver {
      */
     private static class WindowFunctionChecker extends AstTraverser<Expr, SlotRef> {
 
-        private CreateMaterializedViewStatement statement;
         private Expr partitionByExpr;
         private final ExprShuttle exprShuttle = new ExprShuttle(this);
 
-        public static void check(CreateMaterializedViewStatement statement, Expr partitionByExpr) {
+        public static void check(CreateMaterializedViewStatement statement, List<Expr> partitionByExprs) {
             WindowFunctionChecker checker = new WindowFunctionChecker();
-            checker.statement = statement;
-            checker.partitionByExpr = partitionByExpr;
-            partitionByExpr.accept(checker.exprShuttle, statement.getQueryStatement().getQueryRelation());
+            for (Expr partitionByExpr : partitionByExprs) {
+                checker.partitionByExpr = partitionByExpr;
+                partitionByExpr.accept(checker.exprShuttle, statement.getQueryStatement().getQueryRelation());
+            }
         }
 
         private void checkWindowFunction(SelectRelation node) {
@@ -290,8 +290,8 @@ public class MVPartitionSlotRefResolver {
         return expr.accept(EXPR_SHUTTLE, queryStatement.getQueryRelation());
     }
 
-    public static void checkWindowFunction(CreateMaterializedViewStatement statement, Expr partitionByExpr) {
-        WindowFunctionChecker.check(statement, partitionByExpr);
+    public static void checkWindowFunction(CreateMaterializedViewStatement statement, List<Expr> partitionByExprs) {
+        WindowFunctionChecker.check(statement, partitionByExprs);
     }
 
     public static Expr resolveExpr(Expr expr, Relation relation) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -250,7 +251,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 try (Timer ignored = Tracers.watchScope("MVRefreshSyncPartitions")) {
                     // sync partitions between materialized view and base tables out of lock
                     // do it outside lock because it is a time-cost operation
-                    syncPartitions();
+                    if (!syncPartitions()) {
+                        LOG.warn("Sync partitions failed for materialized view: {}", materializedView.getName());
+                        return false;
+                    }
                 }
             }
 
@@ -318,7 +322,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         // log mv basic info, it may throw exception if mv is invalid since base table has dropped
         try {
-            LOG.info("Do mv refresh, mv:{}, refBaseTablePartitionExprMap:{}," +
+            LOG.debug("Start to refresh mv:{}, refBaseTablePartitionExprMap:{}," +
                             "refBaseTablePartitionSlotMap:{}, refBaseTablePartitionColumnMap:{}," +
                             "baseTableInfos:{}", materializedView.getName(),
                     materializedView.getRefBaseTablePartitionExprs(), materializedView.getRefBaseTablePartitionSlots(),
@@ -337,8 +341,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
 
         long refreshDurationMs = System.currentTimeMillis() - startRefreshTs;
-        LOG.info("Refresh {} success, cost time(s): {}", materializedView.getName(),
-                DebugUtil.DECIMAL_FORMAT_SCALE_3.format(refreshDurationMs / 1000.0));
+        LOG.info("Refresh {} success, cost time(ms): {}", materializedView.getName(),
+                DebugUtil.DECIMAL_FORMAT_SCALE_3.format(refreshDurationMs));
         mvEntity.updateRefreshDuration(refreshDurationMs);
         return result;
     }
@@ -415,7 +419,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         Map<TableSnapshotInfo, Set<String>> baseTableCandidatePartitions = Maps.newHashMap();
         if (Config.enable_materialized_view_external_table_precise_refresh) {
             try (Timer ignored = Tracers.watchScope("MVRefreshComputeCandidatePartitions")) {
-                syncPartitions();
+                if (!syncPartitions()) {
+                    throw new DmlException(String.format("materialized view %s refresh task failed: sync partition failed",
+                            materializedView.getName()));
+                }
                 Set<String> mvCandidatePartition = checkMvToRefreshedPartitions(context, true);
                 baseTableCandidatePartitions = getRefTableRefreshPartitions(mvCandidatePartition);
             } catch (Exception e) {
@@ -480,6 +487,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      */
     private InsertStmt prepareRefreshPlan(Set<String> mvToRefreshedPartitions, Map<String, Set<String>> refTablePartitionNames)
             throws AnalysisException, LockTimeoutException {
+        long startTime = System.currentTimeMillis();
         // 1. Prepare context
         ConnectContext ctx = mvContext.getCtx();
         ctx.getAuditEventBuilder().reset();
@@ -549,7 +557,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     materializedView.getName(), String.join(",", mvToRefreshedPartitions), refTablePartitionNames);
         }
         mvContext.setExecPlan(execPlan);
-        LOG.info("Finished mv refresh plan for {}", materializedView.getName());
+        LOG.info("Finished mv refresh plan for {}, costs:{}(ms)",
+                materializedView.getName(), System.currentTimeMillis() - startTime);
         return insertStmt;
     }
 
@@ -805,7 +814,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private void updateMeta(Set<String> mvRefreshedPartitions,
                             ExecPlan execPlan,
                             Map<TableSnapshotInfo, Set<String>> refTableAndPartitionNames) {
-        LOG.info("start to update meta for mv:{}", materializedView.getName());
+        LOG.debug("Start to update meta for mv:{}", materializedView.getName());
 
         // check
         Table mv = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), materializedView.getId());
@@ -945,7 +954,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         // do sync partitions (add or drop partitions) for materialized view
         boolean result = mvRefreshPartitioner.syncAddOrDropPartitions();
-        LOG.info("Finish sync mv:{} partitions, cost(ms): {}", materializedView.getName(),
+        LOG.info("Finish sync {} partitions, cost: {}(ms)", materializedView.getName(),
                 stopwatch.elapsed(TimeUnit.MILLISECONDS));
         return result;
     }
@@ -1088,16 +1097,20 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     if (!(mvPartitionInfo.isRangePartition())) {
                         return false;
                     }
-                    Map<Table, Column> partitionTableAndColumn = materializedView.getRefBaseTablePartitionColumns();
+                    Map<Table, List<Column>> partitionTableAndColumns = materializedView.getRefBaseTablePartitionColumns();
                     // For Non-partition based base table, it's not necessary to check the partition changed.
-                    if (!partitionTableAndColumn.containsKey(snapshotTable)) {
+                    if (!partitionTableAndColumns.containsKey(snapshotTable)) {
                         return false;
                     }
-                    Column partitionColumn = partitionTableAndColumn.get(snapshotTable);
+                    List<Column> partitionColumns = partitionTableAndColumns.get(snapshotTable);
+                    Preconditions.checkArgument(partitionColumns.size() == 1,
+                            "Only support one partition column in range partition");
+                    Column partitionColumn = partitionColumns.get(0);
+                    Expr rangePartitionExpr = materializedView.getRangePartitionExpr();
                     Map<String, Range<PartitionKey>> snapshotPartitionMap = PartitionUtil.getPartitionKeyRange(
-                            snapshotTable, partitionColumn, MaterializedView.getPartitionExpr(materializedView));
+                            snapshotTable, partitionColumn, rangePartitionExpr);
                     Map<String, Range<PartitionKey>> currentPartitionMap = PartitionUtil.getPartitionKeyRange(
-                            table, partitionColumn, MaterializedView.getPartitionExpr(materializedView));
+                            table, partitionColumn, rangePartitionExpr);
                     if (SyncPartitionUtils.hasRangePartitionChanged(snapshotPartitionMap, currentPartitionMap)) {
                         return true;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1106,7 +1106,11 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     Preconditions.checkArgument(partitionColumns.size() == 1,
                             "Only support one partition column in range partition");
                     Column partitionColumn = partitionColumns.get(0);
-                    Expr rangePartitionExpr = materializedView.getRangePartitionExpr();
+                    Optional<Expr> rangePartitionExprOpt = materializedView.getRangePartitionFirstExpr();
+                    if (rangePartitionExprOpt.isEmpty()) {
+                        return false;
+                    }
+                    Expr rangePartitionExpr = rangePartitionExprOpt.get();
                     Map<String, Range<PartitionKey>> snapshotPartitionMap = PartitionUtil.getPartitionKeyRange(
                             snapshotTable, partitionColumn, rangePartitionExpr);
                     Map<String, Range<PartitionKey>> currentPartitionMap = PartitionUtil.getPartitionKeyRange(

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
@@ -70,11 +70,8 @@ public class TableSnapshotInfo {
 
     @Override
     public String toString() {
-        return "TableSnapshotInfo{" +
-                "baseTableInfo=" + baseTableInfo +
-                ", baseTable=" + baseTable.getName() +
-                ", refreshedPartitionInfos=" + refreshedPartitionInfos +
-                '}';
+        return "baseTable=" + baseTable.getName() +
+                ", refreshedPartitionInfos=" + refreshedPartitionInfos;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTMetaRepairer.java
@@ -57,7 +57,7 @@ public class MVPCTMetaRepairer {
     public void repairTableIfNeeded(Table table,
                                     BaseTableInfo baseTableInfo) throws DmlException {
         if (baseTableInfo.getTableIdentifier().equals(table.getTableIdentifier())) {
-            LOG.info("base table:{} identifier has not changed, no need to repair",
+            LOG.debug("base table:{} identifier has not changed, no need to repair",
                     baseTableInfo.getTableInfoStr());
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -27,6 +27,7 @@ import com.starrocks.scheduler.TaskRunContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -48,7 +49,7 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
 
     @Override
     public Expr generatePartitionPredicate(Table table, Set<String> refBaseTablePartitionNames,
-                                           Expr mvPartitionSlotRef) {
+                                           List<Expr> mvPartitionSlotRefs) {
         // do nothing
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPlanBuilder.java
@@ -15,7 +15,6 @@ package com.starrocks.scheduler.mv;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -80,12 +79,12 @@ public class MVPCTRefreshPlanBuilder {
         if (table == null || partitionPredicate == null) {
             return;
         }
-        mvPlanBuildMessage.put(table.getName(), partitionPredicate.debugString());
+        mvPlanBuildMessage.put(table.getName(), partitionPredicate.toSql());
     }
 
     private void tracePartitionPredicates(List<Expr> partitionPredicate) {
         mvPlanBuildMessage.put(EXTRA_PREDICATE_KEY,
-                partitionPredicate.stream().map(Expr::debugString).collect(Collectors.joining(",")));
+                partitionPredicate.stream().map(Expr::toSql).collect(Collectors.joining(",")));
     }
 
     public Map<String, String> getPlanBuilderMessage() {
@@ -126,8 +125,8 @@ public class MVPCTRefreshPlanBuilder {
         QueryRelation queryRelation = queryStatement.getQueryRelation();
         List<Expr> extraPartitionPredicates = Lists.newArrayList();
         Multimap<String, TableRelation> tableRelations = AnalyzerUtils.collectAllTableRelation(queryStatement);
-        Map<Table, SlotRef> mvRefBaseTablePartitionSlotRefs = mv.getRefBaseTablePartitionSlots();
-        if (CollectionUtils.sizeIsEmpty(mvRefBaseTablePartitionSlotRefs)) {
+        Map<Table, List<SlotRef>> refBaseTablePartitionSlots = mv.getRefBaseTablePartitionSlots();
+        if (CollectionUtils.sizeIsEmpty(refBaseTablePartitionSlots)) {
             throw new AnalysisException(String.format("MV refresh cannot generate partition predicates " +
                     "because of mv %s contains no ref base table's partitions", mv.getName()));
         }
@@ -155,13 +154,13 @@ public class MVPCTRefreshPlanBuilder {
                         "%s failed: table is null", mv.getName(), tableRelation.getName()));
             }
             // skip it table is not ref base table.
-            if (!mvRefBaseTablePartitionSlotRefs.containsKey(table)) {
+            if (!refBaseTablePartitionSlots.containsKey(table)) {
                 LOG.warn("Skip to generate partition predicate because it's mv direct ref base table:{}, mv:{}, " +
-                        "refBaseTableAndCol: {}", table, mv.getName(), mvRefBaseTablePartitionSlotRefs);
+                        "refBaseTableAndCol: {}", table, mv.getName(), refBaseTablePartitionSlots);
                 continue;
             }
-            SlotRef refTablePartitionSlotRef = mvRefBaseTablePartitionSlotRefs.get(table);
-            if (refTablePartitionSlotRef == null) {
+            List<SlotRef> refTablePartitionSlotRefs = refBaseTablePartitionSlots.get(table);
+            if (CollectionUtils.isEmpty(refTablePartitionSlotRefs)) {
                 throw new AnalysisException(String.format("Generate partition predicate failed: " +
                         "cannot find partition slot ref %s from query relation"));
             }
@@ -171,7 +170,7 @@ public class MVPCTRefreshPlanBuilder {
             // since it will deduce `hasTableHints` to true and causes rewrite failed.
             boolean isPushDownBelowTable = (relations.size() == 1);
             if (isPushDownBelowTable) {
-                boolean ret = pushDownPartitionPredicates(table, tableRelation, refTablePartitionSlotRef,
+                boolean ret = pushDownPartitionPredicates(table, tableRelation, refTablePartitionSlotRefs,
                         tablePartitionNames, isEnableMVRefreshQueryRewrite);
                 if (ret) {
                     numOfPushDownIntoTables += 1;
@@ -191,18 +190,18 @@ public class MVPCTRefreshPlanBuilder {
                 }
                 // Use the mv's partition info ref column to generate incremental partition predicates rather than ref base
                 // table's slot ref since ref base table's partition column may be aliased in the query relation.
-                String mvPartitionInfoRefColName = getMVPartitionInfoRefColumnName();
+                List<String> mvPartitionInfoRefColNames = getMVPartitionInfoRefColumnName();
                 // if it hasn't pushed down into table, add it into the query relation's predicate
-                Expr mvPartitionOutputExpr = getPartitionOutputExpr(queryStatement, mvPartitionInfoRefColName);
-                if (mvPartitionOutputExpr == null) {
+                List<Expr> mvPartitionOutputExprs = getPartitionOutputExpr(queryStatement, mvPartitionInfoRefColNames);
+                if (CollectionUtils.isEmpty(mvPartitionOutputExprs)) {
                     LOG.warn("Fail to generate partition predicates for self-join table because output expr is null, " +
-                            "table: {}, refTablePartitionSlotRef:{}", table.getName(), refTablePartitionSlotRef);
+                            "table: {}, refTablePartitionSlotRef:{}", table.getName(), refTablePartitionSlotRefs);
                     continue;
                 }
-                Expr partitionPredicate = generatePartitionPredicate(table, tablePartitionNames, mvPartitionOutputExpr);
+                Expr partitionPredicate = generatePartitionPredicate(table, tablePartitionNames, mvPartitionOutputExprs);
                 if (partitionPredicate == null) {
                     LOG.warn("Fail to generate partition predicates for self-join table, " +
-                            "table: {}, refTablePartitionSlotRef:{}", table.getName(), refTablePartitionSlotRef);
+                            "table: {}, refTablePartitionSlotRef:{}", table.getName(), refTablePartitionSlotRefs);
                     continue;
                 }
                 hasGenerateNonPushDownPredicates = true;
@@ -242,18 +241,18 @@ public class MVPCTRefreshPlanBuilder {
 
     private boolean pushDownPartitionPredicates(Table table,
                                                 TableRelation tableRelation,
-                                                SlotRef refBaseTablePartitionSlot,
+                                                List<SlotRef> refBaseTablePartitionSlots,
                                                 Set<String> tablePartitionNames,
                                                 boolean isEnableMVRefreshQueryRewrite) throws AnalysisException {
         if (isEnableMVRefreshQueryRewrite) {
             // When `isEnableMVRefreshQueryRewrite` is true, disable push down partition names into scan node since
             // mv rewrite will disable rewrite if table scan contains table partitions/tablets hint.
-            return pushDownByPredicate(table, tableRelation, refBaseTablePartitionSlot, tablePartitionNames);
+            return pushDownByPredicate(table, tableRelation, refBaseTablePartitionSlots, tablePartitionNames);
         } else {
             if (pushDownByPartitionNames(table, tableRelation, tablePartitionNames)) {
                 return true;
             }
-            if (pushDownByPredicate(table, tableRelation, refBaseTablePartitionSlot, tablePartitionNames)) {
+            if (pushDownByPredicate(table, tableRelation, refBaseTablePartitionSlots, tablePartitionNames)) {
                 return true;
             }
             return false;
@@ -278,7 +277,7 @@ public class MVPCTRefreshPlanBuilder {
 
     private boolean pushDownByPredicate(Table table,
                                         TableRelation tableRelation,
-                                        SlotRef refBaseTablePartitionSlot,
+                                        List<SlotRef> refBaseTablePartitionSlots,
                                         Set<String> tablePartitionNames) throws AnalysisException {
         // generate partition predicate for the select relation, so can generate partition predicates
         // for non-ref base tables.
@@ -289,24 +288,29 @@ public class MVPCTRefreshPlanBuilder {
         //  non-ref-base-table  : t2.dt
         // so add partition predicates for select relation when refresh partitions incrementally(eg: dt=20230810):
         // (select * from t1 join t2 on t1.dt = t2.dt) where t1.dt=20230810
-        SlotRef cloned = (SlotRef) refBaseTablePartitionSlot.clone();
-        cloned.setTblName(null);
-        Expr partitionPredicate = generatePartitionPredicate(table,
-                tablePartitionNames, cloned);
-        if (partitionPredicate == null) {
-            LOG.warn("Generate partition predicate failed, table:{}, tablePartitionNames:{}, outputMRefVPartitionExpr:{}",
-                    table, tablePartitionNames, cloned);
-            return false;
-        }
-        // try to push down into table relation
-        final List<SlotRef> slots = ImmutableList.of(cloned);
         Scope tableRelationScope = tableRelation.getScope();
-        if (!canResolveSlotsInTheScope(slots, tableRelationScope)) {
+
+        List<SlotRef> cloneds = Lists.newArrayList();
+        for (SlotRef slotRef : refBaseTablePartitionSlots) {
+            SlotRef cloned = (SlotRef) slotRef.clone();
+            cloned.setTblName(null);
+            cloneds.add(cloned);
+        }
+        if (!canResolveSlotsInTheScope(cloneds, tableRelationScope)) {
             throw new AnalysisException(String.format("Cannot generate partition predicate " +
                             "because cannot find partition slot ref in ref table's scope, refBaseTable:%s, " +
                             "refBaseTablePartitionSlot:%s, tablePartitionNames:%s",
-                    table, cloned, tablePartitionNames));
+                    table, refBaseTablePartitionSlots, tablePartitionNames));
         }
+        // try to push down into table relation
+        List<Expr> mvPartitionExprs = cloneds.stream().map(x -> (Expr) x).collect(Collectors.toList());
+        Expr partitionPredicate = generatePartitionPredicate(table, tablePartitionNames, mvPartitionExprs);
+        if (partitionPredicate == null) {
+            LOG.warn("Generate partition predicate failed, table:{}, tablePartitionNames:{}, outputMRefVPartitionExpr:{}",
+                    table, tablePartitionNames, cloneds);
+            return false;
+        }
+
         LOG.info("Optimize materialized view {} refresh task, push down partition predicate into table " +
                         "relation {},  partition predicate:{} ",
                 mv.getName(), tableRelation.getName(), partitionPredicate.toSql());
@@ -319,19 +323,23 @@ public class MVPCTRefreshPlanBuilder {
      * This is only used to self-joins table for now and to be compatible with before.
      */
     @Deprecated
-    private Expr getPartitionOutputExpr(QueryStatement queryStatement, String mvPartitionInfoRefColName) {
-        if (mvPartitionInfoRefColName == null) {
+    private List<Expr> getPartitionOutputExpr(QueryStatement queryStatement, List<String> mvPartitionInfoRefColNames) {
+        if (CollectionUtils.isEmpty(mvPartitionInfoRefColNames)) {
             LOG.warn("Generate partition predicate failed: " +
                     "mv partition info ref column is null, mv:{}", mv.getName());
             return null;
         }
-        Expr outputPartitionSlot = findPartitionOutputExpr(queryStatement, mvPartitionInfoRefColName);
-        if (outputPartitionSlot == null) {
-            LOG.warn("Generate partition predicate failed: " +
-                    "cannot find partition slot ref {} from query relation", mvPartitionInfoRefColName);
-            return null;
+        List<Expr> mvPartitionExprs = Lists.newArrayList();
+        for (String mvPartitionInfoRefColName : mvPartitionInfoRefColNames) {
+            Expr outputPartitionSlot = findPartitionOutputExpr(queryStatement, mvPartitionInfoRefColName);
+            if (outputPartitionSlot == null) {
+                LOG.warn("Generate partition predicate failed: " +
+                        "cannot find partition slot ref {} from query relation", mvPartitionInfoRefColName);
+                return null;
+            }
+            mvPartitionExprs.add(outputPartitionSlot);
         }
-        return outputPartitionSlot;
+        return mvPartitionExprs;
     }
 
     private Expr findPartitionOutputExpr(QueryStatement queryStatement, String mvPartitionInfoRefColName) {
@@ -368,7 +376,7 @@ public class MVPCTRefreshPlanBuilder {
      *  mv: create mv as select dt as dt1, key1 from table1;
      * then mv partition info ref column name is dt1 rather than dt.
      */
-    private String getMVPartitionInfoRefColumnName() {
+    private List<String> getMVPartitionInfoRefColumnName() {
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (partitionInfo.isExprRangePartitioned()) {
             ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
@@ -378,12 +386,11 @@ public class MVPCTRefreshPlanBuilder {
             exprs.get(0).collect(SlotRef.class, slotRefs);
             // if partitionExpr is FunctionCallExpr, get first SlotRef
             Preconditions.checkState(slotRefs.size() == 1);
-            return slotRefs.get(0).getColumnName();
+            return Lists.newArrayList(slotRefs.get(0).getColumnName());
         } else if (partitionInfo.isListPartition()) {
             ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
             List<Column> partitionColumns = listPartitionInfo.getPartitionColumns(mv.getIdToColumn());
-            Preconditions.checkState(partitionColumns.size() == 1);
-            return partitionColumns.get(0).getName();
+            return partitionColumns.stream().map(col -> col.getName()).collect(Collectors.toList());
         }
         return null;
     }
@@ -396,13 +403,13 @@ public class MVPCTRefreshPlanBuilder {
      * @throws AnalysisException
      */
     private Expr generatePartitionPredicate(Table table, Set<String> tablePartitionNames,
-                                            Expr mvPartitionOutputExpr)
+                                            List<Expr> mvPartitionOutputExprs)
             throws AnalysisException {
         if (tablePartitionNames.isEmpty()) {
             // If the updated partition names are empty, it means that the table should not be refreshed.
             return new BoolLiteral(false);
         }
-        return mvRefreshPartitioner.generatePartitionPredicate(table, tablePartitionNames, mvPartitionOutputExpr);
+        return mvRefreshPartitioner.generatePartitionPredicate(table, tablePartitionNames, mvPartitionOutputExprs);
     }
 
     private void doIfNoPushDownPredicates(int numOfPushDownIntoTables,
@@ -422,7 +429,6 @@ public class MVPCTRefreshPlanBuilder {
 
     /**
      * Check whether to push down predicate expr with the slot refs into the scope.
-     *
      * @param slots : slot refs that are contained in the predicate expr
      * @param scope : scope that try to push down into.
      * @return

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -90,7 +90,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
     public boolean syncAddOrDropPartitions() throws AnalysisException {
         String start = context == null ? null : context.getProperties().get(TaskRun.PARTITION_START);
         String end = context == null ? null : context.getProperties().get(TaskRun.PARTITION_END);
-        Optional<Column> partitionColumnOpt = mv.getPartitionColumn();
+        Optional<Column> partitionColumnOpt = mv.getRangePartitionColumn();
         Preconditions.checkState(partitionColumnOpt.isPresent());
         Column partitionColumn = partitionColumnOpt.get();
         Range<PartitionKey> rangeToInclude = SyncPartitionUtils.createRange(start, end, partitionColumn);
@@ -119,7 +119,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                 mv.getName(), adds);
 
         // used to get partitions to refresh
-        Map<Table, Expr> tableToExprMap = mv.getRefBaseTablePartitionExprs();
+        Map<Table, List<Expr>> tableToExprMap = mv.getRefBaseTablePartitionExprs();
         Map<Table, Map<String, Set<String>>> baseToMvNameRef = RangePartitionDiffer
                 .generateBaseRefMap(result.refBaseTablePartitionMap, tableToExprMap, result.mvRangePartitionMap);
         Map<String, Map<Table, Set<String>>> mvToBaseNameRef = RangePartitionDiffer
@@ -134,7 +134,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
 
     @Override
     public Expr generatePartitionPredicate(Table table, Set<String> refBaseTablePartitionNames,
-                                           Expr mvPartitionSlotRef) throws AnalysisException {
+                                           List<Expr> mvPartitionSlotRefs) throws AnalysisException {
         List<Range<PartitionKey>> sourceTablePartitionRange = Lists.newArrayList();
         for (String partitionName : refBaseTablePartitionNames) {
             sourceTablePartitionRange.add(mvContext.getRefBaseTableRangePartitionMap()
@@ -143,14 +143,16 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         sourceTablePartitionRange = MvUtils.mergeRanges(sourceTablePartitionRange);
         // for nested mv, the base table may be another mv, which is partition by str2date(dt, '%Y%m%d')
         // here we should convert date into '%Y%m%d' format
-        Expr partitionExpr = mv.getPartitionExpr();
-        Map<Table, Column> partitionTableAndColumn = mv.getRefBaseTablePartitionColumns();
+        Expr partitionExpr = mv.getRangePartitionExpr();
+        Map<Table, List<Column>> partitionTableAndColumn = mv.getRefBaseTablePartitionColumns();
         if (!partitionTableAndColumn.containsKey(table)) {
             LOG.warn("Cannot generate mv refresh partition predicate because cannot decide the partition column of table {}," +
                     "partitionTableAndColumn:{}", table.getName(), partitionTableAndColumn);
             return null;
         }
-        boolean isConvertToDate = PartitionUtil.isConvertToDate(partitionExpr, partitionTableAndColumn.get(table));
+        List<Column> refPartitionColumns = partitionTableAndColumn.get(table);
+        Preconditions.checkState(refPartitionColumns.size() == 1);
+        boolean isConvertToDate = PartitionUtil.isConvertToDate(partitionExpr, refPartitionColumns.get(0));
         if (isConvertToDate && partitionExpr instanceof FunctionCallExpr
                 && !sourceTablePartitionRange.isEmpty() && MvUtils.isDateRange(sourceTablePartitionRange.get(0))) {
             Optional<FunctionCallExpr> functionCallExprOpt = getStr2DateExpr(partitionExpr);
@@ -169,6 +171,12 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
             }
             sourceTablePartitionRange = converted;
         }
+        if (mvPartitionSlotRefs.size() != 1) {
+            LOG.warn("Cannot generate mv refresh partition predicate because mvPartitionSlotRefs size is not 1, " +
+                    "mvPartitionSlotRefs:{}", mvPartitionSlotRefs);
+            return null;
+        }
+        Expr mvPartitionSlotRef = mvPartitionSlotRefs.get(0);
         List<Expr> partitionPredicates =
                 MvUtils.convertRange(mvPartitionSlotRef, sourceTablePartitionRange);
         // range contains the min value could be null value
@@ -279,7 +287,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
             String start = mvRefreshParams.getRangeStart();
             String end = mvRefreshParams.getRangeEnd();
             Set<String> result = Sets.newHashSet();
-            Column partitionColumn = materializedView.getPartitionColumn().get();
+            Column partitionColumn = materializedView.getRangePartitionColumn().get();
             Range<PartitionKey> rangeToInclude = createRange(start, end, partitionColumn);
             Map<String, Range<PartitionKey>> rangeMap = materializedView.getValidRangePartitionMap(partitionTTLNumber);
             for (Map.Entry<String, Range<PartitionKey>> entry : rangeMap.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
@@ -81,7 +81,7 @@ public class MVVersionManager {
         if (changedTablePartitionInfos.isEmpty()) {
             return;
         }
-        LOG.info("update meta for mv {} with olap tables:{}, refBaseTableIds:{}", mv.getName(),
+        LOG.info("Update meta for mv {} with olap tables:{}, refBaseTableIds:{}", mv.getName(),
                 changedTablePartitionInfos, refBaseTableIds);
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> currentVersionMap =
                 refreshContext.getBaseTableVisibleVersionMap();
@@ -112,7 +112,7 @@ public class MVVersionManager {
             Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo =
                     currentVersionMap.get(tableId);
             Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = snapshotInfo.getRefreshedPartitionInfos();
-            LOG.info("Update materialized view {} meta for base table {} with partitions info: {}, old partition infos:{}",
+            LOG.debug("Update materialized view {} meta for base table {} with partitions info: {}, old partition infos:{}",
                     mv.getName(), snapshotTable.getName(), partitionInfoMap, currentTablePartitionInfo);
             currentTablePartitionInfo.putAll(partitionInfoMap);
 
@@ -142,7 +142,7 @@ public class MVVersionManager {
         if (changedTablePartitionInfos.isEmpty()) {
             return;
         }
-        LOG.info("update meta for mv {} with external tables:{}, refBaseTableIds:{}", mv.getName(),
+        LOG.info("Update meta for mv {} with external tables:{}, refBaseTableIds:{}", mv.getName(),
                 changedTablePartitionInfos, refBaseTableIds);
         Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> currentVersionMap =
                 refreshContext.getBaseTableInfoVisibleVersionMap();
@@ -172,7 +172,7 @@ public class MVVersionManager {
             currentVersionMap.computeIfAbsent(baseTableInfo, (v) -> Maps.newConcurrentMap());
             Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo = currentVersionMap.get(baseTableInfo);
             Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = snapshotInfo.getRefreshedPartitionInfos();
-            LOG.info("Update materialized view {} meta for external base table {} with partitions info: {}, " +
+            LOG.debug("Update materialized view {} meta for external base table {} with partitions info: {}, " +
                             "old partition infos:{}", mv.getName(), snapshotTable.getName(),
                     partitionInfoMap, currentTablePartitionInfo);
             // overwrite old partition names
@@ -248,7 +248,7 @@ public class MVVersionManager {
         ChangeMaterializedViewRefreshSchemeLog changeRefreshSchemeLog =
                 new ChangeMaterializedViewRefreshSchemeLog(mv);
         GlobalStateMgr.getCurrentState().getEditLog().logMvChangeRefreshScheme(changeRefreshSchemeLog);
-        LOG.info("update edit log after version changed for mv {}, maxChangedTableRefreshTime:{}",
+        LOG.info("Update edit log after version changed for mv {}, maxChangedTableRefreshTime:{}",
                 mv.getName(), maxChangedTableRefreshTime);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -49,7 +49,6 @@ import com.starrocks.alter.AlterJobExecutor;
 import com.starrocks.alter.AlterMVJobExecutor;
 import com.starrocks.alter.MaterializedViewHandler;
 import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.HintNode;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.SetVarHint;
@@ -67,7 +66,6 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.Index;
@@ -254,6 +252,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -3016,9 +3015,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         materializedView.getWarehouseId());
                 materializedView.addPartition(partition);
             } else {
-                Expr partitionExpr = stmt.getPartitionByExpr();
-                Map<Expr, SlotRef> partitionExprMaps = MVPartitionExprResolver.getMVPartitionExprsChecked(partitionExpr,
-                        stmt.getQueryStatement(), stmt.getBaseTableInfos());
+                List<Expr> mvPartitionExprs = stmt.getPartitionByExprs();
+                LinkedHashMap<Expr, SlotRef> partitionExprMaps = MVPartitionExprResolver.getMVPartitionExprsChecked(
+                        mvPartitionExprs, stmt.getQueryStatement(), stmt.getBaseTableInfos());
                 LOG.info("Generate mv {} partition exprs: {}", mvName, partitionExprMaps);
                 materializedView.setPartitionExprMaps(partitionExprMaps);
             }
@@ -3060,30 +3059,31 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     public static PartitionInfo buildPartitionInfo(CreateMaterializedViewStatement stmt) throws DdlException {
-        Expr partitionByExpr = stmt.getPartitionByExpr();
+        List<Expr> partitionByExprs = stmt.getPartitionByExprs();
         PartitionType partitionType = stmt.getPartitionType();
-        if (partitionByExpr != null) {
+        List<Column> mvPartitionColumns = stmt.getPartitionColumns();
+        if (CollectionUtils.isNotEmpty(partitionByExprs)) {
+            if (partitionByExprs.size() != mvPartitionColumns.size()) {
+                throw new DdlException(String.format("Partition by exprs size %s is not equal to partition columns size %s",
+                        partitionByExprs.size(), mvPartitionColumns.size()));
+            }
+
             if (partitionType == PartitionType.LIST) {
-                if (!(partitionByExpr instanceof SlotRef)) {
-                    throw new DdlException("List partition only support partition by slot ref column:"
-                            + partitionByExpr.toSql());
-                }
-                return new ListPartitionInfo(PartitionType.LIST, Collections.singletonList(stmt.getPartitionColumn()));
-            } else {
-                ExpressionPartitionDesc expressionPartitionDesc = new ExpressionPartitionDesc(partitionByExpr);
-                if ((partitionByExpr instanceof FunctionCallExpr)) {
-                    FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionByExpr;
-                    if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)) {
-                        Column partitionColumn = new Column(stmt.getPartitionColumn());
-                        partitionColumn.setType(com.starrocks.catalog.Type.DATE);
-                        return expressionPartitionDesc.toPartitionInfo(
-                                Collections.singletonList(partitionColumn),
-                                Maps.newHashMap(), false);
+                for (Expr partitionByExpr : partitionByExprs) {
+                    if (!(partitionByExpr instanceof SlotRef)) {
+                        throw new DdlException("List partition only support partition by slot ref column:"
+                                + partitionByExpr.toSql());
                     }
                 }
-                return expressionPartitionDesc.toPartitionInfo(
-                        Collections.singletonList(stmt.getPartitionColumn()),
-                        Maps.newHashMap(), false);
+                return new ListPartitionInfo(PartitionType.LIST, mvPartitionColumns);
+            } else {
+                if (partitionByExprs.size() > 1) {
+                    throw new DdlException("Only support one partition column for range partition");
+                }
+
+                Expr partitionByExpr = partitionByExprs.get(0);
+                ExpressionPartitionDesc expressionPartitionDesc = new ExpressionPartitionDesc(partitionByExpr);
+                return expressionPartitionDesc.toPartitionInfo(mvPartitionColumns, Maps.newHashMap(), false);
             }
         } else {
             if (partitionType != PartitionType.UNPARTITIONED && partitionType != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -52,7 +52,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private RefreshSchemeClause refreshSchemeDesc;
 
     // partition by clause which may be list or range partition expr.
-    private final Expr partitionByExpr;
+    private final List<Expr> partitionByExprs;
     // partition type of the mv which is deduced by its referred base table.
     private PartitionType partitionType;
 
@@ -77,9 +77,10 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     // Sink table information
     private List<Column> mvColumnItems = Lists.newArrayList();
     private List<Index> mvIndexes = Lists.newArrayList();
-    private Column partitionColumn;
-    // record expression which related with partition by clause
-    private Expr partitionRefTableExpr;
+    // MV's output columns that are referred by mv's partition expressions
+    private List<Column> partitionColumns;
+    // Ref base table partition expression referred by mv's partition by expressions
+    private List<Expr> partitionRefTableExprs;
 
     // Materialized view's output columns may be different from defined query's output columns.
     // Record the indexes based on materialized view's column output.
@@ -94,7 +95,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
                                            List<IndexDef> indexDefs,
                                            String comment,
                                            RefreshSchemeClause refreshSchemeDesc,
-                                           Expr partitionByExpr,
+                                           List<Expr> partitionByExprs,
                                            DistributionDesc distributionDesc, List<String> sortKeys,
                                            Map<String, String> properties,
                                            QueryStatement queryStatement,
@@ -107,7 +108,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.ifNotExists = ifNotExists;
         this.comment = comment;
         this.refreshSchemeDesc = refreshSchemeDesc;
-        this.partitionByExpr = partitionByExpr;
+        this.partitionByExprs = partitionByExprs;
         this.distributionDesc = distributionDesc;
         this.sortKeys = sortKeys;
         this.properties = properties;
@@ -158,8 +159,8 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     /**
      * Get partition by expr of the mv
      */
-    public Expr getPartitionByExpr() {
-        return partitionByExpr;
+    public List<Expr> getPartitionByExprs() {
+        return partitionByExprs;
     }
 
     /**
@@ -262,20 +263,20 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.baseTableInfos = baseTableInfos;
     }
 
-    public Column getPartitionColumn() {
-        return partitionColumn;
+    public List<Column> getPartitionColumns() {
+        return partitionColumns;
     }
 
-    public void setPartitionColumn(Column partitionColumn) {
-        this.partitionColumn = partitionColumn;
+    public void setPartitionColumns(List<Column> partitionColumns) {
+        this.partitionColumns = partitionColumns;
     }
 
-    public Expr getPartitionRefTableExpr() {
-        return partitionRefTableExpr;
+    public List<Expr> getPartitionRefTableExpr() {
+        return partitionRefTableExprs;
     }
 
-    public void setPartitionRefTableExpr(Expr partitionRefTableExpr) {
-        this.partitionRefTableExpr = partitionRefTableExpr;
+    public void setPartitionRefTableExpr(List<Expr> partitionRefTableExprs) {
+        this.partitionRefTableExprs = partitionRefTableExprs;
     }
 
     public ExecPlan getMaintenancePlan() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffResult.java
@@ -16,7 +16,6 @@ package com.starrocks.sql.common;
 
 import com.starrocks.catalog.Table;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,18 +30,13 @@ public class ListPartitionDiffResult extends PartitionDiffResult {
     // The diff result of partition range between materialized view and base tables
     public final ListPartitionDiff listPartitionDiff;
 
-    // MV partition column ref index for each base table's partition columns
-    public final Map<Table, List<Integer>> refBaseTableRefIdxMap;
-
     public ListPartitionDiffResult(Map<String, PListCell> mvListPartitionMap,
                                    Map<Table, Map<String, PListCell>> refBaseTablePartitionMap,
                                    ListPartitionDiff listPartitionDiff,
-                                   Map<Table, List<Integer>> refBaseTableRefIdxMap,
                                    Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMap) {
         super(refBaseTableMVPartitionMap);
         this.mvListPartitionMap = mvListPartitionMap;
         this.refBaseTablePartitionMap = refBaseTablePartitionMap;
         this.listPartitionDiff = listPartitionDiff;
-        this.refBaseTableRefIdxMap = refBaseTableRefIdxMap;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PListCell.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.common;
 
-import com.google.api.client.util.Lists;
 import com.google.api.client.util.Sets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
@@ -105,21 +104,6 @@ public final class PListCell extends PCell implements Comparable<PListCell> {
      */
     public void addItems(List<List<String>> items) {
         partitionItems.addAll(items);
-    }
-
-    /**
-     * Construct a new partition cell by using selected idx
-     */
-    public PListCell toPListCell(List<Integer> selectColIds) {
-        List<List<String>> partitionItems = Lists.newArrayList();
-        for (List<String> partitionKey : this.partitionItems) {
-            List<String> selectedPartitionKey = Lists.newArrayList();
-            for (Integer i : selectColIds) {
-                selectedPartitionKey.add(partitionKey.get(i));
-            }
-            partitionItems.add(selectedPartitionKey);
-        }
-        return new PListCell(partitionItems);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.PartitionUtil;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -33,31 +34,31 @@ public abstract class PartitionDiffer {
      * @param partitionTableAndColumns the partition table and its partition column
      * @param result the result map
      */
-    public static void collectExternalPartitionNameMapping(Map<Table, Column> partitionTableAndColumns,
+    public static void collectExternalPartitionNameMapping(Map<Table, List<Column>> partitionTableAndColumns,
                                                            Map<Table, Map<String, Set<String>>> result) throws AnalysisException {
-        for (Map.Entry<Table, Column> e1 : partitionTableAndColumns.entrySet()) {
-            Table refBaseTable = e1.getKey();
-            Column refPartitionColumn = e1.getValue();
-            collectExternalBaseTablePartitionMapping(refBaseTable, refPartitionColumn, result);
+        for (Map.Entry<Table, List<Column>> e : partitionTableAndColumns.entrySet()) {
+            Table refBaseTable = e.getKey();
+            List<Column> refPartitionColumns = e.getValue();
+            collectExternalBaseTablePartitionMapping(refBaseTable, refPartitionColumns, result);
         }
     }
 
     /**
      * Collect the external base table's partition name to its intersected materialized view names.
      * @param refBaseTable the base table
-     * @param refTablePartitionColumn the partition column of the base table
+     * @param refTablePartitionColumns the partition column of the base table
      * @param result the result map
      * @throws AnalysisException
      */
     private static void collectExternalBaseTablePartitionMapping(
             Table refBaseTable,
-            Column refTablePartitionColumn,
+            List<Column> refTablePartitionColumns,
             Map<Table, Map<String, Set<String>>> result) throws AnalysisException {
         if (refBaseTable.isNativeTableOrMaterializedView()) {
             return;
         }
         Map<String, Set<String>> mvPartitionNameMap = PartitionUtil.getMVPartitionNameMapOfExternalTable(refBaseTable,
-                refTablePartitionColumn, PartitionUtil.getPartitionNames(refBaseTable));
+                refTablePartitionColumns, PartitionUtil.getPartitionNames(refBaseTable));
         result.put(refBaseTable, mvPartitionNameMap);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -218,24 +218,24 @@ public final class RangePartitionDiffer extends PartitionDiffer {
     /**
      * Collect the ref base table's partition range map.
      * @param mv the materialized view to compute diff
-     * @param basePartitionMaps the external base table's partition name map which to be updated
      * @return the ref base table's partition range map: <ref base table, <partition name, partition range>>
      */
     public static Map<Table, Map<String, Range<PartitionKey>>> syncBaseTablePartitionInfos(MaterializedView mv,
                                                                                            Expr mvPartitionExpr) {
-        Map<Table, Column> partitionTableAndColumn = mv.getRefBaseTablePartitionColumns();
+        Map<Table, List<Column>> partitionTableAndColumn = mv.getRefBaseTablePartitionColumns();
         if (partitionTableAndColumn.isEmpty()) {
             return Maps.newHashMap();
         }
 
         Map<Table, Map<String, Range<PartitionKey>>> refBaseTablePartitionMap = Maps.newHashMap();
         try {
-            for (Map.Entry<Table, Column> entry : partitionTableAndColumn.entrySet()) {
+            for (Map.Entry<Table, List<Column>> entry : partitionTableAndColumn.entrySet()) {
                 Table refBT = entry.getKey();
-                Column refBTPartitionColumn = entry.getValue();
+                List<Column> refBTPartitionColumns = entry.getValue();
+                Preconditions.checkArgument(refBTPartitionColumns.size() == 1);
                 // Collect the ref base table's partition range map.
                 Map<String, Range<PartitionKey>> refTablePartitionKeyMap =
-                        PartitionUtil.getPartitionKeyRange(refBT, refBTPartitionColumn,
+                        PartitionUtil.getPartitionKeyRange(refBT, refBTPartitionColumns.get(0),
                                 mvPartitionExpr);
                 refBaseTablePartitionMap.put(refBT, refTablePartitionKeyMap);
             }
@@ -325,7 +325,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
     public static RangePartitionDiffResult computeRangePartitionDiff(MaterializedView mv,
                                                                      Range<PartitionKey> rangeToInclude,
                                                                      boolean isQueryRewrite) {
-        Expr mvPartitionExpr = mv.getPartitionExpr();
+        Expr mvPartitionExpr = mv.getRangePartitionExpr();
         Map<Table, Map<String, Range<PartitionKey>>> rBTPartitionMap = syncBaseTablePartitionInfos(mv, mvPartitionExpr);
         return computeRangePartitionDiff(mv, rangeToInclude, rBTPartitionMap, isQueryRewrite);
     }
@@ -335,9 +335,9 @@ public final class RangePartitionDiffer extends PartitionDiffer {
             Range<PartitionKey> rangeToInclude,
             Map<Table, Map<String, Range<PartitionKey>>> rBTPartitionMap,
             boolean isQueryRewrite) {
-        Expr mvPartitionExpr = mv.getPartitionExpr();
-        Map<Table, Column> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
-        Preconditions.checkArgument(!refBaseTableAndColumns.isEmpty());
+        Expr mvPartitionExpr = mv.getRangePartitionExpr();
+        Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
+        Preconditions.checkArgument(!refBaseTablePartitionColumns.isEmpty());
         // get the materialized view's partition range map
         Map<String, Range<PartitionKey>> mvRangePartitionMap = mv.getRangePartitionMap();
 
@@ -352,8 +352,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
             try {
                 // Check unaligned partitions, unaligned partitions may cause uncorrected result which is not supported for now.
                 List<RangePartitionDiff> rangePartitionDiffList = Lists.newArrayList();
-                for (Map.Entry<Table, Column> entry : refBaseTableAndColumns.entrySet()) {
-                    Table refBaseTable = entry.getKey();
+                for (Table refBaseTable : refBaseTablePartitionColumns.keySet()) {
                     RangePartitionDiffer differ = RangePartitionDiffer.build(mv, rangeToInclude);
                     rangePartitionDiffList.add(PartitionUtil.getPartitionDiff(mvPartitionExpr,
                             rBTPartitionMap.get(refBaseTable), mvRangePartitionMap, differ));
@@ -384,7 +383,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
             if (!isQueryRewrite) {
                 // To solve multi partition columns' problem of external table, record the mv partition name to all the same
                 // partition names map here.
-                collectExternalPartitionNameMapping(refBaseTableAndColumns, extRBTMVPartitionNameMap);
+                collectExternalPartitionNameMapping(refBaseTablePartitionColumns, extRBTMVPartitionNameMap);
             }
             return new RangePartitionDiffResult(mvRangePartitionMap, rBTPartitionMap,
                     extRBTMVPartitionNameMap, rangePartitionDiff);
@@ -443,7 +442,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
      */
     public static Map<Table, Map<String, Set<String>>> generateBaseRefMap(
             Map<Table, Map<String, Range<PartitionKey>>> baseRangeMap,
-            Map<Table, Expr> basePartitionExprMap,
+            Map<Table, List<Expr>> basePartitionExprMap,
             Map<String, Range<PartitionKey>> mvRangeMap) {
         Map<Table, Map<String, Set<String>>> result = Maps.newHashMap();
         // for each partition of base, find the corresponding partition of mv
@@ -452,7 +451,9 @@ public final class RangePartitionDiffer extends PartitionDiffer {
             Table baseTable = entry.getKey();
             Map<String, Range<PartitionKey>> refreshedPartitionsMap = entry.getValue();
             Preconditions.checkState(basePartitionExprMap.containsKey(baseTable));
-            Expr partitionExpr = basePartitionExprMap.get(baseTable);
+            List<Expr> partitionExprs = basePartitionExprMap.get(baseTable);
+            Preconditions.checkArgument(partitionExprs.size() == 1);
+            Expr partitionExpr = partitionExprs.get(0);
             List<PRangeCellPlus> baseRanges = toPRangeCellPlus(refreshedPartitionsMap, partitionExpr);
             for (PRangeCellPlus baseRange : baseRanges) {
                 int mid = Collections.binarySearch(mvRanges, baseRange);
@@ -488,7 +489,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
      */
     public static Map<String, Map<Table, Set<String>>> generateMvRefMap(
             Map<String, Range<PartitionKey>> mvRangeMap,
-            Map<Table, Expr> basePartitionExprMap,
+            Map<Table, List<Expr>> basePartitionExprMap,
             Map<Table, Map<String, Range<PartitionKey>>> baseRangeMap) {
         Map<String, Map<Table, Set<String>>> result = Maps.newHashMap();
         // for each partition of mv, find all corresponding partition of base
@@ -502,7 +503,9 @@ public final class RangePartitionDiffer extends PartitionDiffer {
             Map<String, Range<PartitionKey>> refreshedPartitionsMap = entry.getValue();
 
             Preconditions.checkState(basePartitionExprMap.containsKey(baseTable));
-            Expr partitionExpr = basePartitionExprMap.get(baseTable);
+            List<Expr> partitionExprs = basePartitionExprMap.get(baseTable);
+            Preconditions.checkArgument(partitionExprs.size() == 1);
+            Expr partitionExpr = partitionExprs.get(0);
             List<PRangeCellPlus> baseRanges = toPRangeCellPlus(refreshedPartitionsMap, partitionExpr);
             baseRangesMap.put(entry.getKey(), baseRanges);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -48,6 +48,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.common.mv.MVRangePartitionMapper;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -749,6 +750,14 @@ public class SyncPartitionUtils {
             return;
         }
         if (StringUtils.isEmpty(tableName.getCatalog()) || InternalCatalog.isFromDefault(tableName)) {
+            return;
+        }
+        List<Expr> mvPartitionRefTableExprs = mv.getPartitionRefTableExprs();
+        if (CollectionUtils.isEmpty(mvPartitionRefTableExprs)) {
+            return;
+        }
+        // TODO: support multiple partition columns
+        if (mvPartitionRefTableExprs.size() > 1) {
             return;
         }
         Expr expr = mv.getPartitionRefTableExprs().get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -46,6 +46,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -373,7 +374,11 @@ public class MaterializationContext {
                 if (!partitionInfo.isRangePartition()) {
                     return LOWEST_ORDERING;
                 }
-                Expr mvPartitionExpr = mv.getRangePartitionExpr();
+                Optional<Expr> mvPartitionExprOpt = mv.getRangePartitionFirstExpr();
+                if (mvPartitionExprOpt.isEmpty()) {
+                    return LOWEST_ORDERING;
+                }
+                Expr mvPartitionExpr = mvPartitionExprOpt.get();
                 if (mvPartitionExpr == null || !(mvPartitionExpr instanceof FunctionCallExpr)) {
                     return LOWEST_ORDERING;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -373,7 +373,7 @@ public class MaterializationContext {
                 if (!partitionInfo.isRangePartition()) {
                     return LOWEST_ORDERING;
                 }
-                Expr mvPartitionExpr = mv.getPartitionExpr();
+                Expr mvPartitionExpr = mv.getRangePartitionExpr();
                 if (mvPartitionExpr == null || !(mvPartitionExpr instanceof FunctionCallExpr)) {
                     return LOWEST_ORDERING;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedTimeSeriesRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedTimeSeriesRewriter.java
@@ -134,7 +134,11 @@ public class AggregatedTimeSeriesRewriter extends MaterializedViewRewriter {
         if (!partitionInfo.isRangePartition()) {
             return false;
         }
-        Expr mvPartitionExpr = mv.getRangePartitionExpr();
+        Optional<Expr> mvPartitionExprOpt = mv.getRangePartitionFirstExpr();
+        if (mvPartitionExprOpt.isEmpty()) {
+            return false;
+        }
+        Expr mvPartitionExpr = mvPartitionExprOpt.get();
         if (mvPartitionExpr == null || !(mvPartitionExpr instanceof FunctionCallExpr)) {
             return false;
         }
@@ -523,7 +527,11 @@ public class AggregatedTimeSeriesRewriter extends MaterializedViewRewriter {
         if (!partitionInfo.isExprRangePartitioned()) {
             return null;
         }
-        Expr partitionExpr = mv.getRangePartitionExpr();
+        Optional<Expr> partitionExprOpt = mv.getRangePartitionFirstExpr();
+        if (partitionExprOpt.isEmpty()) {
+            return null;
+        }
+        Expr partitionExpr = partitionExprOpt.get();
         if (partitionExpr == null || !(partitionExpr instanceof FunctionCallExpr)) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1495,21 +1495,18 @@ public class MvUtils {
      * @param table             the base table to find the specific partition expr
      * @return the mv partition expr if found, otherwise empty
      */
-    public static Optional<MVPartitionExpr> getMvPartitionExpr(Map<Expr, SlotRef> partitionExprMaps, Table table) {
+    public static List<MVPartitionExpr> getMvPartitionExpr(Map<Expr, SlotRef> partitionExprMaps, Table table) {
         if (partitionExprMaps == null || partitionExprMaps.isEmpty() || table == null) {
-            return Optional.empty();
+            return null;
         }
         return partitionExprMaps.entrySet().stream()
                 .filter(entry -> SRStringUtils.areTableNamesEqual(table, entry.getValue().getTblNameWithoutAnalyzed().getTbl()))
                 .map(entry -> new MVPartitionExpr(entry.getKey(), entry.getValue()))
-                .findFirst();
+                .collect(Collectors.toList());
     }
 
     /**
-     * Get the column by slot ref from table's columns
-     *
-     * @param columns base table's columns
-     * @param slotRef the base table's partition slot ref to find
+     * Get the column by slot ref from table's columns.
      * @return the column if found, otherwise empty
      */
     public static Optional<Column> getColumnBySlotRef(List<Column> columns, SlotRef slotRef) {
@@ -1530,15 +1527,35 @@ public class MvUtils {
         return baseTableInfos.stream().map(BaseTableInfo::getReadableString).collect(Collectors.joining(","));
     }
 
-    public static ScalarOperator convertPartitionKeysToListPredicate(ScalarOperator partitionColRef,
+    public static ScalarOperator convertPartitionKeysToListPredicate(List<ScalarOperator> partitionColRefs,
                                                                      Collection<PartitionKey> partitionRanges) {
         List<ScalarOperator> values = Lists.newArrayList();
-        for (PartitionKey partitionKey : partitionRanges) {
-            LiteralExpr literalExpr = partitionKey.getKeys().get(0);
-            ConstantOperator upperBound = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
-            values.add(upperBound);
+        if (partitionColRefs.size() == 1) {
+            for (PartitionKey partitionKey : partitionRanges) {
+                List<LiteralExpr> literalExprs = partitionKey.getKeys();
+                Preconditions.checkArgument(literalExprs.size() == partitionColRefs.size());
+                LiteralExpr literalExpr = literalExprs.get(0);
+                ConstantOperator upperBound = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
+                values.add(upperBound);
+            }
+            return MvUtils.convertToInPredicate(partitionColRefs.get(0), values);
+        } else {
+            for (PartitionKey partitionKey : partitionRanges) {
+                List<LiteralExpr> literalExprs = partitionKey.getKeys();
+                Preconditions.checkArgument(literalExprs.size() == partitionColRefs.size());
+                // TODO: use row operator instead
+                List<ScalarOperator> predicates = Lists.newArrayList();
+                for (int i = 0; i < literalExprs.size(); i++) {
+                    ScalarOperator partitionColRef = partitionColRefs.get(i);
+                    LiteralExpr literalExpr = literalExprs.get(i);
+                    ConstantOperator upperBound = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
+                    ScalarOperator eq = new BinaryPredicateOperator(BinaryType.EQ, partitionColRef, upperBound);
+                    predicates.add(eq);
+                }
+                values.add(Utils.compoundAnd(predicates));
+            }
+            return Utils.compoundOr(values);
         }
-        return MvUtils.convertToInPredicate(partitionColRef, values);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -82,7 +82,7 @@ public class OptExpressionDuplicator {
     private final ReplaceColumnRefRewriter rewriter;
     private final boolean partialPartitionRewrite;
     private final OptimizerContext optimizerContext;
-    private final Map<Table, Column> mvRefBaseTableColumns;
+    private final Map<Table, List<Column>> mvRefBaseTableColumns;
 
     public OptExpressionDuplicator(MaterializationContext materializationContext) {
         this.columnRefFactory = materializationContext.getQueryRefFactory();
@@ -259,11 +259,13 @@ public class OptExpressionDuplicator {
                 LogicalOlapScanOperator olapScan = (LogicalOlapScanOperator) optExpression.getOp();
                 OlapTable table = (OlapTable) olapScan.getTable();
                 if (mvRefBaseTableColumns.containsKey(table)) {
-                    Column partitionColumn = mvRefBaseTableColumns.get(table);
-                    if (!columnRefOperatorColumnMap.containsValue(partitionColumn) &&
-                            newColumnMetaToColRefMap.containsKey(partitionColumn)) {
-                        ColumnRefOperator partitionColumnRef = newColumnMetaToColRefMap.get(partitionColumn);
-                        columnRefColumnMapBuilder.put(partitionColumnRef, partitionColumn);
+                    List<Column> partitionColumns = mvRefBaseTableColumns.get(table);
+                    for (Column partitionColumn : partitionColumns) {
+                        if (!columnRefOperatorColumnMap.containsValue(partitionColumn) &&
+                                newColumnMetaToColRefMap.containsKey(partitionColumn)) {
+                            ColumnRefOperator partitionColumnRef = newColumnMetaToColRefMap.get(partitionColumn);
+                            columnRefColumnMapBuilder.put(partitionColumnRef, partitionColumn);
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
@@ -102,8 +102,8 @@ public class MVCompensationBuilder {
         }
 
         MaterializedView mv = mvContext.getMv();
-        Map<Table, Column> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
-        if (CollectionUtils.sizeIsEmpty(refBaseTableAndColumns)) {
+        Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
+        if (CollectionUtils.sizeIsEmpty(refBaseTablePartitionColumns)) {
             logMVRewrite("MV's not partitioned, failed to get partition keys: {}", mv.getName());
             return MVCompensation.createUnkownState(sessionVariable);
         }
@@ -111,7 +111,7 @@ public class MVCompensationBuilder {
         Map<Table, BaseCompensation<?>> compensations = Maps.newHashMap();
         for (LogicalScanOperator scanOperator : scanOperators) {
             Table refBaseTable = scanOperator.getTable();
-            if (!refBaseTableAndColumns.containsKey(refBaseTable)) {
+            if (!refBaseTablePartitionColumns.containsKey(refBaseTable)) {
                 continue;
             }
             // If the ref table contains no partitions to refresh, no need compensate.
@@ -151,8 +151,8 @@ public class MVCompensationBuilder {
         }
 
         MaterializedView mv = mvContext.getMv();
-        Map<Table, Column> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
-        if (CollectionUtils.sizeIsEmpty(refBaseTableAndColumns)) {
+        Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
+        if (CollectionUtils.sizeIsEmpty(refBaseTablePartitionColumns)) {
             logMVRewrite("MV's not partitioned, failed to get partition keys: {}", mv.getName());
             return MVCompensation.createUnkownState(sessionVariable);
         }
@@ -160,7 +160,7 @@ public class MVCompensationBuilder {
         Map<Table, MvBaseTableUpdateInfo> baseTableUpdateInfoMap = mvUpdateInfo.getBaseTableUpdateInfos();
         for (Map.Entry<Table, MvBaseTableUpdateInfo> e : baseTableUpdateInfoMap.entrySet()) {
             Table refBaseTable = e.getKey();
-            if (!refBaseTableAndColumns.containsKey(refBaseTable)) {
+            if (!refBaseTablePartitionColumns.containsKey(refBaseTable)) {
                 continue;
             }
             // If the ref table contains no partitions to refresh, no need compensate.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/OptCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/OptCompensator.java
@@ -32,13 +32,13 @@ import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import org.apache.iceberg.Snapshot;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.operator.OpRuleBit.OP_PARTITION_PRUNED;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.SUPPORTED_PARTITION_COMPENSATE_EXTERNAL_SCAN_TYPES;
@@ -114,17 +114,17 @@ public class OptCompensator extends OptExpressionVisitor<OptExpression, Void> {
 
         // NOTE: This is necessary because iceberg's physical plan will not use selectedPartitionIds to
         // prune partitions.
-        final Map<Table, Column> partitionTableAndColumns = mv.getRefBaseTablePartitionColumns();
-        if (partitionTableAndColumns == null || !partitionTableAndColumns.containsKey(refBaseTable)) {
+        final Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
+        if (refBaseTablePartitionColumns == null || !refBaseTablePartitionColumns.containsKey(refBaseTable)) {
             return scanOperator;
         }
-        Column refBaseTablePartitionCol = partitionTableAndColumns.get(refBaseTable);
-        Preconditions.checkState(refBaseTablePartitionCol != null);
-        ColumnRefOperator partitionColumnRef = scanOperator.getColumnReference(refBaseTablePartitionCol);
-        Preconditions.checkState(partitionColumnRef != null);
-
-        ScalarOperator externalExtraPredicate = convertPartitionKeysToListPredicate(partitionColumnRef,
-                partitionKeys);
+        List<Column> refBaseTablePartitionCols = refBaseTablePartitionColumns.get(refBaseTable);
+        Preconditions.checkState(refBaseTablePartitionCols != null);
+        List<ScalarOperator> partitionColumnRefs = refBaseTablePartitionCols
+                .stream()
+                .map(col -> scanOperator.getColumnReference(col))
+                .collect(Collectors.toList());
+        ScalarOperator externalExtraPredicate = convertPartitionKeysToListPredicate(partitionColumnRefs, partitionKeys);
         Preconditions.checkState(externalExtraPredicate != null);
         externalExtraPredicate.setRedundant(true);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1881,7 +1881,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
         RefreshSchemeClause refreshSchemeDesc = null;
         Map<String, String> properties = new HashMap<>();
-        Expr partitionByExpr = null;
+        List<Expr> partitionByExprs = null;
         DistributionDesc distributionDesc = null;
         List<String> sortKeys = null;
 
@@ -1908,21 +1908,27 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             }
 
             // process partition by
-            if (desc.primaryExpression() != null) {
-                if (partitionByExpr != null) {
+            if (desc.mvPartitionExprs() != null) {
+                if (partitionByExprs != null) {
                     throw new ParsingException(PARSER_ERROR_MSG.duplicatedClause("PARTITION", "building materialized view"),
                             clausePos);
                 }
-                Expr expr = (Expr) visit(desc.primaryExpression());
-                if (expr instanceof SlotRef) {
-                    partitionByExpr = expr;
-                } else if (expr instanceof FunctionCallExpr) {
-                    AnalyzerUtils.checkAndExtractPartitionCol((FunctionCallExpr) expr, null,
-                            AnalyzerUtils.MV_DATE_TRUNC_SUPPORTED_PARTITION_FORMAT);
-                    partitionByExpr = expr;
-                } else {
-                    throw new ParsingException(PARSER_ERROR_MSG.unsupportedExprWithInfo(expr.toSql(), "PARTITION BY"),
-                            expr.getPos());
+                partitionByExprs = Lists.newArrayList();
+                List<StarRocksParser.PrimaryExpressionContext> primaryExpressionContexts =
+                        desc.mvPartitionExprs().primaryExpression();
+
+                for (var primaryExpression : primaryExpressionContexts) {
+                    Expr expr = (Expr) visit(primaryExpression);
+                    if (expr instanceof SlotRef) {
+                        partitionByExprs.add(expr);
+                    } else if (expr instanceof FunctionCallExpr) {
+                        AnalyzerUtils.checkAndExtractPartitionCol((FunctionCallExpr) expr, null,
+                                AnalyzerUtils.MV_DATE_TRUNC_SUPPORTED_PARTITION_FORMAT);
+                        partitionByExprs.add(expr);
+                    } else {
+                        throw new ParsingException(PARSER_ERROR_MSG.unsupportedExprWithInfo(expr.toSql(), "PARTITION BY"),
+                                expr.getPos());
+                    }
                 }
             }
 
@@ -1953,9 +1959,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             }
         }
         if (refreshSchemeDesc instanceof SyncRefreshSchemeDesc) {
-            if (partitionByExpr != null) {
+            if (CollectionUtils.isNotEmpty(partitionByExprs)) {
                 throw new ParsingException(PARSER_ERROR_MSG.forbidClauseInMV("SYNC refresh type", "PARTITION BY"),
-                        partitionByExpr.getPos());
+                        partitionByExprs.get(0));
             }
             if (distributionDesc != null) {
                 throw new ParsingException(PARSER_ERROR_MSG.forbidClauseInMV("SYNC refresh type", "DISTRIBUTION BY"),
@@ -1976,7 +1982,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 context.indexDesc() == null ? null : getIndexDefs(context.indexDesc()),
                 comment,
                 refreshSchemeDesc,
-                partitionByExpr, distributionDesc, sortKeys, properties, queryStatement, queryStartIndex,
+                partitionByExprs, distributionDesc, sortKeys, properties, queryStatement, queryStartIndex,
                 createPos(context));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -643,8 +643,13 @@ createMaterializedViewStatement
     AS queryStatement
     ;
 
+mvPartitionExprs:
+    primaryExpression
+    | '(' primaryExpression (',' primaryExpression)* ')'
+    ;
+
 materializedViewDesc
-    : (PARTITION BY primaryExpression)
+    : (PARTITION BY mvPartitionExprs)
     | distributionDesc
     | orderByDesc
     | refreshSchemeDesc

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MVPartitionExprResolverTest.java
@@ -233,7 +233,8 @@ public class MVPartitionExprResolverTest extends MVRefreshTestBase {
 
     private Map<Expr, SlotRef> checkMVPartitionExprs(String sql, Expr slot, int expect) {
         QueryStatement query = getQueryStatement(sql);
-        Map<Expr, SlotRef> result = MVPartitionExprResolver.getMVPartitionExprsChecked(slot, query, null);
+        Map<Expr, SlotRef> result = MVPartitionExprResolver.getMVPartitionExprsChecked(
+                Lists.newArrayList(slot), query, null);
         Assert.assertEquals(expect, result.size());
         return result;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -286,7 +286,7 @@ public class MaterializedViewTest {
         MaterializedView oldMv = (MaterializedView) table;
         Assert.assertTrue(oldMv.getRefreshScheme().isAsync());
         Assert.assertTrue(oldMv.getRefreshScheme().toString().contains("MvRefreshScheme"));
-        Map<Table, Column> partitionMap = oldMv.getRefBaseTablePartitionColumns();
+        Map<Table, List<Column>> partitionMap = oldMv.getRefBaseTablePartitionColumns();
         Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         Assert.assertTrue(partitionMap.containsKey(table1));
         List<Table.TableType> baseTableType = oldMv.getBaseTableTypes();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MIcebergTable.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MIcebergTable.java
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.apache.iceberg.Schema;
+
+import java.io.IOException;
+import java.util.List;
+
+public abstract class MIcebergTable {
+    abstract String getTableName();
+
+    abstract TestTables.TestTable getTestTable(Schema schema) throws IOException;
+
+    abstract List<String> getTransformTablePartitionNames(String tblName);
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MIcebergTableMeta.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MIcebergTableMeta.java
@@ -1,0 +1,174 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.connector.iceberg.MockIcebergMetadata.MOCKED_PARTITIONED_TRANSFORMS_DB_NAME;
+import static com.starrocks.connector.iceberg.MockIcebergMetadata.getStarRocksHome;
+
+public class MIcebergTableMeta {
+
+    // multi partition columns: id, data, hour(ts)
+    public static final MIcebergTable T0_MULTI_HOUR = new MIcebergTable() {
+        @Override
+        public String getTableName() {
+            return "t0_multi_hour";
+        }
+
+        @Override
+        public TestTables.TestTable getTestTable(Schema schema) throws IOException {
+            PartitionSpec spec =
+                    PartitionSpec.builderFor(schema)
+                            .identity("id")
+                            .identity("data")
+                            .hour("ts")
+                            .build();
+            String tableName = getTableName();
+            return TestTables.create(
+                    new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                            + tableName), tableName, schema, spec, 1);
+        }
+
+        @Override
+        public List<String> getTransformTablePartitionNames(String tblName) {
+            return Lists.newArrayList("id=1/data=a/ts_hour=2022-01-01-00", "id=2/data=a/ts_year=2022-01-01-01");
+        }
+    };
+
+    // multi partition columns: id, data, day(ts)
+    public static final MIcebergTable T0_MULTI_DAY = new MIcebergTable() {
+        @Override
+        public String getTableName() {
+            return "t0_multi_day";
+        }
+
+        @Override
+        public TestTables.TestTable getTestTable(Schema schema) throws IOException {
+            PartitionSpec spec =
+                    PartitionSpec.builderFor(schema)
+                            .identity("id")
+                            .identity("data")
+                            .day("ts")
+                            .build();
+            String tableName = getTableName();
+            return TestTables.create(
+                    new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                            + tableName), tableName, schema, spec, 1);
+        }
+
+        @Override
+        public List<String> getTransformTablePartitionNames(String tblName) {
+            return Lists.newArrayList("id=1/data=a/ts_day=2022-01-01", "id=2/data=a/ts_day=2022-01-02");
+        }
+    };
+
+    // multi partition columns: id, data, month(ts)
+    public static final MIcebergTable T0_MULTI_MONTH = new MIcebergTable() {
+        @Override
+        public String getTableName() {
+            return "t0_multi_month";
+        }
+
+        @Override
+        public TestTables.TestTable getTestTable(Schema schema) throws IOException {
+            PartitionSpec spec =
+                    PartitionSpec.builderFor(schema)
+                            .identity("id")
+                            .identity("data")
+                            .month("ts")
+                            .build();
+            String tableName = getTableName();
+            return TestTables.create(
+                    new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                            + tableName), tableName, schema, spec, 1);
+        }
+
+        @Override
+        public List<String> getTransformTablePartitionNames(String tblName) {
+            return Lists.newArrayList("id=1/data=a/ts_month=2022-01", "id=2/data=a/ts_month=2022-02");
+        }
+    };
+
+    // multi partition columns: id, data, year(ts)
+    public static final MIcebergTable T0_MULTI_YEAR = new MIcebergTable() {
+        @Override
+        public String getTableName() {
+            return "t0_multi_year";
+        }
+
+        @Override
+        public TestTables.TestTable getTestTable(Schema schema) throws IOException {
+            PartitionSpec spec =
+                    PartitionSpec.builderFor(schema)
+                            .identity("id")
+                            .identity("data")
+                            .year("ts")
+                            .build();
+            String tableName = getTableName();
+            return TestTables.create(
+                    new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                            + tableName), tableName, schema, spec, 1);
+        }
+
+        @Override
+        public List<String> getTransformTablePartitionNames(String tblName) {
+            return Lists.newArrayList("id=1/data=a/ts_year=2024", "id=2/data=a/ts_year=2024");
+        }
+    };
+
+    // multi partition columns: id, data, bucket(ts, 10)
+    public static final MIcebergTable T0_MULTI_BUCKET = new MIcebergTable() {
+        @Override
+        public String getTableName() {
+            return "t0_multi_bucket";
+        }
+
+        @Override
+        public TestTables.TestTable getTestTable(Schema schema) throws IOException {
+            PartitionSpec spec =
+                    PartitionSpec.builderFor(schema)
+                            .identity("id")
+                            .identity("data")
+                            .bucket("ts", 10)
+                            .build();
+            String tableName = getTableName();
+            return TestTables.create(
+                    new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                            + tableName), tableName, schema, spec, 1);
+        }
+
+        @Override
+        public List<String> getTransformTablePartitionNames(String tblName) {
+            return Lists.newArrayList("id=1/data=a/ts_bucket=0", "id=2/data=a/ts_bucket=1");
+        }
+    };
+
+    public static Map<String, MIcebergTable> MOCKED_ICEBERG_TABLES = ImmutableMap.<String, MIcebergTable>builder()
+            .put(T0_MULTI_HOUR.getTableName(), T0_MULTI_HOUR)
+            .put(T0_MULTI_DAY.getTableName(), T0_MULTI_DAY)
+            .put(T0_MULTI_MONTH.getTableName(), T0_MULTI_MONTH)
+            .put(T0_MULTI_YEAR.getTableName(), T0_MULTI_YEAR)
+            .put(T0_MULTI_BUCKET.getTableName(), T0_MULTI_BUCKET)
+            .build();
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -330,10 +330,11 @@ public class MaterializedViewTestBase extends PlanTestBase {
     }
 
     public static Pair<Table, Column> getRefBaseTablePartitionColumn(MaterializedView mv) {
-        Map<Table, Column> result = mv.getRefBaseTablePartitionColumns();
+        Map<Table, List<Column>> result = mv.getRefBaseTablePartitionColumns();
         Assert.assertTrue(result.size() == 1);
-        Map.Entry<Table, Column> e = result.entrySet().iterator().next();
-        return Pair.create(e.getKey(), e.getValue());
+        Map.Entry<Table, List<Column>> e = result.entrySet().iterator().next();
+        Assert.assertEquals(1, e.getValue().size());
+        return Pair.create(e.getKey(), e.getValue().get(0));
     }
 
     public String getQueryPlan(String query) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -1296,4 +1296,18 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
             Assert.fail(e.getMessage());
         }
     }
+
+    @Test
+    public void testCreateMVWithMultiPartitionColumns() {
+        starRocksAssert.withTable(T3, () -> {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                    "partition by (province, dt) \n" +
+                    "REFRESH DEFERRED MANUAL \n" +
+                    "properties ('partition_refresh_number' = '-1')" +
+                    "as select dt, province, sum(age) from t3 group by dt, province;");
+            MaterializedView mv = starRocksAssert.getMv("test", "mv1");
+            refreshMV("test", mv);
+            starRocksAssert.dropMaterializedView("mv1");
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -22,9 +22,13 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -195,144 +199,149 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
     }
 
     @Test
-    public void testCreatePartitionedMVForIcebergWithPartitionTransform() throws Exception {
+    public void testCreatePartitionedMVForIcebergWithPartitionTransform1() throws Exception {
         // test partition by year(ts)
-        {
-            String mvName = "iceberg_year_mv1";
-            starRocksAssert.useDatabase("test")
-                        .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_year_mv1`\n" +
-                                    "PARTITION BY ts\n" +
-                                    "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                                    "REFRESH DEFERRED MANUAL\n" +
-                                    "PROPERTIES (\n" +
-                                    "\"replication_num\" = \"1\",\n" +
-                                    "\"storage_medium\" = \"HDD\"\n" +
-                                    ")\n" +
-                                    "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year` as a;");
+        String mvName = "iceberg_year_mv1";
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_year_mv1`\n" +
+                        "PARTITION BY ts\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year` as a;");
 
-            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-            MaterializedView partitionedMaterializedView =
-                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getTable(testDb.getFullName(), "iceberg_year_mv1"));
-            triggerRefreshMv(testDb, partitionedMaterializedView);
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "iceberg_year_mv1"));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
 
-            Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
-            Assert.assertEquals(5, partitions.size());
-            List<String> partitionNames = ImmutableList.of("p20190101000000", "p20200101000000", "p20210101000000",
-                        "p20220101000000", "p20230101000000");
-            Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(5, partitions.size());
+        List<String> partitionNames = ImmutableList.of("p20190101000000", "p20200101000000", "p20210101000000",
+                "p20220101000000", "p20230101000000");
+        Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
 
-            MockIcebergMetadata mockIcebergMetadata =
-                        (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
-                                    getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
-            mockIcebergMetadata.updatePartitions("partitioned_transforms_db", "t0_year",
-                        ImmutableList.of("ts_year=2020"));
-            // refresh only one partition
-            Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
-            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-            initAndExecuteTaskRun(taskRun);
-            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
-                        taskRun.getProcessor();
+        MockIcebergMetadata mockIcebergMetadata =
+                (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
+                        getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
+        mockIcebergMetadata.updatePartitions("partitioned_transforms_db", "t0_year",
+                ImmutableList.of("ts_year=2020"));
+        // refresh only one partition
+        Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        initAndExecuteTaskRun(taskRun);
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                taskRun.getProcessor();
 
-            MvTaskRunContext mvContext = processor.getMvContext();
-            ExecPlan execPlan = mvContext.getExecPlan();
-            assertPlanContains(execPlan, "3: ts >= '2020-01-01 00:00:00', 3: ts < '2021-01-01 00:00:00'");
+        MvTaskRunContext mvContext = processor.getMvContext();
+        ExecPlan execPlan = mvContext.getExecPlan();
+        System.out.println(execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL));
+        assertPlanContains(execPlan, "3: ts >= '2020-01-01 00:00:00', 3: ts < '2021-01-01 00:00:00'");
 
-            // test rewrite
-            starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year`")
-                        .explainContains(mvName);
-            starRocksAssert.dropMaterializedView(mvName);
-        }
+        // test rewrite
+        starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year`")
+                .explainContains(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreatePartitionedMVForIcebergWithPartitionTransform2() throws Exception {
         // test partition by month(ts)
-        {
-            String mvName = "iceberg_month_mv1";
-            starRocksAssert.useDatabase("test")
-                        .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_month_mv1`\n" +
-                                    "PARTITION BY ts\n" +
-                                    "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                                    "REFRESH DEFERRED MANUAL\n" +
-                                    "PROPERTIES (\n" +
-                                    "\"replication_num\" = \"1\",\n" +
-                                    "\"storage_medium\" = \"HDD\"\n" +
-                                    ")\n" +
-                                    "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` as a;");
+        String mvName = "iceberg_month_mv1";
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_month_mv1`\n" +
+                        "PARTITION BY ts\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` as a;");
 
-            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-            MaterializedView partitionedMaterializedView =
-                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getTable(testDb.getFullName(), "iceberg_month_mv1"));
-            triggerRefreshMv(testDb, partitionedMaterializedView);
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "iceberg_month_mv1"));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
 
-            Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
-            Assert.assertEquals(5, partitions.size());
-            List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220201000000", "p20220301000000",
-                        "p20220401000000", "p20220501000000");
-            Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
-            // test rewrite
-            starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month`")
-                        .explainContains(mvName);
-            starRocksAssert.dropMaterializedView(mvName);
-        }
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(5, partitions.size());
+        List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220201000000", "p20220301000000",
+                "p20220401000000", "p20220501000000");
+        Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
+        // test rewrite
+        starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month`")
+                .explainContains(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreatePartitionedMVForIcebergWithPartitionTransform3() throws Exception {
         // test partition by day(ts)
-        {
-            String mvName = "iceberg_day_mv1";
-            starRocksAssert.useDatabase("test")
-                        .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_day_mv1`\n" +
-                                    "PARTITION BY ts\n" +
-                                    "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                                    "REFRESH DEFERRED MANUAL\n" +
-                                    "PROPERTIES (\n" +
-                                    "\"replication_num\" = \"1\",\n" +
-                                    "\"storage_medium\" = \"HDD\"\n" +
-                                    ")\n" +
-                                    "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day` as a;");
+        String mvName = "iceberg_day_mv1";
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_day_mv1`\n" +
+                        "PARTITION BY ts\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day` as a;");
 
-            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-            MaterializedView partitionedMaterializedView =
-                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getTable(testDb.getFullName(), "iceberg_day_mv1"));
-            triggerRefreshMv(testDb, partitionedMaterializedView);
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "iceberg_day_mv1"));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
 
-            Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
-            Assert.assertEquals(5, partitions.size());
-            List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220102000000", "p20220103000000",
-                        "p20220104000000", "p20220105000000");
-            Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
-            // test rewrite
-            starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day`")
-                        .explainContains(mvName);
-            starRocksAssert.dropMaterializedView(mvName);
-        }
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(5, partitions.size());
+        List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220102000000", "p20220103000000",
+                "p20220104000000", "p20220105000000");
+        Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
+        // test rewrite
+        starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day`")
+                .explainContains(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreatePartitionedMVForIcebergWithPartitionTransform4() throws Exception {
         // test partition by hour(ts)
-        {
-            String mvName = "iceberg_hour_mv1";
-            starRocksAssert.useDatabase("test")
-                        .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_hour_mv1`\n" +
-                                    "PARTITION BY ts\n" +
-                                    "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
-                                    "REFRESH DEFERRED MANUAL\n" +
-                                    "PROPERTIES (\n" +
-                                    "\"replication_num\" = \"1\",\n" +
-                                    "\"storage_medium\" = \"HDD\"\n" +
-                                    ")\n" +
-                                    "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_hour` as a;");
+        String mvName = "iceberg_hour_mv1";
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_hour_mv1`\n" +
+                        "PARTITION BY ts\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_hour` as a;");
 
-            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
-            MaterializedView partitionedMaterializedView =
-                        ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getTable(testDb.getFullName(), "iceberg_hour_mv1"));
-            triggerRefreshMv(testDb, partitionedMaterializedView);
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "iceberg_hour_mv1"));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
 
-            Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
-            Assert.assertEquals(5, partitions.size());
-            List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220101010000", "p20220101020000",
-                        "p20220101030000", "p20220101040000");
-            Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
-            // test rewrite
-            starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_hour`")
-                        .explainContains(mvName);
-            starRocksAssert.dropMaterializedView(mvName);
-        }
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(5, partitions.size());
+        List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220101010000", "p20220101020000",
+                "p20220101030000", "p20220101040000");
+        Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
+        // test rewrite
+        starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_hour`")
+                .explainContains(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
     }
 
     @Test
@@ -360,5 +369,108 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
                         Set<String> partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv);
                         Assert.assertTrue(partitionsToRefresh1.isEmpty());
                     });
+    }
+
+    private void testCreateMVWithMultiPartitionColumns(String icebergTable,
+                                                       String updatePartitionName,
+                                                       List<String> expectedPartitionNames,
+                                                       String expectedExecPlan) throws Exception {
+        String mvName = "test_mv1";
+        try {
+            String query = String.format("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.%s as a",
+                    icebergTable);
+            String ddl = String.format("CREATE MATERIALIZED VIEW `%s`\n" +
+                    "PARTITION BY (id, data, ts)\n" +
+                    "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                    "REFRESH DEFERRED MANUAL\n" +
+                    "AS %s;", mvName, query);
+            starRocksAssert.useDatabase("test").withMaterializedView(ddl);
+
+            Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            MaterializedView partitionedMaterializedView =
+                    ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(testDb.getFullName(), mvName));
+            triggerRefreshMv(testDb, partitionedMaterializedView);
+
+            Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+            Assert.assertEquals(expectedPartitionNames.size(), partitions.size());
+            List<String> partitionNames = partitions.stream().map(Partition::getName).collect(Collectors.toList());
+            System.out.println(partitionNames);
+            Assert.assertTrue(partitionNames.stream().allMatch(expectedPartitionNames::contains));
+
+            // update partition
+            MockIcebergMetadata mockIcebergMetadata =
+                    (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
+                            getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
+            mockIcebergMetadata.updatePartitions("partitioned_transforms_db", icebergTable,
+                    ImmutableList.of(updatePartitionName));
+
+            // refresh only one partition
+            Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
+            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+            initAndExecuteTaskRun(taskRun);
+            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                    taskRun.getProcessor();
+
+            MvTaskRunContext mvContext = processor.getMvContext();
+            ExecPlan execPlan = mvContext.getExecPlan();
+            assertPlanContains(execPlan, expectedExecPlan);
+
+            // test rewrite
+            QueryDebugOptions debugOptions = new QueryDebugOptions();
+            debugOptions.setEnableQueryTraceLog(true);
+            connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
+            String plan = UtFrameUtils.getFragmentPlan(connectContext, query);
+            PlanTestBase.assertContains(plan, mvName);
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            try {
+                starRocksAssert.dropMaterializedView(mvName);
+            } catch (Exception e) {
+                // do nothing
+            }
+        }
+    }
+
+    @Test
+    public void testCreatePartitionedMVWithMultiPartitionColumnsHour() throws Exception {
+        testCreateMVWithMultiPartitionColumns("t0_multi_hour", "id=1/data=a/ts_hour=2022-01-01-00",
+                ImmutableList.of("p1_a_20220101000000", "p2_a_20220101010000"),
+                "PREDICATES: 1: id = 1, 2: data = 'a', hour(3: ts) = '2022-01-01 00:00:00'");
+    }
+
+    @Test
+    public void testCreatePartitionedMVWithMultiPartitionColumnsDay() throws Exception {
+        testCreateMVWithMultiPartitionColumns("t0_multi_day", "id=1/data=a/ts_day=2022-01-01",
+                ImmutableList.of("p1_a_20220101000000", "p2_a_20220102000000"),
+                "PREDICATES: 1: id = 1, 2: data = 'a', day(3: ts) = '2022-01-01 00:00:00'");
+    }
+
+    @Test
+    public void testCreatePartitionedMVWithMultiPartitionColumnsMonth() throws Exception {
+        testCreateMVWithMultiPartitionColumns("t0_multi_month", "id=1/data=a/ts_month=2022-01",
+                ImmutableList.of("p1_a_20220101000000", "p2_a_20220201000000"),
+                "PREDICATES: 1: id = 1, 2: data = 'a', month(3: ts) = '2022-01-01 00:00:00'");
+    }
+
+    @Test
+    public void testCreatePartitionedMVWithMultiPartitionColumnsYear() throws Exception {
+        testCreateMVWithMultiPartitionColumns("t0_multi_year", "id=2/data=a/ts_year=2024",
+                ImmutableList.of("p1_a_20240101000000", "p2_a_20240101000000"),
+                "PREDICATES: 1: id = 2, 2: data = 'a', year(3: ts) = '2024-01-01 00:00:00'");
+    }
+
+    @Test
+    public void testCreatePartitionedMVWithMultiPartitionColumnsBucket() {
+        try {
+            testCreateMVWithMultiPartitionColumns("t0_multi_bucket", "id=1/data=a/ts_bucket=0",
+                    ImmutableList.of("p1_a_20240101000000", "p2_a_20240101000000"),
+                    "3: ts >= '2024-01-01 00:00:00', 3: ts < '2025-01-01 00:00:00'");
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Do not support create materialized view when base " +
+                    "iceberg table partition transform has bucket or truncate."));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -347,8 +347,10 @@ public class MvRewritePreprocessorTest extends MvRewriteTestBase {
                 // disable plan cache will make the test more stable
                 connectContext.getSessionVariable().setEnableMaterializedViewPlanCache(false);
                 Set<MaterializedView> validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
-                Assert.assertEquals(2, validMVs.size());
-                Assert.assertTrue(containsMV(validMVs, "mv_1", "mv_3"));
+                Assert.assertTrue(validMVs.size() >= 1);
+                if (validMVs.size() == 2) {
+                    Assert.assertTrue(containsMV(validMVs, "mv_1", "mv_3"));
+                }
                 connectContext.getSessionVariable().setEnableMaterializedViewPlanCache(true);
 
                 // if mv_3 is in the plan cache


### PR DESCRIPTION
# Why I'm doing:
- MV cannot be used if base tables have multi partition columns and cannot be converted into single partition column mv.

# What I'm doing:
> Support to create materialized views with multi partition columns of native/external tables.

## Parser

- Support mutli `primaryExpression`  in creating mv;

```jsx
mvPartitionExprs:
    primaryExpression
    | '(' primaryExpression (',' primaryExpression)* ')'
    ;

materializedViewDesc
    : (PARTITION BY mvPartitionExprs)
```

- Change `CreateMaterializedViewStatement` class member variables

```jsx
// MV's partition expressions
private final List<Expr> partitionByExprs;
// MV's output columns that are referred by mv's partition expressions
private List<Column> partitionColumns;
// Ref base table partition expression referred by mv's partition by expressions
private List<Expr> partitionRefTableExprs;
```

## Analyzer

- [[MaterializedViewAnalyzer.java](https://github.com/StarRocks/starrocks/pull/52577/files#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0)]
    - Check each partition’s validations like single partition expression before.
    - If a mv has multi partition expressions:
        - mv’s partition columns’ number is  the same size with the ref base table’s partition column numbers(`checkPartitionColumnExprs`)
        - all mv’s partition expressions must be column ref rather than function calls(`buildPartitionInfo`)
- [[MVPartitionExprResolver.java](https://github.com/StarRocks/starrocks/pull/52577/files#diff-60d297382359d9fa539c18df2f3d7cc710cc3da036096f1149058ea8fda4d1fb)]
    - NOTE: original `multi-table ref base tables` policy can still apply for `multi partition columns`.
    - `getMVPartitionExprsChecked` iterate each partition column for multi ref base tables and ensure each partition expression must have the same size of ref base tables.

```jsx
create materialized view mv1
partition by (province, dt, age) 
REFRESH DEFERRED MANUAL 
properties ('partition_refresh_number' = '-1')
as 
select dt, province, age, sum(id) from t3 group by dt, province, age 
UNION ALL 
select dt, province, age, sum(id) from t4 group by dt, province, age 
;
```

## MaterializedView

Since `parser`  has supported `multi partition columns` ,  `MaterializedView` should also be changed too.

```jsx
/*
 * A Materialized View is a database object that contains the results of a query.
 * - Base tables are the tables that are referenced in the view definition.
 * - Ref base tables are some special base tables of a materialized view that are referenced by mv's partition expression.
 * </p>
 * In our partition-change-tracking mechanism, we need to track the partition change of ref base tables to refresh the associated
 * partitions of the materialized view.
 * </p>
 * NOTE:
 * - A Materialized View can have multi base-tables which are tables that are referenced in the view definition.
 * - A Materialized View can have multi ref-base-tables which are tables that are referenced by mv's partition expression.
 * - A Materialized View's partition expressions can be range partitioned or list partitioned:
 *      - If mv is range partitioned, it must only have one partition column.
 *      - If mv is list partitioned, it can have multi partition columns.
 */
```

Main Changes:

- Change member variables below to support multi partition columns.
- Use  `LinkedHashMap`  instead of `Map` for `partitionExprMaps` is to keep mv’s partition expression order as user’s defined order, otherwise we cannot decide the correct order in multi partition columns case.

```jsx

    @SerializedName(value = "partitionExprMaps")
    private Map<ExpressionSerializedObject, ExpressionSerializedObject> serializedPartitionExprMaps;
    // Use LinedHashMap to keep the order of partition exprs by the user's defined order which can be used when mv contains multi
    // partition columns.
    private LinkedHashMap<Expr, SlotRef> partitionExprMaps;
    
    // ref base table to partition expression
    private Optional<Map<Table, List<Expr>>> refBaseTablePartitionExprsOpt = Optional.empty();
    // ref bae table to partition column slot ref
    private Optional<Map<Table, List<SlotRef>>> refBaseTablePartitionExprsOpt = Optional.empty();
    // ref bae table to partition column
    private Optional<Map<Table, List<Column>>> refBaseTablePartitionColumnsOpt = Optional.empty()
```

**After the variables’ change, we need to refactor all methods which use those variables which will cause a lot of files’ change.**

NOTE: I do some refactors here:

- move all `refBaseTablePartitionExprsOpt`/refBaseTablePartitionExprsOpt/refBaseTablePartitionColumnsOpt`  ‘s initialization into `onReload` method to avoid initialization in each `get` method, because those variables only need to be analyzed once in the  create/restart.
- rename `getPartitionExpr` to `getRangePartitionExpr`  because this method only can be called in RangeBasedMV.
- rename `getPartitionColumn` to `getRangePartitionColumn` because this method only can be called in RangeBasedMV.

## MV Refresh

### Refresh Partition Predicate

- `generatePartitionPredicate` needs to consider multi partition columns:
    - if mv only contains one partition columns(eg: dt) , partition predicates: `dt in (a, b, c)`
    - if mv only contains one partition columns(eg: dt, area) , partition predicates: `(dt=a and area='x') or (dt=b and area='x') or (dt=b and area='x'))`
- If partition column is an `iceberg` transform, we cannot use slot ref directly, needs to consider `transform` function:
    - if mv only contains one partition columns(eg: dt, area) , and the column’s transform is not `identify`,  partition predicates: `(transform(dt)=a and area='x')`

### [[ConnectorPartitionTraits.java](https://github.com/StarRocks/starrocks/pull/52577/files#diff-0b825974aeac70ada1d7000bb5d1e329d033b910babe40697c49df253aba5498)]

- `getPartitionList`  api should return result as the input partition columns’ order to support mv’s partition columns are not the same with the base table.

```jsx
public abstract Map<String, PListCell> getPartitionList(List<Column> partitionColumns) throws AnalysisException;
```

- `generateMVPartitionName` should respect ref base table which contain multi partition columns.

## MV Rewrite

### [[OptCompensator.java](https://github.com/StarRocks/starrocks/pull/52577/files#diff-735c1d406f93f50fb1d7af7a0690170698dd2b43c7ea8b660885eda799b037b2)]

- `getExternalTableCompensatePlan` needs to consider compensate partition predicates like `MV Refresh`.

Fixes https://github.com/StarRocks/starrocks/issues/52576

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
