### PR TITLE
[BugFix] Fix an exception when reading a Paimon table with array<row> column

### DIFF
--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
@@ -19,8 +19,8 @@ import com.starrocks.jni.connector.ColumnValue;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
-import org.apache.paimon.data.columnar.ColumnarRow;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
@@ -110,7 +110,7 @@ public class PaimonColumnValue implements ColumnValue {
 
     @Override
     public void unpackStruct(List<Integer> structFieldIndex, List<ColumnValue> values) {
-        ColumnarRow array = (ColumnarRow) fieldData;
+        InternalRow array = (InternalRow) fieldData;
         List<DataField> fields = ((RowType) dataType).getFields();
         for (int i = 0; i < structFieldIndex.size(); i++) {
             Integer idx = structFieldIndex.get(i);


### PR DESCRIPTION
Co-authored: @songpcmusic

## Why I'm doing:
When creating a Paimon table with following properties:
```
'fields.claim_info.aggregate-function' = 'nested_update'
'fields.claim_info.nested-key' = 'claim_id'
```
and the table includes a column like 
```
claim_info      ARRAY<ROW<claim_id varchar, gmt_claim varchar, is_valid BIGINT, leads_entity_id varchar>>
```

It may return
```
E20241103 14:41:48.883949 140614797981248 scan_operator.cpp:445] scan fragment b28ba51d-99ae-11ef-a342-02422170dcd7 driver 6 Scan tasks error: Internal error: Failed to call the nextChunkOf
fHeap method of off-heap table scanner. java exception details: java.io.IOException: Failed to get the next off-heap table chunk of paimon.
        at com.starrocks.paimon.reader.PaimonSplitScanner.getNext(PaimonSplitScanner.java:163)                                                                      
        at com.starrocks.jni.connector.ConnectorScanner.getNextOffHeapChunk(ConnectorScanner.java:101)
Caused by: java.lang.ClassCastException: class org.apache.paimon.data.NestedRow cannot be cast to class org.apache.paimon.data.columnar.ColumnarRow (org.apache.paimon.data.NestedRow and org
.apache.paimon.data.columnar.ColumnarRow are in unnamed module of loader com.starrocks.utils.loader.ChildFirstClassLoader @6ebd78d1)
        at com.starrocks.paimon.reader.PaimonColumnValue.unpackStruct(PaimonColumnValue.java:113)
        at com.starrocks.jni.connector.OffHeapColumnVector.appendValue(OffHeapColumnVector.java:568)
        at com.starrocks.jni.connector.OffHeapColumnVector.appendArray(OffHeapColumnVector.java:426)
        at com.starrocks.jni.connector.OffHeapColumnVector.appendValue(OffHeapColumnVector.java:556)                                                                
        at com.starrocks.jni.connector.OffHeapTable.appendData(OffHeapTable.java:95)
        at com.starrocks.jni.connector.ConnectorScanner.appendData(ConnectorScanner.java:86)
        at com.starrocks.paimon.reader.PaimonSplitScanner.getNext(PaimonSplitScanner.java:153)
        ... 1 more

be/src/exec/jni_scanner.cpp:144 _check_jni_exception(env, "Failed to call the nextChunkOffHeap method of off-heap table scanner.")
be/src/exec/jni_scanner.cpp:391 _get_next_chunk(env, &chunk_meta)                                                                                                   
be/src/exec/jni_scanner.cpp:378 value_or_err_L378
be/src/connector/hive_connector.cpp:690 _scanner->get_next(state, chunk)
```

## What I'm doing:

The row maybe `NestedRow`, not a `ColumnarRow`. Using `InternalRow` can solve this problem.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
