### PR TITLE
[Enhancement] enhance sql digest

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2442,6 +2442,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_collect_query_detail_info = false;
 
+    @ConfField(mutable = true,
+            comment = "Enable the sql digest feature, building a parameterized digest for each sql in the query detail")
+    public static boolean enable_sql_digest = false;
+
     @ConfField(mutable = true, comment = "explain level of query plan in this detail")
     public static String query_detail_explain_level = "COSTS";
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -216,7 +216,6 @@ public class ConnectProcessor {
                 // err query
                 MetricRepo.COUNTER_QUERY_ERR.increase(1L);
                 ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
-                ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
                 //represent analysis err
                 if (ctx.getState().getErrType() == QueryState.ErrType.ANALYSIS_ERR) {
                     MetricRepo.COUNTER_QUERY_ANALYSIS_ERR.increase(1L);
@@ -228,12 +227,12 @@ public class ConnectProcessor {
                 MetricRepo.COUNTER_QUERY_SUCCESS.increase(1L);
                 MetricRepo.HISTO_QUERY_LATENCY.update(elapseMs);
                 ResourceGroupMetricMgr.updateQueryLatency(ctx, elapseMs);
-                if (elapseMs > Config.qe_slow_log_ms || ctx.getSessionVariable().isEnableSQLDigest()) {
-                    if (elapseMs > Config.qe_slow_log_ms) {
-                        MetricRepo.COUNTER_SLOW_QUERY.increase(1L);
-                    }
-                    ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
+                if (elapseMs > Config.qe_slow_log_ms) {
+                    MetricRepo.COUNTER_SLOW_QUERY.increase(1L);
                 }
+            }
+            if (Config.enable_sql_digest) {
+                ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
             }
             ctx.getAuditEventBuilder().setIsQuery(true);
             if (ctx.getSessionVariable().isEnableBigQueryLog()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -231,7 +231,7 @@ public class ConnectProcessor {
                     MetricRepo.COUNTER_SLOW_QUERY.increase(1L);
                 }
             }
-            if (Config.enable_sql_digest) {
+            if (Config.enable_sql_digest || ctx.getSessionVariable().isEnableSQLDigest()) {
                 ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
             }
             ctx.getAuditEventBuilder().setIsQuery(true);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1086,6 +1086,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD_DEPTH, flag = VariableMgr.INVISIBLE)
     private int cboPruneJsonSubfieldDepth = 20;
 
+    // Deprecated by fe.conf/enable_sql_digest
+    @Deprecated
     @VarAttr(name = ENABLE_SQL_DIGEST, flag = VariableMgr.INVISIBLE)
     private boolean enableSQLDigest = false;
 
@@ -3493,10 +3495,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isCboPushDownDistinctBelowWindow() {
         return this.cboPushDownDistinctBelowWindow;
-    }
-
-    public boolean isEnableSQLDigest() {
-        return enableSQLDigest;
     }
 
     public void enableJoinReorder(boolean value) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1086,8 +1086,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD_DEPTH, flag = VariableMgr.INVISIBLE)
     private int cboPruneJsonSubfieldDepth = 20;
 
-    // Deprecated by fe.conf/enable_sql_digest
-    @Deprecated
     @VarAttr(name = ENABLE_SQL_DIGEST, flag = VariableMgr.INVISIBLE)
     private boolean enableSQLDigest = false;
 
@@ -3495,6 +3493,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isCboPushDownDistinctBelowWindow() {
         return this.cboPushDownDistinctBelowWindow;
+    }
+
+    public boolean isEnableSQLDigest() {
+        return enableSQLDigest;
     }
 
     public void enableJoinReorder(boolean value) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -20,9 +20,12 @@ import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.util.ParseUtil;
+import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.FieldReference;
+import com.starrocks.sql.ast.MapExpr;
 import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
@@ -384,6 +387,33 @@ public class AstToSQLBuilder {
                 return buildColumnName(expr.getTblNameWithoutAnalyzed(),
                         expr.getColumnName(), expr.getColumnName());
             }
+        }
+
+        @Override
+        public String visitArrayExpr(ArrayExpr node, Void context) {
+            StringBuilder sb = new StringBuilder();
+            Type type = AnalyzerUtils.replaceNullType2Boolean(node.getType());
+            sb.append(type.toString());
+            sb.append('[');
+            sb.append(node.getChildren().stream().map(this::visit).collect(Collectors.joining(", ")));
+            sb.append(']');
+            return sb.toString();
+        }
+
+        @Override
+        public String visitMapExpr(MapExpr node, Void context) {
+            StringBuilder sb = new StringBuilder();
+            Type type = AnalyzerUtils.replaceNullType2Boolean(node.getType());
+            sb.append(type.toString());
+            sb.append("{");
+            for (int i = 0; i < node.getChildren().size(); i = i + 2) {
+                if (i > 0) {
+                    sb.append(',');
+                }
+                sb.append(visit(node.getChild(i)) + ":" + visit(node.getChild(i + 1)));
+            }
+            sb.append("}");
+            return sb.toString();
         }
 
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -20,15 +20,9 @@ import com.starrocks.analysis.ParseNode;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.Type;
 import com.starrocks.common.util.ParseUtil;
-import com.starrocks.common.util.PrintableMap;
-import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.FieldReference;
-import com.starrocks.sql.ast.FileTableFunctionRelation;
-import com.starrocks.sql.ast.InsertStmt;
-import com.starrocks.sql.ast.MapExpr;
 import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
@@ -38,8 +32,6 @@ import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.TableFunctionRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.ViewRelation;
-import com.starrocks.sql.ast.pipe.CreatePipeStmt;
-import com.starrocks.sql.parser.NodePosition;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -394,108 +386,5 @@ public class AstToSQLBuilder {
             }
         }
 
-        @Override
-        public String visitInsertStatement(InsertStmt insert, Void context) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("INSERT ");
-
-            // add hint
-            if (insert.getHintNodes() != null) {
-                sb.append(extractHintStr(insert.getHintNodes()));
-            }
-
-
-            if (insert.isOverwrite()) {
-                sb.append("OVERWRITE ");
-            } else {
-                sb.append("INTO ");
-            }
-
-            // target
-            if (insert.useTableFunctionAsTargetTable()) {
-                sb.append(visitFileTableFunction(
-                        new FileTableFunctionRelation(insert.getTableFunctionProperties(), NodePosition.ZERO), context));
-            } else if (insert.useBlackHoleTableAsTargetTable()) {
-                sb.append("blackhole()");
-            } else {
-                sb.append(insert.getTableName().toSql());
-            }
-            sb.append(" ");
-
-            // target partition
-            if (insert.getTargetPartitionNames() != null &&
-                    CollectionUtils.isNotEmpty(insert.getTargetPartitionNames().getPartitionNames())) {
-                List<String> names = insert.getTargetPartitionNames().getPartitionNames();
-                sb.append("PARTITION (").append(Joiner.on(",").join(names)).append(") ");
-            }
-
-            // label
-            if (StringUtils.isNotEmpty(insert.getLabel())) {
-                sb.append("WITH LABEL `").append(insert.getLabel()).append("` ");
-            }
-
-            // target column
-            if (CollectionUtils.isNotEmpty(insert.getTargetColumnNames())) {
-                String columns = insert.getTargetColumnNames().stream()
-                        .map(x -> '`' + x + '`')
-                        .collect(Collectors.joining(","));
-                sb.append("(").append(columns).append(") ");
-            }
-
-            // source
-            if (insert.getQueryStatement() != null) {
-                sb.append(visit(insert.getQueryStatement()));
-            }
-            return sb.toString();
-        }
-
-        @Override
-        public String visitCreatePipeStatement(CreatePipeStmt stmt, Void context) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("CREATE ");
-            if (stmt.isReplace()) {
-                sb.append("OR REPLACE ");
-            }
-            sb.append("PIPE ");
-            if (stmt.isIfNotExists()) {
-                sb.append("IF NOT EXISTS ");
-            }
-            sb.append(stmt.getPipeName()).append(" ");
-
-            Map<String, String> properties = stmt.getProperties();
-            if (properties != null && !properties.isEmpty()) {
-                sb.append("PROPERTIES(").append(new PrintableMap<>(properties, "=", true, false, hideCredential)).append(") ");
-            }
-
-            sb.append("AS ").append(visitInsertStatement(stmt.getInsertStmt(), context));
-            return sb.toString();
-        }
-
-        @Override
-        public String visitArrayExpr(ArrayExpr node, Void context) {
-            StringBuilder sb = new StringBuilder();
-            Type type = AnalyzerUtils.replaceNullType2Boolean(node.getType());
-            sb.append(type.toString());
-            sb.append('[');
-            sb.append(node.getChildren().stream().map(this::visit).collect(Collectors.joining(", ")));
-            sb.append(']');
-            return sb.toString();
-        }
-
-        @Override
-        public String visitMapExpr(MapExpr node, Void context) {
-            StringBuilder sb = new StringBuilder();
-            Type type = AnalyzerUtils.replaceNullType2Boolean(node.getType());
-            sb.append(type.toString());
-            sb.append("{");
-            for (int i = 0; i < node.getChildren().size(); i = i + 2) {
-                if (i > 0) {
-                    sb.append(',');
-                }
-                sb.append(visit(node.getChild(i)) + ":" + visit(node.getChild(i + 1)));
-            }
-            sb.append("}");
-            return sb.toString();
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlDigestBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlDigestBuilder.java
@@ -53,7 +53,7 @@ public class SqlDigestBuilder {
         @Override
         public String visitValues(ValuesRelation node, Void scope) {
             if (node.isNullValues()) {
-                return "";
+                return "VALUES(NULL)";
             }
 
             StringBuilder sqlBuilder = new StringBuilder("VALUES");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlDigestBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlDigestBuilder.java
@@ -14,18 +14,68 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.base.Joiner;
+import com.starrocks.analysis.InPredicate;
 import com.starrocks.analysis.LimitElement;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.ValuesRelation;
+import org.apache.commons.lang3.StringUtils;
 
-//Used to build sql digests
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Used to build sql digest(string without any dynamic parameters in it)
+ */
 public class SqlDigestBuilder {
+
     public static String build(StatementBase statement) {
         return new SqlDigestBuilderVisitor().visit(statement);
     }
 
     private static class SqlDigestBuilderVisitor extends AstToStringBuilder.AST2StringBuilderVisitor {
+
+        @Override
+        public String visitInPredicate(InPredicate node, Void context) {
+            if (!node.isLiteralChildren()) {
+                return super.visitInPredicate(node, context);
+            } else {
+                StringBuilder strBuilder = new StringBuilder();
+                String notStr = (node.isNotIn()) ? "NOT " : "";
+                strBuilder.append(printWithParentheses(node.getChild(0))).append(" ").append(notStr).append("IN ");
+                strBuilder.append("(?)");
+                return strBuilder.toString();
+            }
+        }
+
+        @Override
+        public String visitValues(ValuesRelation node, Void scope) {
+            if (node.isNullValues()) {
+                return null;
+            }
+
+            StringBuilder sqlBuilder = new StringBuilder("VALUES");
+            if (!node.getRows().isEmpty()) {
+                StringBuilder rowBuilder = new StringBuilder();
+                rowBuilder.append("(");
+                List<String> rowStrings =
+                        node.getRows().get(0).stream().map(this::visit).collect(Collectors.toList());
+                rowBuilder.append(Joiner.on(", ").join(rowStrings));
+                rowBuilder.append(")");
+                sqlBuilder.append(rowBuilder.toString());
+            }
+            return sqlBuilder.toString();
+        }
+
+        @Override
+        protected void visitInsertLabel(String label, StringBuilder sb) {
+            if (StringUtils.isNotEmpty(label)) {
+                sb.append("WITH LABEL ? ");
+            }
+        }
+
         @Override
         public String visitLiteral(LiteralExpr expr, Void context) {
             return "?";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlDigestBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlDigestBuilder.java
@@ -53,7 +53,7 @@ public class SqlDigestBuilder {
         @Override
         public String visitValues(ValuesRelation node, Void scope) {
             if (node.isNullValues()) {
-                return null;
+                return "";
             }
 
             StringBuilder sqlBuilder = new StringBuilder("VALUES");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SqlDigestBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SqlDigestBuilderTest.java
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class SqlDigestBuilderTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        PlanTestBase.afterClass();
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiterString = "|", value = {
+            "select * from t2| SELECT * FROM test.t2",
+            "select * from t1 where v4 = 1 and v5 = 2|SELECT * FROM test.t1 WHERE (test.t1.v4 = ?) AND (test.t1.v5 = " +
+                    "?)",
+            "select * from t1 where v4 = 1 or v5 = 2|SELECT * FROM test.t1 WHERE (test.t1.v4 = ?) OR (test.t1.v5 = ?)",
+            "select * from t1 where v4 = 1 and (v5 = 2 or v6 = 3)| SELECT * FROM test.t1 WHERE (test.t1.v4 = ?) AND (" +
+                    "(test.t1.v5 = ?) OR (test.t1.v6 = ?))",
+            "select v4 from t1 limit 1|SELECT test.t1.v4 FROM test.t1 LIMIT  ? ",
+            "select * from t1 where v4 in (1, 2, 3) | SELECT * FROM test.t1 WHERE test.t1.v4 IN (?)",
+            "select * from t1 where v4 in (select v5 from t1)| SELECT * FROM test.t1 WHERE test.t1.v4 IN (((SELECT " +
+                    "test.t1.v5 FROM test.t1)))",
+            // with set_var
+            "select /*+set_var(query_timeout=123)*/ * from t2| SELECT * FROM test.t2",
+
+            // insert
+            "insert into t1 values (1, 2, 3)| INSERT INTO `test`.`t1` VALUES(?, ?, ?)",
+            "insert into t1 values (1, 2, 3),(4,5,6)| INSERT INTO `test`.`t1` VALUES(?, ?, ?)",
+            "insert into t1 select * from t1| INSERT INTO `test`.`t1` SELECT * FROM test.t1",
+            "insert into t1 with label abc select * from t1| " +
+                    "INSERT INTO `test`.`t1` WITH LABEL ? SELECT * FROM test.t1",
+
+            // delete
+            "delete from t1 where v4 = 1|DELETE FROM `test`.`t1` WHERE v4 = ?",
+
+            // partition dml
+            "insert into part_t1 partition (p1) values(1,2,3) " +
+                    "|INSERT INTO `test`.`part_t1` PARTITION (p1) VALUES(?, ?, ?)",
+            "insert overwrite part_t1 partition (p1) values(1,2,3) " +
+                    "|INSERT OVERWRITE `test`.`part_t1` PARTITION (p1) VALUES(?, ?, ?)",
+    })
+    public void testBuild(String sql, String expectedDigest) throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        Assertions.assertEquals(StringUtils.trim(expectedDigest), StringUtils.trim(SqlDigestBuilder.build(stmt)));
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -70,6 +70,17 @@ public class PlanTestBase extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
+        starRocksAssert.withTable("CREATE TABLE `part_t1` (\n" +
+                "  `v4` bigint NULL COMMENT \"\",\n" +
+                "  `v5` bigint NULL COMMENT \"\",\n" +
+                "  `v6` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "PARTITION BY list(v4) ( partition p1 values in ('1'), partition p2 values in ('2')) \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
         starRocksAssert.withTable("CREATE TABLE `t2` (\n" +
                 "  `v7` bigint NULL COMMENT \"\",\n" +
                 "  `v8` bigint NULL COMMENT \"\",\n" +


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Parameterization
    1. Literal values
    2. `INSERT WITH LABEL xxx` => `WITH LABEL ?` 
    3. `X IN (1,2,3)`  => ` X IN (?)` 
    4. `VALUES(1,2,3), (4,5,6)` will be parameterized into `VALUES(?,?,?)`


Configuration change:
1. Add a fe configuration `enable_sql_digest` to turn on this functionality, whose default is still false
2. Whether `set enable_sql_digest =true` or set the configuration to true in fe.conf, both can take affect

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
