### PR TITLE
[BugFix] Fix missing iceberg tableFullMORParams in the PruneHDFSScanColumnRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
@@ -149,8 +149,10 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
                 newScanOperator.setTableVersionRange(scanOperator.getTableVersionRange());
 
                 if (newScanOperator.getOpType() == OperatorType.LOGICAL_ICEBERG_SCAN) {
-                    ((LogicalIcebergScanOperator) newScanOperator).setMORParam(
-                            ((LogicalIcebergScanOperator) scanOperator).getMORParam());
+                    LogicalIcebergScanOperator newIcebergScanOp = (LogicalIcebergScanOperator) newScanOperator;
+                    newIcebergScanOp.setMORParam(((LogicalIcebergScanOperator) scanOperator).getMORParam());
+                    newIcebergScanOp.setTableFullMORParams(((LogicalIcebergScanOperator) scanOperator).
+                            getTableFullMORParams());
                 }
 
                 return Lists.newArrayList(new OptExpression(newScanOperator));


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8840

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
