### PR TITLE
[Enhancement] Use dynamic batch size for simdjson to parse multiple json document

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1518,4 +1518,6 @@ CONF_mBool(batch_write_trace_log_enable, "false");
 // ignore union type tag in avro kafka routine load
 CONF_mBool(avro_ignore_union_type_tag, "false");
 
+CONF_mInt32(json_parse_many_batch_size, "0");
+CONF_mBool(enable_dynamic_batch_size_for_json_parse_many, "true");
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1518,6 +1518,7 @@ CONF_mBool(batch_write_trace_log_enable, "false");
 // ignore union type tag in avro kafka routine load
 CONF_mBool(avro_ignore_union_type_tag, "false");
 
-CONF_mInt32(json_parse_many_batch_size, "0");
+// default batch size for simdjson lib
+CONF_mInt32(json_parse_many_batch_size, "1000000");
 CONF_mBool(enable_dynamic_batch_size_for_json_parse_many, "true");
 } // namespace starrocks::config

--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -48,7 +48,7 @@ Status JsonDocumentStreamParser::parse(char* data, size_t len, size_t allocated)
 }
 
 bool JsonDocumentStreamParser::_check_and_new_doc_stream_iterator() {
-    size_t cur_left_len = _len - _last_begin_offset;
+    size_t cur_left_len = _first_object_parsed ? _len - _last_begin_offset : _len;
     if (_batch_size >= cur_left_len) {
         // nothing can do for the batch_size
         return false;

--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -23,8 +23,9 @@ namespace starrocks {
 const size_t MAX_RAW_JSON_LEN = 64;
 
 JsonDocumentStreamParser::JsonDocumentStreamParser(simdjson::ondemand::parser* parser) : JsonParser(parser) {
-    _batch_size = (config::json_parse_many_batch_size > simdjson::dom::MINIMAL_BATCH_SIZE) ?
-                   config::json_parse_many_batch_size : simdjson::dom::DEFAULT_BATCH_SIZE;
+    _batch_size = (config::json_parse_many_batch_size > simdjson::dom::MINIMAL_BATCH_SIZE)
+                          ? config::json_parse_many_batch_size
+                          : simdjson::dom::DEFAULT_BATCH_SIZE;
 }
 
 Status JsonDocumentStreamParser::parse(char* data, size_t len, size_t allocated) noexcept {
@@ -33,7 +34,7 @@ Status JsonDocumentStreamParser::parse(char* data, size_t len, size_t allocated)
         _len = len;
 
         _doc_stream = _parser->iterate_many(data, len,
-                      config::enable_dynamic_batch_size_for_json_parse_many ? _batch_size : _len);
+                                            config::enable_dynamic_batch_size_for_json_parse_many ? _batch_size : _len);
 
         _doc_stream_itr = _doc_stream.begin();
 
@@ -64,7 +65,8 @@ bool JsonDocumentStreamParser::_check_and_new_doc_stream_iterator() {
         if (_first_object_parsed) {
             ++_doc_stream_itr;
         }
-    } while (_batch_size < cur_left_len && _doc_stream_itr.error() != simdjson::SUCCESS); /* make sure get a valid iterator after ++ */
+    } while (_batch_size < cur_left_len &&
+             _doc_stream_itr.error() != simdjson::SUCCESS); /* make sure get a valid iterator after ++ */
 
     if (_doc_stream_itr.error() != simdjson::SUCCESS) { 
         return false;

--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -22,12 +22,18 @@ namespace starrocks {
 
 const size_t MAX_RAW_JSON_LEN = 64;
 
+JsonDocumentStreamParser::JsonDocumentStreamParser(simdjson::ondemand::parser* parser) : JsonParser(parser) {
+    _batch_size = (config::json_parse_many_batch_size > simdjson::dom::MINIMAL_BATCH_SIZE) ?
+                   config::json_parse_many_batch_size : simdjson::dom::DEFAULT_BATCH_SIZE;
+}
+
 Status JsonDocumentStreamParser::parse(char* data, size_t len, size_t allocated) noexcept {
     try {
         _data = data;
         _len = len;
 
-        _doc_stream = _parser->iterate_many(data, len, len);
+        _doc_stream = _parser->iterate_many(data, len,
+                      config::enable_dynamic_batch_size_for_json_parse_many ? _batch_size : _len);
 
         _doc_stream_itr = _doc_stream.begin();
 
@@ -40,6 +46,73 @@ Status JsonDocumentStreamParser::parse(char* data, size_t len, size_t allocated)
     return Status::OK();
 }
 
+bool JsonDocumentStreamParser::_check_and_new_doc_stream_iterator() {
+    size_t cur_left_len = _len - _last_begin_offset;
+    if (_batch_size >= cur_left_len) {
+        // nothing can do for the batch_size
+        return false;
+    }
+
+    // The following code should be no-exception by designed.
+    _curr_ready = false;
+    do {
+        _batch_size = std::min(_batch_size * 8, cur_left_len);
+        _doc_stream = _parser->iterate_many(_data + _last_begin_offset, cur_left_len, _batch_size);
+        _doc_stream_itr = _doc_stream.begin();
+
+        // skip the last parsed object
+        if (_first_object_parsed) {
+            ++_doc_stream_itr;
+        }
+    } while (_batch_size < cur_left_len && _doc_stream_itr.error() != simdjson::SUCCESS); /* make sure get a valid iterator after ++ */
+
+    if (_doc_stream_itr.error() != simdjson::SUCCESS) { 
+        return false;
+    }
+
+    return true;
+}
+
+Status JsonDocumentStreamParser::_get_current_impl(simdjson::ondemand::object* row) {
+    while (true) {
+        try {
+            if (_doc_stream_itr != _doc_stream.end()) {
+                simdjson::ondemand::document_reference doc = *_doc_stream_itr;
+                // simdjson version 3.9.4 and JsonFunctions::to_json_string may crash when json is invalid.
+                // TODO: add value in error message
+                if (doc.type() == simdjson::ondemand::json_type::array) {
+                    return Status::DataQualityError(
+                            "The value is array type in json document stream, you can set strip_outer_array=true to parse "
+                            "each element of the array as individual rows");
+                } else if (doc.type() != simdjson::ondemand::json_type::object) {
+                    return Status::DataQualityError("The value should be object type in json document stream");
+                }
+
+                _curr = doc.get_object();
+                *row = _curr;
+                _curr_ready = true;
+
+                _last_begin_offset = _doc_stream_itr.current_index();
+
+                if (!_first_object_parsed) {
+                    _first_object_parsed = true;
+                }
+
+                return Status::OK();
+            }
+            return Status::EndOfFile("all documents of the stream are iterated");
+        } catch (simdjson::simdjson_error& e) {
+            /*
+             * The worst-case here is the exception is not cause by the size of batch_size
+             * and the following function will try to reset the batch_size until _len - _last_begin_offset.
+            */
+            if (!_check_and_new_doc_stream_iterator()) {
+                throw;
+            }
+        }
+    }
+}
+
 Status JsonDocumentStreamParser::get_current(simdjson::ondemand::object* row) noexcept {
     if (UNLIKELY(_curr_ready)) {
         _curr.reset();
@@ -48,25 +121,7 @@ Status JsonDocumentStreamParser::get_current(simdjson::ondemand::object* row) no
     }
 
     try {
-        if (_doc_stream_itr != _doc_stream.end()) {
-            simdjson::ondemand::document_reference doc = *_doc_stream_itr;
-            // simdjson version 3.9.4 and JsonFunctions::to_json_string may crash when json is invalid.
-            // https://github.com/StarRocks/StarRocksTest/issues/8327
-            // TODO: add value in error message
-            if (doc.type() == simdjson::ondemand::json_type::array) {
-                return Status::DataQualityError(
-                        "The value is array type in json document stream, you can set strip_outer_array=true to parse "
-                        "each element of the array as individual rows");
-            } else if (doc.type() != simdjson::ondemand::json_type::object) {
-                return Status::DataQualityError("The value should be object type in json document stream");
-            }
-
-            _curr = doc.get_object();
-            *row = _curr;
-            _curr_ready = true;
-            return Status::OK();
-        }
-        return Status::EndOfFile("all documents of the stream are iterated");
+        return _get_current_impl(row);
     } catch (simdjson::simdjson_error& e) {
         std::string err_msg;
         if (e.error() == simdjson::CAPACITY) {
@@ -85,7 +140,17 @@ Status JsonDocumentStreamParser::get_current(simdjson::ondemand::object* row) no
 
 Status JsonDocumentStreamParser::advance() noexcept {
     _curr_ready = false;
-    if (++_doc_stream_itr != _doc_stream.end()) {
+    if (++_doc_stream_itr != _doc_stream.end() ||
+        /*
+         * When the iterator reach the end, we should always to reset the
+         * batch_size until _len - _last_begin_offset to check if the
+         * iterator failure because of the batch_size.
+         * 
+         * If the iterator reach the end with any exception, this function
+         * will reset the batch_size to _len - _last_begin_offset = length of last record + 64,
+         * This cost is very small compared to allocating large memory before.
+        */
+        _check_and_new_doc_stream_iterator()) {
         return Status::OK();
     }
     return Status::EndOfFile("all documents of the stream are iterated");

--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -24,8 +24,7 @@ const size_t MAX_RAW_JSON_LEN = 64;
 
 JsonDocumentStreamParser::JsonDocumentStreamParser(simdjson::ondemand::parser* parser) : JsonParser(parser) {
     _batch_size = (config::json_parse_many_batch_size > simdjson::dom::MINIMAL_BATCH_SIZE)
-                          ? config::json_parse_many_batch_size
-                          : simdjson::dom::DEFAULT_BATCH_SIZE * 10 /* About 10MB */;
+                          ? config::json_parse_many_batch_size : simdjson::dom::DEFAULT_BATCH_SIZE;
 }
 
 Status JsonDocumentStreamParser::parse(char* data, size_t len, size_t allocated) noexcept {
@@ -34,7 +33,8 @@ Status JsonDocumentStreamParser::parse(char* data, size_t len, size_t allocated)
         _len = len;
 
         _doc_stream = _parser->iterate_many(data, len,
-                                            config::enable_dynamic_batch_size_for_json_parse_many ? _batch_size : _len);
+                                            config::enable_dynamic_batch_size_for_json_parse_many ?
+                                            std::min(_batch_size, _len) : _len);
 
         _doc_stream_itr = _doc_stream.begin();
 

--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -68,7 +68,7 @@ bool JsonDocumentStreamParser::_check_and_new_doc_stream_iterator() {
     } while (_batch_size < cur_left_len &&
              _doc_stream_itr.error() != simdjson::SUCCESS); /* make sure get a valid iterator after ++ */
 
-    if (_doc_stream_itr.error() != simdjson::SUCCESS) { 
+    if (_doc_stream_itr.error() != simdjson::SUCCESS) {
         return false;
     }
 
@@ -84,7 +84,8 @@ Status JsonDocumentStreamParser::_get_current_impl(simdjson::ondemand::object* r
                 // TODO: add value in error message
                 if (doc.type() == simdjson::ondemand::json_type::array) {
                     return Status::DataQualityError(
-                            "The value is array type in json document stream, you can set strip_outer_array=true to parse "
+                            "The value is array type in json document stream, you can set strip_outer_array=true to "
+                            "parse "
                             "each element of the array as individual rows");
                 } else if (doc.type() != simdjson::ondemand::json_type::object) {
                     return Status::DataQualityError("The value should be object type in json document stream");

--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -24,7 +24,8 @@ const size_t MAX_RAW_JSON_LEN = 64;
 
 JsonDocumentStreamParser::JsonDocumentStreamParser(simdjson::ondemand::parser* parser) : JsonParser(parser) {
     _batch_size = (config::json_parse_many_batch_size > simdjson::dom::MINIMAL_BATCH_SIZE)
-                          ? config::json_parse_many_batch_size : simdjson::dom::DEFAULT_BATCH_SIZE;
+                          ? config::json_parse_many_batch_size
+                          : simdjson::dom::DEFAULT_BATCH_SIZE;
 }
 
 Status JsonDocumentStreamParser::parse(char* data, size_t len, size_t allocated) noexcept {
@@ -32,9 +33,8 @@ Status JsonDocumentStreamParser::parse(char* data, size_t len, size_t allocated)
         _data = data;
         _len = len;
 
-        _doc_stream = _parser->iterate_many(data, len,
-                                            config::enable_dynamic_batch_size_for_json_parse_many ?
-                                            std::min(_batch_size, _len) : _len);
+        _doc_stream = _parser->iterate_many(
+                data, len, config::enable_dynamic_batch_size_for_json_parse_many ? std::min(_batch_size, _len) : _len);
 
         _doc_stream_itr = _doc_stream.begin();
 

--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -25,7 +25,7 @@ const size_t MAX_RAW_JSON_LEN = 64;
 JsonDocumentStreamParser::JsonDocumentStreamParser(simdjson::ondemand::parser* parser) : JsonParser(parser) {
     _batch_size = (config::json_parse_many_batch_size > simdjson::dom::MINIMAL_BATCH_SIZE)
                           ? config::json_parse_many_batch_size
-                          : simdjson::dom::DEFAULT_BATCH_SIZE;
+                          : simdjson::dom::DEFAULT_BATCH_SIZE * 10 /* About 10MB */;
 }
 
 Status JsonDocumentStreamParser::parse(char* data, size_t len, size_t allocated) noexcept {

--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -149,7 +149,7 @@ Status JsonDocumentStreamParser::advance() noexcept {
          * batch_size until _len - _last_begin_offset to check if the
          * iterator failure because of the batch_size.
          * 
-         * If the iterator reach the end with any exception, this function
+         * If the iterator reach the end without any exception, this function
          * will reset the batch_size to _len - _last_begin_offset = length of last record + 64,
          * This cost is very small compared to allocating large memory before.
         */

--- a/be/src/exec/json_parser.h
+++ b/be/src/exec/json_parser.h
@@ -45,13 +45,32 @@ protected:
 // input: {"key":1} {"key":2}
 class JsonDocumentStreamParser : public JsonParser {
 public:
-    JsonDocumentStreamParser(simdjson::ondemand::parser* parser) : JsonParser(parser){};
+    JsonDocumentStreamParser(simdjson::ondemand::parser* parser);
     Status parse(char* data, size_t len, size_t allocated) noexcept override;
     Status get_current(simdjson::ondemand::object* row) noexcept override;
     Status advance() noexcept override;
     std::string left_bytes_string(size_t sz) noexcept override;
 
 private:
+    Status _get_current_impl(simdjson::ondemand::object* row);
+    /*
+     * This function is only used for dynamic batch_size for simdjson::ondemand::parser
+     *
+     * For simdjson, caller should pass a size param, which is larger than max json doc size
+     * in the raw buffer, to `iterate_many` for allocating a memory chunk to parse the json doc stream.
+     * If batch_size is too small, parsing will fail.
+     * 
+     * But the problem is that, simdjson does not guarantee the behavior if the parsing failed because of
+     * the small size of batch_size. Any kind of error/expcetion and even iterator failure (error == EMPTY)
+     * can happen in this case. To use to dynamic batch_size, we should handle all possible error
+     * and retry using larger batch_size until the batch_size hit the limit(_len - _last_begin_offset)
+     * 
+     * This function is mainly used in two place for now:
+     * 1. `catch` block for any exception throw by simdjson in `_get_current_impl`.
+     * 2. iterator reach the end.
+    */
+    bool _check_and_new_doc_stream_iterator();
+
     // data is parsed as a document stream.
 
     // iterator context for document stream.
@@ -67,6 +86,12 @@ private:
     simdjson::ondemand::object _curr;
     // _curr_ready denotes whether the _curr has been parsed.
     bool _curr_ready = false;
+    // _last_begin_offset represent begin offet of last success object in _doc_stream
+    size_t _last_begin_offset = 0;
+    // _batch_size using in batch mode parsing
+    size_t _batch_size = simdjson::dom::DEFAULT_BATCH_SIZE;
+    // _first_object_parsed is true if there is at least one object is parsed successfully
+    bool _first_object_parsed = false;
 };
 
 // JsonArrayParser parse json in json array

--- a/be/test/exec/json_parser_test.cpp
+++ b/be/test/exec/json_parser_test.cpp
@@ -881,6 +881,7 @@ PARALLEL_TEST(JsonParserTest, test_big_value) {
 }
 
 PARALLEL_TEST(JsonParserTest, test_big_json) {
+    config::json_parse_many_batch_size = 1;
     simdjson::ondemand::parser simdjson_parser;
     // The padded_string would allocate memory with simdjson::SIMDJSON_PADDING bytes padding.
     simdjson::padded_string input = simdjson::padded_string::load("./be/test/exec/test_data/json_scanner/big.json");

--- a/be/test/exec/json_parser_test.cpp
+++ b/be/test/exec/json_parser_test.cpp
@@ -33,6 +33,345 @@ public:
     void SetUp() override {}
 };
 
+TEST_F(JsonParserTest, test_json_document_stream_parser_with_dynamic_batch_size_1) {
+    config::json_parse_many_batch_size = 41;
+    // ndjson with ' ', '/t', '\n'
+    std::string input = R"(   {"key0": [{"key1": 1},  {"key2": 2}]}    {"key0": [{"key3": 3},
+    {"key4": 4}]})";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    std::vector<SimpleJsonPath> jsonroot;
+    ASSERT_OK(JsonFunctions::parse_json_paths("$.key0", &jsonroot));
+
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new ExpandedJsonDocumentStreamParserWithRoot(&simdjson_parser, jsonroot));
+
+    auto st = parser->parse(input.data(), size, padded_size);
+
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    int64_t val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    // double get.
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key2").get_int64();
+    ASSERT_EQ(val, 2);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key3").get_int64();
+    ASSERT_EQ(val, 3);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key4").get_int64();
+    ASSERT_EQ(val, 4);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.is_end_of_file());
+}
+
+TEST_F(JsonParserTest, test_json_document_stream_parser_with_dynamic_batch_size_2) {
+    config::json_parse_many_batch_size = 40;
+    // ndjson with ' ', '/t', '\n'
+    std::string input = R"(   {"key0": [{"key1": 1},  {"key2": 2}]}    {"key0": [{"key3": 3},
+    {"key4": 4}]} {xxxxxxxxxx})";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    std::vector<SimpleJsonPath> jsonroot;
+    ASSERT_OK(JsonFunctions::parse_json_paths("$.key0", &jsonroot));
+
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new ExpandedJsonDocumentStreamParserWithRoot(&simdjson_parser, jsonroot));
+
+    auto st = parser->parse(input.data(), size, padded_size);
+
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    int64_t val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    // double get.
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key2").get_int64();
+    ASSERT_EQ(val, 2);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key3").get_int64();
+    ASSERT_EQ(val, 3);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key4").get_int64();
+    ASSERT_EQ(val, 4);
+
+    st = parser->advance();
+    ASSERT_FALSE(st.ok());
+}
+
+TEST_F(JsonParserTest, test_json_document_stream_parser_with_dynamic_batch_size_3) {
+    config::json_parse_many_batch_size = 40;
+    // ndjson with ' ', '/t', '\n'
+    std::string input = R"(   {"key0": [{"key1": 1},  {"key2": 2}]}  {xxxxxxxxxxx}  {"key0": [{"key3": 3},
+    {"key4": 4}]})";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    std::vector<SimpleJsonPath> jsonroot;
+    ASSERT_OK(JsonFunctions::parse_json_paths("$.key0", &jsonroot));
+
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new ExpandedJsonDocumentStreamParserWithRoot(&simdjson_parser, jsonroot));
+
+    auto st = parser->parse(input.data(), size, padded_size);
+
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    int64_t val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    // double get.
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key2").get_int64();
+    ASSERT_EQ(val, 2);
+
+    st = parser->advance();
+    ASSERT_FALSE(st.ok());
+}
+
+TEST_F(JsonParserTest, test_json_document_stream_parser_with_dynamic_batch_size_4) {
+    config::json_parse_many_batch_size = 40;
+    // ndjson with ' ', '/t', '\n'
+    std::string input = R"(   {"key0": [{"key1": 1},  {"key2": 2}]}    {"key0": [{"key3": 3},
+    {"key4": 4}]} asdasd )";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    std::vector<SimpleJsonPath> jsonroot;
+    ASSERT_OK(JsonFunctions::parse_json_paths("$.key0", &jsonroot));
+
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new ExpandedJsonDocumentStreamParserWithRoot(&simdjson_parser, jsonroot));
+
+    auto st = parser->parse(input.data(), size, padded_size);
+
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    int64_t val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    // double get.
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key2").get_int64();
+    ASSERT_EQ(val, 2);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key3").get_int64();
+    ASSERT_EQ(val, 3);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key4").get_int64();
+    ASSERT_EQ(val, 4);
+
+    st = parser->advance();
+    ASSERT_FALSE(st.ok());
+}
+
+TEST_F(JsonParserTest, test_json_document_stream_parser_with_dynamic_batch_size_5) {
+    config::json_parse_many_batch_size = 40;
+    // ndjson with ' ', '/t', '\n'
+    std::string input = R"(   {"key0": [{"key1": 1},  {"key2": 2}]} adasdas   {"key0": [{"key3": 3},
+    {"key4": 4}]})";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    std::vector<SimpleJsonPath> jsonroot;
+    ASSERT_OK(JsonFunctions::parse_json_paths("$.key0", &jsonroot));
+
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new ExpandedJsonDocumentStreamParserWithRoot(&simdjson_parser, jsonroot));
+
+    auto st = parser->parse(input.data(), size, padded_size);
+
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    int64_t val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    // double get.
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key2").get_int64();
+    ASSERT_EQ(val, 2);
+
+    st = parser->advance();
+    ASSERT_FALSE(st.ok());
+}
+
+TEST_F(JsonParserTest, test_json_document_stream_parser_with_dynamic_batch_size_6) {
+    config::json_parse_many_batch_size = 1;
+    // ndjson with ' ', '/t', '\n'
+    std::string input = R"(   {"key1": 1} 
+    {"keyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx2": 2}    
+    {"key3": 3}
+    {"key4": 4})";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser(&simdjson_parser));
+
+    auto st = parser->parse(input.data(), size, padded_size);
+
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    int64_t val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);   
+
+    // double get.
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("keyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx2").get_int64();
+    ASSERT_EQ(val, 2);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key3").get_int64();
+    ASSERT_EQ(val, 3);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    val = row.find_field("key4").get_int64();
+    ASSERT_EQ(val, 4);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.is_end_of_file());
+}
+
 PARALLEL_TEST(JsonParserTest, test_json_document_stream_parser) {
     // ndjson with ' ', '/t', '\n'
     std::string input = R"(   {"key1": 1} {"key2": 2}    {"key3": 3}

--- a/be/test/exec/json_parser_test.cpp
+++ b/be/test/exec/json_parser_test.cpp
@@ -336,7 +336,7 @@ TEST_F(JsonParserTest, test_json_document_stream_parser_with_dynamic_batch_size_
     st = parser->get_current(&row);
     ASSERT_TRUE(st.ok());
     int64_t val = row.find_field("key1").get_int64();
-    ASSERT_EQ(val, 1);   
+    ASSERT_EQ(val, 1);
 
     // double get.
     st = parser->get_current(&row);


### PR DESCRIPTION
## Why I'm doing:
In current implementation, JsonDocumentStreamParser use `simdjson::ondemand::parser::iterate_many` to
parse multiple JSON document. This API need caller pass the max size of JSON document in the file, says
`max_json_lenght_in_file` in a given file to allocate the a memory chunk to finish the parsing process.
But the problem is that, the caller pass the file size instead of `max_json_lenght_in_file` and allocate
huge memory chunk (which may not be used) almost 5~6 time of the file size. This is a huge memory amplification

## What I'm doing:
Introduce `json_parse_many_batch_size` to control the batch_size passed into `simdjson::ondemand::parser::iterate_many`.
If `json_parse_many_batch_size > simdjson::dom::MINIMAL_BATCH_SIZE`, use `json_parse_many_batch_size` as batch size,
otherwise use `simdjson::dom::DEFAULT_BATCH_SIZE`.

But simdjson does not guarantee the behavior if the parsing failed because of the small size of batch_size. Any kind of
error/expcetion and even iterator failure (error == EMPTY) can happen in this case. To use to dynamic batch_size, we should
handle all possible error and retry using larger batch_size until the batch_size hit the limit(file size - last success postition)


Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/8636

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0