### PR TITLE
[Enhancement] enable auto agg pushdown by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1510,7 +1510,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // 0: auto, 1: force push down, -1: don't push down, 2: push down medium, 3: push down high
     @VarAttr(name = "cboPushDownAggregateMode_v1", alias = CBO_PUSH_DOWN_AGGREGATE_MODE,
             show = CBO_PUSH_DOWN_AGGREGATE_MODE, flag = VariableMgr.INVISIBLE)
-    private int cboPushDownAggregateMode = -1;
+    private int cboPushDownAggregateMode = 0;
 
     @VarAttr(name = CBO_PUSH_DOWN_AGGREGATE_ON_BROADCAST_JOIN, flag = VariableMgr.INVISIBLE)
     private boolean cboPushDownAggregateOnBroadcastJoin = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -69,19 +69,29 @@ public class MaterializedViewOptimizer {
                     containsNonDeterministicFunctions.second);
             return new MvPlanContext(false, invalidPlanReason);
         }
-        // get optimized plan of mv's defined query
-        Pair<OptExpression, LogicalPlan> plans =
-                MvUtils.getRuleOptimizedLogicalPlan(stmt, columnRefFactory, connectContext, optimizerConfig, inlineView);
-        if (plans == null) {
-            return new MvPlanContext(false, "No query plan for it");
+        int originAggPushDownMode = connectContext.getSessionVariable().getCboPushDownAggregateMode();
+        if (originAggPushDownMode != -1) {
+            connectContext.getSessionVariable().setCboPushDownAggregateMode(-1);
         }
-        OptExpression mvPlan = plans.first;
-        boolean isValidPlan = MvUtils.isValidMVPlan(mvPlan);
-        // not set it invalid plan if text match rewrite is on because text match rewrite can support all query pattern.
-        String invalidPlanReason = "";
-        if (!isValidPlan) {
-            invalidPlanReason = MvUtils.getInvalidReason(mvPlan, inlineView);
+
+        try {
+            // get optimized plan of mv's defined query
+            Pair<OptExpression, LogicalPlan> plans =
+                    MvUtils.getRuleOptimizedLogicalPlan(stmt, columnRefFactory, connectContext, optimizerConfig, inlineView);
+            if (plans == null) {
+                return new MvPlanContext(false, "No query plan for it");
+            }
+            OptExpression mvPlan = plans.first;
+            boolean isValidPlan = MvUtils.isValidMVPlan(mvPlan);
+            // not set it invalid plan if text match rewrite is on because text match rewrite can support all query pattern.
+            String invalidPlanReason = "";
+            if (!isValidPlan) {
+                invalidPlanReason = MvUtils.getInvalidReason(mvPlan, inlineView);
+            }
+            return new MvPlanContext(mvPlan, plans.second.getOutputColumn(), columnRefFactory, isValidPlan, invalidPlanReason);
+        } finally {
+            connectContext.getSessionVariable().setCboPushDownAggregateMode(originAggPushDownMode);
         }
-        return new MvPlanContext(mvPlan, plans.second.getOutputColumn(), columnRefFactory, isValidPlan, invalidPlanReason);
+
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -367,6 +367,12 @@ public class Optimizer {
         // initialize mv rewrite strategy finally
         mvRewriteStrategy = MvRewriteStrategy.prepareRewriteStrategy(context, connectContext, logicOperatorTree);
         OptimizerTraceUtil.logMVPrepare("MV rewrite strategy: {}", mvRewriteStrategy);
+
+        // TODO(stephen): enable agg push down when query exists related mvs.
+        if (context.getQueryMaterializationContext() != null &&
+                !context.getQueryMaterializationContext().getValidCandidateMVs().isEmpty()) {
+            context.getSessionVariable().setCboPushDownAggregateMode(-1);
+        }
     }
 
     private void pruneTables(OptExpression tree, TaskContext rootTaskContext, ColumnRefSet requiredColumns) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeProjectWithChildRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeProjectWithChildRule.java
@@ -38,6 +38,16 @@ public class MergeProjectWithChildRule extends TransformationRule {
     }
 
     @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        if (!input.getInputs().isEmpty() &&
+                input.getInputs().get(0).getOp().getOpType() == OperatorType.LOGICAL_META_SCAN) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalProjectOperator logicalProjectOperator = (LogicalProjectOperator) input.getOp();
         LogicalOperator child = (LogicalOperator) input.inputAt(0).getOp();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -23,6 +23,7 @@ public class TrinoQueryTest extends TrinoTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
         TrinoTestBase.beforeClass();
+        starRocksAssert.getCtx().getSessionVariable().setCboPushDownAggregateMode(-1);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningTest.java
@@ -40,6 +40,7 @@ public class TablePruningTest extends TablePruningTestBase {
         UtFrameUtils.createMinStarRocksCluster();
         ctx = UtFrameUtils.createDefaultCtx();
         ctx.getSessionVariable().setEnablePipelineEngine(true);
+        ctx.getSessionVariable().setCboPushDownAggregateMode(-1);
         FeConstants.runningUnitTest = true;
         starRocksAssert = new StarRocksAssert(ctx);
         starRocksAssert.withDatabase(StatsConstants.STATISTICS_DB_NAME)

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestBase.java
@@ -29,7 +29,7 @@ public class SchedulerTestBase extends SchedulerTestNoneDBBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
         SchedulerTestNoneDBBase.beforeClass();
-
+        starRocksAssert.getCtx().getSessionVariable().setCboPushDownAggregateMode(-1);
         starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
 
         final String tpchGroup = "tpch_group_" + COLOCATE_GROUP_INDEX.getAndIncrement();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
@@ -96,6 +96,7 @@ public class OptimizerTaskTest {
         ctx.getSessionVariable().setMaxTransformReorderJoins(8);
         ctx.getSessionVariable().setEnableReplicationJoin(false);
         ctx.getSessionVariable().setJoinImplementationMode("auto");
+        ctx.getSessionVariable().setCboPushDownAggregateMode(-1);
         ctx.setDumpInfo(new MockDumpInfo());
         call = new CallOperator(FunctionSet.SUM, Type.BIGINT, Lists.newArrayList(ConstantOperator.createBigint(1)));
         new Expectations(call) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -125,6 +125,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         connectContext.getSessionVariable().setCboCteReuse(true);
         connectContext.getSessionVariable().setCboCTERuseRatio(0);
         connectContext.getSessionVariable().setCboPruneJsonSubfieldDepth(2);
+        connectContext.getSessionVariable().setCboPushDownAggregateMode(-1);
     }
 
     @After


### PR DESCRIPTION
## Why I'm doing:
Currently, most cases have performance improvements after enabling agg pushdown.
for tpcds-1t olap table
|         | no pushdown agg| auto pushdown agg | 
|-------|----|-----|
| sum | 626s | 506s |


## What I'm doing:


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
