### PR TITLE
[BugFix] Use correct lock in Tablet::delete_all_files

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1127,7 +1127,7 @@ void Tablet::delete_all_files() {
     // Release resources like memory and disk space.
     // we have to call list_versions first, or else error occurs when
     // removing hash_map item and iterating hash_map concurrently.
-    std::shared_lock rdlock(_meta_lock);
+    std::unique_lock wlock(_meta_lock);
     for (const auto& it : _rs_version_map) {
         (void)it.second->remove();
     }

--- a/be/test/storage/size_tiered_compaction_policy_test.cpp
+++ b/be/test/storage/size_tiered_compaction_policy_test.cpp
@@ -410,6 +410,7 @@ TEST_F(SizeTieredCompactionPolicyTest, test_tablet_not_running) {
     ASSERT_EQ(1, versions.size());
     ASSERT_EQ(0, versions[0].first);
     ASSERT_EQ(5, versions[0].second);
+    tablet->delete_all_files();
 }
 
 TEST_F(SizeTieredCompactionPolicyTest, test_max_compaction) {


### PR DESCRIPTION
## Why I'm doing:

There is wrong lock usage in Tablet::delete_all_files causing crash
```
*** Aborted at 1731043683 (unix time) try "date -d @1731043683" if you are using GNU date ***
PC: @          0x602bbfd starrocks::Rowset::comparator(std::shared_ptr<starrocks::Rowset> const&, std::shared_ptr<starrocks::Rowset> const&)
*** SIGSEGV (@0x0) received by PID 2407 (TID 0x7fddfa7f7700) from PID 0; stack trace: ***
    @     0x7ff59360c20b __pthread_once_slow
    @          0x7ba4c80 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7ff593615630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x602bbfd starrocks::Rowset::comparator(std::shared_ptr<starrocks::Rowset> const&, std::shared_ptr<starrocks::Rowset> const&)
    @          0x61e5104 void std::__introsort_loop<__gnu_cxx::__normal_iterator<std::shared_ptr<starrocks::Rowset>*, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > >, long, __gnu_cxx::__ops::_Iter_comp_iter<bool (*)(std::shar`^V<D5>^R
    @          0x6232eed starrocks::SizeTieredCompactionPolicy::_pick_rowsets_to_size_tiered_compact(bool, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > >*, double*)
    @          0x6236200 starrocks::SizeTieredCompactionPolicy::need_compaction(double*, starrocks::CompactionType*)
    @          0x60186ca starrocks::Tablet::need_compaction()
    @          0x6226a74 starrocks::CompactionManager::update_tablet(std::shared_ptr<starrocks::Tablet> const&)
    @          0x3832db3 starrocks::ThreadPool::dispatch_thread()
    @          0x382b816 starrocks::Thread::supervise_thread(void*)
    @     0x7ff59360dea5 start_thread
    @     0x7ff592a0eb0d __clone
```

## What I'm doing:

Use correct lock

Fixes https://github.com/StarRocks/StarRocksTest/issues/8811

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
