### PR TITLE
[BugFix] Fix drop partition in different db could not refresh MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1473,10 +1473,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         if (!isTempPartition) {
             try {
                 for (MvId mvId : olapTable.getRelatedMaterializedViews()) {
-                    MaterializedView materializedView = (MaterializedView) getTable(db.getId(), mvId.getId());
+                    MaterializedView materializedView = (MaterializedView) getTable(mvId.getDbId(), mvId.getId());
                     if (materializedView != null && materializedView.isLoadTriggeredRefresh()) {
+                        Database mvDb = getDb(mvId.getDbId());
                         GlobalStateMgr.getCurrentState().getLocalMetastore().refreshMaterializedView(
-                                db.getFullName(), materializedView.getName(), false, null,
+                                mvDb.getFullName(), materializedView.getName(), false, null,
                                 Constants.TaskRunPriority.NORMAL.value(), true, false);
                     }
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -1286,7 +1286,6 @@ public class RefreshMaterializedViewTest extends MvRewriteTestBase {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("drop_db");
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropPartition(db, table, dropPartitionClause);
         starRocksAssert.waitRefreshFinished(mv1.getId());
-
         mvEntity =
                 (MaterializedViewMetricsEntity) MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv1.getMvId());
         count = mvEntity.histRefreshJobDuration.getCount();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -1238,8 +1238,7 @@ public class RefreshMaterializedViewTest extends MvRewriteTestBase {
         String truncateStr = "truncate table trunc_db.t1;";
         TruncateTableStmt truncateTableStmt = (TruncateTableStmt) UtFrameUtils.parseStmtWithNewParser(truncateStr, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt, connectContext);
-        // sleep 3s, wait for the refresh job to complete
-        Thread.sleep(3000);
+        starRocksAssert.waitRefreshFinished(mv1.getId());
 
         mvEntity =
                 (MaterializedViewMetricsEntity) MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv1.getMvId());
@@ -1286,8 +1285,7 @@ public class RefreshMaterializedViewTest extends MvRewriteTestBase {
         dropPartitionClause.setResolvedPartitionNames(ImmutableList.of(p1.getName()));
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("drop_db");
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropPartition(db, table, dropPartitionClause);
-        // sleep 3s, wait for the refresh job to complete
-        Thread.sleep(3000);
+        starRocksAssert.waitRefreshFinished(mv1.getId());
 
         mvEntity =
                 (MaterializedViewMetricsEntity) MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv1.getMvId());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -1266,15 +1266,15 @@ public class RefreshMaterializedViewTest extends MvRewriteTestBase {
                         "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
                         "PROPERTIES('replication_num' = '1');");
 
-        starRocksAssert.createDatabaseIfNotExists("mv_db")
-                .useDatabase("mv_db")
+        starRocksAssert.createDatabaseIfNotExists("drop_mv_db")
+                .useDatabase("drop_mv_db")
                 .withMaterializedView("CREATE MATERIALIZED VIEW test_mv\n"
                         + "DISTRIBUTED BY HASH(`k2`)\n"
                         + "REFRESH ASYNC\n"
                         + "AS select k1, k2, v1  from drop_db.tbl_with_mv;");
 
         executeInsertSql(connectContext, "insert into drop_db.tbl_with_mv partition(p2) values(\"2022-02-20\", 2, 10)");
-        MaterializedView mv1 = getMv("mv_db", "test_mv");
+        MaterializedView mv1 = getMv("drop_mv_db", "test_mv");
         MaterializedViewMetricsEntity mvEntity =
                 (MaterializedViewMetricsEntity) MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv1.getMvId());
         long count = mvEntity.histRefreshJobDuration.getCount();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -36,6 +36,7 @@ import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.DropPartitionClause;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.TruncateTableStmt;
@@ -1237,6 +1238,54 @@ public class RefreshMaterializedViewTest extends MvRewriteTestBase {
         String truncateStr = "truncate table trunc_db.t1;";
         TruncateTableStmt truncateTableStmt = (TruncateTableStmt) UtFrameUtils.parseStmtWithNewParser(truncateStr, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().truncateTable(truncateTableStmt, connectContext);
+        // sleep 3s, wait for the refresh job to complete
+        Thread.sleep(3000);
+
+        mvEntity =
+                (MaterializedViewMetricsEntity) MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv1.getMvId());
+        count = mvEntity.histRefreshJobDuration.getCount();
+        Assert.assertEquals(1, count);
+    }
+
+    @Test
+    public void testDropPartitionTableInDiffDb() throws Exception {
+        starRocksAssert
+                .createDatabaseIfNotExists("drop_db")
+                .useDatabase("drop_db")
+                .withTable("CREATE TABLE tbl_with_mv\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
+                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
+
+        starRocksAssert.createDatabaseIfNotExists("mv_db")
+                .useDatabase("mv_db")
+                .withMaterializedView("CREATE MATERIALIZED VIEW test_mv\n"
+                        + "DISTRIBUTED BY HASH(`k2`)\n"
+                        + "REFRESH ASYNC\n"
+                        + "AS select k1, k2, v1  from drop_db.tbl_with_mv;");
+
+        executeInsertSql(connectContext, "insert into drop_db.tbl_with_mv partition(p2) values(\"2022-02-20\", 2, 10)");
+        MaterializedView mv1 = getMv("mv_db", "test_mv");
+        MaterializedViewMetricsEntity mvEntity =
+                (MaterializedViewMetricsEntity) MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv1.getMvId());
+        long count = mvEntity.histRefreshJobDuration.getCount();
+        Assert.assertEquals(0, count);
+
+        OlapTable table = (OlapTable) getTable("drop_db", "tbl_with_mv");
+        Partition p1 = table.getPartition("p1");
+        DropPartitionClause dropPartitionClause = new DropPartitionClause(false, p1.getName(), false, true);
+        dropPartitionClause.setResolvedPartitionNames(ImmutableList.of(p1.getName()));
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("drop_db");
+        GlobalStateMgr.getCurrentState().getLocalMetastore().dropPartition(db, table, dropPartitionClause);
         // sleep 3s, wait for the refresh job to complete
         Thread.sleep(3000);
 


### PR DESCRIPTION
## Why I'm doing:

MV could not refresh when dropping partition in different db.

## What I'm doing:


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
