### PR TITLE
[Feature] (Part 1) Support drop partitions with common expressions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionClause.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.alter.AlterOpType;
+import com.starrocks.analysis.Expr;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -28,6 +29,7 @@ public class DropPartitionClause extends AlterTableClause {
     private final boolean forceDrop;
     private final MultiRangePartitionDesc multiRangePartitionDesc;
     private final List<String> partitionNames;
+    private final Expr dropWhereExpr;
 
     //Object Resolved by Analyzer
     private List<String> resolvedPartitionNames;
@@ -45,6 +47,7 @@ public class DropPartitionClause extends AlterTableClause {
         this.forceDrop = forceDrop;
         this.multiRangePartitionDesc = null;
         this.partitionNames = null;
+        this.dropWhereExpr = null;
     }
 
     public DropPartitionClause(boolean ifExists, List<String> partitionNames, boolean isTempPartition,
@@ -56,6 +59,7 @@ public class DropPartitionClause extends AlterTableClause {
         this.forceDrop = forceDrop;
         this.multiRangePartitionDesc = null;
         this.partitionNames = partitionNames;
+        this.dropWhereExpr = null;
     }
 
     public DropPartitionClause(boolean ifExists, MultiRangePartitionDesc multiRangePartitionDesc, boolean isTempPartition,
@@ -67,6 +71,23 @@ public class DropPartitionClause extends AlterTableClause {
         this.forceDrop = forceDrop;
         this.multiRangePartitionDesc = multiRangePartitionDesc;
         this.partitionNames = null;
+        this.dropWhereExpr = null;
+    }
+
+    public DropPartitionClause(boolean ifExists, Expr whereExpr, boolean isTempPartition,
+                               boolean forceDrop, NodePosition pos) {
+        super(AlterOpType.DROP_PARTITION, pos);
+        this.ifExists = ifExists;
+        this.partitionName = null;
+        this.isTempPartition = isTempPartition;
+        this.forceDrop = forceDrop;
+        this.multiRangePartitionDesc = null;
+        this.partitionNames = null;
+        this.dropWhereExpr = whereExpr;
+    }
+
+    public Expr getDropWhereExpr() {
+        return dropWhereExpr;
     }
 
     public List<String> getResolvedPartitionNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -57,8 +57,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentNavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.rule.transformation.ListPartitionPruner.collectOlapTablePartitionValuesMap;
 
 public class OptOlapPartitionPruner {
     private static final Logger LOG = LogManager.getLogger(OptOlapPartitionPruner.class);
@@ -85,17 +86,10 @@ public class OptOlapPartitionPruner {
                     .filter(id -> table.getPartition(id).hasData()).collect(Collectors.toList());
         }
 
+        // Do further partition prune if needed
         if (isNeedFurtherPrune(selectedPartitionIds, logicalOlapScanOperator, partitionInfo)) {
-            List<Column> partitionColumns = partitionInfo.getPartitionColumns(table.getIdToColumn());
-            PartitionColPredicateExtractor extractor = new PartitionColPredicateExtractor(
-                    partitionColumns,
-                    (RangePartitionInfo) partitionInfo,
-                    logicalOlapScanOperator.getColumnMetaToColRefMap());
-            PartitionColPredicateEvaluator evaluator = new PartitionColPredicateEvaluator(
-                    partitionColumns,
-                    (RangePartitionInfo) partitionInfo,
-                    selectedPartitionIds);
-            selectedPartitionIds = evaluator.prunePartitions(extractor, logicalOlapScanOperator.getPredicate());
+            selectedPartitionIds = doFurtherPartitionPrune(table, partitionInfo, logicalOlapScanOperator.getPredicate(),
+                    logicalOlapScanOperator.getColumnMetaToColRefMap(), selectedPartitionIds);
         }
 
         final Pair<ScalarOperator, List<ScalarOperator>> prunePartitionPredicate =
@@ -253,17 +247,6 @@ public class OptOlapPartitionPruner {
         return Pair.create(Utils.compoundAnd(scanPredicates), prunedPartitionPredicates);
     }
 
-    private static void putValueMapItem(ConcurrentNavigableMap<LiteralExpr, Set<Long>> partitionValueToIds,
-                                        Long partitionId,
-                                        LiteralExpr value) {
-        Set<Long> partitionIdSet = partitionValueToIds.get(value);
-        if (partitionIdSet == null) {
-            partitionIdSet = new HashSet<>();
-        }
-        partitionIdSet.add(partitionId);
-        partitionValueToIds.put(value, partitionIdSet);
-    }
-
     private static List<Long> listPartitionPrune(OlapTable olapTable, ListPartitionInfo listPartitionInfo,
                                                  LogicalOlapScanOperator operator) {
 
@@ -275,8 +258,6 @@ public class OptOlapPartitionPruner {
         // where two partitions are checked at the same time
         boolean isTemporaryPartitionPrune = false;
         List<Long> specifyPartitionIds = null;
-        // single item list partition has only one column mapper
-        Map<Long, List<LiteralExpr>> literalExprValuesMap = listPartitionInfo.getLiteralExprValues();
         Set<Long> partitionIds = Sets.newHashSet();
         if (operator.getPartitionNames() != null) {
             for (String partName : operator.getPartitionNames().getPartitionNames()) {
@@ -294,59 +275,11 @@ public class OptOlapPartitionPruner {
         } else {
             partitionIds = Sets.newHashSet(listPartitionInfo.getPartitionIds(false));
         }
+        Map<Column, ColumnRefOperator> columnRefMap = operator.getColumnMetaToColRefMap();
 
-        List<Column> partitionColumns = listPartitionInfo.getPartitionColumns(olapTable.getIdToColumn());
-        if (literalExprValuesMap != null && literalExprValuesMap.size() > 0) {
-            ConcurrentNavigableMap<LiteralExpr, Set<Long>> partitionValueToIds = new ConcurrentSkipListMap<>();
-            for (Map.Entry<Long, List<LiteralExpr>> entry : literalExprValuesMap.entrySet()) {
-                Long partitionId = entry.getKey();
-                if (!partitionIds.contains(partitionId)) {
-                    continue;
-                }
-                List<LiteralExpr> values = entry.getValue();
-                if (values == null || values.isEmpty()) {
-                    continue;
-                }
-                values.forEach(value -> putValueMapItem(partitionValueToIds, partitionId, value));
-            }
-            // single item list partition has only one column
-            Column column = partitionColumns.get(0);
-            ColumnRefOperator columnRefOperator = operator.getColumnReference(column);
-            columnToPartitionValuesMap.put(columnRefOperator, partitionValueToIds);
-            columnToNullPartitions.put(columnRefOperator, new HashSet<>());
-        }
-
-        // multiItem list partition mapper
-        Map<Long, List<List<LiteralExpr>>> multiLiteralExprValues = listPartitionInfo.getMultiLiteralExprValues();
-        if (multiLiteralExprValues != null && multiLiteralExprValues.size() > 0) {
-            for (int i = 0; i < partitionColumns.size(); i++) {
-                ConcurrentNavigableMap<LiteralExpr, Set<Long>> partitionValueToIds = new ConcurrentSkipListMap<>();
-                Set<Long> nullPartitionIds = new HashSet<>();
-                for (Map.Entry<Long, List<List<LiteralExpr>>> entry : multiLiteralExprValues.entrySet()) {
-                    Long partitionId = entry.getKey();
-                    if (!partitionIds.contains(partitionId)) {
-                        continue;
-                    }
-                    List<List<LiteralExpr>> multiValues = entry.getValue();
-                    if (multiValues == null || multiValues.isEmpty()) {
-                        continue;
-                    }
-                    for (List<LiteralExpr> values : multiValues) {
-                        LiteralExpr value = values.get(i);
-                        // store null partition value seperated from non-null partition values
-                        if (value.isConstantNull()) {
-                            nullPartitionIds.add(partitionId);
-                        } else {
-                            putValueMapItem(partitionValueToIds, partitionId, value);
-                        }
-                    }
-                }
-                Column column = partitionColumns.get(i);
-                ColumnRefOperator columnRefOperator = operator.getColumnReference(column);
-                columnToPartitionValuesMap.put(columnRefOperator, partitionValueToIds);
-                columnToNullPartitions.put(columnRefOperator, nullPartitionIds);
-            }
-        }
+        // collect partition values map
+        collectOlapTablePartitionValuesMap(olapTable, partitionIds, columnRefMap,
+                columnToPartitionValuesMap, columnToNullPartitions, false);
 
         List<ScalarOperator> scalarOperatorList = Utils.extractConjuncts(operator.getPredicate());
         ListPartitionPruner partitionPruner = new ListPartitionPruner(columnToPartitionValuesMap,
@@ -391,10 +324,35 @@ public class OptOlapPartitionPruner {
         return Lists.newArrayList(keyRangeById.keySet());
     }
 
-    private static boolean isNeedFurtherPrune(List<Long> candidatePartitions, LogicalOlapScanOperator olapScanOperator,
-                                              PartitionInfo partitionInfo) {
-        if (candidatePartitions.isEmpty()
-                || olapScanOperator.getPredicate() == null) {
+    private static boolean isNeedFurtherPrune(List<Long> candidatePartitions,
+                                              LogicalOlapScanOperator olapScanOperator,
+                                             PartitionInfo partitionInfo) {
+        return isNeedFurtherPrune((OlapTable) olapScanOperator.getTable(), candidatePartitions,
+                olapScanOperator.getPredicate(), partitionInfo);
+    }
+
+    public static List<Long> doFurtherPartitionPrune(OlapTable table,
+                                                     PartitionInfo partitionInfo,
+                                                     ScalarOperator predicate,
+                                                     Map<Column, ColumnRefOperator> columnRefOperatorMap,
+                                                     List<Long> selectedPartitionIds) {
+        List<Column> partitionColumns = partitionInfo.getPartitionColumns(table.getIdToColumn());
+        PartitionColPredicateExtractor extractor = new PartitionColPredicateExtractor(
+                partitionColumns,
+                (RangePartitionInfo) partitionInfo,
+                columnRefOperatorMap);
+        PartitionColPredicateEvaluator evaluator = new PartitionColPredicateEvaluator(
+                partitionColumns,
+                (RangePartitionInfo) partitionInfo,
+                selectedPartitionIds);
+        return evaluator.prunePartitions(extractor, predicate);
+    }
+
+    public static boolean isNeedFurtherPrune(OlapTable olapTable,
+                                             List<Long> candidatePartitions,
+                                             ScalarOperator predicate,
+                                             PartitionInfo partitionInfo) {
+        if (candidatePartitions.isEmpty() || predicate == null) {
             return false;
         }
 
@@ -402,7 +360,7 @@ public class OptOlapPartitionPruner {
         // EXPR_RANGE_V2 type like partition by RANGE(cast(substring(col, 3)) as int)) is unsupported
         if (partitionInfo instanceof ExpressionRangePartitionInfo) {
             ExpressionRangePartitionInfo exprPartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
-            List<Expr> partitionExpr = exprPartitionInfo.getPartitionExprs(olapScanOperator.getTable().getIdToColumn());
+            List<Expr> partitionExpr = exprPartitionInfo.getPartitionExprs(olapTable.getIdToColumn());
             if (partitionExpr.size() == 1 && partitionExpr.get(0) instanceof FunctionCallExpr) {
                 FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr.get(0);
                 String functionName = functionCallExpr.getFnName().getFunction();
@@ -469,5 +427,4 @@ public class OptOlapPartitionPruner {
 
         return newPredicateFilterNulls == predicateFilterNulls;
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateExtractor.java
@@ -256,5 +256,4 @@ public class PartitionColPredicateExtractor extends ScalarOperatorVisitor<Scalar
         }
         return false;
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -1,0 +1,428 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.rule.transformation.partition;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.ExprSubstitutionMap;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ListPartitionInfo;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.system.information.InfoSchemaDb;
+import com.starrocks.catalog.system.information.PartitionsMetaSystemTable;
+import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.planner.PartitionColumnFilter;
+import com.starrocks.planner.PartitionPruner;
+import com.starrocks.planner.RangePartitionPruner;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SqlModeHelper;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzeState;
+import com.starrocks.sql.analyzer.ExpressionAnalyzer;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.RelationFields;
+import com.starrocks.sql.analyzer.RelationId;
+import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.function.MetaFunctions;
+import com.starrocks.sql.optimizer.operator.ColumnFilterConverter;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.thrift.TResultBatch;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import jline.internal.Log;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.rewrite.OptOlapPartitionPruner.doFurtherPartitionPrune;
+import static com.starrocks.sql.optimizer.rewrite.OptOlapPartitionPruner.isNeedFurtherPrune;
+
+public class PartitionSelector {
+
+    private static final Logger LOG = LogManager.getLogger(PartitionSelector.class);
+    // why not use `PARTITION_ID` here? because partition_id in partitions_meta is physical partition id which may be confused.
+    private static final String PARTITIONS_META_TEMPLATE = "SELECT PARTITION_NAME FROM INFORMATION_SCHEMA.PARTITIONS_META " +
+            "WHERE DB_NAME ='%s' and TABLE_NAME='%s' AND %s;";
+    private static final String JSON_QUERY_TEMPLATE = "CAST(JSON_QUERY(%s, '$[0].[%d]') AS %s)";
+
+    /**
+     * Return filtered partition names by whereExpr.
+     * @isRecyclingOrRetention, true for recycling/dropping condition, false for retention condition.
+     */
+    public static List<String> getPartitionNamesByExpr(ConnectContext context,
+                                                       TableName tableName,
+                                                       OlapTable olapTable,
+                                                       Expr whereExpr,
+                                                       boolean isRecyclingCondition) {
+        PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+        if (!partitionInfo.isPartitioned()) {
+            throw new SemanticException("Can't drop partitions with where expression since it is not partitioned");
+        }
+        Scope scope = new Scope(RelationId.anonymous(), new RelationFields(
+                olapTable.getBaseSchema().stream()
+                        .map(col -> new Field(col.getName(), col.getType(), tableName, null))
+                        .collect(Collectors.toList())));
+        ExpressionAnalyzer.analyzeExpression(whereExpr, new AnalyzeState(), scope, context);
+        ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+        Map<Column, ColumnRefOperator> columnRefOperatorMap = Maps.newHashMap();
+        List<ColumnRefOperator> columnRefOperators = Lists.newArrayList();
+        for (Column col : olapTable.getBaseSchema()) {
+            ColumnRefOperator columnRefOperator = columnRefFactory.create(col.getName(),
+                    col.getType(), col.isAllowNull());
+            columnRefOperatorMap.put(col, columnRefOperator);
+            columnRefOperators.add(columnRefOperator);
+        }
+        List<Column> partitionCols = olapTable.getPartitionColumns();
+        Map<Column, Integer> partitionColIdxMap = Maps.newHashMap();
+        for (int i = 0; i < partitionCols.size(); i++) {
+            partitionColIdxMap.put(partitionCols.get(i), i);
+        }
+        Set<String> partitionColNames = partitionCols
+                .stream()
+                .map(Column::getName)
+                .collect(Collectors.toSet());
+        // NOTE: columnRefOperators's order should be same with olapTable.getBaseSchema()
+        ExpressionMapping expressionMapping = new ExpressionMapping(scope, columnRefOperators);
+        // expr to column index map
+        Map<Expr, Integer> exprToColumnIdxes = Maps.newHashMap();
+        Map<ScalarOperator, ColumnRefOperator> gcExprToColRefMap = Maps.newHashMap();
+        for (Column column : olapTable.getBaseSchema()) {
+            if (!partitionColNames.contains(column.getName())) {
+                continue;
+            }
+            SlotRef slotRef = new SlotRef(tableName, column.getName());
+            slotRef.setType(column.getType());
+            Expr gcExpr = column.getGeneratedColumnExpr(olapTable.getIdToColumn());
+            if (gcExpr == null) {
+                exprToColumnIdxes.put(slotRef, partitionColIdxMap.get(column));
+                continue;
+            }
+            exprToColumnIdxes.put(gcExpr, partitionColIdxMap.get(column));
+            ExpressionAnalyzer.analyzeExpression(gcExpr, new AnalyzeState(), scope, context);
+            ExpressionAnalyzer.analyzeExpression(slotRef, new AnalyzeState(), scope, context);
+            ScalarOperator scalarOperator = SqlToScalarOperatorTranslator.translate(gcExpr,
+                    expressionMapping, columnRefFactory);
+            gcExprToColRefMap.put(scalarOperator, columnRefOperatorMap.get(column));
+        }
+        expressionMapping.addGeneratedColumnExprOpToColumnRef(gcExprToColRefMap);
+        // translate whereExpr to scalarOperator and replace whereExpr's generatedColumnExpr to partition slotRef.
+        ScalarOperator scalarOperator =
+                SqlToScalarOperatorTranslator.translate(whereExpr, expressionMapping, Lists.newArrayList(),
+                        columnRefFactory, context, null, null, null, false);
+        if (scalarOperator == null) {
+            throw new SemanticException("Failed to translate where expression to scalar operator:" + whereExpr.toSql());
+        }
+
+        List<ColumnRefOperator> usedPartitionColumnRefs = Lists.newArrayList();
+        scalarOperator.getColumnRefs(usedPartitionColumnRefs);
+        if (CollectionUtils.isEmpty(usedPartitionColumnRefs)) {
+            throw new SemanticException("No partition column is used in where clause for drop partition: " + whereExpr.toSql());
+        }
+        // check if all used columns are partition columns
+        for (ColumnRefOperator colRef : usedPartitionColumnRefs) {
+            if (!partitionColNames.contains(colRef.getName())) {
+                throw new SemanticException("Column is not a partition column which can not" +
+                        " be used in where clause for drop partition: " + colRef.getName());
+            }
+        }
+        List<Long> selectedPartitionIds;
+        if (partitionInfo.isRangePartition()) {
+            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
+            selectedPartitionIds = getRangePartitionIdsByExpr(olapTable, rangePartitionInfo, scalarOperator,
+                    columnRefOperatorMap, isRecyclingCondition);
+        } else if (partitionInfo.isListPartition()) {
+            ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
+            selectedPartitionIds = getListPartitionIdsByExpr(tableName.getDb(), olapTable, listPartitionInfo,
+                    whereExpr, scalarOperator, exprToColumnIdxes);
+        } else {
+            throw new SemanticException("Unsupported partition type: " + partitionInfo.getType());
+        }
+        if (selectedPartitionIds == null) {
+            throw new SemanticException("Failed to prune partitions with where expression: " + whereExpr.toSql());
+        }
+        return selectedPartitionIds.stream()
+                .map(p -> olapTable.getPartition(p))
+                .map(Partition::getName)
+                .collect(Collectors.toList());
+    }
+
+    private static Map<ColumnRefOperator, ScalarOperator> buildReplaceMap(Map<ColumnRefOperator, Integer> colRefIdxMap,
+                                                                          List<LiteralExpr> values) {
+        // columnref -> literal
+        Map<ColumnRefOperator, ScalarOperator> replaceMap = Maps.newHashMap();
+        for (Map.Entry<ColumnRefOperator, Integer> entry : colRefIdxMap.entrySet()) {
+            ColumnRefOperator colRef = entry.getKey();
+            ConstantOperator replace =
+                    (ConstantOperator) SqlToScalarOperatorTranslator.translate(values.get(entry.getValue()));
+            replaceMap.put(colRef, replace);
+        }
+        return replaceMap;
+    }
+
+    private static List<Long> getRangePartitionIdsByExpr(OlapTable olapTable,
+                                                         RangePartitionInfo rangePartitionInfo,
+                                                         ScalarOperator predicate,
+                                                         Map<Column, ColumnRefOperator> columnRefOperatorMap,
+                                                         boolean isRecyclingCondition) {
+        Map<Long, Range<PartitionKey>> keyRangeById = rangePartitionInfo.getIdToRange(false);
+        // since partition pruning is false positive which means it may not prune some partitions which should be pruned
+        // but it will not prune partitions which should not be pruned.
+        ScalarOperator fpPredicate = predicate;
+        if (isRecyclingCondition) {
+            // use not condition to prune partitions because it's not safe to prune partitions with where expression directly,
+            ScalarOperator notWhereExpr =
+                    new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.NOT, predicate);
+            ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
+            fpPredicate = rewriter.rewrite(notWhereExpr, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+        }
+
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(fpPredicate);
+        ImmutableMap<String, PartitionColumnFilter> columnFilters = ImmutableMap.copyOf(
+                ColumnFilterConverter.convertColumnFilter(conjuncts, olapTable));
+        PartitionPruner partitionPruner = new RangePartitionPruner(keyRangeById,
+                rangePartitionInfo.getPartitionColumns(olapTable.getIdToColumn()), columnFilters);
+        List<Long> selectedPartitionIds;
+        try {
+            selectedPartitionIds = partitionPruner.prune();
+            // do more prune if necessary
+            if (isNeedFurtherPrune(olapTable, selectedPartitionIds, fpPredicate, rangePartitionInfo)) {
+                selectedPartitionIds = doFurtherPartitionPrune(olapTable, rangePartitionInfo,
+                        fpPredicate, columnRefOperatorMap, selectedPartitionIds);
+            }
+            if (selectedPartitionIds == null) {
+                throw new SemanticException("Failed to prune partitions with where expression: " + predicate.toString());
+            }
+        } catch (Exception e) {
+            throw new SemanticException("Failed to prune partitions with where expression: " + e.getMessage());
+        }
+        // check if all used columns are partition columns
+        if (isRecyclingCondition) {
+            // for recycling, we need to return the partitions which should not be pruned.
+            Set<Long> notMatchedPartitionIds = Sets.newHashSet(selectedPartitionIds);
+            return keyRangeById.keySet().stream()
+                    .filter(id -> !notMatchedPartitionIds.contains(id))
+                    .collect(Collectors.toList());
+        } else {
+            return selectedPartitionIds;
+        }
+    }
+
+    private static List<Long> getListPartitionIdsByExpr(String dbName, OlapTable olapTable,
+                                                        ListPartitionInfo listPartitionInfo,
+                                                        Expr whereExpr,
+                                                        ScalarOperator scalarOperator,
+                                                        Map<Expr, Integer> exprToColumnIdxes) {
+
+        List<Long> result = null;
+        // try to prune partitions by FE's constant evaluation ability
+        try {
+            result = getListPartitionIdsByExprV1(olapTable, listPartitionInfo, scalarOperator);
+            if (result != null) {
+                return result;
+            }
+        } catch (Exception e1) {
+            Log.info("Failed to prune partitions by FE's constant evaluation, transform to partitions_meta instead.");
+        }
+
+        try {
+            return getListPartitionIdsByExprV2(dbName, olapTable, listPartitionInfo, whereExpr, exprToColumnIdxes);
+        } catch (Exception e2) {
+            LOG.warn("Failed to prune partitions with where expression(v2): " + e2.getMessage());
+            throw new SemanticException("Failed to prune partitions with where expression: " + whereExpr.toSql());
+        }
+    }
+
+    /**
+     * Fetch selected partition ids by using FE's constant evaluation ability.
+     */
+    private static List<Long> getListPartitionIdsByExprV1(OlapTable olapTable,
+                                                          ListPartitionInfo listPartitionInfo,
+                                                          ScalarOperator scalarOperator) {
+        // eval for each conjunct
+        Map<ColumnRefOperator, Integer> colRefIdxMap = Maps.newHashMap();
+        List<String> partitionColNames = olapTable.getPartitionColumns().stream()
+                .map(Column::getName).collect(Collectors.toList());
+        List<ColumnRefOperator> usedPartitionColumnRefs = Lists.newArrayList();
+        scalarOperator.getColumnRefs(usedPartitionColumnRefs);
+        for (ColumnRefOperator colRef : usedPartitionColumnRefs) {
+            Preconditions.checkArgument(partitionColNames.contains(colRef.getName()));
+            colRefIdxMap.put(colRef, partitionColNames.indexOf(colRef.getName()));
+        }
+
+        ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
+        List<Long> selectedPartitionIds = Lists.newArrayList();
+        // single partition column
+        Map<Long, List<LiteralExpr>> listPartitions = listPartitionInfo.getLiteralExprValues();
+        for (Map.Entry<Long, List<LiteralExpr>> e : listPartitions.entrySet()) {
+            boolean isConstTrue = false;
+            for (LiteralExpr literalExpr : e.getValue()) {
+                Map<ColumnRefOperator, ScalarOperator> replaceMap = Maps.newHashMap();
+                ConstantOperator replace = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
+                replaceMap.put(usedPartitionColumnRefs.get(0), replace);
+
+                // replace columnRef with literal
+                ReplaceColumnRefRewriter replaceColumnRefRewriter = new ReplaceColumnRefRewriter(replaceMap);
+                ScalarOperator result = replaceColumnRefRewriter.rewrite(scalarOperator);
+                result = rewriter.rewrite(result, ScalarOperatorRewriter.FOLD_CONSTANT_RULES);
+
+                if (!result.isConstant()) {
+                    return null;
+                }
+                if (result.isConstantFalse()) {
+                    isConstTrue = false;
+                    break;
+                } else if (result.isConstantTrue()) {
+                    isConstTrue = true;
+                } else {
+                    return null;
+                }
+            }
+            if (isConstTrue) {
+                selectedPartitionIds.add(e.getKey());
+            }
+        }
+        // multi partition columns
+        Map<Long, List<List<LiteralExpr>>> multiListPartitions = listPartitionInfo.getMultiLiteralExprValues();
+        for (Map.Entry<Long, List<List<LiteralExpr>>> e : multiListPartitions.entrySet()) {
+            boolean isConstTrue = false;
+            for (List<LiteralExpr> values : e.getValue()) {
+                Map<ColumnRefOperator, ScalarOperator> replaceMap = buildReplaceMap(colRefIdxMap, values);
+                ReplaceColumnRefRewriter replaceColumnRefRewriter = new ReplaceColumnRefRewriter(replaceMap);
+                ScalarOperator result = replaceColumnRefRewriter.rewrite(scalarOperator);
+                result = rewriter.rewrite(result, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+                if (!result.isConstant()) {
+                    return null;
+                }
+                if (result.isConstantFalse()) {
+                    isConstTrue = false;
+                    break;
+                } else if (result.isConstantTrue()) {
+                    isConstTrue = true;
+                } else {
+                    return null;
+                }
+            }
+            if (isConstTrue) {
+                selectedPartitionIds.add(e.getKey());
+            }
+        }
+        return selectedPartitionIds;
+    }
+
+    /**
+     * Use `information_schema.partitions_meta` to filter selected partition names by using whereExpr.
+     */
+    private static List<Long> getListPartitionIdsByExprV2(String dbName,
+                                                          OlapTable olapTable,
+                                                          ListPartitionInfo listPartitionInfo,
+                                                          Expr whereExpr,
+                                                          Map<Expr, Integer> exprToColumnIdxes) {
+        Database infoSchemaDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(InfoSchemaDb.DATABASE_NAME);
+        if (infoSchemaDb == null) {
+            return null;
+        }
+        Table partitionsMetaTbl = infoSchemaDb.getTable(PartitionsMetaSystemTable.NAME);
+        if (partitionsMetaTbl == null) {
+            return null;
+        }
+        ExprSubstitutionMap aliasMap = new ExprSubstitutionMap(false);
+        List<Column> partitionCols = olapTable.getPartitionColumns();
+        for (Map.Entry<Expr, Integer> e : exprToColumnIdxes.entrySet()) {
+            Expr alias = buildJsonQuery(partitionCols, e.getValue());
+            aliasMap.put(e.getKey(), alias);
+        }
+        Expr newExpr = whereExpr.substitute(aliasMap);
+        String newWhereSql = newExpr.toSql();
+        String sql = String.format(PARTITIONS_META_TEMPLATE, dbName, olapTable.getName(), newWhereSql);
+        LOG.info("Get partition ids by sql: {}", sql);
+        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        List<String> partitionNames = deserializeLookupResult(batch);
+        // multi items in the single partition is not supported yet since `JSON_QUERY_TEMPLATE` is constructed the first element.
+        Set<Long> excludedPartitionIds = Sets.newHashSet();
+        listPartitionInfo.getLiteralExprValues().entrySet()
+                .stream()
+                .filter(e -> e.getValue().size() > 1)
+                .map(Map.Entry::getKey)
+                .forEach(excludedPartitionIds::add);
+        listPartitionInfo.getMultiLiteralExprValues().entrySet()
+                .stream()
+                .filter(e -> e.getValue().size() > 1)
+                .map(Map.Entry::getKey)
+                .forEach(excludedPartitionIds::add);
+        // ensure all partition names are existed
+        return partitionNames.stream()
+                .map(olapTable::getPartition)
+                .map(Partition::getId)
+                .filter(id -> !excludedPartitionIds.contains(id))
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> deserializeLookupResult(List<TResultBatch> batches) {
+        List<String> result = Lists.newArrayList();
+        for (TResultBatch batch : ListUtils.emptyIfNull(batches)) {
+            for (ByteBuffer buffer : batch.getRows()) {
+                ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                String jsonString = copied.toString(Charset.defaultCharset());
+                List<String> data = MetaFunctions.LookupRecord.fromJson(jsonString).data;
+                if (CollectionUtils.isNotEmpty(data)) {
+                    result.add(data.get(0));
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Expr buildJsonQuery(List<Column> partitionCols,
+                                       int partitionColumnIndex) {
+        Preconditions.checkArgument(partitionColumnIndex >= 0 && partitionColumnIndex < partitionCols.size());
+        Column partitionCol = partitionCols.get(partitionColumnIndex);
+        String partitionColType = partitionCol.getType().toSql();
+        String jsonQuery = String.format(JSON_QUERY_TEMPLATE, "PARTITION_VALUE", partitionColumnIndex, partitionColType);
+        Expr expr = SqlParser.parseSqlToExpr(jsonQuery, SqlModeHelper.MODE_DEFAULT);
+        return expr;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4777,6 +4777,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         } else if (identifier != null) {
             String partitionName = ((Identifier) visit(context.identifier())).getValue();
             return new DropPartitionClause(exists, partitionName, temp, force, createPos(context));
+        } else if (context.where != null) {
+            Expr whereExpr = (Expr) visitIfPresent(context.where);
+            return new DropPartitionClause(exists, whereExpr, temp, force, createPos(context));
         } else {
             if (CollectionUtils.isNotEmpty(identifierList)) {
                 List<String> partitionNames = identifierList.stream().map(i -> i.getValue()).collect(toList());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1133,6 +1133,7 @@ addPartitionClause
 dropPartitionClause
     : DROP TEMPORARY? (PARTITION (IF EXISTS)? identifier | PARTITIONS (IF EXISTS)? identifierList) FORCE?
     | DROP TEMPORARY? PARTITIONS (IF EXISTS)? multiRangePartition FORCE?
+    | DROP TEMPORARY? PARTITIONS (IF EXISTS)? WHERE where=expression FORCE?
     ;
 
 truncatePartitionClause

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
@@ -1,0 +1,603 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.pseudocluster.PseudoCluster;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.statistic.StatisticsMetaManager;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class DropPartitionWithExprListTest {
+    private static final Logger LOG = LogManager.getLogger(DropPartitionWithExprListTest.class);
+    protected static ConnectContext connectContext;
+    protected static PseudoCluster cluster;
+    protected static StarRocksAssert starRocksAssert;
+    private static String T1;
+    private static String T2;
+    private static String T3;
+    private static String T4;
+    private static String T5;
+    private static String T6;
+    private static List<String> TABLES_WITH_STRING_DT_TYPES;
+    private static List<String> TABLES_WITH_DATETIME_DT_TYPES;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        // set default config for async mvs
+        UtFrameUtils.setDefaultConfigForAsyncMVTest(connectContext);
+
+        if (!starRocksAssert.databaseExist("_statistics_")) {
+            StatisticsMetaManager m = new StatisticsMetaManager();
+            m.createStatisticsTablesForTest();
+        }
+        starRocksAssert.withDatabase("test");
+        starRocksAssert.useDatabase("test");
+
+        // table with partition expression whose partitions have multi columns
+        T1 = "CREATE TABLE t1 (\n" +
+                " id BIGINT,\n" +
+                " age SMALLINT,\n" +
+                " dt VARCHAR(10) not null,\n" +
+                " province VARCHAR(64) not null\n" +
+                ")\n" +
+                "PARTITION BY (province, dt) \n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table whose partitions have multi columns
+        T2 = "CREATE TABLE t2 (\n" +
+                " id BIGINT,\n" +
+                " age SMALLINT,\n" +
+                " dt date not null,\n" +
+                " province VARCHAR(64) not null\n" +
+                ")\n" +
+                "PARTITION BY LIST (province, dt) (\n" +
+                "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-01\")),\n" +
+                "     PARTITION p2 VALUES IN ((\"guangdong\", \"2024-01-01\")), \n" +
+                "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-01-02\")),\n" +
+                "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-01-02\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n";
+        T3 = "CREATE TABLE t3 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10),\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province) (\n" +
+                "     PARTITION p1 VALUES IN (\"beijing\",\"chongqing\") ,\n" +
+                "     PARTITION p2 VALUES IN (\"guangdong\", \"shenzhen\"), \n" +
+                "     PARTITION p3 VALUES IN (\"shanghai\"), \n" +
+                "     PARTITION p4 VALUES IN (\"chengdu\") \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table with partition expression whose partitions have multiple values
+        T4 = "CREATE TABLE t4 (\n" +
+                " id BIGINT,\n" +
+                " age SMALLINT,\n" +
+                " dt VARCHAR(10) not null,\n" +
+                " province VARCHAR(64) not null\n" +
+                ")\n" +
+                "PARTITION BY province, str2date(dt, '%Y-%m-%d') \n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table with partition expression whose partitions have multi columns(nullable partition columns)
+        T5 = "CREATE TABLE t5 (\n" +
+                " id BIGINT,\n" +
+                " age SMALLINT,\n" +
+                " dt datetime,\n" +
+                " province VARCHAR(64)\n" +
+                ")\n" +
+                "PARTITION BY province, date_trunc('day', dt) \n" +
+                "DISTRIBUTED BY RANDOM\n";
+        T6 = "CREATE TABLE t6 (\n" +
+                " id BIGINT,\n" +
+                " age SMALLINT,\n" +
+                " dt datetime,\n" +
+                " province VARCHAR(64)\n" +
+                ")\n" +
+                "PARTITION BY str2date(dt, '%Y-%m-%d'), date_trunc('day', dt) \n" +
+                "DISTRIBUTED BY RANDOM\n";
+        TABLES_WITH_STRING_DT_TYPES = Lists.newArrayList(T1, T2);
+        TABLES_WITH_DATETIME_DT_TYPES = Lists.newArrayList(T5, T6);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+    }
+
+    @Before
+    public void before() {
+    }
+
+    @After
+    public void after() throws Exception {
+    }
+
+    public static void executeInsertSql(String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        StatementBase statement = SqlParser.parseSingleStatement(sql, connectContext.getSessionVariable().getSqlMode());
+        new StmtExecutor(connectContext, statement).execute();
+    }
+
+    private String toPartitionVal(String val) {
+        return val == null ? "NULL" : String.format("'%s'", val);
+    }
+
+    private void addListPartition(String tbl, String pName, String pVal1, String pVal2) {
+        String addPartitionSql = String.format("ALTER TABLE %s ADD PARTITION IF NOT EXISTS %s VALUES IN ((%s, %s))",
+                tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
+        StatementBase stmt = SqlParser.parseSingleStatement(addPartitionSql, connectContext.getSessionVariable().getSqlMode());
+        try {
+            new StmtExecutor(connectContext, stmt).execute();
+        } catch (Exception e) {
+            Assert.fail("add partition failed:" + e);
+        }
+    }
+
+    private void withTablePartitions(String tableName) {
+        if (tableName.equalsIgnoreCase("t6")) {
+            addListPartition(tableName, "p1", "2024-01-01", "2024-01-01");
+            addListPartition(tableName, "p2", "2024-01-02", "2024-01-01");
+            addListPartition(tableName, "p3", "2024-01-01", "2024-01-02");
+            addListPartition(tableName, "p4", "2024-01-02", "2024-01-02");
+        } else {
+            addListPartition(tableName, "p1", "beijing", "2024-01-01");
+            addListPartition(tableName, "p2", "guangdong", "2024-01-01");
+            addListPartition(tableName, "p3", "beijing", "2024-01-02");
+            addListPartition(tableName, "p4", "guangdong", "2024-01-02");
+        }
+    }
+
+    private void withTablePartitionsV2(String tableName) {
+        if (tableName.equalsIgnoreCase("t6")) {
+            addListPartition(tableName, "p1", "2024-01-29", "2024-01-30");
+            addListPartition(tableName, "p2", "2024-01-30", "2024-01-31");
+            addListPartition(tableName, "p3", "2024-01-31", "2024-02-01");
+            addListPartition(tableName, "p4", "2024-02-01", "2024-02-02");
+        } else {
+            addListPartition(tableName, "p1", "beijing", "2024-01-29");
+            addListPartition(tableName, "p2", "guangdong", "2024-01-30");
+            addListPartition(tableName, "p3", "beijing", "2024-01-31");
+            addListPartition(tableName, "p4", "guangdong", "2024-02-01");
+        }
+    }
+
+    private void withTablesWithStringDtTypes(StarRocksAssert.ExceptionConsumer<OlapTable> runner) {
+        for (String t : TABLES_WITH_STRING_DT_TYPES) {
+            System.out.println(t);
+            starRocksAssert.withTable(t, (obj) -> {
+                String tableName = (String) obj;
+
+                // Automatic partition creation is not supported in FE UTs
+                //String insertSql = String.format("insert into %s values " +
+                //        "(1, 1, '2024-01-01', 'beijing'), (1, 1, '2024-01-01', 'guangdong')," +
+                //        "(2, 1, '2024-01-02', 'beijing'), (2, 1, '2024-01-02', 'guangdong');", tableName);
+                //executeInsertSql(insertSql);
+                withTablePartitions(tableName);
+
+                OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+                runner.accept(olapTable);
+            });
+        }
+    }
+
+    @Test
+    public void testDropPartitionsWithExprBasic() {
+        starRocksAssert.withTable(T1, (obj) -> {
+            String tableName = (String) obj;
+            withTablePartitions(tableName);
+            OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+            Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+            {
+                try {
+                    String dropPartitionSql = String.format("alter table %s DROP TEMPORARY PARTITIONS " +
+                                    "WHERE dt <= current_date();", tableName);
+                    starRocksAssert.alterTable(dropPartitionSql);
+                    Assert.fail();
+                } catch (Exception e) {
+                    Assert.assertTrue(e.getMessage().contains("Can't drop temp partitions with where expression " +
+                            "and `TEMPORARY` keyword."));
+                }
+            }
+
+            {
+                try {
+                    String dropPartitionSql = String.format("alter table %s DROP PARTITIONS IF EXISTS " +
+                            "WHERE dt <= current_date();", tableName);
+                    starRocksAssert.alterTable(dropPartitionSql);
+                    Assert.fail();
+                } catch (Exception e) {
+                    Assert.assertTrue(e.getMessage().contains("Can't drop partitions with where expression and " +
+                            "`IF EXISTS` keyword."));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testDropPartitionsWithExpr1() {
+        withTablesWithStringDtTypes((olapTable) -> {
+            String tableName = olapTable.getName();
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE dt = '2021-02-01';",
+                        tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            }
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE dt = '2024-01-01';",
+                        tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(2, olapTable.getVisiblePartitions().size());
+            }
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE dt = '2024-01-02';",
+                        tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(0, olapTable.getVisiblePartitions().size());
+            }
+        });
+    }
+
+    @Test
+    public void testDropPartitionsWithExpr2() {
+        withTablesWithStringDtTypes((olapTable) -> {
+            String tableName = olapTable.getName();
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE dt >= current_date();",
+                        tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            }
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE dt <= '2021-02-01';",
+                        tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            }
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE dt >= '2024-01-01';",
+                        tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(0, olapTable.getVisiblePartitions().size());
+            }
+        });
+    }
+
+    @Test
+    public void testDropPartitionsWithExpr3() {
+        withTablesWithStringDtTypes((olapTable) -> {
+            String tableName = olapTable.getName();
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE dt <= current_date();", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(0, olapTable.getVisiblePartitions().size());
+            }
+        });
+    }
+
+    @Test
+    public void testDropPartitionsWithSt2dateExpr1() {
+        starRocksAssert.withTable(T4,
+                (obj) -> {
+                    String tableName = (String) obj;
+
+                    // mock partitions
+                    withTablePartitions(tableName);
+                    OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                    Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+                    {
+                        String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                                "WHERE str2date(dt, '%%Y-%%m-%%d') >= current_date();", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                    }
+
+                    {
+                        String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                "str2date(dt, '%%Y-%%m-%%d') <= '2021-02-01';", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                    }
+
+                    {
+                        String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                "str2date(dt, '%%Y-%%m-%%d') >= '2021-02-01';", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+                        Assert.assertEquals(0, olapTable.getVisiblePartitions().size());
+                    }
+                });
+    }
+
+    @Test
+    public void testDropPartitionsWithSt2dateExpr2() {
+        starRocksAssert.withTable(T4,
+                (obj) -> {
+                    String tableName = (String) obj;
+
+                    // mock partitions
+                    withTablePartitions(tableName);
+                    OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                    Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+                    {
+                        try {
+
+                            String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE dt like '2024%%';",
+                                    tableName);
+                            starRocksAssert.alterTable(dropPartitionSql);
+                            Assert.fail();
+                        } catch (Exception e) {
+                            Assert.assertTrue(e.getMessage().contains("Column is not a partition column which " +
+                                    "can not be used in where clause for drop partition"));
+                        }
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                    }
+
+                    {
+                        try {
+
+                            String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                    "str2date(dt, '%%Y-%%m-%%d') like '2024%%';", tableName);
+                            starRocksAssert.alterTable(dropPartitionSql);
+                            Assert.fail();
+                        } catch (Exception e) {
+                            Assert.assertTrue(e.getMessage().contains("left operand of LIKE must be of type STRING"));
+                        }
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                    }
+
+                    {
+                        try {
+
+                            String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE cast(str2date(dt, " +
+                                    "'%%Y-%%m-%%d') as string) like '2024%%';", tableName);
+                            starRocksAssert.alterTable(dropPartitionSql);
+                            Assert.fail();
+                        } catch (Exception e) {
+                            Assert.assertTrue(e.getMessage().contains("Failed to prune partitions with where expression"));
+                        }
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                    }
+
+                    {
+                        try {
+
+                            String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE str2date(dt, " +
+                                    "'%%Y-%%m-%%d') >= current_date() ;", tableName);
+                            starRocksAssert.alterTable(dropPartitionSql);
+                        } catch (Exception e) {
+                            Assert.fail();
+                        }
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                    }
+
+
+                    {
+                        String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                "str2date(dt, '%%Y-%%m-%%d') >= current_date() and province='guangdong';", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                    }
+
+                    {
+                        String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                "str2date(dt, '%%Y-%%m-%%d') <= '2021-02-01' and province='guangdong';", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                    }
+
+                    {
+                        String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                "str2date(dt, '%%Y-%%m-%%d') >= '2021-02-01' and province='beijing';", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+                        Assert.assertEquals(2, olapTable.getVisiblePartitions().size());
+                    }
+
+                    {
+                        String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                "str2date(dt, '%%Y-%%m-%%d') >= '2021-02-01' and province='guangdong';", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+                        Assert.assertEquals(0, olapTable.getVisiblePartitions().size());
+                    }
+                });
+    }
+
+    @Test
+    public void testDropPartitionsWithDateTrucExpr1() {
+        for (String sql : TABLES_WITH_DATETIME_DT_TYPES) {
+            starRocksAssert.withTable(sql,
+                    (obj) -> {
+                        String tableName = (String) obj;
+
+                        // mock partitions
+                        withTablePartitions(tableName);
+                        OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+                        {
+                            String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                    "date_trunc('day', dt) >= current_date();", tableName);
+                            starRocksAssert.alterTable(dropPartitionSql);
+                            Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                        }
+
+                        {
+                            String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                    "date_trunc('day', dt) <= '2021-02-01';", tableName);
+                            starRocksAssert.alterTable(dropPartitionSql);
+                            Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                        }
+
+                        {
+                            String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                    "date_trunc('day', dt) >= '2021-02-01';", tableName);
+                            starRocksAssert.alterTable(dropPartitionSql);
+                            Assert.assertEquals(0, olapTable.getVisiblePartitions().size());
+                        }
+                    });
+        }
+    }
+
+    @Test
+    public void testDropPartitionsWithDateTrucExpr2() {
+        starRocksAssert.withTable(T5, (obj) -> {
+            String tableName = (String) obj;
+            // mock partitions
+            withTablePartitions(tableName);
+            OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+            Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE date_trunc('day', dt) >= " +
+                        "current_date() and province='guangdong';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            }
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE date_trunc('day', dt) <= " +
+                        "'2021-02-01' and province='guangdong';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            }
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE date_trunc('day', dt) >= " +
+                        "'2021-02-01' and province='beijing';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(2, olapTable.getVisiblePartitions().size());
+            }
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE date_trunc('day', dt) >= " +
+                        "'2021-02-01' and province='guangdong';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(0, olapTable.getVisiblePartitions().size());
+            }
+        });
+    }
+
+    @Test
+    public void testDropPartitionsWithMultiGenerateColumns() {
+        starRocksAssert.withTable(T6,
+                (obj) -> {
+                    String tableName = (String) obj;
+                    // mock partitions
+                    withTablePartitions(tableName);
+                    OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                    Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+                    {
+                        try {
+
+                            String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                    "date_trunc('day', dt) >= current_date() and province='guangdong';", tableName);
+                            starRocksAssert.alterTable(dropPartitionSql);
+                            Assert.fail();
+                        } catch (Exception e) {
+                            Assert.assertTrue(e.getMessage().contains("Column is not a partition column which can not"));
+                        }
+                    }
+                    {
+                        try {
+
+                            String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                    "date_trunc('day', dt2) >= current_date();", tableName);
+                            starRocksAssert.alterTable(dropPartitionSql);
+                            Assert.fail();
+                        } catch (Exception e) {
+                            Assert.assertTrue(e.getMessage().contains("Column 'dt2' cannot be resolve"));
+                        }
+                    }
+
+                    {
+                        String dropPartitionSql = String.format("alter table %s DROP PARTITIONS WHERE " +
+                                "date_trunc('day', dt) = '2024-01-01';", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+                        Assert.assertEquals(2, olapTable.getVisiblePartitions().size());
+                    }
+                });
+    }
+
+    @Test
+    public void testDropPartitionsWithMultiValues1() {
+        starRocksAssert.withTable(T3, (obj) -> {
+            String tableName = (String) obj;
+            withTablePartitions(tableName);
+            OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+            Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE province = 'beijing';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            }
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS (p1);", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(3, olapTable.getVisiblePartitions().size());
+            }
+        });
+    }
+
+    @Test
+    public void testDropPartitionsWithMultiValues2() {
+        starRocksAssert.withTable(T5, (obj) -> {
+            String tableName = (String) obj;
+            withTablePartitionsV2(tableName);
+            OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+            Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE date_trunc('day', dt) <= date_sub(current_date(), 2) and " +
+                        "date_trunc('day', dt) != (date_trunc(\'month\', date_trunc('day', dt)) + interval 1 month - " +
+                        "interval 1 day)", tableName);
+                System.out.println(dropPartitionSql);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(1, olapTable.getVisiblePartitions().size());
+                Partition partition = olapTable.getVisiblePartitions().get(0);
+                // 2024-01-31
+                Assert.assertEquals("p3", partition.getName());
+            }
+        });
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprRangeTest.java
@@ -1,0 +1,282 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.pseudocluster.PseudoCluster;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.statistic.StatisticsMetaManager;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DropPartitionWithExprRangeTest {
+    private static final Logger LOG = LogManager.getLogger(DropPartitionWithExprRangeTest.class);
+    protected static ConnectContext connectContext;
+    protected static PseudoCluster cluster;
+    protected static StarRocksAssert starRocksAssert;
+    private static String R1;
+    private static String R2;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        // set default config for async mvs
+        UtFrameUtils.setDefaultConfigForAsyncMVTest(connectContext);
+        if (!starRocksAssert.databaseExist("_statistics_")) {
+            StatisticsMetaManager m = new StatisticsMetaManager();
+            m.createStatisticsTablesForTest();
+        }
+        starRocksAssert.withDatabase("test");
+        starRocksAssert.useDatabase("test");
+        // range partition table
+        R1 = "CREATE TABLE r1 \n" +
+                "(\n" +
+                "    dt date,\n" +
+                "    k2 int,\n" +
+                "    v1 int \n" +
+                ")\n" +
+                "PARTITION BY RANGE(dt)\n" +
+                "(\n" +
+                "    PARTITION p0 values [('2021-12-01'),('2022-01-01')),\n" +
+                "    PARTITION p1 values [('2022-01-01'),('2022-02-01')),\n" +
+                "    PARTITION p2 values [('2022-02-01'),('2022-03-01')),\n" +
+                "    PARTITION p3 values [('2022-03-01'),('2022-04-01'))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');";
+        R2 = "CREATE TABLE r2 \n" +
+                "(\n" +
+                "    dt date,\n" +
+                "    k2 int,\n" +
+                "    v1 int \n" +
+                ")\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');";
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+    }
+
+    @Before
+    public void before() {
+    }
+
+    @After
+    public void after() throws Exception {
+    }
+
+    public static void executeInsertSql(String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        StatementBase statement = SqlParser.parseSingleStatement(sql, connectContext.getSessionVariable().getSqlMode());
+        new StmtExecutor(connectContext, statement).execute();
+    }
+
+    private String toPartitionVal(String val) {
+        return val == null ? "NULL" : String.format("'%s'", val);
+    }
+
+    private void addRangePartition(String tbl, String pName, String pVal1, String pVal2) {
+        // mock the check to ensure test can run
+        new MockUp<ExpressionRangePartitionInfo>() {
+            @Mock
+            public boolean isAutomaticPartition() {
+                return false;
+            }
+        };
+        new MockUp<ExpressionRangePartitionInfoV2>() {
+            @Mock
+            public boolean isAutomaticPartition() {
+                return false;
+            }
+        };
+        try {
+            String addPartitionSql = String.format("ALTER TABLE %s ADD " +
+                    "PARTITION %s VALUES [(%s),(%s))", tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
+            System.out.println(addPartitionSql);
+            starRocksAssert.alterTable(addPartitionSql);
+        } catch (Exception e) {
+            e.printStackTrace();
+            LOG.error("Failed to add partition", e);
+        }
+    }
+
+    private void withTablePartitions(String tableName) {
+        addRangePartition(tableName, "p1", "2024-01-01", "2024-01-02");
+        addRangePartition(tableName, "p2", "2024-01-02", "2024-01-03");
+        addRangePartition(tableName, "p3", "2024-01-03", "2024-01-04");
+        addRangePartition(tableName, "p4", "2024-01-04", "2024-01-05");
+    }
+
+    private void withTablePartitionsV2(String tableName) {
+        addRangePartition(tableName, "p1", "2024-01-29", "2024-01-30");
+        addRangePartition(tableName, "p2", "2024-01-30", "2024-01-31");
+        addRangePartition(tableName, "p3", "2024-01-31", "2024-02-01");
+        addRangePartition(tableName, "p4", "2024-02-01", "2024-02-02");
+    }
+
+    @Test
+    public void testDropPartitionsWithRangeTable1() {
+        starRocksAssert.withTable(R1, (obj) -> {
+            String tableName = (String) obj;
+            OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+            Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt >= current_date();", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            }
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt >= '2022-03-01';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(3, olapTable.getVisiblePartitions().size());
+            }
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt > '2022-02-02';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(3, olapTable.getVisiblePartitions().size());
+            }
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt >= '2022-01-02';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(2, olapTable.getVisiblePartitions().size());
+            }
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt <= current_date();", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(0, olapTable.getVisiblePartitions().size());
+            }
+        });
+    }
+
+    @Test
+    public void testDropPartitionsWithRangeTable2() {
+        starRocksAssert.withTable(R2, (obj) -> {
+            String tableName = (String) obj;
+            withTablePartitions(tableName);
+            OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+            Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt >= current_date();", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            }
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt >= '2024-01-04';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(3, olapTable.getVisiblePartitions().size());
+            }
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt > '2024-01-04';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(3, olapTable.getVisiblePartitions().size());
+            }
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt >= '2024-01-03';", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(2, olapTable.getVisiblePartitions().size());
+            }
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt <= current_date();", tableName);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(0, olapTable.getVisiblePartitions().size());
+            }
+        });
+    }
+
+    @Test
+    public void testDropPartitionsWithRangeTable3() {
+        starRocksAssert.withTable(R2, (obj) -> {
+            String tableName = (String) obj;
+            withTablePartitionsV2(tableName);
+            OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+            Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE date_trunc('day', dt) <= date_sub(current_date(), 2) and " +
+                        "date_trunc('day', dt) != (date_trunc(\'month\', date_trunc('day', dt)) + interval 1 month - " +
+                        "interval 1 day)", tableName);
+                System.out.println(dropPartitionSql);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            }
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE date_trunc('day', dt) <= date_sub('2024-02-01', 2)", tableName);
+                System.out.println(dropPartitionSql);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(3, olapTable.getVisiblePartitions().size());
+            }
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt <= date_sub(current_date(), 2) and " +
+                        "dt != (date_trunc(\'month\', dt) + interval 1 month - interval 1 day)", tableName);
+                System.out.println(dropPartitionSql);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(3, olapTable.getVisiblePartitions().size());
+            }
+
+            {
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt <= date_sub(current_date(), 2) and " +
+                        "dt <= (date_trunc(\'month\', dt) + interval 1 month - interval 1 day)", tableName);
+                System.out.println(dropPartitionSql);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(3, olapTable.getVisiblePartitions().size());
+            }
+
+            {
+                // bingo!
+                String dropPartitionSql = String.format("alter table %s DROP PARTITIONS " +
+                        "WHERE dt <= date_sub(current_date(), 2) and dt >= '2024-01-01' and dt <= '2024-01-31' and " +
+                        "dt != '2024-01-31'", tableName);
+                System.out.println(dropPartitionSql);
+                starRocksAssert.alterTable(dropPartitionSql);
+                Assert.assertEquals(2, olapTable.getVisiblePartitions().size());
+            }
+        });
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -567,9 +567,9 @@ public class ShowExecutorTest {
         Assert.assertEquals(partitionKey2, "dt, province");
 
         String values1 = resultSet.getResultRows().get(0).get(7);
-        Assert.assertEquals(values1, "(('2022-04-15', 'guangdong'), ('2022-04-15', 'tianjin'))");
+        Assert.assertEquals(values1, "[[\"2022-04-15\",\"guangdong\"],[\"2022-04-15\",\"tianjin\"]]");
         String values2 = resultSet.getResultRows().get(1).get(7);
-        Assert.assertEquals(values2, "(('2022-04-16', 'shanghai'), ('2022-04-16', 'beijing'))");
+        Assert.assertEquals(values2, "[[\"2022-04-16\",\"shanghai\"],[\"2022-04-16\",\"beijing\"]]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
@@ -325,6 +325,9 @@ public class PartitionPruneRuleTest {
             {
                 olapTable.getPartitionInfo();
                 result = partitionInfo;
+                
+                partitionInfo.isListPartition();
+                result = true;
 
                 partitionInfo.getType();
                 result = PartitionType.LIST;
@@ -410,6 +413,9 @@ public class PartitionPruneRuleTest {
 
                 partitionInfo.getLiteralExprValues();
                 result = literalExprValues;
+
+                partitionInfo.isListPartition();
+                result = true;
 
                 olapTable.getPartitions();
                 result = Lists.newArrayList(part1, part2);

--- a/test/sql/test_drop_partition/R/test_drop_partition_list_table_with_where
+++ b/test/sql/test_drop_partition/R/test_drop_partition_list_table_with_where
@@ -1,0 +1,123 @@
+-- name: test_drop_partition_list_table_with_where
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+    dt varchar(20),
+    province string,
+    num int
+)
+PARTITION BY dt, province;
+-- result:
+-- !result
+INSERT INTO t1 VALUES 
+    ("2020-07-01", "beijing",  1), ("2020-07-01", "chengdu",  2),
+    ("2020-07-02", "beijing",  3), ("2020-07-02", "hangzhou", 4),
+    ("2020-07-03", "chengdu",  1), ("2020-07-04", "hangzhou", 1),
+    (NULL, NULL, 10);
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+7
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE province like '%chengdu%';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+5
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE str2date(dt, '%Y-%m-%d') = '2020-07-01' AND province = 'beijing';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+4
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE dt >= '2020-07-03';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+3
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE dt is null;
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+2
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE dt >= '2020-07-01';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+0
+-- !result
+drop table t1;
+-- result:
+-- !result
+create table t1(
+    k1 datetime, 
+    k2 datetime, 
+    v int
+) partition by date_trunc('day', k1), date_trunc('month', k2);
+-- result:
+-- !result
+insert into t1 values 
+  ('2020-01-01','2020-02-02', 1), ('2020-01-02','2020-02-02', 2), 
+  ('2020-01-03','2020-02-03', 3), ('2020-01-04','2020-02-02', 4), 
+  ('2020-01-05','2020-02-03', 5), ('2020-01-06','2020-02-03', 6),
+  (NULL, NULL, 10);
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+7
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('day', k1) = '2020-01-01';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+6
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('month', k2) = '2020-01-01';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+6
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('month', k2) = '2020-01-01' or date_trunc('day', k1) = '2020-01-02';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+5
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('month', k2) = '2020-02-01';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+1
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('day', k1) is null;
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+0
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_drop_partition/R/test_drop_partition_range_table_with_where
+++ b/test/sql/test_drop_partition/R/test_drop_partition_range_table_with_where
@@ -1,0 +1,135 @@
+-- name: test_drop_partition_range_table_with_where
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+    dt date,
+    province string,
+    v1 int 
+)
+PARTITION BY RANGE(dt)
+(
+    PARTITION p0 values [('2020-07-01'),('2020-07-02')),
+    PARTITION p1 values [('2020-07-02'),('2020-07-03')),
+    PARTITION p2 values [('2020-07-03'),('2020-07-04')),
+    PARTITION p3 values [('2020-07-04'),('2020-07-05'))
+)
+DISTRIBUTED BY HASH(dt) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO t1 VALUES 
+    ("2020-07-01", "beijing",  1), ("2020-07-01", "chengdu",  2),
+    ("2020-07-02", "beijing",  3), ("2020-07-02", "hangzhou", 4),
+    ("2020-07-03", "chengdu",  1), ("2020-07-04", "hangzhou", 1);
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+4
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE province like '%a%';
+-- result:
+[REGEX].*Column is not a partition column which can not be used in where clause for drop partition.*
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+4
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE str2date(dt, '%Y-%m-%d') = '2020-07-01';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+4
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE dt >= '2020-07-03';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+2
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE dt is null;
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+2
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE dt >= '2020-07-01';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+0
+-- !result
+drop table t1;
+-- result:
+-- !result
+CREATE TABLE t1
+(
+    k1 date,
+    k2 string,
+    v1 int 
+)
+PARTITION BY date_trunc('day', k1)
+DISTRIBUTED BY HASH(k2) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t1 values 
+  ('2020-01-01','2020-02-02', 1), ('2020-01-02','2020-02-02', 2), 
+  ('2020-01-03','2020-02-03', 3), ('2020-01-04','2020-02-02', 4), 
+  ('2020-01-05','2020-02-03', 5), ('2020-01-06','2020-02-03', 6),
+  (NULL, NULL, 10);
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+7
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE k1 >= '2020-01-01' and k1 <= '2020-01-02';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+6
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('month', k1) = '2020-02-01';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+6
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE k1 >= '2020-01-05';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+4
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE  k1 is null;
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+4
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE k1 <= current_date();
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+-- result:
+0
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_drop_partition/T/test_drop_partition_list_table_with_where
+++ b/test/sql/test_drop_partition/T/test_drop_partition_list_table_with_where
@@ -1,0 +1,58 @@
+-- name: test_drop_partition_list_table_with_where
+create database db_${uuid0};
+use db_${uuid0};
+
+-- test case for drop partition with where
+CREATE TABLE t1 (
+    dt varchar(20),
+    province string,
+    num int
+)
+PARTITION BY dt, province;
+
+INSERT INTO t1 VALUES 
+    ("2020-07-01", "beijing",  1), ("2020-07-01", "chengdu",  2),
+    ("2020-07-02", "beijing",  3), ("2020-07-02", "hangzhou", 4),
+    ("2020-07-03", "chengdu",  1), ("2020-07-04", "hangzhou", 1),
+    (NULL, NULL, 10);
+
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE province like '%chengdu%';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE str2date(dt, '%Y-%m-%d') = '2020-07-01' AND province = 'beijing';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE dt >= '2020-07-03';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE dt is null;
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE dt >= '2020-07-01';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+drop table t1;
+
+-- test table with multiple partition columns 
+create table t1(
+    k1 datetime, 
+    k2 datetime, 
+    v int
+) partition by date_trunc('day', k1), date_trunc('month', k2);
+
+insert into t1 values 
+  ('2020-01-01','2020-02-02', 1), ('2020-01-02','2020-02-02', 2), 
+  ('2020-01-03','2020-02-03', 3), ('2020-01-04','2020-02-02', 4), 
+  ('2020-01-05','2020-02-03', 5), ('2020-01-06','2020-02-03', 6),
+  (NULL, NULL, 10);
+
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('day', k1) = '2020-01-01';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('month', k2) = '2020-01-01';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('month', k2) = '2020-01-01' or date_trunc('day', k1) = '2020-01-02';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('month', k2) = '2020-02-01';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('day', k1) is null;
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+
+drop table t1;
+drop database db_${uuid0};

--- a/test/sql/test_drop_partition/T/test_drop_partition_range_table_with_where
+++ b/test/sql/test_drop_partition/T/test_drop_partition_range_table_with_where
@@ -1,0 +1,68 @@
+-- name: test_drop_partition_range_table_with_where
+create database db_${uuid0};
+use db_${uuid0};
+
+-- test case for drop partition with where
+CREATE TABLE t1 (
+    dt date,
+    province string,
+    v1 int 
+)
+PARTITION BY RANGE(dt)
+(
+    PARTITION p0 values [('2020-07-01'),('2020-07-02')),
+    PARTITION p1 values [('2020-07-02'),('2020-07-03')),
+    PARTITION p2 values [('2020-07-03'),('2020-07-04')),
+    PARTITION p3 values [('2020-07-04'),('2020-07-05'))
+)
+DISTRIBUTED BY HASH(dt) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO t1 VALUES 
+    ("2020-07-01", "beijing",  1), ("2020-07-01", "chengdu",  2),
+    ("2020-07-02", "beijing",  3), ("2020-07-02", "hangzhou", 4),
+    ("2020-07-03", "chengdu",  1), ("2020-07-04", "hangzhou", 1);
+
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE province like '%a%';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE str2date(dt, '%Y-%m-%d') = '2020-07-01';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE dt >= '2020-07-03';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE dt is null;
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE dt >= '2020-07-01';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+drop table t1;
+
+-- test table with multiple partition columns 
+CREATE TABLE t1
+(
+    k1 date,
+    k2 string,
+    v1 int 
+)
+PARTITION BY date_trunc('day', k1)
+DISTRIBUTED BY HASH(k2) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+insert into t1 values 
+  ('2020-01-01','2020-02-02', 1), ('2020-01-02','2020-02-02', 2), 
+  ('2020-01-03','2020-02-03', 3), ('2020-01-04','2020-02-02', 4), 
+  ('2020-01-05','2020-02-03', 5), ('2020-01-06','2020-02-03', 6),
+  (NULL, NULL, 10);
+
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE k1 >= '2020-01-01' and k1 <= '2020-01-02';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE date_trunc('month', k1) = '2020-02-01';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE k1 >= '2020-01-05';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE  k1 is null;
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+ALTER TABLE t1 DROP PARTITIONS WHERE k1 <= current_date();
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
+
+drop table t1;
+drop database db_${uuid0};

--- a/test/sql/test_list_partition/R/test_add_list_partition
+++ b/test/sql/test_list_partition/R/test_add_list_partition
@@ -1,4 +1,10 @@
 -- name: test_add_list_partition
+create database test_db_${uuid0};
+-- result:
+-- !result
+use test_db_${uuid0};
+-- result:
+-- !result
 CREATE TABLE t_p_error (
   calendar_day varchar(65533) NOT NULL COMMENT "",
   calendar_year varchar(65533) NOT NULL COMMENT "",
@@ -12,10 +18,10 @@ PROPERTIES ( "replication_num" = "1");
 insert into t_p_error values ('2022-01-01','2011','104979534377373696');
 -- result:
 -- !result
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 -- result:
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	()
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2011'))
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2011"]]
 -- !result
 insert into t_p_error 
 select calendar_day, cast(calendar_year as int) + 1, calendar_id from t_p_error;
@@ -26,11 +32,11 @@ insert into t_p_error values
     ('2022-01-01','2012','104979534377373696');
 -- result:
 -- !result
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 -- result:
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	()
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2011'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2012'))
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2011"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2012"]]
 -- !result
 ALTER TABLE t_p_error ADD PARTITION IF NOT EXISTS p2024 VALUES IN ('2024');
 -- result:
@@ -42,12 +48,12 @@ SELECT * FROM t_p_error WHERE calendar_year = '2024';
 -- result:
 2022-01-01	2024	abc
 -- !result
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 -- result:
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	()
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2011'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2012'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2024'))
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2011"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2012"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2024"]]
 -- !result
 ALTER TABLE t_p_error ADD PARTITION IF NOT EXISTS p2024 VALUES IN (('2030'));
 -- result:
@@ -59,13 +65,13 @@ SELECT * FROM t_p_error WHERE calendar_year = '2030';
 -- result:
 2022-01-01	2030	abc
 -- !result
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 -- result:
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	()
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2011'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2012'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2024'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2030'))
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2011"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2012"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2024"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2030"]]
 -- !result
 ALTER TABLE t_p_error ADD TEMPORARY PARTITION IF NOT EXISTS p2024_tmp VALUES IN ('2024');
 -- result:
@@ -77,25 +83,25 @@ SELECT * FROM t_p_error WHERE calendar_year = '2024';
 -- result:
 2022-01-01	2024	abc
 -- !result
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 -- result:
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	()
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2011'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2012'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2024'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2030'))
-1	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2024'))
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2011"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2012"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2024"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2030"]]
+1	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2024"]]
 -- !result
 ALTER TABLE t_p_error REPLACE PARTITION (p2024) WITH TEMPORARY PARTITION (p2024_tmp);
 -- result:
 -- !result
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 -- result:
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	()
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2011'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2012'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2030'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2024'))
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2011"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2012"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2030"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2024"]]
 -- !result
 SELECT * FROM t_p_error WHERE calendar_year = '2024';
 -- result:
@@ -104,16 +110,16 @@ SELECT * FROM t_p_error WHERE calendar_year = '2024';
 insert into t_p_error select calendar_day, cast(calendar_year as int) + 1, calendar_id from t_p_error;
 -- result:
 -- !result
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND  table_name = 't_p_error' ORDER BY PARTITION_ID;
 -- result:
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	()
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2011'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2012'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2030'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2024'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2025'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2031'))
-0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	(('2013'))
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2011"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2012"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2030"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2024"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2025"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2013"]]
+0	`calendar_year` varchar(65533) NOT NULL COMMENT ""	[["2031"]]
 -- !result
 SELECT * FROM t_p_error WHERE calendar_year = '2024';
 -- result:
@@ -130,4 +136,7 @@ SELECT * FROM t_p_error WHERE calendar_year = '2011';
 -- result:
 2022-01-01	2011	104979534377373696
 2022-01-01	2011	104979534377373696
+-- !result
+DROP database test_db_${uuid0} FORCE;
+-- result:
 -- !result

--- a/test/sql/test_list_partition/T/test_add_list_partition
+++ b/test/sql/test_list_partition/T/test_add_list_partition
@@ -1,5 +1,6 @@
 -- name: test_add_list_partition
-
+create database test_db_${uuid0};
+use test_db_${uuid0};
 
 CREATE TABLE t_p_error (
   calendar_day varchar(65533) NOT NULL COMMENT "",
@@ -13,7 +14,7 @@ PROPERTIES ( "replication_num" = "1");
 
 -- INSERT VALUES auto add partitions
 insert into t_p_error values ('2022-01-01','2011','104979534377373696');
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 
 -- INSERT-SELECT 
 insert into t_p_error 
@@ -22,34 +23,35 @@ select calendar_day, cast(calendar_year as int) + 1, calendar_id from t_p_error;
 insert into t_p_error values 
     ('2022-01-01','2011','104979534377373696'),
     ('2022-01-01','2012','104979534377373696');
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 
 -- add partition
 ALTER TABLE t_p_error ADD PARTITION IF NOT EXISTS p2024 VALUES IN ('2024');
 insert into t_p_error values ('2022-01-01','2024','abc');
 SELECT * FROM t_p_error WHERE calendar_year = '2024';
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 
 -- add partition like multi-column format
 ALTER TABLE t_p_error ADD PARTITION IF NOT EXISTS p2024 VALUES IN (('2030'));
 insert into t_p_error values ('2022-01-01','2030','abc');
 SELECT * FROM t_p_error WHERE calendar_year = '2030';
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 
 -- add temp partition
 ALTER TABLE t_p_error ADD TEMPORARY PARTITION IF NOT EXISTS p2024_tmp VALUES IN ('2024');
 insert into t_p_error TEMPORARY PARTITION(p2024_tmp) values ('2022-01-01','2024','xyz');
 SELECT * FROM t_p_error WHERE calendar_year = '2024';
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 
 -- replace temp partition
 ALTER TABLE t_p_error REPLACE PARTITION (p2024) WITH TEMPORARY PARTITION (p2024_tmp);
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't_p_error' ORDER BY PARTITION_ID;
 SELECT * FROM t_p_error WHERE calendar_year = '2024';
 
 -- INSERT-SELECT again
 insert into t_p_error select calendar_day, cast(calendar_year as int) + 1, calendar_id from t_p_error;
-SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE table_name = 't_p_error' ORDER BY PARTITION_ID;
+SELECT IS_TEMP, PARTITION_KEY, PARTITION_VALUE FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND  table_name = 't_p_error' ORDER BY PARTITION_ID;
 SELECT * FROM t_p_error WHERE calendar_year = '2024';
 SELECT * FROM t_p_error WHERE calendar_year = '2012';
 SELECT * FROM t_p_error WHERE calendar_year = '2011';
+DROP database test_db_${uuid0} FORCE;


### PR DESCRIPTION
## Why I'm doing:
If the partition method of a Native Table is List Partition, it currently does not support Partition TTL, which means partitions can only be deleted manually and cannot be automatically managed; https://github.com/StarRocks/starrocks/pull/43539 has already supported batch deletion of partitions, which can improve ease of use to some extent, but there are still many inconvenient aspects.


## What I'm doing:
- Support for `ALTER TABLE xxx DROP PARTITION WHERE xxxx ` common partition expression;
  -  List partition tables: 
    -- iterate all partition values to check whether it's valid by evaluating each partition's value using FE's constant evaluation ability.
    --  if it cannot be evaluated, query `partitions_meta` to evaluate it in be.
  - Range Partition tables: reuse FE's partition pruning ability to prune range partitions.


NOTE: `partition_value` of `information_schema.partition_metas` will be changed to `json` format if the olap table is list partitioned to be further queried:
```
select partition_value from information_schema.partition_metas;
```
Fixes https://github.com/StarRocks/starrocks/issues/53117

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0