### PR TITLE
[BugFix] fix cloud native index file decryption

### DIFF
--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -1574,6 +1574,8 @@ INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,
                          ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false},
                                            PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE},
                                            PrimaryKeyParam{true, PersistentIndexTypePB::LOCAL,
+                                                           PartialUpdateMode::ROW_MODE, true},
+                                           PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE,
                                                            PartialUpdateMode::ROW_MODE, true}));
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:
After cloud native index compaction, read from sst file will fail after enable transparent data encryption:
```
W20241108 14:17:00.189412 140095629813312 transactions.cpp:328] Fail to apply txn log : Corruption: not an sstable (bad magic number)
be/src/storage/lake/persistent_index_sstable.cpp:35 sstable::Table::Open(options, rf.get(), sstable_pb.filesize(), &table)
be/src/storage/lake/lake_persistent_index.cpp:520 sstable->init(std::move(rf), sstable_pb, block_cache->cache())
be/src/storage/lake/update_manager.cpp:834 index.apply_opcompaction(metadata, op_compaction)
be/src/storage/lake/txn_log_applier.cpp:122 check_and_recover([&]() { return apply_compaction_log(log.op_compaction(), log.txn_id()); }) tablet_id=10152 txn=txn_id: 60
```

## What I'm doing:
This pull request includes changes to enhance the handling of encrypted metadata and extend test coverage for primary key publishing. The most important changes include adding encryption handling in the `apply_opcompaction` method and updating the test suite to include additional test parameters.

Enhancements to encrypted metadata handling:

* [`be/src/storage/lake/lake_persistent_index.cpp`](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1L515-R521): Added logic to handle encryption metadata when creating a new random access file, including setting encryption options if metadata is present.

Test coverage improvements:

* [`be/test/storage/lake/primary_key_publish_test.cpp`](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0R1577-R1578): Added new test parameters to the `LakePrimaryKeyPublishTest` suite to cover additional scenarios involving partial update modes and encryption settings.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
