### PR TITLE
[Enhancement] Opt memory tracker for FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryTrackable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryTrackable.java
@@ -22,6 +22,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public interface MemoryTrackable {
+    // The default implementation of estimateSize only calculate the shadow size of the object.
+    // The shadow size is the same for all instances of the specified class,
+    // so using CLASS_SIZE to cache the class's instance shadow size.
+    // the key is class name, the value is size
     Map<String, Long> CLASS_SIZE = new ConcurrentHashMap<>();
 
     default long estimateSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryTrackable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryTrackable.java
@@ -15,12 +15,15 @@
 package com.starrocks.memory;
 
 import com.starrocks.common.Pair;
-import org.apache.spark.util.SizeEstimator;
+import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public interface MemoryTrackable {
+    Map<String, Long> CLASS_SIZE = new ConcurrentHashMap<>();
+
     default long estimateSize() {
         List<Pair<List<Object>, Long>> samples = getSamples();
         long totalBytes = 0;
@@ -28,11 +31,17 @@ public interface MemoryTrackable {
             List<Object> sampleObjects = pair.first;
             long size = pair.second;
             if (!sampleObjects.isEmpty()) {
-                totalBytes += (long) (((double) SizeEstimator.estimate(sampleObjects)) / sampleObjects.size() * size);
+                long sampleSize = sampleObjects.stream().mapToLong(this::getInstanceSize).sum();
+                totalBytes += (long) (((double) sampleSize) / sampleObjects.size() * size);
             }
         }
 
         return totalBytes;
+    }
+
+    default long getInstanceSize(Object object) {
+        String className = object.getClass().getName();
+        return CLASS_SIZE.computeIfAbsent(className, s -> ClassLayout.parseInstance(object).instanceSize());
     }
 
     Map<String, Long> estimateCount();


### PR DESCRIPTION
## Why I'm doing:
`SizeEstimator.estimate` will calculate the retained size of the object, that is the size of the param object and all the referenced objects. This will lead to repeated counting when the same object is referenced by many objects, and result in very high resource usage when the param object refers to network object or GlobalMetaStore.

## What I'm doing:
Change to `ClassLayout` to only calculate the shadow size of the object.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0