### PR TITLE
[Feature] Support new syntax for Backup/Restore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -742,6 +742,10 @@ public class Database extends MetaObject implements Writable {
         return functions;
     }
 
+    public synchronized Map<String, List<Function>> getNameToFunction() {
+        return Maps.newHashMap(name2Function);
+    }
+
     public synchronized List<Function> getFunctionsByName(String functionName) {
         return name2Function.getOrDefault(functionName, ImmutableList.of());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/BackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/BackupStmt.java
@@ -22,6 +22,7 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class BackupStmt extends AbstractBackupStmt {
     public enum BackupType {
@@ -31,13 +32,15 @@ public class BackupStmt extends AbstractBackupStmt {
     private BackupType type = BackupType.FULL;
 
     public BackupStmt(LabelName labelName, String repoName, List<TableRef> tblRefs, List<FunctionRef> fnRefs,
+                      Set<BackupObjectType> allMarker, boolean withOnClause, String originDbName,
                       Map<String, String> properties) {
-        super(labelName, repoName, tblRefs, fnRefs, properties, NodePosition.ZERO);
+        super(labelName, repoName, tblRefs, fnRefs, allMarker, withOnClause, originDbName, properties, NodePosition.ZERO);
     }
 
     public BackupStmt(LabelName labelName, String repoName, List<TableRef> tblRefs, List<FunctionRef> fnRefs,
+                      Set<BackupObjectType> allMarker, boolean withOnClause, String originDbName,
                       Map<String, String> properties, NodePosition pos) {
-        super(labelName, repoName, tblRefs, fnRefs, properties, pos);
+        super(labelName, repoName, tblRefs, fnRefs, allMarker, withOnClause, originDbName, properties, pos);
     }
 
     public long getTimeoutMs() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RestoreStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RestoreStmt.java
@@ -23,6 +23,7 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class RestoreStmt extends AbstractBackupStmt {
     private boolean allowLoad = false;
@@ -32,14 +33,16 @@ public class RestoreStmt extends AbstractBackupStmt {
     private int starrocksMetaVersion = -1;
 
     public RestoreStmt(LabelName labelName, String repoName, List<TableRef> tblRefs,
-                       List<FunctionRef> fnRefs, Map<String, String> properties) {
-        this(labelName, repoName, tblRefs, fnRefs, properties, NodePosition.ZERO);
+                       List<FunctionRef> fnRefs, Set<BackupObjectType> allMarker,
+                       boolean withOnClause, String originDbName, Map<String, String> properties) {
+        this(labelName, repoName, tblRefs, fnRefs, allMarker, withOnClause, originDbName, properties, NodePosition.ZERO);
     }
 
     public RestoreStmt(LabelName labelName, String repoName, List<TableRef> tblRefs,
-                       List<FunctionRef> fnRefs, Map<String, String> properties,
-                       NodePosition pos) {
-        super(labelName, repoName, tblRefs, fnRefs, properties, pos);
+                       List<FunctionRef> fnRefs, Set<BackupObjectType> allMarker,
+                       boolean withOnClause, String originDbName,
+                       Map<String, String> properties, NodePosition pos) {
+        super(labelName, repoName, tblRefs, fnRefs, allMarker, withOnClause, originDbName, properties, pos);
     }
 
     public boolean allowLoad() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
@@ -222,4 +222,13 @@ public interface ParserErrorMsg {
     String nullIdentifierCancelBackupRestore();
     @BaseMessage("Value count in PIVOT {0} must match number of FOR columns {1}")
     String pivotValueArityMismatch(int a0, int a1);
+
+    @BaseMessage("Specifying dbName before snapshot name is forbidden if the DbName is specified explicitly in BACKUP/RESTORE")
+    String unsupportedSepcifyDbNameAfterSnapshotName();
+
+    @BaseMessage("Specifying alias for backup object is forbidden in BACKUP stmt")
+    String unsupportedSepcifyAliasInBackupStmt();
+
+    @BaseMessage("`ON` clause is forbidden if no Database explicitly specified in Restore stmt")
+    String unsupportedOnClauseWithoutAnyDbNameInRestoreStmt();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1731,9 +1731,9 @@ privObjectTypePlural
 // ---------------------------------------- Backup Restore Statement ---------------------------------------------------
 
 backupStatement
-    : BACKUP SNAPSHOT qualifiedName
-    TO identifier
-    (ON '(' backupObjectDesc (',' backupObjectDesc) * ')')?
+    : BACKUP (DATABASE dbName=identifier)?
+    SNAPSHOT qualifiedName TO repoName=identifier
+    (ON '(' backupRestoreObjectDesc (',' backupRestoreObjectDesc) * ')')?
     (PROPERTIES propertyList)?
     ;
 
@@ -1747,8 +1747,9 @@ showBackupStatement
 
 restoreStatement
     : RESTORE SNAPSHOT qualifiedName
-    FROM identifier
-    (ON '(' restoreObjectDesc (',' restoreObjectDesc) * ')')?
+    FROM repoName=identifier
+    (DATABASE dbName=identifier (AS dbAlias=identifier)?)?
+    (ON '(' backupRestoreObjectDesc (',' backupRestoreObjectDesc) * ')')?
     (PROPERTIES propertyList)?
     ;
 
@@ -2513,19 +2514,19 @@ frameBound
 
 // ------------------------------------------- COMMON AST --------------------------------------------------------------
 
-backupObjectDesc
-    : tableDesc | FUNCTION qualifiedName
+backupRestoreObjectDesc
+    : backupRestoreTableDesc
+    | (ALL (FUNCTION | FUNCTIONS) | (FUNCTION | FUNCTIONS) qualifiedName (AS identifier)?)
+    | (ALL (TABLE | TABLES) | (TABLE | TABLES) backupRestoreTableDesc)
+    | (ALL MATERIALIZED (VIEW | VIEWS) | MATERIALIZED (VIEW | VIEWS) qualifiedName (AS identifier)?)
+    | (ALL (VIEW | VIEWS) | (VIEW | VIEWS) qualifiedName (AS identifier)?)
     ;
 
 tableDesc
     : qualifiedName partitionNames?
     ;
 
-restoreObjectDesc
-    : restoreTableDesc | FUNCTION qualifiedName (AS identifier)?
-    ;
-
-restoreTableDesc
+backupRestoreTableDesc
     : qualifiedName partitionNames? (AS identifier)?
     ;
 

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -728,7 +728,8 @@ public class BackupHandlerTest {
                 tbls.add(tbl);
                 Map<Long, SnapshotInfo> snapshotInfos = Maps.newHashMap();
                 for (Partition part : tbl.getPartitions()) {
-                    for (MaterializedIndex idx : part.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                    for (MaterializedIndex idx : part.getDefaultPhysicalPartition()
+                            .getMaterializedIndices(IndexExtState.VISIBLE)) {
                         for (Tablet tablet : idx.getTablets()) {
                             List<String> files = Lists.newArrayList();
                             SnapshotInfo sinfo = new SnapshotInfo(db.getId(), tbl.getId(), part.getId(), idx.getId(),

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -36,6 +36,7 @@ package com.starrocks.backup;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.LabelName;
 import com.starrocks.analysis.TableName;
@@ -65,6 +66,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.analyzer.BackupRestoreAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.AbstractBackupStmt;
 import com.starrocks.sql.ast.BackupStmt;
 import com.starrocks.sql.ast.CancelBackupStmt;
 import com.starrocks.sql.ast.CreateRepositoryStmt;
@@ -104,6 +106,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class BackupHandlerTest {
 
@@ -310,7 +313,7 @@ public class BackupHandlerTest {
         List<TableRef> tblRefs = Lists.newArrayList();
         tblRefs.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));
         BackupStmt backupStmt = new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label1"), "repo", tblRefs,
-                Lists.newArrayList(), null);
+                                               Lists.newArrayList(), null, false, "", null);
         try {
             handler.process(backupStmt);
         } catch (DdlException e1) {
@@ -368,8 +371,8 @@ public class BackupHandlerTest {
         List<TableRef> tblRefs1 = Lists.newArrayList();
         tblRefs1.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL3_NAME), null));
         BackupStmt backupStmt1 =
-                new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs1, Lists.newArrayList(),
-                        null);
+                    new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs1, Lists.newArrayList(),
+                                null, false, "", null);
         try {
             handler.process(backupStmt1);
         } catch (DdlException e1) {
@@ -429,7 +432,7 @@ public class BackupHandlerTest {
         Map<String, String> properties = Maps.newHashMap();
         properties.put("backup_timestamp", "2018-08-08-08-08-08");
         RestoreStmt restoreStmt = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "ss2"), "repo", tblRefs2,
-                Lists.newArrayList(), properties);
+                    Lists.newArrayList(), null, false, "", properties);
         try {
             BackupRestoreAnalyzer.analyze(restoreStmt, new ConnectContext());
         } catch (SemanticException e2) {
@@ -507,7 +510,7 @@ public class BackupHandlerTest {
         Map<String, String> properties1 = Maps.newHashMap();
         properties1.put("backup_timestamp", "2018-08-08-08-08-08");
         RestoreStmt restoreStmt1 = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs3,
-                Lists.newArrayList(), properties1);
+                    Lists.newArrayList(), null, false, "", properties1);
         try {
             BackupRestoreAnalyzer.analyze(restoreStmt1, new ConnectContext());
         } catch (SemanticException e2) {
@@ -582,7 +585,7 @@ public class BackupHandlerTest {
         Map<String, String> properties2 = Maps.newHashMap();
         properties2.put("backup_timestamp", "2018-08-08-08-08-08");
         RestoreStmt restoreStmt2 = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", emptyTableRef,
-                fnRefs, properties2);
+                                                   fnRefs, null, false, "", properties2);
         BackupMeta backupMeta = new BackupMeta(Lists.newArrayList());
         List<Function> fns = Lists.newArrayList();
         Function f1 = new Function(new FunctionName(db.getFullName(), "wrong_name"),
@@ -674,5 +677,173 @@ public class BackupHandlerTest {
         Assert.assertEquals(1, followerHandler.dbIdToBackupOrRestoreJob.size());
 
         UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testCreateDbInRestore(
+                @Mocked GlobalStateMgr globalStateMgr, @Mocked BrokerMgr brokerMgr, @Mocked EditLog editLog) throws Exception {
+        setUpMocker(globalStateMgr, brokerMgr, editLog);
+
+        new Expectations() {
+            {
+                editLog.logCreateRepository((Repository) any);
+                minTimes = 0;
+                result = new Delegate() {
+                    public void logCreateRepository(Repository repo) {
+
+                    }
+                };
+
+                editLog.logDropRepository(anyString);
+                minTimes = 0;
+                result = new Delegate() {
+                    public void logDropRepository(String repoName) {
+
+                    }
+                };
+
+                globalStateMgr.getLocalMetastore().getDb(anyLong);
+                minTimes = 0;
+                result = db;
+            }
+        };
+
+        new MockUp<Repository>() {
+            @Mock
+            public Status initRepository() {
+                return Status.OK;
+            }
+
+            @Mock
+            public Status listSnapshots(List<String> snapshotNames) {
+                snapshotNames.add("ss2");
+                return Status.OK;
+            }
+
+            @Mock
+            public Status getSnapshotInfoFile(String label, String backupTimestamp, List<BackupJobInfo> infos) {
+                OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getFullName(), CatalogMocker.TEST_TBL_NAME);
+                List<Table> tbls = Lists.newArrayList();
+                tbls.add(tbl);
+                Map<Long, SnapshotInfo> snapshotInfos = Maps.newHashMap();
+                for (Partition part : tbl.getPartitions()) {
+                    for (MaterializedIndex idx : part.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                        for (Tablet tablet : idx.getTablets()) {
+                            List<String> files = Lists.newArrayList();
+                            SnapshotInfo sinfo = new SnapshotInfo(db.getId(), tbl.getId(), part.getId(), idx.getId(),
+                                        tablet.getId(), -1, 0, "./path", files);
+                            snapshotInfos.put(tablet.getId(), sinfo);
+                        }
+                    }
+                }
+
+                BackupJobInfo info = BackupJobInfo.fromCatalog(System.currentTimeMillis(),
+                            "ss2", "xxxxx",
+                            CatalogMocker.TEST_DB_ID, tbls, snapshotInfos);
+                infos.add(info);
+                return Status.OK;
+            }
+        };
+
+        new Expectations() {
+            {
+                brokerMgr.containsBroker(anyString);
+                minTimes = 0;
+                result = true;
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getBrokerMgr();
+                minTimes = 0;
+                result = brokerMgr;
+
+                globalStateMgr.getNextId();
+                minTimes = 0;
+                result = idGen++;
+
+                globalStateMgr.getEditLog();
+                minTimes = 0;
+                result = editLog;
+
+                globalStateMgr.getTabletInvertedIndex();
+                minTimes = 0;
+                result = invertedIndex;
+            }
+        };
+
+        new MockUp<LocalMetastore>() {
+            Database database = CatalogMocker.mockDb();
+
+            @Mock
+            public Database getDb(String dbName) {
+                return dbName.equals(CatalogMocker.TEST_DB_NAME) ? database : null;
+            }
+
+            @Mock
+            public Table getTable(String dbName, String tblName) {
+                return database.getTable(tblName);
+            }
+        };
+
+        new MockUp<BackupHandler>() {
+            @Mock
+            protected BackupMeta downloadAndDeserializeMetaInfo(BackupJobInfo jobInfo, Repository repo, RestoreStmt stmt) {
+                return new BackupMeta(Lists.newArrayList());
+            }
+        };
+
+        BackupHandler handler = new BackupHandler(globalStateMgr);
+        CreateRepositoryStmt stmt = new CreateRepositoryStmt(false, "repo", "broker", "bos://location",
+                    Maps.newHashMap());
+        try {
+            handler.createRepository(stmt);
+        } catch (DdlException e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+
+        // process restore
+        List<TableRef> tblRefs2 = Lists.newArrayList();
+        tblRefs2.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("backup_timestamp", "2018-08-08-08-08-08");
+        RestoreStmt restoreStmt = new RestoreStmt(new LabelName(null, "ss2"), "repo", tblRefs2,
+                    Lists.newArrayList(), null, false, "", properties);
+        try {
+            BackupRestoreAnalyzer.analyze(restoreStmt, new ConnectContext());
+        } catch (SemanticException e2) {
+            e2.printStackTrace();
+            Assert.fail();
+        }
+
+        try {
+            handler.process(restoreStmt);
+        } catch (DdlException e1) {
+        }
+
+        Set<AbstractBackupStmt.BackupObjectType> allMarker = Sets.newHashSet();
+        allMarker.add(AbstractBackupStmt.BackupObjectType.TABLE);
+        allMarker.add(AbstractBackupStmt.BackupObjectType.MV);
+        allMarker.add(AbstractBackupStmt.BackupObjectType.VIEW);
+        restoreStmt = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "ss2"), "repo", tblRefs2,
+                          Lists.newArrayList(), allMarker, true, "", properties);
+        try {
+            BackupRestoreAnalyzer.analyze(restoreStmt, new ConnectContext());
+        } catch (SemanticException e2) {
+            e2.printStackTrace();
+            Assert.fail();
+        }
+
+        try {
+            handler.process(restoreStmt);
+        } catch (Exception e1) {
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
@@ -58,6 +58,9 @@ public class AnalyzeBackupRestoreTest {
 
         AnalyzeTestUtil.getStarRocksAssert().withFunction("CREATE FUNCTION Echostring(string) RETURNS string properties" +
                         "(\"symbol\" = \"Echostring\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");
+
+        AnalyzeTestUtil.getStarRocksAssert().withView("CREATE VIEW v1 AS select 1;");
+        AnalyzeTestUtil.getStarRocksAssert().withView("CREATE VIEW v2 AS select 2;");
     }
 
     @Test
@@ -73,6 +76,27 @@ public class AnalyzeBackupRestoreTest {
         analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( t3, T3 ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( FUNCTION Echostring ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( FUNCTION Echostring, ALL VIEW ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( FUNCTION Echostring, ALL VIEW, VIEW v1 ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( FUNCTION Echostring, VIEW v1, ALL VIEW ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo`" +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( ALL FUNCTIONS, " +
+                "ALL TABLES, ALL VIEWS, ALL MATERIALIZED VIEWS ) PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON ( FUNCTION Echostring, ALL VIEW ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON ( FUNCTION Echostring, ALL VIEW, VIEW v1 ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON ( FUNCTION Echostring, VIEW v1, ALL VIEW ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo`" +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON " +
+                "( ALL FUNCTIONS, ALL TABLES, ALL VIEWS, ALL MATERIALIZED VIEWS ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( t0, t0 ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
@@ -92,6 +116,14 @@ public class AnalyzeBackupRestoreTest {
         analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON(t0 PARTITION (p1));");
         analyzeFail("BACKUP SNAPSHOT test1.snapshot_label2 TO `repo` ON(t0 PARTITION (p1), t1) " +
                 "PROPERTIES(\"type\"=\"1\");");
+        analyzeFail("BACKUP DATABASE test SNAPSHOT test.snapshot_label2 TO `repo`" +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeFail("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON (`Echostring`)" +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON (`Echostring`)" +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON (v1 AS newV1)" +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
     }
 
     @Test
@@ -120,6 +152,46 @@ public class AnalyzeBackupRestoreTest {
                 "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"allow_load\"=\"true\"," +
                 "\"replication_num\"=\"1\",\"meta_version\"=\"10\"," +
                 "\"starrocks_meta_version\"=\"10\",\"timeout\"=\"3600\" );");
+        analyzeSuccess("RESTORE SNAPSHOT testNew.`snapshot_2` FROM `repo` ON ( FUNCTION Echostring, ALL FUNCTIONS ) " +
+                "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT testNew.`snapshot_2` FROM `repo` ON ( ALL FUNCTIONS, FUNCTION Echotinyint ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT testNew.`snapshot_2` FROM `repo` ON ( FUNCTION Echotinyint ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT testNew.`snapshot_2` FROM `repo` ON " +
+                        "( ALL FUNCTIONS, FUNCTION Echotinyint, ALL TABLES, v1 ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT testNew.`snapshot_2` FROM `repo` ON " +
+                        "( ALL FUNCTIONS, FUNCTION Echotinyint, ALL TABLES, VIEW v1 ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT testNew.`snapshot_2` FROM `repo` ON " +
+                        "( ALL FUNCTIONS, FUNCTION Echotinyint AS newName, ALL TABLES, VIEW v1 AS V100 ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT testNew.`snapshot_2` FROM `repo` ON " +
+                        "( FUNCTION Echotinyint AS newName, ALL TABLES, VIEW v1 AS V100 ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` DATABASE test AS testNew ON " + 
+                        "( FUNCTION Echostring, ALL FUNCTIONS ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` DATABASE test AS testNew ON " +
+                        "( ALL FUNCTIONS, FUNCTION Echotinyint ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` DATABASE test AS testNew ON ( FUNCTION Echotinyint ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` DATABASE test AS testNew ON " +
+                        "( ALL FUNCTIONS, FUNCTION Echotinyint, ALL TABLES, v1 ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` DATABASE test AS testNew ON " +
+                        "( ALL FUNCTIONS, FUNCTION Echotinyint, ALL TABLES, VIEW v1 ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` DATABASE test AS testNew ON " +
+                        "( ALL FUNCTIONS, FUNCTION Echotinyint AS newName, ALL TABLES, VIEW v1 AS V100 ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` DATABASE test AS testNew ON " +
+                        "( FUNCTION Echotinyint AS newName, ALL TABLES, VIEW v1 AS V100 ) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
         analyzeFail("RESTORE SNAPSHOT test.`snapshot_2` FROM `repo` ON ( `t0` , `t1` AS `new_tbl` ) " +
                 "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"allow_load\"=\"a\" );");
         analyzeFail("RESTORE SNAPSHOT test.`snapshot_2` FROM `repo` ON ( `t0` , `t1` AS `new_tbl` ) " +
@@ -140,6 +212,14 @@ public class AnalyzeBackupRestoreTest {
         analyzeFail("RESTORE SNAPSHOT `snapshot_2` FROM `repo` ON (t99)");
         analyzeFail("RESTORE SNAPSHOT `snapshot_2` FROM `repo` ON (`t0` AS `t1`)");
         analyzeFail("RESTORE SNAPSHOT `snapshot_2` FROM `repo` ON (`t0`PARTITION (p1,p1))");
+        analyzeFail("RESTORE SNAPSHOT test.`snapshot_2` FROM `repo1` DATABASE test ON (`t0`)" +
+                "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"timeout\"=\"a\" );");
+        analyzeFail("RESTORE SNAPSHOT newtest.`snapshot_2` FROM `repo1` DATABASE test AS newtest ON (`t0`)" +
+                "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"timeout\"=\"a\" );");
+        analyzeFail("RESTORE SNAPSHOT `snapshot_2` FROM `repo1` DATABASE test ON (`Echostring`)" +
+                "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"timeout\"=\"a\" );");
+        analyzeFail("RESTORE SNAPSHOT `snapshot_2` FROM `repo1` ON (`t0`)" +
+                "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"timeout\"=\"a\" );");
     }
 
     @Test


### PR DESCRIPTION
## Why we need new syntax for Backup/Restore
1. The semantic design of the old syntax is not easy to understand and is not user-friendly.
2. The newly introduced syntax has better scalability and flexibility to support (multiple) catalog, multiple object type and multiple DBs Backup/Restore in the future.

## New syntax design for Backup/Restore
```Haskell
BACKUP [DATABASE <db_name>] SNAPSHOT [<dbname>.]<snapshot_name>
TO <repo_name>
[ ON ( backup_restore_object [, ...] ) ]
[PROPERTIES]

RESTORE SNAPSHOT [<dbname>.]<snapshot_name> FROM <repo_name>
[DATABASE <db_name> [AS <db_alias>] ]
[ ON ( backup_restore_object [, ...] ) ]
[PROPERTIES]

backup_restore_object ::=
    ALL TABLE[S]             | (TABLE | TABLES) <table_name> [ PARTITION (...) ] [AS <alias>] |
    ALL MATERIALIZED VIEW[S] | MATERIALIZED (VIEW | VIEWS) <mv_name> [AS <alias>] |
    ALL VIEW[S]              | (VIEW | VIEWS) <view_name> [AS <alias>] |
    ALL FUNCTION[S]          | (FUNCTION | FUNCTIONS) <func_name> [AS <alias>] |
    <table_name> [ PARTITION (...) ] [AS <alias>]
```

## The behavioral changes in Backup/Restore syntax
Expansion of `ON` clause:
We introduce the key word `(TABLE(S)/VIEW(S)/MATERIALIZED VIEW(S)/FUNCTION(S))` to identify different type of Backup/Restore object and use `ALL` to represent all objects of a certain type which is much more clear the before.

Allow to specify database explicitly and separated from snapshot name:
`Backup:` User can specify database after DATABASE key word or before snapshot name as before.

`Restore:`
1. If user does not specify dbname at all (both before snapshot name or after `DATABASE` keyword) without `ON` clause, it will create database with the same name in snapshot file and restore all data into it.
2. If specify dbName after `DATABASE` keyword, no dbName can be specified before snapshot name.
3. The dbName after `DATABASE` keyword must exactly match in snapshot file. `DATABASE <db_name> [AS <db_alias>]` means that restore the database named by db_name in snapshot to the database named by db_alias in current cluster. If `AS` is missing, restore to the database with the same name.

Fixes #52746

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
