### PR TITLE
[Feature] Trino dialect, the extract function supports dow and week parameters

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -998,14 +998,9 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
 
     @Override
     protected ParseNode visitExtract(Extract node, ParseTreeContext context) {
-        String fieldString = node.getField().toString();
-        if (fieldString.equalsIgnoreCase("dow")) {
-            fieldString = "dayofweek_iso";
-        } else if (fieldString.equalsIgnoreCase("week")) {
-            fieldString = "week_iso";
-        }
-        return new FunctionCallExpr(fieldString,
-                new FunctionParams(Lists.newArrayList((Expr) visit(node.getExpression(), context))));
+        String fieldString = node.getField().toString().toLowerCase();
+        return  Trino2SRFunctionCallTransformer.convert(fieldString,
+                Lists.newArrayList((Expr) visit(node.getExpression(), context)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -999,6 +999,11 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     @Override
     protected ParseNode visitExtract(Extract node, ParseTreeContext context) {
         String fieldString = node.getField().toString();
+        if (fieldString.equalsIgnoreCase("dow")) {
+            fieldString = "dayofweek_iso";
+        } else if (fieldString.equalsIgnoreCase("week")) {
+            fieldString = "week_iso";
+        }
         return new FunctionCallExpr(fieldString,
                 new FunctionParams(Lists.newArrayList((Expr) visit(node.getExpression(), context))));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -192,6 +192,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -999,8 +1000,10 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     @Override
     protected ParseNode visitExtract(Extract node, ParseTreeContext context) {
         String fieldString = node.getField().toString().toLowerCase();
-        return  Trino2SRFunctionCallTransformer.convert(fieldString,
+        Expr expr = Trino2SRFunctionCallTransformer.convert(fieldString,
                 Lists.newArrayList((Expr) visit(node.getExpression(), context)));
+        return Objects.requireNonNullElseGet(expr, () -> new FunctionCallExpr(fieldString,
+                new FunctionParams(Lists.newArrayList((Expr) visit(node.getExpression(), context)))));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -234,9 +234,9 @@ public class Trino2SRFunctionCallTransformer {
                 List.of(new PlaceholderExpr(1, Expr.class), new StringLiteral("month"))));
 
         // year_of_week  -> weekofyear
-        registerFunctionTransformer("year_of_week", 1, "weekofyear", List.of(Expr.class));
+        registerFunctionTransformer("year_of_week", 1, "week_iso", List.of(Expr.class));
         // yow  -> year_of_week
-        registerFunctionTransformer("yow", 1, "weekofyear", List.of(Expr.class));
+        registerFunctionTransformer("yow", 1, "week_iso", List.of(Expr.class));
     }
 
     private static void registerStringFunctionTransformer() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -235,7 +235,6 @@ public class Trino2SRFunctionCallTransformer {
 
         // year_of_week  -> weekofyear
         registerFunctionTransformer("year_of_week", 1, "weekofyear", List.of(Expr.class));
-
         // yow  -> year_of_week
         registerFunctionTransformer("yow", 1, "weekofyear", List.of(Expr.class));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -235,6 +235,7 @@ public class Trino2SRFunctionCallTransformer {
 
         // year_of_week  -> weekofyear
         registerFunctionTransformer("year_of_week", 1, "weekofyear", List.of(Expr.class));
+
         // yow  -> year_of_week
         registerFunctionTransformer("yow", 1, "weekofyear", List.of(Expr.class));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -233,7 +233,7 @@ public class Trino2SRFunctionCallTransformer {
         registerFunctionTransformer("last_day_of_month", 1, new FunctionCallExpr("last_day",
                 List.of(new PlaceholderExpr(1, Expr.class), new StringLiteral("month"))));
         // year  -> year
-        registerFunctionTransformer("year", 1, "year" ,List.of(Expr.class));
+        registerFunctionTransformer("year", 1, "year", List.of(Expr.class));
     }
 
     private static void registerStringFunctionTransformer() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -232,6 +232,8 @@ public class Trino2SRFunctionCallTransformer {
         // last_day_of_month(x)  -> last_day(x,'month')
         registerFunctionTransformer("last_day_of_month", 1, new FunctionCallExpr("last_day",
                 List.of(new PlaceholderExpr(1, Expr.class), new StringLiteral("month"))));
+        // year  -> year
+        registerFunctionTransformer("year", 1, "year" ,List.of(Expr.class));
     }
 
     private static void registerStringFunctionTransformer() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -232,11 +232,6 @@ public class Trino2SRFunctionCallTransformer {
         // last_day_of_month(x)  -> last_day(x,'month')
         registerFunctionTransformer("last_day_of_month", 1, new FunctionCallExpr("last_day",
                 List.of(new PlaceholderExpr(1, Expr.class), new StringLiteral("month"))));
-
-        // year_of_week  -> weekofyear
-        registerFunctionTransformer("year_of_week", 1, "week_iso", List.of(Expr.class));
-        // yow  -> year_of_week
-        registerFunctionTransformer("yow", 1, "week_iso", List.of(Expr.class));
     }
 
     private static void registerStringFunctionTransformer() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -232,8 +232,12 @@ public class Trino2SRFunctionCallTransformer {
         // last_day_of_month(x)  -> last_day(x,'month')
         registerFunctionTransformer("last_day_of_month", 1, new FunctionCallExpr("last_day",
                 List.of(new PlaceholderExpr(1, Expr.class), new StringLiteral("month"))));
-        // year  -> year
-        registerFunctionTransformer("year", 1, "year", List.of(Expr.class));
+
+        // year_of_week  -> weekofyear
+        registerFunctionTransformer("year_of_week", 1, "weekofyear", List.of(Expr.class));
+
+        // yow  -> year_of_week
+        registerFunctionTransformer("yow", 1, "weekofyear", List.of(Expr.class));
     }
 
     private static void registerStringFunctionTransformer() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -343,7 +343,7 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
     public void testExtractFnTransform() throws Exception {
         String sql = "SELECT extract(dow FROM TIMESTAMP '2022-10-20 05:10:00')";
         assertPlanContains(sql, "dayofweek_iso('2022-10-20 05:10:00')");
-        sql = "SELECT extract(dow FROM TIMESTAMP '2022-10-20 05:10:00')";
+        sql = "SELECT extract(week FROM TIMESTAMP '2022-10-20 05:10:00')";
         assertPlanContains(sql, "week_iso('2022-10-20 05:10:00')");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -340,6 +340,15 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
     }
 
     @Test
+    public void testExtractFnTransform() throws Exception {
+        String sql = "SELECT extract(dow FROM TIMESTAMP '2022-10-20 05:10:00')";
+        assertPlanContains(sql, "dayofweek_iso('2022-10-20 05:10:00')");
+        sql = "SELECT week(dow FROM TIMESTAMP '2022-10-20 05:10:00')";
+        assertPlanContains(sql, "week_iso('2022-10-20 05:10:00')");
+    }
+
+
+    @Test
     public void testBitFnTransform() throws Exception {
         String sql = "select bitwise_and(19,25)";
         assertPlanContains(sql, "17");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -343,7 +343,7 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
     public void testExtractFnTransform() throws Exception {
         String sql = "SELECT extract(dow FROM TIMESTAMP '2022-10-20 05:10:00')";
         assertPlanContains(sql, "dayofweek_iso('2022-10-20 05:10:00')");
-        sql = "SELECT week(dow FROM TIMESTAMP '2022-10-20 05:10:00')";
+        sql = "SELECT extract(dow FROM TIMESTAMP '2022-10-20 05:10:00')";
         assertPlanContains(sql, "week_iso('2022-10-20 05:10:00')");
     }
 


### PR DESCRIPTION
## Why I'm doing:
```
extract(dow FROM TIMESTAMP '2022-10-20 05:10:00') not support trino dialect.

set sql_dialect='trino';
SELECT extract(dow FROM TIMESTAMP '2022-10-20 05:10:00');
ERROR 1064 (HY000): Getting analyzing error. Detail message: No matching function with signature: dow(datetime).

```
## What I'm doing:

Fixes #52698 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
  - [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
