### PR TITLE
[BugFix] Ignore to refresh if base table has dropped one partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/DefaultTraits.java
@@ -161,8 +161,8 @@ public abstract class DefaultTraits extends ConnectorPartitionTraits  {
             for (Map.Entry<String, MaterializedView.BasePartitionInfo> versionEntry : versionMap.entrySet()) {
                 String basePartitionName = versionEntry.getKey();
                 if (!latestPartitionInfo.containsKey(basePartitionName)) {
-                    // TODO: If one partition has been dropped, refresh all existed partitions again.
-                    return latestPartitionInfo.keySet();
+                    // If this partition is dropped, ignore it.
+                    continue;
                 }
                 long basePartitionVersion = latestPartitionInfo.get(basePartitionName).getModifiedTime();
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
@@ -105,8 +105,8 @@ public class OlapPartitionTraits extends DefaultTraits {
             String basePartitionName = versionEntry.getKey();
             Partition basePartition = baseTable.getPartition(basePartitionName);
             if (basePartition == null) {
-                // TODO: Once there is a partition deleted, refresh all partitions.
-                return baseTable.getVisiblePartitionNames();
+                // If this partition is dropped, ignore it.
+                continue;
             }
             MaterializedView.BasePartitionInfo mvRefreshedPartitionInfo = versionEntry.getValue();
             if (mvRefreshedPartitionInfo == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -874,8 +874,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
-            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            Assert.assertTrue(execPlan != null);
+            Assert.assertNull(execPlan);
         }
 
         // run 5
@@ -891,15 +890,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
 
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
-            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            PlanTestBase.assertContains(plan, "TABLE: part_tbl1\n" +
-                    "     PARTITION PREDICATES: 4: par_date IS NOT NULL, 4: par_date >= '2020-01-01', 4: par_date < " +
-                    "'2020-01-05'\n" +
-                    "     partitions=4/4");
-            PlanTestBase.assertContains(plan, "TABLE: part_tbl2\n" +
-                    "     PARTITION PREDICATES: 8: par_date IS NOT NULL, 8: par_date >= '2020-01-01', 8: par_date < " +
-                    "'2020-01-05'\n" +
-                    "     partitions=4/4");
+            Assert.assertNull(execPlan);
         }
 
         starRocksAssert.dropMaterializedView("hive_partition_prune_non_ref_tables2");
@@ -1300,10 +1291,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
-            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            // TODO(fixme): drop partition should not refresh all partitions.
-            PlanTestBase.assertContains(plan, "     TABLE: t1_par\n");
-            PlanTestBase.assertContains(plan, "     partitions=6/6");
+            Assert.assertTrue(execPlan == null);
         }
         starRocksAssert.dropMaterializedView("test_mv1");
     }
@@ -1366,9 +1354,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVRefreshTestBase 
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
-            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            PlanTestBase.assertContains(plan, "     TABLE: t1_par\n");
-            PlanTestBase.assertContains(plan, "     partitions=6/6");
+            Assert.assertTrue(execPlan == null);
         }
         starRocksAssert.dropMaterializedView("test_mv1");
     }


### PR DESCRIPTION
## Why I'm doing:
- If base table's partition has dropped, it will trigger the whole partitions of mv to refresh.

## What I'm doing:
- Ignore to trigger mv refresh if the base table's partitions has been dropped.
- MV refresh will be triggered only if this partition is recreated again.

Fixes https://github.com/StarRocks/starrocks/issues/52576 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
