### PR TITLE
[Enhancement] auto change replication_num of system tables (backport #51799)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -79,7 +79,7 @@ public class LoadsHistorySyncer extends FrontendDaemon {
     private boolean firstSync = true;
 
     private static final TableKeeper KEEPER =
-            new TableKeeper(LOADS_HISTORY_DB_NAME, LOADS_HISTORY_TABLE_NAME, LOADS_HISTORY_TABLE_CREATE, 3,
+            new TableKeeper(LOADS_HISTORY_DB_NAME, LOADS_HISTORY_TABLE_NAME, LOADS_HISTORY_TABLE_CREATE,
                     () -> Math.max(1, Config.loads_history_retained_days));
 
     public static TableKeeper createKeeper() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/FileListTableRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/FileListTableRepo.java
@@ -16,7 +16,6 @@ package com.starrocks.load.pipe.filelist;
 
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.common.UserException;
-import com.starrocks.common.util.AutoInferUtil;
 import com.starrocks.load.pipe.PipeFileRecord;
 import com.starrocks.statistic.StatsConstants;
 import org.apache.commons.collections.CollectionUtils;
@@ -64,7 +63,7 @@ public class FileListTableRepo extends FileListRepo {
                     "properties('replication_num' = '%d') ";
 
     protected static final String CORRECT_FILE_LIST_REPLICATION_NUM =
-            "ALTER TABLE %s SET ('replication_num'='3')";
+            "ALTER TABLE %s SET ('replication_num'='%d')";
 
     protected static final String ALL_COLUMNS =
             "`pipe_id`, `file_name`, `file_version`, `file_size`, `state`, `last_modified`, `staged_time`," +
@@ -155,15 +154,14 @@ public class FileListTableRepo extends FileListRepo {
      */
     static class SQLBuilder {
 
-        public static String buildCreateTableSql() throws UserException {
-            int replica = AutoInferUtil.calDefaultReplicationNum();
+        public static String buildCreateTableSql(int replicationNum) throws UserException {
             return String.format(FILE_LIST_TABLE_CREATE,
-                    CatalogUtils.normalizeTableName(FILE_LIST_DB_NAME, FILE_LIST_TABLE_NAME), replica);
+                    CatalogUtils.normalizeTableName(FILE_LIST_DB_NAME, FILE_LIST_TABLE_NAME), replicationNum);
         }
 
-        public static String buildAlterTableSql() {
+        public static String buildAlterTableSql(int replicationNum) {
             return String.format(CORRECT_FILE_LIST_REPLICATION_NUM,
-                    CatalogUtils.normalizeTableName(FILE_LIST_DB_NAME, FILE_LIST_TABLE_NAME));
+                    CatalogUtils.normalizeTableName(FILE_LIST_DB_NAME, FILE_LIST_TABLE_NAME), replicationNum);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
@@ -14,9 +14,9 @@
 
 package com.starrocks.load.pipe.filelist;
 
-import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.UserException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.statistic.StatisticUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -30,7 +30,6 @@ public class RepoCreator {
 
     private static boolean databaseExists = false;
     private static boolean tableExists = false;
-    private static boolean tableCorrected = false;
 
     public static RepoCreator getInstance() {
         return INSTANCE;
@@ -50,10 +49,7 @@ public class RepoCreator {
                 LOG.info("table created: " + FileListTableRepo.FILE_LIST_TABLE_NAME);
                 tableExists = true;
             }
-            if (!tableCorrected && correctTable()) {
-                LOG.info("table corrected: " + FileListTableRepo.FILE_LIST_TABLE_NAME);
-                tableCorrected = true;
-            }
+            correctTable();
         } catch (Exception e) {
             LOG.error("error happens in RepoCreator: ", e);
         }
@@ -64,29 +60,14 @@ public class RepoCreator {
     }
 
     public static void createTable() throws UserException {
-        String sql = FileListTableRepo.SQLBuilder.buildCreateTableSql();
+        int expectedReplicationNum =
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getSystemTableExpectedReplicationNum();
+        String sql = FileListTableRepo.SQLBuilder.buildCreateTableSql(expectedReplicationNum);
         RepoExecutor.getInstance().executeDDL(sql);
     }
 
     public static boolean correctTable() {
-        int numBackends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber();
-        int replica = GlobalStateMgr.getCurrentState()
-                .mayGetDb(FileListTableRepo.FILE_LIST_DB_NAME)
-                .flatMap(db -> db.mayGetTable(FileListTableRepo.FILE_LIST_TABLE_NAME))
-                .map(tbl -> ((OlapTable) tbl).getPartitionInfo().getMinReplicationNum())
-                .orElse((short) 1);
-        if (numBackends < 3) {
-            LOG.info("not enough backends in the cluster, expected 3 but got {}", numBackends);
-            return false;
-        }
-        if (replica < 3) {
-            String sql = FileListTableRepo.SQLBuilder.buildAlterTableSql();
-            RepoExecutor.getInstance().executeDDL(sql);
-        } else {
-            LOG.info("table {} already has {} replicas, no need to alter replication_num",
-                    FileListTableRepo.FILE_LIST_FULL_NAME, replica);
-        }
-        return true;
+        return StatisticUtils.alterSystemTableReplicationNumIfNecessary(FileListTableRepo.FILE_LIST_TABLE_NAME);
     }
 
     public boolean isDatabaseExists() {
@@ -95,9 +76,5 @@ public class RepoCreator {
 
     public boolean isTableExists() {
         return tableExists;
-    }
-
-    public boolean isTableCorrected() {
-        return tableCorrected;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -43,7 +43,6 @@ public class TableKeeper {
     private final String databaseName;
     private final String tableName;
     private final String createTableSql;
-    private final int tableReplicas;
 
     private boolean databaseExisted = false;
     private boolean tableExisted = false;
@@ -53,12 +52,10 @@ public class TableKeeper {
     public TableKeeper(String database,
                        String table,
                        String createTable,
-                       int expectedReplicas,
                        Supplier<Integer> ttlSupplier) {
         this.databaseName = database;
         this.tableName = table;
         this.createTableSql = createTable;
-        this.tableReplicas = expectedReplicas;
         this.ttlSupplier = ttlSupplier;
     }
 
@@ -101,23 +98,21 @@ public class TableKeeper {
     }
 
     public void correctTable() {
-        int numBackends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber();
+        int expectedReplicationNum =
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getSystemTableExpectedReplicationNum();
         int replica = GlobalStateMgr.getCurrentState()
                 .mayGetDb(databaseName)
                 .flatMap(db -> db.mayGetTable(tableName))
                 .map(tbl -> ((OlapTable) tbl).getPartitionInfo().getMinReplicationNum())
                 .orElse((short) 1);
-        if (numBackends < tableReplicas) {
-            LOG.info("not enough backends in the cluster, expected {} but got {}",
-                    tableReplicas, numBackends);
-            return;
-        }
-        if (replica < tableReplicas) {
-            String sql = alterTableReplicas();
+
+        if (replica != expectedReplicationNum) {
+            String sql = alterTableReplicas(expectedReplicationNum);
             if (StringUtils.isNotEmpty(sql)) {
                 RepoExecutor.getInstance().executeDDL(sql);
             }
-            LOG.info("changed replication_number of table {} to {}", tableName, replica);
+            LOG.info("changed replication_number of table {} from {} to {}",
+                    tableName, replica, expectedReplicationNum);
         }
     }
 
@@ -149,7 +144,7 @@ public class TableKeeper {
                 .flatMap(x -> Optional.of((OlapTable) x));
     }
 
-    private String alterTableReplicas() {
+    private String alterTableReplicas(int replicationNum) {
         Optional<OlapTable> table = mayGetTable();
         if (table.isEmpty()) {
             return "";
@@ -157,13 +152,13 @@ public class TableKeeper {
         PartitionInfo partitionInfo = table.get().getPartitionInfo();
         if (partitionInfo.isRangePartition()) {
             String sql1 = String.format("ALTER TABLE %s.%s MODIFY PARTITION(*) SET ('replication_num'='%d');",
-                    databaseName, tableName, tableReplicas);
+                    databaseName, tableName, replicationNum);
             String sql2 = String.format("ALTER TABLE %s.%s SET ('default.replication_num'='%d');",
-                    databaseName, tableName, tableReplicas);
+                    databaseName, tableName, replicationNum);
             return sql1 + sql2;
         } else {
             return String.format("ALTER TABLE %s.%s SET ('replication_num'='%d')",
-                    databaseName, tableName, tableReplicas);
+                    databaseName, tableName, replicationNum);
         }
     }
 
@@ -183,10 +178,6 @@ public class TableKeeper {
         return createTableSql;
     }
 
-    public int getTableReplicas() {
-        return tableReplicas;
-    }
-
     public boolean isDatabaseExisted() {
         return databaseExisted;
     }
@@ -201,14 +192,6 @@ public class TableKeeper {
 
     public void setDatabaseExisted(boolean databaseExisted) {
         this.databaseExisted = databaseExisted;
-    }
-
-    public void setTableExisted(boolean tableExisted) {
-        this.tableExisted = tableExisted;
-    }
-
-    public void setTableCorrected(boolean tableCorrected) {
-        this.tableCorrected = tableCorrected;
     }
 
     public static TableKeeperDaemon startDaemon() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -52,7 +52,6 @@ public class TaskRunHistoryTable {
     public static final String DATABASE_NAME = StatsConstants.STATISTICS_DB_NAME;
     public static final String TABLE_NAME = "task_run_history";
     public static final String TABLE_FULL_NAME = DATABASE_NAME + "." + TABLE_NAME;
-    public static final int TABLE_REPLICAS = 3;
     public static final String CREATE_TABLE =
             String.format("CREATE TABLE IF NOT EXISTS %s (" +
                     // identifiers
@@ -93,7 +92,7 @@ public class TaskRunHistoryTable {
             "SELECT history_content_json " + "FROM " + TABLE_FULL_NAME + " WHERE ";
 
     private static final TableKeeper KEEPER =
-            new TableKeeper(DATABASE_NAME, TABLE_NAME, CREATE_TABLE, TABLE_REPLICAS,
+            new TableKeeper(DATABASE_NAME, TABLE_NAME, CREATE_TABLE,
                     () -> Math.max(1, Config.task_runs_ttl_second / 3600 / 24));
 
     public static TableKeeper createKeeper() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2719,6 +2719,14 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
+    public Optional<Table> mayGetTable(long dbId, long tableId) {
+        return Optional.ofNullable(getTable(dbId, tableId));
+    }
+
+    public Optional<Table> mayGetTable(String dbName, String tableName) {
+        return Optional.ofNullable(getTable(dbName, tableName));
+    }
+
     public Table getTable(long dbId, long tableId) {
         Database db = idToDb.get(dbId);
         if (db == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -20,11 +20,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
-import com.starrocks.catalog.LocalTablet;
-import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.Partition;
 import com.starrocks.common.Config;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.AutoInferUtil;
@@ -37,7 +33,6 @@ import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
-import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.KeysDesc;
 import com.starrocks.sql.common.EngineType;
@@ -52,9 +47,6 @@ import java.util.Map;
 
 public class StatisticsMetaManager extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(StatisticsMetaManager.class);
-
-    // If all replicas are lost more than 3 times in a row, rebuild the statistics table
-    private int lossTableCount = 0;
 
     public StatisticsMetaManager() {
         super("statistics meta manager", 60L * 1000L);
@@ -81,42 +73,6 @@ public class StatisticsMetaManager extends FrontendDaemon {
         Database db = GlobalStateMgr.getCurrentState().getDb(StatsConstants.STATISTICS_DB_NAME);
         Preconditions.checkState(db != null);
         return db.getTable(tableName) != null;
-    }
-
-    private boolean checkReplicateNormal(String tableName) {
-        int aliveSize = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAliveBackendNumber();
-        int total = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber();
-        // maybe cluster just shutdown, ignore
-        if (aliveSize <= total / 2) {
-            lossTableCount = 0;
-            return true;
-        }
-
-        Database db = GlobalStateMgr.getCurrentState().getDb(StatsConstants.STATISTICS_DB_NAME);
-        Preconditions.checkState(db != null);
-        OlapTable table = (OlapTable) db.getTable(tableName);
-        Preconditions.checkState(table != null);
-        if (table.isCloudNativeTableOrMaterializedView()) {
-            return true;
-        }
-
-        boolean check = true;
-        for (Partition partition : table.getPartitions()) {
-            // check replicate miss
-            if (partition.getBaseIndex().getTablets().stream()
-                    .anyMatch(t -> ((LocalTablet) t).getNormalReplicaBackendIds().isEmpty())) {
-                check = false;
-                break;
-            }
-        }
-
-        if (!check) {
-            lossTableCount++;
-        } else {
-            lossTableCount = 0;
-        }
-
-        return lossTableCount < 3;
     }
 
     private static final List<String> KEY_COLUMN_NAMES = ImmutableList.of(
@@ -322,21 +278,6 @@ public class StatisticsMetaManager extends FrontendDaemon {
         }
     }
 
-    private boolean dropTable(String tableName) {
-        LOG.info("drop statistics table start");
-        DropTableStmt stmt = new DropTableStmt(true,
-                new TableName(StatsConstants.STATISTICS_DB_NAME, tableName), true);
-
-        try {
-            GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(stmt);
-        } catch (DdlException e) {
-            LOG.warn("Failed to drop table", e);
-            return false;
-        }
-        LOG.info("drop statistics table done");
-        return !checkTableExist(tableName);
-    }
-
     private void trySleep(long millis) {
         try {
             Thread.sleep(millis);
@@ -347,39 +288,33 @@ public class StatisticsMetaManager extends FrontendDaemon {
 
     private boolean createTable(String tableName) {
         ConnectContext context = StatisticUtils.buildConnectContext();
-        context.setThreadLocalInfo();
-
-        if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
-            return createSampleStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.FULL_STATISTICS_TABLE_NAME)) {
-            return createFullStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
-            return createHistogramStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
-            return createExternalFullStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME)) {
-            return createExternalHistogramStatisticsTable(context);
-        } else {
-            throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
+        try (ConnectContext.ScopeGuard guard = context.bindScope()) {
+            if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
+                return createSampleStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.FULL_STATISTICS_TABLE_NAME)) {
+                return createFullStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
+                return createHistogramStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
+                return createExternalFullStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME)) {
+                return createExternalHistogramStatisticsTable(context);
+            } else {
+                throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
+            }
         }
     }
 
     private void refreshStatisticsTable(String tableName) {
-        while (checkTableExist(tableName) && !checkReplicateNormal(tableName)) {
-            LOG.info("statistics table " + tableName + " replicate is not normal, will drop table and rebuild");
-            if (dropTable(tableName)) {
-                break;
-            }
-            LOG.warn("drop statistics table " + tableName + " failed");
-            trySleep(10000);
-        }
-
         while (!checkTableExist(tableName)) {
             if (createTable(tableName)) {
                 break;
             }
             LOG.warn("create statistics table " + tableName + " failed");
             trySleep(10000);
+        }
+        if (checkTableExist(tableName)) {
+            StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -50,6 +50,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -816,6 +817,17 @@ public class SystemInfoService implements GsonPostProcessable {
         return getBackendIds(true).size();
     }
 
+    public int getRetainedBackendNumber() {
+        return getRetainedBackends().size();
+    }
+
+    public int getSystemTableExpectedReplicationNum() {
+        if (RunMode.isSharedDataMode()) {
+            return 1;
+        }
+        return Integer.max(1, Integer.min(Config.default_replication_num, getRetainedBackendNumber()));
+    }
+
     public int getTotalBackendNumber() {
         return idToBackendRef.size();
     }
@@ -917,10 +929,20 @@ public class SystemInfoService implements GsonPostProcessable {
         return Lists.newArrayList(idToBackendRef.values());
     }
 
+    /**
+     * Available: not decommissioned and alive
+     */
     public List<Backend> getAvailableBackends() {
         return getBackends().stream()
                 .filter(ComputeNode::isAvailable)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Retained: not decommissioned, whatever alive or not
+     */
+    public List<Backend> getRetainedBackends() {
+        return getBackends().stream().filter(x -> !x.isDecommissioned()).collect(Collectors.toList());
     }
 
     public List<ComputeNode> getComputeNodes() {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -154,7 +154,6 @@ public class TaskRunHistoryTest {
         assertEquals(StatsConstants.STATISTICS_DB_NAME, keeper.getDatabaseName());
         assertEquals(TaskRunHistoryTable.TABLE_NAME, keeper.getTableName());
         assertEquals(TaskRunHistoryTable.CREATE_TABLE, keeper.getCreateTableSql());
-        assertEquals(TaskRunHistoryTable.TABLE_REPLICAS, keeper.getTableReplicas());
 
         // database not exists
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticUtilsTest.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import com.starrocks.common.Config;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class StatisticUtilsTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        UtFrameUtils.createMinStarRocksCluster();
+        if (!starRocksAssert.databaseExist("_statistics_")) {
+            StatisticsMetaManager m = new StatisticsMetaManager();
+            m.createStatisticsTablesForTest();
+        }
+        UtFrameUtils.addMockBackend(123);
+        UtFrameUtils.addMockBackend(124);
+    }
+
+    @Test
+    void alterSystemTableReplicationNumIfNecessary() {
+        // 1. Has sufficient backends
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public int getRetainedBackendNumber() {
+                return 100;
+            }
+        };
+        final String tableName = "column_statistics";
+        Assert.assertTrue(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertFalse(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertEquals("3",
+                starRocksAssert.getTable(StatsConstants.STATISTICS_DB_NAME, tableName).getProperties().get(
+                        "replication_num"));
+
+        // 2. change default_replication_num
+        Config.default_replication_num = 1;
+        Assert.assertTrue(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertFalse(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertEquals("1",
+                starRocksAssert.getTable(StatsConstants.STATISTICS_DB_NAME, tableName).getProperties().get(
+                        "replication_num"));
+        Config.default_replication_num = 3;
+        Assert.assertTrue(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+
+        // 3. Has no sufficient backends
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public int getRetainedBackendNumber() {
+                return 1;
+            }
+        };
+        Assert.assertTrue(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertFalse(StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName));
+        Assert.assertEquals("1",
+                starRocksAssert.getTable(StatsConstants.STATISTICS_DB_NAME, tableName).getProperties().get(
+                        "replication_num"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When scale-in the cluster from 3 nodes to 1 node:
- Since the system tables in `_statistics_` database will have 3 replicas, they would stop the scale-in
- The current solution is to drop this database and recreate it, but which is not safe actually

## What I'm doing:

Auto change replication_num of several system tables
- When scaling out to more than 3 nodes, change the replication_num to 3
- When scaling in to 1 node, change the replication_num to 1, otherwise scale-in would never succeed

Affected system tables:
- `column_statistics`             
- `histogram_statistics`        
- `table_statistic_v1`            
- `external_column_statistics`    
- `external_histogram_statistics`
- 3.2: `pipe_file_list`                
- 3.3: `loads_history`                 
- 3.3: `task_run_history`              

Behavior change:
- before: the replication_num will only be increased but not decreased
- now: the replication_num will be increased when scale-out, and decreased when scale-in

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
<hr>This is an automatic backport of pull request #51799 done by [Mergify](https://mergify.com).
## Why I'm doing:

When scale-in the cluster from 3 nodes to 1 node:
- Since the system tables in `_statistics_` database will have 3 replicas, they would stop the scale-in
- The current solution is to drop this database and recreate it, but which is not safe actually

## What I'm doing:

Auto change replication_num of several system tables
- When scaling out to more than 3 nodes, change the replication_num to 3
- When scaling in to 1 node, change the replication_num to 1, otherwise scale-in would never succeed

Affected system tables:
- `column_statistics`             
- `histogram_statistics`        
- `table_statistic_v1`            
- `external_column_statistics`    
- `external_histogram_statistics`
- 3.2: `pipe_file_list`                
- 3.3: `loads_history`                 
- 3.3: `task_run_history`              

Behavior change:
- before: the replication_num will only be increased but not decreased
- now: the replication_num will be increased when scale-out, and decreased when scale-in

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr


## Why I'm doing:

When scale-in the cluster from 3 nodes to 1 node:
- Since the system tables in `_statistics_` database will have 3 replicas, they would stop the scale-in
- The current solution is to drop this database and recreate it, but which is not safe actually

## What I'm doing:

Auto change replication_num of several system tables
- When scaling out to more than 3 nodes, change the replication_num to 3
- When scaling in to 1 node, change the replication_num to 1, otherwise scale-in would never succeed

Affected system tables:
- `column_statistics`             
- `histogram_statistics`        
- `table_statistic_v1`            
- `external_column_statistics`    
- `external_histogram_statistics`
- 3.2: `pipe_file_list`                
- 3.3: `loads_history`                 
- 3.3: `task_run_history`              

Behavior change:
- before: the replication_num will only be increased but not decreased
- now: the replication_num will be increased when scale-out, and decreased when scale-in

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

