### PR TITLE
[BugFix] Fix Expr::open crash when evaluate const throw exception

### DIFF
--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -83,7 +83,11 @@ Status ExprContext::open(RuntimeState* state) {
     // original's fragment state and only need to have thread-local state initialized.
     FunctionContext::FunctionStateScope scope =
             _is_clone ? FunctionContext::THREAD_LOCAL : FunctionContext::FRAGMENT_LOCAL;
-    return _root->open(state, this, scope);
+    try {
+        return _root->open(state, this, scope);
+    } catch (std::runtime_error& e) {
+        return Status::RuntimeError(fmt::format("Expr evaluate meet error: {}", e.what()));
+    }
 }
 
 Status ExprContext::open(std::vector<ExprContext*> evals, RuntimeState* state) {

--- a/test/sql/test_exception/R/test_number_overflow
+++ b/test/sql/test_exception/R/test_number_overflow
@@ -1,0 +1,12 @@
+-- name: test_number_overflow
+set sql_mode="ERROR_IF_OVERFLOW";
+-- result:
+-- !result
+select cast(abs(1234567890123456789) as decimal(4,3));
+-- result:
+[REGEX].*Expr evaluate meet error: The type cast from other types to decimal overflows.*
+-- !result
+select 1 in (cast(abs(1234567890123456789) as decimal(4,3)), cast(abs(1234567890123456789) as decimal(4,3)));
+-- result:
+[REGEX].*Expr evaluate meet error: The type cast from other types to decimal overflows.*
+-- !result

--- a/test/sql/test_exception/T/test_number_overflow
+++ b/test/sql/test_exception/T/test_number_overflow
@@ -1,0 +1,7 @@
+-- name: test_number_overflow
+set sql_mode="ERROR_IF_OVERFLOW";
+
+-- exception in evaluate
+select cast(abs(1234567890123456789) as decimal(4,3));
+-- exception in open
+select 1 in (cast(abs(1234567890123456789) as decimal(4,3)), cast(abs(1234567890123456789) as decimal(4,3)));


### PR DESCRIPTION
## Why I'm doing:
```
*** SIGABRT (@0x3eb00138aa5) received by PID 1280677 (TID 0x7f1e2cdfd640) from PID 1280677; stack trace: ***
    @     0x7f1f29989ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0x8e6d929 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f1f29932520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f1f299869fc pthread_kill
    @     0x7f1f29932476 raise
    @     0x7f1f299187f3 abort
    @          0xc5f6023 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @          0xc5f45fc __cxxabiv1::__terminate(void (*)())
    @          0xc5f4667 std::terminate()
    @          0xc5f47c9 __cxa_throw
    @          0x66ef486 starrocks::DecimalNonDecimalCast<(starrocks::OverflowMode)2, (starrocks::LogicalType)48, (starrocks::LogicalType)9, int, int>::decimal_from(std::shared_ptr<starrocks::Column> const&, int, int)
    @          0x66ef5f0 std::shared_ptr<starrocks::Column> starrocks::UnpackConstColumnUnaryFunction<starrocks::DecimalFrom<(starrocks::OverflowMode)2> >::evaluate<(starrocks::LogicalType)9, (starrocks::LogicalType)48, int const&, int const&>(std::shared_ptr<starrocks::Column> co5^A
    @          0x66ef7b1 std::shared_ptr<starrocks::Column> starrocks::DealNullableColumnUnaryFunction<starrocks::UnpackConstColumnUnaryFunction<starrocks::DecimalFrom<(starrocks::OverflowMode)2> > >::evaluate<(starrocks::LogicalType)9, (starrocks::LogicalType)48, int const&, int 5^A
    @          0x66f049c starrocks::VectorizedCastExpr<(starrocks::LogicalType)9, (starrocks::LogicalType)48, false>::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0x6834aa4 starrocks::VectorizedInConstPredicate<(starrocks::LogicalType)48>::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope)
    @          0x5d8a1e1 starrocks::ExprContext::open(starrocks::RuntimeState*)
    @          0x5d8c680 starrocks::Expr::open(std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const&, starrocks::RuntimeState*)
    @          0x4e4fc86 starrocks::pipeline::ProjectOperatorFactory::prepare(starrocks::RuntimeState*)
    @          0x5009ded starrocks::pipeline::NormalExecutionGroup::prepare_pipelines(starrocks::RuntimeState*)
    @          0x4f42996 starrocks::pipeline::FragmentContext::prepare_all_pipelines()
    @          0x4e2da6e starrocks::pipeline::FragmentExecutor::_prepare_pipeline_driver(starrocks::ExecEnv*, starrocks::pipeline::UnifiedExecPlanFragmentParams const&)
    @          0x4e31acd starrocks::pipeline::FragmentExecutor::prepare(starrocks::ExecEnv*, starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0x7a9ad86 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0x7aa0d95 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*)
    @          0x7aab7cf starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)
    @          0x7943f0d starrocks::PriorityThreadPool::work_thread(int)
    @          0x8e0f93b thread_proxy
```

## What I'm doing:

close https://github.com/StarRocks/starrocks/issues/52748

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
