### PR TITLE
[BugFix] Support Generated Column rewrite for logical view with customize column name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RelationId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RelationId.java
@@ -40,6 +40,10 @@ public class RelationId {
         return new RelationId(requireNonNull(sourceNode, "source cannot be null"));
     }
 
+    public Relation getSourceNode() {
+        return sourceNode;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/test/sql/test_materialized_column/R/test_generated_column_rewrite
+++ b/test/sql/test_materialized_column/R/test_generated_column_rewrite
@@ -708,3 +708,87 @@ None
 DROP VIEW v2;
 -- result:
 -- !result
+-- name: test_view_analyzed_rewrite_failure
+CREATE TABLE `t_view_analyzed_rewrite_failure_1` (
+  `id_1` bigint(20) NOT NULL COMMENT "",
+  `col_2` STRING AS CONCAT(CAST(id_1 AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id_1`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t_view_analyzed_rewrite_failure_2` (
+  `id_3` bigint(20) NOT NULL COMMENT "",
+  `col_4` STRING AS CONCAT(CAST(id_3 AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id_3`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_view_analyzed_rewrite_failure_1 VALUES (1);
+-- result:
+-- !result
+INSERT INTO t_view_analyzed_rewrite_failure_2 VALUES (1);
+-- result:
+-- !result
+INSERT INTO t_view_analyzed_rewrite_failure_2 VALUES (2);
+-- result:
+-- !result
+CREATE VIEW v1 (v1_col1, v1_col2, v1_col3, v1_col4) as
+WITH tmp as (SELECT id_1, col_2 from `t_view_analyzed_rewrite_failure_1`)
+select tmp.id_1, tmp.col_2, t_view_analyzed_rewrite_failure_2.id_3, t_view_analyzed_rewrite_failure_2.col_4 from tmp, t_view_analyzed_rewrite_failure_2 where
+CONCAT(CAST(tmp.id_1 AS STRING), "_abc") = CONCAT(CAST(t_view_analyzed_rewrite_failure_2.id_3 AS STRING), "_abc");
+-- result:
+-- !result
+CREATE VIEW v2 (v1_col1, v1_col2, v1_col3, v1_col4) as
+(WITH tmp as (SELECT id_1, col_2 from `t_view_analyzed_rewrite_failure_1`)
+select tmp.id_1, tmp.col_2, t_view_analyzed_rewrite_failure_2.id_3, t_view_analyzed_rewrite_failure_2.col_4 from tmp, t_view_analyzed_rewrite_failure_2 where
+CONCAT(CAST(tmp.id_1 AS STRING), "_abc") = CONCAT(CAST(t_view_analyzed_rewrite_failure_2.id_3 AS STRING), "_abc"));
+-- result:
+-- !result
+CREATE VIEW v3 (v1_col1, v1_col2, v1_col3, v1_col4) as
+WITH tmp as (SELECT id_1, col_2 from `t_view_analyzed_rewrite_failure_1`)
+select tmp.id_1 AS new_col1, tmp.col_2 AS new_col2, t_view_analyzed_rewrite_failure_2.id_3 AS new_col3, t_view_analyzed_rewrite_failure_2.col_4 AS new_col4 from tmp, t_view_analyzed_rewrite_failure_2 where
+CONCAT(CAST(tmp.id_1 AS STRING), "_abc") = CONCAT(CAST(t_view_analyzed_rewrite_failure_2.id_3 AS STRING), "_abc");
+-- result:
+-- !result
+function: assert_explain_not_contains('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v1', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v1', "SELECT v1_col2 from v1")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v2', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v2', "SELECT v1_col2 from v2")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v3', "abc")
+-- result:
+None
+-- !result
+function: assert_is_identical_explain_plan('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v3', "SELECT v1_col2 from v3")
+-- result:
+None
+-- !result

--- a/test/sql/test_materialized_column/T/test_generated_column_rewrite
+++ b/test/sql/test_materialized_column/T/test_generated_column_rewrite
@@ -409,3 +409,62 @@ DROP VIEW v1;
 CREATE VIEW v2 AS WITH tmp AS (SELECT t1.k AS col1, t1.v AS col2, t2.k AS col3, t2.v AS col4 FROM t1, t2) SELECT tmp.col1 + 10, tmp.col3 + 10 FROM tmp;
 function: assert_explain_contains('SELECT * FROM v2', "k + 10")
 DROP VIEW v2;
+
+-- name: test_view_analyzed_rewrite_failure
+CREATE TABLE `t_view_analyzed_rewrite_failure_1` (
+  `id_1` bigint(20) NOT NULL COMMENT "",
+  `col_2` STRING AS CONCAT(CAST(id_1 AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id_1`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t_view_analyzed_rewrite_failure_2` (
+  `id_3` bigint(20) NOT NULL COMMENT "",
+  `col_4` STRING AS CONCAT(CAST(id_3 AS STRING), "_abc")
+) ENGINE=OLAP 
+DUPLICATE KEY(`id_3`)
+DISTRIBUTED BY RANDOM BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+INSERT INTO t_view_analyzed_rewrite_failure_1 VALUES (1);
+INSERT INTO t_view_analyzed_rewrite_failure_2 VALUES (1);
+INSERT INTO t_view_analyzed_rewrite_failure_2 VALUES (2);
+
+CREATE VIEW v1 (v1_col1, v1_col2, v1_col3, v1_col4) as
+WITH tmp as (SELECT id_1, col_2 from `t_view_analyzed_rewrite_failure_1`)
+select tmp.id_1, tmp.col_2, t_view_analyzed_rewrite_failure_2.id_3, t_view_analyzed_rewrite_failure_2.col_4 from tmp, t_view_analyzed_rewrite_failure_2 where
+CONCAT(CAST(tmp.id_1 AS STRING), "_abc") = CONCAT(CAST(t_view_analyzed_rewrite_failure_2.id_3 AS STRING), "_abc");
+
+CREATE VIEW v2 (v1_col1, v1_col2, v1_col3, v1_col4) as
+(WITH tmp as (SELECT id_1, col_2 from `t_view_analyzed_rewrite_failure_1`)
+select tmp.id_1, tmp.col_2, t_view_analyzed_rewrite_failure_2.id_3, t_view_analyzed_rewrite_failure_2.col_4 from tmp, t_view_analyzed_rewrite_failure_2 where
+CONCAT(CAST(tmp.id_1 AS STRING), "_abc") = CONCAT(CAST(t_view_analyzed_rewrite_failure_2.id_3 AS STRING), "_abc"));
+
+CREATE VIEW v3 (v1_col1, v1_col2, v1_col3, v1_col4) as
+WITH tmp as (SELECT id_1, col_2 from `t_view_analyzed_rewrite_failure_1`)
+select tmp.id_1 AS new_col1, tmp.col_2 AS new_col2, t_view_analyzed_rewrite_failure_2.id_3 AS new_col3, t_view_analyzed_rewrite_failure_2.col_4 AS new_col4 from tmp, t_view_analyzed_rewrite_failure_2 where
+CONCAT(CAST(tmp.id_1 AS STRING), "_abc") = CONCAT(CAST(t_view_analyzed_rewrite_failure_2.id_3 AS STRING), "_abc");
+
+function: assert_explain_not_contains('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v1', "abc")
+function: assert_is_identical_explain_plan('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v1', "SELECT v1_col2 from v1")
+
+function: assert_explain_not_contains('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v2', "abc")
+function: assert_is_identical_explain_plan('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v2', "SELECT v1_col2 from v2")
+
+function: assert_explain_not_contains('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v3', "abc")
+function: assert_is_identical_explain_plan('SELECT CONCAT(CAST(v1_col1 AS STRING), "_abc") from v3', "SELECT v1_col2 from v3")


### PR DESCRIPTION
## Why I'm doing:
In current implementation, if the logical view sepecify the customize column name which is different from the projection output of the SQL definition, optimizer will not rewrite Generated Column expression although all column have been output.
This issue is caused by lack of alias information in SelectItem in this case. The alias information can be found in scope for logical view.

## What I'm doing:
1. Use alias information in scope for logical view rewriting.
2. Refactoring some code.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
