### PR TITLE
[Enhancement] split  Metric "query_error"  into there part

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
@@ -104,6 +104,11 @@ public class ErrorReport {
         throw new TimeoutException(reportCommon(null, errorCode, objs));
     }
 
+    public static void reportNoAliveBackendException(ErrorCode errorCode, Object... objs)
+            throws NoAliveBackendException {
+        throw new NoAliveBackendException(reportCommon(null, errorCode, objs));
+    }
+
     public interface DdlExecutor {
         void apply() throws UserException;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorReport.java
@@ -99,6 +99,11 @@ public class ErrorReport {
         throw new UserException(reportCommon(null, errorCode, objs));
     }
 
+    public static void reportTimeoutException(ErrorCode errorCode, Object... objs)
+            throws TimeoutException {
+        throw new TimeoutException(reportCommon(null, errorCode, objs));
+    }
+
     public interface DdlExecutor {
         void apply() throws UserException;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Status.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Status.java
@@ -146,6 +146,11 @@ public class Status {
         this.errorMsg = msg;
     }
 
+    public void setTimeOutStatus(String msg) {
+        this.errorCode = TStatusCode.TIMEOUT;
+        this.errorMsg = msg;
+    }
+
     public void rewriteErrorMsg() {
         if (ok()) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/common/UserException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/UserException.java
@@ -39,7 +39,7 @@ import com.google.common.base.Strings;
 /**
  * Thrown for non-internal server errors.
  * such as analyze error/parser error
- * which implies this is a user error.so we don't need pay attention to it
+ * which implies this is a user error.so we don't need to pay attention to it
  */
 public class UserException extends Exception {
     private final InternalErrorCode errorCode;

--- a/fe/fe-core/src/main/java/com/starrocks/common/UserException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/UserException.java
@@ -37,7 +37,9 @@ package com.starrocks.common;
 import com.google.common.base.Strings;
 
 /**
- * Thrown for internal server errors.
+ * Thrown for non-internal server errors.
+ * such as analyze error/parser error
+ * which implies this is a user error.so we don't need pay attention to it
  */
 public class UserException extends Exception {
     private final InternalErrorCode errorCode;

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -54,6 +54,10 @@ public class MetricCalculator extends TimerTask {
     private long lastQueryCounter = -1;
     private long lastRequestCounter = -1;
     private long lastQueryErrCounter = -1;
+    private long lastQueryInternalErrCounter = -1;
+    private long lastQueryAnalysisErrCounter = -1;
+    private long lastQueryTimeOutCounter = -1;
+
     private long lastQueryEventTime = -1;
 
     @Override
@@ -68,6 +72,9 @@ public class MetricCalculator extends TimerTask {
             lastQueryCounter = MetricRepo.COUNTER_QUERY_ALL.getValue();
             lastRequestCounter = MetricRepo.COUNTER_REQUEST_ALL.getValue();
             lastQueryErrCounter = MetricRepo.COUNTER_QUERY_ERR.getValue();
+            lastQueryInternalErrCounter = MetricRepo.COUNTER_QUERY_INTERNAL_ERR.getValue();
+            lastQueryAnalysisErrCounter = MetricRepo.COUNTER_QUERY_ANALYSIS_ERR.getValue();
+            lastQueryTimeOutCounter = MetricRepo.COUNTER_QUERY_TIMEOUT.getValue();
             lastQueryEventTime = System.currentTimeMillis() * 1000000;
             return;
         }
@@ -91,6 +98,24 @@ public class MetricCalculator extends TimerTask {
         double errRate = (double) (currentErrCounter - lastQueryErrCounter) / interval;
         MetricRepo.GAUGE_QUERY_ERR_RATE.setValue(errRate < 0 ? 0.0 : errRate);
         lastQueryErrCounter = currentErrCounter;
+
+        // internal err rate
+        long currentInternalErrCounter = MetricRepo.COUNTER_QUERY_INTERNAL_ERR.getValue();
+        double internalErrRate = (double) (currentInternalErrCounter - lastQueryInternalErrCounter) / interval;
+        MetricRepo.GAUGE_QUERY_INTERNAL_ERR_RATE.setValue(errRate < 0 ? 0.0 : internalErrRate);
+        lastQueryInternalErrCounter = currentErrCounter;
+
+        // analysis error rate
+        long currentAnalysisErrCounter = MetricRepo.COUNTER_QUERY_ANALYSIS_ERR.getValue();
+        double analysisErrRate = (double) (currentAnalysisErrCounter - lastQueryAnalysisErrCounter) / interval;
+        MetricRepo.GAUGE_QUERY_ANALYSIS_ERR_RATE.setValue(errRate < 0 ? 0.0 : analysisErrRate);
+        lastQueryAnalysisErrCounter = currentErrCounter;
+
+        // query timeout rate
+        long currentTimeoutErrCounter = MetricRepo.COUNTER_QUERY_TIMEOUT.getValue();
+        double timeoutErrRate = (double) (currentTimeoutErrCounter - lastQueryTimeOutCounter) / interval;
+        MetricRepo.GAUGE_QUERY_TIMEOUT_RATE.setValue(errRate < 0 ? 0.0 : timeoutErrRate);
+        lastQueryTimeOutCounter = currentErrCounter;
 
         lastTs = currentTs;
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -174,6 +174,10 @@ public final class MetricRepo {
     public static GaugeMetricImpl<Double> GAUGE_QUERY_PER_SECOND;
     public static GaugeMetricImpl<Double> GAUGE_REQUEST_PER_SECOND;
     public static GaugeMetricImpl<Double> GAUGE_QUERY_ERR_RATE;
+    public static GaugeMetricImpl<Double> GAUGE_QUERY_INTERNAL_ERR_RATE;
+    public static GaugeMetricImpl<Double> GAUGE_QUERY_ANALYSIS_ERR_RATE;
+    public static GaugeMetricImpl<Double> GAUGE_QUERY_TIMEOUT_RATE;
+
     // these query latency is different from HISTO_QUERY_LATENCY, for these only summarize the latest queries, but HISTO_QUERY_LATENCY summarizes all queries.
     public static GaugeMetricImpl<Double> GAUGE_QUERY_LATENCY_MEAN;
     public static GaugeMetricImpl<Double> GAUGE_QUERY_LATENCY_MEDIAN;
@@ -333,6 +337,21 @@ public final class MetricRepo {
         GAUGE_QUERY_ERR_RATE.setValue(0.0);
         STARROCKS_METRIC_REGISTER.addMetric(GAUGE_QUERY_ERR_RATE);
 
+        GAUGE_QUERY_INTERNAL_ERR_RATE =
+                new GaugeMetricImpl<>("query_internal_err_rate", MetricUnit.NOUNIT, "query internal error rate");
+        GAUGE_QUERY_INTERNAL_ERR_RATE.setValue(0.0);
+        STARROCKS_METRIC_REGISTER.addMetric(GAUGE_QUERY_INTERNAL_ERR_RATE);
+
+        GAUGE_QUERY_ANALYSIS_ERR_RATE =
+                new GaugeMetricImpl<>("query_analysis_err_rate", MetricUnit.NOUNIT, "query analysis error rate");
+        GAUGE_QUERY_ANALYSIS_ERR_RATE.setValue(0.0);
+        STARROCKS_METRIC_REGISTER.addMetric(GAUGE_QUERY_ANALYSIS_ERR_RATE);
+
+        GAUGE_QUERY_TIMEOUT_RATE =
+                new GaugeMetricImpl<>("query_timeout_rate", MetricUnit.NOUNIT, "query timeout rate");
+        GAUGE_QUERY_TIMEOUT_RATE.setValue(0.0);
+        STARROCKS_METRIC_REGISTER.addMetric(GAUGE_QUERY_TIMEOUT_RATE);
+
         GAUGE_MAX_TABLET_COMPACTION_SCORE = new GaugeMetricImpl<>("max_tablet_compaction_score",
                 MetricUnit.NOUNIT, "max tablet compaction score of all backends");
         GAUGE_MAX_TABLET_COMPACTION_SCORE.setValue(0L);
@@ -455,6 +474,7 @@ public final class MetricRepo {
         COUNTER_QUERY_ANALYSIS_ERR = new LongCounterMetric("query_analysis_err", MetricUnit.REQUESTS,
                                                            "total analysis error query");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_ANALYSIS_ERR);
+
         COUNTER_QUERY_INTERNAL_ERR = new LongCounterMetric("query_internal_err", MetricUnit.REQUESTS, 
                                                            "total internal error query");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_INTERNAL_ERR);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -304,6 +304,8 @@ public class ConnectProcessor {
                 .setCatalog(ctx.getCurrentCatalog())
                 .setWarehouse(ctx.getCurrentWarehouseName());
         Tracers.register(ctx);
+        // set isQuery before `forwardToLeader` to make it right for audit log.
+        ctx.getState().setIsQuery(true);
 
         // execute this query.
         StatementBase parsedStmt = null;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -220,6 +220,8 @@ public class ConnectProcessor {
                 //represent analysis err
                 if (ctx.getState().getErrType() == QueryState.ErrType.ANALYSIS_ERR) {
                     MetricRepo.COUNTER_QUERY_ANALYSIS_ERR.increase(1L);
+                } else if (ctx.getState().getErrType() == QueryState.ErrType.EXEC_TIME_OUT) {
+                    MetricRepo.COUNTER_QUERY_TIMEOUT.increase(1L);
                 } else {
                     MetricRepo.COUNTER_QUERY_INTERNAL_ERR.increase(1L);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -44,6 +44,8 @@ import com.starrocks.catalog.FsBroker;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.Status;
@@ -907,6 +909,8 @@ public class DefaultCoordinator extends Coordinator {
                 if (copyStatus.isCancelled() &&
                         copyStatus.getErrorMsg().equals(FeConstants.BACKEND_NODE_NOT_FOUND_ERROR)) {
                     ec = InternalErrorCode.CANCEL_NODE_NOT_ALIVE_ERR;
+                } else if (copyStatus.isTimeout()) {
+                    ErrorReport.reportTimeoutException(ErrorCode.ERR_QUERY_TIMEOUT, errMsg);
                 }
                 throw new UserException(ec, errMsg);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
@@ -70,6 +70,9 @@ public class QueryState {
 
         IO_ERR,
 
+        // execution Timeout
+        EXEC_TIME_OUT,
+
         UNKNOWN
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -36,7 +36,6 @@ package com.starrocks.qe;
 
 import com.starrocks.common.Status;
 import com.starrocks.common.util.DebugUtil;
-import com.starrocks.metric.MetricRepo;
 import com.starrocks.proto.PFetchDataResult;
 import com.starrocks.proto.PUniqueId;
 import com.starrocks.rpc.BackendServiceClient;
@@ -148,11 +147,8 @@ public class ResultReceiver {
             }
         } catch (TimeoutException e) {
             LOG.warn("fetch result timeout, finstId={}", DebugUtil.printId(finstId), e);
-            status.setInternalErrorStatus(String.format("Query exceeded time limit of %d seconds",
+            status.setTimeOutStatus(String.format("Query exceeded time limit of %d seconds",
                     ConnectContext.get().getSessionVariable().getQueryTimeoutS()));
-            if (MetricRepo.hasInit) {
-                MetricRepo.COUNTER_QUERY_TIMEOUT.increase(1L);
-            }
         }
 
         if (isCancel) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -489,10 +489,6 @@ public class StmtExecutor {
         }
 
         try {
-            boolean isQuery = parsedStmt instanceof QueryStatement;
-            // set isQuery before `forwardToLeader` to make it right for audit log.
-            context.getState().setIsQuery(isQuery);
-
             if (parsedStmt.isExistQueryScopeHint()) {
                 processQueryScopeHint();
             }
@@ -585,7 +581,7 @@ public class StmtExecutor {
 
             // For follower: verify sql in BlackList before forward to leader
             // For leader: if this is a proxy sql, no need to verify sql in BlackList because every fe has its own blacklist
-            if ((isQuery || parsedStmt instanceof InsertStmt)
+            if ((parsedStmt instanceof QueryStatement || parsedStmt instanceof InsertStmt)
                     && Config.enable_sql_blacklist && !parsedStmt.isExplain() && !isProxy) {
                 OriginStatement origStmt = parsedStmt.getOrigStmt();
                 if (origStmt != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -68,6 +68,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.QueryDumpLog;
 import com.starrocks.common.Status;
@@ -754,6 +755,8 @@ public class StmtExecutor {
                 context.getState().setErrType(QueryState.ErrType.IGNORE_ERR);
             } else if (e instanceof TimeoutException) {
                 context.getState().setErrType(QueryState.ErrType.EXEC_TIME_OUT);
+            } else if (e instanceof NoAliveBackendException) {
+                context.getState().setErrType(QueryState.ErrType.INTERNAL_ERR);
             } else {
                 // TODO: some UserException doesn't belong to analysis error
                 // we should set such error type to internal error
@@ -2322,7 +2325,7 @@ public class StmtExecutor {
                     }
 
                     coord.cancel(ErrorCode.ERR_QUERY_EXCEPTION.formatErrorMsg());
-                    ErrorReport.reportDdlException(ErrorCode.ERR_QUERY_EXCEPTION);
+                    ErrorReport.reportNoAliveBackendException(ErrorCode.ERR_QUERY_EXCEPTION);
                 } else {
                     coord.cancel(ErrorCode.ERR_QUERY_TIMEOUT.formatErrorMsg());
                     if (coord.isThriftServerHighLoad()) {


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/50250 add query internal error and query analysis error in FE metric, which is part of query error. But has some problem which already exists befor 50250:
1. when query timeout, it will count to  analysis error, becasue it throws UserException
2. if one query fails in parser,  no query error will be record, because at this time, ctx.getState().isQuery() is false
3.  some UserException doesn't belong to analysis error, we should set such error type to internal error. Key point is some UserException actually is not user' s probelm  sucn as "BE is down but we throw DdlException which is a UserException"

## What I'm doing:

1. Fixes problem 1 and  problem 2
2. add three error rate metric: internal error rate, analysis error rate, timeout rate
3. for problem 3, just fix what i konw: "BE is down but we throw DdlException which is a UserException"

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
