### PR TITLE
[Feature] support collect routine load latency metric

### DIFF
--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -294,6 +294,8 @@ public:
     // A hint for the left time of this batch to finish
     int64_t batch_left_time_nanos = -1;
 
+    uint64_t first_msg_timestamp = 0;
+
 public:
     bool is_channel_stream_load_context() { return channel_id != -1; }
     ExecEnv* exec_env() { return _exec_env; }

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -482,6 +482,8 @@ bool StreamLoadExecutor::collect_load_stat(StreamLoadContext* ctx, TTxnCommitAtt
         if (!ctx->error_url.empty()) {
             rl_attach.__set_errorLogUrl(ctx->error_url);
         }
+        rl_attach.__isset.firstMsgTimestamp = true;
+        rl_attach.__set_firstMsgTimestamp(ctx->first_msg_timestamp);
         return true;
     }
     case TLoadSourceType::PULSAR: {
@@ -496,6 +498,8 @@ bool StreamLoadExecutor::collect_load_stat(StreamLoadContext* ctx, TTxnCommitAtt
         if (!ctx->error_url.empty()) {
             rl_attach.__set_errorLogUrl(ctx->error_url);
         }
+        rl_attach.__isset.firstMsgTimestamp = true;
+        rl_attach.__set_firstMsgTimestamp(ctx->first_msg_timestamp);
         return true;
     }
     default:

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3329,6 +3329,12 @@ public class Config extends ConfigBase {
 
     public static int batch_write_executor_threads_num = 4096;
 
+    /**
+     * Whether to collect routine load latency metrics.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_routine_load_latency_metrics = false;
+
     @ConfField(mutable = true)
     public static int arrow_token_cache_size = 1024;
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -454,6 +454,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                 Long.valueOf((totalRows - errorRows - unselectedRows) * 1000 / totalTaskExcutionTimeMs));
         summary.put("committedTaskNum", Long.valueOf(committedTaskNum));
         summary.put("abortedTaskNum", Long.valueOf(abortedTaskNum));
+        summary.putAll(getLatency());
         Gson gson = new GsonBuilder().disableHtmlEscaping().create();
         return gson.toJson(summary);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
@@ -401,6 +401,7 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
                 (totalRows - errorRows - unselectedRows) * 1000 / totalTaskExcutionTimeMs);
         summary.put("committedTaskNum", committedTaskNum);
         summary.put("abortedTaskNum", abortedTaskNum);
+        summary.putAll(getLatency());
         Gson gson = new GsonBuilder().disableHtmlEscaping().create();
         return gson.toJson(summary);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
@@ -66,6 +66,7 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
     private RoutineLoadProgress timestampProgress;
     private String errorLogUrl;
     private long loadedBytes;
+    private long firstMsgTimestamp;
 
     public RLTaskTxnCommitAttachment() {
         super(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK);
@@ -99,6 +100,10 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
 
         if (rlTaskTxnCommitAttachment.isSetErrorLogUrl()) {
             this.errorLogUrl = rlTaskTxnCommitAttachment.getErrorLogUrl();
+        }
+
+        if (rlTaskTxnCommitAttachment.isSetFirstMsgTimestamp()) {
+            this.firstMsgTimestamp = rlTaskTxnCommitAttachment.getFirstMsgTimestamp();
         }
     }
 
@@ -148,6 +153,10 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
 
     public String getErrorLogUrl() {
         return errorLogUrl;
+    }
+
+    public long getFirstMsgTimestamp() {
+        return firstMsgTimestamp;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -831,6 +831,11 @@ public final class MetricRepo {
         // collect starmgr related metrics as well
         StarMgrServer.getCurrentState().visitMetrics(visitor);
 
+        // collect routine load consume latency metrics
+        if (Config.enable_routine_load_latency_metrics) {
+            RoutineLoadLatencyMetricMgr.visitLatency();
+        }
+
         // node info
         visitor.getNodeInfo();
         return visitor.build();

--- a/fe/fe-core/src/main/java/com/starrocks/metric/RoutineLoadLatencyMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/RoutineLoadLatencyMetricMgr.java
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.starrocks.load.routineload.RoutineLoadJob;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+public class RoutineLoadLatencyMetricMgr {
+    private static final Logger LOG = LogManager.getLogger(RoutineLoadLatencyMetricMgr.class);
+
+    private static final String ROUTINE_LOAD_LATENCY = "routine_load_latency";
+    private static final ConcurrentHashMap<String, RoutineLoadLatencyMetrics> ROUTINE_LOAD_LATENCY_MAP
+            = new ConcurrentHashMap<>();
+
+    private RoutineLoadLatencyMetricMgr() {
+        throw new UnsupportedOperationException("can't instantiate this class");
+    }
+
+    private static String formatJobName(RoutineLoadJob job) {
+        return job.getDbId() + "." + job.getName();
+    }
+
+    public static void visitLatency() {
+        for (Map.Entry<String, RoutineLoadLatencyMetrics> entry : ROUTINE_LOAD_LATENCY_MAP.entrySet()) {
+            RoutineLoadLatencyMetrics metrics = ROUTINE_LOAD_LATENCY_MAP.get(entry.getKey());
+            metrics.update();
+        }
+    }
+
+    public static void updateLatency(RoutineLoadJob job, Long elapseMs) {
+        RoutineLoadLatencyMetrics metrics = createRoutineLoadLatencyMetrics(formatJobName(job));
+        if (metrics != null) {
+            metrics.histogram.update(elapseMs);
+        }
+    }
+
+    public static Snapshot getLatency(RoutineLoadJob job) {
+        RoutineLoadLatencyMetrics metrics = createRoutineLoadLatencyMetrics(formatJobName(job));
+        if (metrics != null) {
+            return metrics.histogram.getSnapshot();
+        }
+        return null;
+    }
+
+    private static RoutineLoadLatencyMetrics createRoutineLoadLatencyMetrics(String jobName) {
+        ROUTINE_LOAD_LATENCY_MAP.computeIfAbsent(jobName, ROUTINE_LOAD_LATENCY_METRICS_FUNCTION);
+        return ROUTINE_LOAD_LATENCY_MAP.get(jobName);
+    }
+
+    private static final Function<String, RoutineLoadLatencyMetrics> ROUTINE_LOAD_LATENCY_METRICS_FUNCTION =
+            routineLoadJobName -> new RoutineLoadLatencyMetrics(ROUTINE_LOAD_LATENCY, routineLoadJobName);
+
+    private static final class RoutineLoadLatencyMetrics {
+        private static final String[] ROUTINE_LOAD_LATENCY_LABEL =
+                {"median", "95_quantile", "99_quantile", "max"};
+
+        private final MetricRegistry metricRegistry;
+        private Histogram histogram;
+        private final List<GaugeMetricImpl<Double>> metricsList;
+        private final String metricsName;
+
+        private RoutineLoadLatencyMetrics(String metricsName, String routineLoadJobName) {
+            this.metricsName = metricsName;
+            this.metricRegistry = new MetricRegistry();
+            initHistogram(metricsName);
+            this.metricsList = new ArrayList<>();
+            for (String label : ROUTINE_LOAD_LATENCY_LABEL) {
+                GaugeMetricImpl<Double> metrics =
+                        new GaugeMetricImpl<>(metricsName, Metric.MetricUnit.MILLISECONDS,
+                                label + " of routine load latency");
+                metrics.addLabel(new MetricLabel("type", label));
+                metrics.addLabel(new MetricLabel("name", routineLoadJobName));
+                metrics.setValue(0.0);
+                MetricRepo.addMetric(metrics);
+                LOG.info("Add {} metric, routine load job name is {}", ROUTINE_LOAD_LATENCY, routineLoadJobName);
+                this.metricsList.add(metrics);
+            }
+        }
+
+        private void initHistogram(String metricsName) {
+            this.histogram = this.metricRegistry.histogram(metricsName);
+        }
+
+        private void update() {
+            Histogram oldHistogram = this.histogram;
+            this.metricRegistry.remove(this.metricsName);
+            initHistogram(metricsName);
+
+            Snapshot snapshot = oldHistogram.getSnapshot();
+            metricsList.get(0).setValue(snapshot.getMedian());
+            metricsList.get(1).setValue(snapshot.get95thPercentile());
+            metricsList.get(2).setValue(snapshot.get99thPercentile());
+            metricsList.get(3).setValue((double) snapshot.getMax());
+        }
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1002,6 +1002,7 @@ struct TRLTaskTxnCommitAttachment {
     10: optional TKafkaRLTaskProgress kafkaRLTaskProgress
     11: optional string errorLogUrl
     12: optional TPulsarRLTaskProgress pulsarRLTaskProgress
+    13: optional i64 firstMsgTimestamp
 }
 
 struct TMiniLoadTxnCommitAttachment {


### PR DESCRIPTION

## Why I'm doing:
Fixes #52890

need a metric to watch routine load latency

## What I'm doing:
Add a metric to record routine load consume latency (duration between kafka/pulsar publish time to sr transaction finish time)



New add metrics list are:

```

starrocks_fe_routine_load_latency{type="median", name="11253.test_rl_01"} 72676.0
starrocks_fe_routine_load_latency{type="95_quantile", name="11253.test_rl_01"} 74549.0
starrocks_fe_routine_load_latency{type="99_quantile", name="11253.test_rl_01"} 74549.0
starrocks_fe_routine_load_latency{type="max", name="11253.test_rl_01"} 74549
```

Show routine load command can also see latency detail in Statistic field:

```sql
MySQL [test_db]> show routine load for rl_test_01 \G
*************************** 1. row ***************************
                  Id: 4906906
                Name: rl_test_01
          CreateTime: 2024-11-13 10:47:30
           PauseTime: NULL
             EndTime: NULL
              DbName: test_db
           TableName: test_tbl_01
               State: RUNNING
      DataSourceType: KAFKA
      CurrentTaskNum: 1
       JobProperties: {"partial_update_mode":"null","timezone":"Asia/Shanghai","columnSeparator":"|","log_rejected_record_num":"0","taskTimeoutSecond":"200","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","currentTaskConcurrentNum":"1","escape":"0","enclose":"0","partitions":"*","rowDelimiter":"\n","partial_update":"false","trim_space":"false","columnToColumnExpr":"noop01,noop02,GameSvrId,dtEventTime,GameAppID,OpenID,PlatID,AreaID","maxBatchIntervalS":"10","whereExpr":"*","format":"csv","json_root":"","taskConsumeSecond":"30","desireTaskConcurrentNum":"1","maxErrorNum":"10030000","strip_outer_array":"false","maxBatchRows":"3000000"}
DataSourceProperties: {"topic":"test_topic_01","currentKafkaPartitions":"0,1,2","brokerList":"127.0.0.1:9092"}
    CustomProperties: {"kafka_default_offsets":"OFFSET_END","group.id":"k_loadtest_01","client.id":"k_loadtest_01"}
           Statistic: {"receivedBytes":10218406607,"latency99thPercentileMs":1896300.0,"errorRows":190223,"totalRows":1062515,"taskExecuteTimeMs":420835,"committedTaskNum":11,"latencyMedianMs":1892339.0,"loadedRows":872292,"loadRowsRate":2072,"abortedTaskNum":39,"latency95thPercentileMs":1896300.0,"unselectedRows":0,"receivedBytesRate":24281266,"latencyMaxMs":1896300}
            Progress: {"0":"15585573","1":"15583250","2":"15587519","3":"15591153","4":"15587126","5":"15584607","6":"15584767","7":"15586486","8":"15585819","9":"15582431","10":"15583384","11":"15586928"}
   TimestampProgress: {}
ReasonOfStateChanged: 
        ErrorLogUrls: 
         TrackingSQL: 
            OtherMsg: [2024-11-13 17:51:10] [task id: 962e7a84-f522-493f-8c0f-d50103598ba6] [txn id: -1] there is no new data in kafka, wait for 10 seconds to schedule again
LatestSourcePosition: {"0":"15585574","11":"15586929","1":"15583251","2":"15587520","3":"15591154","4":"15587127","5":"15584608","6":"15584768","7":"15586487","8":"15585820","9":"15582432","10":"15583385"}
1 row in set (0.00 sec)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
