### PR TITLE
[BugFix] close hudi fsview to avoid resource leak

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CachingRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CachingRemoteFileIO.java
@@ -55,7 +55,6 @@ public class CachingRemoteFileIO implements RemoteFileIO {
                     @Override
                     public List<RemoteFileDesc> load(RemotePathKey key) throws Exception {
                         List<RemoteFileDesc> res = loadRemoteFiles(key);
-                        key.drop();
                         return res;
                     }
                 }, executor));
@@ -116,7 +115,6 @@ public class CachingRemoteFileIO implements RemoteFileIO {
         } else {
             cache.put(pathKey, loadRemoteFiles(pathKey));
         }
-        pathKey.drop();
     }
 
     public synchronized void invalidateAll() {
@@ -132,7 +130,6 @@ public class CachingRemoteFileIO implements RemoteFileIO {
         } else {
             cache.invalidate(pathKey);
         }
-        pathKey.drop();
     }
 
     private static CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshSec, long maximumSize) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
@@ -19,7 +19,6 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
 /*
@@ -38,8 +37,8 @@ public class RemoteFileScanContext {
     public String tableLocation = null;
 
     // ---- concurrent initialization -----
-    public AtomicBoolean init = new AtomicBoolean(false);
     public ReentrantLock lock = new ReentrantLock();
+    public int usedCount = 0;
 
     // ---- hudi related fields -----
     public HoodieTableFileSystemView hudiFsView = null;
@@ -47,6 +46,11 @@ public class RemoteFileScanContext {
     public HoodieInstant hudiLastInstant = null;
 
     public void close() {
-        hudiFsView.close();
+        if (hudiFsView != null) {
+            hudiFsView.close();
+            hudiFsView = null;
+            hudiTimeline = null;
+            hudiLastInstant = null;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
@@ -45,4 +45,8 @@ public class RemoteFileScanContext {
     public HoodieTableFileSystemView hudiFsView = null;
     public HoodieTimeline hudiTimeline = null;
     public HoodieInstant hudiLastInstant = null;
+
+    public void close() {
+        hudiFsView.close();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
@@ -80,6 +80,7 @@ public class RemotePathKey {
 
     public void drop() {
         if (scanContext != null) {
+            scanContext.close();
             scanContext = null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemotePathKey.java
@@ -78,13 +78,6 @@ public class RemotePathKey {
         return sb.toString();
     }
 
-    public void drop() {
-        if (scanContext != null) {
-            scanContext.close();
-            scanContext = null;
-        }
-    }
-
     public void setScanContext(RemoteFileScanContext ctx) {
         scanContext = ctx;
         tableLocation = ctx.tableLocation;


### PR DESCRIPTION
## Why I'm doing:

Hudi bitcask temp files descriptors are leaked. 

## What I'm doing:

Close hudi filesystem view when we don't need it.

Fixes #52737

-------------

This fix has a potential drawback but we can avoid that.

Before this PR, we create fileststem view when the request comes, and we only create the fsview for once. However, we don't know when to close this fsview.  And fsview is left in opened state, and resource leak happens.

![image](https://github.com/user-attachments/assets/3fa71957-8bc7-4710-a755-edc670d8883d)

To fix this problem, we have to close this fsview when no requests need this fsview.   We can use reference count to solve it.   However we don't know how many total requests will be issued.  Because some request will be cached without using this fsview, we don't know how many requests will use fsview in advance. 

![image](https://github.com/user-attachments/assets/23a93750-f6a3-4d64-af76-5f2f1ccac148)

However there is a potential drawback. If some requests are not overlapped, fsview will be created and closed for multiple times.  In practice it seldom happens.

![image](https://github.com/user-attachments/assets/f263cc09-a842-4eaf-9b5c-02137740353c)


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
