### PR TITLE
[BugFix]Fix the bug of limit optimization on prune partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -706,7 +706,8 @@ public class IcebergMetadata implements ConnectorMetadata {
         // Under the condition of ensuring that the data is correct, we disabled the limit optimization when table has
         // partition evolution because this may cause data diff.
         boolean canPruneManifests = limit != -1 && !icebergTable.isV2Format() && onlyHasPartitionPredicate(table, predicate)
-                && limit < Integer.MAX_VALUE && nativeTbl.spec().specId() == 0 && enablePruneManifest();
+                && limit < Integer.MAX_VALUE && nativeTbl.spec().specId() == 0 && enablePruneManifest()
+                && icebergTable.isAllPartitionColumnsAlwaysIdentity();
 
         if (canPruneManifests) {
             // After iceberg uses partition predicate plan files, each manifests entry must have at least one row of data.


### PR DESCRIPTION
## Why I'm doing:

How to reproduce:

```
spark-sql> CREATE TABLE lxh_t_2 (
         >     c1 bigint,
         >     c2 string,
         >     c3 int,
         >     c4 int)
         > USING iceberg
         > PARTITIONED BY (bucket(2, c3), bucket(2, c4))  TBLPROPERTIES(
         >     'format' = 'iceberg/parquet',
         >     'format-version' = '1',
         >     'write.format.default' = 'parquet'
         > );
Time taken: 0.218 seconds
spark-sql> insert into lxh_t_2 values (0, 0, 0, 0), (1, 1, 1, 1), (2, 2, 2, 2), (3, 3, 3, 3), (4, 4, 4, 4), (5, 5, 5, 5), (6, 6, 6, 6), (7, 7, 7, 7), (8, 8, 8, 8);

mysql> select * from lxh_iceberg_hb.lxh_iceberg_test.lxh_t_2 where c3=3 and c4=3 limit 1;                                                                                                                                                                                         
Empty set (0.03 sec)
```

If type of partition transform is not `Identity Transform`, we should not use the opt for `prune iceberg manifests with limit`.

The optimization is introduced by the pr: #30648 .

In main branch, we support `incremental scan range` #52248, the limit optimization is useless, so we only fix on 3.3 and 3.2

## What I'm doing:

Only perform Limit optimization on identity Transform.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

