### PR TITLE
[BugFix] fix slot id conflicts in array_map

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -47,12 +47,11 @@ Status ArrayMapExpr::prepare(RuntimeState* state, ExprContext* context) {
     }
 
     auto lambda_expr = down_cast<LambdaFunction*>(_children[0]);
-
     LambdaFunction::ExtractContext extract_ctx;
     // assign slot ids to outer common exprs starting with max_used_slot_id + 1
-    extract_ctx.next_slot_id = lambda_expr->max_used_slot_id() + 1;
+    extract_ctx.next_slot_id = context->root()->max_used_slot_id() + 1;
 
-    RETURN_IF_ERROR(lambda_expr->extract_outer_common_exprs(state, &extract_ctx));
+    RETURN_IF_ERROR(lambda_expr->extract_outer_common_exprs(state, context, &extract_ctx));
     _outer_common_exprs.swap(extract_ctx.outer_common_exprs);
     for (auto [_, expr] : _outer_common_exprs) {
         RETURN_IF_ERROR(expr->prepare(state, context));

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -70,10 +70,16 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
     // create a new chunk to evaluate the lambda expression
     auto cur_chunk = std::make_shared<Chunk>();
     auto tmp_chunk = std::make_shared<Chunk>();
+    {
+        // see more details: https://github.com/StarRocks/starrocks/pull/52692
+        for (const auto& [slot_id, _] : chunk->get_slot_id_to_index_map()) {
+            tmp_chunk->append_column(chunk->get_column_by_slot_id(slot_id), slot_id);
+        }
+    }
+
     // 1. evaluate outer common expressions
     for (const auto& [slot_id, expr] : _outer_common_exprs) {
-        ASSIGN_OR_RETURN(auto col, context->evaluate(expr, chunk));
-        // chunk->append_column(col, slot_id);
+        ASSIGN_OR_RETURN(auto col, context->evaluate(expr, tmp_chunk.get()));
         tmp_chunk->append_column(col, slot_id);
     }
 
@@ -84,8 +90,8 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
     // 2. check captured columns' size
     for (auto slot_id : capture_slot_ids) {
         DCHECK(slot_id > 0);
-        auto captured_column = chunk->is_slot_exist(slot_id) ? chunk->get_column_by_slot_id(slot_id): tmp_chunk->get_column_by_slot_id(slot_id);
-        // auto captured_column = chunk->get_column_by_slot_id(slot_id);
+        auto captured_column = chunk->is_slot_exist(slot_id) ? chunk->get_column_by_slot_id(slot_id)
+                                                             : tmp_chunk->get_column_by_slot_id(slot_id);
         if (UNLIKELY(captured_column->size() < input_elements[0]->size())) {
             return Status::InternalError(fmt::format("The size of the captured column {} is less than array's size.",
                                                      captured_column->get_name()));
@@ -145,7 +151,8 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
 
     // 4. prepare capture columns
     for (auto slot_id : capture_slot_ids) {
-        auto captured_column = chunk->get_column_by_slot_id(slot_id);
+        auto captured_column = chunk->is_slot_exist(slot_id) ? chunk->get_column_by_slot_id(slot_id)
+                                                             : tmp_chunk->get_column_by_slot_id(slot_id);
         if constexpr (independent_lambda_expr) {
             cur_chunk->append_column(captured_column, slot_id);
         } else {

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -50,8 +50,6 @@ Status ArrayMapExpr::prepare(RuntimeState* state, ExprContext* context) {
     LambdaFunction::ExtractContext extract_ctx;
     // assign slot ids to outer common exprs starting with max_used_slot_id + 1
     extract_ctx.next_slot_id = context->root()->max_used_slot_id() + 1;
-    // @TODO not enough....need global slot id
-    LOG(INFO) << "max_used_slot_id: " << context->root()->max_used_slot_id() << ", ctx:" << (void*)context;
 
     RETURN_IF_ERROR(lambda_expr->extract_outer_common_exprs(state, context, &extract_ctx));
     _outer_common_exprs.swap(extract_ctx.outer_common_exprs);

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -891,6 +891,12 @@ bool Expr::is_index_only_filter() const {
     return is_index_only_filter;
 }
 
+SlotId Expr::max_used_slot_id() const {
+    SlotId max_slot_id = 0;
+    for_each_slot_id([&max_slot_id](SlotId slot_id) { max_slot_id = std::max(max_slot_id, slot_id); });
+    return max_slot_id;
+}
+
 } // namespace starrocks
 
 #pragma clang diagnostic pop

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -267,6 +267,7 @@ public:
 #if BE_TEST
     void set_type(TypeDescriptor t) { _type = t; }
 #endif
+    SlotId max_used_slot_id() const;
 
 protected:
     friend class MathFunctions;

--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -87,7 +87,7 @@ Status LambdaFunction::extract_outer_common_exprs(RuntimeState* state, ExprConte
             });
 #endif
             ColumnRef* column_ref = state->obj_pool()->add(new ColumnRef(child->type(), slot_id));
-            LOG(INFO) << "add new common expr, slot_id: " << slot_id << ", new expr: " << column_ref->debug_string()
+            VLOG(2) << "add new common expr, slot_id: " << slot_id << ", new expr: " << column_ref->debug_string()
                     << ", old expr: " << child->debug_string();
             expr->_children[i] = column_ref;
             ctx->outer_common_exprs.insert({slot_id, child});

--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -87,7 +87,7 @@ Status LambdaFunction::extract_outer_common_exprs(RuntimeState* state, ExprConte
             });
 #endif
             ColumnRef* column_ref = state->obj_pool()->add(new ColumnRef(child->type(), slot_id));
-            VLOG(2) << "add new common expr, slot_id: " << slot_id << ", new expr: " << column_ref->debug_string()
+            LOG(INFO) << "add new common expr, slot_id: " << slot_id << ", new expr: " << column_ref->debug_string()
                     << ", old expr: " << child->debug_string();
             expr->_children[i] = column_ref;
             ctx->outer_common_exprs.insert({slot_id, child});

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -68,8 +68,6 @@ public:
     Expr* get_lambda_expr() const { return _children[0]; }
     std::string debug_string() const override;
 
-    SlotId max_used_slot_id() const;
-
     struct ExtractContext {
         std::unordered_set<SlotId> lambda_arguments;
         // slot id of common sub expr inside lambda expr
@@ -87,13 +85,13 @@ public:
     // `any_match(array_map(x->x<10, arr1))` is an outer common expr. it will create 2 column ref exprs to replace them.
     // 1. slot 1 -> array_map(x->x<10, arr1)
     // 2. slot 2 -> any_match(slot 1, arr1)
-    Status extract_outer_common_exprs(RuntimeState* state, ExtractContext* ctx);
+    Status extract_outer_common_exprs(RuntimeState* state, ExprContext* expr_ctx, ExtractContext* ctx);
 
 private:
     Status collect_lambda_argument_ids();
     Status collect_capture_slot_ids();
     Status collect_common_sub_exprs();
-    Status extract_outer_common_exprs(RuntimeState* state, Expr* expr, ExtractContext* ctx);
+    Status extract_outer_common_exprs(RuntimeState* state, ExprContext* expr_ctx, Expr* expr, ExtractContext* ctx);
 
     std::vector<SlotId> _captured_slot_ids;
     std::vector<SlotId> _arguments_ids;

--- a/test/sql/test_array_fn/R/test_array_map_2
+++ b/test/sql/test_array_fn/R/test_array_map_2
@@ -111,6 +111,27 @@ select k from t where coalesce(element_at(array_map(x->x+any_match(array_map(x->
 1
 3
 -- !result
+select k from t where coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_0)), arr_0), 1))>0 and coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1)) < 10  order by k;
+-- result:
+1
+2
+3
+4
+-- !result
+select k, coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_0)), arr_0), 1)) as col1 from t order by k;
+-- result:
+1	2
+2	3
+3	2
+4	3
+-- !result
+select k, coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_0)), arr_0), 1)) as col1, coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1)) as col2 from t order by k;
+-- result:
+1	2	2
+2	3	3
+3	2	2
+4	3	3
+-- !result
 select array_map(x->x, arr_0) from t order by k;
 -- result:
 [1,2]

--- a/test/sql/test_array_fn/R/test_array_map_2
+++ b/test/sql/test_array_fn/R/test_array_map_2
@@ -106,6 +106,11 @@ select array_map((x)->x*x, arr_0) from t order by k;
 [1,4]
 [1,4]
 -- !result
+select k from t where coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_0)), arr_0), 1))=2 order by k;
+-- result:
+1
+3
+-- !result
 select array_map(x->x, arr_0) from t order by k;
 -- result:
 [1,2]

--- a/test/sql/test_array_fn/T/test_array_map_2
+++ b/test/sql/test_array_fn/T/test_array_map_2
@@ -46,7 +46,9 @@ select array_map((x,y,z,d)->x+y+z+d, arr_0, arr_1, arr_2, [1,2]) from t order by
 select array_map((x,y,z,d)->x+y+z+d, arr_0, arr_1, arr_2, [1]) from t order by k;
 select array_map((x)->x*x, arr_0) from t order by k;
 select k from t where coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_0)), arr_0), 1))=2 order by k;
-
+select k from t where coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_0)), arr_0), 1))>0 and coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1)) < 10  order by k;
+select k, coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_0)), arr_0), 1)) as col1 from t order by k;
+select k, coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_0)), arr_0), 1)) as col1, coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1)) as col2 from t order by k;
 select array_map(x->x, arr_0) from t order by k;
 -- independent expr
 select array_map((x,y,z)->10, arr_0, arr_1, arr_2) from t;

--- a/test/sql/test_array_fn/T/test_array_map_2
+++ b/test/sql/test_array_fn/T/test_array_map_2
@@ -45,7 +45,7 @@ select array_map((x,y,z)->x+y+z, arr_0, arr_1, arr_2) from t order by k;
 select array_map((x,y,z,d)->x+y+z+d, arr_0, arr_1, arr_2, [1,2]) from t order by k;
 select array_map((x,y,z,d)->x+y+z+d, arr_0, arr_1, arr_2, [1]) from t order by k;
 select array_map((x)->x*x, arr_0) from t order by k;
-
+select k from t where coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_0)), arr_0), 1))=2 order by k;
 
 select array_map(x->x, arr_0) from t order by k;
 -- independent expr


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Before we rewrite the lambda expression, we need to find the max slot id currently used, and the slot id of new rewritten `ColumnRef` needs to be allocated from then on.

In the previous implementation, max_used_slot_id only counts the slot ids used in the lambda expression.
If multiple children of the same expression contain lambda expression, such as `coalesce(element_at(array_map(x->x+any_match(array_map(x->x<10,arr_1)), arr_1), 1),element_at(array_map(x->x+any_match(array_map(x->x<10,arr_2)), arr_2),1))`, then there is a possibility of duplicate allocation of slot ids.

In this PR, I made some changes to avoid this problem:
1. When allocating slot ids, allocate from the maximum slot id used by the entire expression tree to avoid conflicts in slot ids within the expression tree. But this is not global after all. If there are multiple expression trees doing the same thing, there may still be problems with duplicate allocations.
2. Considering that the result of outer common expression will only be used locally by the lambda function, as long as we avoid polluting the input chunk, it doesn’t matter even if the local slot id is repeated, so we choose to use a temporary chunk to execute the lambda expression.


Note: *This is just a temporary solution and a bit ugly*. When we support expression reuse strategy of scan predicates, the slot id allocation of common expressions will be handed over to FE, which has a global perspective and will definitely ensure that there will be no duplicate allocations. This is the most elegant solution. I will support it later.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
