### PR TITLE
[BugFix] Fix incorrect directory replacement in datacache for old persistent cache data.

### DIFF
--- a/be/src/block_cache/datacache_utils.cpp
+++ b/be/src/block_cache/datacache_utils.cpp
@@ -158,8 +158,8 @@ void DataCacheUtils::clean_residual_datacache(const std::string& disk_path) {
 }
 
 Status DataCacheUtils::change_disk_path(const std::string& old_disk_path, const std::string& new_disk_path) {
-    std::filesystem::path new_path(old_disk_path);
-    std::filesystem::path old_path(new_disk_path);
+    std::filesystem::path old_path(old_disk_path);
+    std::filesystem::path new_path(new_disk_path);
     if (std::filesystem::exists(old_path)) {
         if (DiskInfo::disk_id(old_path.c_str()) != DiskInfo::disk_id(new_path.c_str())) {
             LOG(ERROR) << "fail to rename the old dataache directory [" << old_path.string() << "] to the new one ["


### PR DESCRIPTION
## Why I'm doing:
The old datacache directory replacement logic cause the incorrect data location and may cause BE crash when starting.

## What I'm doing:
Fix incorrect directory replacement in datacache for old persistent cache data.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
