### PR TITLE
[Enhancement] support sys_log_warn_modules in fe conf

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -97,6 +97,8 @@ public class Config extends ConfigBase {
     public static String sys_log_roll_mode = "SIZE-MB-1024";
     @ConfField
     public static boolean sys_log_enable_compress = false;
+    @ConfField
+    public static String[] sys_log_warn_modules = {};
     /**
      * Log to file by default. set to `true` if you want to log to console
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -175,9 +175,6 @@ public class Log4jConfig extends XmlConfiguration {
             "    <Logger name=\"profile\" level=\"INFO\" additivity=\"false\">\n" +
             "      <AppenderRef ref=\"ProfileFile\"/>\n" +
             "    </Logger>\n" +
-            "    <Logger name=\"org.apache.kafka\" level=\"WARN\"> \n" +
-            "      <AppenderRef ref=\"SysWF\"/>\n" +
-            "    </Logger>\n" +
             "<!--REPLACED BY AUDIT AND VERBOSE MODULE NAMES-->" +
             "  </Loggers>\n" +
             "</Configuration>";
@@ -199,6 +196,12 @@ public class Log4jConfig extends XmlConfiguration {
     private static String[] internalModules;
     private static boolean compressSysLog;
     private static boolean compressAuditLog;
+    private static String[] warnModules;
+    private static String[] builtinWarnModules = {
+            "org.apache.kafka",
+            "org.apache.hudi",
+            "org.apache.hadoop.io.compress",
+    };
 
     @VisibleForTesting
     static String generateActiveLog4jXmlConfig() throws IOException {
@@ -348,6 +351,12 @@ public class Log4jConfig extends XmlConfiguration {
         for (String s : bigQueryModules) {
             sb.append("    <Logger name='big_query.").append(s).append("' level='INFO'/>\n");
         }
+        for (String s : builtinWarnModules) {
+            sb.append("    <Logger name='").append(s).append("' level='WARN'><AppenderRef ref='SysWF'/></Logger>\n");
+        }
+        for (String s : warnModules) {
+            sb.append("    <Logger name='").append(s).append("' level='WARN'><AppenderRef ref='SysWF'/></Logger>\n");
+        }
 
         String newXmlConfTemplate = APPENDER_TEMPLATE;
         newXmlConfTemplate += log2Console ? CONSOLE_LOGGER_TEMPLATE : FILE_LOGGER_TEMPLATE;
@@ -384,6 +393,7 @@ public class Log4jConfig extends XmlConfiguration {
         internalModules = Config.internal_log_modules;
         compressSysLog = Config.sys_log_enable_compress;
         compressAuditLog = Config.audit_log_enable_compress;
+        warnModules = Config.sys_log_warn_modules;
         reconfig();
     }
 


### PR DESCRIPTION
## Why I'm doing:

There are a lot of hudi logs when pulling files. So I have to change hudi package log level to warn.

## What I'm doing:

This PR is to do:
1. extend fe.conf to support to change some modules to warn level.
2. add some builtin modules to warn level.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
