### PR TITLE
[BugFix] olap view should not participate in MV processing logic

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -142,6 +142,26 @@ public class PlanTestBase extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
+        starRocksAssert.withTable("CREATE TABLE `t7` (\n" +
+                "  `k1` string NULL COMMENT \"\",\n" +
+                "  `k2` string NULL COMMENT \"\",\n" +
+                "  `k3` string NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE `t8` (\n" +
+                "  `k1` string NULL COMMENT \"\",\n" +
+                "  `k2` string NULL COMMENT \"\",\n" +
+                "  `k3` string NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
         starRocksAssert.withTable("CREATE TABLE `colocate_t0` (\n" +
                 "  `v1` bigint NULL COMMENT \"\",\n" +
                 "  `v2` bigint NULL COMMENT \"\",\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -1776,4 +1776,23 @@ public class ViewPlanTest extends PlanTestBase {
         String sql = "select `select` from (select v1 from t0) `abc.bcd`(`select`);";
         testView(sql);
     }
+
+    @Test
+    public void testViewNotInvolveMv() throws Exception {
+        starRocksAssert.getCtx().getSessionVariable().setEnableViewBasedMvRewrite(true);
+        String createView = "create view v_l as select k1, k2 as k22, k3 as k33 from t7";
+        starRocksAssert.withView(createView);
+
+        createView = "create view v_r as select k1, k2 as k222, k3 as k333 from t8";
+        starRocksAssert.withView(createView);
+
+        String sql = "select l.k1 from v_l l left join v_r r1 on l.k22=r1.k222 left join" +
+                " v_r r2 on trim(l.k33)=r2.k333; ";
+        String sqlPlan = getFragmentPlan(sql);
+        Assert.assertTrue(sqlPlan.contains("OlapScanNode"));
+
+        starRocksAssert.dropView("v_l");
+        starRocksAssert.dropView("v_r");
+        starRocksAssert.getCtx().getSessionVariable().setEnableViewBasedMvRewrite(false);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
reproduce case:
```
create table t0 (k1 string, k2 string, k3 string);
create table t1 (k1 string, k2 string, k3 string);
create view v_l as select k1, k2 as k22, k3 as k33;
create view v_r as select k1, k2 as k222, k3 as k332;

select l.k1 from v_l l left join v_r r1 on l.k22=r1.k222 left join v_r r2 on trim(l.k33)=r2.k333;
```
error msg
```
com.starrocks.sql.common.StarRocksPlannerException: only found column statistics: {1: k1, 2: k2, 3: k3, 15: k3}, but missing statistic of col: 19: trim.

```


## What I'm doing:
If the olap view does not have mv, the optimizer process will be polluted.  like https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java#L266

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
