### PR TITLE
[Enhancement] Do not do filter pushdown for project that contains lambda function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -229,7 +229,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
     public static final String MAX_PUSHDOWN_CONDITIONS_PER_COLUMN = "max_pushdown_conditions_per_column";
 
-    public static final String DISABLE_LAMBDA_PUSHDOWN = "disable_lambda_pushdown";
+    public static final String ENABLE_LAMBDA_PUSHDOWN = "enable_lambda_pushdown";
     // use new execution engine instead of the old one if enable_pipeline_engine is true,
     // the new execution engine split a fragment into pipelines, then create several drivers
     // from the pipeline for parallel executing, threads from global pool pick out the
@@ -1259,8 +1259,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int maxScanKeyNum = -1;
     @VariableMgr.VarAttr(name = MAX_PUSHDOWN_CONDITIONS_PER_COLUMN)
     private int maxPushdownConditionsPerColumn = -1;
-    @VariableMgr.VarAttr(name = DISABLE_LAMBDA_PUSHDOWN)
-    private boolean disableLambdaPushdown = false;
+    @VariableMgr.VarAttr(name = ENABLE_LAMBDA_PUSHDOWN)
+    private boolean enableLambdaPushdown = true;
 
     @VariableMgr.VarAttr(name = HASH_JOIN_PUSH_DOWN_RIGHT_TABLE)
     private boolean hashJoinPushDownRightTable = true;
@@ -3462,12 +3462,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return cboPushDownAggregateMode;
     }
 
-    public boolean getDisableLambdaPushDown() {
-        return disableLambdaPushdown;
+    public boolean getEnableLambdaPushDown() {
+        return enableLambdaPushdown;
     }
 
-    public void setDisableLambdaPushdown(boolean disableLambdaPushdown) {
-        this.disableLambdaPushdown = disableLambdaPushdown;
+    public void setEnableLambdaPushdown(boolean enableLambdaPushdown) {
+        this.enableLambdaPushdown = enableLambdaPushdown;
     }
 
     public void setCboPushDownAggregateMode(int cboPushDownAggregateMode) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3466,6 +3466,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return disableLambdaPushdown;
     }
 
+    public void setDisableLambdaPushdown(boolean disableLambdaPushdown) {
+        this.disableLambdaPushdown = disableLambdaPushdown;
+    }
+
     public void setCboPushDownAggregateMode(int cboPushDownAggregateMode) {
         this.cboPushDownAggregateMode = cboPushDownAggregateMode;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -44,7 +44,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.ToNumberPolicy;
 import com.starrocks.catalog.InternalCatalog;
-import com.starrocks.common.VectorSearchOptions;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.CompressionUtils;
@@ -107,7 +106,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // The optional values are "compute_nodes_only" and "all_nodes".
     public static final String COMPUTATION_FRAGMENT_SCHEDULING_POLICY = "computation_fragment_scheduling_policy";
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";
-    public static final String VECTOR_DISTANCE_COLUMN_NAME = "vector_distance_column_name";
 
     /**
      * configure the mem limit of load process on BE.
@@ -190,7 +188,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM = "parallel_fragment_exec_instance_num";
     public static final String MAX_PARALLEL_SCAN_INSTANCE_NUM = "max_parallel_scan_instance_num";
     public static final String ENABLE_INSERT_STRICT = "enable_insert_strict";
-    public static final String INSERT_MAX_FILTER_RATIO = "insert_max_filter_ratio";
     public static final String ENABLE_SPILL = "enable_spill";
     public static final String ENABLE_SPILL_TO_REMOTE_STORAGE = "enable_spill_to_remote_storage";
     public static final String DISABLE_SPILL_TO_LOCAL_DISK = "disable_spill_to_local_disk";
@@ -228,6 +225,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // see comment of `starrocks_max_scan_key_num` and `max_pushdown_conditions_per_column` in BE config
     public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
     public static final String MAX_PUSHDOWN_CONDITIONS_PER_COLUMN = "max_pushdown_conditions_per_column";
+
+    public static final String DISABLE_LAMBDA_PUSHDOWN = "disable_lambda_pushdown";
 
     // use new execution engine instead of the old one if enable_pipeline_engine is true,
     // the new execution engine split a fragment into pipelines, then create several drivers
@@ -295,7 +294,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             "enable_filter_unused_columns_in_scan_stage";
 
     public static final String JOIN_LATE_MATERIALIZATION = "join_late_materialization";
-    public static final String ENABLE_PARTITION_HASH_JOIN = "enable_partition_hash_join";
 
     public static final String ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER =
             "enable_prune_column_after_index_filter";
@@ -325,7 +323,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_GROUPBY_USE_OUTPUT_ALIAS = "enable_groupby_use_output_alias";
     public static final String ENABLE_QUERY_DUMP = "enable_query_dump";
     public static final String QUERY_DEBUG_OPTIONS = "query_debug_options";
-    public static final String VECTOR_SEARCH_OPTIONS = "vector_search_options";
 
     // --------------------------- Limitations for Materialized View ------------------------------------ //
     public static final String OPTIMIZER_MATERIALIZED_VIEW_TIMELIMIT = "optimizer_materialized_view_timelimit";
@@ -422,11 +419,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_READ_ICEBERG_PUFFIN_NDV = "enable_read_iceberg_puffin_ndv";
 
     public static final String ENABLE_ICEBERG_COLUMN_STATISTICS = "enable_iceberg_column_statistics";
-    public static final String ENABLE_READ_ICEBERG_EQUALITY_DELETE_WITH_PARTITION_EVOLUTION =
-            "enable_read_iceberg_equality_delete_with_partition_evolution";
     public static final String ENABLE_DELTA_LAKE_COLUMN_STATISTICS = "enable_delta_lake_column_statistics";
-    public static final String ENABLE_QUERY_TRIGGER_ANALYZE = "enable_query_trigger_analyze";
-
     public static final String PLAN_MODE = "plan_mode";
 
     public static final String ENABLE_HIVE_COLUMN_STATS = "enable_hive_column_stats";
@@ -534,8 +527,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_MATERIALIZED_VIEW_REWRITE_PARTITION_COMPENSATE =
             "enable_materialized_view_rewrite_partition_compensate";
     public static final String ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE = "enable_materialized_view_agg_pushdown_rewrite";
-    public static final String ENABLE_MATERIALIZED_VIEW_TIMESERIES_AGG_PUSHDOWN_REWRITE =
-            "enable_materialized_view_timeseries_agg_pushdown_rewrite";
 
     public static final String ENABLE_MATERIALIZED_VIEW_TEXT_MATCH_REWRITE =
             "enable_materialized_view_text_match_rewrite";
@@ -559,13 +550,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_PHASED_SCHEDULER = "enable_phased_scheduler";
     public static final String PHASED_SCHEDULER_MAX_CONCURRENCY = "phased_scheduler_max_concurrency";
 
-    public static final String CUSTOM_QUERY_ID = "custom_query_id";
-
     // Access ORC columns by name. By default, columns in ORC files are accessed by
     // their ordinal position in the Hive table definition.
     public static final String ORC_USE_COLUMN_NAMES = "orc_use_column_names";
-
-    public static final String ENABLE_EXECUTION_ONLY = "enable_execution_only";
 
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
@@ -607,9 +594,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE =
             "enable_materialized_view_view_delta_rewrite";
-
-    public static final String MATERIALIZED_VIEW_MAX_RELATION_MAPPING_SIZE =
-            "materialized_view_max_relation_mapping_size";
 
     public static final String MATERIALIZED_VIEW_JOIN_SAME_TABLE_PERMUTATION_LIMIT =
             "materialized_view_join_same_table_permutation_limit";
@@ -700,10 +684,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String SCAN_OR_TO_UNION_THRESHOLD = "scan_or_to_union_threshold";
 
-    public static final String ENABLE_PUSHDOWN_OR_PREDICATE = "enable_pushdown_or_predicate";
-
-    public static final String ENABLE_SHOW_PREDICATE_TREE_IN_PROFILE = "enable_show_predicate_tree_in_profile";
-
     public static final String SELECT_RATIO_THRESHOLD = "select_ratio_threshold";
 
     public static final String DISABLE_FUNCTION_FOLD_CONSTANTS = "disable_function_fold_constants";
@@ -730,10 +710,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // binary, json, compact
     public static final String THRIFT_PLAN_PROTOCOL = "thrift_plan_protocol";
 
-    public static final String COUNT_DISTINCT_IMPLEMENTATION = "count_distinct_implementation";
-
-    public static final String ENABLE_COUNT_DISTINCT_REWRITE_BY_HLL_BITMAP = "enable_count_distinct_rewrite_by_hll_bitmap";
-
     // 0 means disable interleaving, positive value sets the group size, but adaptively enable interleaving,
     // negative value means force interleaving under the group size of abs(interleaving_group_size)
     public static final String INTERLEAVING_GROUP_SIZE = "interleaving_group_size";
@@ -747,10 +723,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ALLOW_HIVE_WITHOUT_PARTITION_FILTER = "allow_hive_without_partition_filter";
 
     public static final String SCAN_HIVE_PARTITION_NUM_LIMIT = "scan_hive_partition_num_limit";
-
-    public static final String ENABLE_CROSS_JOIN = "enable_cross_join";
-
-    public static final String ENABLE_NESTED_LOOP_JOIN = "enable_nested_loop_join";
 
     public static final String AUDIT_EXECUTE_STMT = "audit_execute_stmt";
 
@@ -773,16 +745,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // whether rewrite bitmap_union(to_bitmap(x)) to bitmap_agg(x) directly.
     public static final String ENABLE_REWRITE_BITMAP_UNION_TO_BITMAP_AGG = "enable_rewrite_bitmap_union_to_bitamp_agg";
 
-    public static final String ENABLE_PREDICATE_MOVE_AROUND = "enable_predicate_move_around";
-
     public static final String JIT_LEVEL = "jit_level";
-
-    // ann params like: nprobe
-    public static final String ANN_PARAMS = "ann_params";
-
-    public static final String PQ_REFINE_FACTOR = "pq_refine_factor";
-
-    public static final String K_FACTOR = "k_factor";
 
     /**
      * Used to split files stored in dfs such as object storage or hdfs into smaller files.
@@ -805,15 +768,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // would be consolidated, since when the number of like predicates is too small, its corresponding
     // regexp predicate is less efficient than like predicates.
     public static final String LIKE_PREDICATE_CONSOLIDATE_MIN = "like_predicate_consolidate_min";
-
-    public static final String CONNECTOR_REMOTE_FILE_ASYNC_QUEUE_SIZE = "connector_remote_file_async_queue_size";
-    public static final String CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE = "connector_remote_file_async_task_size";
-    public static final String ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES = "enable_connector_incremental_scan_ranges";
-    public static final String CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE = "connector_incremental_scan_ranges_size";
-
-    public static final String ENABLE_PLAN_ANALYZER = "enable_plan_analyzer";
-
-    public static final String ENABLE_PLAN_ADVISOR = "enable_plan_advisor";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -976,7 +930,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = TRANSACTION_ISOLATION)
     private String transactionIsolation = "REPEATABLE-READ";
     @VariableMgr.VarAttr(name = TRANSACTION_READ_ONLY, alias = TX_READ_ONLY)
-    private boolean transactionReadOnly = false;
+    private String transactionReadOnly = "OFF";
     // this is used to make c3p0 library happy
     @VariableMgr.VarAttr(name = CHARACTER_SET_CLIENT)
     private String charsetClient = "utf8";
@@ -1081,7 +1035,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // it's need BE to enable flat json, else will take a poor performance
     @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD)
-    private boolean cboPruneJsonSubfield = true;
+    private boolean cboPruneJsonSubfield = false;
 
     @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD_DEPTH, flag = VariableMgr.INVISIBLE)
     private int cboPruneJsonSubfieldDepth = 20;
@@ -1112,15 +1066,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkGlobalShuffle = true;
 
+
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_SPILL, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkSpill = true;
 
     @VariableMgr.VarAttr(name = CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD, flag = VariableMgr.INVISIBLE)
     private double connectorSinkSpillMemLimitThreshold = 0.5;
-
-    // execute sql don't return result, for performance test
-    @VarAttr(name = ENABLE_EXECUTION_ONLY, flag = VariableMgr.INVISIBLE)
-    private boolean enableExecutionOnly = false;
 
     /*
      * The maximum pipeline dop limit which only takes effect when pipeline_dop=0.
@@ -1150,9 +1101,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT)
     private boolean enableInsertStrict = true;
-
-    @VariableMgr.VarAttr(name = INSERT_MAX_FILTER_RATIO)
-    private double insertMaxFilterRatio = 0;
 
     @VariableMgr.VarAttr(name = ENABLE_SPILL)
     private boolean enableSpill = false;
@@ -1259,6 +1207,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = MAX_PUSHDOWN_CONDITIONS_PER_COLUMN)
     private int maxPushdownConditionsPerColumn = -1;
 
+    @VariableMgr.VarAttr(name = DISABLE_LAMBDA_PUSHDOWN)
+    private boolean disableLambdaPushdown = false;
+
     @VariableMgr.VarAttr(name = HASH_JOIN_PUSH_DOWN_RIGHT_TABLE)
     private boolean hashJoinPushDownRightTable = true;
 
@@ -1273,9 +1224,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = JOIN_LATE_MATERIALIZATION)
     private boolean joinLateMaterialization = false;
-
-    @VariableMgr.VarAttr(name = ENABLE_PARTITION_HASH_JOIN)
-    private boolean enablePartitionHashJoin = true;
 
     @VariableMgr.VarAttr(name = ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER, flag = VariableMgr.INVISIBLE)
     private boolean enablePruneColumnAfterIndexFilter = true;
@@ -1572,31 +1520,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_HYPERSCAN_VEC)
     private boolean enableHyperscanVec = true;
 
-    @VarAttr(name = ENABLE_PLAN_ANALYZER, flag = VariableMgr.INVISIBLE)
-    private boolean enablePlanAnalyzer = false;
-
-    @VarAttr(name = ENABLE_PLAN_ADVISOR)
-    private boolean enablePlanAdvisor = true;
-
-    @VarAttr(name = COUNT_DISTINCT_IMPLEMENTATION)
-    private String countDistinctImplementation = "default";
-
-    // By default, we always use the created mv's bitmap/hll to rewrite count distinct, but result is not
-    // exactly matched with the original result.
-    // If we want to get the exactly matched result, we can disable this.
-    @VarAttr(name = ENABLE_COUNT_DISTINCT_REWRITE_BY_HLL_BITMAP)
-    private boolean enableCountDistinctRewriteByHllBitmap = true;
-
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
     }
 
     public void setCboPruneJsonSubfieldDepth(int cboPruneJsonSubfieldDepth) {
         this.cboPruneJsonSubfieldDepth = cboPruneJsonSubfieldDepth;
-    }
-
-    public boolean isEnableExecutionOnly() {
-        return enableExecutionOnly;
     }
 
     public boolean isCboPruneJsonSubfield() {
@@ -1862,9 +1791,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE)
     private boolean enableMaterializedViewPushDownRewrite = false;
 
-    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_TIMESERIES_AGG_PUSHDOWN_REWRITE)
-    private boolean enableMaterializedViewTimeSeriesPushDownRewrite = true;
-
     @VarAttr(name = ENABLE_FORCE_RULE_BASED_MV_REWRITE)
     private boolean enableForceRuleBasedMvRewrite = true;
 
@@ -1876,9 +1802,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE)
     private boolean enableMaterializedViewViewDeltaRewrite = true;
-
-    @VarAttr(name = MATERIALIZED_VIEW_MAX_RELATION_MAPPING_SIZE)
-    private int materializedViewMaxRelationMappingSize = 10;
 
     @VarAttr(name = MATERIALIZED_VIEW_JOIN_SAME_TABLE_PERMUTATION_LIMIT, flag = VariableMgr.INVISIBLE)
     private int materializedViewJoinSameTablePermutationLimit = 5;
@@ -2017,12 +1940,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = SCAN_OR_TO_UNION_THRESHOLD, flag = VariableMgr.INVISIBLE)
     private long scanOrToUnionThreshold = 50000000;
 
-    @VarAttr(name = ENABLE_PUSHDOWN_OR_PREDICATE, flag = VariableMgr.INVISIBLE)
-    private boolean enablePushdownOrPredicate = true;
-
-    @VarAttr(name = ENABLE_SHOW_PREDICATE_TREE_IN_PROFILE, flag = VariableMgr.INVISIBLE)
-    private boolean enableShowPredicateTreeInProfile = false;
-
     @VarAttr(name = SELECT_RATIO_THRESHOLD, flag = VariableMgr.INVISIBLE)
     private double selectRatioThreshold = 0.15;
 
@@ -2059,12 +1976,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = SCAN_HIVE_PARTITION_NUM_LIMIT)
     private int scanHivePartitionNumLimit = 0;
 
-    @VarAttr(name = ENABLE_CROSS_JOIN)
-    private boolean enableCrossJoin = true;
-
-    @VarAttr(name = ENABLE_NESTED_LOOP_JOIN)
-    private boolean enableNestedLoopJoin = true;
-
     @VariableMgr.VarAttr(name = AUDIT_EXECUTE_STMT)
     private boolean auditExecuteStmt = false;
 
@@ -2099,18 +2010,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_ENABLE_PARALLEL_PREPARE_METADATA)
     private boolean enableParallelPrepareMetadata = false;
-
-    // To set ANN tuning parameters for user.
-    // Since the session variables does not support map variables,
-    // it needs to be passed in the form of a JSON string.
-    @VarAttr(name = ANN_PARAMS)
-    private String annParams = "";
-
-    @VarAttr(name = PQ_REFINE_FACTOR)
-    private double pqRefineFactor = 1;
-
-    @VarAttr(name = K_FACTOR)
-    private double kFactor = 1;
 
     public int getPrepareMetadataPoolSize() {
         return prepareMetadataPoolSize;
@@ -2150,14 +2049,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_ICEBERG_COLUMN_STATISTICS)
     private boolean enableIcebergColumnStatistics = false;
 
-    @VarAttr(name = ENABLE_READ_ICEBERG_EQUALITY_DELETE_WITH_PARTITION_EVOLUTION)
-    private boolean enableReadIcebergEqDeleteWithPartitionEvolution = false;
-
     @VarAttr(name = ENABLE_DELTA_LAKE_COLUMN_STATISTICS)
     private boolean enableDeltaLakeColumnStatistics = false;
-
-    @VarAttr(name = ENABLE_QUERY_TRIGGER_ANALYZE)
-    private boolean enableQueryTriggerAnalyze = true;
 
     @VarAttr(name = PLAN_MODE)
     private String planMode = PlanMode.AUTO.modeName();
@@ -2197,21 +2090,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CHOOSE_EXECUTE_INSTANCES_MODE)
     private String chooseExecuteInstancesMode = LOCALITY.name();
-
-    @VarAttr(name = ENABLE_PREDICATE_MOVE_AROUND)
-    private boolean enablePredicateMoveAround = true;
-
-    @VarAttr(name = CONNECTOR_REMOTE_FILE_ASYNC_QUEUE_SIZE, flag = VariableMgr.INVISIBLE)
-    private int connectorRemoteFileAsyncQueueSize = 1000;
-
-    @VarAttr(name = CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE, flag = VariableMgr.INVISIBLE)
-    private int connectorRemoteFileAsyncTaskSize = 4;
-
-    @VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES)
-    private boolean enableConnectorIncrementalScanRanges = false;
-
-    @VarAttr(name = CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE)
-    private int connectorIncrementalScanRangeSize = 500;
 
     public SessionVariableConstants.ChooseInstancesMode getChooseExecuteInstancesMode() {
         return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
@@ -2265,24 +2143,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableIcebergColumnStatistics;
     }
 
-    public boolean enableReadIcebergEqDeleteWithPartitionEvolution() {
-        return enableReadIcebergEqDeleteWithPartitionEvolution;
-    }
-
-    public void setEnableReadIcebergEqDeleteWithPartitionEvolution(boolean enableReadIcebergEqDeleteWithPartitionEvolution) {
-        this.enableReadIcebergEqDeleteWithPartitionEvolution = enableReadIcebergEqDeleteWithPartitionEvolution;
-    }
-
     public void setEnableDeltaLakeColumnStatistics(boolean enableDeltaLakeColumnStatistics) {
         this.enableDeltaLakeColumnStatistics = enableDeltaLakeColumnStatistics;
     }
 
     public void setEnableIcebergColumnStatistics(boolean enableIcebergColumnStatistics) {
         this.enableIcebergColumnStatistics = enableIcebergColumnStatistics;
-    }
-
-    public boolean isEnableQueryTriggerAnalyze() {
-        return enableQueryTriggerAnalyze;
     }
 
     public String getPlanMode() {
@@ -2331,7 +2197,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public int getPhasedSchedulerMaxConcurrency() {
         return phasedSchedulerMaxConcurrency;
     }
-
     public void setPhasedSchedulerMaxConcurrency(int phasedSchedulerMaxConcurrency) {
         this.phasedSchedulerMaxConcurrency = phasedSchedulerMaxConcurrency;
     }
@@ -2339,7 +2204,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public boolean enablePhasedScheduler() {
         return enablePhasedScheduler;
     }
-
     public void setEnablePhasedScheduler(boolean enablePhasedScheduler) {
         this.enablePhasedScheduler = enablePhasedScheduler;
     }
@@ -2364,9 +2228,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = LIKE_PREDICATE_CONSOLIDATE_MIN)
     private int likePredicateConsolidateMin = 2;
-
-    @VarAttr(name = CUSTOM_QUERY_ID, flag = VariableMgr.SESSION_ONLY)
-    private String customQueryId = "";
 
     public int getExprChildrenLimit() {
         return exprChildrenLimit;
@@ -2499,10 +2360,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableCacheSelect = enableCacheSelect;
     }
 
-    public void setConnectorIoTasksPerScanOperator(int connectorIoTasksPerScanOperator) {
-        this.connectorIoTasksPerScanOperator = connectorIoTasksPerScanOperator;
-    }
-
     public boolean isCboUseDBLock() {
         return cboUseDBLock;
     }
@@ -2551,7 +2408,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setComputationFragmentSchedulingPolicy(String computationFragmentSchedulingPolicy) {
         SessionVariableConstants.ComputationFragmentSchedulingPolicy result =
                 Enums.getIfPresent(SessionVariableConstants.ComputationFragmentSchedulingPolicy.class,
-                        StringUtils.upperCase(computationFragmentSchedulingPolicy)).orNull();
+                                   StringUtils.upperCase(computationFragmentSchedulingPolicy)).orNull();
         if (result == null) {
             String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ComputationFragmentSchedulingPolicy.values());
             throw new IllegalArgumentException("Legal values of computation_fragment_scheduling_policy are " + legalValues);
@@ -2561,7 +2418,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public SessionVariableConstants.ComputationFragmentSchedulingPolicy getComputationFragmentSchedulingPolicy() {
         return Enums.getIfPresent(SessionVariableConstants.ComputationFragmentSchedulingPolicy.class,
-                        StringUtils.upperCase(computationFragmentSchedulingPolicy))
+                StringUtils.upperCase(computationFragmentSchedulingPolicy))
                 .or(SessionVariableConstants.ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY);
     }
 
@@ -2817,14 +2674,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableInsertStrict = enableInsertStrict;
     }
 
-    public double getInsertMaxFilterRatio() {
-        return insertMaxFilterRatio;
-    }
-
-    public void setInsertMaxFilterRatio(double insertMaxFilterRatio) {
-        this.insertMaxFilterRatio = insertMaxFilterRatio;
-    }
-
     public boolean isEnableSpill() {
         return enableSpill;
     }
@@ -2937,6 +2786,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.maxPushdownConditionsPerColumn = maxPushdownConditionsPerColumn;
     }
 
+
+
     public boolean isHashJoinPushDownRightTable() {
         return this.hashJoinPushDownRightTable;
     }
@@ -2983,10 +2834,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isJoinLateMaterialization() {
         return joinLateMaterialization;
-    }
-
-    public boolean enablePartitionHashJoin() {
-        return enablePartitionHashJoin;
     }
 
     public void disableTrimOnlyFilteredColumnsInScanStage() {
@@ -3459,6 +3306,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return cboPushDownAggregateMode;
     }
 
+    public boolean getDisableLambdaPushDown() {
+        return disableLambdaPushdown;
+    }
+
     public void setCboPushDownAggregateMode(int cboPushDownAggregateMode) {
         this.cboPushDownAggregateMode = cboPushDownAggregateMode;
     }
@@ -3695,28 +3546,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableMaterializedViewPushDownRewrite = enableMaterializedViewPushDownRewrite;
     }
 
-    public boolean isEnableMaterializedViewTimeSeriesPushDownRewrite() {
-        return enableMaterializedViewTimeSeriesPushDownRewrite;
-    }
-
-    public void setEnableMaterializedViewTimeSeriesPushDownRewrite(boolean enableMaterializedViewTimeSeriesPushDownRewrite) {
-        this.enableMaterializedViewTimeSeriesPushDownRewrite = enableMaterializedViewTimeSeriesPushDownRewrite;
-    }
-
     public boolean isEnableMaterializedViewViewDeltaRewrite() {
         return enableMaterializedViewViewDeltaRewrite;
     }
 
     public void setEnableMaterializedViewViewDeltaRewrite(boolean enableMaterializedViewViewDeltaRewrite) {
         this.enableMaterializedViewViewDeltaRewrite = enableMaterializedViewViewDeltaRewrite;
-    }
-
-    public int getMaterializedViewMaxRelationMappingSize() {
-        return materializedViewMaxRelationMappingSize;
-    }
-
-    public void setMaterializedViewMaxRelationMappingSize(int materializedViewMaxRelationMappingSize) {
-        this.materializedViewMaxRelationMappingSize = materializedViewMaxRelationMappingSize;
     }
 
     public int getMaterializedViewJoinSameTablePermutationLimit() {
@@ -3981,14 +3816,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.scanOrToUnionThreshold = scanOrToUnionThreshold;
     }
 
-    public boolean isEnablePushdownOrPredicate() {
-        return enablePushdownOrPredicate;
-    }
-
-    public boolean isEnableShowPredicateTreeInProfile() {
-        return enableShowPredicateTreeInProfile;
-    }
-
     public double getSelectRatioThreshold() {
         return selectRatioThreshold;
     }
@@ -4051,22 +3878,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setScanHivePartitionNumLimit(int scanHivePartitionNumLimit) {
         this.scanHivePartitionNumLimit = scanHivePartitionNumLimit;
-    }
-
-    public boolean isEnableCrossJoin() {
-        return enableCrossJoin;
-    }
-
-    public void setEnableCrossJoin(boolean enableCrossJoin) {
-        this.enableCrossJoin = enableCrossJoin;
-    }
-
-    public boolean isEnableNestedLoopJoin() {
-        return enableNestedLoopJoin;
-    }
-
-    public void setEnableNestedLoopJoin(boolean enableNestedLoopJoin) {
-        this.enableNestedLoopJoin = enableNestedLoopJoin;
     }
 
     public boolean enableCboDeriveRangeJoinPredicate() {
@@ -4212,14 +4023,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         enableConnectorSplitIoTasks = v;
     }
 
-    public boolean isEnablePredicateMoveAround() {
-        return enablePredicateMoveAround;
-    }
-
-    public void setEnablePredicateMoveAround(boolean enablePredicateMoveAround) {
-        this.enablePredicateMoveAround = enablePredicateMoveAround;
-    }
-
     public boolean isEnableConstantExecuteInFE() {
         return enableConstantExecuteInFE;
     }
@@ -4234,70 +4037,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setLikePredicateConsolidateMin(int value) {
         this.likePredicateConsolidateMin = value;
-    }
-
-    public String getCustomQueryId() {
-        return customQueryId;
-    }
-
-    public void setCustomQueryId(String customQueryId) {
-        this.customQueryId = customQueryId;
-    }
-
-    public int getConnectorRemoteFileAsyncQueueSize() {
-        return connectorRemoteFileAsyncQueueSize;
-    }
-
-    public int getConnectorRemoteFileAsyncTaskSize() {
-        return connectorRemoteFileAsyncTaskSize;
-    }
-
-    public boolean isEnablePlanAnalyzer() {
-        return enablePlanAnalyzer;
-    }
-
-    public void setEnablePlanAnalyzer(boolean enablePlanAnalyzer) {
-        this.enablePlanAnalyzer = enablePlanAnalyzer;
-    }
-
-    public boolean isEnablePlanAdvisor() {
-        return enablePlanAdvisor;
-    }
-
-    public void setEnablePlanAdvisor(boolean enablePlanAdvisor) {
-        this.enablePlanAdvisor = enablePlanAdvisor;
-    }
-
-    public void setCountDistinctImplementation(String countDistinctImplementation) {
-        this.countDistinctImplementation = countDistinctImplementation;
-    }
-
-    public SessionVariableConstants.CountDistinctImplMode getCountDistinctImplementation() {
-        return SessionVariableConstants.CountDistinctImplMode.parse(countDistinctImplementation);
-    }
-
-    public boolean isEnableCountDistinctRewriteByHllBitmap() {
-        return enableCountDistinctRewriteByHllBitmap;
-    }
-
-    public void setEnableCountDistinctRewriteByHllBitmap(boolean enableCountDistinctRewriteByHllBitmap) {
-        this.enableCountDistinctRewriteByHllBitmap = enableCountDistinctRewriteByHllBitmap;
-    }
-
-    public int getConnectorIncrementalScanRangeNumber() {
-        return connectorIncrementalScanRangeSize;
-    }
-
-    public void setConnectorIncrementalScanRangeNumber(int v) {
-        connectorIncrementalScanRangeSize = v;
-    }
-
-    public boolean isEnableConnectorIncrementalScanRanges() {
-        return enableConnectorIncrementalScanRanges;
-    }
-
-    public void setEnableConnectorIncrementalScanRanges(boolean v) {
-        enableConnectorIncrementalScanRanges = v;
     }
 
     // Serialize to thrift object
@@ -4435,9 +4174,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setConnector_io_tasks_slow_io_latency_ms(connectorIoTasksSlowIoLatency);
         tResult.setConnector_scan_use_query_mem_ratio(connectorScanUseQueryMemRatio);
         tResult.setScan_use_query_mem_ratio(scanUseQueryMemRatio);
-        tResult.setAnn_params(VectorSearchOptions.readAnnParams(annParams));
-        tResult.setPq_refine_factor(pqRefineFactor);
-        tResult.setK_factor(kFactor);
         tResult.setEnable_collect_table_level_scan_stats(enableCollectTableLevelScanStats);
         tResult.setEnable_pipeline_level_shuffle(enablePipelineLevelShuffle);
         tResult.setEnable_hyperscan_vec(enableHyperscanVec);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3462,6 +3462,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return cboPushDownAggregateMode;
     }
 
+    public boolean getDisableLambdaPushDown() {
+        return disableLambdaPushdown;
+    }
+
     public void setCboPushDownAggregateMode(int cboPushDownAggregateMode) {
         this.cboPushDownAggregateMode = cboPushDownAggregateMode;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -44,6 +44,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.ToNumberPolicy;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.common.VectorSearchOptions;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.CompressionUtils;
@@ -106,6 +107,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // The optional values are "compute_nodes_only" and "all_nodes".
     public static final String COMPUTATION_FRAGMENT_SCHEDULING_POLICY = "computation_fragment_scheduling_policy";
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";
+    public static final String VECTOR_DISTANCE_COLUMN_NAME = "vector_distance_column_name";
 
     /**
      * configure the mem limit of load process on BE.
@@ -188,6 +190,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM = "parallel_fragment_exec_instance_num";
     public static final String MAX_PARALLEL_SCAN_INSTANCE_NUM = "max_parallel_scan_instance_num";
     public static final String ENABLE_INSERT_STRICT = "enable_insert_strict";
+    public static final String INSERT_MAX_FILTER_RATIO = "insert_max_filter_ratio";
     public static final String ENABLE_SPILL = "enable_spill";
     public static final String ENABLE_SPILL_TO_REMOTE_STORAGE = "enable_spill_to_remote_storage";
     public static final String DISABLE_SPILL_TO_LOCAL_DISK = "disable_spill_to_local_disk";
@@ -225,8 +228,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // see comment of `starrocks_max_scan_key_num` and `max_pushdown_conditions_per_column` in BE config
     public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
     public static final String MAX_PUSHDOWN_CONDITIONS_PER_COLUMN = "max_pushdown_conditions_per_column";
-
-    public static final String DISABLE_LAMBDA_PUSHDOWN = "disable_lambda_pushdown";
 
     // use new execution engine instead of the old one if enable_pipeline_engine is true,
     // the new execution engine split a fragment into pipelines, then create several drivers
@@ -294,6 +295,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             "enable_filter_unused_columns_in_scan_stage";
 
     public static final String JOIN_LATE_MATERIALIZATION = "join_late_materialization";
+    public static final String ENABLE_PARTITION_HASH_JOIN = "enable_partition_hash_join";
 
     public static final String ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER =
             "enable_prune_column_after_index_filter";
@@ -323,6 +325,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_GROUPBY_USE_OUTPUT_ALIAS = "enable_groupby_use_output_alias";
     public static final String ENABLE_QUERY_DUMP = "enable_query_dump";
     public static final String QUERY_DEBUG_OPTIONS = "query_debug_options";
+    public static final String VECTOR_SEARCH_OPTIONS = "vector_search_options";
 
     // --------------------------- Limitations for Materialized View ------------------------------------ //
     public static final String OPTIMIZER_MATERIALIZED_VIEW_TIMELIMIT = "optimizer_materialized_view_timelimit";
@@ -419,7 +422,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_READ_ICEBERG_PUFFIN_NDV = "enable_read_iceberg_puffin_ndv";
 
     public static final String ENABLE_ICEBERG_COLUMN_STATISTICS = "enable_iceberg_column_statistics";
+    public static final String ENABLE_READ_ICEBERG_EQUALITY_DELETE_WITH_PARTITION_EVOLUTION =
+            "enable_read_iceberg_equality_delete_with_partition_evolution";
     public static final String ENABLE_DELTA_LAKE_COLUMN_STATISTICS = "enable_delta_lake_column_statistics";
+    public static final String ENABLE_QUERY_TRIGGER_ANALYZE = "enable_query_trigger_analyze";
+
     public static final String PLAN_MODE = "plan_mode";
 
     public static final String ENABLE_HIVE_COLUMN_STATS = "enable_hive_column_stats";
@@ -527,6 +534,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_MATERIALIZED_VIEW_REWRITE_PARTITION_COMPENSATE =
             "enable_materialized_view_rewrite_partition_compensate";
     public static final String ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE = "enable_materialized_view_agg_pushdown_rewrite";
+    public static final String ENABLE_MATERIALIZED_VIEW_TIMESERIES_AGG_PUSHDOWN_REWRITE =
+            "enable_materialized_view_timeseries_agg_pushdown_rewrite";
 
     public static final String ENABLE_MATERIALIZED_VIEW_TEXT_MATCH_REWRITE =
             "enable_materialized_view_text_match_rewrite";
@@ -550,9 +559,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_PHASED_SCHEDULER = "enable_phased_scheduler";
     public static final String PHASED_SCHEDULER_MAX_CONCURRENCY = "phased_scheduler_max_concurrency";
 
+    public static final String CUSTOM_QUERY_ID = "custom_query_id";
+
     // Access ORC columns by name. By default, columns in ORC files are accessed by
     // their ordinal position in the Hive table definition.
     public static final String ORC_USE_COLUMN_NAMES = "orc_use_column_names";
+
+    public static final String ENABLE_EXECUTION_ONLY = "enable_execution_only";
 
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
@@ -594,6 +607,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE =
             "enable_materialized_view_view_delta_rewrite";
+
+    public static final String MATERIALIZED_VIEW_MAX_RELATION_MAPPING_SIZE =
+            "materialized_view_max_relation_mapping_size";
 
     public static final String MATERIALIZED_VIEW_JOIN_SAME_TABLE_PERMUTATION_LIMIT =
             "materialized_view_join_same_table_permutation_limit";
@@ -684,6 +700,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String SCAN_OR_TO_UNION_THRESHOLD = "scan_or_to_union_threshold";
 
+    public static final String ENABLE_PUSHDOWN_OR_PREDICATE = "enable_pushdown_or_predicate";
+
+    public static final String ENABLE_SHOW_PREDICATE_TREE_IN_PROFILE = "enable_show_predicate_tree_in_profile";
+
     public static final String SELECT_RATIO_THRESHOLD = "select_ratio_threshold";
 
     public static final String DISABLE_FUNCTION_FOLD_CONSTANTS = "disable_function_fold_constants";
@@ -710,6 +730,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // binary, json, compact
     public static final String THRIFT_PLAN_PROTOCOL = "thrift_plan_protocol";
 
+    public static final String COUNT_DISTINCT_IMPLEMENTATION = "count_distinct_implementation";
+
+    public static final String ENABLE_COUNT_DISTINCT_REWRITE_BY_HLL_BITMAP = "enable_count_distinct_rewrite_by_hll_bitmap";
+
     // 0 means disable interleaving, positive value sets the group size, but adaptively enable interleaving,
     // negative value means force interleaving under the group size of abs(interleaving_group_size)
     public static final String INTERLEAVING_GROUP_SIZE = "interleaving_group_size";
@@ -723,6 +747,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ALLOW_HIVE_WITHOUT_PARTITION_FILTER = "allow_hive_without_partition_filter";
 
     public static final String SCAN_HIVE_PARTITION_NUM_LIMIT = "scan_hive_partition_num_limit";
+
+    public static final String ENABLE_CROSS_JOIN = "enable_cross_join";
+
+    public static final String ENABLE_NESTED_LOOP_JOIN = "enable_nested_loop_join";
 
     public static final String AUDIT_EXECUTE_STMT = "audit_execute_stmt";
 
@@ -745,7 +773,16 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // whether rewrite bitmap_union(to_bitmap(x)) to bitmap_agg(x) directly.
     public static final String ENABLE_REWRITE_BITMAP_UNION_TO_BITMAP_AGG = "enable_rewrite_bitmap_union_to_bitamp_agg";
 
+    public static final String ENABLE_PREDICATE_MOVE_AROUND = "enable_predicate_move_around";
+
     public static final String JIT_LEVEL = "jit_level";
+
+    // ann params like: nprobe
+    public static final String ANN_PARAMS = "ann_params";
+
+    public static final String PQ_REFINE_FACTOR = "pq_refine_factor";
+
+    public static final String K_FACTOR = "k_factor";
 
     /**
      * Used to split files stored in dfs such as object storage or hdfs into smaller files.
@@ -768,6 +805,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // would be consolidated, since when the number of like predicates is too small, its corresponding
     // regexp predicate is less efficient than like predicates.
     public static final String LIKE_PREDICATE_CONSOLIDATE_MIN = "like_predicate_consolidate_min";
+
+    public static final String CONNECTOR_REMOTE_FILE_ASYNC_QUEUE_SIZE = "connector_remote_file_async_queue_size";
+    public static final String CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE = "connector_remote_file_async_task_size";
+    public static final String ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES = "enable_connector_incremental_scan_ranges";
+    public static final String CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE = "connector_incremental_scan_ranges_size";
+
+    public static final String ENABLE_PLAN_ANALYZER = "enable_plan_analyzer";
+
+    public static final String ENABLE_PLAN_ADVISOR = "enable_plan_advisor";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -930,7 +976,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = TRANSACTION_ISOLATION)
     private String transactionIsolation = "REPEATABLE-READ";
     @VariableMgr.VarAttr(name = TRANSACTION_READ_ONLY, alias = TX_READ_ONLY)
-    private String transactionReadOnly = "OFF";
+    private boolean transactionReadOnly = false;
     // this is used to make c3p0 library happy
     @VariableMgr.VarAttr(name = CHARACTER_SET_CLIENT)
     private String charsetClient = "utf8";
@@ -1035,7 +1081,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // it's need BE to enable flat json, else will take a poor performance
     @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD)
-    private boolean cboPruneJsonSubfield = false;
+    private boolean cboPruneJsonSubfield = true;
 
     @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD_DEPTH, flag = VariableMgr.INVISIBLE)
     private int cboPruneJsonSubfieldDepth = 20;
@@ -1066,12 +1112,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkGlobalShuffle = true;
 
-
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_SPILL, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkSpill = true;
 
     @VariableMgr.VarAttr(name = CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD, flag = VariableMgr.INVISIBLE)
     private double connectorSinkSpillMemLimitThreshold = 0.5;
+
+    // execute sql don't return result, for performance test
+    @VarAttr(name = ENABLE_EXECUTION_ONLY, flag = VariableMgr.INVISIBLE)
+    private boolean enableExecutionOnly = false;
 
     /*
      * The maximum pipeline dop limit which only takes effect when pipeline_dop=0.
@@ -1101,6 +1150,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT)
     private boolean enableInsertStrict = true;
+
+    @VariableMgr.VarAttr(name = INSERT_MAX_FILTER_RATIO)
+    private double insertMaxFilterRatio = 0;
 
     @VariableMgr.VarAttr(name = ENABLE_SPILL)
     private boolean enableSpill = false;
@@ -1207,9 +1259,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = MAX_PUSHDOWN_CONDITIONS_PER_COLUMN)
     private int maxPushdownConditionsPerColumn = -1;
 
-    @VariableMgr.VarAttr(name = DISABLE_LAMBDA_PUSHDOWN)
-    private boolean disableLambdaPushdown = false;
-
     @VariableMgr.VarAttr(name = HASH_JOIN_PUSH_DOWN_RIGHT_TABLE)
     private boolean hashJoinPushDownRightTable = true;
 
@@ -1224,6 +1273,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = JOIN_LATE_MATERIALIZATION)
     private boolean joinLateMaterialization = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_PARTITION_HASH_JOIN)
+    private boolean enablePartitionHashJoin = true;
 
     @VariableMgr.VarAttr(name = ENABLE_PRUNE_COLUMN_AFTER_INDEX_FILTER, flag = VariableMgr.INVISIBLE)
     private boolean enablePruneColumnAfterIndexFilter = true;
@@ -1520,12 +1572,31 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_HYPERSCAN_VEC)
     private boolean enableHyperscanVec = true;
 
+    @VarAttr(name = ENABLE_PLAN_ANALYZER, flag = VariableMgr.INVISIBLE)
+    private boolean enablePlanAnalyzer = false;
+
+    @VarAttr(name = ENABLE_PLAN_ADVISOR)
+    private boolean enablePlanAdvisor = true;
+
+    @VarAttr(name = COUNT_DISTINCT_IMPLEMENTATION)
+    private String countDistinctImplementation = "default";
+
+    // By default, we always use the created mv's bitmap/hll to rewrite count distinct, but result is not
+    // exactly matched with the original result.
+    // If we want to get the exactly matched result, we can disable this.
+    @VarAttr(name = ENABLE_COUNT_DISTINCT_REWRITE_BY_HLL_BITMAP)
+    private boolean enableCountDistinctRewriteByHllBitmap = true;
+
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
     }
 
     public void setCboPruneJsonSubfieldDepth(int cboPruneJsonSubfieldDepth) {
         this.cboPruneJsonSubfieldDepth = cboPruneJsonSubfieldDepth;
+    }
+
+    public boolean isEnableExecutionOnly() {
+        return enableExecutionOnly;
     }
 
     public boolean isCboPruneJsonSubfield() {
@@ -1791,6 +1862,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_AGG_PUSHDOWN_REWRITE)
     private boolean enableMaterializedViewPushDownRewrite = false;
 
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_TIMESERIES_AGG_PUSHDOWN_REWRITE)
+    private boolean enableMaterializedViewTimeSeriesPushDownRewrite = true;
+
     @VarAttr(name = ENABLE_FORCE_RULE_BASED_MV_REWRITE)
     private boolean enableForceRuleBasedMvRewrite = true;
 
@@ -1802,6 +1876,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE)
     private boolean enableMaterializedViewViewDeltaRewrite = true;
+
+    @VarAttr(name = MATERIALIZED_VIEW_MAX_RELATION_MAPPING_SIZE)
+    private int materializedViewMaxRelationMappingSize = 10;
 
     @VarAttr(name = MATERIALIZED_VIEW_JOIN_SAME_TABLE_PERMUTATION_LIMIT, flag = VariableMgr.INVISIBLE)
     private int materializedViewJoinSameTablePermutationLimit = 5;
@@ -1940,6 +2017,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = SCAN_OR_TO_UNION_THRESHOLD, flag = VariableMgr.INVISIBLE)
     private long scanOrToUnionThreshold = 50000000;
 
+    @VarAttr(name = ENABLE_PUSHDOWN_OR_PREDICATE, flag = VariableMgr.INVISIBLE)
+    private boolean enablePushdownOrPredicate = true;
+
+    @VarAttr(name = ENABLE_SHOW_PREDICATE_TREE_IN_PROFILE, flag = VariableMgr.INVISIBLE)
+    private boolean enableShowPredicateTreeInProfile = false;
+
     @VarAttr(name = SELECT_RATIO_THRESHOLD, flag = VariableMgr.INVISIBLE)
     private double selectRatioThreshold = 0.15;
 
@@ -1976,6 +2059,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = SCAN_HIVE_PARTITION_NUM_LIMIT)
     private int scanHivePartitionNumLimit = 0;
 
+    @VarAttr(name = ENABLE_CROSS_JOIN)
+    private boolean enableCrossJoin = true;
+
+    @VarAttr(name = ENABLE_NESTED_LOOP_JOIN)
+    private boolean enableNestedLoopJoin = true;
+
     @VariableMgr.VarAttr(name = AUDIT_EXECUTE_STMT)
     private boolean auditExecuteStmt = false;
 
@@ -2010,6 +2099,18 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_ENABLE_PARALLEL_PREPARE_METADATA)
     private boolean enableParallelPrepareMetadata = false;
+
+    // To set ANN tuning parameters for user.
+    // Since the session variables does not support map variables,
+    // it needs to be passed in the form of a JSON string.
+    @VarAttr(name = ANN_PARAMS)
+    private String annParams = "";
+
+    @VarAttr(name = PQ_REFINE_FACTOR)
+    private double pqRefineFactor = 1;
+
+    @VarAttr(name = K_FACTOR)
+    private double kFactor = 1;
 
     public int getPrepareMetadataPoolSize() {
         return prepareMetadataPoolSize;
@@ -2049,8 +2150,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_ICEBERG_COLUMN_STATISTICS)
     private boolean enableIcebergColumnStatistics = false;
 
+    @VarAttr(name = ENABLE_READ_ICEBERG_EQUALITY_DELETE_WITH_PARTITION_EVOLUTION)
+    private boolean enableReadIcebergEqDeleteWithPartitionEvolution = false;
+
     @VarAttr(name = ENABLE_DELTA_LAKE_COLUMN_STATISTICS)
     private boolean enableDeltaLakeColumnStatistics = false;
+
+    @VarAttr(name = ENABLE_QUERY_TRIGGER_ANALYZE)
+    private boolean enableQueryTriggerAnalyze = true;
 
     @VarAttr(name = PLAN_MODE)
     private String planMode = PlanMode.AUTO.modeName();
@@ -2090,6 +2197,21 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CHOOSE_EXECUTE_INSTANCES_MODE)
     private String chooseExecuteInstancesMode = LOCALITY.name();
+
+    @VarAttr(name = ENABLE_PREDICATE_MOVE_AROUND)
+    private boolean enablePredicateMoveAround = true;
+
+    @VarAttr(name = CONNECTOR_REMOTE_FILE_ASYNC_QUEUE_SIZE, flag = VariableMgr.INVISIBLE)
+    private int connectorRemoteFileAsyncQueueSize = 1000;
+
+    @VarAttr(name = CONNECTOR_REMOTE_FILE_ASYNC_TASK_SIZE, flag = VariableMgr.INVISIBLE)
+    private int connectorRemoteFileAsyncTaskSize = 4;
+
+    @VarAttr(name = ENABLE_CONNECTOR_INCREMENTAL_SCAN_RANGES)
+    private boolean enableConnectorIncrementalScanRanges = false;
+
+    @VarAttr(name = CONNECTOR_INCREMENTAL_SCAN_RANGE_SIZE)
+    private int connectorIncrementalScanRangeSize = 500;
 
     public SessionVariableConstants.ChooseInstancesMode getChooseExecuteInstancesMode() {
         return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
@@ -2143,12 +2265,24 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableIcebergColumnStatistics;
     }
 
+    public boolean enableReadIcebergEqDeleteWithPartitionEvolution() {
+        return enableReadIcebergEqDeleteWithPartitionEvolution;
+    }
+
+    public void setEnableReadIcebergEqDeleteWithPartitionEvolution(boolean enableReadIcebergEqDeleteWithPartitionEvolution) {
+        this.enableReadIcebergEqDeleteWithPartitionEvolution = enableReadIcebergEqDeleteWithPartitionEvolution;
+    }
+
     public void setEnableDeltaLakeColumnStatistics(boolean enableDeltaLakeColumnStatistics) {
         this.enableDeltaLakeColumnStatistics = enableDeltaLakeColumnStatistics;
     }
 
     public void setEnableIcebergColumnStatistics(boolean enableIcebergColumnStatistics) {
         this.enableIcebergColumnStatistics = enableIcebergColumnStatistics;
+    }
+
+    public boolean isEnableQueryTriggerAnalyze() {
+        return enableQueryTriggerAnalyze;
     }
 
     public String getPlanMode() {
@@ -2197,6 +2331,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public int getPhasedSchedulerMaxConcurrency() {
         return phasedSchedulerMaxConcurrency;
     }
+
     public void setPhasedSchedulerMaxConcurrency(int phasedSchedulerMaxConcurrency) {
         this.phasedSchedulerMaxConcurrency = phasedSchedulerMaxConcurrency;
     }
@@ -2204,6 +2339,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public boolean enablePhasedScheduler() {
         return enablePhasedScheduler;
     }
+
     public void setEnablePhasedScheduler(boolean enablePhasedScheduler) {
         this.enablePhasedScheduler = enablePhasedScheduler;
     }
@@ -2228,6 +2364,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = LIKE_PREDICATE_CONSOLIDATE_MIN)
     private int likePredicateConsolidateMin = 2;
+
+    @VarAttr(name = CUSTOM_QUERY_ID, flag = VariableMgr.SESSION_ONLY)
+    private String customQueryId = "";
 
     public int getExprChildrenLimit() {
         return exprChildrenLimit;
@@ -2360,6 +2499,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableCacheSelect = enableCacheSelect;
     }
 
+    public void setConnectorIoTasksPerScanOperator(int connectorIoTasksPerScanOperator) {
+        this.connectorIoTasksPerScanOperator = connectorIoTasksPerScanOperator;
+    }
+
     public boolean isCboUseDBLock() {
         return cboUseDBLock;
     }
@@ -2408,7 +2551,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setComputationFragmentSchedulingPolicy(String computationFragmentSchedulingPolicy) {
         SessionVariableConstants.ComputationFragmentSchedulingPolicy result =
                 Enums.getIfPresent(SessionVariableConstants.ComputationFragmentSchedulingPolicy.class,
-                                   StringUtils.upperCase(computationFragmentSchedulingPolicy)).orNull();
+                        StringUtils.upperCase(computationFragmentSchedulingPolicy)).orNull();
         if (result == null) {
             String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ComputationFragmentSchedulingPolicy.values());
             throw new IllegalArgumentException("Legal values of computation_fragment_scheduling_policy are " + legalValues);
@@ -2418,7 +2561,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public SessionVariableConstants.ComputationFragmentSchedulingPolicy getComputationFragmentSchedulingPolicy() {
         return Enums.getIfPresent(SessionVariableConstants.ComputationFragmentSchedulingPolicy.class,
-                StringUtils.upperCase(computationFragmentSchedulingPolicy))
+                        StringUtils.upperCase(computationFragmentSchedulingPolicy))
                 .or(SessionVariableConstants.ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY);
     }
 
@@ -2674,6 +2817,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableInsertStrict = enableInsertStrict;
     }
 
+    public double getInsertMaxFilterRatio() {
+        return insertMaxFilterRatio;
+    }
+
+    public void setInsertMaxFilterRatio(double insertMaxFilterRatio) {
+        this.insertMaxFilterRatio = insertMaxFilterRatio;
+    }
+
     public boolean isEnableSpill() {
         return enableSpill;
     }
@@ -2786,8 +2937,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.maxPushdownConditionsPerColumn = maxPushdownConditionsPerColumn;
     }
 
-
-
     public boolean isHashJoinPushDownRightTable() {
         return this.hashJoinPushDownRightTable;
     }
@@ -2834,6 +2983,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isJoinLateMaterialization() {
         return joinLateMaterialization;
+    }
+
+    public boolean enablePartitionHashJoin() {
+        return enablePartitionHashJoin;
     }
 
     public void disableTrimOnlyFilteredColumnsInScanStage() {
@@ -3306,10 +3459,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return cboPushDownAggregateMode;
     }
 
-    public boolean getDisableLambdaPushDown() {
-        return disableLambdaPushdown;
-    }
-
     public void setCboPushDownAggregateMode(int cboPushDownAggregateMode) {
         this.cboPushDownAggregateMode = cboPushDownAggregateMode;
     }
@@ -3546,12 +3695,28 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableMaterializedViewPushDownRewrite = enableMaterializedViewPushDownRewrite;
     }
 
+    public boolean isEnableMaterializedViewTimeSeriesPushDownRewrite() {
+        return enableMaterializedViewTimeSeriesPushDownRewrite;
+    }
+
+    public void setEnableMaterializedViewTimeSeriesPushDownRewrite(boolean enableMaterializedViewTimeSeriesPushDownRewrite) {
+        this.enableMaterializedViewTimeSeriesPushDownRewrite = enableMaterializedViewTimeSeriesPushDownRewrite;
+    }
+
     public boolean isEnableMaterializedViewViewDeltaRewrite() {
         return enableMaterializedViewViewDeltaRewrite;
     }
 
     public void setEnableMaterializedViewViewDeltaRewrite(boolean enableMaterializedViewViewDeltaRewrite) {
         this.enableMaterializedViewViewDeltaRewrite = enableMaterializedViewViewDeltaRewrite;
+    }
+
+    public int getMaterializedViewMaxRelationMappingSize() {
+        return materializedViewMaxRelationMappingSize;
+    }
+
+    public void setMaterializedViewMaxRelationMappingSize(int materializedViewMaxRelationMappingSize) {
+        this.materializedViewMaxRelationMappingSize = materializedViewMaxRelationMappingSize;
     }
 
     public int getMaterializedViewJoinSameTablePermutationLimit() {
@@ -3816,6 +3981,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.scanOrToUnionThreshold = scanOrToUnionThreshold;
     }
 
+    public boolean isEnablePushdownOrPredicate() {
+        return enablePushdownOrPredicate;
+    }
+
+    public boolean isEnableShowPredicateTreeInProfile() {
+        return enableShowPredicateTreeInProfile;
+    }
+
     public double getSelectRatioThreshold() {
         return selectRatioThreshold;
     }
@@ -3878,6 +4051,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setScanHivePartitionNumLimit(int scanHivePartitionNumLimit) {
         this.scanHivePartitionNumLimit = scanHivePartitionNumLimit;
+    }
+
+    public boolean isEnableCrossJoin() {
+        return enableCrossJoin;
+    }
+
+    public void setEnableCrossJoin(boolean enableCrossJoin) {
+        this.enableCrossJoin = enableCrossJoin;
+    }
+
+    public boolean isEnableNestedLoopJoin() {
+        return enableNestedLoopJoin;
+    }
+
+    public void setEnableNestedLoopJoin(boolean enableNestedLoopJoin) {
+        this.enableNestedLoopJoin = enableNestedLoopJoin;
     }
 
     public boolean enableCboDeriveRangeJoinPredicate() {
@@ -4023,6 +4212,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         enableConnectorSplitIoTasks = v;
     }
 
+    public boolean isEnablePredicateMoveAround() {
+        return enablePredicateMoveAround;
+    }
+
+    public void setEnablePredicateMoveAround(boolean enablePredicateMoveAround) {
+        this.enablePredicateMoveAround = enablePredicateMoveAround;
+    }
+
     public boolean isEnableConstantExecuteInFE() {
         return enableConstantExecuteInFE;
     }
@@ -4037,6 +4234,70 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setLikePredicateConsolidateMin(int value) {
         this.likePredicateConsolidateMin = value;
+    }
+
+    public String getCustomQueryId() {
+        return customQueryId;
+    }
+
+    public void setCustomQueryId(String customQueryId) {
+        this.customQueryId = customQueryId;
+    }
+
+    public int getConnectorRemoteFileAsyncQueueSize() {
+        return connectorRemoteFileAsyncQueueSize;
+    }
+
+    public int getConnectorRemoteFileAsyncTaskSize() {
+        return connectorRemoteFileAsyncTaskSize;
+    }
+
+    public boolean isEnablePlanAnalyzer() {
+        return enablePlanAnalyzer;
+    }
+
+    public void setEnablePlanAnalyzer(boolean enablePlanAnalyzer) {
+        this.enablePlanAnalyzer = enablePlanAnalyzer;
+    }
+
+    public boolean isEnablePlanAdvisor() {
+        return enablePlanAdvisor;
+    }
+
+    public void setEnablePlanAdvisor(boolean enablePlanAdvisor) {
+        this.enablePlanAdvisor = enablePlanAdvisor;
+    }
+
+    public void setCountDistinctImplementation(String countDistinctImplementation) {
+        this.countDistinctImplementation = countDistinctImplementation;
+    }
+
+    public SessionVariableConstants.CountDistinctImplMode getCountDistinctImplementation() {
+        return SessionVariableConstants.CountDistinctImplMode.parse(countDistinctImplementation);
+    }
+
+    public boolean isEnableCountDistinctRewriteByHllBitmap() {
+        return enableCountDistinctRewriteByHllBitmap;
+    }
+
+    public void setEnableCountDistinctRewriteByHllBitmap(boolean enableCountDistinctRewriteByHllBitmap) {
+        this.enableCountDistinctRewriteByHllBitmap = enableCountDistinctRewriteByHllBitmap;
+    }
+
+    public int getConnectorIncrementalScanRangeNumber() {
+        return connectorIncrementalScanRangeSize;
+    }
+
+    public void setConnectorIncrementalScanRangeNumber(int v) {
+        connectorIncrementalScanRangeSize = v;
+    }
+
+    public boolean isEnableConnectorIncrementalScanRanges() {
+        return enableConnectorIncrementalScanRanges;
+    }
+
+    public void setEnableConnectorIncrementalScanRanges(boolean v) {
+        enableConnectorIncrementalScanRanges = v;
     }
 
     // Serialize to thrift object
@@ -4174,6 +4435,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setConnector_io_tasks_slow_io_latency_ms(connectorIoTasksSlowIoLatency);
         tResult.setConnector_scan_use_query_mem_ratio(connectorScanUseQueryMemRatio);
         tResult.setScan_use_query_mem_ratio(scanUseQueryMemRatio);
+        tResult.setAnn_params(VectorSearchOptions.readAnnParams(annParams));
+        tResult.setPq_refine_factor(pqRefineFactor);
+        tResult.setK_factor(kFactor);
         tResult.setEnable_collect_table_level_scan_stats(enableCollectTableLevelScanStats);
         tResult.setEnable_pipeline_level_shuffle(enablePipelineLevelShuffle);
         tResult.setEnable_hyperscan_vec(enableHyperscanVec);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -229,6 +229,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
     public static final String MAX_PUSHDOWN_CONDITIONS_PER_COLUMN = "max_pushdown_conditions_per_column";
 
+    public static final String DISABLE_LAMBDA_PUSHDOWN = "disable_lambda_pushdown";
     // use new execution engine instead of the old one if enable_pipeline_engine is true,
     // the new execution engine split a fragment into pipelines, then create several drivers
     // from the pipeline for parallel executing, threads from global pool pick out the
@@ -1258,6 +1259,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int maxScanKeyNum = -1;
     @VariableMgr.VarAttr(name = MAX_PUSHDOWN_CONDITIONS_PER_COLUMN)
     private int maxPushdownConditionsPerColumn = -1;
+    @VariableMgr.VarAttr(name = DISABLE_LAMBDA_PUSHDOWN)
+    private boolean disableLambdaPushdown = false;
 
     @VariableMgr.VarAttr(name = HASH_JOIN_PUSH_DOWN_RIGHT_TABLE)
     private boolean hashJoinPushDownRightTable = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
@@ -92,7 +92,7 @@ public class PushDownPredicateProjectRule extends TransformationRule {
 
         LogicalProjectOperator project = (LogicalProjectOperator) (child.getOp());
 
-        if (context.getSessionVariable().getDisableLambdaPushDown()) {
+        if (!context.getSessionVariable().getEnableLambdaPushDown()) {
             Map<ColumnRefOperator, ScalarOperator> m = project.getColumnRefMap();
             for (var entry : m.entrySet()) {
                 if (hasLambda(entry.getValue())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
@@ -92,10 +92,12 @@ public class PushDownPredicateProjectRule extends TransformationRule {
 
         LogicalProjectOperator project = (LogicalProjectOperator) (child.getOp());
 
-        Map<ColumnRefOperator, ScalarOperator> m = project.getColumnRefMap();
-        for (var entry : m.entrySet()) {
-            if (hasLambda( entry.getValue())) {
-                return Lists.newArrayList();
+        if (context.getSessionVariable().getDisableLambdaPushDown()) {
+            Map<ColumnRefOperator, ScalarOperator> m = project.getColumnRefMap();
+            for (var entry : m.entrySet()) {
+                if (hasLambda(entry.getValue())) {
+                    return Lists.newArrayList();
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
@@ -23,6 +23,8 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
@@ -34,6 +36,7 @@ import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class PushDownPredicateProjectRule extends TransformationRule {
@@ -67,12 +70,39 @@ public class PushDownPredicateProjectRule extends TransformationRule {
         return !assertColumn.isPresent();
     }
 
+    private boolean hasLambda(ScalarOperator op) {
+        if (op == null) {
+            return false;
+        }
+        System.out.println("hasLambda " + op.debugString());
+
+        if (op instanceof LambdaFunctionOperator) {
+            System.out.println("found LambdaFunctionOperator");
+            return true;
+        }
+
+        for (var c : op.getChildren()) {
+            if (hasLambda(c)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalFilterOperator filter = (LogicalFilterOperator) input.getOp();
         OptExpression child = input.getInputs().get(0);
 
         LogicalProjectOperator project = (LogicalProjectOperator) (child.getOp());
+
+        Map<ColumnRefOperator, ScalarOperator> xx = project.getColumnRefMap();
+        for (var entry : xx.entrySet()) {
+            if (hasLambda( entry.getValue())) {
+                return Lists.newArrayList();
+            }
+        }
+
         ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(project.getColumnRefMap());
         ScalarOperator newPredicate = rewriter.rewrite(filter.getPredicate());
 
@@ -87,5 +117,4 @@ public class PushDownPredicateProjectRule extends TransformationRule {
         OptExpression newProject = OptExpression.create(project, newFilter);
         return Lists.newArrayList(newProject);
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownPredicateProjectRule.java
@@ -74,13 +74,9 @@ public class PushDownPredicateProjectRule extends TransformationRule {
         if (op == null) {
             return false;
         }
-        System.out.println("hasLambda " + op.debugString());
-
         if (op instanceof LambdaFunctionOperator) {
-            System.out.println("found LambdaFunctionOperator");
             return true;
         }
-
         for (var c : op.getChildren()) {
             if (hasLambda(c)) {
                 return true;
@@ -96,8 +92,8 @@ public class PushDownPredicateProjectRule extends TransformationRule {
 
         LogicalProjectOperator project = (LogicalProjectOperator) (child.getOp());
 
-        Map<ColumnRefOperator, ScalarOperator> xx = project.getColumnRefMap();
-        for (var entry : xx.entrySet()) {
+        Map<ColumnRefOperator, ScalarOperator> m = project.getColumnRefMap();
+        for (var entry : m.entrySet()) {
             if (hasLambda( entry.getValue())) {
                 return Lists.newArrayList();
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -815,4 +815,64 @@ public class CTEPlanTest extends PlanTestBase {
                 "  0:OlapScanNode\n" +
                 "     TABLE: t0");
     }
+
+    @Test
+    public void testDisableLambdaPushdownTrue() throws Exception {
+        String sql =
+                "with input1 as (\n" +
+                "  select [1,2,3] as x\n" +
+                "),\n" +
+                "input2 AS (\n" +
+                "  SELECT\n" +
+                "    array_min( array_map(x -> coalesce(x, 0), x )) AS x\n" +
+                "  FROM\n" +
+                "    input1\n" +
+                "),\n" +
+                "input3 as (\n" +
+                "  select x+1 as a, x+2 as b, x+3 as c\n" +
+                "  from input2\n" +
+                ")\n" +
+                "SELECT * from input3\n" +
+                "where a + b + c <10";
+
+        connectContext.getSessionVariable().setDisableLambdaPushdown(true);
+        defaultCTEReuse();
+        String plan = getFragmentPlan(sql);
+        connectContext.getSessionVariable().setDisableLambdaPushdown(false);
+
+        assertContains(plan, "predicates: CAST(CAST(CAST(4: array_min AS SMALLINT) + 1 AS INT) + " +
+                "CAST(CAST(4: array_min AS SMALLINT) + 2 AS INT) AS BIGINT) + CAST(CAST(4: array_min AS SMALLINT) + " +
+                "3 AS BIGINT) < 10");
+    }
+
+    @Test
+    public void testDisableLambdaPushdownFalse() throws Exception {
+        String sql =
+                "with input1 as (\n" +
+                        "  select [1,2,3] as x\n" +
+                        "),\n" +
+                        "input2 AS (\n" +
+                        "  SELECT\n" +
+                        "    array_min( array_map(x -> coalesce(x, 0), x )) AS x\n" +
+                        "  FROM\n" +
+                        "    input1\n" +
+                        "),\n" +
+                        "input3 as (\n" +
+                        "  select x+1 as a, x+2 as b, x+3 as c\n" +
+                        "  from input2\n" +
+                        ")\n" +
+                        "SELECT * from input3\n" +
+                        "where a + b + c <10";
+
+        connectContext.getSessionVariable().setDisableLambdaPushdown(false);
+        defaultCTEReuse();
+        String plan = getFragmentPlan(sql);
+
+        assertContains(plan,
+                "CAST(CAST(CAST(array_min(array_map(<slot 3> -> coalesce(<slot 3>, 0), [1,2,3])) " +
+                        "AS SMALLINT) + 1 AS INT) + CAST(CAST(array_min(array_map(<slot 3> -> " +
+                        "coalesce(<slot 3>, 0), [1,2,3])) AS SMALLINT) + 2 AS INT) AS BIGINT) + " +
+                        "CAST(CAST(array_min(array_map(<slot 3> -> coalesce(<slot 3>, 0), [1,2,3])) AS SMALLINT) + " +
+                        "3 AS BIGINT) < 10");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -817,7 +817,7 @@ public class CTEPlanTest extends PlanTestBase {
     }
 
     @Test
-    public void testDisableLambdaPushdownTrue() throws Exception {
+    public void testEnableLambdaPushdownFalse() throws Exception {
         String sql =
                 "with input1 as (\n" +
                 "  select [1,2,3] as x\n" +
@@ -846,7 +846,7 @@ public class CTEPlanTest extends PlanTestBase {
     }
 
     @Test
-    public void testDisableLambdaPushdownFalse() throws Exception {
+    public void testEnableLambdaPushdownTrue() throws Exception {
         String sql =
                 "with input1 as (\n" +
                         "  select [1,2,3] as x\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -835,10 +835,10 @@ public class CTEPlanTest extends PlanTestBase {
                 "SELECT * from input3\n" +
                 "where a + b + c <10";
 
-        connectContext.getSessionVariable().setDisableLambdaPushdown(true);
+        connectContext.getSessionVariable().setEnableLambdaPushdown(false);
         defaultCTEReuse();
         String plan = getFragmentPlan(sql);
-        connectContext.getSessionVariable().setDisableLambdaPushdown(false);
+        connectContext.getSessionVariable().setEnableLambdaPushdown(true);
 
         assertContains(plan, "predicates: CAST(CAST(CAST(4: array_min AS SMALLINT) + 1 AS INT) + " +
                 "CAST(CAST(4: array_min AS SMALLINT) + 2 AS INT) AS BIGINT) + CAST(CAST(4: array_min AS SMALLINT) + " +
@@ -864,7 +864,7 @@ public class CTEPlanTest extends PlanTestBase {
                         "SELECT * from input3\n" +
                         "where a + b + c <10";
 
-        connectContext.getSessionVariable().setDisableLambdaPushdown(false);
+        connectContext.getSessionVariable().setEnableLambdaPushdown(true);
         defaultCTEReuse();
         String plan = getFragmentPlan(sql);
 


### PR DESCRIPTION
## Why I'm doing:

prevent expensive array_map from being pushed down.


## What I'm doing:

Optionally disable predicate pushdown for lambda expressions through the new set variable:

set disable_lambda_pushdown=true

Example:

```
query:
set pipeline_dop=1;
explain
WITH input AS (
  SELECT
    array_min( array_map(x -> coalesce(x, ""), CELONIS__CACHE_ARRAY_STRING__1 )) + rand() AS x
  FROM
    test.O_CUSTOM_AUFTRAG
),
input2 as (
  select length(x)+1 as a, length(x)+2 as b, length(x)+3 as c
  from input
)

SELECT * from input2
where a + b + c <10
```

explain:

```
PLAN FRAGMENT 0
 OUTPUT EXPRS:9: expr | 10: expr | 11: expr
  PARTITION: UNPARTITIONED

  RESULT SINK

  4:EXCHANGE

PLAN FRAGMENT 1
 OUTPUT EXPRS:
  PARTITION: RANDOM

  STREAM DATA SINK
    EXCHANGE ID: 04
    UNPARTITIONED

  3:Project
  |  <slot 9> : 14: cast + 1
  |  <slot 10> : 14: cast + 2
  |  <slot 11> : 14: cast + 3
  |  common expressions:
  |  <slot 12> : CAST(8: expr AS VARCHAR)
  |  <slot 13> : length(12: cast)
  |  <slot 14> : CAST(13: length AS BIGINT)
  |  
  2:SELECT
  |  predicates: CAST(length(CAST(8: expr AS VARCHAR)) AS BIGINT) + 1 + CAST(length(CAST(8: expr AS VARCHAR)) AS BIGINT) + 2 + CAST(length(CAST(8: expr AS VARCHAR)) AS BIGINT) + 3 < 10
  |  
  1:Project
  |  <slot 8> : CAST(array_min(array_map(<slot 7> -> coalesce(<slot 7>, ''), 5: CELONIS__CACHE_ARRAY_STRING__1)) AS DOUBLE) + rand()
  |  
  0:OlapScanNode
     TABLE: O_CUSTOM_AUFTRAG
     PREAGGREGATION: ON
     partitions=1/1
     rollup: O_CUSTOM_AUFTRAG
     tabletRatio=3620/3620
     tabletList=17430,17432,17434,17436,17438,17440,17442,17444,17446,17448 ...
     cardinality=2
     avgRowSize=2.0
```






Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
