### PR TITLE
[Enhancement]patch poco for keep-alive

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -561,6 +561,7 @@ if [[ -d $TP_SOURCE_DIR/$POCO_SOURCE ]] ; then
     if [ ! -f "$PATCHED_MARK" ] && [[ $POCO_SOURCE == "poco-1.12.5-release" ]] ; then
         patch -p1 < "$TP_PATCH_DIR/poco-1.12.5-ca.patch"
         patch -p1 < "$TP_PATCH_DIR/poco-1.12.5-zero-copy.patch"
+        patch -p1 < "$TP_PATCH_DIR/poco-1.12.5-keep-alive.patch"
         touch "$PATCHED_MARK"
     fi
     cd -

--- a/thirdparty/patches/poco-1.12.5-keep-alive.patch
+++ b/thirdparty/patches/poco-1.12.5-keep-alive.patch
@@ -1,0 +1,27 @@
+diff --git a/Net/src/HTTPClientSession.cpp b/Net/src/HTTPClientSession.cpp
+index b9591f0..f5ac624 100644
+--- a/Net/src/HTTPClientSession.cpp
++++ b/Net/src/HTTPClientSession.cpp
+@@ -465,7 +465,7 @@ int HTTPClientSession::write(const char* buffer, std::streamsize length)
+ 		_reconnect = false;
+ 		return rc;
+ 	}
+-	catch (IOException&)
++	catch (Poco::Exception&)
+ 	{
+ 		if (_reconnect)
+ 		{
+diff --git a/Net/src/HTTPStream.cpp b/Net/src/HTTPStream.cpp
+index 61fce2b..9a801e5 100644
+--- a/Net/src/HTTPStream.cpp
++++ b/Net/src/HTTPStream.cpp
+@@ -43,7 +43,8 @@ void HTTPStreamBuf::close()
+ 	if (_mode & std::ios::out)
+ 	{
+ 		sync();
+-		_session.socket().shutdownSend();
++		if (!_session.getKeepAlive())
++			_session.socket().shutdownSend();
+ 	}
+ }
+ 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
cherry-pick https://github.com/pocoproject/poco/commit/311ab4463973ff07d4a90499e611e3e009ba40ee for poco to keep-alive, then we can use it in connection pool.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
