### PR TITLE
[BugFix] Refresh MV's ref base table infos to get the newest snapshots

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
@@ -76,14 +76,7 @@ public class MvBaseTableUpdateInfo {
 
     /**
      * Add partition name that needs to be refreshed and its associated list partition key
-     * @param partitionName base table partition name
-     * @param listPartitionKey the associated list partition
      */
-    public void addListPartitionKeys(String partitionName,
-                                     PListCell listPartitionKey) {
-        nameToPartKeys.put(partitionName, listPartitionKey);
-    }
-
     public void addListPartitionKeys(Map<String, PListCell> listPartitionKeys) {
         nameToPartKeys.putAll(listPartitionKeys);
     }
@@ -107,7 +100,7 @@ public class MvBaseTableUpdateInfo {
     public Map<String, PListCell> getPartitionNameWithLists() {
         Map<String, PListCell> result = Maps.newHashMap();
         for (Map.Entry<String, PCell> e : nameToPartKeys.entrySet()) {
-            Preconditions.checkState(e.getValue() instanceof PRangeCell);
+            Preconditions.checkState(e.getValue() instanceof PListCell);
             PListCell listCell = (PListCell) e.getValue();
             result.put(e.getKey(), listCell);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -153,6 +153,11 @@ public abstract class ConnectorPartitionTraits {
 
     public abstract String getDbName();
 
+    /**
+     * `createPartitionKeyWithType` is deprecated, use `createPartitionKey` instead.
+     * partition values should take care time zone for Iceberg table which is handled by `createPartitionKey`.
+     */
+    @Deprecated
     public abstract PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException;
 
     public abstract PartitionKey createPartitionKey(List<String> partitionValues, List<Column> partitionColumns)

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -101,10 +101,15 @@ public class PartitionUtil {
 
     public static final String MYSQL_PARTITION_MAXVALUE = "MAXVALUE";
 
+    @Deprecated
     public static PartitionKey createPartitionKey(List<String> values, List<Column> columns) throws AnalysisException {
         return createPartitionKey(values, columns, Table.TableType.HIVE);
     }
 
+    /**
+     * Use createPartitionKey instead, because `createPartitionKeyWithType` not takes care timezone.
+     */
+    @Deprecated
     public static PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types,
                                                           Table.TableType tableType) throws AnalysisException {
         return ConnectorPartitionTraits.build(tableType).createPartitionKeyWithType(values, types);
@@ -406,7 +411,7 @@ public class PartitionUtil {
                                 .map(p -> getPartitionNameForJDBCTable(partitionColumns.get(p), partitionName))
                                 .collect(Collectors.toList()),
                         partitionColumnIdxes.stream().map(partitionColumns::get).collect(Collectors.toList()),
-                        table.getType());
+                        table);
                 String mvPartitionName = generateMVPartitionName(partitionKey);
                 mvPartitionKeySetMap.computeIfAbsent(mvPartitionName, x -> Sets.newHashSet())
                         .add(partitionName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/IntervalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/IntervalLiteral.java
@@ -21,6 +21,7 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TExprNode;
 
+
 public class IntervalLiteral extends LiteralExpr {
     private final Expr value;
     private final UnitIdentifier unitIdentifier;
@@ -45,7 +46,7 @@ public class IntervalLiteral extends LiteralExpr {
 
     @Override
     protected String toSqlImpl() {
-        return "interval " + value.toSql() + unitIdentifier;
+        return "interval " + value.toSql() + " " + unitIdentifier.toSql();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UnitIdentifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UnitIdentifier.java
@@ -37,6 +37,11 @@ public class UnitIdentifier implements ParseNode {
     }
 
     @Override
+    public String toSql() {
+        return description;
+    }
+
+    @Override
     public NodePosition getPos() {
         return pos;
     }


### PR DESCRIPTION
## Why I'm doing:
- Fix bugs introduced by PR(https://github.com/StarRocks/starrocks/pull/52577).
- `tableToBaseTableInfoCache` is deleted wrongly.

## What I'm doing:
- Add `tableToBaseTableInfoCache` into MaterializedView again to refresh snapshots for each query.

Fixes https://github.com/StarRocks/starrocks/issues/52576


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
