### PR TITLE
[Enhancement]Change python interpreter from python to python3 in fe-core module

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -42,7 +42,7 @@ under the License.
         <paimon.version>0.8.2</paimon.version>
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>
         <staros.version>3.3-rc5</staros.version>
-        <python>python</python>
+        <python>python3</python>
     </properties>
 
     <profiles>


### PR DESCRIPTION
## Why I'm doing:
It is more reasonable. In Starrrock 3.3.5/master
In some enviroment, python infer python2,it cause error blow, if we build fe using mvn clean install -DskipTests:
```
ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java:[75,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
[ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java:[44,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
[ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java:[27,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
[ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java:[31,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
[ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java:[43,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
[ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java:[44,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
[ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/http/action/IndexAction.java:[38,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
[ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/http/rest/FeatureAction.java:[17,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
[ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpSerializer.java:[29,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
[ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java:[39,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
[ERROR] starrocks/fe/fe-core/src/main/java/com/starrocks/http/rest/BootstrapFinishAction.java:[41,28] cannot find symbol
[ERROR]   symbol:   class Version
[ERROR]   location: package com.starrocks.common
```
## What I'm doing:
Change python interpreter from python to python3
Fixes #https://github.com/StarRocks/starrocks/issues/52733

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
