### PR TITLE
[BugFix] fix concat expr with multiple args nullsFraction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -643,8 +643,8 @@ public class ExpressionStatisticCalculator {
                     distinctValues = Math.min(rowCount,
                             childColumnStatisticList.stream().mapToDouble(ColumnStatistic::getDistinctValuesCount).sum());
                     averageRowSize = childColumnStatisticList.stream().mapToDouble(ColumnStatistic::getAverageRowSize).sum();
-                    nullsFraction = 1 - childColumnStatisticList.stream().mapToDouble(ColumnStatistic::getAverageRowSize)
-                            .reduce(1, (a, b) -> (1 - a) * (1 - b));
+                    nullsFraction = 1 - childColumnStatisticList.stream().mapToDouble(ColumnStatistic::getNullsFraction)
+                            .reduce(1.0, (accumulator, nullFraction) -> accumulator * (1 - nullFraction));
                     return new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
                             nullsFraction, averageRowSize, distinctValues);
                 default:

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
@@ -15,10 +15,12 @@
 
 package com.starrocks.sql.optimizer.statistics;
 
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -110,5 +112,19 @@ public class PredicateStatisticsCalculatorTest {
                 PredicateStatisticsCalculator.statisticsCalculate(binaryPredicateOperator, statistics);
         Assert.assertEquals(5000, estimatedStatistics.getOutputRowCount(), 0.001);
         Assert.assertEquals(1, estimatedStatistics.getColumnStatistic(c1).getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testConcatExpressionCalculate() {
+        ColumnRefOperator c1 = new ColumnRefOperator(0, Type.VARCHAR, "c1", true);
+        ConstantOperator c2 = new ConstantOperator("-", Type.VARCHAR);
+        ColumnRefOperator c3 = new ColumnRefOperator(1, Type.VARCHAR, "c3", true);
+        CallOperator concat = new CallOperator("concat", Type.VARCHAR, Lists.newArrayList(c1, c2, c3));
+        Statistics statistics = Statistics.builder()
+                .addColumnStatistic(c1, ColumnStatistic.builder().setNullsFraction(0.2).setDistinctValuesCount(10).build())
+                .addColumnStatistic(c3, ColumnStatistic.builder().setNullsFraction(0.4).setDistinctValuesCount(10).build())
+                .setOutputRowCount(10000).build();
+        ColumnStatistic estimatedStatistics = ExpressionStatisticCalculator.calculate(concat, statistics);
+        Assert.assertEquals(0.52, estimatedStatistics.getNullsFraction(), 0.001);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
The current nullsFraction method for concat calculation is incorrect and may be negative. This will cause the cardinality of the join node to be 1.
```
  8:HASH JOIN
  |  join op: LEFT OUTER JOIN (BROADCAST)
  |  equal join conjunct: [44: xxx, LARGEINT, true] = [127: ccc, LARGEINT, true]
  |  other predicates: concat[(cast([9: CLAIM_STATUS_CD, BIGINT, true] as VARCHAR), ' - ', [126: LOOKUP_DETAIL, VARCHAR, true]); args: VARCHAR; result: VARCHAR; args nullable: true; result nullable: true] = '3 - CLEARED'
  |  output columns: 3, 8, 9, 43, 54, 126
  |  can local shuffle: false
  |  cardinality: 1
  |  column statistics: 
  |  * aaa-->[4.446678308E9, 1.8487815906E10, 0.0, 8.0, 1.0] ESTIMATE
  |  * vvv-->[-Infinity, Infinity, 0.0, 1.0000000994337923, 1.0] ESTIMATE
  |  * ccc-->[1.0, 42.0, 0.0, 8.0, 1.0] ESTIMATE
  |  * www-->[-1.3145022026298428E38, 1.2734555494779917E38, 0.0, 16.0, 1.0] ESTIMATE
  |  * qqqq-->[-1.5620653915393402E38, 1.2734555494779917E38, 0.0, 16.0, 1.0] ESTIMATE
  |  * rrr-->[-1.7007341574472433E38, 1.7003487503261273E38, 0.0, 16.0, 1.0] ESTIMATE
  |  * ccaa-->[-Infinity, Infinity, 0.0, 7.076923076923077, 1.0] ESTIMATE
  |  * aafff-->[-1.5620653915393402E38, 1.2734555494779917E38, 0.0, 16.0, 1.0] ESTIMATE
  |  
  |----7:EXCHANGE
  |       distribution type: BROADCAST
  |       cardinality: 13
  |    
  5:OlapScanNode
     table: table, rollup: table
     preAggregation: on
     partitionsRatio=1/1, tabletsRatio=814/814
     tabletList=30250908,30250912,30250916,30250920,30250924,30250928,30250932,30250936,30250940,30250944 ...
     actualRows=643644364, avgRowSize=65.0
     cardinality: 643644364
     column statistics: 
     * afffa-->[4.446678308E9, 1.8487815906E10, 0.0, 8.0, 6.4845024E8] ESTIMATE
     * dsdf-->[-Infinity, Infinity, 0.0, 1.0000000994337923, 7.0] ESTIMATE
     * ccc-->[1.0, 42.0, 0.0, 8.0, 10.0] ESTIMATE
     * fff-->[-1.3145022026298428E38, 1.2734555494779917E38, 0.0, 16.0, 7.0] ESTIMATE
     * aaaa-->[-1.5620653915393402E38, 1.2734555494779917E38, 0.0, 16.0, 10.0] ESTIMATE
     * wwww-->[-1.7007341574472433E38, 1.7003487503261273E38, 0.0, 16.0, 9105.0] ESTIMATE
 ```

## What I'm doing:
Reference binaryExpressionCalculate nullsFraction algorithm is `1 - ((1 - left.getNullsFraction ()) * ( 1 - right.getNullsFraction ()))`. Fix multiaryExpressionCalculate

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
