### PR TITLE
[Enhancement] try to prevent create pk table with __op column name by mistake

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -93,6 +93,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
@@ -1050,6 +1051,10 @@ public class SchemaChangeHandler extends AlterHandler {
             if (newColumn.getAggregationType() != null && newColumn.getAggregationType() != AggregateType.REPLACE) {
                 throw new DdlException(
                         "Can not assign aggregation method on column in Primary data model table: " + newColName);
+            }
+            // check reserved column for PK table
+            if (FeNameFormat.FORBIDDEN_COLUMN_NAMES.contains(newColName)) {
+                throw new DdlException("Column name '" + newColName + "' is reserved for primary key table");
             }
             newColumn.setAggregationType(AggregateType.REPLACE, true);
         } else if (KeysType.AGG_KEYS == olapTable.getKeysType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -52,6 +52,7 @@ import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddRollupClause;
 import com.starrocks.sql.ast.AlterClause;
@@ -266,6 +267,12 @@ public class OlapTableFactory implements AbstractTableFactory {
             table.setUseFastSchemaEvolution(useFastSchemaEvolution);
             for (Column column : baseSchema) {
                 column.setUniqueId(table.incAndGetMaxColUniqueId());
+                // check reserved column for PK table
+                if (table.getKeysType() == KeysType.PRIMARY_KEYS
+                        && FeNameFormat.FORBIDDEN_COLUMN_NAMES.contains(column.getName())) {
+                    throw new DdlException("Column name '" + column.getName()
+                            + "' is reserved for primary key table");
+                }
             }
             List<Integer> sortKeyUniqueIds = new ArrayList<>();
             if (useFastSchemaEvolution) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
@@ -23,7 +23,6 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.server.RunMode;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
 import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
@@ -57,7 +58,7 @@ public class FeNameFormat {
     public static final Set<String> FORBIDDEN_COLUMN_NAMES;
 
     static {
-        FORBIDDEN_COLUMN_NAMES = new HashSet<>();
+        FORBIDDEN_COLUMN_NAMES = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         FORBIDDEN_COLUMN_NAMES.add("__op");
         FORBIDDEN_COLUMN_NAMES.add("__row");
         String allowedSpecialCharacters = "";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.java
@@ -54,7 +54,7 @@ public class FeNameFormat {
 
     public static final String FORBIDDEN_PARTITION_NAME = "placeholder_";
 
-    private static final Set<String> FORBIDDEN_COLUMN_NAMES;
+    public static final Set<String> FORBIDDEN_COLUMN_NAMES;
 
     static {
         FORBIDDEN_COLUMN_NAMES = new HashSet<>();
@@ -121,7 +121,7 @@ public class FeNameFormat {
             if (FORBIDDEN_COLUMN_NAMES.contains(columnName)) {
                 throw new SemanticException(
                         "Column name [" + columnName + "] is a system reserved name. " +
-                        "If you are sure you want to use it, please set FE configuration allow_system_reserved_names");
+                                "Please choose a different one.");
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -692,6 +692,38 @@ public class CreateTableTest {
     }
 
     @Test
+    public void testCreateTableWithReserveColumn() {
+        Config.allow_system_reserved_names = true;
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Column name '__op' is reserved for primary key table",
+                () -> createTable(
+                "CREATE TABLE test.test_op (\n" +
+                        "k1 INT,\n" +
+                        "__op INT\n" +
+                        ") ENGINE=OLAP\n" +
+                        "PRIMARY KEY(k1)\n" +
+                        "COMMENT \"OLAP\"\n" +
+                        "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\"\n" +
+                        ");"));
+
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Column name '__row' is reserved for primary key table",
+                        () -> createTable(
+                        "CREATE TABLE test.test_row (\n" +
+                                "k1 INT,\n" +
+                                "__row INT\n" +
+                                ") ENGINE=OLAP\n" +
+                                "PRIMARY KEY(k1)\n" +
+                                "COMMENT \"OLAP\"\n" +
+                                "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ");"));
+
+        Config.allow_system_reserved_names = false;
+    }
+
+    @Test
     public void testCreateSumAgg() throws Exception {
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.useDatabase("test");
@@ -2061,7 +2093,7 @@ public class CreateTableTest {
                 " distributed by hash(key0) properties(\"replication_num\"=\"1\");";
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Getting analyzing error." +
                         " Detail message: Column name [__op] is a system reserved name." +
-                        " If you are sure you want to use it, please set FE configuration allow_system_reserved_names",
+                        " Please choose a different one.",
                 () -> starRocksAssert.withTable(sql1));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -720,6 +720,19 @@ public class CreateTableTest {
                                 "\"replication_num\" = \"1\"\n" +
                                 ");"));
 
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Column name '__ROW' is reserved for primary key table",
+                        () -> createTable(
+                        "CREATE TABLE test.test_row (\n" +
+                                "k1 INT,\n" +
+                                "__ROW INT\n" +
+                                ") ENGINE=OLAP\n" +
+                                "PRIMARY KEY(k1)\n" +
+                                "COMMENT \"OLAP\"\n" +
+                                "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                                "PROPERTIES (\n" +
+                                "\"replication_num\" = \"1\"\n" +
+                                ");"));
+
         Config.allow_system_reserved_names = false;
     }
 


### PR DESCRIPTION
## Why I'm doing:
When user try to create table with `__op` column, SR will return error like:
```
message: Column name [__op] is a system reserved name. If you are sure you want to use it, please set FE configuration allow_system_reserved_names
```
This is a warning, but user can still create PK table with `__op` column by enable `allow_system_reserved_names`.
And it will lead to BE crash while ingestion.

## What I'm doing:
This pull request introduces several changes to enforce restrictions on reserved column names for primary key tables and includes corresponding test cases. The most important changes are grouped into two themes: enforcing reserved column names and updating test cases.

Enforcing reserved column names:

* Added checks in `SchemaChangeHandler` and `OlapTableFactory` to throw `DdlException` if a reserved column name is used for primary key tables (`[[1]](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cR1055-R1058)`, `[[2]](diffhunk://#diff-b0209c12a04a4b700190e7d3048526b6c15a75a7fc7fdd3ecf3ef9422fe259c9R270-R275)`).
* Made `FORBIDDEN_COLUMN_NAMES` public in `FeNameFormat` to allow access from other classes (`[fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.javaL57-R57](diffhunk://#diff-b0c1f56aa37b2143b40020f6bd5c03e7623c67bfe407b04c4344ed2c75401e6cL57-R57)`).
* Updated error message in `FeNameFormat` to instruct users to choose a different column name instead of setting a configuration (`[fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FeNameFormat.javaL124-R124](diffhunk://#diff-b0c1f56aa37b2143b40020f6bd5c03e7623c67bfe407b04c4344ed2c75401e6cL124-R124)`).

Updating test cases:

* Added a test case in `SchemaChangeHandlerTest` to verify that adding a reserved column name to a primary key table throws the correct exception (`[fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.javaR441-R479](diffhunk://#diff-25dc89cdb0b52b9c06bbb66cc1ca6254cce6619417afea0f8a6e5387436a3b3dR441-R479)`).
* Added test cases in `CreateTableTest` to verify that creating a table with a reserved column name for primary key throws the correct exception (`[[1]](diffhunk://#diff-757f7742c81fc420499dc70347e0ec1f1fa5f0551a265796a44f6f6a81b54523R694-R725)`, `[[2]](diffhunk://#diff-757f7742c81fc420499dc70347e0ec1f1fa5f0551a265796a44f6f6a81b54523L2064-R2096)`).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
