### PR TITLE
[Feature]Trino dialect supports insert into syntax

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -71,6 +71,7 @@ import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.ExceptRelation;
+import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.LambdaArgument;
@@ -92,6 +93,7 @@ import com.starrocks.sql.ast.UnionRelation;
 import com.starrocks.sql.ast.UnitIdentifier;
 import com.starrocks.sql.ast.ValueList;
 import com.starrocks.sql.ast.ValuesRelation;
+import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.parser.ParsingException;
 import io.trino.sql.tree.AliasedRelation;
 import io.trino.sql.tree.AllColumns;
@@ -134,6 +136,7 @@ import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.IfExpression;
 import io.trino.sql.tree.InListExpression;
 import io.trino.sql.tree.InPredicate;
+import io.trino.sql.tree.Insert;
 import io.trino.sql.tree.Intersect;
 import io.trino.sql.tree.IntervalLiteral;
 import io.trino.sql.tree.IsNotNullPredicate;
@@ -195,6 +198,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.starrocks.analysis.AnalyticWindow.BoundaryType.CURRENT_ROW;
@@ -1242,6 +1246,15 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     @Override
     protected ParseNode visitCast(Cast node, ParseTreeContext context) {
         return new CastExpr(new TypeDef(getType(node.getType())), (Expr) visit(node.getExpression(), context));
+    }
+
+    @Override
+    protected ParseNode visitInsert(Insert node, ParseTreeContext context) {
+        List<String> parts  = node.getTarget().getParts();
+        String tableName = parts.get(parts.size() - 1);
+        return new InsertStmt(qualifiedNameToTableName(convertQualifiedName(node.getTarget())), null,
+                tableName.concat(UUID.randomUUID().toString()), null,
+        (QueryStatement) visit(node.getQuery(), context), true, new HashMap<>(0), NodePosition.ZERO);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/TrinoParserUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/TrinoParserUtils.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.ast.StatementBase;
 import io.trino.sql.tree.CreateTableAsSelect;
 import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
+import io.trino.sql.tree.Insert;
 import io.trino.sql.tree.Query;
 import io.trino.sql.tree.Statement;
 
@@ -40,7 +41,7 @@ public class TrinoParserUtils {
         String trimmedQuery = query.trim();
         Statement statement = TrinoParser.parse(trimmedQuery);
         if (statement instanceof Query || statement instanceof Explain || statement instanceof ExplainAnalyze
-                || statement instanceof CreateTableAsSelect) {
+                || statement instanceof CreateTableAsSelect || statement instanceof Insert) {
             return (StatementBase) statement.accept(new AstBuilder(sqlMode), new ParseTreeContext());
         } else {
             throw trinoParserUnsupportedException("Unsupported statement type: " + statement.getClass().getName());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoInsertTest.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.parser.trino;
+
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.parser.SqlParser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TrinoInsertTest extends TrinoTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        TrinoTestBase.beforeClass();
+    }
+
+    @Test
+    public void testInsertTrinoDialect() throws Exception {
+        String insertSql = "insert into t3 select doy(date '2022-03-06')";
+        try {
+            connectContext.getSessionVariable().setSqlDialect("trino");
+            InsertStmt ctasStmt =
+                    (InsertStmt) SqlParser.parse(insertSql, connectContext.getSessionVariable()).get(0);
+            QueryStatement queryStmt = ctasStmt.getQueryStatement();
+            assertPlanContains(queryStmt, "dayofyear('2022-03-06 00:00:00')");
+
+            connectContext.getSessionVariable().setSqlDialect("starrocks");
+            analyzeFail(insertSql, "No matching function with signature: doy(date)");
+        } finally {
+            connectContext.getSessionVariable().setSqlDialect("trino");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
@@ -94,6 +94,10 @@ public class TrinoTestBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
+        starRocksAssert.withTable("CREATE TABLE `t3` (\n" +
+                "`day` int NULL COMMENT \"\") \n" +
+                "PROPERTIES ('replication_num' = '1')");
+
         starRocksAssert.withTable("CREATE TABLE `tall` (\n" +
                 "  `ta` varchar(20) NULL COMMENT \"\",\n" +
                 "  `tb` smallint(6) NULL COMMENT \"\",\n" +


### PR DESCRIPTION
## Why I'm doing:
```
CREATE TABLE t3 (
    day int)
    PROPERTIES (
"replication_num" = "1"
);

set sql_dialect='trino';
select doy(date '2022-03-06');
+-------------------------+
| dayofyear('2022-03-06') |
+-------------------------+
|                      65 |
+-------------------------+
1 row in set (0.04 sec)

insert into t3 select doy(date '2022-03-06');
ERROR 1064 (HY000): Getting analyzing error from line 1, column 22 to line 1, column 43. Detail message: No matching function with signature: doy(date)
```
## What I'm doing:

Fixes #52665

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
