### PR TITLE
[BugFix] Fix chunk accumulator miss assign _max_size

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -24,6 +24,7 @@ Status SpillableAggregateBlockingSourceOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(AggregateBlockingSourceOperator::prepare(state));
     RETURN_IF_ERROR(_stream_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get()));
     RETURN_IF_ERROR(_stream_aggregator->open(state));
+    _accumulator.set_max_size(state->chunk_size());
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -182,6 +182,7 @@ Status SpillableAggregateDistinctBlockingSourceOperator::prepare(RuntimeState* s
     RETURN_IF_ERROR(AggregateDistinctBlockingSourceOperator::prepare(state));
     RETURN_IF_ERROR(_stream_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get()));
     RETURN_IF_ERROR(_stream_aggregator->open(state));
+    _accumulator.set_max_size(state->chunk_size());
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/hash_partition_context.cpp
+++ b/be/src/exec/pipeline/hash_partition_context.cpp
@@ -37,6 +37,7 @@ Status HashPartitionContext::prepare(RuntimeState* state, RuntimeProfile* profil
         _has_nullable_key = _has_nullable_key || _partition_types[i].is_nullable;
     }
 
+    _acc.set_max_size(state->chunk_size());
     _chunks_partitioner = std::make_unique<ChunksPartitioner>(_has_nullable_key, _partition_exprs, _partition_types);
     return _chunks_partitioner->prepare(state, profile);
 }

--- a/test/sql/test_spill/R/test_spill_aggregate
+++ b/test/sql/test_spill/R/test_spill_aggregate
@@ -208,3 +208,14 @@ select count(*) from (select distinct c0, c1 from t5 limit 10) tb;
 -- result:
 10
 -- !result
+set chunk_size = 1024;
+-- result:
+-- !result
+select max(s1), avg(s2) from (select sum(c1) s1, sum(c0) s2 from t5 group by c0) tb;
+-- result:
+649999	325000.5
+-- !result
+select count(*) from (select distinct c0, c1 from t5) tb;
+-- result:
+650000
+-- !result

--- a/test/sql/test_spill/T/test_spill_aggregate
+++ b/test/sql/test_spill/T/test_spill_aggregate
@@ -98,3 +98,7 @@ select count(s1), count(s2) from (select sum(c1) s1, sum(c0) s2, c0 from t5 grou
 select count(s1), count(s2) from (select sum(c1) s1, sum(c0) s2, c0, c1 from t5 group by c0, c1 limit 10) tb;
 select distinct c0, c1 from t5 order by 1, 2 limit 1;
 select count(*) from (select distinct c0, c1 from t5 limit 10) tb;
+
+set chunk_size = 1024;
+select max(s1), avg(s2) from (select sum(c1) s1, sum(c0) s2 from t5 group by c0) tb;
+select count(*) from (select distinct c0, c1 from t5) tb;


### PR DESCRIPTION
## Why I'm doing:

```
(java.sql.SQLException)(conn=143)Intermediate chunk size mustnot be greater than 1024,actually 4095 after 0-th operator spillable_org .mariadb.jdbc.export.ExceptionFactory.createException():299
org.mariadb.jdbc.export.ExceptionFactory.create():370
org .mariadb.jdbc.message.ClientMessage.readPacket():137org.mariadb.jdbc.client.impl.StandardClient.readPacket():840org .mariadb.jdbc.client.impl.StandardClient.readResults():779org.mariadb.jdbc.client.impl.StandardClient.readResponse():698org. mariadb.jdbc.client.impl.StandardClient.execute():641
org .mariadb.jdbc.client.impl.MultiPrimaryClient.execute():347
org.mariadb.jdbc.Statement.executelnternal():935
org.mariadb.jdbc.Statement.executeUpdate():917
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
