### PR TITLE
[BugFix] Fix no retries when materialized view refresh try lock timeout failed.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -430,7 +430,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                         materializedView.getName(), DebugUtil.getRootStackTrace(e));
                 // Since at here we sync partitions before the refreshExternalTable, the situation may happen that
                 // the base-table not exists before refreshExternalTable, so we just need to swallow this exception
-                if (e.getMessage() == null || !e.getMessage().contains("not exist")) {
+                if (e.getMessage() == null || !e.getMessage().contains("not exist") || e instanceof LockTimeoutException) {
                     throw e;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -430,7 +430,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                         materializedView.getName(), DebugUtil.getRootStackTrace(e));
                 // Since at here we sync partitions before the refreshExternalTable, the situation may happen that
                 // the base-table not exists before refreshExternalTable, so we just need to swallow this exception
-                if (e.getMessage() == null || !e.getMessage().contains("not exist") || e instanceof LockTimeoutException) {
+                if (e.getMessage() == null || !e.getMessage().contains("not exist")
+                        || e instanceof LockTimeoutException) {
                     throw e;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -430,8 +430,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                         materializedView.getName(), DebugUtil.getRootStackTrace(e));
                 // Since at here we sync partitions before the refreshExternalTable, the situation may happen that
                 // the base-table not exists before refreshExternalTable, so we just need to swallow this exception
-                if (e.getMessage() == null || !e.getMessage().contains("not exist")
-                        || e instanceof LockTimeoutException) {
+                if (e.getMessage() == null || !e.getMessage().contains("not exist") || e instanceof LockTimeoutException) {
                     throw e;
                 }
             }


### PR DESCRIPTION
## Why I'm doing:

In `external_table_precise_refresh` mode, the parameter `max_mv_refresh_try_lock_failure_retry_times` may become ineffective.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x]  I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
