### PR TITLE
[BugFix] follow the output type after eliminating agg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateAggRule.java
@@ -19,8 +19,6 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
-import com.starrocks.catalog.PrimitiveType;
-import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -145,21 +143,23 @@ public class EliminateAggRule extends TransformationRule {
         } else if (fnName.equals(FunctionSet.SUM) || fnName.equals(FunctionSet.AVG) ||
                 fnName.equals(FunctionSet.FIRST_VALUE) || fnName.equals(FunctionSet.MAX) ||
                 fnName.equals(FunctionSet.MIN) || fnName.equals(FunctionSet.GROUP_CONCAT)) {
-            return rewriteCastFunction(callOperator);
+            return rewriteNormalFunction(callOperator);
         }
         return callOperator;
     }
 
     private ScalarOperator rewriteCountFunction(CallOperator callOperator) {
+        Type outType = callOperator.getType();
+
         if (callOperator.getArguments().isEmpty()) {
-            return ConstantOperator.createInt(1);
+            return rewriteCastFunction(outType, ConstantOperator.createInt(1));
         }
 
         IsNullPredicateOperator isNullPredicateOperator =
                 new IsNullPredicateOperator(callOperator.getArguments().get(0));
         ArrayList<ScalarOperator> ifArgs = Lists.newArrayList();
-        ScalarOperator thenExpr = ConstantOperator.createInt(0);
-        ScalarOperator elseExpr = ConstantOperator.createInt(1);
+        ScalarOperator thenExpr = rewriteCastFunction(outType, ConstantOperator.createInt(0));
+        ScalarOperator elseExpr = rewriteCastFunction(outType, ConstantOperator.createInt(1));
         ifArgs.add(isNullPredicateOperator);
         ifArgs.add(thenExpr);
         ifArgs.add(elseExpr);
@@ -167,15 +167,19 @@ public class EliminateAggRule extends TransformationRule {
         Type[] argumentTypes = ifArgs.stream().map(ScalarOperator::getType).toArray(Type[]::new);
         Function fn =
                 Expr.getBuiltinFunction(FunctionSet.IF, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-        return new CallOperator(FunctionSet.IF, ScalarType.createType(PrimitiveType.TINYINT), ifArgs, fn);
+        return new CallOperator(FunctionSet.IF, outType, ifArgs, fn);
     }
 
-    private ScalarOperator rewriteCastFunction(CallOperator callOperator) {
+    private ScalarOperator rewriteNormalFunction(CallOperator callOperator) {
         ScalarOperator argument = callOperator.getArguments().get(0);
-        if (callOperator.getType().equals(argument.getType())) {
-            return argument;
+        return rewriteCastFunction(callOperator.getType(), argument);
+    }
+
+    private ScalarOperator rewriteCastFunction(Type outType, ScalarOperator func) {
+        if (outType.equals(func.getType())) {
+            return func;
         }
-        return new CastOperator(callOperator.getType(), argument);
+        return new CastOperator(outType, func);
     }
 
 }


### PR DESCRIPTION
## Why I'm doing:

When eliminating aggregation by a unique key, the aggregation node is rewritten to a project node. The output of `COUNT` aggregation function is `BIGINT`, but it is rewritten to `TINYINT`.

```
Refresh materialized view lineitem_agg_mv1 failed after retrying 1 times(try-lock 0 times), error-msg : com.starrocks.common.UserException: type of exprs is not match slot's, expr_type=1, slot_type=7, slot_name=count_qty backend [id=10001] [host=172.26.95.192]
	at com.starrocks.qe.DefaultCoordinator.handleErrorExecution(DefaultCoordinator.java:719)
	at com.starrocks.qe.scheduler.Deployer.waitForDeploymentCompletion(Deployer.java:251)
	at com.starrocks.qe.scheduler.Deployer.deployFragments(Deployer.java:121)
	at com.starrocks.qe.scheduler.dag.AllAtOnceExecutionSchedule.schedule(AllAtOnceExecutionSchedule.java:45)
	at com.starrocks.qe.DefaultCoordinator.deliverExecFragments(DefaultCoordinator.java:645)
	at com.starrocks.qe.DefaultCoordinator.startScheduling(DefaultCoordinator.java:543)
	at com.starrocks.qe.scheduler.Coordinator.startScheduling(Coordinator.java:115)
	at com.starrocks.qe.scheduler.Coordinator.exec(Coordinator.java:94)
	at com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor.java:2300)
 [wrapped] com.starrocks.common.UserException: type of exprs is not match slot's, expr_type=1, slot_type=7, slot_name=count_qty backend [id=10001] [host=172.26.95.192]
	at com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor.java:2571)
	at com.starrocks.load.InsertOverwriteJobRunner.executeInsert(InsertOverwriteJobRunner.java:356)
	at com.starrocks.load.InsertOverwriteJobRunner.doLoad(InsertOverwriteJobRunner.java:170)
	at com.starrocks.load.InsertOverwriteJobRunner.handle(InsertOverwriteJobRunner.java:150)
	at com.starrocks.load.InsertOverwriteJobRunner.transferTo(InsertOverwriteJobRunner.java:211)
	at com.starrocks.load.InsertOverwriteJobRunner.prepare(InsertOverwriteJobRunner.java:255)
	at com.starrocks.load.InsertOverwriteJobRunner.handle(InsertOverwriteJobRunner.java:147)
	at com.starrocks.load.InsertOverwriteJobRunner.run(InsertOverwriteJobRunner.java:135)
	at com.starrocks.load.InsertOverwriteJobMgr.executeJob(InsertOverwriteJobMgr.java:91)
	at com.starrocks.qe.StmtExecutor.handleInsertOverwrite(StmtExecutor.java:2100)
	at com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor.java:2195)
	at com.starrocks.qe.StmtExecutor.handleDMLStmtWithProfile(StmtExecutor.java:2109)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.refreshMaterializedView(PartitionBasedMvRefreshProcessor.java:1159)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:467)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:373)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:332)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:204)
	at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:270)
	at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:58)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

## What I'm doing:

Follow the output type of the aggregation after eliminating agg.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
