### PR TITLE
[BugFix]fix out-of-bound access for bit unpacking with simd

### DIFF
--- a/be/src/util/bit_packing_adapter.h
+++ b/be/src/util/bit_packing_adapter.h
@@ -51,9 +51,10 @@ public:
             // the prior (x - 1) batch has used (x - 1) * bit_width bytes, and the last batch use
             // (bit_width + 7) / 8 * 8 bytes, so there should be
             // (x - 1) * bit_width + (bit_width + 7) / 8 <= in_bytes
-            const int64_t batches_to_read = std::max(
-                    (int64_t)0,
-                    std::min((in_bytes - (bit_width + 7) / 8 * 8) / bit_width + 1, values_to_read / BATCH_SIZE));
+            const int64_t batches_to_read = in_bytes > (bit_width + 7) / 8 * 8
+                                                    ? std::min((in_bytes - (bit_width + 7) / 8 * 8) / bit_width + 1,
+                                                               values_to_read / BATCH_SIZE)
+                                                    : 0;
 
             if (batches_to_read > 0) {
                 starrocks::util::unpack(bit_width, in, in_bytes, batches_to_read * BATCH_SIZE, out);

--- a/be/src/util/bit_packing_adapter.h
+++ b/be/src/util/bit_packing_adapter.h
@@ -51,7 +51,7 @@ public:
             // the prior (x - 1) batch has used (x - 1) * bit_width bytes, and the last batch use
             // (bit_width + 7) / 8 * 8 bytes, so there should be
             // (x - 1) * bit_width + (bit_width + 7) / 8 <= in_bytes
-            const int64_t batches_to_read = in_bytes > (bit_width + 7) / 8 * 8
+            const int64_t batches_to_read = (in_bytes > (bit_width + 7) / 8 * 8)
                                                     ? std::min((in_bytes - (bit_width + 7) / 8 * 8) / bit_width + 1,
                                                                values_to_read / BATCH_SIZE)
                                                     : 0;


### PR DESCRIPTION
## Why I'm doing:
we want to use `/`(divide) to get the floor of the result, but we get the ceil when the num is negative.
which made the batch is incorrect.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
