### PR TITLE
[Feature] Support setting the cost model weights

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -77,6 +77,9 @@ public final class GlobalVariable {
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN = "activate_all_roles_on_login";
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN_V2 = "activate_all_roles_on_login_v2";
     public static final String ENABLE_TDE = "enable_tde";
+    public static final String CPU_COST_WEIGHT = "costmodel_cpu_cost_weight";
+    public static final String NETWORK_COST_WEIGHT = "costmodel_network_cost_weight";
+    public static final String MEMORY_COST_WEIGHT = "costmodel_memory_cost_weight";
 
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH;
@@ -177,6 +180,15 @@ public final class GlobalVariable {
 
     @VariableMgr.VarAttr(name = ENABLE_TDE, flag = VariableMgr.GLOBAL | VariableMgr.READ_ONLY)
     public static boolean enableTde = KeyMgr.isEncrypted();
+
+    @VariableMgr.VarAttr(name = CPU_COST_WEIGHT, flag = VariableMgr.GLOBAL)
+    public static final double cpuCostWeight = 0.5;
+
+    @VariableMgr.VarAttr(name = MEMORY_COST_WEIGHT, flag = VariableMgr.GLOBAL)
+    public static final double memoryCostWeight = 2;
+
+    @VariableMgr.VarAttr(name = NETWORK_COST_WEIGHT, flag = VariableMgr.GLOBAL)
+    public static final double networkCostWeight = 1.5;
 
     public static boolean isEnableQueryQueueSelect() {
         return enableQueryQueueSelect;
@@ -310,6 +322,18 @@ public final class GlobalVariable {
 
     public static void setActivateAllRolesOnLogin(boolean activateAllRolesOnLogin) {
         GlobalVariable.activateAllRolesOnLogin = activateAllRolesOnLogin;
+    }
+
+    public static double getCpuCostWeight() {
+        return cpuCostWeight;
+    }
+
+    public static double getMemoryCostWeight() {
+        return cpuCostWeight;
+    }
+
+    public static double getNetworkCostWeight() {
+        return cpuCostWeight;
     }
 
     // Don't allow create instance.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.ErrorType;
@@ -117,12 +118,9 @@ public class CostModel {
     }
 
     public static double getRealCost(CostEstimate costEstimate) {
-        double cpuCostWeight = 0.5;
-        double memoryCostWeight = 2;
-        double networkCostWeight = 1.5;
-        return costEstimate.getCpuCost() * cpuCostWeight +
-                costEstimate.getMemoryCost() * memoryCostWeight +
-                costEstimate.getNetworkCost() * networkCostWeight;
+        return costEstimate.getCpuCost() * GlobalVariable.getCpuCostWeight() +
+                costEstimate.getMemoryCost() * GlobalVariable.getMemoryCostWeight() +
+                costEstimate.getNetworkCost() * GlobalVariable.getNetworkCostWeight();
     }
 
     private static class CostEstimator extends OperatorVisitor<CostEstimate, ExpressionContext> {


### PR DESCRIPTION
## Why I'm doing:

At different times, the resource bottlenecks in a cluster can vary; sometimes it might be the CPU, while other times it might be memory. Additionally, there may be other services on the same physical machine that require substantial memory or bandwidth resources. Currently, the weight parameters in StarRocks are fixed values. Therefore, I think it would be very useful to support user-configurable weight parameters in the cost model.

## What I'm doing:

Support setting the cost model weights

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x]  I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
