### PR TITLE
[BugFix] Add HistogramMetric to support histogram with tags

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/HistogramMetric.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/HistogramMetric.java
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.metric;
+
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Histogram;
+import com.google.api.client.util.Lists;
+import com.google.common.base.Joiner;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Histogram metric with tags to distinguish different metrics with the same name.
+ * e.g. mv_refresh_duration{mv_db_name="db1", mv_name="mv1"}
+ */
+public final class HistogramMetric extends Histogram {
+    private final List<MetricLabel> labels = Lists.newArrayList();
+    private final String name;
+
+    public HistogramMetric(String name) {
+        super(new ExponentiallyDecayingReservoir());
+        this.name = name;
+    }
+
+    public void addLabel(MetricLabel label) {
+        labels.add(label);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getTagName() {
+        List<String> labelStrings = labels.stream().map(l -> l.getKey() + "=\"" + l.getValue()
+                + "\"").collect(Collectors.toList());
+        return Joiner.on(", ").join(labelStrings);
+    }
+
+    /**
+     * Get the histogram name with tags in the format of "name_tag1=value1, tag2=value2"
+     */
+    public String getHistogramName() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(name);
+        sb.append("_");
+        sb.append(getTagName());
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/metric/HistogramMetric.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/HistogramMetric.java
@@ -56,10 +56,11 @@ public final class HistogramMetric extends Histogram {
      * Get the histogram name with tags in the format of "name_tag1=value1, tag2=value2"
      */
     public String getHistogramName() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(name);
-        sb.append("_");
-        sb.append(getTagName());
-        return sb.toString();
+        String tagName = getTagName();
+        if (!tagName.isEmpty()) {
+            return name + "_" + tagName;
+        } else {
+            return name;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/JsonMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/JsonMetricVisitor.java
@@ -133,6 +133,11 @@ public class JsonMetricVisitor extends MetricVisitor {
     }
 
     @Override
+    public void visitHistogram(HistogramMetric histogram) {
+
+    }
+
+    @Override
     public void visitHistogram(String name, Histogram histogram) {
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -162,8 +162,10 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
             MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
                         .getTable(db.getId(), mvId.getId());
-            histRefreshJobDuration = metricRegistry.histogram(MetricRegistry.name("mv_refresh_duration",
-                        db.getFullName(), mv.getName()));
+            HistogramMetric histogram = new HistogramMetric("mv_refresh_duration");
+            histogram.addLabel(new MetricLabel("db_name", db.getFullName()));
+            histogram.addLabel(new MetricLabel("mv_name", mv.getName()));
+            histRefreshJobDuration = metricRegistry.histogram(histogram.getHistogramName(), () -> histogram);
         } catch (Exception e) {
             LOG.warn("Ignore histogram metrics for materialized view: {}", mvId);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricVisitor.java
@@ -54,6 +54,8 @@ public abstract class MetricVisitor {
 
     public abstract void visitHistogram(String name, Histogram histogram);
 
+    public abstract void visitHistogram(HistogramMetric histogram);
+
     public abstract void getNodeInfo();
 
     public abstract String build();

--- a/fe/fe-core/src/main/java/com/starrocks/metric/PrometheusMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/PrometheusMetricVisitor.java
@@ -37,6 +37,7 @@ package com.starrocks.metric;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Snapshot;
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.starrocks.monitor.jvm.JvmStats;
 import com.starrocks.monitor.jvm.JvmStats.BufferPool;
 import com.starrocks.monitor.jvm.JvmStats.GarbageCollector;
@@ -189,10 +190,41 @@ public class PrometheusMetricVisitor extends MetricVisitor {
     }
 
     @Override
+    public void visitHistogram(HistogramMetric histogram) {
+        final String fullName = prefix + "_" + histogram.getName();
+
+        if (!metricNames.contains(fullName)) {
+            sb.append(HELP).append(fullName).append(" ").append("\n");
+            sb.append(TYPE).append(fullName).append(" ").append("summary\n");
+            metricNames.add(fullName);
+        }
+
+        Snapshot snapshot = histogram.getSnapshot();
+        String tagName = histogram.getTagName();
+        String delimiter = Strings.isNullOrEmpty(tagName) ? "" : ", ";
+        sb.append(fullName).append("{quantile=\"0.75\"").append(delimiter).append(tagName).append("} ")
+                .append(snapshot.get75thPercentile()).append("\n");
+        sb.append(fullName).append("{quantile=\"0.95\"").append(delimiter).append(tagName).append("} ")
+                .append(snapshot.get95thPercentile()).append("\n");
+        sb.append(fullName).append("{quantile=\"0.98\"").append(delimiter).append(tagName).append("} ")
+                .append(snapshot.get98thPercentile()).append("\n");
+        sb.append(fullName).append("{quantile=\"0.99\"").append(delimiter).append(tagName).append("} ")
+                .append(snapshot.get99thPercentile()).append("\n");
+        sb.append(fullName).append("{quantile=\"0.999\"").append(delimiter).append(tagName).append("} ")
+                .append(snapshot.get999thPercentile()).append("\n");
+        sb.append(fullName).append("_sum ").append(histogram.getCount() * snapshot.getMean()).append("\n");
+        sb.append(fullName).append("_count ").append(histogram.getCount()).append("\n");
+    }
+
+    @Override
     public void visitHistogram(String name, Histogram histogram) {
         final String fullName = prefix + "_" + name.replaceAll("\\.", "_");
-        sb.append(HELP).append(fullName).append(" ").append("\n");
-        sb.append(TYPE).append(fullName).append(" ").append("summary\n");
+
+        if (!metricNames.contains(fullName)) {
+            sb.append(HELP).append(fullName).append(" ").append("\n");
+            sb.append(TYPE).append(fullName).append(" ").append("summary\n");
+            metricNames.add(fullName);
+        }
 
         Snapshot snapshot = histogram.getSnapshot();
         sb.append(fullName).append("{quantile=\"0.75\"} ").append(snapshot.get75thPercentile()).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/metric/SimpleCoreMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/SimpleCoreMetricVisitor.java
@@ -131,6 +131,10 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
     }
 
     @Override
+    public void visitHistogram(HistogramMetric histogram) {
+    }
+
+    @Override
     public void visitHistogram(String name, Histogram histogram) {
         if (!CORE_METRICS.containsKey(name)) {
             return;

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
@@ -140,4 +140,26 @@ public class MetricsTest {
         Assert.assertEquals(m.getLabels().get(0).getValue(), "v1");
         Assert.assertEquals(m.getLabels().get(1).getValue(), "v2");
     }
+
+    @Test
+    public void testPrometheusHistogramMetrics() {
+        PrometheusMetricVisitor prometheusMetricVisitor = new PrometheusMetricVisitor("sr");
+        HistogramMetric histogramMetric = new HistogramMetric("duration");
+        histogramMetric.addLabel(new MetricLabel("k1", "v1"));
+        histogramMetric.addLabel(new MetricLabel("k2", "v2"));
+        prometheusMetricVisitor.visitHistogram(histogramMetric);
+        String output = prometheusMetricVisitor.build();
+        List<String> metricNames = Arrays.asList(
+                "sr_duration{quantile=\"0.75\", k1=\"v1\", k2=\"v2\"}",
+                "sr_duration{quantile=\"0.95\", k1=\"v1\", k2=\"v2\"}",
+                "sr_duration{quantile=\"0.98\", k1=\"v1\", k2=\"v2\"}",
+                "sr_duration{quantile=\"0.99\", k1=\"v1\", k2=\"v2\"}",
+                "sr_duration{quantile=\"0.999\", k1=\"v1\", k2=\"v2\"}",
+                "sr_duration_sum",
+                "sr_duration_count"
+        );
+        for (String metricName : metricNames) {
+            Assert.assertTrue(output.contains(metricName));
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
- `Histogram` can only store `tags` in the name, if the tag has some special symbols(eg: $), `Prometheus` cannot parse it.

## What I'm doing:

- Support Histogram metric with tags to distinguish different metrics with the same name.
```
 * e.g. mv_refresh_duration{mv_db_name="db1", mv_name="mv1"}
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
