### PR TITLE
[BugFix] Use STARROCKS_ROOT env

### DIFF
--- a/docker/dockerfiles/be/upload_coredump.sh
+++ b/docker/dockerfiles/be/upload_coredump.sh
@@ -5,6 +5,8 @@ coredump_log()
     echo "[`date`] [coredump] $@" >&2
 }
 
+STARROCKS_ROOT=${STARROCKS_ROOT:-"/opt/starrocks"}
+
 # Define constant for 1TB in bytes
 TB_IN_BYTES=$((1024 * 1024 * 1024 * 1024))
 

--- a/docker/dockerfiles/be/upload_coredump.sh
+++ b/docker/dockerfiles/be/upload_coredump.sh
@@ -82,7 +82,7 @@ while true; do
   coredump_log "$(ls -lh ${COREDUMP_FILE_ZIP})"
 
 
-  rclone --config=/opt/starrocks/rclone.conf --bwlimit 1000M --multi-thread-streams 100 --multi-thread-cutoff 8M --progress sync $COREDUMP_FILE_ZIP coredump:${COREDUMP_BLOBSTORE_PREFIX}/${KUBE_CLUSTER_NAME}/${POD_NAMESPACE}
+  rclone --config=$STARROCKS_ROOT/rclone.conf --bwlimit 1000M --multi-thread-streams 100 --multi-thread-cutoff 8M --progress sync $COREDUMP_FILE_ZIP coredump:${COREDUMP_BLOBSTORE_PREFIX}/${KUBE_CLUSTER_NAME}/${POD_NAMESPACE}
 
 
   coredump_log "Upload complete: ${latestCoreFile}"

--- a/docker/dockerfiles/fe/fe-ubi.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubi.Dockerfile
@@ -58,7 +58,7 @@ COPY --from=artifacts --chown=$USER:$GROUP /release/fe_artifacts/ $STARROCKS_ROO
 COPY --chown=$USER:$GROUP docker/dockerfiles/fe/*.sh $STARROCKS_ROOT/
 
 # Create directory for FE metadata
-RUN mkdir -p /opt/starrocks/fe/meta
+RUN mkdir -p $STARROCKS_ROOT/fe/meta
 
 # run as root by default
 USER $RUN_AS_USER

--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -58,6 +58,6 @@ COPY --from=artifacts --chown=$USER:$GROUP /release/fe_artifacts/ $STARROCKS_ROO
 COPY --chown=$USER:$GROUP docker/dockerfiles/fe/*.sh $STARROCKS_ROOT/
 
 # Create directory for FE metadata
-RUN mkdir -p /opt/starrocks/fe/meta
+RUN mkdir -p $STARROCKS_ROOT/fe/meta
 
 USER $RUN_AS_USER


### PR DESCRIPTION
## Why I'm doing:

Use STARROCKS_ROOT env instead on hard code `/opt/starrocks`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
