### PR TITLE
[BugFix] add lock to avoid publish and update schema run concurrency for pk table

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1830,7 +1830,7 @@ void Tablet::_get_rewrite_meta_rs(std::vector<RowsetSharedPtr>& rewrite_meta_rs)
     }
 
     if (_updates) {
-        _updates->rewrite_rs_meta();
+        _updates->rewrite_rs_meta(true);
     }
 }
 

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -1746,6 +1746,14 @@ Status TabletMetaManager::remove_tablet_persistent_index_meta(DataDir* store, TT
     return meta->write_batch(&batch);
 }
 
+Status TabletMetaManager::put_pending_rowset_meta(DataDir* store, WriteBatch* batch, TTabletId tablet_id,
+                                                  int64_t version, const RowsetMetaPB& rowset) {
+    auto h = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
+    auto k = encode_meta_pending_rowset_key(tablet_id, version);
+    auto v = rowset.SerializeAsString();
+    return to_status(batch->Put(h, k, v));
+}
+
 // methods for operating pending commits
 Status TabletMetaManager::pending_rowset_commit(DataDir* store, TTabletId tablet_id, int64_t version,
                                                 const RowsetMetaPB& rowset, const string& rowset_meta_key) {

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -137,6 +137,8 @@ public:
     using RowsetIterateFunc = std::function<bool(RowsetMetaSharedPtr rowset_meta)>;
     static Status rowset_iterate(DataDir* store, TTabletId tablet_id, const RowsetIterateFunc& func);
 
+    static Status put_pending_rowset_meta(DataDir* store, WriteBatch* batch, TTabletId tablet_id, int64_t version,
+                                          const RowsetMetaPB& rowset);
     // methods for operating pending commits
     static Status pending_rowset_commit(DataDir* store, TTabletId tablet_id, int64_t version,
                                         const RowsetMetaPB& rowset, const string& rowset_meta_key);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2648,7 +2648,7 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
     // too much time.
     {
         std::unique_lock wrlock(_tablet.get_header_lock());
-        rewrite_rs_meta();
+        rewrite_rs_meta(false);
     }
 
     // GC works that can be done outside of lock
@@ -5685,37 +5685,50 @@ void TabletUpdates::_reset_apply_status(const EditVersionInfo& version_info_appl
     }
 }
 
-void TabletUpdates::rewrite_rs_meta() {
+void TabletUpdates::rewrite_rs_meta(bool is_fatal) {
     std::lock_guard lg(_lock);
+    Status st;
+    rocksdb::WriteBatch wb;
+    auto kv_store = _tablet.data_dir()->get_meta();
+    int32_t pending_rs = 0;
+    int32_t published_rs = 0;
+
     for (auto& [version, rs] : _pending_commits) {
         if (rs->rowset_meta()->skip_tablet_schema()) {
             rs->rowset_meta()->set_skip_tablet_schema(false);
             RowsetMetaPB meta_pb;
             rs->rowset_meta()->get_full_meta_pb(&meta_pb);
-            Status st = TabletMetaManager::pending_rowset_commit(
-                    _tablet.data_dir(), _tablet.tablet_id(), version, meta_pb,
-                    RowsetMetaManager::get_rowset_meta_key(_tablet.tablet_uid(), rs->rowset_id()));
-            LOG_IF(FATAL, !st.ok()) << "fail to save pending rowset meta:" << st
-                                    << ". tablet_id=" << _tablet.tablet_id() << ", rowset_id=" << rs->rowset_id();
+            st = TabletMetaManager::put_pending_rowset_meta(_tablet.data_dir(), &wb, _tablet.tablet_id(), version,
+                                                            meta_pb);
+            if (!st.ok()) break;
+            pending_rs++;
         }
     }
 
-    auto kv_store = _tablet.data_dir()->get_meta();
-    int32_t published_rs = 0;
-    rocksdb::WriteBatch wb;
-    for (auto& [_, rs] : _rowsets) {
-        if (rs->rowset_meta()->skip_tablet_schema()) {
-            rs->rowset_meta()->set_skip_tablet_schema(false);
-            RowsetMetaPB meta_pb;
-            rs->rowset_meta()->get_full_meta_pb(&meta_pb);
-            Status st = TabletMetaManager::put_rowset_meta(_tablet.data_dir(), &wb, _tablet.tablet_id(), meta_pb);
-            LOG_IF(FATAL, !st.ok()) << "fail to put published rowset meta:" << st
-                                    << ". tablet_id=" << _tablet.tablet_id() << ", rowset_id=" << rs->rowset_id();
+    if (st.ok()) {
+        for (auto& [_, rs] : _rowsets) {
+            if (rs->rowset_meta()->skip_tablet_schema()) {
+                rs->rowset_meta()->set_skip_tablet_schema(false);
+                RowsetMetaPB meta_pb;
+                rs->rowset_meta()->get_full_meta_pb(&meta_pb);
+                st = TabletMetaManager::put_rowset_meta(_tablet.data_dir(), &wb, _tablet.tablet_id(), meta_pb);
+                if (!st.ok()) break;
+                published_rs++;
+            }
         }
     }
-    Status st = kv_store->write_batch(&wb);
-    LOG_IF(FATAL, !st.ok()) << "fail to write published rowset meta:" << st << ". tablet_id=" << _tablet.tablet_id()
-                            << ", rowset num=" << published_rs;
+
+    if (st.ok()) {
+        st = kv_store->write_batch(&wb);
+    }
+
+    LOG_IF(FATAL, is_fatal && !st.ok()) << "fail to rewrite rowset meta: " << st
+                                        << ". tablet_id=" << _tablet.tablet_id()
+                                        << ", pending rowset num=" << pending_rs
+                                        << ", published rowset num=" << published_rs;
+    LOG_IF(WARNING, !is_fatal && !st.ok())
+            << "fail to rewrite rowset meta: " << st << ". tablet_id=" << _tablet.tablet_id()
+            << ", pending rowset num=" << pending_rs << ", published rowset num=" << published_rs;
 }
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5686,25 +5686,33 @@ void TabletUpdates::_reset_apply_status(const EditVersionInfo& version_info_appl
 }
 
 void TabletUpdates::rewrite_rs_meta() {
-    std::lock_guard lg(_lock);
-    for (auto& [version, rs] : _pending_commits) {
-        if (rs->rowset_meta()->skip_tablet_schema()) {
-            rs->rowset_meta()->set_skip_tablet_schema(false);
-            RowsetMetaPB meta_pb;
-            rs->rowset_meta()->get_full_meta_pb(&meta_pb);
-            Status st = TabletMetaManager::pending_rowset_commit(
-                    _tablet.data_dir(), _tablet.tablet_id(), version, meta_pb,
-                    RowsetMetaManager::get_rowset_meta_key(_tablet.tablet_uid(), rs->rowset_id()));
-            LOG_IF(FATAL, !st.ok()) << "fail to save pending rowset meta:" << st
-                                    << ". tablet_id=" << _tablet.tablet_id() << ", rowset_id=" << rs->rowset_id();
+    std::vector<RowsetSharedPtr> published_rs;
+    {
+        std::lock_guard lg(_lock);
+        for (auto& [version, rs] : _pending_commits) {
+            if (rs->rowset_meta()->skip_tablet_schema()) {
+                rs->rowset_meta()->set_skip_tablet_schema(false);
+                RowsetMetaPB meta_pb;
+                rs->rowset_meta()->get_full_meta_pb(&meta_pb);
+                Status st = TabletMetaManager::pending_rowset_commit(
+                        _tablet.data_dir(), _tablet.tablet_id(), version, meta_pb,
+                        RowsetMetaManager::get_rowset_meta_key(_tablet.tablet_uid(), rs->rowset_id()));
+                LOG_IF(FATAL, !st.ok()) << "fail to save pending rowset meta:" << st
+                                        << ". tablet_id=" << _tablet.tablet_id() << ", rowset_id=" << rs->rowset_id();
+            }
+        }
+        for (auto& [_, rs] : _rowsets) {
+            if (rs->rowset_meta()->skip_tablet_schema()) {
+                rs->rowset_meta()->set_skip_tablet_schema(false);
+                published_rs.emplace_back(rs);
+            }
         }
     }
 
     auto kv_store = _tablet.data_dir()->get_meta();
     rocksdb::WriteBatch wb;
-    for (auto& [_, rs] : _rowsets) {
+    for (auto& [_, rs] : published_rs) {
         if (rs->rowset_meta()->skip_tablet_schema()) {
-            rs->rowset_meta()->set_skip_tablet_schema(false);
             RowsetMetaPB meta_pb;
             rs->rowset_meta()->get_full_meta_pb(&meta_pb);
             Status st = TabletMetaManager::put_rowset_meta(_tablet.data_dir(), &wb, _tablet.tablet_id(), meta_pb);
@@ -5714,7 +5722,7 @@ void TabletUpdates::rewrite_rs_meta() {
     }
     Status st = kv_store->write_batch(&wb);
     LOG_IF(FATAL, !st.ok()) << "fail to write published rowset meta:" << st << ". tablet_id=" << _tablet.tablet_id()
-                            << ", rowset nul=" << published_rs.size();
+                            << ", rowset num=" << published_rs.size();
 }
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5686,33 +5686,26 @@ void TabletUpdates::_reset_apply_status(const EditVersionInfo& version_info_appl
 }
 
 void TabletUpdates::rewrite_rs_meta() {
-    std::vector<RowsetSharedPtr> published_rs;
-    {
-        std::lock_guard lg(_lock);
-        for (auto& [version, rs] : _pending_commits) {
-            if (rs->rowset_meta()->skip_tablet_schema()) {
-                rs->rowset_meta()->set_skip_tablet_schema(false);
-                RowsetMetaPB meta_pb;
-                rs->rowset_meta()->get_full_meta_pb(&meta_pb);
-                Status st = TabletMetaManager::pending_rowset_commit(
-                        _tablet.data_dir(), _tablet.tablet_id(), version, meta_pb,
-                        RowsetMetaManager::get_rowset_meta_key(_tablet.tablet_uid(), rs->rowset_id()));
-                LOG_IF(FATAL, !st.ok()) << "fail to save pending rowset meta:" << st
-                                        << ". tablet_id=" << _tablet.tablet_id() << ", rowset_id=" << rs->rowset_id();
-            }
-        }
-        for (auto& [_, rs] : _rowsets) {
-            if (rs->rowset_meta()->skip_tablet_schema()) {
-                rs->rowset_meta()->set_skip_tablet_schema(false);
-                published_rs.emplace_back(rs);
-            }
+    std::lock_guard lg(_lock);
+    for (auto& [version, rs] : _pending_commits) {
+        if (rs->rowset_meta()->skip_tablet_schema()) {
+            rs->rowset_meta()->set_skip_tablet_schema(false);
+            RowsetMetaPB meta_pb;
+            rs->rowset_meta()->get_full_meta_pb(&meta_pb);
+            Status st = TabletMetaManager::pending_rowset_commit(
+                    _tablet.data_dir(), _tablet.tablet_id(), version, meta_pb,
+                    RowsetMetaManager::get_rowset_meta_key(_tablet.tablet_uid(), rs->rowset_id()));
+            LOG_IF(FATAL, !st.ok()) << "fail to save pending rowset meta:" << st
+                                    << ". tablet_id=" << _tablet.tablet_id() << ", rowset_id=" << rs->rowset_id();
         }
     }
 
     auto kv_store = _tablet.data_dir()->get_meta();
+    int32_t published_rs = 0;
     rocksdb::WriteBatch wb;
-    for (auto& [_, rs] : published_rs) {
+    for (auto& [_, rs] : _rowsets) {
         if (rs->rowset_meta()->skip_tablet_schema()) {
+            rs->rowset_meta()->set_skip_tablet_schema(false);
             RowsetMetaPB meta_pb;
             rs->rowset_meta()->get_full_meta_pb(&meta_pb);
             Status st = TabletMetaManager::put_rowset_meta(_tablet.data_dir(), &wb, _tablet.tablet_id(), meta_pb);
@@ -5722,7 +5715,7 @@ void TabletUpdates::rewrite_rs_meta() {
     }
     Status st = kv_store->write_batch(&wb);
     LOG_IF(FATAL, !st.ok()) << "fail to write published rowset meta:" << st << ". tablet_id=" << _tablet.tablet_id()
-                            << ", rowset num=" << published_rs.size();
+                            << ", rowset num=" << published_rs;
 }
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -384,7 +384,7 @@ public:
         }
     }
 
-    void rewrite_rs_meta();
+    void rewrite_rs_meta(bool is_fatal);
 
 private:
     friend class Tablet;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3800,7 +3800,7 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
         ASSERT_TRUE(rs_meta.tablet_schema() == nullptr);
     }
 
-    _tablet->updates()->rewrite_rs_meta();
+    _tablet->updates()->rewrite_rs_meta(true);
     {
         std::string rs1_meta_value;
         ASSERT_TRUE(TabletMetaManager::get_committed_rowset_meta_value(_tablet->data_dir(), _tablet->tablet_id(),


### PR DESCRIPTION
## Why I'm doing:
We need to rewrite rowset meta when we update tablet schema. For non-primary key table, we use `_meta_lock` to prevent publish and update schema run concurrency. However, primary key table does not hold `_meta_lock` during publish, so update schema and publish could run concurrency. If run concurrency, the `pengding_rowset_meta` maybe write again after delete and can not be gc.

## What I'm doing:
Add lock to prevent run concurrency. 

In my test, rewrite 10000 rowset meta(200 columns table) in HDD cost about 1 second. So I believe that holding the lock in rewrite_rs_meta is acceptable.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
