### PR TITLE
[Refactor] Remove meaningless profiler operator mem peaks

### DIFF
--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -15,6 +15,7 @@
 #include "exec/pipeline/operator.h"
 
 #include <algorithm>
+#include <memory>
 #include <utility>
 
 #include "common/logging.h"
@@ -23,6 +24,7 @@
 #include "exprs/expr_context.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
 #include "runtime/runtime_filter_cache.h"
 #include "runtime/runtime_state.h"
 #include "util/failpoint/fail_point.h"
@@ -68,7 +70,7 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
 
 Status Operator::prepare(RuntimeState* state) {
     FAIL_POINT_TRIGGER_RETURN_ERROR(random_error);
-    _mem_tracker = state->query_ctx()->operator_mem_tracker(_plan_node_id);
+    _mem_tracker = std::make_shared<MemTracker>();
     _total_timer = ADD_TIMER(_common_metrics, "OperatorTotalTime");
     _push_timer = ADD_TIMER(_common_metrics, "PushTotalTime");
     _pull_timer = ADD_TIMER(_common_metrics, "PullTotalTime");
@@ -120,24 +122,6 @@ void Operator::close(RuntimeState* state) {
         _init_rf_counters(false);
         _runtime_in_filter_num_counter->set((int64_t)runtime_in_filters().size());
         _runtime_bloom_filter_num_counter->set((int64_t)rf_bloom_filters->size());
-    }
-
-    if (!_is_subordinate) {
-        _common_metrics
-                ->add_counter("OperatorPeakMemoryUsage", TUnit::BYTES,
-                              RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG,
-                                                                       TCounterMergeType::SKIP_FIRST_MERGE))
-                ->set(_mem_tracker->peak_consumption());
-        _common_metrics
-                ->add_counter("OperatorAllocatedMemoryUsage", TUnit::BYTES,
-                              RuntimeProfile::Counter::create_strategy(TCounterAggregateType::SUM,
-                                                                       TCounterMergeType::SKIP_FIRST_MERGE))
-                ->set(_mem_tracker->allocation());
-        _common_metrics
-                ->add_counter("OperatorDeallocatedMemoryUsage", TUnit::BYTES,
-                              RuntimeProfile::Counter::create_strategy(TCounterAggregateType::SUM,
-                                                                       TCounterMergeType::SKIP_FIRST_MERGE))
-                ->set(_mem_tracker->deallocation());
     }
 
     // Pipeline do not need the built in total time counter

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -148,7 +148,7 @@ public:
 
     int32_t get_plan_node_id() const { return _plan_node_id; }
 
-    MemTracker* mem_tracker() const { return _mem_tracker; }
+    MemTracker* mem_tracker() const { return _mem_tracker.get(); }
 
     virtual std::string get_name() const {
         return strings::Substitute("$0_$1_$2($3)", _name, _plan_node_id, this, is_finished() ? "X" : "O");
@@ -327,11 +327,7 @@ private:
     void _init_rf_counters(bool init_bloom);
     void _init_conjuct_counters();
 
-    // All the memory usage will be automatically added to this MemTracker by memory allocate hook.
-    // DO NOT use this MemTracker manually.
-    // The MemTracker is owned by QueryContext, so that all the operators with the same plan_node_id can share
-    // the same MemTracker.
-    MemTracker* _mem_tracker = nullptr;
+    std::shared_ptr<MemTracker> _mem_tracker;
     std::vector<ExprContext*> _runtime_in_filters;
 };
 

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -311,7 +311,6 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                 // operator
                 StatusOr<ChunkPtr> maybe_chunk;
                 {
-                    SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(curr_op);
                     SCOPED_TIMER(curr_op->_pull_timer);
                     QUERY_TRACE_SCOPED(curr_op->get_name(), "pull_chunk");
                     maybe_chunk = curr_op->pull_chunk(runtime_state);
@@ -344,7 +343,6 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
 
                         total_rows_moved += row_num;
                         {
-                            SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(next_op);
                             SCOPED_TIMER(next_op->_push_timer);
                             QUERY_TRACE_SCOPED(next_op->get_name(), "push_chunk");
                             _adjust_memory_usage(runtime_state, query_mem_tracker.get(), next_op, maybe_chunk.value());
@@ -788,7 +786,6 @@ Status PipelineDriver::_mark_operator_finishing(OperatorPtr& op, RuntimeState* s
     VLOG_ROW << strings::Substitute("[Driver] finishing operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(op);
         SCOPED_TIMER(op->_finishing_timer);
         op_state = OperatorStage::FINISHING;
         QUERY_TRACE_SCOPED(op->get_name(), "set_finishing");
@@ -806,7 +803,6 @@ Status PipelineDriver::_mark_operator_finished(OperatorPtr& op, RuntimeState* st
     VLOG_ROW << strings::Substitute("[Driver] finished operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(op);
         SCOPED_TIMER(op->_finished_timer);
         op_state = OperatorStage::FINISHED;
         QUERY_TRACE_SCOPED(op->get_name(), "set_finished");
@@ -830,7 +826,6 @@ Status PipelineDriver::_mark_operator_cancelled(OperatorPtr& op, RuntimeState* s
     VLOG_ROW << strings::Substitute("[Driver] cancelled operator [fragment_id=$0] [driver=$1] [operator=$2]",
                                     print_id(state->fragment_instance_id()), to_readable_string(), op->get_name());
     {
-        SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(op);
         op_state = OperatorStage::CANCELLED;
         return op->set_cancelled(state);
     }
@@ -852,7 +847,6 @@ Status PipelineDriver::_mark_operator_closed(OperatorPtr& op, RuntimeState* stat
 
     VLOG_ROW << msg;
     {
-        SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(op);
         SCOPED_TIMER(op->_close_timer);
         op_state = OperatorStage::CLOSED;
         QUERY_TRACE_SCOPED(op->get_name(), "close");

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -160,17 +160,6 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
     });
 }
 
-MemTracker* QueryContext::operator_mem_tracker(int32_t plan_node_id) {
-    std::lock_guard<std::mutex> l(_operator_mem_trackers_lock);
-    auto it = _operator_mem_trackers.find(plan_node_id);
-    if (it != _operator_mem_trackers.end()) {
-        return it->second.get();
-    }
-    auto mem_tracker = std::make_shared<MemTracker>();
-    _operator_mem_trackers[plan_node_id] = mem_tracker;
-    return mem_tracker.get();
-}
-
 Status QueryContext::init_spill_manager(const TQueryOptions& query_options) {
     Status st;
     std::call_once(_init_spill_manager_once, [this, &st, &query_options]() {

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -168,8 +168,6 @@ public:
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
     MemTracker* connector_scan_mem_tracker() { return _connector_scan_mem_tracker.get(); }
 
-    MemTracker* operator_mem_tracker(int32_t plan_node_id);
-
     Status init_spill_manager(const TQueryOptions& query_options);
     Status init_query_once(workgroup::WorkGroup* wg, bool enable_group_level_query_queue);
     /// Release the workgroup token only once to avoid double-free.
@@ -309,8 +307,6 @@ private:
     TPipelineProfileLevel::type _profile_level;
     std::shared_ptr<MemTracker> _mem_tracker;
     std::shared_ptr<MemTracker> _connector_scan_mem_tracker;
-    std::mutex _operator_mem_trackers_lock;
-    std::unordered_map<int32_t, std::shared_ptr<MemTracker>> _operator_mem_trackers;
     ObjectPool _object_pool;
     DescriptorTbl* _desc_tbl = nullptr;
     std::once_flag _query_trace_init_flag;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -419,7 +419,6 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             // driver_id will be used in some Expr such as regex_replace
             SCOPED_SET_TRACE_INFO(driver_id, state->query_id(), state->fragment_instance_id());
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(state->instance_mem_tracker());
-            SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(this);
 
             auto& chunk_source = _chunk_sources[chunk_source_index];
             SCOPED_SET_CUSTOM_COREDUMP_MSG(chunk_source->get_custom_coredump_msg());

--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -39,10 +39,6 @@ starrocks::MemTracker* CurrentThread::mem_tracker() {
     }
 }
 
-starrocks::MemTracker* CurrentThread::operator_mem_tracker() {
-    return tls_operator_mem_tracker;
-}
-
 starrocks::MemTracker* CurrentThread::singleton_check_mem_tracker() {
     return tls_singleton_check_mem_tracker;
 }

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -34,9 +34,6 @@
 #define SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(mem_tracker) \
     auto VARNAME_LINENUM(tracker_setter) = CurrentThreadSingletonCheckMemTrackerSetter(mem_tracker)
 
-#define SCOPED_THREAD_LOCAL_OPERATOR_MEM_TRACKER_SETTER(operator) \
-    auto VARNAME_LINENUM(tracker_setter) = CurrentThreadOperatorMemTrackerSetter(operator->mem_tracker())
-
 #define SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(check) \
     auto VARNAME_LINENUM(check_setter) = CurrentThreadCheckMemLimitSetter(check)
 
@@ -57,7 +54,6 @@ namespace starrocks {
 class TUniqueId;
 
 inline thread_local MemTracker* tls_mem_tracker = nullptr;
-inline thread_local MemTracker* tls_operator_mem_tracker = nullptr;
 inline thread_local MemTracker* tls_exceed_mem_tracker = nullptr;
 // `tls_singleton_check_mem_tracker` is used when you want to separate the mem tracker and check tracker,
 // you can add a new check tracker by set up `tls_singleton_check_mem_tracker`.
@@ -69,7 +65,7 @@ class CurrentThread {
 private:
     class MemCacheManager {
     public:
-        MemCacheManager(std::function<MemTracker*()>&& loader) : _loader(std::move(loader)) {}
+        MemCacheManager() = default;
         MemCacheManager(const MemCacheManager&) = delete;
         MemCacheManager(MemCacheManager&&) = delete;
 
@@ -84,7 +80,7 @@ private:
         }
 
         bool try_mem_consume(int64_t size) {
-            MemTracker* cur_tracker = _loader();
+            MemTracker* cur_tracker = CurrentThread::mem_tracker();
             int64_t prev_reserved = _reserved_bytes;
             size = _consume_from_reserved(size);
             _cache_size += size;
@@ -122,7 +118,7 @@ private:
         }
 
         bool try_mem_consume_with_limited_tracker(int64_t size) {
-            MemTracker* cur_tracker = _loader();
+            MemTracker* cur_tracker = CurrentThread::mem_tracker();
             _cache_size += size;
             _allocated_cache_size += size;
             _total_consumed_bytes += size;
@@ -172,7 +168,7 @@ private:
         }
 
         void commit(bool is_ctx_shift) {
-            MemTracker* cur_tracker = _loader();
+            MemTracker* cur_tracker = CurrentThread::mem_tracker();
             if (cur_tracker != nullptr) {
                 cur_tracker->consume(_cache_size);
             }
@@ -210,8 +206,6 @@ private:
 
         const static int64_t BATCH_SIZE = 2 * 1024 * 1024;
 
-        std::function<MemTracker*()> _loader;
-
         int64_t _reserved_bytes = 0;
 
         // Allocated or delocated but not committed memory bytes, can be negative
@@ -225,13 +219,10 @@ private:
     };
 
 public:
-    CurrentThread() : _mem_cache_manager(mem_tracker), _operator_mem_cache_manager(operator_mem_tracker) {
-        tls_is_thread_status_init = true;
-    }
+    CurrentThread() { tls_is_thread_status_init = true; }
     ~CurrentThread();
 
     void mem_tracker_ctx_shift() { _mem_cache_manager.commit(true); }
-    void operator_mem_tracker_ctx_shift() { _operator_mem_cache_manager.commit(true); }
 
     void set_query_id(const starrocks::TUniqueId& query_id) { _query_id = query_id; }
     const starrocks::TUniqueId& query_id() { return _query_id; }
@@ -256,14 +247,6 @@ public:
         return prev;
     }
 
-    // Return prev memory tracker.
-    starrocks::MemTracker* set_operator_mem_tracker(starrocks::MemTracker* operator_mem_tracker) {
-        operator_mem_tracker_ctx_shift();
-        auto* prev = tls_operator_mem_tracker;
-        tls_operator_mem_tracker = operator_mem_tracker;
-        return prev;
-    }
-
     bool set_check_mem_limit(bool check) {
         bool prev_check = _check;
         _check = check;
@@ -273,7 +256,6 @@ public:
     bool check_mem_limit() { return _check; }
 
     static starrocks::MemTracker* mem_tracker();
-    static starrocks::MemTracker* operator_mem_tracker();
     static starrocks::MemTracker* singleton_check_mem_tracker();
 
     static CurrentThread& current();
@@ -292,14 +274,10 @@ public:
 
     static bool is_catched() { return tls_is_catched; }
 
-    void mem_consume(int64_t size) {
-        _mem_cache_manager.consume(size);
-        _operator_mem_cache_manager.consume(size);
-    }
+    void mem_consume(int64_t size) { _mem_cache_manager.consume(size); }
 
     bool try_mem_consume(int64_t size) {
         if (_mem_cache_manager.try_mem_consume(size)) {
-            _operator_mem_cache_manager.consume(size);
             return true;
         }
         return false;
@@ -323,7 +301,6 @@ public:
             _mem_cache_manager.release_to_reserved(size);
         } else {
             _mem_cache_manager.release(size);
-            _operator_mem_cache_manager.release(size);
         }
     }
 
@@ -360,13 +337,7 @@ public:
     int64_t get_consumed_bytes() const { return _mem_cache_manager.get_consumed_bytes(); }
 
 private:
-    // In order to record operator level memory trace while keep up high performance, we need to
-    // record the normal MemTracker's tree and operator's isolated MemTracker independently.
-    // `tls_operator_mem_tracker` will be updated every time when `Operator::pull_chunk` or `Operator::push_chunk`
-    // is invoked, the frequrency is a little bit high, but it does little harm to performance,
-    // because operator's MemTracker, which is a dangling MemTracker(withouth parent), has no concurrency conflicts
     MemCacheManager _mem_cache_manager;
-    MemCacheManager _operator_mem_cache_manager;
     // Store in TLS for diagnose coredump easier
     TUniqueId _query_id;
     TUniqueId _fragment_instance_id;
@@ -397,34 +368,6 @@ public:
     CurrentThreadMemTrackerSetter(const CurrentThreadMemTrackerSetter&) = delete;
     void operator=(const CurrentThreadMemTrackerSetter&) = delete;
     CurrentThreadMemTrackerSetter(CurrentThreadMemTrackerSetter&&) = delete;
-    void operator=(CurrentThreadMemTrackerSetter&&) = delete;
-
-private:
-    MemTracker* _old_mem_tracker;
-    bool _is_same;
-};
-
-class CurrentThreadOperatorMemTrackerSetter {
-public:
-    explicit CurrentThreadOperatorMemTrackerSetter(MemTracker* new_mem_tracker) {
-        // operator's mem tracker must have no parent
-        DCHECK(new_mem_tracker == nullptr || new_mem_tracker->parent() == nullptr);
-        _old_mem_tracker = tls_thread_status.operator_mem_tracker();
-        _is_same = (_old_mem_tracker == new_mem_tracker);
-        if (!_is_same) {
-            tls_thread_status.set_operator_mem_tracker(new_mem_tracker);
-        }
-    }
-
-    ~CurrentThreadOperatorMemTrackerSetter() {
-        if (!_is_same) {
-            (void)tls_thread_status.set_operator_mem_tracker(_old_mem_tracker);
-        }
-    }
-
-    CurrentThreadOperatorMemTrackerSetter(const CurrentThreadOperatorMemTrackerSetter&) = delete;
-    void operator=(const CurrentThreadOperatorMemTrackerSetter&) = delete;
-    CurrentThreadOperatorMemTrackerSetter(CurrentThreadOperatorMemTrackerSetter&&) = delete;
     void operator=(CurrentThreadMemTrackerSetter&&) = delete;
 
 private:

--- a/docs/en/administration/query_profile_details.md
+++ b/docs/en/administration/query_profile_details.md
@@ -247,18 +247,6 @@ Description: Number of times the pipeline is blocked due to unmet preconditions.
 
 ### Operator General Metrics
 
-##### OperatorAllocatedMemoryUsage
-
-Description: Cumulative memory allocated by the Operator.
-
-##### OperatorDeallocatedMemoryUsage
-
-Description: Cumulative memory deallocated by the Operator.
-
-##### OperatorPeakMemoryUsage
-
-Description: Peak memory usage by the Operator across all compute nodes. This metric is meaningful for certain materialization operators, such as aggregation, sorting, Join, etc. It is not relevant for operators like Project because memory is allocated by the current operator and released by subsequent operators, making peak memory equivalent to cumulative allocated memory for the current operator. In versions earlier than v3.1.8 and v3.2.3, this metric represents the peak memory usage by the Operator across all *PipelineDrivers*.
-
 ##### PrepareTime
 
 Description: Time spent on preparation.

--- a/docs/zh/administration/query_profile_details.md
+++ b/docs/zh/administration/query_profile_details.md
@@ -247,18 +247,6 @@ Query Profile 包含大量查询执行详细信息的指标。在大多数情况
 
 ### Operator 通用指标
 
-##### OperatorAllocatedMemoryUsage
-
-描述：Operator 累计分配的内存。
-
-##### OperatorDeallocatedMemoryUsage
-
-描述：Operator 累计释放的内存。
-
-##### OperatorPeakMemoryUsage
-
-描述：所有计算节点中，该 Operator 的峰值内存。该指标仅对于部分物化算子有意义，例如聚合、排序、Join 等。而对于 Project、Scan 等算子无意义，因为内存在当前算子分配，在后续算子释放，对于当前算子来说，峰值内存就等同于累计分配的内存。在 v3.1.8 和 v3.2.3 之前的版本中，该指标的含义为 “所有 *PipelineDriver* 中，该 Operator 的峰值内存”。
-
 ##### PrepareTime
 
 描述：Prepare 的时间。


### PR DESCRIPTION
## Why I'm doing:
remove profile nodes:
```
    OperatorPeakMemoryUsage
    OperatorAllocatedMemoryUsage
    OperatorDeallocatedMemoryUsage
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0