### PR TITLE
[Feature] Unify cache instance between DLA and cloud native datacache.

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -192,6 +192,14 @@ Status BlockCache::shutdown() {
     return st;
 }
 
+void BlockCache::disk_spaces(std::vector<DirSpace>* spaces) {
+    spaces->clear();
+    auto metrics = _kv_cache->cache_metrics(0);
+    for (auto& dir : metrics.disk_dir_spaces) {
+        spaces->push_back({.path = dir.path, .size = dir.quota_bytes});
+    }
+}
+
 DataCacheEngineType BlockCache::engine_type() {
     return _kv_cache->engine_type();
 }

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -94,6 +94,8 @@ public:
 
     DataCacheEngineType engine_type();
 
+    std::shared_ptr<starcache::StarCache> starcache_instance() { return _kv_cache->starcache_instance(); }
+
     static const size_t MAX_BLOCK_SIZE;
 
 private:
@@ -103,7 +105,7 @@ private:
     void _refresh_quota();
 
     size_t _block_size = 0;
-    std::unique_ptr<KvCache> _kv_cache;
+    std::shared_ptr<KvCache> _kv_cache;
     std::unique_ptr<DiskSpaceMonitor> _disk_space_monitor;
     std::atomic<bool> _initialized = false;
     std::atomic<size_t> _mem_quota = 0;

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -92,6 +92,8 @@ public:
 
     bool available() const { return is_initialized() && (has_mem_cache() || has_disk_cache()); }
 
+    void disk_spaces(std::vector<DirSpace>* spaces);
+
     DataCacheEngineType engine_type();
 
     std::shared_ptr<starcache::StarCache> starcache_instance() { return _kv_cache->starcache_instance(); }
@@ -107,6 +109,7 @@ private:
     size_t _block_size = 0;
     std::shared_ptr<KvCache> _kv_cache;
     std::unique_ptr<DiskSpaceMonitor> _disk_space_monitor;
+    std::vector<std::string> _disk_paths;
     std::atomic<bool> _initialized = false;
     std::atomic<size_t> _mem_quota = 0;
     std::atomic<size_t> _disk_quota = 0;

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -52,6 +52,7 @@ struct CacheOptions {
     bool enable_checksum = false;
     bool enable_direct_io = false;
     bool enable_tiered_cache = true;
+    bool enable_datacache_persistence = false;
     std::string engine;
     size_t max_concurrent_inserts = 0;
     size_t max_flying_memory_mb = 0;

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -58,6 +58,7 @@ struct CacheOptions {
     size_t max_flying_memory_mb = 0;
     double scheduler_threads_per_cpu = 0;
     double skip_read_factor = 0;
+    uint32_t inline_item_count_limit = 0;
 };
 
 struct WriteCacheOptions {

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -59,6 +59,7 @@ struct CacheOptions {
     double scheduler_threads_per_cpu = 0;
     double skip_read_factor = 0;
     uint32_t inline_item_count_limit = 0;
+    std::string eviction_policy;
 };
 
 struct WriteCacheOptions {
@@ -77,6 +78,13 @@ struct WriteCacheOptions {
     // and improve cache hit rate sometimes.
     // It is expressed as a percentage. If evict_probability is 10, it means the probability to evict other data is 10%.
     int32_t evict_probability = 100;
+
+    // The base frequency for target cache.
+    // When using multiple segment lru, a higher frequency may cause the cache is written to warm segment directly.
+    // For the default cache options, that `lru_segment_freq_bits` is 0:
+    // * The default `frequency=0` indicates the cache will be written to cold segment.
+    // * A frequency value greater than 0 indicates writing this cache directly to the warm segment.
+    int8_t frequency = 0;
 
     struct Stats {
         int64_t write_mem_bytes = 0;

--- a/be/src/block_cache/datacache_utils.h
+++ b/be/src/block_cache/datacache_utils.h
@@ -37,6 +37,8 @@ public:
                                                    std::vector<DirSpace>* disk_spaces);
 
     static void clean_residual_datacache(const std::string& disk_path);
+
+    static Status change_disk_path(const std::string& old_disk_path, const std::string& new_disk_path);
 };
 
 } // namespace starrocks

--- a/be/src/block_cache/disk_space_monitor.cpp
+++ b/be/src/block_cache/disk_space_monitor.cpp
@@ -253,14 +253,17 @@ bool DiskSpaceMonitor::_adjust_spaces_by_disk_usage(bool immediate) {
         // If the current available disk space is too small, cache quota will be reset to zero to avoid overly frequent
         // population and eviction.
         _reset_spaces();
-        total_cache_quota = 0;
         if (_total_cache_quota == 0) {
             // If the cache quata is already zero, skip adjusting it repeatedly.
+            VLOG(1) << "Skip updating the cache quota because the target quota is less than "
+                    << "`datacache_min_disk_quota_for_adjustment`, target cache quota: " << total_cache_quota;
+            total_cache_quota = 0;
             return false;
         } else {
             // This warning log only be printed when the cache disk quota is adjust from a non-zero integer to zero.
             LOG(WARNING) << "The current available disk space is too small, so disable the disk cache directly. If you "
                          << "still need it, you could reduce the value of `datacache_min_disk_quota_for_adjustment`";
+            total_cache_quota = 0;
         }
     }
     LOG(INFO) << "Adjusting datacache disk quota from " << _total_cache_quota << " to " << total_cache_quota;

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -81,6 +81,8 @@ public:
     virtual Status shutdown() = 0;
 
     virtual DataCacheEngineType engine_type() = 0;
+
+    virtual std::shared_ptr<starcache::StarCache> starcache_instance() = 0;
 };
 
 } // namespace starrocks

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -38,6 +38,9 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
     opt.max_flying_memory_mb = options.max_flying_memory_mb;
     _cache_adaptor.reset(starcache::create_default_adaptor(options.skip_read_factor));
     opt.cache_adaptor = _cache_adaptor.get();
+    if (options.enable_datacache_persistence) {
+        opt.durability_type = starcache::DurabilityType::ROCKSDB;
+    }
     opt.instance_name = "dla_cache";
     _enable_tiered_cache = options.enable_tiered_cache;
     _cache = std::make_unique<starcache::StarCache>();

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -46,6 +46,12 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
         opt.durability_type = starcache::DurabilityType::ROCKSDB;
     }
     opt.instance_name = "default_cache";
+
+    if (options.eviction_policy == "slru") {
+        opt.lru_segment_ratios = {35, 65};
+    }
+    opt.lru_segment_freq_bits = 0;
+
     _enable_tiered_cache = options.enable_tiered_cache;
     _enable_datacache_persistence = options.enable_datacache_persistence;
     _cache = std::make_unique<starcache::StarCache>();

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -30,7 +30,8 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
     for (auto& dir : options.disk_spaces) {
         opt.disk_dir_spaces.push_back({.path = dir.path, .quota_bytes = dir.size});
     }
-    opt.block_size = options.block_size;
+    //opt.block_size = options.block_size;
+    opt.block_size = 256uL * 1024;
     opt.enable_disk_checksum = options.enable_checksum;
     opt.max_concurrent_writes = options.max_concurrent_inserts;
     opt.enable_os_page_cache = !options.enable_direct_io;

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -56,8 +56,10 @@ public:
 
     DataCacheEngineType engine_type() override { return DataCacheEngineType::STARCACHE; }
 
+    std::shared_ptr<starcache::StarCache> starcache_instance() override { return _cache; }
+
 private:
-    std::unique_ptr<starcache::StarCache> _cache;
+    std::shared_ptr<starcache::StarCache> _cache;
     std::unique_ptr<starcache::TimeBasedCacheAdaptor> _cache_adaptor;
     bool _enable_tiered_cache = false;
 };

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -62,6 +62,7 @@ private:
     std::shared_ptr<starcache::StarCache> _cache;
     std::unique_ptr<starcache::TimeBasedCacheAdaptor> _cache_adaptor;
     bool _enable_tiered_cache = false;
+    bool _enable_datacache_persistence = false;
 };
 
 // In order to split the starcache library to a separate registry for other users such as the cloud team,

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1182,9 +1182,9 @@ CONF_mBool(datacache_auto_adjust_enable, "true");
 // The high disk usage level, which trigger the cache eviction and quota decreased.
 CONF_mInt64(datacache_disk_high_level, "90");
 // The safe disk usage level, the cache quota will be decreased to this level once it reach the high level.
-CONF_mInt64(datacache_disk_safe_level, "70");
+CONF_mInt64(datacache_disk_safe_level, "80");
 // The low disk usage level, which trigger the cache expansion and quota increased.
-CONF_mInt64(datacache_disk_low_level, "50");
+CONF_mInt64(datacache_disk_low_level, "60");
 // The interval seconds to check the disk usage and trigger adjustment.
 CONF_mInt64(datacache_disk_adjust_interval_seconds, "10");
 // The silent period, only when the disk usage falls bellow the low level for a time longer than this period,
@@ -1200,7 +1200,7 @@ CONF_mInt64(datacache_min_disk_quota_for_adjustment, "107374182400");
 // Set the parameter to `0` will turn off this optimization.
 CONF_Int32(datacache_inline_item_count_limit, "130172");
 // Whether use an unified datacache instance.
-CONF_mBool(datacache_unified_instance, "true");
+CONF_Bool(datacache_unified_instance_enable, "true");
 
 // The following configurations will be deprecated, and we use the `datacache` prefix instead.
 // But it is temporarily necessary to keep them for a period of time to be compatible with

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1163,6 +1163,7 @@ CONF_Double(datacache_scheduler_threads_per_cpu, "0.125");
 // For object data, such as parquet footer object, which can only be cached in memory are not affected
 // by this configuration.
 CONF_Bool(datacache_tiered_cache_enable, "true");
+CONF_Bool(datacache_persistence_enable, "false");
 // DataCache engines, alternatives: starcache.
 // `cachelib` is not support now.
 // Set the default value empty to indicate whether it is manully configured by users.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1135,8 +1135,6 @@ CONF_mInt64(max_length_for_bitmap_function, "1000000");
 CONF_Bool(datacache_enable, "true");
 CONF_mString(datacache_mem_size, "0");
 CONF_mString(datacache_disk_size, "0");
-CONF_mString(datacache_disk_path, "");
-CONF_String(datacache_meta_path, "");
 CONF_Int64(datacache_block_size, "262144"); // 256K
 CONF_Bool(datacache_checksum_enable, "false");
 CONF_Bool(datacache_direct_io_enable, "false");
@@ -1163,7 +1161,8 @@ CONF_Double(datacache_scheduler_threads_per_cpu, "0.125");
 // For object data, such as parquet footer object, which can only be cached in memory are not affected
 // by this configuration.
 CONF_Bool(datacache_tiered_cache_enable, "true");
-CONF_Bool(datacache_persistence_enable, "false");
+// Whether to persist cached data
+CONF_Bool(datacache_persistence_enable, "true");
 // DataCache engines, alternatives: starcache.
 // `cachelib` is not support now.
 // Set the default value empty to indicate whether it is manully configured by users.
@@ -1179,13 +1178,13 @@ CONF_mInt32(report_datacache_metrics_interval_ms, "60000");
 // On the other hand, if the cache is full and the disk usage falls below the disk low level for a long time,
 // which is configured by `datacache_disk_idle_seconds_for_expansion`, the cache quota will be increased to keep the
 // disk usage around the disk safe level.
-CONF_mBool(datacache_auto_adjust_enable, "false");
+CONF_mBool(datacache_auto_adjust_enable, "true");
 // The high disk usage level, which trigger the cache eviction and quota decreased.
-CONF_mInt64(datacache_disk_high_level, "80");
+CONF_mInt64(datacache_disk_high_level, "90");
 // The safe disk usage level, the cache quota will be decreased to this level once it reach the high level.
 CONF_mInt64(datacache_disk_safe_level, "70");
 // The low disk usage level, which trigger the cache expansion and quota increased.
-CONF_mInt64(datacache_disk_low_level, "60");
+CONF_mInt64(datacache_disk_low_level, "50");
 // The interval seconds to check the disk usage and trigger adjustment.
 CONF_mInt64(datacache_disk_adjust_interval_seconds, "10");
 // The silent period, only when the disk usage falls bellow the low level for a time longer than this period,
@@ -1195,6 +1194,13 @@ CONF_mInt64(datacache_disk_idle_seconds_for_expansion, "7200");
 // cache quota will be reset to zero to avoid overly frequent population and eviction.
 // Default: 100G
 CONF_mInt64(datacache_min_disk_quota_for_adjustment, "107374182400");
+// The maxmum inline cache item count in datacache.
+// When a cache item has a really small data size, we will try to cache it inline with its metadata
+// to optimize the io performance and reduce disk waste.
+// Set the parameter to `0` will turn off this optimization.
+CONF_Int32(datacache_inline_item_count_limit, "130172");
+// Whether use an unified datacache instance.
+CONF_mBool(datacache_unified_instance, "true");
 
 // The following configurations will be deprecated, and we use the `datacache` prefix instead.
 // But it is temporarily necessary to keep them for a period of time to be compatible with

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1201,6 +1201,10 @@ CONF_mInt64(datacache_min_disk_quota_for_adjustment, "107374182400");
 CONF_Int32(datacache_inline_item_count_limit, "130172");
 // Whether use an unified datacache instance.
 CONF_Bool(datacache_unified_instance_enable, "true");
+// The eviction policy for datacache, alternatives: [lru, slru].
+// * lru: the typical `Least Recently Used` eviction policy.
+// * slru: segment lru eviction policies, which can better reduce cache pollution problem.
+CONF_String(datacache_eviction_policy, "slru");
 
 // The following configurations will be deprecated, and we use the `datacache` prefix instead.
 // But it is temporarily necessary to keep them for a period of time to be compatible with

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -146,7 +146,9 @@ void calculate_metrics(void* arg_this) {
                 datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
             }
 #ifdef USE_STAROS
-            datacache_mem_bytes += staros::starlet::fslib::star_cache_get_memory_usage();
+            if (!config::datacache_unified_instance) {
+                datacache_mem_bytes += staros::starlet::fslib::star_cache_get_memory_usage();
+            }
 #endif
             datacache_mem_tracker->set(datacache_mem_bytes);
         }

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -146,7 +146,7 @@ void calculate_metrics(void* arg_this) {
                 datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
             }
 #ifdef USE_STAROS
-            if (!config::datacache_unified_instance) {
+            if (!config::datacache_unified_instance_enable) {
                 datacache_mem_bytes += staros::starlet::fslib::star_cache_get_memory_usage();
             }
 #endif

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -116,16 +116,19 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         });
         _config_callback.emplace("datacache_disk_size", [&]() -> Status {
             std::vector<DirSpace> spaces;
-            Status st = DataCacheUtils::parse_conf_datacache_disk_spaces(
-                    config::datacache_disk_path, config::datacache_disk_size, config::ignore_broken_disk, &spaces);
-            if (!st.ok()) {
-                LOG(WARNING) << "Failed to update datacache disk spaces";
-                return st;
+            BlockCache::instance()->disk_spaces(&spaces);
+            for (auto& space : spaces) {
+                int64_t disk_size =
+                        DataCacheUtils::parse_conf_datacache_disk_size(space.path, config::datacache_disk_size, -1);
+                if (disk_size < 0) {
+                    LOG(WARNING) << "Failed to update datacache disk spaces for the invalid disk_size: " << disk_size;
+                    return Status::InternalError("Fail to update datacache disk spaces");
+                }
+                space.size = disk_size;
             }
-            st = BlockCache::instance()->adjust_disk_spaces(spaces);
+            Status st = BlockCache::instance()->adjust_disk_spaces(spaces);
             return st;
         });
-        _config_callback.emplace("datacache_disk_path", _config_callback["datacache_disk_size"]);
         _config_callback.emplace("max_compaction_concurrency", [&]() -> Status {
             if (!config::enable_event_based_compaction_framework) {
                 return Status::InvalidArgument(

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -394,6 +394,7 @@ void CacheInputStream::_populate_to_cache(const char* p, int64_t offset, int64_t
         options.evict_probability = _datacache_evict_probability;
         options.priority = _priority;
         options.ttl_seconds = _ttl_seconds;
+        options.frequency = _frequency;
         if (options.async && sb) {
             auto cb = [sb](int code, const std::string& msg) {
                 // We only need to keep the shared buffer pointer

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -75,6 +75,8 @@ public:
 
     void set_priority(const int8_t priority) { _priority = priority; }
 
+    void set_frequency(const int8_t frequency) { _frequency = frequency; }
+
     void set_ttl_seconds(const uint64_t ttl_seconds) { _ttl_seconds = ttl_seconds; }
 
     int64_t get_align_size() const;
@@ -119,6 +121,7 @@ protected:
     std::unordered_map<int64_t, BlockBuffer> _block_map;
     int8_t _priority = 0;
     uint64_t _ttl_seconds = 0;
+    int8_t _frequency = 0;
 
 private:
     inline int64_t _calculate_remote_latency_per_block(int64_t io_bytes, int64_t read_time_ns);

--- a/be/src/io/cache_select_input_stream.hpp
+++ b/be/src/io/cache_select_input_stream.hpp
@@ -28,6 +28,8 @@ public:
         set_enable_async_populate_mode(false);
         set_enable_cache_io_adaptor(false);
         set_enable_block_buffer(false);
+        // Set a high frequecy for cache item that will be populated by cache select.
+        set_frequency(1);
     }
 
     ~CacheSelectInputStream() override = default;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -130,6 +130,7 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
         cache_options.enable_tiered_cache = config::datacache_tiered_cache_enable;
         cache_options.skip_read_factor = starrocks::config::datacache_skip_read_factor;
         cache_options.scheduler_threads_per_cpu = starrocks::config::datacache_scheduler_threads_per_cpu;
+        cache_options.enable_datacache_persistence = starrocks::config::datacache_persistence_enable;
         cache_options.engine = config::datacache_engine;
         return cache->init(cache_options);
     }

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -62,8 +62,6 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
         config::datacache_enable = true;
         config::datacache_mem_size = std::to_string(config::block_cache_mem_size);
         config::datacache_disk_size = std::to_string(config::block_cache_disk_size);
-        config::datacache_disk_path = config::block_cache_disk_path;
-        config::datacache_meta_path = config::block_cache_meta_path;
         config::datacache_block_size = config::block_cache_block_size;
         config::datacache_max_concurrent_inserts = config::block_cache_max_concurrent_inserts;
         config::datacache_checksum_enable = config::block_cache_checksum_enable;
@@ -90,29 +88,73 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
         }
         RETURN_IF_ERROR(DataCacheUtils::parse_conf_datacache_mem_size(config::datacache_mem_size, mem_limit,
                                                                       &cache_options.mem_space_size));
-        if (config::datacache_disk_path.value().empty()) {
-            // If the disk cache does not be configured for datacache, set default path according storage path.
-            std::vector<std::string> datacache_paths;
-            std::for_each(storage_paths.begin(), storage_paths.end(), [&](const StorePath& root_path) {
-                datacache_paths.push_back(root_path.path + "/datacache");
-                // Clear the residual datacache files
-                std::filesystem::path sp(root_path.path);
-                auto old_path = sp.parent_path() / "datacache";
-                DataCacheUtils::clean_residual_datacache(old_path.string());
-            });
-            config::datacache_disk_path = JoinStrings(datacache_paths, ";");
-        }
-        RETURN_IF_ERROR(DataCacheUtils::parse_conf_datacache_disk_spaces(
-                config::datacache_disk_path, config::datacache_disk_size, config::ignore_broken_disk,
-                &cache_options.disk_spaces));
 
-        size_t total_quota_byts = 0;
-        for (auto& space : cache_options.disk_spaces) {
-            total_quota_byts += space.size;
+        size_t total_quota_bytes = 0;
+        for (auto& root_path : storage_paths) {
+            // Because we have unified the datacache between datalake and starlet, we also need to unify the
+            // cache path and quota.
+            // To reuse the old cache data in `starlet_cache` directory, we try to rename it to the new `datacache`
+            // directory if it exists. To avoid the risk of cross disk renaming of a large amount of cached data,
+            // we do not automatically rename it when the source and destination directories are on different disks.
+            // In this case, users should manually remount the directories and restart them.
+            std::filesystem::path datacache_path(root_path.path + "/datacache");
+#ifdef USE_STAROS
+            if (config::datacache_unified_instance) {
+                std::filesystem::path starlet_cache_path(root_path.path + "/starlet_cache/star_cache");
+                if (std::filesystem::exists(starlet_cache_path)) {
+                    if (DiskInfo::disk_id(starlet_cache_path.c_str()) != DiskInfo::disk_id(datacache_path.c_str())) {
+                        LOG(ERROR) << "The datacache directory and the old starlet_cache directory cannot be located "
+                                      "on different disks. "
+                                   << "Please manually mount the datacache to the same disk as starlet_cache and then "
+                                      "restart again";
+                        return Status::InternalError(
+                                "The datacache directory is different with old starlet_cache directory");
+                    }
+                    std::error_code ec;
+                    std::filesystem::remove_all(datacache_path, ec);
+                    if (!ec) {
+                        std::filesystem::rename(starlet_cache_path, datacache_path, ec);
+                    }
+                    if (ec) {
+                        LOG(ERROR) << "Fail to rename old starlet_cache directory to datacache, src: "
+                                   << starlet_cache_path.string() << ", dst: " << datacache_path.string()
+                                   << ", reason: " << ec.message();
+                        return Status::InternalError("Fail to handle the old starlet_cache data");
+                    }
+                }
+            }
+#endif
+
+            std::string disk_path = datacache_path.string();
+            // Create it if not exist
+            Status status = FileSystem::Default()->create_dir_if_missing(disk_path);
+            if (!status.ok()) {
+                if (config::ignore_broken_disk) {
+                    continue;
+                }
+                LOG(ERROR) << "Fail to create datacache directory: " << disk_path << ", reason: " << status.message();
+                return Status::InternalError("Fail to create datacache directory");
+            }
+
+            int64_t disk_size =
+                    DataCacheUtils::parse_conf_datacache_disk_size(disk_path, config::datacache_disk_size, -1);
+#ifdef USE_STAROS
+            // If the `datacache_disk_size` is manually set a positive value, we will use the maximum cache quota between
+            // dataleke and starlet cache as the quota of the unified cache. Otherwise, the cache quota will remain zero
+            // and then automatically adjusted based on the current avalible disk space.
+            if (config::datacache_unified_instance && (!config::datacache_auto_adjust_enable || disk_size > 0)) {
+                std::string starlet_cache_percent = fmt::format("{}%", config::starlet_star_cache_disk_size_percent);
+                int64_t starlet_cache_size =
+                        DataCacheUtils::parse_conf_datacache_disk_size(disk_path, starlet_cache_percent, -1);
+                disk_size = std::max(disk_size, starlet_cache_size);
+            }
+#endif
+            cache_options.disk_spaces.push_back({.path = disk_path, .size = static_cast<size_t>(disk_size)});
+            total_quota_bytes += disk_size;
         }
-        if (!cache_options.disk_spaces.empty() && total_quota_byts == 0) {
-            // If disk cache quota is zero, turn on the automatic adjust switch.
-            config::datacache_auto_adjust_enable = true;
+
+        if (cache_options.disk_spaces.empty() || total_quota_bytes != 0) {
+            config::datacache_auto_adjust_enable = false;
         }
 
         // Adjust the default engine based on build switches.
@@ -121,16 +163,16 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
             config::datacache_engine = "starcache";
 #endif
         }
-        cache_options.meta_path = config::datacache_meta_path;
         cache_options.block_size = config::datacache_block_size;
         cache_options.max_flying_memory_mb = config::datacache_max_flying_memory_mb;
         cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
         cache_options.enable_checksum = config::datacache_checksum_enable;
         cache_options.enable_direct_io = config::datacache_direct_io_enable;
         cache_options.enable_tiered_cache = config::datacache_tiered_cache_enable;
-        cache_options.skip_read_factor = starrocks::config::datacache_skip_read_factor;
-        cache_options.scheduler_threads_per_cpu = starrocks::config::datacache_scheduler_threads_per_cpu;
-        cache_options.enable_datacache_persistence = starrocks::config::datacache_persistence_enable;
+        cache_options.skip_read_factor = config::datacache_skip_read_factor;
+        cache_options.scheduler_threads_per_cpu = config::datacache_scheduler_threads_per_cpu;
+        cache_options.enable_datacache_persistence = config::datacache_persistence_enable;
+        cache_options.inline_item_count_limit = config::datacache_inline_item_count_limit;
         cache_options.engine = config::datacache_engine;
         return cache->init(cache_options);
     }
@@ -207,9 +249,8 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 
 #ifdef USE_STAROS
     BlockCache* block_cache = BlockCache::instance();
-    if (block_cache->available()) {
+    if (config::datacache_unified_instance && block_cache->is_initialized()) {
         init_staros_worker(block_cache->starcache_instance());
-        LOG(INFO) << "[Gavin] init staros worker with starcache instance";
     } else {
         init_staros_worker(nullptr);
     }

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -118,8 +118,8 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
             // dataleke and starlet cache as the quota of the unified cache. Otherwise, the cache quota will remain zero
             // and then automatically adjusted based on the current avalible disk space.
             if (config::datacache_unified_instance_enable && (!config::datacache_auto_adjust_enable || disk_size > 0)) {
-                std::string percent = fmt::format("{}%", config::starlet_star_cache_disk_size_percent);
-                int64_t starlet_cache_size = DataCacheUtils::parse_conf_datacache_disk_size(datacache_path, percent, -1);
+                int64_t starlet_cache_size = DataCacheUtils::parse_conf_datacache_disk_size(
+                        datacache_path, fmt::format("{}%", config::starlet_star_cache_disk_size_percent), -1);
                 disk_size = std::max(disk_size, starlet_cache_size);
             }
 #endif
@@ -148,6 +148,7 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
         cache_options.enable_datacache_persistence = config::datacache_persistence_enable;
         cache_options.inline_item_count_limit = config::datacache_inline_item_count_limit;
         cache_options.engine = config::datacache_engine;
+        cache_options.eviction_policy = config::datacache_eviction_policy;
         return cache->init(cache_options);
     }
     return Status::OK();

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -343,7 +343,7 @@ Status to_status(const absl::Status& absl_status) {
     }
 }
 
-void init_staros_worker(std::shared_ptr<starcache::StarCache> star_cache) {
+void init_staros_worker(const std::shared_ptr<starcache::StarCache>& star_cache) {
     if (g_starlet.get() != nullptr) {
         return;
     }

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -343,10 +343,15 @@ Status to_status(const absl::Status& absl_status) {
     }
 }
 
-void init_staros_worker() {
+void init_staros_worker(std::shared_ptr<starcache::StarCache> star_cache) {
     if (g_starlet.get() != nullptr) {
         return;
     }
+
+    if (star_cache) {
+        (void)fslib::star_cache_set(star_cache);
+    }
+
     // skip staros reinit aws sdk
     staros::starlet::fslib::skip_aws_init_api = true;
 

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -349,7 +349,7 @@ void init_staros_worker(std::shared_ptr<starcache::StarCache> star_cache) {
     }
 
     if (star_cache) {
-        (void)fslib::star_cache_set(star_cache);
+        (void)fslib::set_star_cache(star_cache);
     }
 
     // skip staros reinit aws sdk

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -27,6 +27,7 @@
 #include "common/status.h"
 #include "fslib/configuration.h"
 #include "fslib/file_system.h"
+#include "starcache/star_cache.h"
 
 namespace starrocks {
 
@@ -108,7 +109,7 @@ private:
 };
 
 extern std::shared_ptr<StarOSWorker> g_worker;
-void init_staros_worker();
+void init_staros_worker(std::shared_ptr<starcache::StarCache> star_cache);
 void shutdown_staros_worker();
 void update_staros_starcache();
 

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -109,7 +109,7 @@ private:
 };
 
 extern std::shared_ptr<StarOSWorker> g_worker;
-void init_staros_worker(std::shared_ptr<starcache::StarCache> star_cache);
+void init_staros_worker(const std::shared_ptr<starcache::StarCache>& star_cache);
 void shutdown_staros_worker();
 void update_staros_starcache();
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -208,6 +208,7 @@ set(EXEC_FILES
         ./http/datacache_action_test.cpp
         ./http/stream_load_test.cpp
         ./http/transaction_stream_load_test.cpp
+        ./http/action/update_config_action_test.cpp
         ./io/array_input_stream_test.cpp
         ./io/compressed_input_stream_test.cpp
         ./io/io_profiler_test.cpp

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -34,8 +34,13 @@ protected:
 
     static void TearDownTestCase() {}
 
-    void SetUp() override {}
-    void TearDown() override {}
+    void SetUp() override {
+        _saved_enable_auto_adjust = config::datacache_auto_adjust_enable;
+        config::datacache_auto_adjust_enable = false;
+    }
+    void TearDown() override { config::datacache_auto_adjust_enable = _saved_enable_auto_adjust; }
+
+    bool _saved_enable_auto_adjust = false;
 };
 
 TEST_F(BlockCacheTest, copy_to_iobuf) {

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -139,6 +139,7 @@ TEST_F(BlockCacheTest, write_with_overwrite_option) {
     options.max_concurrent_inserts = 100000;
     options.max_flying_memory_mb = 100;
     options.engine = "starcache";
+    options.inline_item_count_limit = 1000;
     Status status = cache->init(options);
     ASSERT_TRUE(status.ok());
 

--- a/be/test/block_cache/datacache_utils_test.cpp
+++ b/be/test/block_cache/datacache_utils_test.cpp
@@ -133,4 +133,27 @@ TEST_F(DataCacheUtilsTest, parse_cache_space_paths) {
     fs::remove_all(cache_dir).ok();
 }
 
+TEST_F(DataCacheUtilsTest, change_cache_path_suc) {
+    const std::string old_dir = "./old_disk_cache_path";
+    const std::string new_dir = "./new_disk_cache_path";
+    ASSERT_TRUE(fs::create_directories(old_dir).ok());
+    ASSERT_TRUE(fs::create_directories(new_dir).ok());
+
+    ASSERT_TRUE(DataCacheUtils::change_disk_path(old_dir, new_dir).ok());
+
+    fs::remove_all(old_dir);
+    fs::remove_all(new_dir);
+}
+
+TEST_F(DataCacheUtilsTest, change_cache_path_fail) {
+    const std::string old_dir = "./old_disk_cache_path2";
+    const std::string new_dir = "./old_disk_cache_path2/subdir";
+    ASSERT_TRUE(fs::create_directories(old_dir).ok());
+    ASSERT_TRUE(fs::create_directories(new_dir).ok());
+
+    ASSERT_FALSE(DataCacheUtils::change_disk_path(old_dir, new_dir).ok());
+
+    fs::remove_all(old_dir);
+}
+
 } // namespace starrocks

--- a/be/test/block_cache/disk_space_monitor_test.cpp
+++ b/be/test/block_cache/disk_space_monitor_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021-present StarRocks, Inc. All rights reserved.
+// Copyright 2020-present StarRocks, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,9 @@ TEST_F(DiskSpaceMonitorTest, adjust_for_empty_cache_dir) {
 TEST_F(DiskSpaceMonitorTest, adjust_for_dirty_cache_dir) {
     SCOPED_UPDATE(bool, config::datacache_auto_adjust_enable, true);
     SCOPED_UPDATE(int64_t, config::datacache_min_disk_quota_for_adjustment, 0);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_high_level, 80);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
     auto space_monitor = std::make_unique<DiskSpaceMonitor>(nullptr);
     MockFileSystem* mock_fs = new MockFileSystem;
@@ -155,6 +158,9 @@ TEST_F(DiskSpaceMonitorTest, auto_increase_cache_quota) {
     SCOPED_UPDATE(int64_t, config::datacache_min_disk_quota_for_adjustment, 0);
     SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 1);
     SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_high_level, 80);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
     auto options = create_simple_options(kBlockSize, 5 * MB, 20 * MB);
     auto cache = create_cache(options);
@@ -213,6 +219,9 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
     SCOPED_UPDATE(int64_t, config::datacache_min_disk_quota_for_adjustment, 0);
     SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 3);
     SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_high_level, 80);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
 
     auto options = create_simple_options(kBlockSize, 0, 50 * MB);
     auto cache = create_cache(options);
@@ -261,6 +270,71 @@ TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota) {
         // other: 100M - 10M - 50M = 40M
         // new quota: 100 * 0.7 - other = 30M
         ASSERT_EQ(new_quota, 30 * MB);
+    }
+
+    cache->shutdown();
+}
+
+TEST_F(DiskSpaceMonitorTest, auto_decrease_cache_quota_to_zero) {
+    SCOPED_UPDATE(bool, config::datacache_enable, true);
+    SCOPED_UPDATE(bool, config::datacache_auto_adjust_enable, false);
+    SCOPED_UPDATE(int64_t, config::datacache_min_disk_quota_for_adjustment, 40 * MB);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_adjust_interval_seconds, 2);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_idle_seconds_for_expansion, 300);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_high_level, 80);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_safe_level, 70);
+    SCOPED_UPDATE(int64_t, config::datacache_disk_low_level, 60);
+
+    auto options = create_simple_options(kBlockSize, 0, 50 * MB);
+    auto cache = create_cache(options);
+
+    MockFileSystem* mock_fs = new MockFileSystem;
+    SpaceInfo space_info = {.capacity = 100 * MB, .free = 20 * MB, .available = 10 * MB};
+    mock_fs->set_space(1, ".", space_info);
+
+    auto& space_monitor = cache->_disk_space_monitor;
+    space_monitor->_fs.reset(mock_fs);
+    auto disk_spaces = options.disk_spaces;
+    space_monitor->adjust_spaces(&disk_spaces);
+
+    // Fill cache data
+    {
+        size_t batch_size = MB;
+        const std::string cache_key = "test_file";
+        for (size_t i = 0; i < 50; ++i) {
+            char ch = 'a' + i % 26;
+            std::string value(batch_size, ch);
+            Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+            ASSERT_TRUE(st.ok());
+        }
+        auto metrics = cache->cache_metrics();
+        int64_t used_rate = metrics.disk_used_bytes * 100 / metrics.disk_quota_bytes;
+        ASSERT_GT(used_rate, DiskSpaceMonitor::AUTO_INCREASE_THRESHOLD);
+    }
+
+    {
+        auto metrics = cache->cache_metrics();
+        ASSERT_EQ(metrics.disk_quota_bytes, 50 * MB);
+    }
+
+    {
+        config::datacache_auto_adjust_enable = true;
+        size_t new_quota = 0;
+        for (int i = 0; i < 6; ++i) {
+            auto metrics = cache->cache_metrics();
+            if (metrics.disk_quota_bytes > 0 && metrics.disk_quota_bytes != 50 * MB) {
+                config::datacache_auto_adjust_enable = false;
+                new_quota = metrics.disk_quota_bytes;
+                break;
+            }
+            sleep(1);
+        }
+        // other: 100M - 10M - 50M = 40M
+        // new quota: 100 * 0.7 - other = 30M < 40M = 0
+        ASSERT_EQ(new_quota, 0);
+        sleep(3);
+        // Adjust to zero again
+        ASSERT_EQ(new_quota, 0);
     }
 
     cache->shutdown();

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/update_config_action.h"
+
+#include <gtest/gtest.h>
+
+#include "block_cache/block_cache.h"
+#include "fs/fs_util.h"
+#include "runtime/exec_env.h"
+#include "testutil/scoped_updater.h"
+
+namespace starrocks {
+
+class UpdateConfigActionTest : public testing::Test {
+public:
+    UpdateConfigActionTest() = default;
+    ~UpdateConfigActionTest() override = default;
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(UpdateConfigActionTest, update_datacache_disk_size) {
+    SCOPED_UPDATE(bool, config::datacache_auto_adjust_enable, false);
+    const std::string cache_dir = "./block_cache_for_update_config";
+    ASSERT_TRUE(fs::create_directories(cache_dir).ok());
+
+    auto cache = BlockCache::instance();
+    CacheOptions options;
+    options.mem_space_size = 0;
+    options.disk_spaces.push_back({.path = cache_dir, .size = 50 * 1024 * 1024});
+    options.max_concurrent_inserts = 100000;
+    options.block_size = 256 * 1024;
+    options.enable_checksum = false;
+    options.engine = "starcache";
+    Status st = BlockCache::instance()->init(options);
+    ASSERT_TRUE(st.ok());
+
+    UpdateConfigAction action(ExecEnv::GetInstance());
+
+    st = action.update_config("datacache_disk_size", "-200");
+    ASSERT_TRUE(!st.ok());
+
+    st = action.update_config("datacache_disk_size", "100000000");
+    ASSERT_TRUE(st.ok());
+
+    std::vector<DirSpace> spaces;
+    cache->disk_spaces(&spaces);
+    ASSERT_EQ(spaces.size(), 1);
+    ASSERT_EQ(spaces[0].size, 100000000);
+
+    fs::remove_all(cache_dir).ok();
+}
+
+} // namespace starrocks

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -74,8 +74,11 @@ public:
         }
     }
 
-    void SetUp() override {}
-    void TearDown() override {}
+    void SetUp() override {
+        _saved_enable_auto_adjust = config::datacache_auto_adjust_enable;
+        config::datacache_auto_adjust_enable = false;
+    }
+    void TearDown() override { config::datacache_auto_adjust_enable = _saved_enable_auto_adjust; }
 
     static void read_stream_data(io::SeekableInputStream* stream, int64_t offset, int64_t size, char* data) {
         ASSERT_OK(stream->seek(offset));
@@ -101,6 +104,9 @@ public:
     }
 
     static const int64_t block_size;
+
+private:
+    bool _saved_enable_auto_adjust = false;
 };
 
 const int64_t CacheInputStreamTest::block_size = 256 * 1024;


### PR DESCRIPTION
## Why I'm doing:
The current DLA and cloud native datacache are both built on the underlying starcache library, but they are two different instances. This leads to:
1. Increased user configuration complexity, requiring users to reserve hardware resources such as disks for two caches and configure them separately. Configure the parameters of two cache instances in order to use them properly.
2. Low resource utilization rate. The inability to achieve global unified scheduling of resources such as disks can easily lead to resource waste.
3. Redundant external configuration and indicator items.
4. There are many redundant development logics.

## What I'm doing:
* Unified cache instance between DLA and cloud native datacache, including the cache instance, configurations and metrics, etc.
* Support slru cache eviction policy.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/52940


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
