### PR TITLE
[Enhancement] support drop materialized view force

### DIFF
--- a/docs/en/sql-reference/sql-statements/materialized_view/DROP_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/DROP_MATERIALIZED_VIEW.md
@@ -19,7 +19,7 @@ This operation requires the DROP privilege on the target materialized view.
 ## Syntax
 
 ```SQL
-DROP MATERIALIZED VIEW [IF EXISTS] [database.]mv_name
+DROP MATERIALIZED VIEW [IF EXISTS] [database.]mv_name [FORCE]
 ```
 
 Parameters in brackets [] is optional.
@@ -30,6 +30,7 @@ Parameters in brackets [] is optional.
 | ------------- | ------------ | ------------------------------------------------------------ |
 | IF EXISTS     | no           | If this parameter is specified, StarRocks will not throw an exception when deleting a materialized view that does not exist. If this parameter is not specified, the system will throw an exception when deleting a materialized view that does not exist. |
 | mv_name       | yes          | The name of the materialized view to delete.                 |
+| FORCE         | no           | If you execute DROP MATERIALIZED VIEW FORCE, the system will not check whether there are unfinished transactions, it will be deleted directly and cannot be recovered, this operation is generally not recommended.                 |
 
 ## Examples
 
@@ -76,3 +77,31 @@ Query OK, 0 rows affected (0.00 sec)
 MySQL > DROP MATERIALIZED VIEW k1_k2;
 ERROR 1064 (HY000): Materialized view k1_k2 is not find
 ```
+
+Example 3: Force Drop an existing materialized view
+
+1. View all existing materialized views in the database.
+
+  ```Plain
+  MySQL > SHOW MATERIALIZED VIEWS\G
+  *************************** 1. row ***************************
+              id: 470740
+          name: order_mv1
+  database_name: default_cluster:sr_hub
+        text: SELECT `sr_hub`.`orders`.`dt` AS `dt`, `sr_hub`.`orders`.`order_id` AS `order_id`, `sr_hub`.`orders`.`user_id` AS `user_id`, sum(`sr_hub`.`orders`.`cnt`) AS `total_cnt`, sum(`sr_hub`.`orders`.`revenue`) AS `total_revenue`, count(`sr_hub`.`orders`.`state`) AS `state_count` FROM `sr_hub`.`orders` GROUP BY `sr_hub`.`orders`.`dt`, `sr_hub`.`orders`.`order_id`, `sr_hub`.`orders`.`user_id`
+          rows: 0
+  1 rows in set (0.00 sec)
+  ```
+
+2. Force Drop the materialized view `order_mv1`.
+
+  ```SQL
+  DROP MATERIALIZED VIEW order_mv1 FORCE;
+  ```
+
+3. Check if the dropped materialized view exists.
+
+  ```Plain
+  MySQL > SHOW MATERIALIZED VIEWS;
+  Empty set (0.01 sec)
+  ```

--- a/docs/zh/sql-reference/sql-statements/materialized_view/DROP_MATERIALIZED_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/materialized_view/DROP_MATERIALIZED_VIEW.md
@@ -17,7 +17,7 @@ displayed_sidebar: docs
 ## 语法
 
 ```SQL
-DROP MATERIALIZED VIEW [IF EXISTS] [database.]mv_name
+DROP MATERIALIZED VIEW [IF EXISTS] [database.]mv_name [FORCE]
 ```
 
 ## 参数
@@ -26,6 +26,7 @@ DROP MATERIALIZED VIEW [IF EXISTS] [database.]mv_name
 | --------- | -------- | ------------------------------------------------------------ |
 | IF EXISTS | 否       | 如果声明该参数，删除不存在的物化视图系统不会报错。如果不声明该参数，删除不存在的物化视图系统会报错。 |
 | mv_name   | 是       | 待删除的物化视图的名称。                                     |
+| FORCE     | 否       | 如果执行DROP MATERIALIZED VIEW FORCE，系统不会检查是否有未完成的事务，会直接删除并且无法恢复，一般不建议执行此操作。                 |
 
 ## 示例
 
@@ -72,3 +73,31 @@ ERROR 1064 (HY000): Materialized view k1_k2 is not found
 MySQL > DROP MATERIALIZED VIEW IF EXISTS k1_k2;
 Query OK, 0 rows affected (0.00 sec)
 ```
+
+示例三: 强制删除现有的物化视图
+
+1. 查看当前数据库中存在的物化视图。
+
+  ```Plain
+  MySQL > SHOW MATERIALIZED VIEWS\G
+  *************************** 1. row ***************************
+              id: 470740
+          name: order_mv1
+  database_name: default_cluster:sr_hub
+        text: SELECT `sr_hub`.`orders`.`dt` AS `dt`, `sr_hub`.`orders`.`order_id` AS `order_id`, `sr_hub`.`orders`.`user_id` AS `user_id`, sum(`sr_hub`.`orders`.`cnt`) AS `total_cnt`, sum(`sr_hub`.`orders`.`revenue`) AS `total_revenue`, count(`sr_hub`.`orders`.`state`) AS `state_count` FROM `sr_hub`.`orders` GROUP BY `sr_hub`.`orders`.`dt`, `sr_hub`.`orders`.`order_id`, `sr_hub`.`orders`.`user_id`
+          rows: 0
+  1 rows in set (0.00 sec)
+  ```
+
+2. 强制删除物化视图 `order_mv1`.
+
+  ```SQL
+  DROP MATERIALIZED VIEW order_mv1 FORCE;
+  ```
+
+3. 删除后重新查看当前数据库中存在的物化视图将不会显示该物化视图。
+
+  ```Plain
+  MySQL > SHOW MATERIALIZED VIEWS;
+  Empty set (0.01 sec)
+  ```

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3150,7 +3150,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         stmt.getDbMvName().getTbl());
             }
 
-            db.dropTable(table.getName(), stmt.isSetIfExists(), true);
+            db.dropTable(table.getName(), stmt.isSetIfExists(), stmt.isForceDrop());
         } else {
             stateMgr.getAlterJobMgr().processDropMaterializedView(stmt);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropMaterializedViewStmt.java
@@ -31,15 +31,21 @@ public class DropMaterializedViewStmt extends DdlStmt {
 
     private final boolean ifExists;
     private final TableName dbMvName;
+    private final boolean forceDrop;
 
     public DropMaterializedViewStmt(boolean ifExists, TableName dbMvName) {
-        this(ifExists, dbMvName, NodePosition.ZERO);
+        this(ifExists, dbMvName, false, NodePosition.ZERO);
     }
 
-    public DropMaterializedViewStmt(boolean ifExists, TableName dbMvName, NodePosition pos) {
+    public DropMaterializedViewStmt(boolean ifExists, TableName dbMvName, boolean forceDrop) {
+        this(ifExists, dbMvName, forceDrop, NodePosition.ZERO);
+    }
+
+    public DropMaterializedViewStmt(boolean ifExists, TableName dbMvName, boolean forceDrop, NodePosition pos) {
         super(pos);
         this.ifExists = ifExists;
         this.dbMvName = dbMvName;
+        this.forceDrop = forceDrop;
     }
 
     public boolean isSetIfExists() {
@@ -56,6 +62,10 @@ public class DropMaterializedViewStmt extends DdlStmt {
 
     public TableName getDbMvName() {
         return dbMvName;
+    }
+
+    public boolean isForceDrop() {
+        return this.forceDrop;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2001,7 +2001,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitDropMaterializedViewStatement(StarRocksParser.DropMaterializedViewStatementContext context) {
         QualifiedName mvQualifiedName = getQualifiedName(context.qualifiedName());
         TableName mvName = qualifiedNameToTableName(mvQualifiedName);
-        return new DropMaterializedViewStmt(context.IF() != null, mvName, createPos(context));
+        boolean force = context.FORCE() != null;
+        return new DropMaterializedViewStmt(context.IF() != null, mvName, force, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -656,7 +656,7 @@ showMaterializedViewsStatement
     ;
 
 dropMaterializedViewStatement
-    : DROP MATERIALIZED VIEW (IF EXISTS)? mvName=qualifiedName
+    : DROP MATERIALIZED VIEW (IF EXISTS)? mvName=qualifiedName FORCE?
     ;
 
 alterMaterializedViewStatement


### PR DESCRIPTION
## Why I'm doing:
Currently, `DROP MATERIALIZED VIEW` always performs a force drop (unconditionally calling `db.dropTable(..., true)`), which bypasses important transaction safety checks.
This PR makes this behavior explicit by:
1. Introducing the `FORCE` keyword as an opt-in mechanism
2. **Flipping the default** to non-force, matching `DROP TABLE` semantics
3. Enabling the `existCommittedTxns` safety check to protect against data inconsistency

## What I'm doing:
Updating the `DROP MATERIALIZED VIEW` statement to support an optional `FORCE` keyword. By default (without `FORCE`), the system will check for unfinished transactions before dropping, preventing potential data loss scenarios

mysql> drop materialized view lo_mv2 FORCE;
Query OK, 0 rows affected (0.01 sec)

Fixes #52472

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5