### PR TITLE
[Feature](batch write part4) Add http api _stream_load_meta to get available nodes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -85,6 +85,7 @@ import com.starrocks.http.rest.ShowProcAction;
 import com.starrocks.http.rest.ShowRuntimeInfoAction;
 import com.starrocks.http.rest.StopFeAction;
 import com.starrocks.http.rest.StorageTypeCheckAction;
+import com.starrocks.http.rest.StreamLoadMetaAction;
 import com.starrocks.http.rest.SyncCloudTableMetaAction;
 import com.starrocks.http.rest.TableQueryPlanAction;
 import com.starrocks.http.rest.TableRowCountAction;
@@ -149,6 +150,7 @@ public class HttpServer {
     private void registerActions() throws IllegalArgException {
         // add rest action
         LoadAction.registerAction(controller);
+        StreamLoadMetaAction.registerAction(controller);
         TransactionLoadAction.registerAction(controller);
         GetLoadInfoAction.registerAction(controller);
         SetConfigAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/StreamLoadMetaAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/StreamLoadMetaAction.java
@@ -45,6 +45,27 @@ public class StreamLoadMetaAction extends RestBaseAction {
 
     private static final Logger LOG = LogManager.getLogger(StreamLoadMetaAction.class);
 
+    // batch write stream load parameters =====================================================
+
+    // The parameter name to specify the type of metas.
+    private static final String TYPE_PARAM_NAME = "type";
+
+    // The type name for nodes meta. The response will return available BE nodes that can accept load requests.
+    // You can also set the parameter NODE_SERVICE_PARAM to specify the required service the nodes can provide.
+    // There will be a key named "nodes" in the response json, and the value is also a json which contains fields
+    // for each service type. For example, if you want both http and brpc service, the response will be like:
+    // "nodes": {
+    //      "http":"be_ip1:http_port1,be_ip2:http_port2",
+    //      "brpc":"be_ip1:brpc_port1,be_ip2:brpc_port2"
+    // }
+    private static final String NODES_TYPE = "nodes";
+
+    // The parameter name to specify the service type of the nodes. The value can be "http" or "brpc".
+    // If not set this parameter, the response will return all service types. Each type will be a field
+    // in the json, such as "http":"be_ip1:http_port1,be_ip2:http_port2" for http service, and
+    // "brpc":"be_ip1:brpc_port1,be_ip2:brpc_port2" for brpc service
+    private static final String NODE_SERVICE_PARAM = "node_service";
+
     public StreamLoadMetaAction(ActionController controller) {
         super(controller);
     }
@@ -94,26 +115,6 @@ public class StreamLoadMetaAction extends RestBaseAction {
                 new StreamLoadMetaResult(TStatusCode.OK.name(), ActionStatus.OK, "");
         sendResult(request, response, responseResult);
     }
-
-    // batch write stream load =====================================================
-
-    // The parameter name to specify the type of metas.
-    private static final String TYPE_PARAM_NAME = "type";
-
-    // The type name for nodes meta. The response will return available BE nodes that can accept load requests.
-    // You can also set the parameter NODE_SERVICE_PARAM to specify the required service the nodes can provide.
-    // There will be a key named "nodes" in the response json, and the value is also a json which contains fields
-    // for each service type. For example, if you want both http and brpc service, the response will be like:
-    // "nodes": {
-    //      "http":"be_ip1:http_port1,be_ip2:http_port2",
-    //      "brpc":"be_ip1:brpc_port1,be_ip2:brpc_port2"
-    // }
-    private static final String NODES_TYPE = "nodes";
-    // The parameter name to specify the service type of the nodes. The value can be "http" or "brpc".
-    // If not set this parameter, the response will return all service types. Each type will be a field
-    // in the json, such as "http":"be_ip1:http_port1,be_ip2:http_port2" for http service, and
-    // "brpc":"be_ip1:brpc_port1,be_ip2:brpc_port2" for brpc service
-    private static final String NODE_SERVICE_PARAM = "node_service";
 
     private void processBatchWriteStreamLoad(
             BaseRequest request, BaseResponse response, String dbName, String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/StreamLoadMetaAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/StreamLoadMetaAction.java
@@ -1,0 +1,176 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.google.common.base.Strings;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.DdlException;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.load.batchwrite.RequestCoordinatorBackendResult;
+import com.starrocks.load.batchwrite.TableId;
+import com.starrocks.load.streamload.StreamLoadHttpHeader;
+import com.starrocks.load.streamload.StreamLoadKvParams;
+import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.privilege.PrivilegeType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TStatusCode;
+import io.netty.handler.codec.http.HttpMethod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class StreamLoadMetaAction extends RestBaseAction {
+
+    private static final Logger LOG = LogManager.getLogger(StreamLoadMetaAction.class);
+
+    public StreamLoadMetaAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        controller.registerHandler(HttpMethod.GET,
+                "/api/{" + DB_KEY + "}/{" + TABLE_KEY + "}/_stream_load_meta",
+                new StreamLoadMetaAction(controller));
+    }
+
+    @Override
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException,
+            AccessDeniedException {
+        boolean enableBatchWrite = "true".equalsIgnoreCase(
+                request.getRequest().headers().get(StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE));
+        if (enableBatchWrite && redirectToLeader(request, response)) {
+            return;
+        }
+
+        String dbName = request.getSingleParameter(DB_KEY);
+        if (Strings.isNullOrEmpty(dbName)) {
+            StreamLoadMetaResult responseResult = new StreamLoadMetaResult(
+                    TStatusCode.INVALID_ARGUMENT.name(), ActionStatus.FAILED, "No database selected");
+            sendResult(request, response, responseResult);
+        }
+
+        String tableName = request.getSingleParameter(TABLE_KEY);
+        if (Strings.isNullOrEmpty(tableName)) {
+            StreamLoadMetaResult responseResult = new StreamLoadMetaResult(
+                    TStatusCode.INVALID_ARGUMENT.name(), ActionStatus.FAILED, "No table selected");
+            sendResult(request, response, responseResult);
+        }
+
+        Authorizer.checkTableAction(ConnectContext.get().getCurrentUserIdentity(), ConnectContext.get().getCurrentRoleIds(),
+                dbName, tableName, PrivilegeType.INSERT);
+
+        if (!enableBatchWrite) {
+            processNormalStreamLoad(request, response, dbName, tableName);
+        } else {
+            processBatchWriteStreamLoad(request, response, dbName, tableName);
+        }
+    }
+
+    private void processNormalStreamLoad(BaseRequest request, BaseResponse response, String dbName, String tableName) {
+        // currently there is no meta for normal stream load, and just return a success response.
+        StreamLoadMetaResult responseResult =
+                new StreamLoadMetaResult(TStatusCode.OK.name(), ActionStatus.OK, "");
+        sendResult(request, response, responseResult);
+    }
+
+    // batch write stream load =====================================================
+
+    // The parameter name to specify the type of metas.
+    private static final String TYPE_PARAM_NAME = "type";
+
+    // The type name for nodes meta. The response will return available BE nodes that can accept load requests.
+    // You can also set the parameter NODE_SERVICE_PARAM to specify the required service the nodes can provide.
+    // There will be a key named "nodes" in the response json, and the value is also a json which contains fields
+    // for each service type. For example, if you want both http and brpc service, the response will be like:
+    // "nodes": {
+    //      "http":"be_ip1:http_port1,be_ip2:http_port2",
+    //      "brpc":"be_ip1:brpc_port1,be_ip2:brpc_port2"
+    // }
+    private static final String NODES_TYPE = "nodes";
+    // The parameter name to specify the service type of the nodes. The value can be "http" or "brpc".
+    // If not set this parameter, the response will return all service types. Each type will be a field
+    // in the json, such as "http":"be_ip1:http_port1,be_ip2:http_port2" for http service, and
+    // "brpc":"be_ip1:brpc_port1,be_ip2:brpc_port2" for brpc service
+    private static final String NODE_SERVICE_PARAM = "node_service";
+
+    private void processBatchWriteStreamLoad(
+            BaseRequest request, BaseResponse response, String dbName, String tableName) {
+        TableId tableId = new TableId(dbName, tableName);
+        StreamLoadKvParams params = StreamLoadKvParams.fromHttpHeaders(request.getRequest().headers());
+        RequestCoordinatorBackendResult result = GlobalStateMgr.getCurrentState()
+                .getBatchWriteMgr().requestCoordinatorBackends(tableId, params);
+        if (!result.isOk()) {
+            StreamLoadMetaResult responseResult = new StreamLoadMetaResult(
+                    result.getStatus().status_code.name(), ActionStatus.FAILED,
+                    result.getStatus().error_msgs.get(0));
+            sendResult(request, response, responseResult);
+            return;
+        }
+
+        List<ComputeNode> nodes = result.getValue();
+        StreamLoadMetaResult responseResult =
+                new StreamLoadMetaResult(TStatusCode.OK.name(), ActionStatus.OK, "");
+        List<String> metaTypeList = request.getArrayParameter(TYPE_PARAM_NAME);
+        boolean allMetas = metaTypeList == null || metaTypeList.isEmpty();
+
+        if (allMetas || metaTypeList.contains(NODES_TYPE)) {
+            List<String> serviceTypeList = request.getArrayParameter(NODE_SERVICE_PARAM);
+            boolean allServiceTypes = serviceTypeList == null || serviceTypeList.isEmpty();
+            if (allServiceTypes || serviceTypeList.contains("http")) {
+                String httpNodes = nodes.stream()
+                        .map(node -> node.getHost() + ":" + node.getHttpPort())
+                        .collect(Collectors.joining(","));
+                responseResult.addNodesMeta("http", httpNodes);
+            }
+            if (allServiceTypes || serviceTypeList.contains("brpc")) {
+                String brpcNodes = nodes.stream()
+                        .map(node -> node.getHost() + ":" + node.getBrpcPort())
+                        .collect(Collectors.joining(","));
+                responseResult.addNodesMeta("brpc", brpcNodes);
+            }
+        }
+        sendResult(request, response, responseResult);
+    }
+
+    public static class StreamLoadMetaResult extends RestBaseResult {
+
+        // metas for batch write ========================================
+
+        // service type -> nodes list in format "be_ip1:port1,be_ip2:port2"
+        @SerializedName(NODES_TYPE)
+        private Map<String, String> nodesMap;
+
+        public StreamLoadMetaResult(String code, ActionStatus status, String msg) {
+            super(code, status, msg);
+        }
+
+        public void addNodesMeta(String serviceType, String nodes) {
+            if (nodesMap == null) {
+                nodesMap = new HashMap<>();
+            }
+            nodesMap.put(serviceType, nodes);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.http;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Multimap;
 import com.starrocks.load.batchwrite.BatchWriteMgr;
 import com.starrocks.load.batchwrite.RequestCoordinatorBackendResult;
@@ -33,7 +32,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -45,7 +43,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -55,7 +52,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class LoadActionTest extends StarRocksHttpTestCase {
@@ -143,13 +139,6 @@ public class LoadActionTest extends StarRocksHttpTestCase {
 
     private String getLoadUrl(String host, int port) {
         return String.format("http://%s:%d/api/%s/%s/_stream_load", host, port, DB_NAME, TABLE_NAME);
-    }
-
-    private static Map<String, Object> parseResponseBody(Response response) throws IOException {
-        ResponseBody body = response.body();
-        assertNotNull(body);
-        String bodyStr = body.string();
-        return objectMapper.readValue(bodyStr, new TypeReference<>() {});
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.http;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -89,11 +90,14 @@ import mockit.Mocked;
 import okhttp3.Credentials;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
+import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -102,6 +106,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNotNull;
 
 public abstract class StarRocksHttpTestCase {
 
@@ -608,5 +614,13 @@ public abstract class StarRocksHttpTestCase {
         }
 
         request.getContext().write(responseObj).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    protected static Map<String, Object> parseResponseBody(Response response) throws IOException {
+        assertNotNull(response);
+        ResponseBody body = response.body();
+        assertNotNull(body);
+        String bodyStr = body.string();
+        return objectMapper.readValue(bodyStr, new TypeReference<>() {});
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/StreamLoadMetaActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StreamLoadMetaActionTest.java
@@ -1,0 +1,236 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.starrocks.load.batchwrite.BatchWriteMgr;
+import com.starrocks.load.batchwrite.RequestCoordinatorBackendResult;
+import com.starrocks.load.batchwrite.TableId;
+import com.starrocks.load.streamload.StreamLoadKvParams;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import mockit.Mock;
+import mockit.MockUp;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE;
+import static org.junit.Assert.assertEquals;
+
+public class StreamLoadMetaActionTest extends StarRocksHttpTestCase {
+
+    private final OkHttpClient client = new OkHttpClient.Builder()
+            .readTimeout(1000, TimeUnit.SECONDS)
+            .followRedirects(false)
+            .build();
+
+
+    @Test
+    public void testNormalStreamLoad() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("format", "csv");
+        Request request = buildRequest(headers, HashMultimap.create());
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            Map<String, Object> result = parseResponseBody(response);
+            assertEquals(4, result.size());
+            assertEquals("OK", result.get("status"));
+            assertEquals("OK", result.get("code"));
+            assertEquals("", result.get("msg"));
+            assertEquals("", result.get("message"));
+        }
+    }
+
+    @Test
+    public void testBatchWriteRequireOnlyHttpNodes() throws Exception {
+        testBatchWriteRequireNodesBase(Collections.singletonList("http"));
+    }
+
+    @Test
+    public void testBatchWriteRequireOnlyBrpcNodes() throws Exception {
+        testBatchWriteRequireNodesBase(Collections.singletonList("brpc"));
+    }
+
+    @Test
+    public void testBatchWriteRequireAllTypeNodes() throws Exception {
+        testBatchWriteRequireNodesBase(List.of("http", "brpc"));
+        testBatchWriteRequireNodesBase(Collections.emptyList());
+    }
+
+    private void testBatchWriteRequireNodesBase(List<String> serviceTypes) throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HTTP_ENABLE_BATCH_WRITE, "true");
+        Multimap<String, String> parameters = HashMultimap.create();
+        parameters.put("type", "nodes");
+        for (String serviceType : serviceTypes) {
+            parameters.put("node_service", serviceType);
+        }
+        Request request = buildRequest(headers, parameters);
+        List<ComputeNode> computeNodes = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            String host = "192.0.0." + i;
+            computeNodes.add(new ComputeNode(i, host, 9050));
+            computeNodes.get(i - 1).setHttpPort(8040);
+            computeNodes.get(i - 1).setBrpcPort(8060);
+        }
+        Map<String, String> expectedNodes = new HashMap<>();
+        if (serviceTypes.isEmpty() || serviceTypes.contains("http")) {
+            expectedNodes.put("http", "192.0.0.1:8040,192.0.0.2:8040,192.0.0.3:8040");
+        }
+        if (serviceTypes.isEmpty() || serviceTypes.contains("brpc")) {
+            expectedNodes.put("brpc", "192.0.0.1:8060,192.0.0.2:8060,192.0.0.3:8060");
+        }
+
+        new MockUp<BatchWriteMgr>() {
+            @Mock
+            public RequestCoordinatorBackendResult requestCoordinatorBackends(TableId tableId, StreamLoadKvParams params) {
+                return new RequestCoordinatorBackendResult(new TStatus(TStatusCode.OK), computeNodes);
+            }
+        };
+
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            Map<String, Object> result = parseResponseBody(response);
+            assertEquals(5, result.size());
+            assertEquals("OK", result.get("status"));
+            assertEquals("OK", result.get("code"));
+            assertEquals("", result.get("msg"));
+            assertEquals("", result.get("message"));
+            assertEquals(expectedNodes, result.get("nodes"));
+        }
+    }
+
+    @Test
+    public void testBatchWriteRequireAllMetas() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HTTP_ENABLE_BATCH_WRITE, "true");
+        Request request = buildRequest(headers, HashMultimap.create());
+        new MockUp<BatchWriteMgr>() {
+            @Mock
+            public RequestCoordinatorBackendResult requestCoordinatorBackends(TableId tableId, StreamLoadKvParams params) {
+                ComputeNode node = new ComputeNode(1, "192.0.0.1", 9050);
+                node.setHttpPort(8040);
+                node.setBrpcPort(8060);
+                return new RequestCoordinatorBackendResult(new TStatus(TStatusCode.OK), Collections.singletonList(node));
+            }
+        };
+
+        Map<String, String> expectedNodes = new HashMap<>();
+        expectedNodes.put("http", "192.0.0.1:8040");
+        expectedNodes.put("brpc", "192.0.0.1:8060");
+
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            Map<String, Object> result = parseResponseBody(response);
+            assertEquals(5, result.size());
+            assertEquals("OK", result.get("status"));
+            assertEquals("OK", result.get("code"));
+            assertEquals("", result.get("msg"));
+            assertEquals("", result.get("message"));
+            assertEquals(expectedNodes, result.get("nodes"));
+        }
+    }
+
+    @Test
+    public void testBatchWriteFail() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HTTP_ENABLE_BATCH_WRITE, "true");
+        Request request = buildRequest(headers, HashMultimap.create());
+
+        new MockUp<BatchWriteMgr>() {
+            @Mock
+            public RequestCoordinatorBackendResult requestCoordinatorBackends(TableId tableId, StreamLoadKvParams params) {
+                TStatus status = new TStatus();
+                status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+                status.addToError_msgs("artificial failure");
+                return new RequestCoordinatorBackendResult(status, null);
+            }
+        };
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            Map<String, Object> result = parseResponseBody(response);
+            assertEquals("INTERNAL_ERROR", result.get("code"));
+            assertEquals("FAILED", result.get("status"));
+            assertEquals("artificial failure", result.get("message"));
+            assertEquals("artificial failure", result.get("msg"));
+        }
+    }
+
+    @Test
+    public void testDatabaseAndTableInvalid() throws Exception {
+        Request emptyDbRequest = new Request.Builder()
+                .addHeader("Authorization", rootAuth)
+                .addHeader("format", "csv")
+                .url(String.format(
+                        "http://localhost:%s/api/%s/%s/_stream_load_meta",
+                        HTTP_PORT, "", TABLE_NAME))
+                .build();
+        try (Response response = client.newCall(emptyDbRequest).execute()) {
+            assertEquals(200, response.code());
+            Map<String, Object> result = parseResponseBody(response);
+            assertEquals("INVALID_ARGUMENT", result.get("code"));
+            assertEquals("FAILED", result.get("status"));
+            assertEquals("No database selected", result.get("message"));
+            assertEquals("No database selected", result.get("msg"));
+        }
+
+        Request emptyTableRequest = new Request.Builder()
+                .addHeader("Authorization", rootAuth)
+                .addHeader("format", "csv")
+                .url(String.format(
+                        "http://localhost:%s/api/%s/%s/_stream_load_meta",
+                        HTTP_PORT, DB_NAME, ""))
+                .build();
+        try (Response response = client.newCall(emptyTableRequest).execute()) {
+            assertEquals(200, response.code());
+            Map<String, Object> result = parseResponseBody(response);
+            assertEquals("INVALID_ARGUMENT", result.get("code"));
+            assertEquals("FAILED", result.get("status"));
+            assertEquals("No table selected", result.get("message"));
+            assertEquals("No table selected", result.get("msg"));
+        }
+    }
+
+    private Request buildRequest(Map<String, String> headers, Multimap<String, String> parameters) {
+        Request.Builder builder = new Request.Builder();
+        builder.addHeader("Authorization", rootAuth);
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            builder.addHeader(entry.getKey(), entry.getValue());
+        }
+        HttpUrl.Builder urlBuilder = new HttpUrl.Builder()
+                .scheme("http")
+                .host("localhost")
+                .port(HTTP_PORT)
+                .addPathSegment("api")
+                .addPathSegment(DB_NAME)
+                .addPathSegment(TABLE_NAME)
+                .addPathSegment("_stream_load_meta");
+        parameters.forEach(urlBuilder::addQueryParameter);
+        builder.url(urlBuilder.build());
+        return builder.build();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.http;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
@@ -51,7 +50,6 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import okio.BufferedSink;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
@@ -76,7 +74,6 @@ import java.util.function.BiConsumer;
 
 import static com.starrocks.common.jmockit.Deencapsulation.setField;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @FixMethodOrder(MethodSorters.JVM)
@@ -1622,16 +1619,6 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
     private static String toUri(TransactionOperation txnOpt) {
         return String.format("http://localhost:%d/api/transaction/%s", HTTP_PORT, txnOpt.getValue());
-    }
-
-    private static Map<String, Object> parseResponseBody(Response response) throws IOException {
-        assertNotNull(response);
-        ResponseBody body = response.body();
-        assertNotNull(body);
-        String bodyStr = body.string();
-        System.out.println("Response body:\n" + bodyStr);
-        return objectMapper.readValue(bodyStr, new TypeReference<>() {
-        });
     }
 
     private static TransactionState newTxnState(long txnId,


### PR DESCRIPTION
## Why I'm doing:
Sometimes we want to get the metas of a batch write. For example
1. the client wants to get and cache the available backends, then it can send the data to the backend without the redirection of FE. This can relieve the pressure of FE especially in the high concurrency scenario. Also it can break the limitation that the FE only supports to redirect http request, but not brpc request
2. the observability needs to get the status of the batch write, such as the current running or history transactions

So we need an interface to get the meta of the batch write. And this PR will first support to get the available backends using the interface

## What I'm doing:
Add a new http interface `/api/{"DB_KEY"}/{"TABLE_KEY"}/_stream_load_meta` to get metas of stream load. The API specifications
* need http `GET` method
* support both normal and batch write stream load. Currently the normal stream load doest not have any metas, and will return an success response with no meta
* the header requirements are same as that of API `_stream_load`, and FE will return metas according to the load behavior defined by the headers
* use url query parameters to tell what type of metas you want. If no parameter is specified, all metas are returned. Supported parameters in this PR
     * `type`: the type of the meta. Only support `nodes` currently. The `nodes` meta will return the backends that can accept load requests. 
   * `node_service`: only valid if need `nodes` meta. The value can be "http" or "brpc". If not set, the response will return all service types. Each type will be a field in the json, such as "http":"be_ip1:http_port1,be_ip2:http_port2" for http service, and "brpc":"be_ip1:brpc_port1,be_ip2:brpc_port2" for brpc service

Examples:
* normal stream load
```
curl --location-trusted -u root: \
    -H "format:json" \
    -H "strip_outer_array:true" \
    -XGET \
    "http://${FE_HOST}:${FE_HTTP_PORT}/api/test/tbl/_stream_load_meta"

{
   "status": "OK",
  "code": "OK",
  "msg": "",
  "message": ""  
}
```
* batch write with no parameters. return both http and brpc nodes
```
curl --location-trusted -u root: \
    -H "format:json" \
    -H "strip_outer_array:true" \
    -H "enable_merge_commit:true" \
    -H "merge_commit_async:false" \
    -H "merge_commit_interval_ms:5000" \
    -H "merge_commit_parallel:2" \
    -XGET \
    "http://${FE_HOST}:${FE_HTTP_PORT}/api/test/tbl/_stream_load_meta"

{
   "status": "OK",
  "code": "OK",
  "msg": "",
  "message": "" ,
  "nodes": {
    "http": "192.0.0.1:8040,192.0.0.2:8040",
    "brpc": "192.0.0.1:8060,192.0.0.2:8060"
  }
}
```

* batch write with parameters `type`=`nodes` and `node_service`=`http`. return only http nodes
```
curl --location-trusted -u root: \
    -H "format:json" \
    -H "strip_outer_array:true" \
    -H "enable_merge_commit:true" \
    -H "merge_commit_async:false" \
    -H "merge_commit_interval_ms:5000" \
    -H "merge_commit_parallel:2" \
    -XGET \
    "http://${FE_HOST}:${FE_HTTP_PORT}/api/test/tbl/_stream_load_meta?type=nodes&node_service=http"

{
   "status": "OK",
  "code": "OK",
  "msg": "",
  "message": "" ,
  "nodes": {
    "http": "192.0.0.1:8040,192.0.0.2:8040"
  }
}
```

* batch write with parameters `type`=`nodes` and `node_service`=`brpc`. return only brpc nodes
```
curl --location-trusted -u root: \
    -H "format:json" \
    -H "strip_outer_array:true" \
    -H "enable_merge_commit:true" \
    -H "merge_commit_async:false" \
    -H "merge_commit_interval_ms:5000" \
    -H "merge_commit_parallel:2" \
    -XGET \
    "http://${FE_HOST}:${FE_HTTP_PORT}/api/test/tbl/_stream_load_meta?type=nodes&node_service=brpc"

{
   "status": "OK",
  "code": "OK",
  "msg": "",
  "message": "" ,
  "nodes": {
    "brpc": "192.0.0.1:8060,192.0.0.2:8060"
  }
}
```

Fixes #51085

## What type of PR is this:

- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
