### PR TITLE
[Refactor] Refactor PartitionBasedMvRefreshProcessor for better logging

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/StarRocksLoggerFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/StarRocksLoggerFactory.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.common;
+
+import com.google.common.base.Strings;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+
+/**
+ * A logger factory that adds a prefix to all log messages.
+ */
+public class StarRocksLoggerFactory {
+    private final String prefix;
+
+    public StarRocksLoggerFactory(String prefix) {
+        this.prefix = prefix == null ? "" : prefix;
+    }
+
+    public StarRocksLoggerFactory() {
+        this("");
+    }
+
+    public Logger getLogger(Class<?> clazz) {
+        if (Strings.isNullOrEmpty(prefix)) {
+            return LogManager.getLogger(clazz);
+        } else {
+            return LogManager.getLogger(clazz, new PrefixedMessageFactory(prefix));
+        }
+    }
+
+    public class PrefixedMessageFactory implements MessageFactory {
+        private final String prefix;
+
+        public PrefixedMessageFactory(String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public Message newMessage(String message, Object... params) {
+            return new ParameterizedMessage("[" + prefix + "] " + message, params);
+        }
+
+        @Override
+        public Message newMessage(String message) {
+            return new ParameterizedMessage("[" + prefix + "] " + message);
+        }
+
+        @Override
+        public Message newMessage(Object message) {
+            return new ParameterizedMessage("[" + prefix + "] " + message.toString());
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -104,6 +104,8 @@ public class MVMetaVersionRepairer {
         long maxChangedTableRefreshTime =
                 MvUtils.getMaxTablePartitionInfoRefreshTime(Lists.newArrayList(changedVersions));
         MVVersionManager.updateEditLogAfterVersionMetaChanged(mv, maxChangedTableRefreshTime);
+        LOG.info("Update edit log after version changed for mv {}, maxChangedTableRefreshTime:{}",
+                mv.getName(), maxChangedTableRefreshTime);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/BaseTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/BaseTaskRunProcessor.java
@@ -24,6 +24,11 @@ import org.apache.commons.lang3.StringUtils;
 
 public abstract class BaseTaskRunProcessor implements TaskRunProcessor {
     @Override
+    public void prepare(TaskRunContext context) throws Exception {
+        // do nothing
+    }
+
+    @Override
     public void processTaskRun(TaskRunContext context) throws Exception {
         throw new NotImplementedException("Method processTaskRun need to implement");
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -90,7 +90,6 @@ import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
@@ -108,14 +107,11 @@ import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.scheduler.TaskRun.MV_ID;
 
 /**
- * Core logic of materialized view refresh task run
+ * Core logic of mv refresh task run
  * PartitionBasedMvRefreshProcessor is not thread safe for concurrent runs of the same materialized view
  */
 public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
-
-    private static final Logger LOG = LogManager.getLogger(PartitionBasedMvRefreshProcessor.class);
     private static final AtomicLong STMT_ID_GENERATOR = new AtomicLong(0);
-
     // session.enable_spill
     private static final String MV_SESSION_ENABLE_SPILL =
             PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX + SessionVariable.ENABLE_SPILL;
@@ -127,10 +123,11 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX + SessionVariable.INSERT_TIMEOUT;
 
     private Database db;
-    private MaterializedView materializedView;
+    private MaterializedView mv;
+    private Logger logger;
     private MvTaskRunContext mvContext;
 
-    // Collect all bases tables of the materialized view to be updated meta after mv refresh success.
+    // Collect all bases tables of the mv to be updated meta after mv refresh success.
     // format :     table id -> <base table info, snapshot table>
     private Map<Long, TableSnapshotInfo> snapshotBaseTables = Maps.newHashMap();
 
@@ -151,6 +148,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private TaskRun nextTaskRun = null;
 
     public PartitionBasedMvRefreshProcessor() {
+        // to avoid NPE in some test cases
+        this.logger = MVTraceUtils.getLogger(null, PartitionBasedMvRefreshProcessor.class);
     }
 
     @VisibleForTesting
@@ -175,7 +174,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     // Core logics:
     // 1. prepare to check some conditions
     // 2. sync partitions with base tables(add or drop partitions, which will be optimized  by dynamic partition creation later)
-    // 3. decide which partitions of materialized view to refresh and the corresponding base tables' source partitions
+    // 3. decide which partitions of mv to refresh and the corresponding base tables' source partitions
     // 4. construct the refresh sql and execute it
     // 5. update the source table version map if refresh task completes successfully
     @Override
@@ -201,8 +200,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             // do refresh
             try (Timer ignored = Tracers.watchScope("MVRefreshDoWholeRefresh")) {
                 // refresh mv
-                Preconditions.checkState(materializedView != null);
-                mvEntity = MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(materializedView.getMvId());
+                Preconditions.checkState(mv != null);
+                mvEntity = MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
                 RefreshJobStatus status = doMvRefresh(context, mvEntity);
                 // update metrics
                 mvEntity.increaseRefreshJobStatus(status);
@@ -223,7 +222,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 runtimeProfile = new RuntimeProfile();
                 Tracers.toRuntimeProfile(runtimeProfile);
             }
-            LOG.info("Refresh mv {} trace logs: {}", materializedView.getName(), Tracers.getTrace(mvRefreshTraceMode));
+            if (logger.isDebugEnabled()) {
+                logger.debug("refresh mv trace logs: {}", Tracers.getTrace(mvRefreshTraceMode));
+            }
             Tracers.close();
             postProcess();
         }
@@ -237,7 +238,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                            Map<TableSnapshotInfo, Set<String>> baseTableCandidatePartitions)
             throws AnalysisException, LockTimeoutException {
         // collect partition infos of ref base tables
-        LOG.debug("Start to sync and check partitions for mv: {}", materializedView.getName());
         int retryNum = 0;
         boolean checked = false;
         Stopwatch stopwatch = Stopwatch.createStarted();
@@ -250,10 +250,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
             if (!Config.enable_materialized_view_external_table_precise_refresh) {
                 try (Timer ignored = Tracers.watchScope("MVRefreshSyncPartitions")) {
-                    // sync partitions between materialized view and base tables out of lock
+                    // sync partitions between mv and base tables out of lock
                     // do it outside lock because it is a time-cost operation
                     if (!syncPartitions()) {
-                        LOG.warn("Sync partitions failed for materialized view: {}", materializedView.getName());
+                        logger.warn("Sync partitions failed.");
                         return false;
                     }
                 }
@@ -262,9 +262,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             try (Timer ignored = Tracers.watchScope("MVRefreshCheckBaseTableChange")) {
                 // check whether there are partition changes for base tables, eg: partition rename
                 // retry to sync partitions if any base table changed the partition infos
-                if (checkBaseTablePartitionChange(materializedView)) {
-                    LOG.info("materialized view:{} base partition has changed. retry to sync partitions, retryNum:{}",
-                            materializedView.getName(), retryNum);
+                if (checkBaseTablePartitionChange(mv)) {
+                    logger.info("materialized view base partition has changed. retry to sync partitions, retryNum:{}", retryNum);
                     // sleep 100ms
                     Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
                     continue;
@@ -273,9 +272,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             checked = true;
         }
         Tracers.record("MVRefreshSyncPartitionsRetryTimes", String.valueOf(retryNum));
-
-        LOG.info("Sync and check materialized view {} partition changing after {} times: {}, costs: {} ms",
-                materializedView.getName(), retryNum, checked, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        logger.info("sync and check mv partition changing after {} times: {}, costs: {} ms",
+                retryNum, checked, stopwatch.elapsed(TimeUnit.MILLISECONDS));
         return checked;
     }
 
@@ -288,10 +286,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             throws AnalysisException, LockTimeoutException {
         Set<String> mvToRefreshedPartitions = null;
         Locker locker = new Locker();
-        if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), materializedView.getId(),
+        if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(),
                 LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
-            LOG.warn("Failed to lock database: {} in checkMvToRefreshedPartitions for mv refresh {}", db.getFullName(),
-                    materializedView.getName());
+            logger.warn("failed to lock database: {} in checkMvToRefreshedPartitions", db.getFullName());
             throw new LockTimeoutException("Failed to lock database: " + db.getFullName());
         }
         try {
@@ -299,21 +296,20 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             mvToRefreshedPartitions = getPartitionsToRefreshForMaterializedView(
                     context.getProperties(), mvPotentialPartitionNames, tentative);
             if (mvToRefreshedPartitions.isEmpty()) {
-                LOG.info("no partitions to refresh for materialized view {}", materializedView.getName());
+                logger.info("no partitions to refresh for materialized view");
                 return mvToRefreshedPartitions;
             }
 
             // Only refresh the first partition refresh number partitions, other partitions will generate new tasks
-            filterPartitionByRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, materializedView,
+            filterPartitionByRefreshNumber(mvToRefreshedPartitions, mvPotentialPartitionNames, mv,
                     tentative);
-            int partitionRefreshNumber = materializedView.getTableProperty().getPartitionRefreshNumber();
-            LOG.info("Filter partitions to refresh for materialized view {}, partitionRefreshNumber={}, " +
-                            "partitionsToRefresh:{}, mvPotentialPartitionNames:{}, next start:{}, next end:{}, " +
-                            "next list values:{}",
-                    materializedView.getName(), partitionRefreshNumber, mvToRefreshedPartitions, mvPotentialPartitionNames,
+            int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
+            logger.info("filter partitions to refresh partitionRefreshNumber={}, partitionsToRefresh:{}, " +
+                            "mvPotentialPartitionNames:{}, next start:{}, next end:{}, next list values:{}",
+                    partitionRefreshNumber, mvToRefreshedPartitions, mvPotentialPartitionNames,
                     mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), mvContext.getNextPartitionValues());
         } finally {
-            locker.unLockTableWithIntensiveDbLock(db.getId(), materializedView.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.READ);
         }
         return mvToRefreshedPartitions;
     }
@@ -323,14 +319,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         // log mv basic info, it may throw exception if mv is invalid since base table has dropped
         try {
-            LOG.debug("Start to refresh mv:{}, refBaseTablePartitionExprMap:{}," +
-                            "refBaseTablePartitionSlotMap:{}, refBaseTablePartitionColumnMap:{}," +
-                            "baseTableInfos:{}", materializedView.getName(),
-                    materializedView.getRefBaseTablePartitionExprs(), materializedView.getRefBaseTablePartitionSlots(),
-                    materializedView.getRefBaseTablePartitionColumns(),
-                    MvUtils.formatBaseTableInfos(materializedView.getBaseTableInfos()));
+            logger.debug("refBaseTablePartitionExprMap:{},refBaseTablePartitionSlotMap:{}, " +
+                            "refBaseTablePartitionColumnMap:{},baseTableInfos:{}",
+                    mv.getRefBaseTablePartitionExprs(), mv.getRefBaseTablePartitionSlots(),
+                    mv.getRefBaseTablePartitionColumns(), MvUtils.formatBaseTableInfos(mv.getBaseTableInfos()));
         } catch (Throwable e) {
-            LOG.warn("Log mv basic info failed:", e);
+            logger.warn("Log mv basic info failed:", e);
         }
 
         // refresh materialized view
@@ -342,8 +336,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
 
         long refreshDurationMs = System.currentTimeMillis() - startRefreshTs;
-        LOG.info("Refresh {} success, cost time(ms): {}", materializedView.getName(),
-                DebugUtil.DECIMAL_FORMAT_SCALE_3.format(refreshDurationMs));
+        logger.info("refresh mv success, cost time(ms): {}", DebugUtil.DECIMAL_FORMAT_SCALE_3.format(refreshDurationMs));
         mvEntity.updateRefreshDuration(refreshDurationMs);
         return result;
     }
@@ -364,8 +357,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                                                 IMaterializedViewMetricsEntity mvEntity) throws DmlException {
         // Use current connection variables instead of mvContext's session variables to be better debug.
         int maxRefreshMaterializedViewRetryNum = getMaxRefreshMaterializedViewRetryNum(taskRunContext.getCtx());
-        LOG.info("Start to refresh mv:{} with retry times:{}",
-                materializedView.getName(), maxRefreshMaterializedViewRetryNum);
+        logger.info("start to refresh mv with retry times:{}", maxRefreshMaterializedViewRetryNum);
 
         Throwable lastException = null;
         int lockFailedTimes = 0;
@@ -379,13 +371,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             } catch (LockTimeoutException e) {
                 // if lock timeout, retry to refresh
                 lockFailedTimes += 1;
-                LOG.warn("Refresh materialized view {} failed at {}th time because try lock failed: {}",
-                        this.materializedView.getName(), lockFailedTimes, DebugUtil.getStackTrace(e));
+                logger.warn("refresh mv failed at {}th time because try lock failed: {}",
+                        lockFailedTimes, DebugUtil.getStackTrace(e));
                 lastException = e;
             } catch (Throwable e) {
                 refreshFailedTimes += 1;
-                LOG.warn("Refresh materialized view {} failed at {}th time: {}",
-                        this.materializedView.getName(), refreshFailedTimes, DebugUtil.getRootStackTrace(e));
+                logger.warn("refresh mv failed at {}th time: {}", refreshFailedTimes, DebugUtil.getRootStackTrace(e));
                 lastException = e;
             }
 
@@ -395,8 +386,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         // throw the last exception if all retries failed
         String errorMsg = MvUtils.shrinkToSize(DebugUtil.getRootStackTrace(lastException), MAX_FIELD_VARCHAR_LENGTH);
-        throw new DmlException("Refresh materialized view %s failed after retrying %s times(try-lock %s times), error-msg : " +
-                "%s", lastException, this.materializedView.getName(), refreshFailedTimes, lockFailedTimes, errorMsg);
+        throw new DmlException("Refresh mv %s failed after %s/%s times, error-msg : " +
+                "%s", lastException, mv.getName(), refreshFailedTimes, lockFailedTimes, errorMsg);
     }
 
     private static int getMaxRefreshMaterializedViewRetryNum(ConnectContext currConnectCtx) {
@@ -422,13 +413,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             try (Timer ignored = Tracers.watchScope("MVRefreshComputeCandidatePartitions")) {
                 if (!syncPartitions()) {
                     throw new DmlException(String.format("materialized view %s refresh task failed: sync partition failed",
-                            materializedView.getName()));
+                            mv.getName()));
                 }
                 Set<String> mvCandidatePartition = checkMvToRefreshedPartitions(context, true);
                 baseTableCandidatePartitions = getRefTableRefreshPartitions(mvCandidatePartition);
             } catch (Exception e) {
-                LOG.warn("Failed to compute candidate partitions for materialized view {} in sync partitions",
-                        materializedView.getName(), DebugUtil.getRootStackTrace(e));
+                logger.warn("failed to compute candidate partitions in sync partitions", DebugUtil.getRootStackTrace(e));
                 // Since at here we sync partitions before the refreshExternalTable, the situation may happen that
                 // the base-table not exists before refreshExternalTable, so we just need to swallow this exception
                 if (e.getMessage() == null || !e.getMessage().contains("not exist")) {
@@ -441,7 +431,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         try (Timer ignored = Tracers.watchScope("MVRefreshSyncAndCheckPartitions")) {
             if (!syncAndCheckPartitions(context, mvEntity, baseTableCandidatePartitions)) {
                 throw new DmlException(String.format("materialized view %s refresh task failed: sync partition failed",
-                        materializedView.getName()));
+                        mv.getName()));
             }
         }
 
@@ -453,14 +443,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             if (CollectionUtils.isEmpty(mvToRefreshedPartitions)) {
                 return RefreshJobStatus.EMPTY;
             }
-            // ref table of materialized view : refreshed partition names
+            // ref table of mv : refreshed partition names
             refTableRefreshPartitions = getRefTableRefreshPartitions(mvToRefreshedPartitions);
-            // ref table of materialized view : refreshed partition names
+            // ref table of mv : refreshed partition names
             refTablePartitionNames = refTableRefreshPartitions.entrySet().stream()
                     .collect(Collectors.toMap(x -> x.getKey().getName(), Map.Entry::getValue));
-            LOG.info("Check mv {} to refresh partitions: mvToRefreshedPartitions:{}, " +
-                            "refTableRefreshPartitions:{}",
-                    materializedView.getName(), mvToRefreshedPartitions, refTableRefreshPartitions);
+            logger.info("mvToRefreshedPartitions:{}, refTableRefreshPartitions:{}",
+                    mvToRefreshedPartitions, refTableRefreshPartitions);
             // add a message into information_schema
             logMvToRefreshInfoIntoTaskRun(mvToRefreshedPartitions, refTablePartitionNames);
             updateBaseTablePartitionSnapshotInfos(refTableRefreshPartitions);
@@ -475,7 +464,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             refreshMaterializedView(mvContext, mvContext.getExecPlan(), insertStmt);
         }
 
-        ///// 3. insert execute successfully, update the meta of materialized view according to ExecPlan
+        ///// 3. insert execute successfully, update the meta of mv according to ExecPlan
         try (Timer ignored = Tracers.watchScope("MVRefreshUpdateMeta")) {
             updateMeta(mvToRefreshedPartitions, mvContext.getExecPlan(), refTableRefreshPartitions);
         }
@@ -505,7 +494,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         // 3. AST
         InsertStmt insertStmt = null;
         try (Timer ignored = Tracers.watchScope("MVRefreshParser")) {
-            insertStmt = generateInsertAst(mvToRefreshedPartitions, materializedView, ctx);
+            insertStmt = generateInsertAst(mvToRefreshedPartitions, mv, ctx);
         }
 
         PlannerMetaLocker locker = new PlannerMetaLocker(ctx, insertStmt);
@@ -514,7 +503,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             throw new LockTimeoutException("Failed to lock database in prepareRefreshPlan");
         }
 
-        MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(materializedView, mvContext, mvRefreshPartitioner);
+        MVPCTRefreshPlanBuilder planBuilder = new MVPCTRefreshPlanBuilder(mv, mvContext, mvRefreshPartitioner);
         try {
             // 4. Analyze and prepare a partition & Rebuild insert statement by
             // considering to-refresh partitions of ref tables/ mv
@@ -538,28 +527,22 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 return;
             }
             Map<String, String> planBuildMessage = planBuilder.getPlanBuilderMessage();
-            LOG.info("MV Refresh PlanBuilderMessage: {}", planBuildMessage);
+            logger.info("MV Refresh PlanBuilderMessage: {}", planBuildMessage);
             message.setPlanBuilderMessage(planBuildMessage);
         });
 
         QueryDebugOptions debugOptions = ctx.getSessionVariable().getQueryDebugOptions();
         // log the final mv refresh plan for each refresh for better trace and debug
-        if (LOG.isDebugEnabled() || debugOptions.isEnableQueryTraceLog()) {
-            LOG.info("MV Refresh Final Plan" +
-                            "\nMV: {}" +
-                            "\nMV PartitionsToRefresh: {}" +
-                            "\nBase PartitionsToScan: {}" +
-                            "\nInsert Plan:\n{}",
-                    materializedView.getName(),
+        if (logger.isDebugEnabled() || debugOptions.isEnableQueryTraceLog()) {
+            logger.info("MV Refresh Final Plan\nMV PartitionsToRefresh: {}\nBase PartitionsToScan: {}\n" +
+                            "Insert Plan:\n{}",
                     String.join(",", mvToRefreshedPartitions), refTablePartitionNames,
                     execPlan != null ? execPlan.getExplainString(StatementBase.ExplainLevel.VERBOSE) : "");
         } else {
-            LOG.info("MV Refresh Final Plan, mv: {}, MV PartitionsToRefresh: {}, Base PartitionsToScan: {}",
-                    materializedView.getName(), String.join(",", mvToRefreshedPartitions), refTablePartitionNames);
+            logger.info("MV Refresh Final Plan, MV PartitionsToRefresh: {}, Base PartitionsToScan: {}",
+                    String.join(",", mvToRefreshedPartitions), refTablePartitionNames);
         }
         mvContext.setExecPlan(execPlan);
-        LOG.info("Finished mv refresh plan for {}, costs:{}(ms)",
-                materializedView.getName(), System.currentTimeMillis() - startTime);
         return insertStmt;
     }
 
@@ -572,7 +555,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      */
     private void changeDefaultConnectContextIfNeeded(ConnectContext mvConnectCtx) {
         // add resource group if resource group is enabled
-        TableProperty mvProperty = materializedView.getTableProperty();
+        TableProperty mvProperty = mv.getTableProperty();
         SessionVariable mvSessionVariable = mvConnectCtx.getSessionVariable();
         if (mvSessionVariable.isEnableResourceGroup()) {
             String rg = ResourceGroup.DEFAULT_MV_RESOURCE_GROUP_NAME;
@@ -623,13 +606,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             mvSessionVariable.setNestedMvRewriteMaxLevel(1);
         }
         // always exclude the current mv name from rewrite
-        mvSessionVariable.setQueryExcludingMVNames(materializedView.getName());
+        mvSessionVariable.setQueryExcludingMVNames(mv.getName());
         mvConnectCtx.setUseConnectorMetadataCache(Optional.of(true));
     }
 
     private boolean isMVPropertyContains(String key) {
         String mvKey = PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX + key;
-        return materializedView.getTableProperty().getProperties().containsKey(mvKey);
+        return mv.getTableProperty().getProperties().containsKey(mvKey);
     }
 
     private void postProcess() {
@@ -642,7 +625,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private boolean isEnableMVRefreshQueryRewrite(ConnectContext ctx,
                                                   Set<Table> baseTables) {
         Set<MaterializedView> relatedMvs = MvUtils.getRelatedMvs(ctx, 1, baseTables);
-        LOG.info("Refresh mv {} with related mvs: {}", materializedView.getName(), relatedMvs);
+        logger.info("refresh mv with related mvs: {}", relatedMvs);
         // only enable mv rewrite when there are more than one related mvs
         return relatedMvs.size() > 1;
     }
@@ -657,24 +640,24 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     @VisibleForTesting
     public void filterPartitionByRefreshNumber(Set<String> partitionsToRefresh,
                                                Set<String> mvPotentialPartitionNames,
-                                               MaterializedView materializedView) {
-        filterPartitionByRefreshNumber(partitionsToRefresh, mvPotentialPartitionNames, materializedView, false);
+                                               MaterializedView mv) {
+        filterPartitionByRefreshNumber(partitionsToRefresh, mvPotentialPartitionNames, mv, false);
     }
 
     public void filterPartitionByRefreshNumber(Set<String> partitionsToRefresh,
                                                Set<String> mvPotentialPartitionNames,
-                                               MaterializedView materializedView,
+                                               MaterializedView mv,
                                                boolean tentative) {
         // refresh all partition when it's a sync refresh, otherwise updated partitions may be lost.
         if (mvContext.executeOption != null && mvContext.executeOption.getIsSync()) {
             return;
         }
         // ignore if mv is not partitioned.
-        if (!materializedView.isPartitionedTable()) {
+        if (!mv.isPartitionedTable()) {
             return;
         }
         // ignore if partition_fresh_limit is not set
-        int partitionRefreshNumber = materializedView.getTableProperty().getPartitionRefreshNumber();
+        int partitionRefreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
         if (partitionRefreshNumber <= 0) {
             return;
         }
@@ -694,7 +677,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 newProperties.put(proEntry.getKey(), proEntry.getValue());
             }
         }
-        PartitionInfo partitionInfo = materializedView.getPartitionInfo();
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (partitionInfo.isListPartition()) {
             //TODO: partition values may be too long, need to be optimized later.
             newProperties.put(TaskRun.PARTITION_VALUES, mvContext.getNextPartitionValues());
@@ -721,8 +704,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         int priority = mvContext.executeOption.getPriority() > Constants.TaskRunPriority.LOWEST.value() ?
                 mvContext.executeOption.getPriority() : Constants.TaskRunPriority.HIGHER.value();
         ExecuteOption option = new ExecuteOption(priority, true, newProperties);
-        LOG.info("[MV] Generate a task to refresh next batches of partitions for MV {}-{}, start={}, end={}, " +
-                        "priority={}", materializedView.getName(), materializedView.getId(),
+        logger.info("[MV] Generate a task to refresh next batches of partitions for MV {}-{}, start={}, end={}, " +
+                        "priority={}", mv.getName(), mv.getId(),
                 mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), priority);
 
         if (properties.containsKey(TaskRun.IS_TEST) && properties.get(TaskRun.IS_TEST).equalsIgnoreCase("true")) {
@@ -740,23 +723,21 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     private void refreshExternalTable(TaskRunContext context,
                                       Map<TableSnapshotInfo, Set<String>> baseTableCandidatePartitions) {
-        List<BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
+        List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
         // use it if refresh external table fails
         ConnectContext connectContext = context.getCtx();
         List<Pair<Table, BaseTableInfo>> toRepairTables = new ArrayList<>();
         for (BaseTableInfo baseTableInfo : baseTableInfos) {
             Optional<Database> dbOpt = GlobalStateMgr.getCurrentState().getMetadataMgr().getDatabase(baseTableInfo);
             if (dbOpt.isEmpty()) {
-                LOG.warn("database {} do not exist when refreshing materialized view:{}",
-                        baseTableInfo.getDbInfoStr(), materializedView.getName());
+                logger.warn("database {} do not exist in refreshing materialized view", baseTableInfo.getDbInfoStr());
                 throw new DmlException("database " + baseTableInfo.getDbInfoStr() + " do not exist.");
             }
 
             Optional<Table> optTable = MvUtils.getTable(baseTableInfo);
             if (optTable.isEmpty()) {
-                LOG.warn("table {} do not exist when refreshing materialized view:{}",
-                        baseTableInfo.getTableInfoStr(), materializedView.getName());
-                materializedView.setInactiveAndReason(
+                logger.warn("table {} do not exist when refreshing materialized view", baseTableInfo.getTableInfoStr());
+                mv.setInactiveAndReason(
                         MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(baseTableInfo.getTableName()));
                 throw new DmlException("Materialized view base table: %s not exist.", baseTableInfo.getTableInfoStr());
             }
@@ -764,7 +745,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             // refresh old table
             Table table = optTable.get();
             if (table.isNativeTableOrMaterializedView() || table.isConnectorView()) {
-                LOG.debug("No need to refresh table:{} because it is native table or materialized view or connector view",
+                logger.debug("No need to refresh table:{} because it is native table or mv or connector view",
                         baseTableInfo.getTableInfoStr());
                 continue;
             }
@@ -788,9 +769,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             // check new table
             Optional<Table> optNewTable = MvUtils.getTable(baseTableInfo);
             if (optNewTable.isEmpty()) {
-                LOG.warn("table {} does not exist after refreshing materialized view:{}",
-                        baseTableInfo.getTableInfoStr(), materializedView.getName());
-                materializedView.setInactiveAndReason(
+                logger.warn("table {} does not exist after refreshing materialized view", baseTableInfo.getTableInfoStr());
+                mv.setInactiveAndReason(
                         MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(baseTableInfo.getTableName()));
                 throw new DmlException("Materialized view base table: %s not exist.", baseTableInfo.getTableInfoStr());
             }
@@ -800,14 +780,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     && ((HiveTable) newTable).getHiveTableType() == HiveTable.HiveTableType.EXTERNAL_TABLE) {
                 toRepairTables.add(Pair.create(newTable, baseTableInfo));
             } else {
-                LOG.info("Table:{} is not an hive external table, no need to repair",
-                        baseTableInfo.getTableInfoStr());
+                logger.info("Table:{} is not an hive external table, no need to repair", baseTableInfo.getTableInfoStr());
             }
         }
 
         // do repair if needed
         if (!toRepairTables.isEmpty()) {
-            MVPCTMetaRepairer repairer = new MVPCTMetaRepairer(db, materializedView);
+            MVPCTMetaRepairer repairer = new MVPCTMetaRepairer(db, mv);
             for (Pair<Table, BaseTableInfo> pair : toRepairTables) {
                 repairer.repairTableIfNeeded(pair.first, pair.second);
             }
@@ -815,26 +794,22 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     }
 
     /**
-     * After materialized view is refreshed, update materialized view's meta info to record history refreshes.
+     * After mv is refreshed, update materialized view's meta info to record history refreshes.
      *
      * @param refTableAndPartitionNames : refreshed base table and its partition names mapping.
      */
     private void updateMeta(Set<String> mvRefreshedPartitions,
                             ExecPlan execPlan,
                             Map<TableSnapshotInfo, Set<String>> refTableAndPartitionNames) {
-        LOG.debug("Start to update meta for mv:{}", materializedView.getName());
-
         // check
-        Table mv = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), materializedView.getId());
+        Table mv = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), this.mv.getId());
         if (mv == null) {
-            throw new DmlException(
-                    "update meta failed. materialized view:" + materializedView.getName() + " not exist");
+            throw new DmlException("update meta failed. materialized view:" + this.mv.getName() + " not exist");
         }
         // check
         if (mvRefreshedPartitions == null || refTableAndPartitionNames == null) {
-            LOG.info("no partitions to refresh for materialized view {}, mvRefreshedPartitions:{}, " +
-                            "refTableAndPartitionNames:{}", materializedView.getName(), mvRefreshedPartitions,
-                    refTableAndPartitionNames);
+            logger.info("no partitions to refresh, mvRefreshedPartitions:{}, refTableAndPartitionNames:{}",
+                    mvRefreshedPartitions, refTableAndPartitionNames);
             return;
         }
 
@@ -845,22 +820,20 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         Locker locker = new Locker();
         // update the meta if succeed
-        if (!locker.lockDatabaseAndCheckExist(db, materializedView, LockType.WRITE)) {
-            LOG.warn("Failed to lock database: {} in updateMeta for mv refresh {}", db.getFullName(),
-                    materializedView.getName());
+        if (!locker.lockDatabaseAndCheckExist(db, this.mv, LockType.WRITE)) {
+            logger.warn("failed to lock database: {} in updateMeta for mv refresh", db.getFullName());
             throw new DmlException("update meta failed. database:" + db.getFullName() + " not exist");
         }
 
-
-        MVVersionManager mvVersionManager = new MVVersionManager(materializedView, mvContext);
+        MVVersionManager mvVersionManager = new MVVersionManager(this.mv, mvContext);
         try {
             mvVersionManager.updateMVVersionInfo(snapshotBaseTables, mvRefreshedPartitions,
                     refBaseTableIds, refTableAndPartitionNames);
         } catch (Exception e) {
-            LOG.warn("update final meta failed after mv refreshed:", DebugUtil.getRootStackTrace(e));
+            logger.warn("update final meta failed after mv refreshed:", DebugUtil.getRootStackTrace(e));
             throw e;
         } finally {
-            locker.unLockTableWithIntensiveDbLock(db.getId(), materializedView.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), this.mv.getId(), LockType.WRITE);
         }
 
         // update mv status message
@@ -868,11 +841,11 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             try {
                 MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
                 Map<String, Set<String>> baseTableRefreshedPartitionsByExecPlan =
-                        MVTraceUtils.getBaseTableRefreshedPartitionsByExecPlan(materializedView, execPlan);
+                        MVTraceUtils.getBaseTableRefreshedPartitionsByExecPlan(this.mv, execPlan);
                 extraMessage.setBasePartitionsToRefreshMap(baseTableRefreshedPartitionsByExecPlan);
             } catch (Exception e) {
                 // just log warn and no throw exceptions for an updating task runs message.
-                LOG.warn("update task run messages failed:", DebugUtil.getRootStackTrace(e));
+                logger.warn("update task run messages failed:", DebugUtil.getRootStackTrace(e));
             }
         });
     }
@@ -880,34 +853,28 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     @VisibleForTesting
     public void prepare(TaskRunContext context) {
         Map<String, String> properties = context.getProperties();
+        logger.info("prepare refresh mv, properties:{}", properties);
         // NOTE: mvId is set in Task's properties when creating
         long mvId = Long.parseLong(properties.get(MV_ID));
-        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(context.ctx.getDatabase());
         if (db == null) {
-            LOG.warn("database {} do not exist when refreshing materialized view:{}", context.ctx.getDatabase(), mvId);
             throw new DmlException("database " + context.ctx.getDatabase() + " do not exist.");
         }
-        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId);
-        if (table == null) {
-            LOG.warn("materialized view:{} in database:{} do not exist when refreshing", mvId,
-                    context.ctx.getDatabase());
+        if (mv == null) {
             throw new DmlException(String.format("materialized view:%s in database:%s do not exist when refreshing",
                     mvId, context.ctx.getDatabase()));
         }
-        materializedView = (MaterializedView) table;
-
         // try to activate the mv before refresh
-        if (!materializedView.isActive()) {
-            MVActiveChecker.tryToActivate(materializedView);
-            LOG.info("Activated the MV before refreshing: {}", materializedView.getName());
+        if (!mv.isActive()) {
+            MVActiveChecker.tryToActivate(mv);
+            logger.info("Activated the MV before refreshing: {}", mv.getName());
         }
 
         IMaterializedViewMetricsEntity mvEntity =
-                MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(materializedView.getMvId());
-        if (!materializedView.isActive()) {
+                MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
+        if (!mv.isActive()) {
             String errorMsg = String.format("Materialized view: %s/%d is not active due to %s.",
-                    materializedView.getName(), mvId, materializedView.getInactiveReason());
-            LOG.warn(errorMsg);
+                    mv.getName(), mvId, mv.getInactiveReason());
+            logger.warn(errorMsg);
             mvEntity.increaseRefreshJobStatus(RefreshJobStatus.FAILED);
             throw new DmlException(errorMsg);
         }
@@ -927,12 +894,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         // prepare mv context
         mvContext = new MvTaskRunContext(context);
         // prepare partition ttl number
-        int partitionTTLNumber = materializedView.getTableProperty().getPartitionTTLNumber();
+        int partitionTTLNumber = mv.getTableProperty().getPartitionTTLNumber();
         mvContext.setPartitionTTLNumber(partitionTTLNumber);
         // prepare mv refresh partitioner
-        this.mvRefreshPartitioner = buildMvRefreshPartitioner(materializedView, context);
+        this.mvRefreshPartitioner = buildMvRefreshPartitioner(mv, context);
 
-        LOG.info("finish prepare refresh of mv:{}, mv name:{}, jobId: {}", mvId, materializedView.getName(), jobId);
+        logger.info("finish prepare refresh mv:{}, jobId: {}", mvId, jobId);
     }
 
     /**
@@ -958,12 +925,11 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private boolean syncPartitions() throws AnalysisException, LockTimeoutException {
         Stopwatch stopwatch = Stopwatch.createStarted();
         // collect base table snapshot infos
-        snapshotBaseTables = collectBaseTableSnapshotInfos(materializedView);
+        snapshotBaseTables = collectBaseTableSnapshotInfos(mv);
 
         // do sync partitions (add or drop partitions) for materialized view
         boolean result = mvRefreshPartitioner.syncAddOrDropPartitions();
-        LOG.info("Finish sync {} partitions, cost: {}(ms)", materializedView.getName(),
-                stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        logger.info("finish sync partitions, cost(ms): {}", stopwatch.elapsed(TimeUnit.MILLISECONDS));
         return result;
     }
 
@@ -975,7 +941,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                                                  Set<String> mvPotentialPartitionNames,
                                                                  boolean tentative)
             throws AnalysisException {
-        PartitionInfo partitionInfo = materializedView.getPartitionInfo();
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
         MVRefreshParams mvRefreshParams = new MVRefreshParams(partitionInfo, properties, tentative);
         Set<String> needRefreshMvPartitionNames = getPartitionsToRefreshForMaterializedView(partitionInfo,
                 mvRefreshParams, mvPotentialPartitionNames);
@@ -1026,8 +992,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     /**
      * Build an AST for insert stmt
      */
-    private InsertStmt generateInsertAst(Set<String> materializedViewPartitions, MaterializedView materializedView,
-                                         ConnectContext ctx) {
+    private InsertStmt generateInsertAst(Set<String> materializedViewPartitions, MaterializedView mv, ConnectContext ctx) {
         String definition = mvContext.getDefinition();
         InsertStmt insertStmt =
                 (InsertStmt) SqlParser.parse(definition, ctx.getSessionVariable()).get(0);
@@ -1035,11 +1000,11 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         insertStmt.setTargetPartitionNames(new PartitionNames(false, new ArrayList<>(materializedViewPartitions)));
         // insert overwrite mv must set system = true
         insertStmt.setSystem(true);
-        // if materialized view has set sort keys, materialized view's output columns
+        // if mv has set sort keys, materialized view's output columns
         // may be different from the defined query's output.
         // so set materialized view's defined outputs as target columns.
-        List<Integer> queryOutputIndexes = materializedView.getQueryOutputIndices();
-        List<Column> baseSchema = materializedView.getBaseSchemaWithoutGeneratedColumn();
+        List<Integer> queryOutputIndexes = mv.getQueryOutputIndices();
+        List<Column> baseSchema = mv.getBaseSchemaWithoutGeneratedColumn();
         if (queryOutputIndexes != null && baseSchema.size() == queryOutputIndexes.size()) {
             List<String> targetColumnNames = queryOutputIndexes.stream()
                     .map(baseSchema::get)
@@ -1048,12 +1013,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     .collect(Collectors.toList());
             insertStmt.setTargetColumnNames(targetColumnNames);
         }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Generate refresh materialized view {} insert-overwrite statement, " +
-                            "materialized view's target partition names:{}, " +
-                            "materialized view's target columns: {}, " +
-                            "definition:{}",
-                    materializedView.getName(),
+        if (logger.isDebugEnabled()) {
+            logger.debug("generate insert-overwrite statement, materialized view's target partition names:{}, " +
+                            "mv's target columns: {}, definition:{}",
                     Joiner.on(",").join(materializedViewPartitions),
                     insertStmt.getTargetColumnNames() == null ? "" : Joiner.on(",").join(insertStmt.getTargetColumnNames()),
                     definition);
@@ -1098,13 +1060,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 if (snapshotTable.isUnPartitioned()) {
                     return false;
                 } else {
-                    PartitionInfo mvPartitionInfo = materializedView.getPartitionInfo();
+                    PartitionInfo mvPartitionInfo = mv.getPartitionInfo();
                     // TODO: Support list partition later.
                     // do not need to check base partition table changed when mv is not partitioned
                     if (!(mvPartitionInfo.isRangePartition())) {
                         return false;
                     }
-                    Map<Table, List<Column>> partitionTableAndColumns = materializedView.getRefBaseTablePartitionColumns();
+                    Map<Table, List<Column>> partitionTableAndColumns = mv.getRefBaseTablePartitionColumns();
                     // For Non-partition based base table, it's not necessary to check the partition changed.
                     if (!partitionTableAndColumns.containsKey(snapshotTable)) {
                         return false;
@@ -1113,7 +1075,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     Preconditions.checkArgument(partitionColumns.size() == 1,
                             "Only support one partition column in range partition");
                     Column partitionColumn = partitionColumns.get(0);
-                    Optional<Expr> rangePartitionExprOpt = materializedView.getRangePartitionFirstExpr();
+                    Optional<Expr> rangePartitionExprOpt = mv.getRangePartitionFirstExpr();
                     if (rangePartitionExprOpt.isEmpty()) {
                         return false;
                     }
@@ -1128,7 +1090,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 }
             }
         } catch (StarRocksException e) {
-            LOG.warn("Materialized view compute partition change failed", DebugUtil.getRootStackTrace(e));
+            logger.warn("Materialized view compute partition change failed", DebugUtil.getRootStackTrace(e));
             return true;
         }
         return false;
@@ -1140,13 +1102,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      *
      * @return: true if the base table's partition has changed, otherwise false.
      */
-    private boolean checkBaseTablePartitionChange(MaterializedView materializedView) throws LockTimeoutException {
-        LockParams lockParams = collectDatabases(materializedView);
+    private boolean checkBaseTablePartitionChange(MaterializedView mv) throws LockTimeoutException {
+        LockParams lockParams = collectDatabases(mv);
         Locker locker = new Locker();
         if (!locker.tryLockTableWithIntensiveDbLock(lockParams,
                 LockType.READ, Config.mv_refresh_try_lock_timeout_ms, TimeUnit.MILLISECONDS)) {
-            LOG.warn("Failed to lock database: {} in checkBaseTablePartitionChange for mv refresh: {}",
-                    lockParams, materializedView.getName());
+            logger.warn("failed to lock database: {} in checkBaseTablePartitionChange", lockParams);
             throw new LockTimeoutException("Failed to lock database: " + lockParams
                     + " in checkBaseTablePartitionChange");
         }
@@ -1166,8 +1127,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         ConnectContext ctx = mvContext.getCtx();
 
         if (mvContext.getTaskRun().isKilled()) {
-            LOG.warn("[QueryId:{}] refresh materialized view {} is killed", ctx.getQueryId(),
-                    materializedView.getName());
+            logger.warn("[QueryId:{}] refresh materialized view {} is killed", ctx.getQueryId(),
+                    mv.getName());
             throw new StarRocksException("User Cancelled");
         }
 
@@ -1178,15 +1139,14 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             parentStmtExecutor.registerSubStmtExecutor(executor);
         }
         ctx.setStmtId(STMT_ID_GENERATOR.incrementAndGet());
-        LOG.info("[QueryId:{}] start to refresh materialized view {}", ctx.getQueryId(), materializedView.getName());
+        logger.info("[QueryId:{}] start to refresh mv in DML", ctx.getQueryId());
         try {
             executor.handleDMLStmtWithProfile(execPlan, insertStmt);
         } catch (Exception e) {
-            LOG.warn("[QueryId:{}] refresh materialized view {} failed: {}", ctx.getQueryId(), materializedView.getName(), e);
+            logger.warn("[QueryId:{}] refresh mv {} failed in DML", ctx.getQueryId(), e);
             throw e;
         } finally {
-            LOG.info("[QueryId:{}] finished to refresh materialized view {}", ctx.getQueryId(),
-                    materializedView.getName());
+            logger.info("[QueryId:{}] finished to refresh mv in DML", ctx.getQueryId());
             auditAfterExec(mvContext, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
         }
     }
@@ -1194,17 +1154,16 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     /**
      * Collect all deduplicated databases of the materialized view's base tables.
      *
-     * @param materializedView: the materialized view to check
+     * @param mv: the mv to check
      * @return: the deduplicated databases of the materialized view's base tables,
      * throw exception if the database does not exist.
      */
-    private LockParams collectDatabases(MaterializedView materializedView) {
+    private LockParams collectDatabases(MaterializedView mv) {
         LockParams lockParams = new LockParams();
-        for (BaseTableInfo baseTableInfo : materializedView.getBaseTableInfos()) {
+        for (BaseTableInfo baseTableInfo : mv.getBaseTableInfos()) {
             Optional<Database> dbOpt = GlobalStateMgr.getCurrentState().getMetadataMgr().getDatabase(baseTableInfo);
             if (dbOpt.isEmpty()) {
-                LOG.warn("database {} do not exist when refreshing materialized view:{}",
-                        baseTableInfo.getDbInfoStr(), materializedView.getName());
+                logger.warn("database {} do not exist", baseTableInfo.getDbInfoStr());
                 throw new DmlException("database " + baseTableInfo.getDbInfoStr() + " do not exist.");
             }
             Database db = dbOpt.get();
@@ -1214,38 +1173,35 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     }
 
     /**
-     * Collect all base table snapshot infos for the materialized view which the snapshot infos are kept and used in the final
+     * Collect all base table snapshot infos for the mv which the snapshot infos are kept and used in the final
      * update meta phase.
      * </p>
      * NOTE:
      * 1. deep copy of the base table's metadata may be time costing, we can optimize it later.
      * 2. no needs to lock the base table's metadata since the metadata is not changed during the refresh process.
      *
-     * @param materializedView the materialized view to collect
+     * @param mv the mv to collect
      * @return the base table and its snapshot info map
      */
     @VisibleForTesting
-    public Map<Long, TableSnapshotInfo> collectBaseTableSnapshotInfos(MaterializedView materializedView)
+    public Map<Long, TableSnapshotInfo> collectBaseTableSnapshotInfos(MaterializedView mv)
             throws LockTimeoutException {
         Map<Long, TableSnapshotInfo> tables = Maps.newHashMap();
-        List<BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
+        List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
 
-        LockParams lockParams = collectDatabases(materializedView);
+        LockParams lockParams = collectDatabases(mv);
         Locker locker = new Locker();
         if (!locker.tryLockTableWithIntensiveDbLock(lockParams, LockType.READ, Config.mv_refresh_try_lock_timeout_ms,
                 TimeUnit.MILLISECONDS)) {
-            LOG.warn("Failed to lock database: {} in collectBaseTableSnapshotInfos for mv refresh: {}",
-                    lockParams, materializedView.getName());
-            throw new LockTimeoutException("Failed to lock database: " + lockParams
-                    + " in collectBaseTableSnapshotInfos");
+            logger.warn("failed to lock database: {} in collectBaseTableSnapshotInfos for mv refresh", lockParams);
+            throw new LockTimeoutException("Failed to lock database: " + lockParams + " in collectBaseTableSnapshotInfos");
         }
         Stopwatch stopwatch = Stopwatch.createStarted();
         try {
             for (BaseTableInfo baseTableInfo : baseTableInfos) {
                 Optional<Table> tableOpt = MvUtils.getTableWithIdentifier(baseTableInfo);
                 if (tableOpt.isEmpty()) {
-                    LOG.warn("table {} do not exist when refreshing materialized view:{}",
-                            baseTableInfo.getTableInfoStr(), materializedView.getName());
+                    logger.warn("table {} doesn't exist", baseTableInfo.getTableInfoStr());
                     throw new DmlException("Materialized view base table: %s not exist.",
                             baseTableInfo.getTableInfoStr());
                 }
@@ -1273,8 +1229,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         } finally {
             locker.unLockTableWithIntensiveDbLock(lockParams, LockType.READ);
         }
-        LOG.info("Collect base table snapshot infos for materialized view: {}, cost: {} ms",
-                materializedView.getName(), stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        logger.info("collect base table snapshot infos cost: {} ms", stopwatch.elapsed(TimeUnit.MILLISECONDS));
         return tables;
     }
 
@@ -1310,7 +1265,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     }
 
     /**
-     * @param mvToRefreshedPartitions :  to-refreshed materialized view partition names
+     * @param mvToRefreshedPartitions :  to-refreshed mv partition names
      * @return : return to-refreshed base table's table name and partition names mapping
      */
     @VisibleForTesting
@@ -1336,8 +1291,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     // It's ok to add empty set for a table, means no partition corresponding to this mv partition
                     needRefreshTablePartitionNames.addAll(mvToBaseNameRef.get(snapshotTable));
                 } else {
-                    LOG.info("MV {}'s refTable {} is not found in `mvRefBaseTableIntersectedPartitions` " +
-                            "because of empty update", materializedView.getName(), snapshotTable.getName());
+                    logger.info("ref-base-table {} is not found in `mvRefBaseTableIntersectedPartitions` " +
+                            "because of empty update", snapshotTable.getName());
                 }
             }
             if (needRefreshTablePartitionNames != null) {
@@ -1384,8 +1339,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 Partition partition = olapTable.getPartition(partitionName);
                 // it's ok to skip because only existed partitions are updated in the version map.
                 if (partition == null) {
-                    LOG.warn("Partition {} not found in base table {} in refreshing {}, refreshedPartitionNames:{}",
-                            partitionName, baseTable.getName(), materializedView.getName(), refreshedPartitionNames);
+                    logger.warn("partition {} not found in base table {}, refreshedPartitionNames:{}",
+                            partitionName, baseTable.getName(), refreshedPartitionNames);
                     continue;
                 }
                 MaterializedView.BasePartitionInfo basePartitionInfo = new MaterializedView.BasePartitionInfo(
@@ -1394,15 +1349,16 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                         partition.getDefaultPhysicalPartition().getVisibleVersionTime());
                 partitionInfos.put(partition.getName(), basePartitionInfo);
             }
-            LOG.debug("Collect olap base table {}'s refreshed partition infos: {}", baseTable.getName(), partitionInfos);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Collect olap base table {}'s refreshed partition infos: {}", baseTable.getName(), partitionInfos);
+            }
             return partitionInfos;
         } else if (ConnectorPartitionTraits.isSupportPCTRefresh(baseTable.getType())) {
             return getSelectedPartitionInfos(baseTable, Lists.newArrayList(refreshedPartitionNames), baseTableInfo);
         } else {
             // FIXME: base table does not support partition-level refresh and does not update the meta
             //  in materialized view.
-            LOG.warn("Refresh materialized view {} with non-supported-partition-level refresh base table {}",
-                    materializedView.getName(), baseTable.getName());
+            logger.warn("refresh mv with non-supported-partition-level refresh base table {}", baseTable.getName());
             return Maps.newHashMap();
         }
     }
@@ -1468,7 +1424,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     public void postTaskRun(TaskRunContext context) throws Exception {
         // recreate post run context for each task run
         final ConnectContext ctx = context.getCtx();
-        final String postRun = getPostRun(ctx, materializedView);
+        final String postRun = getPostRun(ctx, mv);
         // visible for tests
         if (mvContext != null) {
             mvContext.setPostRun(postRun);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -282,6 +282,9 @@ public class TaskRun implements Comparable<TaskRun> {
         taskRunContext.setExecuteOption(executeOption);
         taskRunContext.setTaskRun(this);
 
+        // prepare to execute task run, move it here so that we can catch the exception and set the status
+        processor.prepare(taskRunContext);
+        // process task run
         processor.processTaskRun(taskRunContext);
 
         QueryState queryState = runCtx.getState();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -36,6 +36,7 @@ public class TaskRunExecutor {
      */
     public boolean executeTaskRun(TaskRun taskRun) {
         if (taskRun == null) {
+            LOG.warn("TaskRun is null, avoid execute it again");
             return false;
         }
         TaskRunStatus status = taskRun.getStatus();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunProcessor.java
@@ -16,6 +16,12 @@
 package com.starrocks.scheduler;
 
 public interface TaskRunProcessor {
+    /**
+     * Before task run, prepare the context.
+     * @param context: task run context
+     */
+    void prepare(TaskRunContext context) throws Exception;
+
     void processTaskRun(TaskRunContext context) throws Exception;
 
     void postTaskRun(TaskRunContext context) throws Exception;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -54,7 +54,6 @@ import com.starrocks.sql.common.PartitionDiffResult;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
@@ -70,8 +69,8 @@ import java.util.stream.Collectors;
 import static com.starrocks.connector.iceberg.IcebergPartitionUtils.getIcebergTablePartitionPredicateExpr;
 
 public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
-    private static final Logger LOG = LogManager.getLogger(MVPCTRefreshListPartitioner.class);
     private final ListPartitionDiffer differ;
+    private final Logger logger;
 
     public MVPCTRefreshListPartitioner(MvTaskRunContext mvContext,
                                        TaskRunContext context,
@@ -79,6 +78,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
                                        MaterializedView mv) {
         super(mvContext, context, db, mv);
         this.differ = new ListPartitionDiffer(mv, false);
+        this.logger = MVTraceUtils.getLogger(mv, MVPCTRefreshListPartitioner.class);
     }
 
     @Override
@@ -93,7 +93,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         try {
             result = differ.computePartitionDiff(null);
             if (result == null) {
-                LOG.warn("compute list partition diff failed: mv: {}", mv.getName());
+                logger.warn("compute list partition diff failed, result is null");
                 return false;
             }
         } finally {
@@ -108,7 +108,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         for (String mvPartitionName : deletes.keySet()) {
             dropPartition(db, mv, mvPartitionName);
         }
-        LOG.info("The process of synchronizing materialized view [{}] delete partitions list [{}]",
+        logger.info("The process of synchronizing materialized view [{}] delete partitions list [{}]",
                 mv.getName(), deletes);
 
         // add partitions
@@ -119,7 +119,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         filterPartitionsByTTL(adds, true);
         // add partitions for mv
         addListPartitions(db, mv, adds, partitionProperties, distributionDesc);
-        LOG.info("The process of synchronizing materialized view [{}] add partitions list [{}]",
+        logger.info("The process of synchronizing materialized view [{}] add partitions list [{}]",
                 mv.getName(), adds);
 
         // add into mv context
@@ -148,7 +148,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         }
         Map<String, PCell> baseListPartitionMap = basePartitionMaps.get(refBaseTable);
         if (baseListPartitionMap == null) {
-            LOG.warn("Generate incremental partition predicate failed, " +
+            logger.warn("Generate incremental partition predicate failed, " +
                     "basePartitionMaps:{} contains no refBaseTable:{}", basePartitionMaps, refBaseTable);
             return null;
         }
@@ -159,14 +159,14 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         // base table's partition columns, not mv's partition columns
         Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
         if (refBaseTablePartitionColumns == null || !refBaseTablePartitionColumns.containsKey(refBaseTable)) {
-            LOG.warn("Generate incremental partition failed, partitionTableAndColumn {} contains no ref table {}",
+            logger.warn("Generate incremental partition failed, partitionTableAndColumn {} contains no ref table {}",
                     refBaseTablePartitionColumns, refBaseTable);
             return null;
         }
         // base table's partition columns that are referred by mv
         List<Column> refPartitionColumns = refBaseTablePartitionColumns.get(refBaseTable);
         if (refPartitionColumns.size() != mvPartitionSlotRefs.size()) {
-            LOG.warn("Generate incremental partition failed, refPartitionColumns size {} != mvPartitionSlotRefs size {}",
+            logger.warn("Generate incremental partition failed, refPartitionColumns size {} != mvPartitionSlotRefs size {}",
                     refPartitionColumns.size(), mvPartitionSlotRefs.size());
             return null;
         }
@@ -283,27 +283,27 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             }
         } else {
             // check the ref base table
-            Set<String> needRefreshMvPartitionNames = getMvPartitionNamesToRefresh(mvListPartitionNames);
+            Set<String> mvToRefreshPartitionNames = getMvPartitionNamesToRefresh(mvListPartitionNames);
             Map<Table, Set<String>> baseChangedPartitionNames =
-                    getBasePartitionNamesByMVPartitionNames(needRefreshMvPartitionNames);
+                    getBasePartitionNamesByMVPartitionNames(mvToRefreshPartitionNames);
             if (baseChangedPartitionNames.isEmpty()) {
-                LOG.info("Cannot get associated base table change partitions from mv's refresh partitions {}, mv: {}",
-                        needRefreshMvPartitionNames, mv.getName());
-                return needRefreshMvPartitionNames;
+                logger.info("Cannot get associated base table change partitions from mv's refresh partitions {}",
+                        mvToRefreshPartitionNames);
+                return mvToRefreshPartitionNames;
             }
             // because the relation of partitions between materialized view and base partition table is n : m,
             // should calculate the candidate partitions recursively.
             if (isCalcPotentialRefreshPartition()) {
-                LOG.info("Start calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
-                        " baseChangedPartitionNames: {}", needRefreshMvPartitionNames, baseChangedPartitionNames);
-                SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
+                logger.info("Start calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
+                        " baseChangedPartitionNames: {}", mvToRefreshPartitionNames, baseChangedPartitionNames);
+                SyncPartitionUtils.calcPotentialRefreshPartition(mvToRefreshPartitionNames, baseChangedPartitionNames,
                         mvContext.getRefBaseTableMVIntersectedPartitions(),
                         mvContext.getMvRefBaseTableIntersectedPartitions(),
                         mvPotentialPartitionNames);
-                LOG.info("Finish calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
-                        " baseChangedPartitionNames: {}", needRefreshMvPartitionNames, baseChangedPartitionNames);
+                logger.info("Finish calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
+                        " baseChangedPartitionNames: {}", mvToRefreshPartitionNames, baseChangedPartitionNames);
             }
-            return needRefreshMvPartitionNames;
+            return mvToRefreshPartitionNames;
         }
     }
 
@@ -320,6 +320,8 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     public Set<String> getMVPartitionNamesWithTTL(MaterializedView mv,
                                                   MVRefreshParams mvRefreshParams,
                                                   boolean isAutoRefresh) {
+        int autoRefreshPartitionsLimit = mv.getTableProperty().getAutoRefreshPartitionsLimit();
+
         // if the user specifies the start and end ranges, only refresh the specified partitions
         boolean isCompleteRefresh = mvRefreshParams.isCompleteRefresh();
         Map<String, PCell> mvListPartitionMap = Maps.newHashMap();
@@ -356,7 +358,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
         for (String partitionName : mvPartitionsToRefresh) {
             PListCell listCell = listPartitionMap.get(partitionName);
             if (listCell == null) {
-                LOG.warn("Partition {} is not found in materialized view {}", partitionName, mv.getName());
+                logger.warn("Partition {} is not found in materialized view {}", partitionName, mv.getName());
                 continue;
             }
             partitionToCells.put(partitionName, listCell);
@@ -392,7 +394,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             // remove the partition which is not reserved
             toRefreshPartitions.remove(entry.getKey());
         }
-        LOG.info("Filter partitions by partition_ttl_number, ttl_number:{}, result:{}, remains:{}",
+        logger.info("Filter partitions by partition_ttl_number, ttl_number:{}, result:{}, remains:{}",
                 filterNumber, toRefreshPartitions, nextPartitionValues);
         // do filter input mvPartitionsToRefresh since it's a reference
         mvPartitionsToRefresh.retainAll(toRefreshPartitions.keySet());
@@ -423,14 +425,14 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
                     new MultiItemListPartitionDesc(false, mvPartitionName, partitionItems, partitionProperties);
             AddPartitionClause addPartitionClause =
                     new AddPartitionClause(multiItemListPartitionDesc, distributionDesc, partitionProperties, false);
-            AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(materializedView);
+            AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(mv);
             analyzer.analyze(mvContext.getCtx(), addPartitionClause);
             try {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().addPartitions(
-                        mvContext.getCtx(), database, materializedView.getName(), addPartitionClause);
+                        mvContext.getCtx(), database, mv.getName(), addPartitionClause);
             } catch (Exception e) {
                 throw new DmlException("add list partition failed: %s, db: %s, table: %s", e, e.getMessage(),
-                        database.getFullName(), materializedView.getName());
+                        database.getFullName(), mv.getName());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -320,8 +320,6 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     public Set<String> getMVPartitionNamesWithTTL(MaterializedView mv,
                                                   MVRefreshParams mvRefreshParams,
                                                   boolean isAutoRefresh) {
-        int autoRefreshPartitionsLimit = mv.getTableProperty().getAutoRefreshPartitionsLimit();
-
         // if the user specifies the start and end ranges, only refresh the specified partitions
         boolean isCompleteRefresh = mvRefreshParams.isCompleteRefresh();
         Map<String, PCell> mvListPartitionMap = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -24,16 +24,12 @@ import com.starrocks.catalog.Table;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TableSnapshotInfo;
 import com.starrocks.scheduler.TaskRunContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
-    private static final Logger LOG = LogManager.getLogger(MVPCTRefreshNonPartitioner.class);
-
     public MVPCTRefreshNonPartitioner(MvTaskRunContext mvContext,
                                       TaskRunContext context,
                                       Database db,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -39,7 +39,6 @@ import com.starrocks.sql.ast.DropPartitionClause;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCell;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
@@ -56,12 +55,11 @@ import static com.starrocks.sql.optimizer.rule.transformation.partition.Partitio
  * refresh.
  */
 public abstract class MVPCTRefreshPartitioner {
-    private static final Logger LOG = LogManager.getLogger(MVPCTRefreshPartitioner.class);
-
     protected final MvTaskRunContext mvContext;
     protected final TaskRunContext context;
     protected final Database db;
     protected final MaterializedView mv;
+    private final Logger logger;
 
     public MVPCTRefreshPartitioner(MvTaskRunContext mvContext,
                                    TaskRunContext context,
@@ -71,6 +69,7 @@ public abstract class MVPCTRefreshPartitioner {
         this.context = context;
         this.db = db;
         this.mv = mv;
+        this.logger = MVTraceUtils.getLogger(mv, MVPCTRefreshPartitioner.class);
     }
 
     /**
@@ -149,14 +148,14 @@ public abstract class MVPCTRefreshPartitioner {
         Set<String> result = Sets.newHashSet();
         Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMaps = mvContext.getRefBaseTableMVIntersectedPartitions();
         if (refBaseTableMVPartitionMaps == null || !refBaseTableMVPartitionMaps.containsKey(refBaseTable)) {
-            LOG.warn("Cannot find need refreshed ref base table partition from synced partition info: {}, " +
+            logger.warn("Cannot find need refreshed ref base table partition from synced partition info: {}, " +
                     "refBaseTableMVPartitionMaps: {}", refBaseTable, refBaseTableMVPartitionMaps);
             return null;
         }
         Map<String, Set<String>> refBaseTableMVPartitionMap = refBaseTableMVPartitionMaps.get(refBaseTable);
         for (String basePartitionName : baseTablePartitionNames) {
             if (!refBaseTableMVPartitionMap.containsKey(basePartitionName)) {
-                LOG.warn("Cannot find need refreshed ref base table partition from synced partition info: {}, " +
+                logger.warn("Cannot find need refreshed ref base table partition from synced partition info: {}, " +
                         "refBaseTableMVPartitionMaps: {}", basePartitionName, refBaseTableMVPartitionMaps);
                 // refBaseTableMVPartitionMap may not contain basePartitionName if it's filtered by ttl.
                 continue;
@@ -177,7 +176,7 @@ public abstract class MVPCTRefreshPartitioner {
         for (Table baseTable : refBaseTablePartitionColumns.keySet()) {
             // refresh all mv partitions when the ref base table is not supported partition refresh
             if (!isPartitionRefreshSupported(baseTable)) {
-                LOG.info("The ref base table {} is not supported partition refresh, refresh all " +
+                logger.info("The ref base table {} is not supported partition refresh, refresh all " +
                         "partitions of mv {}: {}", baseTable.getName(), mv.getName(), mvPartitionNames);
                 return mvPartitionNames;
             }
@@ -191,7 +190,7 @@ public abstract class MVPCTRefreshPartitioner {
             }
             Set<String> refBaseTablePartitionNames = mvBaseTableUpdateInfo.getToRefreshPartitionNames();
             if (refBaseTablePartitionNames.isEmpty()) {
-                LOG.info("The ref base table {} has no updated partitions, and no update related mv partitions: {}",
+                logger.info("The ref base table {} has no updated partitions, and no update related mv partitions: {}",
                         baseTable.getName(), mvPartitionNames);
                 continue;
             }
@@ -203,7 +202,7 @@ public abstract class MVPCTRefreshPartitioner {
                         " mv %s:, ref partitions: %s", baseTable.getName(), mv.getName(), refBaseTablePartitionNames));
             }
             ans.retainAll(mvPartitionNames);
-            LOG.info("The ref base table {} has updated partitions: {}, the corresponding " +
+            logger.info("The ref base table {} has updated partitions: {}, the corresponding " +
                             "mv partitions to refresh: {}, " + "mvRangePartitionNames: {}", baseTable.getName(),
                     refBaseTablePartitionNames, ans, mvPartitionNames);
             result.addAll(ans);
@@ -255,7 +254,7 @@ public abstract class MVPCTRefreshPartitioner {
         String dropPartitionName = materializedView.getPartition(mvPartitionName).getName();
         Locker locker = new Locker();
         if (!locker.lockDatabaseAndCheckExist(db, materializedView, LockType.WRITE)) {
-            LOG.warn("Fail to lock database {} in drop partition for mv refresh {}", db.getFullName(),
+            logger.warn("Fail to lock database {} in drop partition for mv refresh {}", db.getFullName(),
                     materializedView.getName());
             throw new DmlException("drop partition failed. database:" + db.getFullName() + " not exist");
         }
@@ -293,7 +292,7 @@ public abstract class MVPCTRefreshPartitioner {
                 mvContext.getMvRefBaseTableIntersectedPartitions();
         for (String mvPartitionName : mvPartitionNames) {
             if (mvRefBaseTablePartitionMaps == null || !mvRefBaseTablePartitionMaps.containsKey(mvPartitionName)) {
-                LOG.warn("Cannot find need refreshed mv table partition from synced partition info: {}",
+                logger.warn("Cannot find need refreshed mv table partition from synced partition info: {}",
                         mvPartitionName);
                 continue;
             }
@@ -324,7 +323,7 @@ public abstract class MVPCTRefreshPartitioner {
                         toRefreshPartitions, isMockPartitionIds);
                 // remove the expired partitions
                 if (CollectionUtils.isNotEmpty(expiredPartitionNames)) {
-                    LOG.info("Filter partitions by partition_retention_condition, ttl_condition:{}, expired:{}",
+                    logger.info("Filter partitions by partition_retention_condition, ttl_condition:{}, expired:{}",
                             ttlCondition, expiredPartitionNames);
                     expiredPartitionNames.stream()
                             .forEach(toRefreshPartitions::remove);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -59,7 +59,6 @@ import com.starrocks.sql.common.RangePartitionDiffer;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections4.ListUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
@@ -77,8 +76,7 @@ import static com.starrocks.sql.optimizer.rule.transformation.materialization.Mv
 
 public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner {
     private static final int CREATE_PARTITION_BATCH_SIZE = 64;
-
-    private static final Logger LOG = LogManager.getLogger(MVPCTRefreshRangePartitioner.class);
+    private final Logger logger;
 
     private final RangePartitionDiffer differ;
     public MVPCTRefreshRangePartitioner(MvTaskRunContext mvContext,
@@ -87,6 +85,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                                         MaterializedView mv) {
         super(mvContext, context, db, mv);
         this.differ = new RangePartitionDiffer(mv, false, null);
+        this.logger = MVTraceUtils.getLogger(mv, MVPCTRefreshRangePartitioner.class);
     }
 
     @Override
@@ -99,7 +98,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         Range<PartitionKey> rangeToInclude = SyncPartitionUtils.createRange(start, end, partitionColumn);
         PartitionDiffResult result = differ.computePartitionDiff(rangeToInclude);
         if (result == null) {
-            LOG.warn("compute range partition diff failed: mv: {}", mv.getName());
+            logger.warn("compute range partition diff failed: mv: {}", mv.getName());
             return false;
         }
 
@@ -108,8 +107,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         for (String mvPartitionName : deletes.keySet()) {
             dropPartition(db, mv, mvPartitionName);
         }
-        LOG.info("The process of synchronizing materialized view [{}] delete partitions range [{}]",
-                mv.getName(), deletes);
+        logger.info("The process of synchronizing materialized view delete partitions range [{}]", deletes);
 
         // Create new added materialized views' ranges
         Map<String, PCell> adds = result.diff.getAdds();
@@ -120,7 +118,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         DistributionDesc distributionDesc = MvUtils.getDistributionDesc(mv);
         addRangePartitions(db, mv, adds, partitionProperties, distributionDesc);
         adds.entrySet().stream().forEach(entry -> mvPartitionToCells.put(entry.getKey(), entry.getValue()));
-        LOG.info("The process of synchronizing materialized view [{}] add partitions range [{}]",
+        logger.info("The process of synchronizing materialized view [{}] add partitions range [{}]",
                 mv.getName(), adds);
 
         // used to get partitions to refresh
@@ -152,7 +150,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         // here we should convert date into '%Y%m%d' format
         Map<Table, List<Column>> partitionTableAndColumn = mv.getRefBaseTablePartitionColumns();
         if (!partitionTableAndColumn.containsKey(table)) {
-            LOG.warn("Cannot generate mv refresh partition predicate because cannot decide the partition column of table {}," +
+            logger.warn("Cannot generate mv refresh partition predicate because cannot decide the partition column of table {}," +
                     "partitionTableAndColumn:{}", table.getName(), partitionTableAndColumn);
             return null;
         }
@@ -168,7 +166,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                 && !sourceTablePartitionRange.isEmpty() && MvUtils.isDateRange(sourceTablePartitionRange.get(0))) {
             Optional<FunctionCallExpr> functionCallExprOpt = getStr2DateExpr(partitionExpr);
             if (!functionCallExprOpt.isPresent()) {
-                LOG.warn("invalid partition expr:{}", partitionExpr);
+                logger.warn("Invalid partition expr:{}", partitionExpr);
                 return null;
             }
             FunctionCallExpr functionCallExpr = functionCallExprOpt.get();
@@ -183,7 +181,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
             sourceTablePartitionRange = converted;
         }
         if (mvPartitionSlotRefs.size() != 1) {
-            LOG.warn("Cannot generate mv refresh partition predicate because mvPartitionSlotRefs size is not 1, " +
+            logger.warn("Cannot generate mv refresh partition predicate because mvPartitionSlotRefs size is not 1, " +
                     "mvPartitionSlotRefs:{}", mvPartitionSlotRefs);
             return null;
         }
@@ -214,7 +212,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         String end = mvRefreshParams.getRangeEnd();
         boolean force = mvRefreshParams.isForce();
         Set<String> mvRangePartitionNames = getMVPartitionNamesWithTTL(mv, mvRefreshParams, isAutoRefresh);
-        LOG.info("Get partition names by range with partition limit, mv name: {}, start: {}, end: {}, force:{}, " +
+        logger.info("Get partition names by range with partition limit, mv name: {}, start: {}, end: {}, force:{}, " +
                         "partitionTTLNumber: {}, isAutoRefresh: {}, mvRangePartitionNames: {}, isRefreshMvBaseOnNonRefTables:{}",
                 mv.getName(), start, end, force, partitionTTLNumber, isAutoRefresh, mvRangePartitionNames,
                 isRefreshMvBaseOnNonRefTables);
@@ -252,17 +250,17 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         }
 
         // check the related partition table
-        Set<String> needRefreshMvPartitionNames = getMvPartitionNamesToRefresh(mvRangePartitionNames);
-        if (needRefreshMvPartitionNames.isEmpty()) {
-            LOG.info("No need to refresh materialized view partitions, mv: {}", mv.getName());
-            return needRefreshMvPartitionNames;
+        Set<String> mvToRefreshPartitionNames = getMvPartitionNamesToRefresh(mvRangePartitionNames);
+        if (mvToRefreshPartitionNames.isEmpty()) {
+            logger.info("No need to refresh materialized view partitions");
+            return mvToRefreshPartitionNames;
         }
 
-        Map<Table, Set<String>> baseChangedPartitionNames = getBasePartitionNamesByMVPartitionNames(needRefreshMvPartitionNames);
+        Map<Table, Set<String>> baseChangedPartitionNames = getBasePartitionNamesByMVPartitionNames(mvToRefreshPartitionNames);
         if (baseChangedPartitionNames.isEmpty()) {
-            LOG.info("Cannot get associated base table change partitions from mv's refresh partitions {}, mv: {}",
-                    needRefreshMvPartitionNames, mv.getName());
-            return needRefreshMvPartitionNames;
+            logger.info("Cannot get associated base table change partitions from mv's refresh partitions {}",
+                    mvToRefreshPartitionNames);
+            return mvToRefreshPartitionNames;
         }
 
         List<TableWithPartitions> baseTableWithPartitions = baseChangedPartitionNames.keySet().stream()
@@ -272,19 +270,19 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                 mvContext.getRefBaseTableToCellMap();
         Map<String, PCell> mvRangePartitionMap = mvContext.getMVToCellMap();
         if (mv.isCalcPotentialRefreshPartition(baseTableWithPartitions,
-                refBaseTableRangePartitionMap, needRefreshMvPartitionNames, mvRangePartitionMap)) {
+                refBaseTableRangePartitionMap, mvToRefreshPartitionNames, mvRangePartitionMap)) {
             // because the relation of partitions between materialized view and base partition table is n : m,
             // should calculate the candidate partitions recursively.
-            LOG.info("Start calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
-                    " baseChangedPartitionNames: {}", needRefreshMvPartitionNames, baseChangedPartitionNames);
-            SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
+            logger.info("Start calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
+                    " baseChangedPartitionNames: {}", mvToRefreshPartitionNames, baseChangedPartitionNames);
+            SyncPartitionUtils.calcPotentialRefreshPartition(mvToRefreshPartitionNames, baseChangedPartitionNames,
                     mvContext.getRefBaseTableMVIntersectedPartitions(),
                     mvContext.getMvRefBaseTableIntersectedPartitions(),
                     mvPotentialPartitionNames);
-            LOG.info("Finish calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
-                    " baseChangedPartitionNames: {}", needRefreshMvPartitionNames, baseChangedPartitionNames);
+            logger.info("Finish calcPotentialRefreshPartition, needRefreshMvPartitionNames: {}," +
+                    " baseChangedPartitionNames: {}", mvToRefreshPartitionNames, baseChangedPartitionNames);
         }
-        return needRefreshMvPartitionNames;
+        return mvToRefreshPartitionNames;
     }
 
     @Override
@@ -366,8 +364,8 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
             String mvPartitionName = mvToRefreshPartitionsIter.next();
             // skip if partition is not in the mv's partition range map
             if (!mvRangePartitionMap.containsKey(mvPartitionName)) {
-                LOG.warn("Partition {} is not in the materialized view's partition range map for mv:{}, " +
-                        "remove it from refresh list", mvPartitionName, mv.getName());
+                logger.warn("Partition {} is not in the materialized view's partition range map, " +
+                        "remove it from refresh list", mvPartitionName);
                 mvToRefreshPartitionsIter.remove();
                 continue;
             }
@@ -481,17 +479,17 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
         // create partitions in small batch, to avoid create too many partitions at once
         for (List<PartitionDesc> batch : ListUtils.partition(partitionDescs, CREATE_PARTITION_BATCH_SIZE)) {
             RangePartitionDesc rangePartitionDesc =
-                    new RangePartitionDesc(materializedView.getPartitionColumnNames(), batch);
+                    new RangePartitionDesc(mv.getPartitionColumnNames(), batch);
             AddPartitionClause alterPartition = new AddPartitionClause(rangePartitionDesc, distributionDesc,
                     partitionProperties, false);
-            AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(materializedView);
+            AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(mv);
             analyzer.analyze(mvContext.getCtx(), alterPartition);
             try {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().addPartitions(mvContext.getCtx(),
-                        database, materializedView.getName(), alterPartition);
+                        database, mv.getName(), alterPartition);
             } catch (Exception e) {
                 throw new DmlException("Expression add partition failed: %s, db: %s, table: %s", e, e.getMessage(),
-                        database.getFullName(), materializedView.getName());
+                        database.getFullName(), mv.getName());
             }
             Uninterruptibles.sleepUninterruptibly(Config.mv_create_partition_batch_interval_ms, TimeUnit.MILLISECONDS);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTraceUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTraceUtils.java
@@ -22,13 +22,14 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.common.StarRocksLoggerFactory;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.planner.HdfsScanNode;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.sql.plan.ExecPlan;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -42,8 +43,6 @@ import java.util.stream.Collectors;
  * MV trace utils to help mv refresh trace in task runs.
  */
 public class MVTraceUtils {
-
-    private static final Logger LOG = LogManager.getLogger(MVTraceUtils.class);
 
     /**
      * Extract refreshed/scanned base table and its refreshed partition names
@@ -106,5 +105,20 @@ public class MVTraceUtils {
                     PartitionUtil.toHivePartitionName(partitionColumnNames, partitionKey)).collect(Collectors.toList());
         }
         return selectedPartitionNames;
+    }
+
+    private static String getLogPrefix(MaterializedView mv) {
+        if (mv == null || Strings.isNullOrEmpty(mv.getName())) {
+            return "";
+        } else {
+            return mv.getName();
+        }
+    }
+
+    /**
+     * Get logger with mv name prefix.
+     */
+    public static Logger getLogger(MaterializedView mv, Class<?> clazz) {
+        return new StarRocksLoggerFactory(getLogPrefix(mv)).getLogger(clazz);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MockTaskRunProcessor.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MockTaskRunProcessor.java
@@ -33,6 +33,11 @@ public class MockTaskRunProcessor implements TaskRunProcessor {
     }
 
     @Override
+    public void prepare(TaskRunContext context) throws Exception {
+        // do nothing
+    }
+
+    @Override
     public void processTaskRun(TaskRunContext context) throws Exception {
         if (sleepTimeMs > 0) {
             Thread.sleep(sleepTimeMs);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -866,7 +866,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         Assert.assertEquals(3, baseTableVisibleVersionMap.get(tbl1.getId()).get("p100").getVersion());
     }
 
-    private PartitionBasedMvRefreshProcessor createProcessor(TaskRun taskRun, MaterializedView mv) {
+    private PartitionBasedMvRefreshProcessor createProcessor(TaskRun taskRun, MaterializedView mv) throws Exception {
         TaskRunContext context = new TaskRunContext();
         context.setTaskRun(taskRun);
         context.setCtx(connectContext);
@@ -875,7 +875,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         Map<String, String> props = Maps.newHashMap();
         props.put(MV_ID, String.valueOf(mv.getId()));
         mvContext.setProperties(props);
-        PartitionBasedMvRefreshProcessor processor = new PartitionBasedMvRefreshProcessor(context.getTaskRun());
+        PartitionBasedMvRefreshProcessor processor = new PartitionBasedMvRefreshProcessor();
         processor.setMvContext(mvContext);
         processor.prepare(mvContext);
         return processor;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -866,15 +866,16 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         Assert.assertEquals(3, baseTableVisibleVersionMap.get(tbl1.getId()).get("p100").getVersion());
     }
 
-    private PartitionBasedMvRefreshProcessor createProcessor(MaterializedView mv) {
+    private PartitionBasedMvRefreshProcessor createProcessor(TaskRun taskRun, MaterializedView mv) {
         TaskRunContext context = new TaskRunContext();
+        context.setTaskRun(taskRun);
         context.setCtx(connectContext);
         context.getCtx().setDatabase("test");
         MvTaskRunContext mvContext = new MvTaskRunContext(context);
         Map<String, String> props = Maps.newHashMap();
         props.put(MV_ID, String.valueOf(mv.getId()));
         mvContext.setProperties(props);
-        PartitionBasedMvRefreshProcessor processor = new PartitionBasedMvRefreshProcessor();
+        PartitionBasedMvRefreshProcessor processor = new PartitionBasedMvRefreshProcessor(context.getTaskRun());
         processor.setMvContext(mvContext);
         processor.prepare(mvContext);
         return processor;
@@ -902,7 +903,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         initAndExecuteTaskRun(taskRun);
         materializedView.getTableProperty().setPartitionRefreshNumber(3);
 
-        PartitionBasedMvRefreshProcessor processor = createProcessor(materializedView);
+        PartitionBasedMvRefreshProcessor processor = createProcessor(taskRun, materializedView);
         processor.filterPartitionByRefreshNumber(materializedView.getPartitionNames(), Sets.newHashSet(), materializedView);
         MvTaskRunContext mvContext = processor.getMvContext();
         Assert.assertEquals("2022-03-01", mvContext.getNextPartitionStart());
@@ -941,7 +942,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
         materializedView.getTableProperty().setPartitionRefreshNumber(1);
 
-        PartitionBasedMvRefreshProcessor processor = createProcessor(materializedView);
+        PartitionBasedMvRefreshProcessor processor = createProcessor(taskRun, materializedView);
         Set<String> allPartitions = new HashSet<>(materializedView.getPartitionNames());
 
         // ascending refresh


### PR DESCRIPTION
## Why I'm doing:
- Refresh mv cannot be traced by `mv name` because a lot of logging forgets to log `mv name`.

## What I'm doing:
- Add StarRocksLoggerFactory class to support add a prefix for logging.
- Refactor PartitionBasedMvRefreshProcessor for better logging


new logging:
```
2024-11-13 19:04:50 [main] INFO  PartitionBasedMvRefreshProcessor:862 - [test_mv1] prepare refresh of mv:{mvId=10332}, properties:{}
2024-11-13 19:04:50 [main] INFO  PartitionBasedMvRefreshProcessor:908 - [test_mv1] finish prepare refresh mv:10332, jobId: 1a990784-a1af-11ef-84a5-6ac53215a80a
2024-11-13 19:04:50 [main] INFO  PartitionBasedMvRefreshProcessor:373 - [test_mv1] start to refresh mv with retry times:3
2024-11-13 19:04:50 [main] INFO  PartitionBasedMvRefreshProcessor:1236 - [test_mv1] collect base table snapshot infos cost: 3 ms
2024-11-13 19:04:50 [main] INFO  MVPCTRefreshRangePartitioner:108 - [test_mv1] The process of synchronizing materialized view delete partitions range [{}]
2024-11-13 19:04:51 [main] INFO  MVPCTRefreshRangePartitioner:116 - [test_mv1] The process of synchronizing materialized view add partitions range [{p202203_202204=[types: [DATE]; keys: [2022-03-01]; ..types: [DATE]; keys: [2022-04-01]; ), p202204_202205=[types: [DATE]; keys: [2022-04-01]; ..types: [DATE]; keys: [2022-05-01]; ), p202112_202201=[types: [DATE]; keys: [2021-12-01]; ..types: [DATE]; keys: [2022-01-01]; ), p202201_202202=[types: [DATE]; keys: [2022-01-01]; ..types: [DATE]; keys: [2022-02-01]; ), p202202_202203=[types: [DATE]; keys: [2022-02-01]; ..types: [DATE]; keys: [2022-03-01]; )}]
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:938 - [test_mv1] finish sync partitions, cost(ms): 1039
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:320 - [test_mv1] filter partitions to refresh partitionRefreshNumber=-1, partitionsToRefresh:[p202203_202204, p202204_202205, p202112_202201, p202201_202202, p202202_202203], mvPotentialPartitionNames:[], next start:null, next end:null, next list values:null
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:288 - [test_mv1] sync and check mv partition changing after 1 times: true, costs: 5 ms
2024-11-13 19:04:52 [main] INFO  MVPCTRefreshRangePartitioner:207 - [test_mv1] Get partition names by range with partition limit, start: null, end: null, force:false, partitionTTLNumber: -1, isAutoRefresh: false, mvRangePartitionNames: [p202203_202204, p202204_202205, p202112_202201, p202201_202202, p202202_202203], isRefreshMvBaseOnNonRefTables:false
2024-11-13 19:04:52 [main] INFO  MVPCTRefreshPartitioner:199 - [test_mv1] The ref base table tbl1 has updated partitions: [p3], the corresponding mv partitions to refresh: [p202203_202204], mvRangePartitionNames: [p202203_202204, p202204_202205, p202112_202201, p202201_202202, p202202_202203]
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:320 - [test_mv1] filter partitions to refresh partitionRefreshNumber=-1, partitionsToRefresh:[p202203_202204], mvPotentialPartitionNames:[], next start:null, next end:null, next list values:null
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:464 - [test_mv1] mvToRefreshedPartitions:[p202203_202204], refTableRefreshPartitions:{baseTable=tbl1, refreshedPartitionInfos={}=[p3]}
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:1354 - [test_mv1] collect olap base table tbl1's refreshed partition infos: {p3=BasePartitionInfo{id=10052, version=2, lastRefreshTime=1731495890933, lastFileModifiedTime=-1, fileNumber=-1}}
2024-11-13 19:04:52 [main] INFO  MVPCTRefreshPlanBuilder:269 - [test_mv1] Optimize materialized view test_mv1 refresh task, push down partition names into table relation test.tbl1, filtered partition names:p3 
2024-11-13 19:04:52 [main] INFO  MVPCTRefreshPlanBuilder:213 - [test_mv1] Generate partition extra predicates empty, mv:test_mv1, numOfPushDownIntoTables:1
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:543 - [test_mv1] MV Refresh PlanBuilderMessage: {tbl1=p3}
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:555 - [test_mv1] MV Refresh Final Plan, MV PartitionsToRefresh: p202203_202204, Base PartitionsToScan: {tbl1=[p3]}
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:1146 - [test_mv1] [QueryId:1a99cad5-a1af-11ef-84a5-6ac53215a80a] start to refresh mv in DML
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:1153 - [test_mv1] [QueryId:1a99cad5-a1af-11ef-84a5-6ac53215a80a] finished to refresh mv in DML
2024-11-13 19:04:52 [main] INFO  MVVersionManager:173 - [test_mv1] update meta for mv test_mv1 with olap tables:[baseTable=tbl1, refreshedPartitionInfos={p3=BasePartitionInfo{id=10052, version=2, lastRefreshTime=1731495890933, lastFileModifiedTime=-1, fileNumber=-1}}], refBaseTableIds:[10054]
2024-11-13 19:04:52 [main] INFO  MVVersionManager:203 - [test_mv1] Update materialized view test_mv1 meta for base table tbl1 with partitions info: {p3=BasePartitionInfo{id=10052, version=2, lastRefreshTime=1731495890933, lastFileModifiedTime=-1, fileNumber=-1}}, old partition infos:{}
2024-11-13 19:04:52 [main] INFO  MVVersionManager:159 - [test_mv1] Update edit log after version changed for mv test_mv1, maxChangedTableRefreshTime:1731495890933
2024-11-13 19:04:52 [main] INFO  PartitionBasedMvRefreshProcessor:352 - [test_mv1] refresh mv success, cost time(ms): 1193.00
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
