### PR TITLE
[BugFix] consider constant column for arrays_overlaps

### DIFF
--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -374,6 +374,13 @@ std::pair<bool, size_t> ColumnHelper::num_packed_rows(const Columns& columns) {
     return {all_const, 1};
 }
 
+std::pair<bool, size_t> ColumnHelper::num_packed_rows(const Column* column) {
+    if (column->is_constant()) {
+        return {true, 1};
+    }
+    return {false, column->size()};
+}
+
 using ColumnsConstIterator = Columns::const_iterator;
 bool ColumnHelper::is_all_const(ColumnsConstIterator const& begin, ColumnsConstIterator const& end) {
     for (auto it = begin; it < end; ++it) {

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -387,6 +387,7 @@ public:
     //     which could reduce unnecessary calculations.
     //     Don't forget to resize the result constant columns if necessary.
     static std::pair<bool, size_t> num_packed_rows(const Columns& columns);
+    static std::pair<bool, size_t> num_packed_rows(const Column* column);
 
     using ColumnsConstIterator = Columns::const_iterator;
     static bool is_all_const(ColumnsConstIterator const& begin, ColumnsConstIterator const& end);

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -391,7 +391,7 @@ private:
 
     static ColumnPtr _array_overlap(const Columns& columns) {
         const size_t num_rows = columns[0]->size();
-        auto [is_all_const, num_packed_rows] = ColumnHelper::num_packed_rows(columns);
+        const auto [is_all_const, num_packed_rows] = ColumnHelper::num_packed_rows(columns);
 
         auto result_data_column = BooleanColumn::create(num_packed_rows, 0);
         auto& result_data = result_data_column->get_data();

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -359,8 +359,10 @@ public:
 
 private:
     static ColumnPtr _array_overlap_const(const ArrayOverlapState<HashSet>& state, const Column& column) {
-        size_t chunk_size = column.size();
-        auto result_data_column = BooleanColumn::create(chunk_size, 0);
+        const size_t num_rows = column.size();
+        const auto [is_const, num_packed_rows] = ColumnHelper::num_packed_rows(&column);
+
+        auto result_data_column = BooleanColumn::create(num_packed_rows, 0);
         auto& result_data = result_data_column->get_data();
         NullColumnPtr result_null_column;
         const ArrayColumn* src_data_column = ColumnHelper::get_data_column_by_type<TYPE_ARRAY>(&column);
@@ -372,20 +374,26 @@ private:
 
         DCHECK(src_data_column->elements_column()->is_nullable());
 
-        for (size_t i = 0; i < chunk_size; i++) {
+        for (size_t i = 0; i < num_packed_rows; i++) {
             result_data[i] = _check_column_overlap_nullable(*state.hash_set, *src_data_column, i, state.has_null);
         }
 
-        if (result_null_column != nullptr) {
-            return NullableColumn::create(result_data_column, result_null_column);
+        if (is_const) {
+            // Const null column is handled by `RETURN_IF_COLUMNS_ONLY_NULL` in `process`.
+            DCHECK(result_null_column == nullptr);
+            return ConstColumn::create(std::move(result_data_column), num_rows);
+        } else if (result_null_column != nullptr) {
+            return NullableColumn::create(std::move(result_data_column), std::move(result_null_column));
         } else {
             return result_data_column;
         }
     }
 
     static ColumnPtr _array_overlap(const Columns& columns) {
-        size_t chunk_size = columns[0]->size();
-        auto result_data_column = BooleanColumn::create(chunk_size, 0);
+        const size_t num_rows = columns[0]->size();
+        auto [is_all_const, num_packed_rows] = ColumnHelper::num_packed_rows(columns);
+
+        auto result_data_column = BooleanColumn::create(num_packed_rows, 0);
         auto& result_data = result_data_column->get_data();
 
         const auto* src_data_column_0 = ColumnHelper::get_data_column_by_type<TYPE_ARRAY>(columns[0].get());
@@ -395,15 +403,30 @@ private:
 
         DCHECK(src_data_column_0->elements_column()->is_nullable());
 
-        //TODO: use small array to build hash set
-        for (size_t i = 0; i < chunk_size; i++) {
+        if (!is_all_const && (columns[0]->is_constant() || columns[1]->is_constant())) {
+            const auto* const_data_column = columns[0]->is_constant() ? src_data_column_0 : src_data_column_1;
+            const auto* non_const_column = columns[0]->is_constant() ? src_data_column_1 : src_data_column_0;
+
             HashSet hash_set;
-            bool has_null = _put_array_to_hash_set(*src_data_column_1, i, &hash_set);
-            result_data[i] = _check_column_overlap_nullable(hash_set, *src_data_column_0, i, has_null);
+            const bool has_null = _put_array_to_hash_set(*const_data_column, 0, &hash_set);
+            for (size_t i = 0; i < num_packed_rows; i++) {
+                result_data[i] = _check_column_overlap_nullable(hash_set, *non_const_column, i, has_null);
+            }
+        } else {
+            //TODO: use small array to build hash set
+            for (size_t i = 0; i < num_packed_rows; i++) {
+                HashSet hash_set;
+                const bool has_null = _put_array_to_hash_set(*src_data_column_1, i, &hash_set);
+                result_data[i] = _check_column_overlap_nullable(hash_set, *src_data_column_0, i, has_null);
+            }
         }
 
-        if (result_null_column != nullptr) {
-            return NullableColumn::create(result_data_column, result_null_column);
+        if (is_all_const) {
+            // Const null column is handled by `RETURN_IF_COLUMNS_ONLY_NULL` in `process`.
+            DCHECK(result_null_column == nullptr);
+            return ConstColumn::create(std::move(result_data_column), num_rows);
+        } else if (result_null_column != nullptr) {
+            return NullableColumn::create(std::move(result_data_column), std::move(result_null_column));
         } else {
             return result_data_column;
         }

--- a/test/sql/test_array_fn/R/test_arrays_overlap
+++ b/test/sql/test_array_fn/R/test_arrays_overlap
@@ -695,3 +695,135 @@ select arrays_overlap([4, 3], [1, null]);
 -- result:
 0
 -- !result
+-- name: test_arrays_overlap_constant_columns
+CREATE TABLE `t1` (
+  `k1` int(11) NULL,
+  `a1` array<String> NULL,
+  `a2` array<String> NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 values
+    (1, null, ['a', 'c', 'b', null]),
+    (2, null, ['a', 'c', 'b']),
+    (3, null, ['a', 'c']),
+    (4, null, ['a']);
+-- result:
+-- !result
+select k1, a1, a2, arrays_overlap(ifnull(a1, []), ['a', 'c', 'b', null]) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	0
+2	None	["a","c","b"]	0
+3	None	["a","c"]	0
+4	None	["a"]	0
+-- !result
+select k1, a1, a2, arrays_overlap(['a', 'c', 'b', null], ifnull(a1, [])) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	0
+2	None	["a","c","b"]	0
+3	None	["a","c"]	0
+4	None	["a"]	0
+-- !result
+select k1, a1, a2, arrays_overlap(ifnull(a1, [null]), ['a', 'c', 'b', null]) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	1
+2	None	["a","c","b"]	1
+3	None	["a","c"]	1
+4	None	["a"]	1
+-- !result
+select k1, a1, a2, arrays_overlap(['a', 'c', 'b', null], ifnull(a1, [null])) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	1
+2	None	["a","c","b"]	1
+3	None	["a","c"]	1
+4	None	["a"]	1
+-- !result
+select k1, a1, a2, arrays_overlap(ifnull(a1, null), ['a', 'c', 'b', null]) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	None
+2	None	["a","c","b"]	None
+3	None	["a","c"]	None
+4	None	["a"]	None
+-- !result
+select k1, a1, a2, arrays_overlap(['a', 'c', 'b', null], ifnull(a1, null)) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	None
+2	None	["a","c","b"]	None
+3	None	["a","c"]	None
+4	None	["a"]	None
+-- !result
+select k1, a1, a2, arrays_overlap(ifnull(a1, []), a2) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	0
+2	None	["a","c","b"]	0
+3	None	["a","c"]	0
+4	None	["a"]	0
+-- !result
+select k1, a1, a2, arrays_overlap(a2, ifnull(a1, [])) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	0
+2	None	["a","c","b"]	0
+3	None	["a","c"]	0
+4	None	["a"]	0
+-- !result
+select k1, a1, a2, arrays_overlap(ifnull(a1, null), a2) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	None
+2	None	["a","c","b"]	None
+3	None	["a","c"]	None
+4	None	["a"]	None
+-- !result
+select k1, a1, a2, arrays_overlap(a2, ifnull(a1, null)) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	None
+2	None	["a","c","b"]	None
+3	None	["a","c"]	None
+4	None	["a"]	None
+-- !result
+select k1, a1, a2, arrays_overlap(ifnull(a1, [null]), a2) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	1
+2	None	["a","c","b"]	0
+3	None	["a","c"]	0
+4	None	["a"]	0
+-- !result
+select k1, a1, a2, arrays_overlap(a2, ifnull(a1, [null])) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	1
+2	None	["a","c","b"]	0
+3	None	["a","c"]	0
+4	None	["a"]	0
+-- !result
+select k1, a1, a2, arrays_overlap(ifnull(a1, ['a']), ifnull(a1, ['a', 'b'])) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	1
+2	None	["a","c","b"]	1
+3	None	["a","c"]	1
+4	None	["a"]	1
+-- !result
+select k1, a1, a2, arrays_overlap(ifnull(a1, null), ifnull(a1, ['a', 'b'])) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	None
+2	None	["a","c","b"]	None
+3	None	["a","c"]	None
+4	None	["a"]	None
+-- !result
+select k1, a1, a2, arrays_overlap(ifnull(a1, ['a', null]), ifnull(a1, ['a', 'b'])) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	1
+2	None	["a","c","b"]	1
+3	None	["a","c"]	1
+4	None	["a"]	1
+-- !result
+select k1, a1, a2, arrays_overlap(ifnull(a1, ['a', null]), ifnull(a1, ['a', 'b', null])) from t1 order by k1;
+-- result:
+1	None	["a","c","b",null]	1
+2	None	["a","c","b"]	1
+3	None	["a","c"]	1
+4	None	["a"]	1
+-- !result

--- a/test/sql/test_array_fn/T/test_arrays_overlap
+++ b/test/sql/test_array_fn/T/test_arrays_overlap
@@ -147,3 +147,52 @@ select arrays_overlap([row(1,2,3), row(3,4,5), row(4,5,6)], [row(3,4,5)]);
 
 select arrays_overlap([1, null], [4, 3]);
 select arrays_overlap([4, 3], [1, null]);
+
+
+-- name: test_arrays_overlap_constant_columns
+
+CREATE TABLE `t1` (
+  `k1` int(11) NULL,
+  `a1` array<String> NULL,
+  `a2` array<String> NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t1 values
+    (1, null, ['a', 'c', 'b', null]),
+    (2, null, ['a', 'c', 'b']),
+    (3, null, ['a', 'c']),
+    (4, null, ['a']);
+
+-- one static constant column, one runtime constant column.
+select k1, a1, a2, arrays_overlap(ifnull(a1, []), ['a', 'c', 'b', null]) from t1 order by k1;
+select k1, a1, a2, arrays_overlap(['a', 'c', 'b', null], ifnull(a1, [])) from t1 order by k1;
+
+select k1, a1, a2, arrays_overlap(ifnull(a1, [null]), ['a', 'c', 'b', null]) from t1 order by k1;
+select k1, a1, a2, arrays_overlap(['a', 'c', 'b', null], ifnull(a1, [null])) from t1 order by k1;
+
+select k1, a1, a2, arrays_overlap(ifnull(a1, null), ['a', 'c', 'b', null]) from t1 order by k1;
+select k1, a1, a2, arrays_overlap(['a', 'c', 'b', null], ifnull(a1, null)) from t1 order by k1;
+
+-- one none-constant column, one runtime constant column.
+select k1, a1, a2, arrays_overlap(ifnull(a1, []), a2) from t1 order by k1;
+select k1, a1, a2, arrays_overlap(a2, ifnull(a1, [])) from t1 order by k1;
+
+select k1, a1, a2, arrays_overlap(ifnull(a1, null), a2) from t1 order by k1;
+select k1, a1, a2, arrays_overlap(a2, ifnull(a1, null)) from t1 order by k1;
+
+select k1, a1, a2, arrays_overlap(ifnull(a1, [null]), a2) from t1 order by k1;
+select k1, a1, a2, arrays_overlap(a2, ifnull(a1, [null])) from t1 order by k1;
+
+-- two runtime constant columns.
+select k1, a1, a2, arrays_overlap(ifnull(a1, ['a']), ifnull(a1, ['a', 'b'])) from t1 order by k1;
+
+select k1, a1, a2, arrays_overlap(ifnull(a1, null), ifnull(a1, ['a', 'b'])) from t1 order by k1;
+
+select k1, a1, a2, arrays_overlap(ifnull(a1, ['a', null]), ifnull(a1, ['a', 'b'])) from t1 order by k1;
+
+select k1, a1, a2, arrays_overlap(ifnull(a1, ['a', null]), ifnull(a1, ['a', 'b', null])) from t1 order by k1;


### PR DESCRIPTION
## Why I'm doing:

The `arrays_overlaps` function does not account for runtime constant columns, which are constant columns generated by upstream operators, rather than literals in SQL.

The function uses `num_rows` based on the unpacked row count (**>1**), while the data column is based on the packed row count (**=1**), leading to out-of-bounds access.

## What I'm doing:


Fixes #52837

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
