### PR TITLE
[Enhancement] Optimize NodeSelector#seqChooseBackendOrComputeId()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/NodeSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/NodeSelector.java
@@ -66,17 +66,18 @@ public class NodeSelector {
     }
 
     public Long seqChooseBackendOrComputeId() throws UserException {
+        if (RunMode.isSharedDataMode()) {
+            List<Long> computeNodes = seqChooseComputeNodes(1, true, false);
+            if (CollectionUtils.isNotEmpty(computeNodes)) {
+                return computeNodes.get(0);
+            }
+        }
+
         List<Long> backendIds = seqChooseBackendIds(1, true, false, null);
         if (CollectionUtils.isNotEmpty(backendIds)) {
             return backendIds.get(0);
         }
-        if (RunMode.isSharedNothingMode()) {
-            throw new UserException("No backend alive.");
-        }
-        List<Long> computeNodes = seqChooseComputeNodes(1, true, false);
-        if (CollectionUtils.isNotEmpty(computeNodes)) {
-            return computeNodes.get(0);
-        }
+
         throw new UserException("No backend or compute node alive.");
     }
 


### PR DESCRIPTION
## Why I'm doing:

Shared-data clusters do not necessarily (or should not) have BE nodes, thus invoking `NodeSelector#seqChooseBackendOrComputeId()` method will produce `failed to find any backend` logs, which are somewhat confusing.

## What I'm doing:

Refactor that method to check for CN nodes under shared-data mode first, then check for BE under both modes.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5