### PR TITLE
[Feature]Add parameter to set whether trino dialect is downgraded

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -624,7 +624,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String SQL_DIALECT = "sql_dialect";
 
     // Is Trino dialect downgraded to Starrocks
-    public static final String ENABLE_DIALECT_DOWNGRADE ="enable_dialect_downgrade";
+    public static final String ENABLE_DIALECT_DOWNGRADE = "enable_dialect_downgrade";
 
     public static final String ENABLE_OUTER_JOIN_REORDER = "enable_outer_join_reorder";
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -623,6 +623,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String SQL_DIALECT = "sql_dialect";
 
+    // Is Trino dialect downgraded to Starrocks
+    public static final String ENABLE_DIALECT_DOWNGRADE ="enable_dialect_downgrade";
+
     public static final String ENABLE_OUTER_JOIN_REORDER = "enable_outer_join_reorder";
 
     public static final String CBO_REORDER_THRESHOLD_USE_EXHAUSTIVE = "cbo_reorder_threshold_use_exhaustive";
@@ -1897,6 +1900,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = SQL_DIALECT)
     private String sqlDialect = "StarRocks";
+
+    @VarAttr(name = ENABLE_DIALECT_DOWNGRADE)
+    private boolean enableDialectDowngrade = true;
 
     @VarAttr(name = ENABLE_OUTER_JOIN_REORDER)
     private boolean enableOuterJoinReorder = true;
@@ -3709,6 +3715,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setSqlDialect(String dialect) {
         this.sqlDialect = dialect;
+    }
+
+    public boolean isEnableDialectDowngrade() {
+        return enableOuterJoinReorder;
+    }
+
+    public void setEnableDialectDowngrade(boolean enableDialectDowngrade) {
+        this.enableDialectDowngrade = enableDialectDowngrade;
     }
 
     public boolean isEnableOuterJoinReorder() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3718,7 +3718,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public boolean isEnableDialectDowngrade() {
-        return enableOuterJoinReorder;
+        return enableDialectDowngrade;
     }
 
     public void setEnableDialectDowngrade(boolean enableDialectDowngrade) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -92,17 +92,26 @@ public class SqlParser {
             // In Trino parser AstBuilder, it could throw ParsingException for unexpected exception,
             // use StarRocks parser to parse now.
             LOG.warn("Trino parse sql [{}] error, cause by {}", sql, e);
-            return tryParseWithStarRocksDialect(sql, sessionVariable, e);
+            if (sessionVariable.isEnableDialectDowngrade()) {
+                return tryParseWithStarRocksDialect(sql, sessionVariable, e);
+            }
+            throw e;
         } catch (io.trino.sql.parser.ParsingException e) {
             // This sql does not use Trino syntax，use StarRocks parser to parse now.
             if (sql.toLowerCase().contains("select")) {
                 LOG.warn("Trino parse sql [{}] error, cause by {}", sql, e);
             }
-            return tryParseWithStarRocksDialect(sql, sessionVariable, e);
+            if (sessionVariable.isEnableDialectDowngrade()) {
+                return tryParseWithStarRocksDialect(sql, sessionVariable, e);
+            }
+            throw e;
         } catch (TrinoParserUnsupportedException e) {
             // We only support Trino partial syntax now, and for Trino parser unsupported statement,
             // try to use StarRocks parser to parse
-            return tryParseWithStarRocksDialect(sql, sessionVariable, e);
+            if (sessionVariable.isEnableDialectDowngrade()) {
+                return tryParseWithStarRocksDialect(sql, sessionVariable, e);
+            }
+            throw e;
         } catch (UnsupportedException e) {
             // For unsupported statement, it can not be parsed by trino or StarRocks parser, both parser
             // can not support it now, we just throw the exception here to give user more information

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoDialectDowngradeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoDialectDowngradeTest.java
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 package com.starrocks.connector.parser.trino;
-import com.starrocks.sql.ast.QueryStatement;
-import com.starrocks.sql.parser.SqlParser;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoDialectDowngradeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoDialectDowngradeTest.java
@@ -24,13 +24,13 @@ public class TrinoDialectDowngradeTest extends TrinoTestBase {
 
     @Test
     public void testTrinoDialectDowngrade() throws Exception {
-        String querySql = "select date_add('2010-11-30 23:59:59', INTERVAL 2 DAY);";
+        String querySql = "select date_add('2010-11-30 23:59:59', INTERVAL 3 DAY);";
         try {
             connectContext.getSessionVariable().setEnableDialectDowngrade(true);
             connectContext.getSessionVariable().setSqlDialect("trino");
             analyzeSuccess(querySql);
             connectContext.getSessionVariable().setEnableDialectDowngrade(false);
-            analyzeFail(querySql, "mismatched input '2'. Expecting: '+', '-', <string>");
+            analyzeFail(querySql, "mismatched input '3'. Expecting: '+', '-', <string>");
         } finally {
             connectContext.getSessionVariable().setSqlDialect("trino");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoDialectDowngradeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoDialectDowngradeTest.java
@@ -26,19 +26,15 @@ public class TrinoDialectDowngradeTest extends TrinoTestBase {
 
     @Test
     public void testTrinoDialectDowngrade() throws Exception {
-        String querySql = "select doy(date '2022-03-06')";
+        String querySql = "select date_add('2010-11-30 23:59:59', INTERVAL 2 DAY);";
         try {
             connectContext.getSessionVariable().setEnableDialectDowngrade(true);
             connectContext.getSessionVariable().setSqlDialect("trino");
-            QueryStatement queryStmt =
-                    (QueryStatement) SqlParser.parse(querySql, connectContext.getSessionVariable()).get(0);
-            assertPlanContains(queryStmt, "dayofyear('2022-03-06 00:00:00')");
-            connectContext.getSessionVariable().setEnableDialectDowngrade(true);
-            analyzeFail(querySql, "No matching function with signature: doy(date)");
+            analyzeSuccess(querySql);
+            connectContext.getSessionVariable().setEnableDialectDowngrade(false);
+            analyzeFail(querySql, "mismatched input '2'. Expecting: '+', '-', <string>");
         } finally {
             connectContext.getSessionVariable().setSqlDialect("trino");
         }
     }
-
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoDialectDowngradeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoDialectDowngradeTest.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.parser.trino;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.parser.SqlParser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TrinoDialectDowngradeTest extends TrinoTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        TrinoTestBase.beforeClass();
+    }
+
+    @Test
+    public void testTrinoDialectDowngrade() throws Exception {
+        String querySql = "select doy(date '2022-03-06')";
+        try {
+            connectContext.getSessionVariable().setEnableDialectDowngrade(true);
+            connectContext.getSessionVariable().setSqlDialect("trino");
+            QueryStatement queryStmt =
+                    (QueryStatement) SqlParser.parse(querySql, connectContext.getSessionVariable()).get(0);
+            assertPlanContains(queryStmt, "dayofyear('2022-03-06 00:00:00')");
+            connectContext.getSessionVariable().setEnableDialectDowngrade(true);
+            analyzeFail(querySql, "No matching function with signature: doy(date)");
+        } finally {
+            connectContext.getSessionVariable().setSqlDialect("trino");
+        }
+    }
+
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
@@ -173,7 +173,7 @@ public class TrinoTestBase {
                     connectContext.getSessionVariable()).get(0);
             Analyzer.analyze(statementBase, connectContext);
             Assert.fail("Miss semantic error exception");
-        } catch (ParsingException | StarRocksPlannerException e) {
+        } catch (ParsingException | StarRocksPlannerException | io.trino.sql.parser.ParsingException e) {
             if (!exceptMessage.equals("")) {
                 Assert.assertTrue(e.getMessage(), e.getMessage().contains(exceptMessage));
             }


### PR DESCRIPTION
## Why I'm doing:
```
set sql_dialect = 'trino';
select json_extract(json, '$.store.book')  --正常
select date_sub(current_date, interval 14 day) --正常
但是
select json_extract(json, '$.store.book') , date_sub(current_date, interval 14 day)  -- 不正常
原因是 json_extract符合trino语法，date_sub(current_date, interval 14 day) 符合SR语法，所以两个单独查询没问题，但是联合查时会有异常，会带来困惑
```

## What I'm doing:
Fixes #52702 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
