### PR TITLE
[BugFix] Fix show keys from support external catalog (backport #52977)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1316,7 +1316,11 @@ public class ShowExecutor {
     private void handleShowIndex() throws AnalysisException {
         ShowIndexStmt showStmt = (ShowIndexStmt) stmt;
         List<List<String>> rows = Lists.newArrayList();
-        Database db = connectContext.getGlobalStateMgr().getDb(showStmt.getDbName());
+        String catalogName = showStmt.getTableName().getCatalog();
+        if (catalogName == null) {
+            catalogName = connectContext.getCurrentCatalog();
+        }
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, showStmt.getDbName());
         MetaUtils.checkDbNullAndReport(db, showStmt.getDbName());
         db.readLock();
         try {


### PR DESCRIPTION
## Why I'm doing:
When Power BI connects to external tables, it executes the SHOW KEYS FROM $database.$table statement. This statement is supported for internal tables but not for external tables, resulting in Power BI failing to connect to external tables.

## What I'm doing:
To fix this issue, modify the SHOW KEYS FROM statement to take the catalog into account, ensuring that the corresponding database and table can be located properly.

Fixes #52977

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
