### PR TITLE
[BugFix] Return error asap while executing ShortCircuitHybridScanNode.

### DIFF
--- a/be/src/exec/short_circuit_hybrid.cpp
+++ b/be/src/exec/short_circuit_hybrid.cpp
@@ -203,6 +203,7 @@ Status ShortCircuitHybridScanNode::_process_value_chunk(std::vector<bool>& found
         if (!status.ok()) {
             // todo retry
             LOG(WARNING) << "fail to execute multi get: " << status.detailed_message();
+            return status;
         }
 
         // merge all tablet result


### PR DESCRIPTION
## Why I'm doing:

When executing a point query through ShortCircuitHybridScanNode, if the tablet version is updated by another writing thread, it will fail because of a low read version, like below:

![image](https://github.com/user-attachments/assets/cf95cbe9-5337-412a-8e42-76b02c879ee6)

However, it will not throw any exceptions for users, and users may just get an empty result set.

## What I'm doing:

Return error status as soon as possible while executing ShortCircuitHybridScanNode.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0