### PR TITLE
[BugFix] Fix tablet scheduler exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1795,12 +1795,19 @@ public class TabletScheduler extends FrontendDaemon {
                 // no more tablets
                 break;
             }
-            // ignore tablets that will expire and erase soon
-            if (checkIfTabletExpired(tablet)) {
+            try {
+                // ignore tablets that will expire and erase soon
+                if (checkIfTabletExpired(tablet)) {
+                    continue;
+                }
+                list.add(tablet);
+                count--;
+            } catch (Exception e) {
+                LOG.warn("got unexpected exception, discard this schedule. tablet: {}",
+                        tablet.getTabletId(), e);
+                finalizeTabletCtx(tablet, TabletSchedCtx.State.UNEXPECTED, e.getMessage());
                 continue;
             }
-            list.add(tablet);
-            count--;
         }
         return list;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1801,13 +1801,13 @@ public class TabletScheduler extends FrontendDaemon {
                     continue;
                 }
                 list.add(tablet);
-                count--;
             } catch (Exception e) {
                 LOG.warn("got unexpected exception, discard this schedule. tablet: {}",
                         tablet.getTabletId(), e);
                 finalizeTabletCtx(tablet, TabletSchedCtx.State.UNEXPECTED, e.getMessage());
                 continue;
             }
+            count--;
         }
         return list;
     }


### PR DESCRIPTION
## Why I'm doing:
If `TabletScheduler` encountered an unhandled exception when scheduling pending tablets, it only removed the task but did not remove the task_ctx. Consequently, subsequent scheduling will ignore these tablets, and clone and other tasks will no longer be triggered, ultimately causing the alter task to stall.

e.g
```
[OlapTable.renamePartition():1348] rename partition duplicate_complex_table_200_abnormal_base_async_hash_mv in table duplicate_complex_table_200_abnormal_base_async_hash_mv

2024-11-18 04:26:59.256+08:00 ERROR (tablet scheduler|35) [Daemon.run():109] daemon thread got exception. name: tablet scheduler
java.util.ConcurrentModificationException: null
        at java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1698) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
        at com.starrocks.catalog.CatalogRecycleBin.getPhysicalPartition(CatalogRecycleBin.java:249) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.checkIfTabletExpired(TabletScheduler.java:558) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.checkIfTabletExpired(TabletScheduler.java:539) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.getNextTabletCtxBatch(TabletScheduler.java:1799) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.schedulePendingTablets(TabletScheduler.java:578) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.runAfterCatalogReady(TabletScheduler.java:452) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:107) ~[starrocks-fe.jar:?]
```

## What I'm doing:

Catch the exception and remove the tablet_ctx.

Fixes https://github.com/StarRocks/StarRocksTest/issues/8829

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
