### PR TITLE
[BugFix] Fix incorrect execution plan when generated column rewrite in join relation if left table and right table has the same column name (backport #52584)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -769,6 +769,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // regexp predicate is less efficient than like predicates.
     public static final String LIKE_PREDICATE_CONSOLIDATE_MIN = "like_predicate_consolidate_min";
 
+    public static final String DISABLE_GENERATED_COLUMN_REWRITE = "disable_generated_column_rewrite";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1519,6 +1521,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_HYPERSCAN_VEC)
     private boolean enableHyperscanVec = true;
+
+    @VarAttr(name = DISABLE_GENERATED_COLUMN_REWRITE, flag = VariableMgr.INVISIBLE)
+    private boolean disableGeneratedColumnRewrite = false;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -4035,6 +4040,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setLikePredicateConsolidateMin(int value) {
         this.likePredicateConsolidateMin = value;
+    }
+
+    public boolean isDisableGeneratedColumnRewrite() {
+        return disableGeneratedColumnRewrite;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -132,6 +132,9 @@ public class QueryAnalyzer {
         }
 
         public Void process(ParseNode node, Scope scope) {
+            if (session.getSessionVariable().isDisableGeneratedColumnRewrite()) {
+                return null;
+            }
             return node.accept(this, scope);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReplaceScalarOperatorRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReplaceScalarOperatorRule.java
@@ -29,11 +29,10 @@ public class ReplaceScalarOperatorRule extends BottomUpScalarOperatorRewriteRule
 
     @Override
     public ScalarOperator visit(ScalarOperator scalarOperator, ScalarOperatorRewriteContext context) {
-        for (Map.Entry<ScalarOperator, ColumnRefOperator> m : translateMap.entrySet()) {
-            if (ScalarOperator.isEquivalent(m.getKey(), scalarOperator)) {
-                return m.getValue();
-            }
+        if (translateMap.containsKey(scalarOperator)) {
+            return translateMap.get(scalarOperator);
         }
+
         return scalarOperator;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GeneratedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GeneratedColumnTest.java
@@ -137,11 +137,11 @@ public class GeneratedColumnTest extends PlanTestBase {
         assertContains(plan, "OUTPUT EXPRS:5: expr");
         assertContains(plan, " group by: 1: v1, 2: v2");
 
-        sql = " select tmc.v1 + 1 from tmc as v,tmc2 as tmc";
+        sql = " select v.v1 + 1 from tmc as v,tmc2 as tmc";
         plan = getFragmentPlan(sql);
         assertContains(plan, "<slot 3> : 3: v3");
 
-        sql = " select tmc.v1 + 1 from tmc as v,tmc2 as tmc";
+        sql = " select v.v1 + 1 from tmc as v,tmc2 as tmc";
         plan = getFragmentPlan(sql);
         assertContains(plan, "<slot 3> : 3: v3");
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2540,6 +2540,16 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
             else:
                 break
 
+    def assert_is_identical_explain_plan(self, query1, query2):
+        """
+        assert whether two plans from query1 and query2 are identical
+        """
+        sql1 = "explain %s" % query1
+        sql2 = "explain %s" % query2
+        res1 = self.execute_sql(sql1, True)
+        res2 = self.execute_sql(sql2, True)
+        tools.assert_true(res1 == res2, "assert two plans are different, plan1: {}, plan2: {}".format(res1["result"], res2["result"]))
+
     def assert_explain_contains(self, query, *expects):
         """
         assert explain result contains expect string

--- a/test/sql/test_materialized_column/R/test_generated_column_rewrite
+++ b/test/sql/test_materialized_column/R/test_generated_column_rewrite
@@ -81,7 +81,15 @@ function: assert_explain_not_contains('SELECT CONCAT(CAST(id AS STRING), "_abc")
 -- result:
 None
 -- !result
+function: assert_is_identical_explain_plan('SELECT CONCAT(CAST(id AS STRING), "_abc") FROM t_generated_column_complex_rewrite_1', "SELECT col FROM t_generated_column_complex_rewrite_1")
+-- result:
+None
+-- !result
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE col IS NOT NULL")
 -- result:
 None
 -- !result
@@ -89,7 +97,15 @@ function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM
 -- result:
 None
 -- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE col IS NOT NULL")
+-- result:
+None
+-- !result
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE col IS NOT NULL")
 -- result:
 None
 -- !result
@@ -97,11 +113,23 @@ function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM
 -- result:
 None
 -- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE col IS NOT NULL")
+-- result:
+None
+-- !result
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col AS col1, id AS id1 FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id1 AS STRING), "_abc") IS NOT NULL', "abc")
 -- result:
 None
 -- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT col AS col1, id AS id1 FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id1 AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT col AS col1, id AS id1 FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE col1 IS NOT NULL")
+-- result:
+None
+-- !result
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', 'abc')
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', 'SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE col IS NOT NULL')
 -- result:
 None
 -- !result
@@ -113,7 +141,15 @@ function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_gen
 -- result:
 None
 -- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE result.col IS NOT NULL")
+-- result:
+None
+-- !result
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE result.col IS NOT NULL")
 -- result:
 None
 -- !result
@@ -121,7 +157,15 @@ function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT t1.id as col
 -- result:
 None
 -- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE t1.id = t2.id) result WHERE CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE t1.id = t2.id) result WHERE result.col2 = result.col4")
+-- result:
+None
+-- !result
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE CONCAT(CAST(t1.id AS STRING), "_abc") = CONCAT(CAST(t2.id AS STRING), "_abc")) result where CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE CONCAT(CAST(t1.id AS STRING), "_abc") = CONCAT(CAST(t2.id AS STRING), "_abc")) result where CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE t1.col = t2.col) result where result.col2 = result.col4")
 -- result:
 None
 -- !result
@@ -129,6 +173,10 @@ CREATE VIEW t_generated_column_complex_rewrite_view AS SELECT * FROM t_generated
 -- result:
 -- !result
 function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col IS NOT NULL")
 -- result:
 None
 -- !result
@@ -142,6 +190,10 @@ function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_c
 -- result:
 None
 -- !result
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col IS NOT NULL")
+-- result:
+None
+-- !result
 DROP VIEW t_generated_column_complex_rewrite_view;
 -- result:
 -- !result
@@ -149,6 +201,10 @@ CREATE VIEW t_generated_column_complex_rewrite_view AS SELECT * FROM (SELECT * F
 -- result:
 -- !result
 function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col IS NOT NULL")
 -- result:
 None
 -- !result
@@ -162,6 +218,10 @@ function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_c
 -- result:
 None
 -- !result
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id1 AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col1 IS NOT NULL")
+-- result:
+None
+-- !result
 DROP VIEW t_generated_column_complex_rewrite_view;
 -- result:
 -- !result
@@ -172,7 +232,15 @@ function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_c
 -- result:
 None
 -- !result
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col2 IS NOT NULL")
+-- result:
+None
+-- !result
 function: assert_explain_not_contains('SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE col2 IS NOT NULL")
 -- result:
 None
 -- !result
@@ -186,7 +254,15 @@ function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_c
 -- result:
 None
 -- !result
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col2 IS NOT NULL")
+-- result:
+None
+-- !result
 function: assert_explain_not_contains('SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE col2 IS NOT NULL")
 -- result:
 None
 -- !result
@@ -196,7 +272,11 @@ DROP VIEW t_generated_column_complex_rewrite_view;
 CREATE VIEW t_generated_column_complex_rewrite_view AS WITH tmp as (SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL) select * from tmp;
 -- result:
 -- !result
-function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view', "abc")
+function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view where col IS NOT NULL")
 -- result:
 None
 -- !result
@@ -206,11 +286,11 @@ DROP VIEW t_generated_column_complex_rewrite_view;
 CREATE VIEW t_generated_column_complex_rewrite_view AS WITH tmp as (SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL) select * from tmp where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL;
 -- result:
 -- !result
-function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view', "abc")
+function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
 -- result:
 None
 -- !result
-function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view where col IS NOT NULL")
 -- result:
 None
 -- !result
@@ -237,6 +317,10 @@ INSERT INTO t_generated_column_complex_rewrite_3 VALUES (1);
 -- result:
 -- !result
 function: assert_explain_contains('SELECT COUNT(*) FROM t_generated_column_complex_rewrite_3 WHERE cast(id + 10 as string) IS NOT NULL', 'col')
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM t_generated_column_complex_rewrite_3 WHERE cast(id + 10 as string) IS NOT NULL', 'SELECT COUNT(*) FROM t_generated_column_complex_rewrite_3 WHERE col IS NOT NULL')
 -- result:
 None
 -- !result
@@ -289,5 +373,332 @@ DROP TABLE t_generated_column_complex_rewrite_4;
 -- result:
 -- !result
 DROP TABLE t_generated_column_complex_rewrite_5;
+-- result:
+-- !result
+-- name: test_bug_join_with_same_column_name
+CREATE TABLE `t_bug_join_with_same_column_name_1` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `col` STRING AS CONCAT(CAST(id AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t_bug_join_with_same_column_name_2` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `col` STRING AS CONCAT(CAST(id AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_bug_join_with_same_column_name_1 VALUES (1);
+-- result:
+-- !result
+INSERT INTO t_bug_join_with_same_column_name_1 VALUES (2);
+-- result:
+-- !result
+INSERT INTO t_bug_join_with_same_column_name_1 VALUES (3);
+-- result:
+-- !result
+INSERT INTO t_bug_join_with_same_column_name_2 VALUES (1);
+-- result:
+-- !result
+INSERT INTO t_bug_join_with_same_column_name_2 VALUES (10);
+-- result:
+-- !result
+INSERT INTO t_bug_join_with_same_column_name_2 VALUES (20);
+-- result:
+-- !result
+SELECT COUNT(*) FROM t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2 WHERE CONCAT(CAST(t1.id AS STRING), "_abc") = CONCAT(CAST(t2.id AS STRING), "_abc");
+-- result:
+1
+-- !result
+SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM
+t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2) AS result WHERE CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc");
+-- result:
+1
+-- !result
+WITH tmp AS (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2)
+SELECT COUNT(*) FROM tmp where CONCAT(CAST(tmp.col1 AS STRING), "_abc") = CONCAT(CAST(tmp.col3 AS STRING), "_abc");
+-- result:
+1
+-- !result
+CREATE VIEW v1 AS SELECT COUNT(*) FROM t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2 WHERE CONCAT(CAST(t1.id AS STRING), "_abc") = CONCAT(CAST(t2.id AS STRING), "_abc");
+-- result:
+-- !result
+SELECT * FROM v1;
+-- result:
+1
+-- !result
+DROP VIEW v1;
+-- result:
+-- !result
+CREATE VIEW v2 AS SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM
+t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2) AS result WHERE CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc");
+-- result:
+-- !result
+SELECT * FROM v2;
+-- result:
+1
+-- !result
+DROP VIEW v2;
+-- result:
+-- !result
+CREATE VIEW v3 AS WITH tmp AS (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2)
+SELECT COUNT(*) FROM tmp where CONCAT(CAST(tmp.col1 AS STRING), "_abc") = CONCAT(CAST(tmp.col3 AS STRING), "_abc");
+-- result:
+-- !result
+SELECT * FROM v3;
+-- result:
+1
+-- !result
+DROP VIEW v3;
+-- result:
+-- !result
+create table testA (
+    `id` bigint(20) NOT NULL,
+    `fields` json NULL,
+    `fields_test_field` varchar(1048576) NULL AS CAST(fields->'testField' AS VARCHAR) COMMENT ""
+) PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+create table testB (
+    `id` bigint(20) NOT NULL,
+    `a_id` bigint(20) NOT NULL,
+    `fields` json NULL
+) PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+create view testA_B_with_gen_columns(
+    id,
+    a_id,
+    fields,
+    _a_id,
+    _a_fields,
+    _a_fields_test_field
+) AS 
+SELECT 
+    b.id,
+    b.a_id,
+    b.fields,
+    a.id as _a_id,
+    a.fields as _a_fields,
+    a.fields_test_field as _a_fields_test_field
+FROM testB b
+JOIN testA a ON b.a_id = a.id;
+-- result:
+-- !result
+create view testA_B_without_gen_columns(
+    id,
+    a_id,
+    fields,
+    _a_id,
+    _a_fields
+) AS 
+SELECT 
+    b.id,
+    b.a_id,
+    b.fields,
+    a.id as _a_id,
+    a.fields as _a_fields
+FROM testB b
+JOIN testA a ON b.a_id = a.id;
+-- result:
+-- !result
+INSERT INTO testA VALUES
+(0, cast('{"testField": "A"}' as JSON)),
+(1, cast('{"testField": "B"}' as JSON)),
+(2, cast('{"testField": "C"}' as JSON)),
+(3, cast('{"notTestField": "A"}' as JSON)),
+(4, cast('{"notTestField": "B"}' as JSON)),
+(5, cast('{"notTestField": "C"}' as JSON)),
+(6, null),
+(7, null),
+(8, null);
+-- result:
+-- !result
+INSERT INTO testB VALUES
+(0, 0, cast('{"testField": "A1"}' as JSON)),
+(1, 1, cast('{"notTestField": "B"}' as JSON)),
+(2, 2, null),
+(3, 3, cast('{"testField": "A1"}' as JSON)),
+(4, 4, cast('{"notTestField": "B"}' as JSON)),
+(5, 5, null),
+(6, 6, cast('{"testField": "A1"}' as JSON)),
+(7, 7, cast('{"notTestField": "B"}' as JSON)),
+(8, 8, null);
+-- result:
+-- !result
+SELECT 
+    id,
+    fields as b_fields,
+    _a_fields as a_fields,
+    CAST(fields->'testField' AS VARCHAR),
+    CAST(fields->'$.testField' AS VARCHAR),
+    CAST(_a_fields->'testField' AS VARCHAR)
+FROM testA_B_with_gen_columns 
+ORDER BY id asc;
+-- result:
+0	{"testField": "A1"}	{"testField": "A"}	A1	A1	A
+1	{"notTestField": "B"}	{"testField": "B"}	None	None	B
+2	None	{"testField": "C"}	None	None	C
+3	{"testField": "A1"}	{"notTestField": "A"}	A1	A1	None
+4	{"notTestField": "B"}	{"notTestField": "B"}	None	None	None
+5	None	{"notTestField": "C"}	None	None	None
+6	{"testField": "A1"}	None	A1	A1	None
+7	{"notTestField": "B"}	None	None	None	None
+8	None	None	None	None	None
+-- !result
+SELECT 
+    id,
+    fields as b_fields,
+    _a_fields as a_fields,
+    CAST(fields->'testField' AS VARCHAR),
+    CAST(fields->'$.testField' AS VARCHAR),
+    CAST(_a_fields->'testField' AS VARCHAR)
+FROM testA_B_without_gen_columns
+ORDER BY id asc;
+-- result:
+0	{"testField": "A1"}	{"testField": "A"}	A1	A1	A
+1	{"notTestField": "B"}	{"testField": "B"}	None	None	B
+2	None	{"testField": "C"}	None	None	C
+3	{"testField": "A1"}	{"notTestField": "A"}	A1	A1	None
+4	{"notTestField": "B"}	{"notTestField": "B"}	None	None	None
+5	None	{"notTestField": "C"}	None	None	None
+6	{"testField": "A1"}	None	A1	A1	None
+7	{"notTestField": "B"}	None	None	None	None
+8	None	None	None	None	None
+-- !result
+CREATE TABLE `t_rewrite_with_some_clause` (
+  `original` bigint(20) NOT NULL COMMENT "",
+  `col` bigint(20) AS original * original + 10
+) ENGINE=OLAP 
+DUPLICATE KEY(`original`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_rewrite_with_some_clause VALUES (1),(20),(40);
+-- result:
+-- !result
+function: assert_explain_not_contains('SELECT SUM(original * original + 10), AVG(original * original + 10) FROM t_rewrite_with_some_clause', "original")
+-- result:
+None
+-- !result
+SELECT SUM(original * original + 10), AVG(original * original + 10) FROM t_rewrite_with_some_clause;
+-- result:
+2031	677.0
+-- !result
+function: assert_explain_not_contains('SELECT CONCAT(CAST(SUM(original * original + 10) AS STRING), CAST(AVG(original * original + 10) AS STRING)) FROM t_rewrite_with_some_clause', "original")
+-- result:
+None
+-- !result
+SELECT CONCAT(CAST(SUM(original * original + 10) AS STRING), CAST(AVG(original * original + 10) AS STRING)) FROM t_rewrite_with_some_clause;
+-- result:
+2031677
+-- !result
+function: assert_explain_not_contains('SELECT original * original + 10 FROM t_rewrite_with_some_clause ORDER by original LIMIT 1', "original * original")
+-- result:
+None
+-- !result
+SELECT original * original + 10 FROM t_rewrite_with_some_clause ORDER by original LIMIT 1;
+-- result:
+11
+-- !result
+CREATE TABLE `t1` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AS k + 10 COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false"
+);
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AS k + 10 COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false"
+);
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1);
+-- result:
+-- !result
+INSERT INTO t2 VALUES (2);
+-- result:
+-- !result
+SET disable_generated_column_rewrite = true;
+-- result:
+-- !result
+function: assert_explain_contains('SELECT k + 10 FROM t1', "k + 10")
+-- result:
+None
+-- !result
+function: assert_explain_contains('SELECT k + 10 FROM t2', "k + 10")
+-- result:
+None
+-- !result
+function: assert_explain_contains('SELECT result.col1 + 10, result.col3 + 10 FROM (SELECT t1.k AS col1, t1.v AS col2, t2.k AS col3, t2.v AS col4 FROM t1, t2) AS result', "k + 10")
+-- result:
+None
+-- !result
+function: assert_explain_contains('WITH tmp AS (SELECT t1.k AS col1, t1.v AS col2, t2.k AS col3, t2.v AS col4 FROM t1, t2) SELECT tmp.col1 + 10, tmp.col3 + 10 FROM tmp', "k + 10")
+-- result:
+None
+-- !result
+CREATE VIEW v1 AS SELECT result.col1 + 10, result.col3 + 10 FROM (SELECT t1.k AS col1, t1.v AS col2, t2.k AS col3, t2.v AS col4 FROM t1, t2) AS result;
+-- result:
+-- !result
+function: assert_explain_contains('SELECT * FROM v1', "k + 10")
+-- result:
+None
+-- !result
+DROP VIEW v1;
+-- result:
+-- !result
+CREATE VIEW v2 AS WITH tmp AS (SELECT t1.k AS col1, t1.v AS col2, t2.k AS col3, t2.v AS col4 FROM t1, t2) SELECT tmp.col1 + 10, tmp.col3 + 10 FROM tmp;
+-- result:
+-- !result
+function: assert_explain_contains('SELECT * FROM v2', "k + 10")
+-- result:
+None
+-- !result
+DROP VIEW v2;
 -- result:
 -- !result

--- a/test/sql/test_materialized_column/T/test_generated_column_rewrite
+++ b/test/sql/test_materialized_column/T/test_generated_column_rewrite
@@ -45,51 +45,82 @@ INSERT INTO t_generated_column_complex_rewrite_2 VALUES (1);
 INSERT INTO t_generated_column_complex_rewrite_2 VALUES (2);
 
 function: assert_explain_not_contains('SELECT CONCAT(CAST(id AS STRING), "_abc") FROM t_generated_column_complex_rewrite_1', "abc")
+function: assert_is_identical_explain_plan('SELECT CONCAT(CAST(id AS STRING), "_abc") FROM t_generated_column_complex_rewrite_1', "SELECT col FROM t_generated_column_complex_rewrite_1")
+
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE col IS NOT NULL")
+
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE col IS NOT NULL")
+
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE col IS NOT NULL")
+
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) t_generated_column_complex_rewrite_1 WHERE col IS NOT NULL")
+
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col AS col1, id AS id1 FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id1 AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT col AS col1, id AS id1 FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id1 AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT col AS col1, id AS id1 FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE col1 IS NOT NULL")
+
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', 'abc')
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', 'SELECT COUNT(*) FROM (SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE col IS NOT NULL')
+
 function: assert_explain_contains('SELECT COUNT(*) FROM (SELECT col AS id FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', 'abc')
+
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE result.col IS NOT NULL")
+
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE CONCAT(CAST(result.id AS STRING), "_abc") IS NOT NULL', "SELECT COUNT(*) FROM (SELECT col, id FROM t_generated_column_complex_rewrite_1 where id = 1) result WHERE result.col IS NOT NULL")
+
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE t1.id = t2.id) result WHERE CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "abc")
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE t1.id = t2.id) result WHERE CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE t1.id = t2.id) result WHERE result.col2 = result.col4")
+
 function: assert_explain_not_contains('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE CONCAT(CAST(t1.id AS STRING), "_abc") = CONCAT(CAST(t2.id AS STRING), "_abc")) result where CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "abc")
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE CONCAT(CAST(t1.id AS STRING), "_abc") = CONCAT(CAST(t2.id AS STRING), "_abc")) result where CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc")', "SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_generated_column_complex_rewrite_1 t1, t_generated_column_complex_rewrite_2 t2 WHERE t1.col = t2.col) result where result.col2 = result.col4")
 
 CREATE VIEW t_generated_column_complex_rewrite_view AS SELECT * FROM t_generated_column_complex_rewrite_1;
 function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col IS NOT NULL")
 DROP VIEW t_generated_column_complex_rewrite_view;
 
 CREATE VIEW t_generated_column_complex_rewrite_view AS SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1;
 function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col IS NOT NULL")
 DROP VIEW t_generated_column_complex_rewrite_view;
 
 CREATE VIEW t_generated_column_complex_rewrite_view AS SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) result;
 function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col IS NOT NULL")
 DROP VIEW t_generated_column_complex_rewrite_view;
 
 CREATE VIEW t_generated_column_complex_rewrite_view AS SELECT * FROM (SELECT id as id1, col as col1 FROM t_generated_column_complex_rewrite_1) result;
 function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id1 AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(id1 AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col1 IS NOT NULL")
 DROP VIEW t_generated_column_complex_rewrite_view;
 
 CREATE VIEW t_generated_column_complex_rewrite_view AS SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 from t_generated_column_complex_rewrite_1 t1 join t_generated_column_complex_rewrite_2 t2 on t1.id = t2.id;
 function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col2 IS NOT NULL")
 function: assert_explain_not_contains('SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE col2 IS NOT NULL")
 DROP VIEW t_generated_column_complex_rewrite_view;
 
 CREATE VIEW t_generated_column_complex_rewrite_view AS SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 from t_generated_column_complex_rewrite_1 t1 join (SELECT * FROM t_generated_column_complex_rewrite_2) t2 on t1.id = t2.id;
 function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view WHERE col2 IS NOT NULL")
 function: assert_explain_not_contains('SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE CONCAT(CAST(col1 AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM (SELECT * FROM t_generated_column_complex_rewrite_view) t_generated_column_complex_rewrite_view WHERE col2 IS NOT NULL")
 DROP VIEW t_generated_column_complex_rewrite_view;
 
 CREATE VIEW t_generated_column_complex_rewrite_view AS WITH tmp as (SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL) select * from tmp;
-function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view', "abc")
+function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view where col IS NOT NULL")
 DROP VIEW t_generated_column_complex_rewrite_view;
 
 CREATE VIEW t_generated_column_complex_rewrite_view AS WITH tmp as (SELECT * FROM (SELECT * FROM t_generated_column_complex_rewrite_1) t_generated_column_complex_rewrite_1 WHERE CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL) select * from tmp where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL;
-function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view', "abc")
 function: assert_explain_not_contains('SELECT count(*) FROM t_generated_column_complex_rewrite_view where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "abc")
+function: assert_is_identical_explain_plan('SELECT count(*) FROM t_generated_column_complex_rewrite_view where CONCAT(CAST(id AS STRING), "_abc") IS NOT NULL', "SELECT count(*) FROM t_generated_column_complex_rewrite_view where col IS NOT NULL")
 DROP VIEW t_generated_column_complex_rewrite_view;
 
 CREATE TABLE `t_generated_column_complex_rewrite_3` (
@@ -109,6 +140,7 @@ PROPERTIES (
 
 INSERT INTO t_generated_column_complex_rewrite_3 VALUES (1);
 function: assert_explain_contains('SELECT COUNT(*) FROM t_generated_column_complex_rewrite_3 WHERE cast(id + 10 as string) IS NOT NULL', 'col')
+function: assert_is_identical_explain_plan('SELECT COUNT(*) FROM t_generated_column_complex_rewrite_3 WHERE cast(id + 10 as string) IS NOT NULL', 'SELECT COUNT(*) FROM t_generated_column_complex_rewrite_3 WHERE col IS NOT NULL')
 DROP table t_generated_column_complex_rewrite_3;
 
 CREATE TABLE `t_generated_column_complex_rewrite_4` (
@@ -148,3 +180,229 @@ select * from (select t4.* from t_generated_column_complex_rewrite_4 as t4 left 
 
 DROP TABLE t_generated_column_complex_rewrite_4;
 DROP TABLE t_generated_column_complex_rewrite_5;
+
+-- name: test_bug_join_with_same_column_name
+CREATE TABLE `t_bug_join_with_same_column_name_1` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `col` STRING AS CONCAT(CAST(id AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t_bug_join_with_same_column_name_2` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `col` STRING AS CONCAT(CAST(id AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_bug_join_with_same_column_name_1 VALUES (1);
+INSERT INTO t_bug_join_with_same_column_name_1 VALUES (2);
+INSERT INTO t_bug_join_with_same_column_name_1 VALUES (3);
+INSERT INTO t_bug_join_with_same_column_name_2 VALUES (1);
+INSERT INTO t_bug_join_with_same_column_name_2 VALUES (10);
+INSERT INTO t_bug_join_with_same_column_name_2 VALUES (20);
+
+-- query with join, case1
+SELECT COUNT(*) FROM t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2 WHERE CONCAT(CAST(t1.id AS STRING), "_abc") = CONCAT(CAST(t2.id AS STRING), "_abc");
+
+-- query with join in subquery, case2
+SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM
+t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2) AS result WHERE CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc");
+
+-- query with join in CTE, case3
+WITH tmp AS (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2)
+SELECT COUNT(*) FROM tmp where CONCAT(CAST(tmp.col1 AS STRING), "_abc") = CONCAT(CAST(tmp.col3 AS STRING), "_abc");
+
+-- query case1 by view
+CREATE VIEW v1 AS SELECT COUNT(*) FROM t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2 WHERE CONCAT(CAST(t1.id AS STRING), "_abc") = CONCAT(CAST(t2.id AS STRING), "_abc");
+SELECT * FROM v1;
+DROP VIEW v1;
+
+-- query case2 by view
+CREATE VIEW v2 AS SELECT COUNT(*) FROM (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM
+t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2) AS result WHERE CONCAT(CAST(result.col1 AS STRING), "_abc") = CONCAT(CAST(result.col3 AS STRING), "_abc");
+SELECT * FROM v2;
+DROP VIEW v2;
+
+-- query case3 by view
+CREATE VIEW v3 AS WITH tmp AS (SELECT t1.id as col1, t1.col as col2, t2.id as col3, t2.col as col4 FROM t_bug_join_with_same_column_name_1 t1, t_bug_join_with_same_column_name_2 t2)
+SELECT COUNT(*) FROM tmp where CONCAT(CAST(tmp.col1 AS STRING), "_abc") = CONCAT(CAST(tmp.col3 AS STRING), "_abc");
+SELECT * FROM v3;
+DROP VIEW v3;
+
+create table testA (
+    `id` bigint(20) NOT NULL,
+    `fields` json NULL,
+    `fields_test_field` varchar(1048576) NULL AS CAST(fields->'testField' AS VARCHAR) COMMENT ""
+) PROPERTIES("replication_num" = "1");
+
+create table testB (
+    `id` bigint(20) NOT NULL,
+    `a_id` bigint(20) NOT NULL,
+    `fields` json NULL
+) PROPERTIES("replication_num" = "1");
+
+create view testA_B_with_gen_columns(
+    id,
+    a_id,
+    fields,
+    _a_id,
+    _a_fields,
+    _a_fields_test_field
+) AS 
+SELECT 
+    b.id,
+    b.a_id,
+    b.fields,
+    a.id as _a_id,
+    a.fields as _a_fields,
+    a.fields_test_field as _a_fields_test_field
+FROM testB b
+JOIN testA a ON b.a_id = a.id;
+
+create view testA_B_without_gen_columns(
+    id,
+    a_id,
+    fields,
+    _a_id,
+    _a_fields
+) AS 
+SELECT 
+    b.id,
+    b.a_id,
+    b.fields,
+    a.id as _a_id,
+    a.fields as _a_fields
+FROM testB b
+JOIN testA a ON b.a_id = a.id;
+
+INSERT INTO testA VALUES
+(0, cast('{"testField": "A"}' as JSON)),
+(1, cast('{"testField": "B"}' as JSON)),
+(2, cast('{"testField": "C"}' as JSON)),
+(3, cast('{"notTestField": "A"}' as JSON)),
+(4, cast('{"notTestField": "B"}' as JSON)),
+(5, cast('{"notTestField": "C"}' as JSON)),
+(6, null),
+(7, null),
+(8, null);
+
+INSERT INTO testB VALUES
+(0, 0, cast('{"testField": "A1"}' as JSON)),
+(1, 1, cast('{"notTestField": "B"}' as JSON)),
+(2, 2, null),
+(3, 3, cast('{"testField": "A1"}' as JSON)),
+(4, 4, cast('{"notTestField": "B"}' as JSON)),
+(5, 5, null),
+(6, 6, cast('{"testField": "A1"}' as JSON)),
+(7, 7, cast('{"notTestField": "B"}' as JSON)),
+(8, 8, null);
+
+SELECT 
+    id,
+    fields as b_fields,
+    _a_fields as a_fields,
+    CAST(fields->'testField' AS VARCHAR),
+    CAST(fields->'$.testField' AS VARCHAR),
+    CAST(_a_fields->'testField' AS VARCHAR)
+FROM testA_B_with_gen_columns 
+ORDER BY id asc;
+
+SELECT 
+    id,
+    fields as b_fields,
+    _a_fields as a_fields,
+    CAST(fields->'testField' AS VARCHAR),
+    CAST(fields->'$.testField' AS VARCHAR),
+    CAST(_a_fields->'testField' AS VARCHAR)
+FROM testA_B_without_gen_columns
+ORDER BY id asc;
+
+-- name test_rewrite_with_some_clause
+CREATE TABLE `t_rewrite_with_some_clause` (
+  `original` bigint(20) NOT NULL COMMENT "",
+  `col` bigint(20) AS original * original + 10
+) ENGINE=OLAP 
+DUPLICATE KEY(`original`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_rewrite_with_some_clause VALUES (1),(20),(40);
+
+function: assert_explain_not_contains('SELECT SUM(original * original + 10), AVG(original * original + 10) FROM t_rewrite_with_some_clause', "original")
+SELECT SUM(original * original + 10), AVG(original * original + 10) FROM t_rewrite_with_some_clause;
+
+function: assert_explain_not_contains('SELECT CONCAT(CAST(SUM(original * original + 10) AS STRING), CAST(AVG(original * original + 10) AS STRING)) FROM t_rewrite_with_some_clause', "original")
+SELECT CONCAT(CAST(SUM(original * original + 10) AS STRING), CAST(AVG(original * original + 10) AS STRING)) FROM t_rewrite_with_some_clause;
+
+function: assert_explain_not_contains('SELECT original * original + 10 FROM t_rewrite_with_some_clause ORDER by original LIMIT 1', "original * original")
+SELECT original * original + 10 FROM t_rewrite_with_some_clause ORDER by original LIMIT 1;
+
+-- name test_disable_generated_column_rewrite
+CREATE TABLE `t1` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AS k + 10 COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false"
+);
+
+CREATE TABLE `t2` (
+  `k` BIGINT NOT NULL COMMENT "",
+  `v` BIGINT AS k + 10 COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false"
+);
+
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (2);
+
+SET disable_generated_column_rewrite = true;
+
+function: assert_explain_contains('SELECT k + 10 FROM t1', "k + 10")
+function: assert_explain_contains('SELECT k + 10 FROM t2', "k + 10")
+function: assert_explain_contains('SELECT result.col1 + 10, result.col3 + 10 FROM (SELECT t1.k AS col1, t1.v AS col2, t2.k AS col3, t2.v AS col4 FROM t1, t2) AS result', "k + 10")
+function: assert_explain_contains('WITH tmp AS (SELECT t1.k AS col1, t1.v AS col2, t2.k AS col3, t2.v AS col4 FROM t1, t2) SELECT tmp.col1 + 10, tmp.col3 + 10 FROM tmp', "k + 10")
+
+CREATE VIEW v1 AS SELECT result.col1 + 10, result.col3 + 10 FROM (SELECT t1.k AS col1, t1.v AS col2, t2.k AS col3, t2.v AS col4 FROM t1, t2) AS result;
+function: assert_explain_contains('SELECT * FROM v1', "k + 10")
+DROP VIEW v1;
+
+CREATE VIEW v2 AS WITH tmp AS (SELECT t1.k AS col1, t1.v AS col2, t2.k AS col3, t2.v AS col4 FROM t1, t2) SELECT tmp.col1 + 10, tmp.col3 + 10 FROM tmp;
+function: assert_explain_contains('SELECT * FROM v2', "k + 10")
+DROP VIEW v2;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

