### PR TITLE
[Enhancement] Improve insert timeout error message

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -168,6 +168,7 @@ import com.starrocks.sql.ast.ExportStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.KillAnalyzeStmt;
 import com.starrocks.sql.ast.KillStmt;
+import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SetCatalogStmt;
@@ -2397,8 +2398,9 @@ public class StmtExecutor {
                                         "or set parallel_fragment_exec_instance_num to a lower value in session variable");
                     } else {
                         ErrorReport.reportTimeoutException(ErrorCode.ERR_TIMEOUT, getExecType(), timeout,
-                                String.format("please increase the '%s' session variable and retry",
-                                        SessionVariable.INSERT_TIMEOUT));
+                                String.format("please increase the '%s' session variable or the '%s' property for " +
+                                                "insert statement and retry",
+                                        SessionVariable.INSERT_TIMEOUT, LoadStmt.TIMEOUT_PROPERTY));
                     }
                 }
             }

--- a/test/sql/test_insert_empty/R/test_insert_timeout
+++ b/test/sql/test_insert_empty/R/test_insert_timeout
@@ -15,7 +15,7 @@ create table t1(k1 int);
 set insert_timeout = 2;
 insert into t1 select sleep(4);
 -- result:
-[REGEX].*Insert reached its timeout of 2 seconds, please increase the 'insert_timeout' session variable.*
+[REGEX].*Insert reached its timeout of 2 seconds, please increase the 'insert_timeout' session variable or the 'timeout' property for insert statement.*
 -- !result
 
 set insert_timeout = 10;


### PR DESCRIPTION
## Why I'm doing:
```
mysql> insert into t1 properties("timeout" = "2") select sleep(4);
ERROR 5024 (HY000): Insert reached its timeout of 2 seconds, please increase the 'insert_timeout' session variable and retry
```

## What I'm doing:
```
mysql> insert into t1 properties("timeout" = "2") select sleep(4);
ERROR 5024 (HY000): Insert reached its timeout of 2 seconds, please increase the 'insert_timeout' session variable or the 'timeout' property for insert statement and retry
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
