### PR TITLE
[BugFix] fix array_map with join

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -143,6 +143,9 @@ void Chunk::append_vector_column(ColumnPtr column, const FieldPtr& field, SlotId
 
 void Chunk::append_column(ColumnPtr column, SlotId slot_id) {
     DCHECK(!_slot_id_to_index.contains(slot_id)) << "slot_id:" + std::to_string(slot_id) << std::endl;
+    if (UNLIKELY(_slot_id_to_index.contains(slot_id))) {
+        throw std::runtime_error(fmt::format("slot_id {} already exists", slot_id));
+    }
     _slot_id_to_index[slot_id] = _columns.size();
     _columns.emplace_back(std::move(column));
     check_or_die();

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -320,7 +320,7 @@ inline const ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) const {
 inline ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) {
     DCHECK(is_slot_exist(slot_id)) << slot_id;
     if (UNLIKELY(!_slot_id_to_index.contains(slot_id))) {
-        throw std::runtime_error("slot_id not found");
+        throw std::runtime_error(fmt::format("slot_id {} not found", slot_id));
     }
     size_t idx = _slot_id_to_index[slot_id];
     return _columns[idx];

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -319,6 +319,9 @@ inline const ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) const {
 
 inline ColumnPtr& Chunk::get_column_by_slot_id(SlotId slot_id) {
     DCHECK(is_slot_exist(slot_id)) << slot_id;
+    if (UNLIKELY(!_slot_id_to_index.contains(slot_id))) {
+        throw std::runtime_error("slot_id not found");
+    }
     size_t idx = _slot_id_to_index[slot_id];
     return _columns[idx];
 }

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -387,9 +387,10 @@ std::string ArrayMapExpr::debug_string() const {
 
 int ArrayMapExpr::get_slot_ids(std::vector<SlotId>* slot_ids) const {
     int num = Expr::get_slot_ids(slot_ids);
-    for (const auto& [slot_id, _] : _outer_common_exprs) {
+    for (const auto& [slot_id, expr] : _outer_common_exprs) {
         slot_ids->push_back(slot_id);
         num++;
+        num += (expr->get_slot_ids(slot_ids));
     }
     return num;
 }

--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -208,7 +208,7 @@ Status LambdaFunction::prepare(starrocks::RuntimeState* state, starrocks::ExprCo
 
 StatusOr<ColumnPtr> LambdaFunction::evaluate_checked(ExprContext* context, Chunk* chunk) {
     for (auto i = 0; i < _common_sub_expr.size(); ++i) {
-        auto sub_col = EVALUATE_NULL_IF_ERROR(context, _common_sub_expr[i], chunk);
+        ASSIGN_OR_RETURN(auto sub_col, context->evaluate(_common_sub_expr[i], chunk));
         chunk->append_column(sub_col, _common_sub_expr_ids[i]);
     }
     return get_child(0)->evaluate_checked(context, chunk);

--- a/test/sql/test_array/R/test_array_map
+++ b/test/sql/test_array/R/test_array_map
@@ -82,4 +82,37 @@ VALUES
 ));
 -- result:
 -- !result
-
+CREATE TABLE table1 (
+    id INT,
+    arr_largeint ARRAY<INT> NOT NULL
+)PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO table1 (id, arr_largeint) VALUES
+(1, [1, 2]),
+(2, [3, 4, 5]),
+(3, [6]);
+-- result:
+-- !result
+CREATE TABLE table2 (
+    id INT,
+    arr_str ARRAY<INT> NOT NULL
+) PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO table2 (id, arr_str) VALUES
+(1, [1, 2, 3]),
+(2, [4, 5]),
+(3, [6, 7, 8, 9]);
+-- result:
+-- !result
+SELECT t1.id AS t1_id, t2.id AS t2_id, t1.arr_largeint
+FROM table1 t1
+LEFT JOIN[broadcast] table2 t2
+ON t1.id = t2.id
+AND array_length(array_map(x -> x + array_length(t2.arr_str), t1.arr_largeint)) >= 2;
+-- result:
+1	1	[1,2]
+2	2	[3,4,5]
+3	None	[6]
+-- !result

--- a/test/sql/test_array/T/test_array_map
+++ b/test/sql/test_array/T/test_array_map
@@ -78,3 +78,31 @@ VALUES
     x -> CAST(x AS STRING), 
     ARRAY_GENERATE(1, 1000)
 ));
+
+-- test array_map with join
+CREATE TABLE table1 (
+    id INT,
+    arr_largeint ARRAY<INT> NOT NULL
+)PROPERTIES ("replication_num" = "1");
+
+
+INSERT INTO table1 (id, arr_largeint) VALUES
+(1, [1, 2]),
+(2, [3, 4, 5]),
+(3, [6]);
+
+CREATE TABLE table2 (
+    id INT,
+    arr_str ARRAY<INT> NOT NULL
+) PROPERTIES ("replication_num" = "1");
+
+INSERT INTO table2 (id, arr_str) VALUES
+(1, [1, 2, 3]),
+(2, [4, 5]),
+(3, [6, 7, 8, 9]);
+
+SELECT t1.id AS t1_id, t2.id AS t2_id, t1.arr_largeint
+FROM table1 t1
+LEFT JOIN[broadcast] table2 t2
+ON t1.id = t2.id
+AND array_length(array_map(x -> x + array_length(t2.arr_str), t1.arr_largeint)) >= 2;


### PR DESCRIPTION
## Why I'm doing:
ArrayMapExpr::get_slot_ids shoud include _outer_common_exprs's slot_id, join rely on get_slot_ids to know columns needed to be kept after probe, if get_slot_ids losts some column, then other predicate evaluation will crash 
![img_v3_00gl_198f934b-dd39-45ea-8d8e-cc25184cb51g](https://github.com/user-attachments/assets/35ac041c-2e69-419d-a0b6-fb08fb9af4ae)


## What I'm doing:
1. fix ArrayMapExpr::get_slot_ids 
2. throw exception if column id is not exist in chunk, and if this happens in expr evaluation, this exception will be caught and avoid BE crash
3. change EVALUATE_NULL_IF_ERROR to ASSIGN_OR_RETURN, EVALUATE_NULL_IF_ERROR will return null when status is not "ok", which will confuse some user

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
