### PR TITLE
[BugFix] fix MetdataCache concurrency issue

### DIFF
--- a/be/src/storage/rowset/metadata_cache.cpp
+++ b/be/src/storage/rowset/metadata_cache.cpp
@@ -32,14 +32,15 @@ MetadataCache::MetadataCache(size_t capacity) {
 }
 
 void MetadataCache::cache_rowset(Rowset* ptr) {
-    _insert(ptr->rowset_id_str(), ptr, ptr->segment_memory_usage());
+    std::weak_ptr<Rowset>* weak_ptr = new std::weak_ptr<Rowset>(ptr->shared_from_this());
+    _insert(ptr->rowset_id_str(), weak_ptr, ptr->segment_memory_usage());
 }
 
 void MetadataCache::evict_rowset(Rowset* ptr) {
     _erase(ptr->rowset_id_str());
 }
 
-void MetadataCache::warmup_rowset(Rowset* ptr) {
+void MetadataCache::refresh_rowset(Rowset* ptr) {
     _warmup(ptr->rowset_id_str());
 }
 
@@ -51,7 +52,7 @@ void MetadataCache::set_capacity(size_t capacity) {
     _cache->set_capacity(capacity);
 }
 
-void MetadataCache::_insert(const std::string& key, Rowset* ptr, size_t size) {
+void MetadataCache::_insert(const std::string& key, std::weak_ptr<Rowset>* ptr, size_t size) {
     Cache::Handle* handle = _cache->insert(CacheKey(key), ptr, size, _cache_value_deleter);
     _cache->release(handle);
 }
@@ -60,9 +61,19 @@ void MetadataCache::_erase(const std::string& key) {
     _cache->erase(CacheKey(key));
 }
 
+// This function is used as a deleter for the cache values.
+// It is called when a cache entry is evicted or removed.
+// The function takes a CacheKey and a void pointer to the value.
+// The value is expected to be a std::weak_ptr<Rowset>.
+// If the weak_ptr can be locked to a shared_ptr, it calls the close() method on the Rowset.
+// Finally, it deletes the weak_ptr.
 void MetadataCache::_cache_value_deleter(const CacheKey& /*key*/, void* value) {
-    // close this rowset, release metadata memory
-    reinterpret_cast<Rowset*>(value)->close();
+    std::weak_ptr<Rowset>* weak_ptr = reinterpret_cast<std::weak_ptr<Rowset>*>(value);
+    auto rowset = weak_ptr->lock();
+    if (rowset != nullptr) {
+        rowset->close();
+    }
+    delete weak_ptr;
 }
 
 void MetadataCache::_warmup(const std::string& key) {

--- a/be/src/storage/rowset/metadata_cache.h
+++ b/be/src/storage/rowset/metadata_cache.h
@@ -46,7 +46,7 @@ public:
     void evict_rowset(Rowset* ptr);
 
     // warmup rowset, so we can make this rowset as newest entry in lru cache.
-    void warmup_rowset(Rowset* ptr);
+    void refresh_rowset(Rowset* ptr);
 
     // Memory usage of lru cache
     size_t get_memory_usage() const;
@@ -55,7 +55,7 @@ public:
     void set_capacity(size_t capacity);
 
 private:
-    void _insert(const std::string& key, Rowset* ptr, size_t size);
+    void _insert(const std::string& key, std::weak_ptr<Rowset>* ptr, size_t size);
     void _erase(const std::string& key);
     void _warmup(const std::string& key);
     static void _cache_value_deleter(const CacheKey& /*key*/, void* value);

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -213,7 +213,7 @@ void Rowset::warmup_lrucache() {
     if (config::metadata_cache_memory_limit_percent > 0 && _keys_type != PRIMARY_KEYS) {
         // Move this item to newest item in lru cache.
         // ONLY support non-pk table now.
-        MetadataCache::instance()->warmup_rowset(this);
+        MetadataCache::instance()->refresh_rowset(this);
     }
 #endif
 }

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -132,11 +132,11 @@ TEST_F(MetadataCacheTest, test_manual_evcit) {
         rowsets.push_back(rowset_ptr);
     }
     for (int i = 0; i < 10; i++) {
-        metadata_cache_ptr->warmup_rowset(rowsets[i].get());
+        metadata_cache_ptr->refresh_rowset(rowsets[i].get());
         ASSERT_TRUE(rowsets[i]->segment_memory_usage() > 0);
         metadata_cache_ptr->evict_rowset(rowsets[i].get());
         ASSERT_TRUE(rowsets[i]->segment_memory_usage() == 0);
-        metadata_cache_ptr->warmup_rowset(rowsets[i].get());
+        metadata_cache_ptr->refresh_rowset(rowsets[i].get());
     }
 }
 
@@ -172,9 +172,40 @@ TEST_F(MetadataCacheTest, test_warmup) {
             rowsets.push_back(rowset_ptr);
         }
         // warmup first rowset
-        metadata_cache_ptr->warmup_rowset(rowsets[0].get());
+        metadata_cache_ptr->refresh_rowset(rowsets[0].get());
         metadata_cache_ptr->set_capacity(rowsets[0]->segment_memory_usage() * 32);
         ASSERT_TRUE(rowsets[0]->segment_memory_usage() > 0);
+    }
+}
+
+TEST_F(MetadataCacheTest, test_concurrency_issue) {
+    const size_t N = 100;
+    vector<int64_t> keys;
+    for (size_t i = 0; i < N; i++) {
+        keys.push_back(i);
+    }
+    vector<RowsetSharedPtr> rowsets;
+    auto tablet_ptr = create_tablet(1002, 10005);
+    auto metadata_cache_ptr = std::make_unique<MetadataCache>(1);
+    std::vector<std::thread> threads;
+    threads.emplace_back([&]() {
+        for (int i = 0; i < 100; i++) {
+            auto rowset_ptr = create_rowset(tablet_ptr, keys);
+            ASSERT_TRUE(rowset_ptr->load().ok());
+            ASSERT_TRUE(rowset_ptr->segment_memory_usage() > 0);
+            metadata_cache_ptr->cache_rowset(rowset_ptr.get());
+        }
+    });
+    threads.emplace_back([&]() {
+        for (int i = 0; i < 100; i++) {
+            auto rowset_ptr = create_rowset(tablet_ptr, keys);
+            ASSERT_TRUE(rowset_ptr->load().ok());
+            ASSERT_TRUE(rowset_ptr->segment_memory_usage() > 0);
+            metadata_cache_ptr->cache_rowset(rowset_ptr.get());
+        }
+    });
+    for (auto& t : threads) {
+        t.join();
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
In previous PR, we introduced `MetadataCache` to achieve LRU strategy for rowset metadata memory manage, and when rowset been evict, then we will call this function:
```
void MetadataCache::_cache_value_deleter(const CacheKey& /*key*/, void* value) {
    reinterpret_cast<Rowset*>(value)->close();
}
```
to close rowset and release metadata memory.

But in some case, this rowset which pointer point to could has been destroy, but `_cache_value_deleter` doesn't know that and will still keep calling `close()`, and it will lead to concurrency issue.

## What I'm doing:
This pull request includes several changes to the `MetadataCache` class and related functionality in the `rowset` module. The main goals are to improve memory management by using `std::weak_ptr` for cached rowsets and to rename the `warmup_rowset` method to `refresh_rowset` for clarity. Additionally, a new concurrency test is added to ensure thread safety.

Memory management improvements:
* [`be/src/storage/rowset/metadata_cache.cpp`](diffhunk://#diff-1e105fb5d95585adad3b608a228a59331b9294ae9f1dfe900baa0e5d2ef6a758L35-R43): Changed `MetadataCache::cache_rowset` to use `std::weak_ptr<Rowset>` for better memory management and updated the `_insert` method accordingly. [[1]](diffhunk://#diff-1e105fb5d95585adad3b608a228a59331b9294ae9f1dfe900baa0e5d2ef6a758L35-R43) [[2]](diffhunk://#diff-1e105fb5d95585adad3b608a228a59331b9294ae9f1dfe900baa0e5d2ef6a758L54-R55)
* [`be/src/storage/rowset/metadata_cache.cpp`](diffhunk://#diff-1e105fb5d95585adad3b608a228a59331b9294ae9f1dfe900baa0e5d2ef6a758R64-R76): Modified `_cache_value_deleter` to handle `std::weak_ptr<Rowset>` and ensure proper cleanup of cached rowsets.

Method renaming for clarity:
* `be/src/storage/rowset/metadata_cache.cpp` and `be/src/storage/rowset/metadata_cache.h`: Renamed `warmup_rowset` to `refresh_rowset` to better reflect its purpose. [[1]](diffhunk://#diff-1e105fb5d95585adad3b608a228a59331b9294ae9f1dfe900baa0e5d2ef6a758L35-R43) [[2]](diffhunk://#diff-5062e14fd99b2cec9f9dc7f955f4fb41a63ea5a0442185d3f38fe1edf57dc6b6L49-R49) [[3]](diffhunk://#diff-5062e14fd99b2cec9f9dc7f955f4fb41a63ea5a0442185d3f38fe1edf57dc6b6L58-R58)
* [`be/src/storage/rowset/rowset.cpp`](diffhunk://#diff-ef62ce4929734fcc8eedf61344862e2df5c35a3fe82cbd39958c110173838d67L216-R216): Updated calls to `warmup_rowset` to use the new `refresh_rowset` method.
* [`be/test/storage/rowset/metadata_cache_test.cpp`](diffhunk://#diff-05799180ade261037d5b12e14d1db7a63ae5d0e874d75026d7b9d55d80bcb868L135-R139): Updated test cases to use `refresh_rowset` instead of `warmup_rowset`. [[1]](diffhunk://#diff-05799180ade261037d5b12e14d1db7a63ae5d0e874d75026d7b9d55d80bcb868L135-R139) [[2]](diffhunk://#diff-05799180ade261037d5b12e14d1db7a63ae5d0e874d75026d7b9d55d80bcb868L175-R211)

New test for concurrency:
* [`be/test/storage/rowset/metadata_cache_test.cpp`](diffhunk://#diff-05799180ade261037d5b12e14d1db7a63ae5d0e874d75026d7b9d55d80bcb868L175-R211): Added a new test `test_concurrency_issue` to verify the thread safety of the `MetadataCache` when caching rowsets concurrently.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
