### PR TITLE
[BugFix] remove unnecessary replicate for outer_common_expr

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -139,28 +139,8 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
     }
     DCHECK(aligned_offsets != nullptr);
 
-    // 4. prepare outer common exprs
-    for (const auto& [slot_id, expr] : _outer_common_exprs) {
-        auto column = chunk->get_column_by_slot_id(slot_id);
-        column = ColumnHelper::unpack_and_duplicate_const_column(column->size(), column);
-        if constexpr (independent_lambda_expr) {
-            // if lambda expr doesn't rely on arguments, we don't need to align offset
-            cur_chunk->append_column(column, slot_id);
-        } else {
-            if (column->is_array()) {
-                auto view_column = ArrayViewColumn::from_array_column(column);
-                cur_chunk->append_column(view_column->replicate(aligned_offsets->get_data()), slot_id);
-            } else {
-                cur_chunk->append_column(column->replicate(aligned_offsets->get_data()), slot_id);
-            }
-        }
-    }
-
-    // 5. prepare capture columns
+    // 4. prepare capture columns
     for (auto slot_id : capture_slot_ids) {
-        if (cur_chunk->is_slot_exist(slot_id)) {
-            continue;
-        }
         auto captured_column = chunk->get_column_by_slot_id(slot_id);
         if constexpr (independent_lambda_expr) {
             cur_chunk->append_column(captured_column, slot_id);
@@ -174,7 +154,7 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
         }
     }
 
-    // 6. evaluate lambda expr
+    // 5. evaluate lambda expr
     ColumnPtr column = nullptr;
     if constexpr (independent_lambda_expr) {
         // if lambda expr doesn't rely on arguments, we evaluate it first, and then align offsets


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


correction from #52598
outer_common_expr may refer to the result of another outer_common_expr , but not every one of them is needed for the lambda expression evaluation. We only need to replicate the final captured column.


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
