### PR TITLE
[Enhancement] Disable arrow flight sql server by default

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -133,7 +133,7 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
         heartbeat_result.backend_info.__set_http_port(config::be_http_port);
         heartbeat_result.backend_info.__set_be_rpc_port(-1);
         heartbeat_result.backend_info.__set_brpc_port(config::brpc_port);
-        heartbeat_result.backend_info.__set_be_arrow_port(config::be_arrow_port);
+        heartbeat_result.backend_info.__set_arrow_flight_port(config::arrow_flight_port);
 #ifdef USE_STAROS
         heartbeat_result.backend_info.__set_starlet_port(config::starlet_port);
         if (StorageEngine::instance()->get_store_num() != 0) {

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -394,8 +394,7 @@ CONF_Int32(be_http_num_workers, "48");
 // Period to update rate counters and sampling counters in ms.
 CONF_mInt32(periodic_counter_update_period_ms, "500");
 
-// Port to start debug Arrow Flight SQL server in BE
-CONF_Int32(be_arrow_port, "9419");
+CONF_Int32(arrow_flight_port, "-1");
 
 // Used for mini Load. mini load data file will be removed after this time.
 CONF_Int64(load_data_reserve_hours, "4");

--- a/be/src/service/service_be/arrow_flight_sql_service.cpp
+++ b/be/src/service/service_be/arrow_flight_sql_service.cpp
@@ -29,6 +29,14 @@
 namespace starrocks {
 
 Status ArrowFlightSqlServer::start(int port) {
+    if (port <= 0) {
+        LOG(INFO) << "[ARROW] Arrow Flight SQL Server is disabled. You can modify `arrow_flight_port` in `be.conf` to "
+                     "a positive value to enable it.";
+        return Status::OK();
+    }
+
+    _running = true;
+
     arrow::flight::Location bind_location;
     RETURN_STATUS_IF_ERROR(arrow::flight::Location::ForGrpcTcp(BackendOptions::get_service_bind_address(), port)
                                    .Value(&bind_location));
@@ -36,6 +44,16 @@ Status ArrowFlightSqlServer::start(int port) {
     RETURN_STATUS_IF_ERROR(Init(flight_options));
 
     return Status::OK();
+}
+
+void ArrowFlightSqlServer::stop() {
+    if (!_running) {
+        return;
+    }
+    _running = false;
+    if (const Status status = Shutdown(); !status.ok()) {
+        LOG(INFO) << "[ARROW] Failed to stop Arrow Flight SQL Server [error=" << status << "]";
+    }
 }
 
 arrow::Result<std::unique_ptr<arrow::flight::FlightInfo>> ArrowFlightSqlServer::GetFlightInfoSchemas(

--- a/be/src/service/service_be/arrow_flight_sql_service.cpp
+++ b/be/src/service/service_be/arrow_flight_sql_service.cpp
@@ -51,7 +51,7 @@ void ArrowFlightSqlServer::stop() {
         return;
     }
     _running = false;
-    if (const Status status = Shutdown(); !status.ok()) {
+    if (const auto status = Shutdown(); !status.ok()) {
         LOG(INFO) << "[ARROW] Failed to stop Arrow Flight SQL Server [error=" << status << "]";
     }
 }

--- a/be/src/service/service_be/arrow_flight_sql_service.h
+++ b/be/src/service/service_be/arrow_flight_sql_service.h
@@ -26,6 +26,7 @@ namespace starrocks {
 class ArrowFlightSqlServer : public arrow::flight::sql::FlightSqlServerBase {
 public:
     Status start(int port);
+    void stop();
 
     arrow::Result<std::unique_ptr<arrow::flight::FlightInfo>> GetFlightInfoSchemas(
             const arrow::flight::ServerCallContext& context, const arrow::flight::sql::GetDbSchemas& command,
@@ -37,6 +38,8 @@ public:
 
 private:
     static arrow::Result<std::pair<std::string, std::string>> decode_ticket(const std::string& ticket);
+
+    bool _running = false;
 };
 
 } // namespace starrocks

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -308,8 +308,10 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 
     // Start Arrow Flight SQL server
     auto arrow_flight_sql_server = std::make_unique<ArrowFlightSqlServer>();
-    if (auto status = arrow_flight_sql_server->start(config::be_arrow_port); !status.ok()) {
-        LOG(ERROR) << process_name << " arrow flight sql server did not start correctly, exiting: " << status.message();
+    if (auto status = arrow_flight_sql_server->start(config::arrow_flight_port); !status.ok()) {
+        LOG(ERROR) << process_name << " Arrow Flight Sql Server did not start correctly, exiting: " << status.message()
+                   << ". Its port might be occupied. You can modify `arrow_flight_port` in `be.conf` to an unused port "
+                      "or set it to -1 to disable it.";
         shutdown_logging();
         exit(1);
     }
@@ -348,6 +350,10 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     heartbeat_server->join();
     heartbeat_server.reset();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": heartbeat server exit successfully";
+
+    arrow_flight_sql_server->stop();
+    arrow_flight_sql_server.reset();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": Arrow Flight SQL server exit successfully";
 
     http_server->stop();
     brpc_server->Stop(0);

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -164,8 +164,7 @@ public class StarRocksFE {
                     ExecuteEnv.getInstance().getScheduler());
             FrontendThriftServer frontendThriftServer = new FrontendThriftServer(Config.rpc_port);
             HttpServer httpServer = new HttpServer(Config.http_port);
-            ArrowFlightSqlService arrowFlightSqlService =
-                    new ArrowFlightSqlService(Config.arrow_flight_port);
+            ArrowFlightSqlService arrowFlightSqlService = new ArrowFlightSqlService(Config.arrow_flight_port);
 
             httpServer.setup();
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -795,12 +795,6 @@ public class Config extends ConfigBase {
     public static int rpc_port = 9020;
 
     /**
-     * Arrow Flight SQL server port
-     */
-    @ConfField
-    public static int arrow_flight_port = 9408;
-
-    /**
      * The connection timeout and socket timeout config for thrift server
      * The value for thrift_client_timeout_ms is set to be larger than zero to prevent
      * some hang up problems in java.net.SocketInputStream.socketRead0
@@ -3328,6 +3322,12 @@ public class Config extends ConfigBase {
     public static int batch_write_idle_ms = 3600000;
 
     public static int batch_write_executor_threads_num = 4096;
+
+    /**
+     * Enable Arrow Flight SQL server only when the port is set to positive value.
+     */
+    @ConfField
+    public static int arrow_flight_port = -1;
 
     @ConfField(mutable = true)
     public static int arrow_token_cache_size = 1024;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -671,24 +671,21 @@ public class StmtExecutor {
                             // to this failed execution.
                             String queryId = DebugUtil.printId(context.getExecutionId());
                             ProfileManager.getInstance().removeProfile(queryId);
-                        }
-
-                        if (context instanceof ArrowFlightSqlConnectContext) {
+                        } else if (context instanceof ArrowFlightSqlConnectContext) {
                             isAsync = true;
                             tryProcessProfileAsync(execPlan, i);
                         } else if (context.isProfileEnabled()) {
                             isAsync = tryProcessProfileAsync(execPlan, i);
-                        }
-
-                        if (parsedStmt.isExplain() &&
-                                StatementBase.ExplainLevel.ANALYZE.equals(parsedStmt.getExplainLevel())) {
-                            if (coord != null && coord.isShortCircuit()) {
-                                throw new UserException(
-                                        "short circuit point query doesn't suppot explain analyze stmt, " +
-                                                "you can set it off by using  set enable_short_circuit=false");
+                            if (parsedStmt.isExplain() &&
+                                    StatementBase.ExplainLevel.ANALYZE.equals(parsedStmt.getExplainLevel())) {
+                                if (coord != null && coord.isShortCircuit()) {
+                                    throw new UserException(
+                                            "short circuit point query doesn't suppot explain analyze stmt, " +
+                                                    "you can set it off by using  set enable_short_circuit=false");
+                                }
+                                handleExplainStmt(ExplainAnalyzer.analyze(
+                                        ProfilingExecPlan.buildFrom(execPlan), profile, null));
                             }
-                            handleExplainStmt(ExplainAnalyzer.analyze(
-                                    ProfilingExecPlan.buildFrom(execPlan), profile, null));
                         }
 
                         if (context.getState().isError()) {
@@ -699,11 +696,9 @@ public class StmtExecutor {
                         }
 
                         if (isAsync) {
-                            int timeout = context.getSessionVariable().getQueryTimeoutS();
                             QeProcessorImpl.INSTANCE
-                                    .monitorQuery(context.getExecutionId(),
-                                            System.currentTimeMillis() + timeout * 1000L +
-                                                    context.getSessionVariable().getProfileTimeout() * 1000L);
+                                    .monitorQuery(context.getExecutionId(), System.currentTimeMillis() +
+                                            context.getSessionVariable().getProfileTimeout() * 1000L);
                         } else {
                             QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
                         }
@@ -1320,7 +1315,7 @@ public class StmtExecutor {
                 sendFields(colNames, outputExprs);
             }
         }
-        
+
         if (batch != null) {
             statisticsForAuditLog = batch.getQueryStatistics();
             if (!isOutfileQuery) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -696,9 +696,8 @@ public class StmtExecutor {
                         }
 
                         if (isAsync) {
-                            QeProcessorImpl.INSTANCE
-                                    .monitorQuery(context.getExecutionId(), System.currentTimeMillis() +
-                                            context.getSessionVariable().getProfileTimeout() * 1000L);
+                            QeProcessorImpl.INSTANCE.monitorQuery(context.getExecutionId(),
+                                    System.currentTimeMillis() + context.getSessionVariable().getProfileTimeout() * 1000L);
                         } else {
                             QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlService.java
@@ -31,13 +31,21 @@ public class ArrowFlightSqlService {
 
     private static final Logger LOG = LogManager.getLogger(ArrowFlightSqlService.class);
 
+    private final Location location;
     private final FlightServer flightServer;
 
-    protected volatile boolean running;
+    protected volatile boolean running = false;
 
     public ArrowFlightSqlService(int port) {
+        // Disable Arrow Flight SQL feature if port is not set to a positive value.
+        if (port <= 0) {
+            this.location = null;
+            this.flightServer = null;
+            return;
+        }
+
         BufferAllocator allocator = new RootAllocator();
-        Location location = Location.forGrpcInsecure("0.0.0.0", port);
+        this.location = Location.forGrpcInsecure("0.0.0.0", port);
 
         ArrowFlightSqlTokenManager arrowFlightSqlTokenManager = new ArrowFlightSqlTokenManager();
         ArrowFlightSqlSessionManager arrowFlightSqlSessionManager =
@@ -49,40 +57,56 @@ public class ArrowFlightSqlService {
         ArrowFlightSqlAuthenticator arrowFlightSqlAuthenticator =
                 new ArrowFlightSqlAuthenticator(arrowFlightSqlTokenManager);
 
-        flightServer = FlightServer.builder(allocator, location, producer)
+        this.flightServer = FlightServer.builder(allocator, location, producer)
                 .headerAuthenticator(arrowFlightSqlAuthenticator)
                 .build();
     }
 
     public void start() {
+        if (location == null) {
+            LOG.info("[ARROW] Arrow Flight SQL server is disabled. You can modify `arrow_flight_port` in `fe.conf` " +
+                    "to a positive value to enable it.");
+            return;
+        }
+
+        if (running) {
+            return;
+        }
+
         try {
             flightServer.start();
             running = true;
-            LOG.info("Arrow Flight SQL server start.");
+            LOG.info("[ARROW] Arrow Flight SQL server starts on {}:{}.",
+                    location.getUri().getHost(), location.getUri().getPort());
             flightServer.awaitTermination();
         } catch (InterruptedException e) {
-            LOG.error("Arrow Flight SQL server was interrupted", e);
+            LOG.error("[ARROW] Arrow Flight SQL server was interrupted", e);
             Thread.currentThread().interrupt();
             System.exit(-1);
         } catch (Exception e) {
-            LOG.error("Arrow Flight SQL server start failed");
+            LOG.error("[ARROW] Failed to start Arrow Flight SQL server on {}:{}. Its port might be occupied. You can " +
+                            "modify `arrow_flight_port` in `fe.conf` to an unused port or set it to -1 to disable it.",
+                    location.getUri().getHost(),
+                    location.getUri().getPort(), e);
             System.exit(-1);
         }
     }
 
     public void stop() {
-        if (running) {
-            running = false;
-            try {
-                LOG.info("Stopping Arrow Flight SQL server .");
-                flightServer.shutdown();
-                flightServer.awaitTermination(1, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                LOG.warn("Interrupted while stopping Arrow Flight SQL server", e);
-                Thread.currentThread().interrupt();
-            } catch (Exception e) {
-                LOG.warn("Error while stopping Arrow Flight SQL server", e);
-            }
+        if (!running) {
+            return;
+        }
+
+        running = false;
+        try {
+            LOG.info("[ARROW] Stopping Arrow Flight SQL server .");
+            flightServer.shutdown();
+            flightServer.awaitTermination(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            LOG.warn("[ARROW] Interrupted while stopping Arrow Flight SQL server", e);
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Error while stopping Arrow Flight SQL server", e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -423,7 +423,12 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
             FlightSql.TicketStatementQuery ticketStatementQuery =
                     FlightSql.TicketStatementQuery.newBuilder().setStatementHandle(handle).build();
 
-            int beArrowPort = be.getBeArrowPort();
+            int beArrowPort = be.getArrowFlightPort();
+            if (beArrowPort <= 0) {
+                throw CallStatus.INTERNAL.withDescription(String.format("BE [%d] has already disabled Arrow Flight Server. " +
+                                "You could set `arrow_flight_port` in `be.conf` to a positive value to enable it.", beId))
+                        .toRuntimeException();
+            }
             Location grpcLocation = Location.forGrpcInsecure(address.hostname, beArrowPort);
             Ticket ticket = new Ticket(Any.pack(ticketStatementQuery).toByteArray());
             List<FlightEndpoint> endpoints = Collections.singletonList(new FlightEndpoint(ticket, grpcLocation));

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
@@ -55,8 +55,8 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private int httpPort;
     @SerializedName(value = "brpcPort")
     private int brpcPort;
-    @SerializedName(value = "beArrowPort")
-    private int beArrowPort;
+    @SerializedName(value = "arrowFlightPort")
+    private int arrowFlightPort;
 
     @SerializedName(value = "starletPort")
     private int starletPort;
@@ -80,15 +80,9 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
 
     public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort,
                              int starletPort, long hbTime, String version, int cpuCores, long memLimitBytes,
-                             boolean isSetStoragePath, int beArrowPort) {
-        this(beId, bePort, httpPort, brpcPort, starletPort, hbTime, version, cpuCores, memLimitBytes, isSetStoragePath);
-        this.beArrowPort = beArrowPort;
-    }
-
-    public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort,
-                             int starletPort, long hbTime, String version, int cpuCores, long memLimitBytes,
-                             boolean isSetStoragePath) {
+                             boolean isSetStoragePath, int arrowFlightPort) {
         this(beId, bePort, httpPort, brpcPort, starletPort, hbTime, version, cpuCores, memLimitBytes);
+        this.arrowFlightPort = arrowFlightPort;
         this.isSetStoragePath = isSetStoragePath;
     }
 
@@ -141,8 +135,8 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         return brpcPort;
     }
 
-    public int getBeArrowPort() {
-        return beArrowPort;
+    public int getArrowFlightPort() {
+        return arrowFlightPort;
     }
 
     public int getStarletPort() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -256,6 +256,10 @@ public class ComputeNode implements IComputable, Writable {
         return arrowFlightPort;
     }
 
+    public void setArrowFlightPort(int arrowFlightPort) {
+        this.arrowFlightPort = arrowFlightPort;
+    }
+
     public TNetworkAddress getAddress() {
         return new TNetworkAddress(host, bePort);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -73,8 +73,8 @@ public class ComputeNode implements IComputable, Writable {
     private volatile int beRpcPort; // be rpc port
     @SerializedName("brpcPort")
     private volatile int brpcPort = -1;
-    @SerializedName("beArrowPort")
-    private volatile int beArrowPort; // be arrow port
+    @SerializedName("arrowFlightPort")
+    private volatile int arrowFlightPort = -1; // be arrow port
 
     @SerializedName("cpuCores")
     private volatile int cpuCores = 0; // Cpu cores of node
@@ -161,7 +161,7 @@ public class ComputeNode implements IComputable, Writable {
         this.bePort = 0;
         this.httpPort = 0;
         this.beRpcPort = 0;
-        this.beArrowPort = 0;
+        this.arrowFlightPort = -1;
 
         this.backendState = Backend.BackendState.free.ordinal();
 
@@ -177,7 +177,7 @@ public class ComputeNode implements IComputable, Writable {
         this.bePort = -1;
         this.httpPort = -1;
         this.beRpcPort = -1;
-        this.beArrowPort = -1;
+        this.arrowFlightPort = -1;
         this.lastUpdateMs = -1L;
         this.lastStartTime = -1L;
 
@@ -252,12 +252,8 @@ public class ComputeNode implements IComputable, Writable {
         return brpcPort;
     }
 
-    public int getBeArrowPort() {
-        return beArrowPort;
-    }
-
-    public void setBeArrowPort(int beArrowPort) {
-        this.beArrowPort = beArrowPort;
+    public int getArrowFlightPort() {
+        return arrowFlightPort;
     }
 
     public TNetworkAddress getAddress() {
@@ -585,9 +581,9 @@ public class ComputeNode implements IComputable, Writable {
                 this.starletPort = hbResponse.getStarletPort();
             }
 
-            if (this.beArrowPort != hbResponse.getBeArrowPort()) {
+            if (this.arrowFlightPort != hbResponse.getArrowFlightPort()) {
                 isChanged = true;
-                this.beArrowPort = hbResponse.getBeArrowPort();
+                this.arrowFlightPort = hbResponse.getArrowFlightPort();
             }
 
             if (RunMode.isSharedDataMode() && this.isSetStoragePath != hbResponse.isSetStoragePath()) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -287,7 +287,7 @@ public class HeartbeatMgr extends FrontendDaemon {
                     TBackendInfo tBackendInfo = result.getBackend_info();
                     int bePort = tBackendInfo.getBe_port();
                     int httpPort = tBackendInfo.getHttp_port();
-                    int beArrowPort = tBackendInfo.getBe_arrow_port();
+                    int arrowPort = tBackendInfo.getArrow_flight_port();
                     int brpcPort = -1;
                     int starletPort = 0;
                     boolean isSetStoragePath = false;
@@ -314,7 +314,7 @@ public class HeartbeatMgr extends FrontendDaemon {
                     BackendHbResponse backendHbResponse = new BackendHbResponse(
                             computeNodeId, bePort, httpPort, brpcPort, starletPort,
                             System.currentTimeMillis(), version, cpuCores, memLimitBytes, isSetStoragePath,
-                            beArrowPort);
+                            arrowPort);
                     if (tBackendInfo.isSetReboot_time()) {
                         backendHbResponse.setRebootTime(tBackendInfo.getReboot_time());
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceTest.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service.arrow.flight.sql;
+
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.apache.arrow.flight.FlightServer;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class ArrowFlightSqlServiceTest {
+    @Test
+    public void testDisable() {
+        ArrowFlightSqlService service = new ArrowFlightSqlService(-1);
+        service.start();
+        service.stop();
+    }
+
+    /**
+     * Mock {@link FlightServer.Builder#build()}.
+     */
+    @Test
+    public void testEnable(@Mocked FlightServer server) throws IOException, InterruptedException {
+        new MockUp<FlightServer.Builder>() {
+            @Mock
+            public FlightServer build() {
+                return server;
+            }
+        };
+
+        new Expectations() {
+            {
+                server.start();
+                result = server;
+                times = 1;
+            }
+
+            {
+                server.shutdown();
+                times = 1;
+            }
+
+            {
+                server.awaitTermination(anyLong, TimeUnit.SECONDS);
+                result = true;
+                times = 1;
+            }
+        };
+
+        ArrowFlightSqlService service = new ArrowFlightSqlService(1234);
+        service.start();
+        service.stop();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/ComputeNodeTest.java
@@ -62,6 +62,7 @@ public class ComputeNodeTest {
 
         BackendHbResponse hbResponse = new BackendHbResponse();
         ComputeNode node = new ComputeNode();
+        node.setArrowFlightPort(hbResponse.getArrowFlightPort());
         node.setBrpcPort(hbResponse.getBrpcPort()); // Don't return needSync by different BrpcPort.
         CoordinatorMonitor coordinatorMonitor = CoordinatorMonitor.getInstance();
 

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -48,7 +48,8 @@ struct TBackendInfo {
     9: optional bool is_set_storage_path
 
     10: optional i64 mem_limit_bytes
-    11: optional Types.TPort be_arrow_port
+
+    11: optional Types.TPort arrow_flight_port
 }
 
 struct THeartbeatResult {


### PR DESCRIPTION
## Why I'm doing:

Currently, after an upgrade, users may encounter issues where the FE and BE fail to start because the Arrow Flight SQL server’s port is already in use.

## What I'm doing:

- By default, disable the Arrow Flight SQL server on both FE and BE by setting `arrow_flight_port` in `fe.conf` and `be.conf` to -1. The server will only start when the value is set to a positive number.
- If the FE starts the Arrow Flight SQL server but the BE does not, an error will occur during query execution:
`BE [1002] has already disabled Arrow Flight Server. You could set 'arrow_flight_port' in 'be.conf' to a positive value to enable it`.
- Enhance the logging for Arrow Flight SQL server startup and startup failures to make it more informative and user-friendly.
- Rename be.conf configuration from `be_arrow_port` to `arrow_flight_port` to maintain consistency with fe.conf.

Related to #50285.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
