### PR TITLE
[BugFix] Fix array_map common-expression crash

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -60,6 +60,20 @@ Status ArrayMapExpr::prepare(RuntimeState* state, ExprContext* context) {
 
     return Status::OK();
 }
+Status ArrayMapExpr::open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
+    RETURN_IF_ERROR(Expr::open(state, context, scope));
+    for (auto [_, expr] : _outer_common_exprs) {
+        RETURN_IF_ERROR(expr->open(state, context, scope));
+    }
+    return Status::OK();
+}
+
+void ArrayMapExpr::close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
+    for (auto [_, expr] : _outer_common_exprs) {
+        expr->close(state, context, scope);
+    }
+    Expr::close(state, context, scope);
+}
 
 template <bool all_const_input, bool independent_lambda_expr>
 StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chunk* chunk,

--- a/be/src/exprs/array_map_expr.h
+++ b/be/src/exprs/array_map_expr.h
@@ -37,6 +37,8 @@ public:
     explicit ArrayMapExpr(TypeDescriptor type);
 
     Status prepare(RuntimeState* state, ExprContext* context) override;
+    Status open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
+    void close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
     Expr* clone(ObjectPool* pool) const override { return pool->add(new ArrayMapExpr(*this)); }
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;

--- a/test/sql/test_array_fn/R/test_array_map_2
+++ b/test/sql/test_array_fn/R/test_array_map_2
@@ -50,6 +50,10 @@ select array_length(array_map((x,y)->x > y, @arr,@arr)) from table(generate_seri
 1000000
 1000000
 -- !result
+select count(*) from array_map_test where array_map((a1) -> concat(split(id, 'd'), split(id, 'd')), arr_str) is not null;
+-- result:
+1
+-- !result
 -- name: test_array_map_3
 CREATE TABLE `t` (
   `k` bigint NOT NULL COMMENT "",

--- a/test/sql/test_array_fn/T/test_array_map_2
+++ b/test/sql/test_array_fn/T/test_array_map_2
@@ -22,6 +22,7 @@ select count(array_map(x->array_length(array_concat(arr_str,[])), arr_largeint))
 
 set @arr=array_repeat("12345",1000000);
 select array_length(array_map((x,y)->x > y, @arr,@arr)) from table(generate_series(1,10,1));
+select count(*) from array_map_test where array_map((a1) -> concat(split(id, 'd'), split(id, 'd')), arr_str) is not null;
 
 -- name: test_array_map_3
 CREATE TABLE `t` (


### PR DESCRIPTION
## Why I'm doing:
```
#0  0x000000000612b73c in starrocks::StringFunctions::split (context=0x144631f75c80, columns=...) at be/src/exprs/split.cpp:131
#1  0x00000000051e1129 in starrocks::VectorizedFunctionCallExpr::evaluate_checked (this=0x142147865c00, context=<optimized out>, ptr=0x144114bdb340) at be/src/exprs/function_call_expr.cpp:186
#2  0x0000000004a4361b in starrocks::ArrayElementExpr::evaluate_checked (this=0x142147865700, context=0x140bc3389180, chunk=0x144114bdb340) at be/src/exprs/array_element_expr.cpp:40
#3  0x00000000052a07d7 in starrocks::LambdaFunction::evaluate_checked (this=0x142147865200, context=0x140bc3389180, chunk=0x144114bdb340) at be/src/exprs/expr.h:100
#4  0x000000000497062b in starrocks::ExprContext::evaluate (this=this@entry=0x140bc3389180, e=<optimized out>, chunk=0x144114bdb340, filter=filter@entry=0x0) at be/src/exprs/expr_context.cpp:184
#5  0x00000000052aa476 in starrocks::ArrayMapExpr::evaluate_lambda_expr<false, false> (this=0x142147864d00, context=0x140bc3389180, chunk=0x14524ee8d210, input_elements=..., result_null_column=...) at be/src/common/status.h:211
#6  0x00000000052a3e5c in starrocks::ArrayMapExpr::evaluate_checked (this=0x142147864d00, context=0x140bc3389180, chunk=0x14524ee8d210) at be/src/exprs/array_map_expr.cpp:367
#7  0x000000000497062b in starrocks::ExprContext::evaluate (this=this@entry=0x140bc3389180, e=<optimized out>, chunk=chunk@entry=0x14524ee8d210, filter=filter@entry=0x0) at be/src/exprs/expr_context.cpp:184
#8  0x00000000052a9925 in starrocks::ArrayMapExpr::evaluate_lambda_expr<false, false> (this=0x142147863e00, context=0x140bc3389180, chunk=0x14524ee8d210, input_elements=..., result_null_column=...)
    at be/src/exprs/array_map_expr.cpp:72
#9  0x00000000052a3e5c in starrocks::ArrayMapExpr::evaluate_checked (this=0x142147863e00, context=0x140bc3389180, chunk=0x14524ee8d210) at be/src/exprs/array_map_expr.cpp:367
#10 0x000000000497062b in starrocks::ExprContext::evaluate (this=this@entry=0x140bc3389180, e=<optimized out>, chunk=chunk@entry=0x14524ee8d210, filter=filter@entry=0x0) at be/src/exprs/expr_context.cpp:184
#11 0x00000000051e0d75 in starrocks::VectorizedFunctionCallExpr::evaluate_checked (this=0x142147863900, context=0x140bc3389180, ptr=0x14524ee8d210) at be/src/exprs/function_call_expr.cpp:162
#12 0x0000000004a43665 in starrocks::ArrayElementExpr::evaluate_checked (this=0x1421471c7900, context=0x140bc3389180, chunk=0x14524ee8d210) at be/src/exprs/array_element_expr.cpp:41
#13 0x000000000497062b in starrocks::ExprContext::evaluate (this=this@entry=0x140bc3389180, e=<optimized out>, chunk=chunk@entry=0x14524ee8d210, filter=filter@entry=0x0) at be/src/exprs/expr_context.cpp:184
#14 0x00000000052a312c in starrocks::ArrayMapExpr::evaluate_checked (this=0x142146106c00, context=0x140bc3389180, chunk=0x14524ee8d210) at be/src/exprs/array_map_expr.cpp:250
#15 0x0000000004a4361b in starrocks::ArrayElementExpr::evaluate_checked (this=0x142146106700, context=0x140bc3389180, chunk=0x14524ee8d210) at be/src/exprs/array_element_expr.cpp:40
#16 0x0000000004a13c21 in starrocks::VectorizedArithmeticExpr<(starrocks::LogicalType)7, starrocks::SubOp>::evaluate_checked (this=0x142146106200, context=0x140bc3389180, ptr=0x14524ee8d210) at be/src/exprs/arithmetic_expr.cpp:96
#17 0x0000000004abe831 in starrocks::VectorizedBinaryPredicate<(starrocks::LogicalType)7, starrocks::BinaryPredFunc<std::greater_equal<long> > >::evaluate_checked (this=0x142146105d00, context=0x140bc3389180, ptr=0x14524ee8d210)
    at be/src/exprs/binary_predicate.cpp:104
#18 0x000000000518452e in starrocks::VectorizedOrCompoundPredicate::evaluate_checked (this=0x142146105800, context=0x140bc3389180, ptr=0x14524ee8d210) at be/src/exprs/compound_predicate.cpp:79
#19 0x000000000518452e in starrocks::VectorizedOrCompoundPredicate::evaluate_checked (this=0x142146105300, context=0x140bc3389180, ptr=0x14524ee8d210) at be/src/exprs/compound_predicate.cpp:79
#20 0x000000000518eb44 in starrocks::VectorizedIfExpr<(starrocks::LogicalType)19>::evaluate_checked (this=0x142146104e00, context=0x140bc3389180, ptr=0x14524ee8d210) at be/src/exprs/condition_expr.cpp:224
#21 0x000000000497062b in starrocks::ExprContext::evaluate (this=this@entry=0x140bc3389180, e=<optimized out>, chunk=chunk@entry=0x14524ee8d210, filter=filter@entry=0x0) at be/src/exprs/expr_context.cpp:184
#22 0x00000000051e0d75 in starrocks::VectorizedFunctionCallExpr::evaluate_checked (this=0x142146104900, context=0x140bc3389180, ptr=0x14524ee8d210) at be/src/exprs/function_call_expr.cpp:162
#23 0x0000000004ac7fc1 in starrocks::VectorizedBinaryPredicate<(starrocks::LogicalType)5, starrocks::BinaryPredFunc<std::greater<int> > >::evaluate_checked (this=0x142146104400, context=0x140bc3389180, ptr=0x14524ee8d210)
    at be/src/exprs/binary_predicate.cpp:104
#24 0x000000000497062b in starrocks::ExprContext::evaluate (this=0x140bc3389180, e=<optimized out>, chunk=0x14524ee8d210, filter=<optimized out>) at be/src/exprs/expr_context.cpp:184
#25 0x0000000004970aaf in starrocks::ExprContext::evaluate (this=<optimized out>, chunk=chunk@entry=0x14524ee8d210, filter=filter@entry=0x0) at be/src/exprs/expr_context.cpp:160
#26 0x00000000036e2a33 in starrocks::eager_prune_eval_conjuncts (ctxs=..., chunk=0x14524ee8d210) at be/src/exec/exec_node.cpp:611
#27 0x00000000036e4786 in starrocks::ExecNode::eval_conjuncts (ctxs=..., chunk=chunk@entry=0x14524ee8d210, filter_ptr=filter_ptr@entry=0x0, apply_filter=apply_filter@entry=true) at be/src/exec/exec_node.cpp:662
#28 0x0000000003a1043f in starrocks::pipeline::Operator::eval_conjuncts_and_in_filters (this=this@entry=0x1442a8059990, conjuncts=..., chunk=0x14524ee8d210, filter=filter@entry=0x0, apply_filter=apply_filter@entry=true)
    at be/src/exec/pipeline/operator.cpp:184
#29 0x0000000003af380f in starrocks::pipeline::AggregateBlockingSourceOperator::pull_chunk (this=0x1442a8059990, state=<optimized out>) at be/src/exec/aggregator.h:276
#30 0x0000000003ac36e6 in starrocks::pipeline::PipelineDriver::process (this=0x1442a807c310, runtime_state=0x144608a74000, worker_id=<optimized out>) at be/src/exec/pipeline/pipeline_driver.cpp:312
#31 0x0000000003ab55bf in starrocks::pipeline::GlobalDriverExecutor::_worker_thread (this=0x146ec8a82b00) at be/src/exec/pipeline/pipeline_driver_executor.cpp:153
#32 0x000000000302f5ec in std::function<void ()>::operator()() const (this=<optimized out>) at /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/std_function.h:248
#33 starrocks::FunctionRunnable::run (this=<optimized out>) at be/src/util/threadpool.cpp:59
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
