### PR TITLE
[BugFix]better bit upacking batch size

### DIFF
--- a/be/src/util/bit_packing_adapter.h
+++ b/be/src/util/bit_packing_adapter.h
@@ -45,8 +45,16 @@ public:
             // First unpack as many full batches as possible.
             const int64_t values_to_read = BitPacking::NumValuesToUnpack(bit_width, in_bytes, num_values);
             constexpr int BATCH_SIZE = 8;
+
             // make sure don't access memory out of bound.
-            const int64_t batches_to_read = values_to_read * bit_width / 8 / 8 * 8 * 8 / bit_width / BATCH_SIZE;
+            // we need make sure the last batch is not out of bound, so if there are x batch,
+            // the prior (x - 1) batch has used (x - 1) * bit_width bytes, and the last batch use
+            // (bit_width + 7) / 8 * 8 bytes, so there should be
+            // (x - 1) * bit_width + (bit_width + 7) / 8 <= in_bytes
+            const int64_t batches_to_read = std::max(
+                    (int64_t)0,
+                    std::min((in_bytes - (bit_width + 7) / 8 * 8) / bit_width + 1, values_to_read / BATCH_SIZE));
+
             if (batches_to_read > 0) {
                 starrocks::util::unpack(bit_width, in, in_bytes, batches_to_read * BATCH_SIZE, out);
                 in_bytes -= batches_to_read * bit_width;

--- a/be/src/util/bit_packing_simd.h
+++ b/be/src/util/bit_packing_simd.h
@@ -262,8 +262,39 @@ static inline void unpack17to21(const uint8_t* __restrict__ in, uint32_t* __rest
     }
 }
 
-// Unpack num_values number of uint32_t values with bit_width in [22, 31] range.
-static inline void unpack22to31(const uint8_t* __restrict__ in, uint32_t* __restrict__ out, int64_t num_values,
+// Unpack num_values number of uint32_t values with bit_width in [22, 24] range.
+static inline void unpack22to24(const uint8_t* __restrict__ in, uint32_t* __restrict__ out, int64_t num_values,
+                                int bit_width) {
+    uint64_t pdepMask = kPdepMask32[bit_width];
+
+    uint8_t rightShift1 = bit_width * 2;
+    uint8_t leftShift1 = 64 - rightShift1;
+    uint8_t rightShift2 = bit_width * 4 - 64;
+    uint8_t leftShift2 = 2 * 64 - bit_width * 4;
+    uint8_t rightShift3 = bit_width * 6 - 2 * 64;
+
+    auto writeEndOffset = out + num_values;
+
+    // Process bit_width bytes (8 values) a time.
+    while (out + 8 <= writeEndOffset) {
+        uint64_t value_0 = *(reinterpret_cast<const uint64_t*>(in));
+        uint64_t value_1 = *(reinterpret_cast<const uint64_t*>(in + 8));
+        uint64_t value_2 = *(reinterpret_cast<const uint64_t*>(in + 16));
+
+        *reinterpret_cast<uint64_t*>(out) = _pdep_u64(value_0, pdepMask);
+        *(reinterpret_cast<uint64_t*>(out) + 1) =
+                _pdep_u64((value_1 << leftShift1) | (value_0 >> rightShift1), pdepMask);
+        *(reinterpret_cast<uint64_t*>(out) + 2) =
+                _pdep_u64((value_2 << leftShift2) | (value_1 >> rightShift2), pdepMask);
+        *(reinterpret_cast<uint64_t*>(out) + 3) = _pdep_u64((value_2 >> rightShift3), pdepMask);
+
+        in += bit_width;
+        out += 8;
+    }
+}
+
+// Unpack num_values number of uint32_t values with bit_width in [25, 31] range.
+static inline void unpack25to31(const uint8_t* __restrict__ in, uint32_t* __restrict__ out, int64_t num_values,
                                 int bit_width) {
     uint64_t pdepMask = kPdepMask32[bit_width];
 
@@ -425,6 +456,8 @@ inline void unpack<uint32_t>(int bit_width, const uint8_t* __restrict__ in, int6
     case 22:
     case 23:
     case 24:
+        unpack22to24(in, out, num_values, bit_width);
+        break;
     case 25:
     case 26:
     case 27:
@@ -432,7 +465,7 @@ inline void unpack<uint32_t>(int bit_width, const uint8_t* __restrict__ in, int6
     case 29:
     case 30:
     case 31:
-        unpack22to31(in, out, num_values, bit_width);
+        unpack25to31(in, out, num_values, bit_width);
         break;
     case 32:
         unpack32(in, out, num_values);


### PR DESCRIPTION
## Why I'm doing:
bit unpacking with simd process data with batch, so there may be out of bound access,
we need check the batch_size to avoid out-of-bound access which leads to crash in asan mode.
and make specific logic for bit_width between 22 and 24.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
