### PR TITLE
[Feature] Support Backup/Restore for external catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -46,8 +46,10 @@ import com.starrocks.backup.AbstractJob.JobType;
 import com.starrocks.backup.BackupJob.BackupJobState;
 import com.starrocks.backup.BackupJobInfo.BackupTableInfo;
 import com.starrocks.backup.mv.MvRestoreContext;
+import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
+import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
@@ -74,6 +76,7 @@ import com.starrocks.sql.ast.AbstractBackupStmt;
 import com.starrocks.sql.ast.BackupStmt;
 import com.starrocks.sql.ast.BackupStmt.BackupType;
 import com.starrocks.sql.ast.CancelBackupStmt;
+import com.starrocks.sql.ast.CatalogRef;
 import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.sql.ast.DropRepositoryStmt;
 import com.starrocks.sql.ast.FunctionRef;
@@ -98,6 +101,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
@@ -124,6 +128,8 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
     // If the last job is finished, user can get the job info from repository. If the last job is cancelled,
     // user can get the error message before submitting the next one.
     // Use ConcurrentMap to get rid of locks.
+    // Backup/Restore job for external catalog using -1 to identify the job in dbIdToBackupOrRestoreJob
+    // which means that only one external catalog backup/restore job can be run in entire cluster
     protected Map<Long, AbstractJob> dbIdToBackupOrRestoreJob = Maps.newConcurrentMap();
 
     protected MvRestoreContext mvRestoreContext = new MvRestoreContext();
@@ -261,11 +267,12 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         // check if repo exist
         String repoName = stmt.getRepoName();
         Repository repository = repoMgr.getRepo(repoName);
+        Database db = null;
+        BackupJobInfo jobInfo = null;
         if (repository == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR, "Repository " + repoName + " does not exist");
         }
 
-        BackupJobInfo jobInfo = null;
         if (stmt instanceof RestoreStmt) {
             // Check if snapshot exist in repository, if existed, get jobInfo for restore process
             List<BackupJobInfo> infos = Lists.newArrayList();
@@ -277,30 +284,49 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
             }
             Preconditions.checkState(infos.size() == 1);
             jobInfo = infos.get(0);
-        }
 
-        // check if db exist
-        String dbName = stmt.getDbName();
-        if (dbName == null) {
-            // if target dbName if null, use dbName in snapshot
-            dbName = jobInfo.dbName;
-        }
-
-        Database db = globalStateMgr.getLocalMetastore().getDb(dbName);
-        if (db == null) {
-            if (stmt instanceof RestoreStmt) {
-                try {
-                    globalStateMgr.getLocalMetastore().createDb(dbName, null);
-                    db = globalStateMgr.getLocalMetastore().getDb(dbName);
-                    if (db == null) {
-                        ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
-                    }
-                } catch (Exception e) {
+            if (jobInfo.dbName == null || jobInfo.dbName.isEmpty()) {
+                // if jobInfo.dbName == null, means that this snapshot only contains external catalog info
+                if ((stmt.getOriginDbName() != null && !stmt.getOriginDbName().isEmpty()) ||
+                        stmt.getDbName() != null && !stmt.getDbName().isEmpty()) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
-                                "Can not create database: " + dbName + " in restore process");
+                                                   "Can not specify database for external catalog snapshot");
                 }
-            } else {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+
+                if (!stmt.containsExternalCatalog()) {
+                    // set `ALL` flag for external catalog restore if no `CATALOG(s)` set in restore stmt
+                    stmt.setAllExternalCatalog();
+                }
+            } else if (stmt.containsExternalCatalog()) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                                "This is not a snapshot for external catalog restore, snapshot: " + stmt.getLabel());
+            }
+        }
+
+        if (!stmt.containsExternalCatalog()) {
+            // check if db exist
+            String dbName = stmt.getDbName();
+            if (dbName == null) {
+                // if target dbName if null, use dbName in snapshot
+                dbName = jobInfo.dbName;
+            }
+    
+            db = globalStateMgr.getLocalMetastore().getDb(dbName);
+            if (db == null) {
+                if (stmt instanceof RestoreStmt) {
+                    try {
+                        globalStateMgr.getLocalMetastore().createDb(dbName, null);
+                        db = globalStateMgr.getLocalMetastore().getDb(dbName);
+                        if (db == null) {
+                            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+                        }
+                    } catch (Exception e) {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                                    "Can not create database: " + dbName + " in restore process");
+                    }
+                } else {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+                }
             }
         }
 
@@ -311,7 +337,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         tryLock();
         try {
             // Check if there is backup or restore job running on this database
-            AbstractJob currentJob = dbIdToBackupOrRestoreJob.get(db.getId());
+            AbstractJob currentJob = dbIdToBackupOrRestoreJob.get(stmt.containsExternalCatalog() ? -1 : db.getId());
             if (currentJob != null && !currentJob.isDone()) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                         "Can only run one backup or restore job of a database at same time");
@@ -351,7 +377,9 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         List<TableRef> tblRefs = stmt.getTableRefs();
         BackupMeta curBackupMeta = null;
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        if (!stmt.containsExternalCatalog()) {
+            locker.lockDatabase(db.getId(), LockType.READ);
+        }
         try {
             List<Table> backupTbls = Lists.newArrayList();
             for (TableRef tblRef : tblRefs) {
@@ -410,7 +438,9 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
             }
             curBackupMeta = new BackupMeta(backupTbls);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            if (!stmt.containsExternalCatalog()) {
+                locker.unLockDatabase(db.getId(), LockType.READ);   
+            }
         }
 
         // Check if label already be used
@@ -448,30 +478,35 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         }
 
         // Create a backup job
-        BackupJob backupJob = new BackupJob(stmt.getLabel(), db.getId(), db.getOriginName(), tblRefs,
+        long dbId = stmt.containsExternalCatalog() ? -1 : db.getId();
+        String dbName = stmt.containsExternalCatalog() ? "" : db.getOriginName();
+
+        BackupJob backupJob = new BackupJob(stmt.getLabel(), dbId, dbName, tblRefs,
                 stmt.getTimeoutMs(), globalStateMgr, repository.getId());
         List<Function> allFunctions = Lists.newArrayList();
         for (FunctionRef fnRef : stmt.getFnRefs()) {
             allFunctions.addAll(fnRef.getFunctions());
         }
         backupJob.setBackupFunctions(allFunctions);
+        backupJob.setBackupCatalogs(stmt.getExternalCatalogRefs().stream()
+                                    .map(CatalogRef::getCatalog).collect(Collectors.toList()));
         // write log
         globalStateMgr.getEditLog().logBackupJob(backupJob);
 
         // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
-        dbIdToBackupOrRestoreJob.put(db.getId(), backupJob);
+        dbIdToBackupOrRestoreJob.put(dbId, backupJob);
 
         LOG.info("finished to submit backup job: {}", backupJob);
     }
 
     private void restore(Repository repository, Database db, RestoreStmt stmt, BackupJobInfo jobInfo) throws DdlException {
+        BackupMeta backupMeta = downloadAndDeserializeMetaInfo(jobInfo, repository, stmt);
+
         // check the original dbName existed in snapshot or not
         if (!stmt.getOriginDbName().isEmpty() && !stmt.getOriginDbName().equals(jobInfo.dbName)) {
             ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                         "target database: " + stmt.getOriginDbName() + " is not existed in snapshot");
         }
-
-        BackupMeta backupMeta = downloadAndDeserializeMetaInfo(jobInfo, repository, stmt);
 
         // If restore statement contains `ON` clause, filter the specified backup objects which are needed through infomation
         // provide in stmt and BackupMeta.
@@ -483,6 +518,10 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         // and `ALL` clause for functions. Otherwise, restore the functions specified after `ON` clause in restore statement.
         if (stmt.withOnClause() && backupMeta != null) {
             checkAndFilterRestoreFunctionsInBackupMeta(stmt, backupMeta);
+        }
+
+        if (stmt.containsExternalCatalog()) {
+            checkAndFilterRestoreCatalogsInBackupMeta(stmt, backupMeta);
         }
 
         // Create a restore job
@@ -498,13 +537,17 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
                 mvRestoreContext.addIntoMvBaseTableBackupInfoIfNeeded(db.getOriginName(), remoteTbl, jobInfo, tblInfo);
             }
         }
+
+        long dbId = stmt.containsExternalCatalog() ? -1 : db.getId();
+        String dbName = stmt.containsExternalCatalog() ? "" : db.getOriginName();
+
         restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
-                db.getId(), db.getOriginName(), jobInfo, stmt.allowLoad(), stmt.getReplicationNum(),
+                dbId, dbName, jobInfo, stmt.allowLoad(), stmt.getReplicationNum(),
                 stmt.getTimeoutMs(), globalStateMgr, repository.getId(), backupMeta, mvRestoreContext);
         globalStateMgr.getEditLog().logRestoreJob(restoreJob);
 
         // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
-        dbIdToBackupOrRestoreJob.put(db.getId(), restoreJob);
+        dbIdToBackupOrRestoreJob.put(dbId, restoreJob);
 
         LOG.info("finished to submit restore job: {}", restoreJob);
     }
@@ -526,6 +569,33 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         }
         Preconditions.checkState(backupMetas.size() == 1);
         return backupMetas.get(0);
+    }
+
+    protected void checkAndFilterRestoreCatalogsInBackupMeta(RestoreStmt stmt, BackupMeta backupMeta) throws DdlException {
+        List<Catalog> catalogsInBackupMeta = backupMeta.getCatalogs();
+        List<Catalog> restoredCatalogs = Lists.newArrayList();
+        for (CatalogRef catalogRef : stmt.getExternalCatalogRefs()) {
+            Optional<Catalog> hitCatalog = catalogsInBackupMeta.stream().filter(x -> catalogRef.getCatalogName()
+                                    .equalsIgnoreCase(x.getName())).findFirst();
+            if (!hitCatalog.isPresent()) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                                               "Can not find restore catalog: " + catalogRef.getCatalogName());
+            }
+
+            if (catalogRef.getAlias() != null && !catalogRef.getAlias().isEmpty()) {
+                if (catalogRef.getAlias().equalsIgnoreCase(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
+                                "Do not support set alias as default catalog for external catalog restore");   
+                }
+                hitCatalog.get().setName(catalogRef.getAlias());
+            }
+
+            restoredCatalogs.add(hitCatalog.get());
+        }
+
+        if (!restoredCatalogs.isEmpty()) {
+            backupMeta.setCatalogs(restoredCatalogs);
+        }
     }
 
     protected void checkAndFilterRestoreFunctionsInBackupMeta(RestoreStmt stmt, BackupMeta backupMeta) throws DdlException {
@@ -630,7 +700,12 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
     }
 
     public void cancel(CancelBackupStmt stmt) throws DdlException {
-        AbstractJob job = getAbstractJobByDbName(stmt.getDbName());
+        AbstractJob job = null;
+        if (!stmt.isExternalCatalog()) {
+            job = getAbstractJobByDbName(stmt.getDbName());
+        } else {
+            job = dbIdToBackupOrRestoreJob.get(-1L);
+        }
         if (job == null || (job instanceof BackupJob && stmt.isRestore())
                 || (job instanceof RestoreJob && !stmt.isRestore())) {
             ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR, "No "

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -46,6 +46,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.backup.Status.ErrCode;
+import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FsBroker;
 import com.starrocks.catalog.Function;
@@ -158,6 +159,8 @@ public class BackupJob extends AbstractJob {
 
     @SerializedName(value = "backupFunctions")
     private List<Function> backupFunctions = Lists.newArrayList();
+    @SerializedName(value = "backupCatalogs")
+    private List<Catalog> backupCatalogs = Lists.newArrayList();
 
     public BackupJob() {
         super(JobType.BACKUP);
@@ -204,6 +207,10 @@ public class BackupJob extends AbstractJob {
 
     public void setBackupFunctions(List<Function> functions) {
         this.backupFunctions = functions;
+    }
+
+    public void setBackupCatalogs(List<Catalog> backupCatalogs) {
+        this.backupCatalogs = backupCatalogs;
     }
 
     public synchronized boolean finishTabletSnapshotTask(SnapshotTask task, TFinishTaskRequest request) {
@@ -463,6 +470,14 @@ public class BackupJob extends AbstractJob {
 
     private void prepareAndSendSnapshotTask() {
         MetricRepo.COUNTER_UNFINISHED_BACKUP_JOB.increase(1L);
+        if (!backupCatalogs.isEmpty()) {
+            // short cut for external catalogs backup
+            backupMeta = new BackupMeta(Lists.newArrayList());
+            backupMeta.setCatalogs(backupCatalogs);
+            state = BackupJobState.SAVE_META;
+
+            return;
+        }
         Database db = globalStateMgr.getLocalMetastore().getDb(dbId);
         if (db == null) {
             status = new Status(ErrCode.NOT_FOUND, "database " + dbId + " does not exist");

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupMeta.java
@@ -37,6 +37,7 @@ package com.starrocks.backup;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.io.Text;
@@ -67,6 +68,8 @@ public class BackupMeta implements Writable, GsonPostProcessable {
     private Map<Long, Table> tblIdMap = Maps.newHashMap();
     @SerializedName(value = "functions")
     private List<Function> functions = Lists.newArrayList();
+    @SerializedName(value = "catalogs")
+    private List<Catalog> catalogs = Lists.newArrayList();
 
     private BackupMeta() {
 
@@ -97,6 +100,14 @@ public class BackupMeta implements Writable, GsonPostProcessable {
 
     public List<Function> getFunctions() {
         return functions;
+    }
+
+    public void setCatalogs(List<Catalog> catalogs) {
+        this.catalogs = catalogs;
+    }
+
+    public List<Catalog> getCatalogs() {
+        return catalogs;
     }
 
     public static BackupMeta fromFile(String filePath, int starrocksMetaVersion) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -70,6 +70,10 @@ public class Catalog implements Writable {
         return name;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public String getType() {
         return config.get(CATALOG_TYPE);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/DefaultAuthorizationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/DefaultAuthorizationProvider.java
@@ -83,8 +83,7 @@ public class DefaultAuthorizationProvider implements AuthorizationProvider {
                 PrivilegeType.USAGE,
                 PrivilegeType.CREATE_DATABASE,
                 PrivilegeType.DROP,
-                PrivilegeType.ALTER,
-                PrivilegeType.EXPORT));
+                PrivilegeType.ALTER));
 
         typeToActionList.put(ObjectType.MATERIALIZED_VIEW, Lists.newArrayList(
                 PrivilegeType.ALTER,
@@ -94,8 +93,7 @@ public class DefaultAuthorizationProvider implements AuthorizationProvider {
 
         typeToActionList.put(ObjectType.FUNCTION, Lists.newArrayList(
                 PrivilegeType.USAGE,
-                PrivilegeType.DROP,
-                PrivilegeType.EXPORT));
+                PrivilegeType.DROP));
 
         typeToActionList.put(ObjectType.RESOURCE_GROUP, Lists.newArrayList(
                 PrivilegeType.ALTER,

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/DefaultAuthorizationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/DefaultAuthorizationProvider.java
@@ -83,7 +83,8 @@ public class DefaultAuthorizationProvider implements AuthorizationProvider {
                 PrivilegeType.USAGE,
                 PrivilegeType.CREATE_DATABASE,
                 PrivilegeType.DROP,
-                PrivilegeType.ALTER));
+                PrivilegeType.ALTER,
+                PrivilegeType.EXPORT));
 
         typeToActionList.put(ObjectType.MATERIALIZED_VIEW, Lists.newArrayList(
                 PrivilegeType.ALTER,
@@ -93,7 +94,8 @@ public class DefaultAuthorizationProvider implements AuthorizationProvider {
 
         typeToActionList.put(ObjectType.FUNCTION, Lists.newArrayList(
                 PrivilegeType.USAGE,
-                PrivilegeType.DROP));
+                PrivilegeType.DROP,
+                PrivilegeType.EXPORT));
 
         typeToActionList.put(ObjectType.RESOURCE_GROUP, Lists.newArrayList(
                 PrivilegeType.ALTER,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1812,6 +1812,15 @@ public class ShowExecutor {
                 List<String> info = backupJob.getInfo();
                 infos.add(info);
             }
+
+            // backup info for external catalog
+            AbstractJob jobI = GlobalStateMgr.getCurrentState().getBackupHandler().getJob(-1L);
+            if (jobI != null && jobI instanceof BackupJob) {
+                BackupJob backupJob = (BackupJob) jobI;
+                List<String> info = backupJob.getInfo();
+                infos.add(info);
+            }
+
             return new ShowResultSet(statement.getMetaData(), infos);
         }
 
@@ -1841,6 +1850,15 @@ public class ShowExecutor {
                 List<String> info = restoreJob.getInfo();
                 infos.add(info);
             }
+
+            // restore info for external catalog
+            AbstractJob jobI = GlobalStateMgr.getCurrentState().getBackupHandler().getJob(-1L);
+            if (jobI != null && jobI instanceof RestoreJob) {  
+                RestoreJob restoreJob = (RestoreJob) jobI;
+                List<String> info = restoreJob.getInfo();
+                infos.add(info); 
+            }
+
             return new ShowResultSet(statement.getMetaData(), infos);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -95,6 +95,11 @@ public class CatalogMgr {
         createCatalog(stmt.getCatalogType(), stmt.getCatalogName(), stmt.getComment(), stmt.getProperties());
     }
 
+    public void createCatalogForRestore(Catalog catalog) throws DdlException {
+        dropCatalogForRestore(catalog, false);
+        createCatalog(catalog.getType(), catalog.getName(), catalog.getComment(), catalog.getConfig());
+    }
+
     // please keep connector and catalog create together, they need keep in consistent asap.
     public void createCatalog(String type, String catalogName, String comment, Map<String, String> properties)
             throws DdlException {
@@ -152,6 +157,16 @@ public class CatalogMgr {
             throw e;
         } finally {
             writeUnLock();
+        }
+    }
+
+    public void dropCatalogForRestore(Catalog catalog, boolean isReplay) {
+        if (!isReplay && catalogExists(catalog.getName())) {
+            DropCatalogStmt stmt = new DropCatalogStmt(catalog.getName());
+            dropCatalog(stmt);
+        } else if (isReplay) {
+            DropCatalogLog dropCatalogLog = new DropCatalogLog(catalog.getName());
+            replayDropCatalog(dropCatalogLog);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -88,6 +88,7 @@ import com.starrocks.sql.ast.CancelCompactionStmt;
 import com.starrocks.sql.ast.CancelExportStmt;
 import com.starrocks.sql.ast.CancelLoadStmt;
 import com.starrocks.sql.ast.CancelRefreshMaterializedViewStmt;
+import com.starrocks.sql.ast.CatalogRef;
 import com.starrocks.sql.ast.CleanTemporaryTableStmt;
 import com.starrocks.sql.ast.CreateAnalyzeJobStmt;
 import com.starrocks.sql.ast.CreateCatalogStmt;
@@ -128,6 +129,7 @@ import com.starrocks.sql.ast.DropUserStmt;
 import com.starrocks.sql.ast.ExecuteAsStmt;
 import com.starrocks.sql.ast.ExecuteScriptStmt;
 import com.starrocks.sql.ast.ExportStmt;
+import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.ast.GrantRoleStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.InstallPluginStmt;
@@ -2110,23 +2112,57 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
                     context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                     PrivilegeType.REPOSITORY.name(), ObjectType.SYSTEM.name(), null);
         }
-        List<TableRef> tableRefs = statement.getTableRefs();
-        if (statement.withOnClause() && tableRefs.isEmpty() && statement.getFnRefs().isEmpty()) {
-            String dBName = statement.getDbName();
-            throw new SemanticException("Database: %s is empty", dBName);
-        }
-        tableRefs.forEach(tableRef -> {
-            TableName tableName = tableRef.getName();
-            try {
-                Authorizer.checkTableAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), tableName,
-                        PrivilegeType.EXPORT);
-            } catch (AccessDeniedException e) {
-                AccessDeniedException.reportAccessDenied(
-                        tableName.getCatalog(),
-                        context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                        PrivilegeType.EXPORT.name(), ObjectType.TABLE.name(), tableName.getTbl());
+        if (!statement.containsExternalCatalog()) {
+            List<TableRef> tableRefs = statement.getTableRefs();
+            List<FunctionRef> functionRefs = statement.getFnRefs();
+            if (tableRefs.isEmpty() && functionRefs.isEmpty()) {
+                String dBName = statement.getDbName();
+                throw new SemanticException("Database: %s is empty", dBName);
             }
-        });
+
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(statement.getDbName());
+            tableRefs.forEach(tableRef -> {
+                TableName tableName = tableRef.getName();
+                try {
+                    Authorizer.checkTableAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), tableName,
+                            PrivilegeType.EXPORT);
+                } catch (AccessDeniedException e) {
+                    AccessDeniedException.reportAccessDenied(
+                            tableName.getCatalog(),
+                            context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                            PrivilegeType.EXPORT.name(), ObjectType.TABLE.name(), tableName.getTbl());
+                }
+            });
+
+            functionRefs.forEach(functionRef -> {
+                List<Function> fns = functionRef.getFunctions();
+                for (Function fn : fns) {
+                    try {
+                        Authorizer.checkFunctionAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                                db, fn, PrivilegeType.EXPORT);
+                    } catch (AccessDeniedException e) {
+                        AccessDeniedException.reportAccessDenied(
+                                InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                                context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                                PrivilegeType.DROP.name(), ObjectType.FUNCTION.name(), fn.getSignature());
+                    }
+                }
+            });
+        } else {
+            List<CatalogRef> externalCatalogs = statement.getExternalCatalogRefs();
+            externalCatalogs.forEach(externalCatalog -> {
+                try {
+                    Authorizer.checkCatalogAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                                externalCatalog.getCatalogName(), PrivilegeType.CREATE_DATABASE);
+                } catch (AccessDeniedException e) {
+                    AccessDeniedException.reportAccessDenied(
+                            externalCatalog.getCatalogName(),
+                            context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                            PrivilegeType.CREATE_DATABASE.name(), ObjectType.CATALOG.name(), externalCatalog.getCatalogName());
+                }
+            });
+        }
+
         return null;
     }
 
@@ -2198,9 +2234,22 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
                     PrivilegeType.REPOSITORY.name(), ObjectType.SYSTEM.name(), null);
         }
 
+        if (statement.containsExternalCatalog()) {
+            try {
+                Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                        PrivilegeType.CREATE_EXTERNAL_CATALOG);
+            } catch (AccessDeniedException e) {
+                AccessDeniedException.reportAccessDenied(
+                        InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                        context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                        PrivilegeType.CREATE_EXTERNAL_CATALOG.name(), ObjectType.SYSTEM.name(), null);
+            }
+            return null;
+        }
+
         List<TableRef> tableRefs = statement.getTableRefs();
         // check create_database on current catalog if we're going to restore the whole database
-        if (!statement.withOnClause() && (tableRefs == null || tableRefs.isEmpty())) {
+        if (!statement.withOnClause()) {
             try {
                 Authorizer.checkCatalogAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                         context.getCurrentCatalog(), PrivilegeType.CREATE_DATABASE);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2153,7 +2153,7 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
             externalCatalogs.forEach(externalCatalog -> {
                 try {
                     Authorizer.checkCatalogAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                                externalCatalog.getCatalogName(), PrivilegeType.CREATE_DATABASE);
+                                externalCatalog.getCatalogName(), PrivilegeType.EXPORT);
                 } catch (AccessDeniedException e) {
                     AccessDeniedException.reportAccessDenied(
                             externalCatalog.getCatalogName(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2139,7 +2139,7 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
                 for (Function fn : fns) {
                     try {
                         Authorizer.checkFunctionAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                                db, fn, PrivilegeType.EXPORT);
+                                db, fn, PrivilegeType.USAGE);
                     } catch (AccessDeniedException e) {
                         AccessDeniedException.reportAccessDenied(
                                 InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
@@ -2153,7 +2153,7 @@ public class AuthorizerStmtVisitor implements AstVisitor<Void, ConnectContext> {
             externalCatalogs.forEach(externalCatalog -> {
                 try {
                     Authorizer.checkCatalogAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                                externalCatalog.getCatalogName(), PrivilegeType.EXPORT);
+                                externalCatalog.getCatalogName(), PrivilegeType.USAGE);
                 } catch (AccessDeniedException e) {
                     AccessDeniedException.reportAccessDenied(
                             externalCatalog.getCatalogName(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AbstractBackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AbstractBackupStmt.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.LabelName;
 import com.starrocks.analysis.TableRef;
+import com.starrocks.sql.ast.CatalogRef;
 import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.parser.NodePosition;
 
@@ -33,12 +34,14 @@ public class AbstractBackupStmt extends DdlStmt {
         MV,
         VIEW,
         FUNCTION,
+        EXTERNAL_CATALOG,
     }
 
     protected LabelName labelName;
     protected String repoName;
     protected List<TableRef> tblRefs;
     protected List<FunctionRef> fnRefs;
+    protected List<CatalogRef> externalCatalogRefs;
 
     protected Set<BackupObjectType> allMarker;
 
@@ -53,7 +56,7 @@ public class AbstractBackupStmt extends DdlStmt {
     protected long timeoutMs;
 
     public AbstractBackupStmt(LabelName labelName, String repoName, List<TableRef> tableRefs,
-                              List<FunctionRef> fnRefs, Set<BackupObjectType> allMarker,
+                              List<FunctionRef> fnRefs, List<CatalogRef> externalCatalogRefs, Set<BackupObjectType> allMarker,
                               boolean withOnClause, String originDbName, Map<String, String> properties, NodePosition pos) {
         super(pos);
         this.labelName = labelName;
@@ -65,6 +68,10 @@ public class AbstractBackupStmt extends DdlStmt {
         this.fnRefs = fnRefs;
         if (this.fnRefs == null) {
             this.fnRefs = Lists.newArrayList();
+        }
+        this.externalCatalogRefs = externalCatalogRefs;
+        if (this.externalCatalogRefs == null) {
+            this.externalCatalogRefs = Lists.newArrayList();
         }
         this.allMarker = allMarker;
         if (this.allMarker == null) {
@@ -100,6 +107,10 @@ public class AbstractBackupStmt extends DdlStmt {
         return fnRefs;
     }
 
+    public List<CatalogRef> getExternalCatalogRefs() {
+        return externalCatalogRefs;
+    }
+
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -124,12 +135,24 @@ public class AbstractBackupStmt extends DdlStmt {
         return allMarker.contains(BackupObjectType.VIEW);
     }
 
+    public boolean allExternalCatalog() {
+        return allMarker.contains(BackupObjectType.EXTERNAL_CATALOG);
+    }
+
+    public void setAllExternalCatalog() {
+        allMarker.add(BackupObjectType.EXTERNAL_CATALOG);
+    }
+
     public long getTimeoutMs() {
         return timeoutMs;
     }
 
     public String getOriginDbName() {
         return this.originDbName;
+    }
+
+    public boolean containsExternalCatalog() {
+        return allExternalCatalog() || !externalCatalogRefs.isEmpty();
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/BackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/BackupStmt.java
@@ -32,15 +32,17 @@ public class BackupStmt extends AbstractBackupStmt {
     private BackupType type = BackupType.FULL;
 
     public BackupStmt(LabelName labelName, String repoName, List<TableRef> tblRefs, List<FunctionRef> fnRefs,
-                      Set<BackupObjectType> allMarker, boolean withOnClause, String originDbName,
-                      Map<String, String> properties) {
-        super(labelName, repoName, tblRefs, fnRefs, allMarker, withOnClause, originDbName, properties, NodePosition.ZERO);
+                      List<CatalogRef> externalCatalogRefs, Set<BackupObjectType> allMarker,
+                      boolean withOnClause, String originDbName, Map<String, String> properties) {
+        super(labelName, repoName, tblRefs, fnRefs, externalCatalogRefs,
+                allMarker, withOnClause, originDbName, properties, NodePosition.ZERO);
     }
 
     public BackupStmt(LabelName labelName, String repoName, List<TableRef> tblRefs, List<FunctionRef> fnRefs,
-                      Set<BackupObjectType> allMarker, boolean withOnClause, String originDbName,
-                      Map<String, String> properties, NodePosition pos) {
-        super(labelName, repoName, tblRefs, fnRefs, allMarker, withOnClause, originDbName, properties, pos);
+                      List<CatalogRef> externalCatalogRefs, Set<BackupObjectType> allMarker,
+                      boolean withOnClause, String originDbName, Map<String, String> properties, NodePosition pos) {
+        super(labelName, repoName, tblRefs, fnRefs, externalCatalogRefs,
+                allMarker, withOnClause, originDbName, properties, pos);
     }
 
     public long getTimeoutMs() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CancelBackupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CancelBackupStmt.java
@@ -21,15 +21,22 @@ public class CancelBackupStmt extends CancelStmt {
 
     private String dbName;
     private final boolean isRestore;
+    private final boolean isExternalCatalog;
 
     public CancelBackupStmt(String dbName, boolean isRestore) {
-        this(dbName, isRestore, NodePosition.ZERO);
+        this(dbName, isRestore, false, NodePosition.ZERO);
     }
 
-    public CancelBackupStmt(String dbName, boolean isRestore, NodePosition pos) {
+    public CancelBackupStmt(String dbName, boolean isRestore, boolean isExternalCatalog) {
+        this(dbName, isRestore, isExternalCatalog, NodePosition.ZERO);
+    }
+
+    public CancelBackupStmt(String dbName, boolean isRestore, boolean isExternalCatalog,
+                            NodePosition pos) {
         super(pos);
         this.dbName = dbName;
         this.isRestore = isRestore;
+        this.isExternalCatalog = isExternalCatalog;
     }
 
     public String getDbName() {
@@ -42,6 +49,10 @@ public class CancelBackupStmt extends CancelStmt {
 
     public boolean isRestore() {
         return isRestore;
+    }
+
+    public boolean isExternalCatalog() {
+        return isExternalCatalog;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CatalogRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CatalogRef.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.ast;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.catalog.Catalog;
+import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.parser.NodePosition;
+
+/**
+ * CatalogRef is used to represent Catalog used in Backup/Restore
+ */
+public class CatalogRef implements ParseNode {
+    private final NodePosition pos;
+    private String catalogName;
+    private String alias;
+    private Catalog catalog;
+    private boolean isAnalyzed;
+
+    public CatalogRef(String catalogName) {
+        this(catalogName, "");
+    }
+
+    public CatalogRef(String catalogName, String alias) {
+        this.catalogName = catalogName;
+        this.alias = alias;
+        this.isAnalyzed = false;
+        this.pos = NodePosition.ZERO;
+    }
+
+    public String getCatalogName() {
+        return this.catalogName;
+    }
+
+    public String getAlias() {
+        return this.alias;
+    }
+
+    public Catalog getCatalog() {
+        Preconditions.checkState(isAnalyzed);
+        return this.catalog;
+    }
+
+    public void analyzeForBackup() {
+        if (catalogName.equalsIgnoreCase(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Do not support Backup/Restore the entire default catalog");   
+        }
+
+        if (!GlobalStateMgr.getCurrentState().getCatalogMgr().catalogExists(catalogName)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "external catalog " + catalogName + " does not existed.");
+        }
+
+        catalog = GlobalStateMgr.getCurrentState().getCatalogMgr().getCatalogByName(catalogName);
+        isAnalyzed = true;
+    }
+
+    @Override
+    public NodePosition getPos() {
+        return pos;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RestoreStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RestoreStmt.java
@@ -33,16 +33,18 @@ public class RestoreStmt extends AbstractBackupStmt {
     private int starrocksMetaVersion = -1;
 
     public RestoreStmt(LabelName labelName, String repoName, List<TableRef> tblRefs,
-                       List<FunctionRef> fnRefs, Set<BackupObjectType> allMarker,
+                       List<FunctionRef> fnRefs, List<CatalogRef> externalCatalogRefs, Set<BackupObjectType> allMarker,
                        boolean withOnClause, String originDbName, Map<String, String> properties) {
-        this(labelName, repoName, tblRefs, fnRefs, allMarker, withOnClause, originDbName, properties, NodePosition.ZERO);
+        this(labelName, repoName, tblRefs, fnRefs, externalCatalogRefs,
+                allMarker, withOnClause, originDbName, properties, NodePosition.ZERO);
     }
 
     public RestoreStmt(LabelName labelName, String repoName, List<TableRef> tblRefs,
-                       List<FunctionRef> fnRefs, Set<BackupObjectType> allMarker,
+                       List<FunctionRef> fnRefs, List<CatalogRef> externalCatalogRefs, Set<BackupObjectType> allMarker,
                        boolean withOnClause, String originDbName,
                        Map<String, String> properties, NodePosition pos) {
-        super(labelName, repoName, tblRefs, fnRefs, allMarker, withOnClause, originDbName, properties, pos);
+        super(labelName, repoName, tblRefs, fnRefs, externalCatalogRefs,
+                allMarker, withOnClause, originDbName, properties, pos);
     }
 
     public boolean allowLoad() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
@@ -237,7 +237,4 @@ public interface ParserErrorMsg {
 
     @BaseMessage("Can not sepcify `ON` clause for external catalog Backup/Restore")
     String unsupportedOnForExternalCatalog();
-
-    @BaseMessage("Can not sepcify database for cancel EXTERNAL CATALOG BACKUP/RESTORE")
-    String unsupportedSepcifyDatabaseForExternalCatalog();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
@@ -231,4 +231,13 @@ public interface ParserErrorMsg {
 
     @BaseMessage("`ON` clause is forbidden if no Database explicitly specified in Restore stmt")
     String unsupportedOnClauseWithoutAnyDbNameInRestoreStmt();
+
+    @BaseMessage("Can not sepcify database name for external catalog Backup/Restore")
+    String unsupportedSepcifyDbForExternalCatalog();
+
+    @BaseMessage("Can not sepcify `ON` clause for external catalog Backup/Restore")
+    String unsupportedOnForExternalCatalog();
+
+    @BaseMessage("Can not sepcify database for cancel EXTERNAL CATALOG BACKUP/RESTORE")
+    String unsupportedSepcifyDatabaseForExternalCatalog();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -187,6 +187,7 @@ import com.starrocks.sql.ast.CancelExportStmt;
 import com.starrocks.sql.ast.CancelLoadStmt;
 import com.starrocks.sql.ast.CancelRefreshDictionaryStmt;
 import com.starrocks.sql.ast.CancelRefreshMaterializedViewStmt;
+import com.starrocks.sql.ast.CatalogRef;
 import com.starrocks.sql.ast.CleanTabletSchedQClause;
 import com.starrocks.sql.ast.CleanTemporaryTableStmt;
 import com.starrocks.sql.ast.ClearDataCacheRulesStmt;
@@ -3439,8 +3440,35 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             backupContext = (StarRocksParser.BackupStatementContext) context;
         }
 
+        List<CatalogRef> externalCatalogRefs = new ArrayList<>();
+        boolean allExternalCatalog = backupContext != null ?
+                                     (backupContext.CATALOGS() != null) : (restoreContext.CATALOGS() != null);
+        if (!allExternalCatalog && (backupContext != null ?
+                                    (backupContext.CATALOG() != null) : (restoreContext.CATALOG() != null))) {
+            if (backupContext != null) {
+                StarRocksParser.IdentifierListContext identifierListContext = backupContext.identifierList();
+                externalCatalogRefs = visit(identifierListContext.identifier(), Identifier.class)
+                                            .stream().map(Identifier::getValue)
+                                            .map(x -> new CatalogRef(x)).collect(Collectors.toList());
+            } else {
+                List<StarRocksParser.IdentifierWithAliasContext> identifierWithAliasList =
+                                                                 restoreContext.identifierWithAliasList().identifierWithAlias();
+                for (StarRocksParser.IdentifierWithAliasContext identifierWithAliasContext : identifierWithAliasList) {
+                    String originalName = getIdentifierName(identifierWithAliasContext.originalName);
+                    String alias = identifierWithAliasContext.AS() != null ?
+                                   getIdentifierName(identifierWithAliasContext.alias) : "";
+                    externalCatalogRefs.add(new CatalogRef(originalName, alias));
+                }
+            }
+        }
+        boolean containsExternalCatalog = allExternalCatalog || !externalCatalogRefs.isEmpty();
+
         boolean specifyDbExplicitly =
                             backupContext != null ? (backupContext.DATABASE() != null) : (restoreContext.DATABASE() != null);
+
+        if (specifyDbExplicitly && containsExternalCatalog) {
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedSepcifyDbForExternalCatalog());
+        }
 
         LabelName labelName = null;
         String repoName = null;
@@ -3458,6 +3486,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         List<FunctionRef> fnRefs = new ArrayList<>();
         Set<BackupObjectType> allMarker = Sets.newHashSet();
 
+        if (allExternalCatalog) {
+            allMarker.add(BackupObjectType.EXTERNAL_CATALOG);
+        }
+
         labelName = qualifiedNameToLabelName(getQualifiedName(backupContext != null ?
                                                               backupContext.qualifiedName() : restoreContext.qualifiedName()));
         if (specifyDbExplicitly) {
@@ -3471,6 +3503,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             }
 
             labelName.setDbName(dbAlias != null ? dbAlias : originDb);
+        } else if (containsExternalCatalog && labelName.getDbName() != null) {
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedSepcifyDbForExternalCatalog());
         }
         repoName = getIdentifierName(backupContext != null ? backupContext.repoName : restoreContext.repoName);
 
@@ -3548,6 +3582,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             throw new ParsingException(PARSER_ERROR_MSG.unsupportedOnClauseWithoutAnyDbNameInRestoreStmt());
         }
 
+        if (withOnClause && containsExternalCatalog) {
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedOnForExternalCatalog());
+        }
+
         // merge mv, view, table
         mixTblRefs.addAll(mvRefs);
         mixTblRefs.addAll(viewRefs);
@@ -3566,10 +3604,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
         AbstractBackupStmt stmt = null;
         if (backupContext != null) {
-            stmt = new BackupStmt(labelName, repoName, mixTblRefs, fnRefs, allMarker, withOnClause,
+            stmt = new BackupStmt(labelName, repoName, mixTblRefs, fnRefs, externalCatalogRefs, allMarker, withOnClause,
                                   originDb != null ? originDb : "", properties, createPos(backupContext));
         } else {
-            stmt = new RestoreStmt(labelName, repoName, mixTblRefs, fnRefs, allMarker, withOnClause,
+            stmt = new RestoreStmt(labelName, repoName, mixTblRefs, fnRefs, externalCatalogRefs, allMarker, withOnClause,
                                    originDb != null ? originDb : "", properties, createPos(restoreContext));
         }
 
@@ -3583,11 +3621,14 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitCancelBackupStatement(StarRocksParser.CancelBackupStatementContext context) {
-        if (context.identifier() == null) {
+        if (context.CATALOG() != null && context.identifier() != null) {
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedSepcifyDatabaseForExternalCatalog());
+        }
+        if (context.CATALOG() == null && context.identifier() == null) {
             throw new ParsingException(PARSER_ERROR_MSG.nullIdentifierCancelBackupRestore());
         }
-        return new CancelBackupStmt(((Identifier) visit(context.identifier())).getValue(),
-                false, createPos(context));
+        return new CancelBackupStmt(context.CATALOG() != null ? "" : ((Identifier) visit(context.identifier())).getValue(),
+                false, context.CATALOG() != null, createPos(context));
     }
 
     @Override
@@ -3606,11 +3647,14 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitCancelRestoreStatement(StarRocksParser.CancelRestoreStatementContext context) {
-        if (context.identifier() == null) {
+        if (context.CATALOG() != null && context.identifier() != null) {
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedSepcifyDatabaseForExternalCatalog());
+        }
+        if (context.CATALOG() == null && context.identifier() == null) {
             throw new ParsingException(PARSER_ERROR_MSG.nullIdentifierCancelBackupRestore());
         }
-        return new CancelBackupStmt(((Identifier) visit(context.identifier())).getValue(), true,
-                createPos(context));
+        return new CancelBackupStmt(context.CATALOG() != null ? "" :  ((Identifier) visit(context.identifier())).getValue(),
+                true, context.CATALOG() != null, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -3622,9 +3622,6 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitCancelBackupStatement(StarRocksParser.CancelBackupStatementContext context) {
-        if (context.CATALOG() != null && context.identifier() != null) {
-            throw new ParsingException(PARSER_ERROR_MSG.unsupportedSepcifyDatabaseForExternalCatalog());
-        }
         if (context.CATALOG() == null && context.identifier() == null) {
             throw new ParsingException(PARSER_ERROR_MSG.nullIdentifierCancelBackupRestore());
         }
@@ -3648,9 +3645,6 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitCancelRestoreStatement(StarRocksParser.CancelRestoreStatementContext context) {
-        if (context.CATALOG() != null && context.identifier() != null) {
-            throw new ParsingException(PARSER_ERROR_MSG.unsupportedSepcifyDatabaseForExternalCatalog());
-        }
         if (context.CATALOG() == null && context.identifier() == null) {
             throw new ParsingException(PARSER_ERROR_MSG.nullIdentifierCancelBackupRestore());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -3442,9 +3442,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
         List<CatalogRef> externalCatalogRefs = new ArrayList<>();
         boolean allExternalCatalog = backupContext != null ?
-                                     (backupContext.CATALOGS() != null) : (restoreContext.CATALOGS() != null);
+                                     (backupContext.ALL() != null) : (restoreContext.ALL() != null);
         if (!allExternalCatalog && (backupContext != null ?
-                                    (backupContext.CATALOG() != null) : (restoreContext.CATALOG() != null))) {
+                                    (backupContext.CATALOG() != null || backupContext.CATALOGS() != null) :
+                                    (restoreContext.CATALOG() != null || restoreContext.CATALOGS() != null))) {
             if (backupContext != null) {
                 StarRocksParser.IdentifierListContext identifierListContext = backupContext.identifierList();
                 externalCatalogRefs = visit(identifierListContext.identifier(), Identifier.class)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1738,7 +1738,7 @@ backupStatement
     ;
 
 cancelBackupStatement
-    : CANCEL (EXTERNAL CATALOG)? BACKUP ((FROM | IN) identifier)?
+    : CANCEL BACKUP ((FROM | IN) identifier | FOR EXTERNAL CATALOG)?
     ;
 
 showBackupStatement
@@ -1755,7 +1755,7 @@ restoreStatement
     ;
 
 cancelRestoreStatement
-    : CANCEL (EXTERNAL CATALOG)? RESTORE ((FROM | IN) identifier)?
+    : CANCEL RESTORE ((FROM | IN) identifier | FOR EXTERNAL CATALOG)?
     ;
 
 showRestoreStatement

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1731,7 +1731,7 @@ privObjectTypePlural
 // ---------------------------------------- Backup Restore Statement ---------------------------------------------------
 
 backupStatement
-    : BACKUP (ALL EXTERNAL CATALOGS | EXTERNAL CATALOG identifierList)? (DATABASE dbName=identifier)?
+    : BACKUP (ALL EXTERNAL CATALOGS | EXTERNAL (CATALOG | CATALOGS) identifierList)? (DATABASE dbName=identifier)?
     SNAPSHOT qualifiedName TO repoName=identifier
     (ON '(' backupRestoreObjectDesc (',' backupRestoreObjectDesc) * ')')?
     (PROPERTIES propertyList)?
@@ -1748,7 +1748,7 @@ showBackupStatement
 restoreStatement
     : RESTORE SNAPSHOT qualifiedName
     FROM repoName=identifier
-    (ALL EXTERNAL CATALOGS | EXTERNAL CATALOG identifierWithAliasList)?
+    (ALL EXTERNAL CATALOGS | EXTERNAL (CATALOG | CATALOGS) identifierWithAliasList)?
     (DATABASE dbName=identifier (AS dbAlias=identifier)?)?
     (ON '(' backupRestoreObjectDesc (',' backupRestoreObjectDesc) * ')')?
     (PROPERTIES propertyList)?

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1731,14 +1731,14 @@ privObjectTypePlural
 // ---------------------------------------- Backup Restore Statement ---------------------------------------------------
 
 backupStatement
-    : BACKUP (DATABASE dbName=identifier)?
+    : BACKUP (ALL EXTERNAL CATALOGS | EXTERNAL CATALOG identifierList)? (DATABASE dbName=identifier)?
     SNAPSHOT qualifiedName TO repoName=identifier
     (ON '(' backupRestoreObjectDesc (',' backupRestoreObjectDesc) * ')')?
     (PROPERTIES propertyList)?
     ;
 
 cancelBackupStatement
-    : CANCEL BACKUP ((FROM | IN) identifier)?
+    : CANCEL (EXTERNAL CATALOG)? BACKUP ((FROM | IN) identifier)?
     ;
 
 showBackupStatement
@@ -1748,13 +1748,14 @@ showBackupStatement
 restoreStatement
     : RESTORE SNAPSHOT qualifiedName
     FROM repoName=identifier
+    (ALL EXTERNAL CATALOGS | EXTERNAL CATALOG identifierWithAliasList)?
     (DATABASE dbName=identifier (AS dbAlias=identifier)?)?
     (ON '(' backupRestoreObjectDesc (',' backupRestoreObjectDesc) * ')')?
     (PROPERTIES propertyList)?
     ;
 
 cancelRestoreStatement
-    : CANCEL RESTORE ((FROM | IN) identifier)?
+    : CANCEL (EXTERNAL CATALOG)? RESTORE ((FROM | IN) identifier)?
     ;
 
 showRestoreStatement
@@ -2813,6 +2814,14 @@ identifier
     | nonReserved            #unquotedIdentifier
     | DIGIT_IDENTIFIER       #digitIdentifier
     | BACKQUOTED_IDENTIFIER  #backQuotedIdentifier
+    ;
+
+identifierWithAlias
+    : originalName=identifier (AS alias=identifier)?
+    ;
+
+identifierWithAliasList
+    : '(' identifierWithAlias (',' identifierWithAlias)* ')'
     ;
 
 identifierList

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -313,7 +313,7 @@ public class BackupHandlerTest {
         List<TableRef> tblRefs = Lists.newArrayList();
         tblRefs.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));
         BackupStmt backupStmt = new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label1"), "repo", tblRefs,
-                                               Lists.newArrayList(), null, false, "", null);
+                                               Lists.newArrayList(), null, null, false, "", null);
         try {
             handler.process(backupStmt);
         } catch (DdlException e1) {
@@ -372,7 +372,7 @@ public class BackupHandlerTest {
         tblRefs1.add(new TableRef(new TableName(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL3_NAME), null));
         BackupStmt backupStmt1 =
                     new BackupStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs1, Lists.newArrayList(),
-                                null, false, "", null);
+                                null, null, false, "", null);
         try {
             handler.process(backupStmt1);
         } catch (DdlException e1) {
@@ -432,7 +432,7 @@ public class BackupHandlerTest {
         Map<String, String> properties = Maps.newHashMap();
         properties.put("backup_timestamp", "2018-08-08-08-08-08");
         RestoreStmt restoreStmt = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "ss2"), "repo", tblRefs2,
-                    Lists.newArrayList(), null, false, "", properties);
+                    Lists.newArrayList(), null, null, false, "", properties);
         try {
             BackupRestoreAnalyzer.analyze(restoreStmt, new ConnectContext());
         } catch (SemanticException e2) {
@@ -510,7 +510,7 @@ public class BackupHandlerTest {
         Map<String, String> properties1 = Maps.newHashMap();
         properties1.put("backup_timestamp", "2018-08-08-08-08-08");
         RestoreStmt restoreStmt1 = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", tblRefs3,
-                    Lists.newArrayList(), null, false, "", properties1);
+                    Lists.newArrayList(), null, null, false, "", properties1);
         try {
             BackupRestoreAnalyzer.analyze(restoreStmt1, new ConnectContext());
         } catch (SemanticException e2) {
@@ -585,7 +585,7 @@ public class BackupHandlerTest {
         Map<String, String> properties2 = Maps.newHashMap();
         properties2.put("backup_timestamp", "2018-08-08-08-08-08");
         RestoreStmt restoreStmt2 = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "label2"), "repo", emptyTableRef,
-                                                   fnRefs, null, false, "", properties2);
+                                                   fnRefs, null, null, false, "", properties2);
         BackupMeta backupMeta = new BackupMeta(Lists.newArrayList());
         List<Function> fns = Lists.newArrayList();
         Function f1 = new Function(new FunctionName(db.getFullName(), "wrong_name"),
@@ -816,7 +816,7 @@ public class BackupHandlerTest {
         Map<String, String> properties = Maps.newHashMap();
         properties.put("backup_timestamp", "2018-08-08-08-08-08");
         RestoreStmt restoreStmt = new RestoreStmt(new LabelName(null, "ss2"), "repo", tblRefs2,
-                    Lists.newArrayList(), null, false, "", properties);
+                    Lists.newArrayList(), null, null, false, "", properties);
         try {
             BackupRestoreAnalyzer.analyze(restoreStmt, new ConnectContext());
         } catch (SemanticException e2) {
@@ -834,7 +834,7 @@ public class BackupHandlerTest {
         allMarker.add(AbstractBackupStmt.BackupObjectType.MV);
         allMarker.add(AbstractBackupStmt.BackupObjectType.VIEW);
         restoreStmt = new RestoreStmt(new LabelName(CatalogMocker.TEST_DB_NAME, "ss2"), "repo", tblRefs2,
-                          Lists.newArrayList(), allMarker, true, "", properties);
+                          Lists.newArrayList(), null, allMarker, true, "", properties);
         try {
             BackupRestoreAnalyzer.analyze(restoreStmt, new ConnectContext());
         } catch (SemanticException e2) {

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -42,6 +42,7 @@ import com.starrocks.analysis.LabelName;
 import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.catalog.BrokerMgr;
+import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.MaterializedIndex;
@@ -602,6 +603,16 @@ public class BackupHandlerTest {
         fns.add(f2);
         backupMeta.setFunctions(fns);
         handler.checkAndFilterRestoreFunctionsInBackupMeta(restoreStmt2, backupMeta);
+
+        // process EXTERNAL CATALOG restore
+        Map<String, String> properties3 = Maps.newHashMap();
+        properties3.put("backup_timestamp", "2018-08-08-08-08-08");
+        RestoreStmt restoreStmt3 = new RestoreStmt(new LabelName(null, "label2"), "repo", Lists.newArrayList(),
+                                                   Lists.newArrayList(), null, null, false, "", properties3);
+        BackupMeta newBackupMeta = new BackupMeta(Lists.newArrayList());
+        Catalog catalog = new Catalog(1111111, "test_catalog", Maps.newHashMap(), "");
+        newBackupMeta.setCatalogs(Lists.newArrayList(catalog));
+        handler.checkAndFilterRestoreCatalogsInBackupMeta(restoreStmt3, newBackupMeta);
 
         // drop repo
         DDLStmtExecutor ddlStmtExecutor = new DDLStmtExecutor(DDLStmtExecutor.StmtExecutorVisitor.getInstance());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -45,6 +45,7 @@ import com.starrocks.backup.BackupJobInfo.BackupTableInfo;
 import com.starrocks.backup.BackupJobInfo.BackupTabletInfo;
 import com.starrocks.backup.RestoreJob.RestoreJobState;
 import com.starrocks.backup.mv.MvRestoreContext;
+import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FakeEditLog;
 import com.starrocks.catalog.Function;
@@ -928,5 +929,20 @@ public class RestoreJobTest {
                 globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
 
         job.addRestoredFunctions(db);
+    }
+
+    @Test
+    public void testRestoreAddCatalog() {
+        backupMeta = new BackupMeta(Lists.newArrayList());
+        Catalog catalog = new Catalog(1111111, "test_catalog", Maps.newHashMap(), "");
+
+        backupMeta.setCatalogs(Lists.newArrayList(catalog));
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
+                new BackupJobInfo(), false, 3, 100000,
+                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        job.setRepo(repo);
+        job.addRestoredFunctions(db);
+        job.run();
+        job.run();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
@@ -276,10 +276,8 @@ public class AnalyzeBackupRestoreTest {
     public void testCancelRestore() {
         analyzeFail("CANCEL BACKUP;");
         analyzeFail("CANCEL RESTORE;");
-        analyzeFail("CANCEL EXTERNAL CATALOG BACKUP FROM test;");
-        analyzeFail("CANCEL EXTERNAL CATALOG RESTORE FROM test;");
-        analyzeSuccess("CANCEL EXTERNAL CATALOG BACKUP;");
-        analyzeSuccess("CANCEL EXTERNAL CATALOG BACKUP;");
+        analyzeSuccess("CANCEL BACKUP FOR EXTERNAL CATALOG;");
+        analyzeSuccess("CANCEL RESTORE FOR EXTERNAL CATALOG;");
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
@@ -61,6 +61,9 @@ public class AnalyzeBackupRestoreTest {
 
         AnalyzeTestUtil.getStarRocksAssert().withView("CREATE VIEW v1 AS select 1;");
         AnalyzeTestUtil.getStarRocksAssert().withView("CREATE VIEW v2 AS select 2;");
+
+        String sqlCatalog = "CREATE EXTERNAL CATALOG catalog1 PROPERTIES(\"type\"=\"hive\", \"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")";
+        AnalyzeTestUtil.getStarRocksAssert().withCatalog(sqlCatalog);
     }
 
     @Test
@@ -98,6 +101,10 @@ public class AnalyzeBackupRestoreTest {
         analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON " +
                 "( ALL FUNCTIONS, ALL TABLES, ALL VIEWS, ALL MATERIALIZED VIEWS ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP ALL EXTERNAL CATALOGS SNAPSHOT snapshot_label2 TO `repo` " +
+                       "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP EXTERNAL CATALOG (catalog1) SNAPSHOT snapshot_label2 TO `repo` " +
+                       "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( t0, t0 ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( t0, t1 ) " +
@@ -124,6 +131,20 @@ public class AnalyzeBackupRestoreTest {
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeFail("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON (v1 AS newV1)" +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeFail("BACKUP ALL EXTERNAL CATALOGS DATABASE test SNAPSHOT snapshot_label2 TO `repo` " +
+                    "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeFail("BACKUP EXTERNAL CATALOG (catalog1) DATABASE test SNAPSHOT snapshot_label2 TO `repo` " +
+                    "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeFail("BACKUP ALL EXTERNAL CATALOGS SNAPSHOT test.snapshot_label2 TO `repo` " +
+                    "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeFail("BACKUP EXTERNAL CATALOG (catalog1) SNAPSHOT test.snapshot_label2 TO `repo` " +
+                    "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeFail("BACKUP ALL EXTERNAL CATALOGS SNAPSHOT snapshot_label2 TO `repo` " +
+                    " ON (`t0`) PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeFail("BACKUP EXTERNAL CATALOG (catalog1) SNAPSHOT snapshot_label2 TO `repo` " +
+                    "ON (`t0`) PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeFail("BACKUP EXTERNAL CATALOG (catalog2) SNAPSHOT snapshot_label2 TO `repo` " +
+                    "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
     }
 
     @Test
@@ -192,6 +213,13 @@ public class AnalyzeBackupRestoreTest {
                         "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
         analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` " +
                         "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` " + "ALL EXTERNAL CATALOGS " +
+                       "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` " + "EXTERNAL CATALOG (catalog1) " +
+                        "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` " + "EXTERNAL CATALOG (catalog1 AS catalog2) " +
+                       "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeSuccess("RESTORE SNAPSHOT `snapshot_2` FROM `repo` PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
         analyzeFail("RESTORE SNAPSHOT test.`snapshot_2` FROM `repo` ON ( `t0` , `t1` AS `new_tbl` ) " +
                 "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"allow_load\"=\"a\" );");
         analyzeFail("RESTORE SNAPSHOT test.`snapshot_2` FROM `repo` ON ( `t0` , `t1` AS `new_tbl` ) " +
@@ -220,6 +248,18 @@ public class AnalyzeBackupRestoreTest {
                 "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"timeout\"=\"a\" );");
         analyzeFail("RESTORE SNAPSHOT `snapshot_2` FROM `repo1` ON (`t0`)" +
                 "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\",\"timeout\"=\"a\" );");
+        analyzeFail("RESTORE SNAPSHOT .`snapshot_2` FROM `repo` " + "ALL EXTERNAL CATALOGS " +
+                    "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeFail("RESTORE SNAPSHOT `test`.`snapshot_2` FROM `repo` " + "EXTERNAL CATALOG (catalog1) " +
+                    "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeFail("RESTORE SNAPSHOT `snapshot_2` FROM `repo` " + "ALL EXTERNAL CATALOGS DATABASE test " +
+                    "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeFail("RESTORE SNAPSHOT `snapshot_2` FROM `repo` " + "EXTERNAL CATALOG (catalog1) DATABASE test " +
+                    "PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeFail("RESTORE SNAPSHOT `snapshot_2` FROM `repo` " + "EXTERNAL CATALOG (catalog1) " +
+                    "ON (`t0`) PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
+        analyzeFail("RESTORE SNAPSHOT `snapshot_2` FROM `repo` " + "ALL EXTERNAL CATALOGS " +
+                    "ON (`t0`) PROPERTIES ( \"backup_timestamp\"=\"2018-05-04-17-11-01\");");
     }
 
     @Test
@@ -236,6 +276,10 @@ public class AnalyzeBackupRestoreTest {
     public void testCancelRestore() {
         analyzeFail("CANCEL BACKUP;");
         analyzeFail("CANCEL RESTORE;");
+        analyzeFail("CANCEL EXTERNAL CATALOG BACKUP FROM test;");
+        analyzeFail("CANCEL EXTERNAL CATALOG RESTORE FROM test;");
+        analyzeSuccess("CANCEL EXTERNAL CATALOG BACKUP;");
+        analyzeSuccess("CANCEL EXTERNAL CATALOG BACKUP;");
     }
 
 }


### PR DESCRIPTION
In this PR, we support Backup/Restore for External Catalog. User can Backup All of or part of External Catalog metadata into snapshot file and restore it into a new cluster.

The following summarizes the behavioral changes caused by this PR:
1. New syntax to support `Backup/Restore` for `External Catalog`, here is the new part for it (old syntax is not shown here):
```
BACKUP { ALL EXTERNAL CATALOGS | EXTERNAL CATALOG[S] <catalog_name> [, ...] }
SNAPSHOT <snapshot_name> TO <repo_name>
[ PROPERTIES ]

RESTORE SNAPSHOT <snapshot_name> FROM <repo_name>
[ ALL EXTERNAL CATALOGS | EXTERNAL CATALOG[S] <catalog_name> AS <alias> [, ...] ]
[ PROPERTIES ]


-- CANCEL
CANCEL { BACKUP | RESTORE } FOR EXTERNAL CATALOG[S]
-- CANCEL { BACKUP | RESTORE } FROM [ DATABASE ] <db_name>
```
2. For `EXTERNAL CATALOG` `Backup/Restore`, no db info and `ON` clause can be specified.
3. Only one `Backup/Restore` job can be executed at the same time in the cluster.
4. `default_catalog` is not support.

Fixes #52902

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
