### PR TITLE
[BugFix] fix compute node replay heartbeat response status inconsistency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -487,7 +487,7 @@ public class Backend extends ComputeNode {
     @Override
     public String toString() {
         return "Backend [id=" + getId() + ", host=" + getHost() + ", heartbeatPort=" + getHeartbeatPort()
-                + ", alive=" + getIsAlive().get() + "]";
+                + ", alive=" + getIsAlive().get() + ", status=" + getStatus() + "]";
     }
 
     public void setTabletMaxCompactionScore(long compactionScore) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/BackendTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/BackendTest.java
@@ -198,7 +198,7 @@ public class BackendTest {
         back2.updateOnce(1, 1, 1);
         Assert.assertFalse(back1.equals(back2));
 
-        Assert.assertEquals("Backend [id=1, host=a, heartbeatPort=1, alive=true]", back1.toString());
+        Assert.assertEquals("Backend [id=1, host=a, heartbeatPort=1, alive=true, status=OK]", back1.toString());
 
         // 3. delete files
         dis.close();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -820,7 +820,7 @@ public class ShowExecutorTest {
         Assert.assertEquals("100.000B", resultSet.getString(23));
         Assert.assertEquals("0", resultSet.getString(24));
         Assert.assertEquals("N/A", resultSet.getString(27));
-        Assert.assertEquals("DISCONNECTED", resultSet.getString(29));
+        Assert.assertEquals("CONNECTING", resultSet.getString(29));
         Assert.assertEquals(String.valueOf(workerId), resultSet.getString(31));
         Assert.assertEquals(String.valueOf(tabletNum), resultSet.getString(11));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
@@ -16,6 +16,7 @@ package com.starrocks.system;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Config;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.CoordinatorMonitor;
 import com.starrocks.qe.scheduler.slot.ResourceUsageMonitor;
 import com.starrocks.server.GlobalStateMgr;
@@ -25,6 +26,7 @@ import mockit.Expectations;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ComputeNodeTest {
@@ -169,8 +171,8 @@ public class ComputeNodeTest {
             // lasUpdateTime will not be updated
             Assert.assertEquals(lastUpdateTime, node.getLastUpdateMs());
 
-            // start from the (heartbeat_retry_times-1)th response (started from 0), the status changed to disconnected.
-            if (i >= Config.heartbeat_retry_times - 1) {
+            // start from the (heartbeat_retry_times)th response (started from 0), the status changed to disconnected.
+            if (i >= Config.heartbeat_retry_times) {
                 Assert.assertEquals(String.format("i=%d", i), ComputeNode.Status.DISCONNECTED, node.getStatus());
                 Assert.assertEquals(String.format("i=%d", i), ComputeNode.Status.DISCONNECTED, nodeInFollower.getStatus());
             } else {
@@ -180,13 +182,17 @@ public class ComputeNodeTest {
         }
     }
 
+    private BackendHbResponse generateReplayResponse(BackendHbResponse response) {
+        return GsonUtils.GSON.fromJson(GsonUtils.GSON.toJson(response), BackendHbResponse.class);
+    }
+
     @Test
     public void testShutdownCancelQuery() {
         CoordinatorMonitor coordinatorMonitor = CoordinatorMonitor.getInstance();
         ResourceUsageMonitor resourceUsageMonitor = GlobalStateMgr.getCurrentState().getResourceUsageMonitor();
 
         int oldHeartbeatRetry = Config.heartbeat_retry_times;
-        Config.heartbeat_retry_times = 2;
+        Config.heartbeat_retry_times = 1;
 
         ComputeNode nodeInLeader = new ComputeNode();
         ComputeNode nodeInFollower = new ComputeNode();
@@ -200,7 +206,7 @@ public class ComputeNodeTest {
         try {
             // first OK hbResponse for both leader and follower
             nodeInLeader.handleHbResponse(hbResponse, false);
-            nodeInFollower.handleHbResponse(hbResponse, true);
+            nodeInFollower.handleHbResponse(generateReplayResponse(hbResponse), true);
 
             // second OK hbResponse for both leader and follower
             {
@@ -208,7 +214,7 @@ public class ComputeNodeTest {
                 Assert.assertTrue(nodeInLeader.isAlive());
                 Assert.assertEquals(ComputeNode.Status.OK, nodeInLeader.getStatus());
 
-                Assert.assertFalse(nodeInFollower.handleHbResponse(hbResponse, true));
+                Assert.assertFalse(nodeInFollower.handleHbResponse(generateReplayResponse(hbResponse), true));
                 Assert.assertTrue(nodeInFollower.isAlive());
                 Assert.assertEquals(ComputeNode.Status.OK, nodeInFollower.getStatus());
             }
@@ -219,7 +225,7 @@ public class ComputeNodeTest {
                 Assert.assertTrue(nodeInLeader.isAlive());
                 Assert.assertEquals(ComputeNode.Status.OK, nodeInLeader.getStatus());
 
-                Assert.assertFalse(nodeInFollower.handleHbResponse(hbResponse, true));
+                Assert.assertFalse(nodeInFollower.handleHbResponse(generateReplayResponse(hbResponse), true));
                 Assert.assertTrue(nodeInFollower.isAlive());
                 Assert.assertEquals(ComputeNode.Status.OK, nodeInFollower.getStatus());
             }
@@ -245,7 +251,7 @@ public class ComputeNodeTest {
                 Assert.assertEquals(ComputeNode.Status.SHUTDOWN, nodeInLeader.getStatus());
                 Assert.assertEquals(shutdownResponse.getHbTime(), nodeInLeader.getLastUpdateMs());
 
-                Assert.assertTrue(nodeInFollower.handleHbResponse(shutdownResponse, true));
+                Assert.assertTrue(nodeInFollower.handleHbResponse(generateReplayResponse(shutdownResponse), true));
                 Assert.assertFalse(nodeInFollower.isAlive());
                 Assert.assertEquals(ComputeNode.Status.SHUTDOWN, nodeInFollower.getStatus());
                 Assert.assertEquals(shutdownResponse.getHbTime(), nodeInFollower.getLastUpdateMs());
@@ -272,7 +278,7 @@ public class ComputeNodeTest {
                 Assert.assertEquals(ComputeNode.Status.SHUTDOWN, nodeInLeader.getStatus());
                 Assert.assertEquals(shutdownResponse.getHbTime(), nodeInLeader.getLastUpdateMs());
 
-                Assert.assertTrue(nodeInFollower.handleHbResponse(shutdownResponse, true));
+                Assert.assertTrue(nodeInFollower.handleHbResponse(generateReplayResponse(shutdownResponse), true));
                 Assert.assertFalse(nodeInFollower.isAlive());
                 Assert.assertEquals(ComputeNode.Status.SHUTDOWN, nodeInFollower.getStatus());
                 Assert.assertEquals(shutdownResponse.getHbTime(), nodeInFollower.getLastUpdateMs());
@@ -302,7 +308,7 @@ public class ComputeNodeTest {
                 Assert.assertNotEquals(errorResponse.getHbTime(), nodeInFollower.getLastUpdateMs());
                 Assert.assertEquals(hbTime, nodeInFollower.getLastUpdateMs());
 
-                Assert.assertTrue(nodeInFollower.handleHbResponse(errorResponse, true));
+                Assert.assertTrue(nodeInFollower.handleHbResponse(generateReplayResponse(errorResponse), true));
                 Assert.assertFalse(nodeInFollower.isAlive());
                 Assert.assertEquals(ComputeNode.Status.SHUTDOWN, nodeInFollower.getStatus());
                 Assert.assertNotEquals(errorResponse.getHbTime(), nodeInFollower.getLastUpdateMs());
@@ -332,7 +338,7 @@ public class ComputeNodeTest {
                 Assert.assertNotEquals(errorResponse.getHbTime(), nodeInFollower.getLastUpdateMs());
                 Assert.assertEquals(hbTime, nodeInFollower.getLastUpdateMs());
 
-                Assert.assertTrue(nodeInFollower.handleHbResponse(errorResponse, true));
+                Assert.assertTrue(nodeInFollower.handleHbResponse(generateReplayResponse(errorResponse), true));
                 Assert.assertFalse(nodeInFollower.isAlive());
                 Assert.assertEquals(ComputeNode.Status.DISCONNECTED, nodeInFollower.getStatus());
                 Assert.assertNotEquals(errorResponse.getHbTime(), nodeInFollower.getLastUpdateMs());
@@ -341,5 +347,123 @@ public class ComputeNodeTest {
         } finally {
             Config.heartbeat_retry_times = oldHeartbeatRetry;
         }
+    }
+
+    private static class VerifyComputeNodeStatus {
+        public boolean isAlive;
+        public HeartbeatResponse.AliveStatus aliveStatus;
+        public ComputeNode.Status status;
+
+        public VerifyComputeNodeStatus() {
+            // nothing
+        }
+        public VerifyComputeNodeStatus(boolean isAlive, HeartbeatResponse.AliveStatus aliveStatus, ComputeNode.Status status) {
+            this.isAlive = isAlive;
+            this.aliveStatus = aliveStatus;
+            this.status = status;
+        }
+    }
+
+    @Test
+    public void testRpcErrorReplayRetryAndAliveStatusMismatch() throws InterruptedException {
+        int prevHeartbeatRetryTimes = Config.heartbeat_retry_times;
+        Config.heartbeat_retry_times = 3;
+        ComputeNode node = new ComputeNode();
+
+        List<BackendHbResponse> replayResponses = new ArrayList<>();
+        List<VerifyComputeNodeStatus> verifyReplayNodeStatus = new ArrayList<>();
+
+        BackendHbResponse hbResponse =
+                new BackendHbResponse(node.getId(), node.getBePort(), node.getHttpPort(), node.getBrpcPort(),
+                        node.getStarletPort(), System.currentTimeMillis(), node.getVersion(), node.getCpuCores(), 0);
+
+        node.handleHbResponse(hbResponse, false);
+
+        { // regular HbResponse
+            Assert.assertFalse(node.handleHbResponse(hbResponse, false));
+            Assert.assertTrue(node.isAlive());
+            Assert.assertEquals(ComputeNode.Status.OK, node.getStatus());
+
+            verifyReplayNodeStatus.add(
+                    new VerifyComputeNodeStatus(node.isAlive(), hbResponse.aliveStatus, node.getStatus()));
+            replayResponses.add(generateReplayResponse(hbResponse));
+        }
+
+        // 4 hbResponses
+        // the first 3 hbResponses still record the node as ALIVE
+        // the 4th hbResponses records the node as NOT_ALIVE
+        for (int i = 0; i <= Config.heartbeat_retry_times; ++i) {
+            BackendHbResponse errorResponse =
+                    new BackendHbResponse(node.getId(), TStatusCode.INTERNAL_ERROR, "Internal Error");
+            Assert.assertTrue(node.handleHbResponse(errorResponse, false));
+
+            VerifyComputeNodeStatus verifyStatus = new VerifyComputeNodeStatus();
+            verifyStatus.isAlive = node.isAlive();
+            verifyStatus.status = node.getStatus();
+
+            if (i == Config.heartbeat_retry_times) {
+                Assert.assertFalse(node.isAlive());
+                Assert.assertEquals(HeartbeatResponse.AliveStatus.NOT_ALIVE, errorResponse.aliveStatus);
+                verifyStatus.aliveStatus = HeartbeatResponse.AliveStatus.NOT_ALIVE;
+            } else {
+                Assert.assertTrue(node.isAlive());
+                Assert.assertEquals(HeartbeatResponse.AliveStatus.ALIVE, errorResponse.aliveStatus);
+                verifyStatus.aliveStatus = HeartbeatResponse.AliveStatus.ALIVE;
+            }
+            replayResponses.add(generateReplayResponse(errorResponse));
+            verifyReplayNodeStatus.add(verifyStatus);
+            // delay a few milliseconds
+            Thread.sleep(1);
+        }
+
+        // now reduce the retry config to 2
+        // the first 2 hbResponses still detect the node as ALIVE
+        // the 3th hbResponse will mark the node as NOT_ALIVE but then dictated by the aliveStatus, force to ALIVE
+        // the 4th hbResponse will mark the node as NOT_ALIVE
+        Config.heartbeat_retry_times = Config.heartbeat_retry_times - 1;
+        ComputeNode replayNode = new ComputeNode();
+        Assert.assertEquals(replayResponses.size(), verifyReplayNodeStatus.size());
+        for (int i = 0; i < replayResponses.size(); ++i) {
+            // even though the `heartbeat_retry_times` changed, the replay result
+            // should be consistent with the one when generating the edit log.
+            BackendHbResponse hb = replayResponses.get(i);
+            VerifyComputeNodeStatus verifyStatus = verifyReplayNodeStatus.get(i);
+
+            replayNode.handleHbResponse(hb, true);
+            Assert.assertEquals(verifyStatus.isAlive, replayNode.isAlive());
+            Assert.assertEquals(verifyStatus.status, replayNode.getStatus());
+            Assert.assertEquals(verifyStatus.aliveStatus, hb.aliveStatus);
+        }
+
+        Config.heartbeat_retry_times = prevHeartbeatRetryTimes;
+    }
+
+    void verifyNodeAliveAndStatus(ComputeNode node, boolean expectedAlive, ComputeNode.Status expectedStatus) {
+        Assert.assertEquals(expectedAlive, node.isAlive());
+        Assert.assertEquals(expectedStatus, node.getStatus());
+    }
+
+    @Test
+    public void testSetAliveInterface() {
+        ComputeNode node = new ComputeNode();
+        verifyNodeAliveAndStatus(node, false, ComputeNode.Status.CONNECTING);
+        Assert.assertTrue(node.setAlive(true));
+        verifyNodeAliveAndStatus(node, true, ComputeNode.Status.OK);
+        // set again, nothing changed
+        Assert.assertFalse(node.setAlive(true));
+        verifyNodeAliveAndStatus(node, true, ComputeNode.Status.OK);
+
+        Assert.assertTrue(node.setAlive(false));
+        verifyNodeAliveAndStatus(node, false, ComputeNode.Status.DISCONNECTED);
+        // set again, nothing changed
+        Assert.assertFalse(node.setAlive(false));
+        verifyNodeAliveAndStatus(node, false, ComputeNode.Status.DISCONNECTED);
+
+        node = new ComputeNode();
+        // isAlive: true, Status: Connecting
+        node.getIsAlive().set(true);
+        // setAlive will only change the alive variable, keep the status unchanged
+        Assert.assertTrue(node.setAlive(false));
+        verifyNodeAliveAndStatus(node, false, ComputeNode.Status.CONNECTING);
     }
 }


### PR DESCRIPTION
* fix inconstent retry times
* properly handle mismatching of retry times between the heartbeat response generated and the heartbeat response replayed.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
