### PR TITLE
[Enhancement] Support cast string to int

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -525,7 +525,8 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
                 if (Type.DATE.equals(type)) {
                     childString = DateUtils.convertDateFormaterToDateKeyFormater(childString);
                 }
-                res = ConstantOperator.createInt(Integer.parseInt(childString.trim()));
+                BigDecimal bd = new BigDecimal(childString.trim());
+                res = ConstantOperator.createInt(bd.setScale(0, RoundingMode.DOWN).intValue());
             } else if (desc.isBigint()) {
                 if (Type.DATE.equals(type)) {
                     childString = DateUtils.convertDateFormaterToDateKeyFormater(childString);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -549,8 +549,8 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
 
         sql = "select TRUNCATE(0.6798916342905857, 3.13);";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
-        Assert.assertTrue(plan.contains("truncate[(0.6798916342905857, cast(3.13 as INT)); args: DOUBLE,INT; " +
-                "result: DOUBLE; args nullable: true; result nullable: true]"));
+        Assert.assertTrue(plan.contains("truncate[(0.6798916342905857, 3); args: DOUBLE,INT; " +
+                "result: DOUBLE; args nullable: false; result nullable: true]"));
 
         sql = "select TRUNCATE(0.6798916342905857, cast('2000-01-31 12:00:00' as datetime));";
         plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2216,9 +2216,11 @@ public class AggregateTest extends PlanTestBase {
 
         sql = "select sum(cast(t1b as int) + cast('1.1' as int)) from test_all_type";
         plan = getVerboseExplain(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
-                "  |  aggregate: sum[(cast([2: t1b, SMALLINT, true] as BIGINT) + cast(cast('1.1' as INT) as BIGINT)); " +
-                "args: BIGINT; result: BIGINT; args nullable: true; result nullable: true]");
+        assertContains(plan, "  1:AGGREGATE (update finalize)\n" +
+                "  |  aggregate: sum[([2: t1b, SMALLINT, true]); " +
+                "args: SMALLINT; result: BIGINT; args nullable: true; result nullable: true], "
+                + "count[([2: t1b, SMALLINT, true]); args: SMALLINT; result: BIGINT; args nullable: true; "
+                + "result nullable: true]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -214,6 +214,7 @@ public class SelectConstTest extends PlanTestBase {
                 "78883632:00:00");
         assertFeExecuteResult("select timediff('1000-01-01 01:01:01.000001', '9999-01-02 01:01:01.123456')",
                 "-78883632:00:01");
+        assertFeExecuteResult("select cast ('123.4' as INT);", "123");
     }
 
     private void assertFeExecuteResult(String sql, String expected) throws Exception {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #52473

```sql
StarRocks> select cast ('123.4' as INT) ;
+-----------------------+
I CAST ('123.4' AS INT) |
+-----------------------+
|                   123 |
+-----------------------+
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
