### PR TITLE
[BugFix] properly handle 100-continue in load action

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
@@ -138,8 +138,12 @@ public abstract class BaseAction implements IAction {
         writeCustomHeaders(response, responseObj);
         writeCookies(response, responseObj);
 
-        boolean keepAlive = HttpUtil.isKeepAlive(request.getRequest());
+        // Connection can be keep-alive only when
+        // - The client requests to keep-alive and,
+        // - The action doesn't close the connection forcibly.
+        boolean keepAlive = HttpUtil.isKeepAlive(request.getRequest()) && !response.isForceCloseConnection();
         if (!keepAlive) {
+            responseObj.headers().set(HttpHeaderNames.CONNECTION.toString(), HttpHeaderValues.CLOSE.toString());
             request.getContext().write(responseObj).addListener(ChannelFutureListener.CLOSE);
         } else {
             responseObj.headers().set(HttpHeaderNames.CONNECTION.toString(), HttpHeaderValues.KEEP_ALIVE.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseResponse.java
@@ -34,12 +34,24 @@ public class BaseResponse {
     protected Map<String, List<String>> customHeaders = Maps.newHashMap();
     private Set<Cookie> cookies = Sets.newHashSet();
 
+    // whether the connection needs to be closed forcibly.
+    // Default: no, allow the client to reuse the connection whenever possible.
+    private boolean forceCloseConnection = false;
+
     public String getContentType() {
         return contentType;
     }
 
     public void setContentType(String contentType) {
         this.contentType = contentType;
+    }
+
+    public boolean isForceCloseConnection() {
+        return forceCloseConnection;
+    }
+
+    public void setForceCloseConnection(boolean closeConnection) {
+        this.forceCloseConnection = closeConnection;
     }
 
     public StringBuilder getContent() {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -54,8 +54,8 @@ import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TNetworkAddress;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpUtil;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -95,10 +95,14 @@ public class LoadAction extends RestBaseAction {
     public void executeWithoutPasswordInternal(BaseRequest request, BaseResponse response) throws DdlException,
             AccessDeniedException {
 
-        // A 'Load' request must have 100-continue header
-        if (!request.getRequest().headers().contains(HttpHeaders.Names.EXPECT)) {
+        // A 'Load' request must have "Expect: 100-continue" header
+        if (!HttpUtil.is100ContinueExpected(request.getRequest())) {
+            // TODO: should respond "HTTP 417 Expectation Failed"
             throw new DdlException("There is no 100-continue header");
         }
+        // close the connection forcibly after the request, so the `Expect: 100-Continue` won't
+        // affect subsequent requests processing.
+        response.setForceCloseConnection(true);
 
         boolean enableBatchWrite = "true".equalsIgnoreCase(
                 request.getRequest().headers().get(StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE));


### PR DESCRIPTION
* set connection close after issue the HTTP 307 redirection
* when client sending http header 'Expect: 100-continue', it is allowed that the client still sends out the data even though the server doesn't respond a '100-Continue'. It will be hard for the server to know if the client sends the request body or not. The safest way is to close the connection no matter the client sends the request body or not.

## Why I'm doing:

## What I'm doing:

Fixes #52516

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
