### PR TITLE
[Enhancement] fix connector mem scan limit adjustment when no chunk source

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -125,9 +125,10 @@ using DataSourcePtr = std::unique_ptr<DataSource>;
 
 class DataSourceProvider {
 public:
-    static constexpr int64_t MIN_DATA_SOURCE_MEM_BYTES = 16 * 1024 * 1024;  // 16MB
-    static constexpr int64_t MAX_DATA_SOURCE_MEM_BYTES = 256 * 1024 * 1024; // 256MB
-    static constexpr int64_t PER_FIELD_MEM_BYTES = 1 * 1024 * 1024;         // 1MB
+    static constexpr int64_t MIN_DATA_SOURCE_MEM_BYTES = 16 * 1024 * 1024;     // 16MB
+    static constexpr int64_t DEFAULT_DATA_SOURCE_MEM_BYTES = 64 * 1024 * 1024; // 64MB
+    static constexpr int64_t MAX_DATA_SOURCE_MEM_BYTES = 256 * 1024 * 1024;    // 256MB
+    static constexpr int64_t PER_FIELD_MEM_BYTES = 1 * 1024 * 1024;            // 1MB
 
     virtual ~DataSourceProvider() = default;
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -238,12 +238,12 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const Unified
         }
     }
 
-    int scan_node_number = 1;
-    if (query_globals.__isset.scan_node_number) {
-        scan_node_number = query_globals.scan_node_number;
+    int connector_scan_node_number = 1;
+    if (query_globals.__isset.connector_scan_node_number) {
+        connector_scan_node_number = query_globals.connector_scan_node_number;
     }
     _query_ctx->init_mem_tracker(option_query_mem_limit, parent_mem_tracker, big_query_mem_limit, spill_mem_limit_ratio,
-                                 wg.get(), runtime_state, scan_node_number);
+                                 wg.get(), runtime_state, connector_scan_node_number);
 
     auto query_mem_tracker = _query_ctx->mem_tracker();
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(query_mem_tracker.get());

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -110,7 +110,7 @@ void QueryContext::cancel(const Status& status) {
 
 void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent, int64_t big_query_mem_limit,
                                     std::optional<double> spill_mem_reserve_ratio, workgroup::WorkGroup* wg,
-                                    RuntimeState* runtime_state, int scan_node_number) {
+                                    RuntimeState* runtime_state, int connector_scan_node_number) {
     std::call_once(_init_mem_tracker_once, [=]() {
         _profile = std::make_shared<RuntimeProfile>("Query" + print_id(_query_id));
         auto* mem_tracker_counter =
@@ -142,7 +142,7 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
             _static_query_mem_limit = std::min(big_query_mem_limit, _static_query_mem_limit);
         }
         _connector_scan_operator_mem_share_arbitrator = _object_pool.add(
-                new ConnectorScanOperatorMemShareArbitrator(_static_query_mem_limit, scan_node_number));
+                new ConnectorScanOperatorMemShareArbitrator(_static_query_mem_limit, connector_scan_node_number));
 
         {
             MemTracker* connector_scan_parent = GlobalEnv::GetInstance()->connector_scan_pool_mem_tracker();

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -164,7 +164,7 @@ public:
     /// that there is a big query memory limit of this resource group.
     void init_mem_tracker(int64_t query_mem_limit, MemTracker* parent, int64_t big_query_mem_limit = -1,
                           std::optional<double> spill_mem_limit = std::nullopt, workgroup::WorkGroup* wg = nullptr,
-                          RuntimeState* state = nullptr, int scan_node_number = 1);
+                          RuntimeState* state = nullptr, int connector_scan_node_number = 1);
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
     MemTracker* connector_scan_mem_tracker() { return _connector_scan_mem_tracker.get(); }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -24,10 +24,11 @@ namespace starrocks::pipeline {
 
 // ==================== ConnectorScanOperatorFactory ====================
 ConnectorScanOperatorMemShareArbitrator::ConnectorScanOperatorMemShareArbitrator(int64_t query_mem_limit,
-                                                                                 int scan_node_number)
+                                                                                 int connector_scan_node_number)
         : query_mem_limit(query_mem_limit),
           scan_mem_limit(query_mem_limit),
-          total_chunk_source_mem_bytes(scan_node_number * connector::DataSourceProvider::MAX_DATA_SOURCE_MEM_BYTES) {}
+          total_chunk_source_mem_bytes(connector_scan_node_number *
+                                       connector::DataSourceProvider::MAX_DATA_SOURCE_MEM_BYTES) {}
 
 int64_t ConnectorScanOperatorMemShareArbitrator::update_chunk_source_mem_bytes(int64_t old_value, int64_t new_value) {
     int64_t diff = new_value - old_value;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -35,7 +35,7 @@ struct ConnectorScanOperatorMemShareArbitrator {
     int64_t scan_mem_limit = 0;
     std::atomic<int64_t> total_chunk_source_mem_bytes = 0;
 
-    ConnectorScanOperatorMemShareArbitrator(int64_t query_mem_limit, int scan_node_number);
+    ConnectorScanOperatorMemShareArbitrator(int64_t query_mem_limit, int connector_scan_node_number);
 
     int64_t set_scan_mem_ratio(double mem_ratio) {
         scan_mem_limit = std::max<int64_t>(1, query_mem_limit * mem_ratio);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
@@ -128,7 +128,8 @@ public class MetaScanNode extends ScanNode {
                 boolean tabletIsNull = true;
                 for (Replica replica : allQueryableReplicas) {
                     ComputeNode node =
-                            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(replica.getBackendId());
+                            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                                    .getBackendOrComputeNode(replica.getBackendId());
                     if (node == null) {
                         LOG.debug("replica {} not exists", replica.getBackendId());
                         continue;
@@ -196,5 +197,10 @@ public class MetaScanNode extends ScanNode {
     @Override
     public boolean canUseRuntimeAdaptiveDop() {
         return true;
+    }
+
+    @Override
+    public boolean isRunningAsConnectorOperator() {
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -514,7 +514,6 @@ public class OlapScanNode extends ScanNode {
         return newLocations;
     }
 
-
     private void checkSomeAliveComputeNode() throws ErrorReportException {
         // Note that it's theoretically possible that there were some living CN earlier in this query's execution, and then
         // they all died, but in that case, the problem this will be surfaced later anyway.
@@ -778,7 +777,8 @@ public class OlapScanNode extends ScanNode {
             long freeMemory = runtime.freeMemory();
             if (totalScanRangeBytes > freeMemory / 2) {
                 LOG.warn(
-                        "Try to allocate too many scan ranges for table {}, which may cause FE OOM, Partition Num:{}, tablet Num:{}, Scan Range Total Bytes:{}",
+                        "Try to allocate too many scan ranges for table {}, which may cause FE OOM, Partition Num:{}, tablet " +
+                                "Num:{}, Scan Range Total Bytes:{}",
                         olapTable.getName(), totalPartitionNum, totalTabletsNum, totalScanRangeBytes);
             }
         }
@@ -941,7 +941,6 @@ public class OlapScanNode extends ScanNode {
 
         return output.toString();
     }
-
 
     private void assignOrderByHints(List<String> keyColumnNames) {
         // assign order by hint
@@ -1513,5 +1512,10 @@ public class OlapScanNode extends ScanNode {
         bucketExprs.clear();
         bucketColumns.clear();
         rowStoreKeyLiterals = Lists.newArrayList();
+    }
+
+    @Override
+    public boolean isRunningAsConnectorOperator() {
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -167,4 +167,10 @@ public abstract class ScanNode extends PlanNode {
     public boolean needCollectExecStats() {
         return true;
     }
+
+    // We use this flag to know how many connector scan nodes at BE side, and connector framework
+    // will use this number to fair share memory usage between those scan nodes.
+    public boolean isRunningAsConnectorOperator() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -58,7 +58,6 @@ import com.starrocks.thrift.TUserIdentity;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -372,7 +371,6 @@ public class SchemaScanNode extends ScanNode {
         return beScanRanges;
     }
 
-
     @Override
     public boolean canUseRuntimeAdaptiveDop() {
         return true;
@@ -384,5 +382,10 @@ public class SchemaScanNode extends ScanNode {
 
     public void setCatalogName(String catalogName) {
         this.catalogName = catalogName;
+    }
+
+    @Override
+    public boolean isRunningAsConnectorOperator() {
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -113,7 +113,7 @@ public class JobSpec {
             if (context.getLastQueryId() != null) {
                 queryGlobals.setLast_query_id(context.getLastQueryId().toString());
             }
-            queryGlobals.setScan_node_number(scanNodes.size());
+            queryGlobals.setConnector_scan_node_number(scanNodes.size());
 
             return new Builder()
                     .queryId(context.getExecutionId())
@@ -143,7 +143,7 @@ public class JobSpec {
             if (context.getLastQueryId() != null) {
                 queryGlobals.setLast_query_id(context.getLastQueryId().toString());
             }
-            queryGlobals.setScan_node_number(scanNodes.size());
+            queryGlobals.setConnector_scan_node_number(scanNodes.size());
 
             return new Builder()
                     .queryId(context.getExecutionId())

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -113,7 +113,7 @@ public class JobSpec {
             if (context.getLastQueryId() != null) {
                 queryGlobals.setLast_query_id(context.getLastQueryId().toString());
             }
-            queryGlobals.setConnector_scan_node_number(scanNodes.size());
+            queryGlobals.setConnector_scan_node_number(scanNodes.stream().filter(x -> x.isRunningAsConnectorOperator()).count());
 
             return new Builder()
                     .queryId(context.getExecutionId())
@@ -143,7 +143,7 @@ public class JobSpec {
             if (context.getLastQueryId() != null) {
                 queryGlobals.setLast_query_id(context.getLastQueryId().toString());
             }
-            queryGlobals.setConnector_scan_node_number(scanNodes.size());
+            queryGlobals.setConnector_scan_node_number(scanNodes.stream().filter(x -> x.isRunningAsConnectorOperator()).count());
 
             return new Builder()
                     .queryId(context.getExecutionId())

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -405,7 +405,7 @@ struct TQueryGlobals {
 
   31: optional i64 timestamp_us
 
-  32: optional i64 scan_node_number
+  32: optional i64 connector_scan_node_number
 }
 
 


### PR DESCRIPTION
## Why I'm doing:

This is the further improvement on this PR: https://github.com/StarRocks/starrocks/pull/50686

We find a bad case that
- if there are many scan nodes
- but most of them does not create any chunk source
- the scan node which has chunk source uses a very few io tasks

And this case can be reproduced by following SQL
- only `select lo_orderkey from ICE` has data
-  the MYSQL does not have any data.

```SQL
set cbo_cte_reuse = false;
with ICE as (
 select lo_orderkey from iceberg.zz_iceberg_ssb_sf100_iceberg_parquet_lz4.lineorder_flat
),
MYSQL(id_int) as (
  select id_int from default_catalog.zya.ext_mysql where id_varchar = 'USA'
),
RESULT(x) as (
select lo_orderkey from ICE
UNION ALL (select lo_orderkey from ICE inner join [broadcast] MYSQL on ICE.lo_orderkey = MYSQL.id_int)
UNION ALL (select lo_orderkey from ICE inner join [broadcast] MYSQL on ICE.lo_orderkey + 1= MYSQL.id_int)
UNION ALL (select lo_orderkey from ICE inner join [broadcast] MYSQL on ICE.lo_orderkey + 2= MYSQL.id_int)
UNION ALL (select lo_orderkey from ICE inner join [broadcast] MYSQL on ICE.lo_orderkey + 3= MYSQL.id_int)
UNION ALL (select lo_orderkey from ICE inner join [broadcast] MYSQL on ICE.lo_orderkey + 4= MYSQL.id_int)
)
select count(distinct x) from RESULT;
```

So the execution profile looks like this

![image](https://github.com/user-attachments/assets/896e23a8-9669-49e6-b0ec-f5dee19f644a)

And if you look at `PeakIOTasks` of `ICE` table, it's very low probably like 3-4, which is bad.

--------------

The root cause is,  since we have this PR: https://github.com/StarRocks/starrocks/pull/50686
- we preallocate $$ScanNodeNumber * 256MB$$ as total memory pool.
- and each scan operator will adjust their chunk source usage from 256MB when creating chunk source.
- and at last, each scan operator will release their chunk source usage down to 0 when doing close
- and during this adjustment,  those scan operators are sharing memory limit according to chunk source usage.

However, there is a corner case that:  if the scan operator does not create any chunk source, it has no chance to adjust it's chunk usage back to 0.  And it affects other scan operator's available mem limit, which leads to low io tasks.

## What I'm doing:

This PR is to:
- adjust chunk source usage when `do_preapre` and `do_close`. so it will do adjustment even there is no chunk source created.
- at FE side,  we change `scan_node_number` to more proper name `connector_scan_node_number`.  So there won't be  problems if there are no-connector scan node and connector scan nodes in a single query.

Fixes #50686

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0