### PR TITLE
[BugFix] Fix random table broker load fails when table has schema change

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -130,7 +130,7 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
         }
 
         if (p_index.has_is_shadow()) {
-            index->is_shadow = p_index.is_shadow;
+            index->is_shadow = p_index.is_shadow();
             _shadow_indexes++;
         }
 

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -131,7 +131,9 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
 
         if (p_index.has_is_shadow()) {
             index->is_shadow = p_index.is_shadow();
-            _shadow_indexes++;
+            if (index->is_shadow) {
+                _shadow_indexes++;
+            }
         }
 
         _indexes.emplace_back(index);
@@ -195,7 +197,9 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema, RuntimeS
         }
         if (t_index.__isset.is_shadow) {
             index->is_shadow = t_index.is_shadow;
-            _shadow_indexes++;
+            if (index->is_shadow) {
+                _shadow_indexes++;
+            }
         }
         _indexes.emplace_back(index);
     }

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -71,6 +71,7 @@ void OlapTableIndexSchema::to_protobuf(POlapTableIndexSchema* pindex) const {
     pindex->set_id(index_id);
     pindex->set_schema_hash(schema_hash);
     pindex->set_schema_id(schema_id);
+    pindex->set_is_shadow(is_shadow);
     for (auto slot : slots) {
         pindex->add_columns(slot->col_name());
     }
@@ -126,6 +127,11 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
 
         for (auto& entry : p_index.column_to_expr_value()) {
             index->column_to_expr_value.insert({entry.first, entry.second});
+        }
+
+        if (p_index.has_is_shadow()) {
+            index->is_shadow = p_index.is_shadow;
+            _shadow_indexes++;
         }
 
         _indexes.emplace_back(index);
@@ -186,6 +192,10 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema, RuntimeS
             for (auto& entry : t_index.column_to_expr_value) {
                 index->column_to_expr_value.insert({entry.first, entry.second});
             }
+        }
+        if (t_index.__isset.is_shadow) {
+            index->is_shadow = t_index.is_shadow;
+            _shadow_indexes++;
         }
         _indexes.emplace_back(index);
     }
@@ -477,10 +487,11 @@ Status OlapTablePartitionParam::add_partitions(const std::vector<TOlapTableParti
 
         part->num_buckets = t_part.num_buckets;
         auto num_indexes = _schema->indexes().size();
-        if (t_part.indexes.size() != num_indexes) {
+        if (t_part.indexes.size() != num_indexes - _schema->shadow_index_size()) {
             std::stringstream ss;
             ss << "number of partition's index is not equal with schema's"
-               << ", num_part_indexes=" << t_part.indexes.size() << ", num_schema_indexes=" << num_indexes;
+               << ", num_part_indexes=" << t_part.indexes.size() << ", num_schema_indexes=" << num_indexes
+               << ", num_shadow_indexes=" << _schema->shadow_index_size();
             LOG(WARNING) << ss.str();
             return Status::InternalError(ss.str());
         }
@@ -490,16 +501,25 @@ Status OlapTablePartitionParam::add_partitions(const std::vector<TOlapTableParti
                       return lhs.index_id < rhs.index_id;
                   });
         // check index
-        for (int j = 0; j < num_indexes; ++j) {
-            if (part->indexes[j].index_id != _schema->indexes()[j]->index_id) {
+        // If an add_partition operation is executed during the ALTER process, the ALTER operation will be canceled first.
+        // Therefore, the latest indexes will not include shadow indexes.
+        // However, the schema's index may still contain shadow indexes, so these shadow indexes need to be ignored.
+        int j = 0;
+        for (int i = 0; i < num_indexes; ++i) {
+            if (_schema->indexes()[i]->is_shadow) {
+                continue;
+            }
+            if (part->indexes[j].index_id != _schema->indexes()[i]->index_id) {
                 std::stringstream ss;
                 ss << "partition's index is not equal with schema's"
                    << ", part_index=" << part->indexes[j].index_id
-                   << ", schema_index=" << _schema->indexes()[j]->index_id;
+                   << ", schema_index=" << _schema->indexes()[i]->index_id;
                 LOG(WARNING) << ss.str();
                 return Status::InternalError(ss.str());
             }
+            j++;
         }
+
         _partitions.emplace(part->id, part);
         if (t_part.__isset.in_keys) {
             for (auto& in_key : part->in_keys) {

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -51,7 +51,7 @@ struct OlapTableIndexSchema {
     OlapTableColumnParam* column_param;
     ExprContext* where_clause = nullptr;
     std::map<std::string, std::string> column_to_expr_value;
-    bool is_shadow;
+    bool is_shadow = false;
 
     void to_protobuf(POlapTableIndexSchema* pindex) const;
 };

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -51,6 +51,7 @@ struct OlapTableIndexSchema {
     OlapTableColumnParam* column_param;
     ExprContext* where_clause = nullptr;
     std::map<std::string, std::string> column_to_expr_value;
+    bool is_shadow;
 
     void to_protobuf(POlapTableIndexSchema* pindex) const;
 };
@@ -81,6 +82,7 @@ public:
         return _proto_schema;
     }
 
+    int64_t shadow_index_size() const { return _shadow_indexes; }
     std::string debug_string() const;
 
 private:
@@ -92,6 +94,8 @@ private:
     mutable POlapTableSchemaParam* _proto_schema = nullptr;
     std::vector<OlapTableIndexSchema*> _indexes;
     mutable ObjectPool _obj_pool;
+
+    int64_t _shadow_indexes = 0;
 };
 
 using OlapTableIndexTablets = TOlapTableIndexTablets;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -376,6 +376,7 @@ public class OlapTableSink extends DataSink {
                     .stream()
                     .map(column -> column.isShadowColumn() ? column.getName() : column.getColumnId().getId())
                     .collect(Collectors.toList()));
+            boolean isShadow = indexMeta.getSchema().stream().anyMatch(column -> column.isShadowColumn());
             for (Column column : indexMeta.getSchema()) {
                 TColumn tColumn = column.toThrift();
                 tColumn.setColumn_name(column.getColumnId().getId());
@@ -400,6 +401,7 @@ public class OlapTableSink extends DataSink {
             indexSchema.setColumn_param(columnParam);
             indexSchema.setSchema_id(indexMeta.getSchemaId());
             indexSchema.setColumn_to_expr_value(columnToExprValue);
+            indexSchema.setIs_shadow(isShadow);
             schemaParam.addToIndexes(indexSchema);
             if (indexMeta.getWhereClause() != null) {
                 Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -76,6 +76,7 @@ message POlapTableIndexSchema {
     optional POlapTableColumnParam column_param = 4;
     optional int64 schema_id = 5;
     map<string, string> column_to_expr_value = 6;
+    optional bool is_shadow = 7;
 };
 
 message POlapTableSchemaParam {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -288,6 +288,7 @@ struct TOlapTableIndexSchema {
     5: optional Exprs.TExpr where_clause
     6: optional i64 schema_id // schema id
     7: optional map<string, string> column_to_expr_value
+    8: optional bool is_shadow
 }
 
 struct TOlapTableSchemaParam {


### PR DESCRIPTION
## Why I'm doing:
If an add_partition operation is executed during the ALTER process, the ALTER operation will be canceled first. Therefore, the latest indexes will not include shadow indexes. but the schema's index may still contain shadow indexes, so the index check will fail and ingestion task will failed. [[1]](https://github.com/StarRocks/starrocks/pull/53041/files#diff-0aa289c4f7a9e1d991317745b18f6be2e61b33a0af7d2a6991163c5a0a37295dL480-L483) [[2]](https://github.com/StarRocks/starrocks/pull/53041/files#diff-0aa289c4f7a9e1d991317745b18f6be2e61b33a0af7d2a6991163c5a0a37295dL493-L501)

## What I'm doing:
Skip the shadow index in the index check.

Fixes https://github.com/StarRocks/StarRocksTest/issues/8833

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0