### PR TITLE
[Enhancement] Kudu scanner should be allowed to do non-share scan.

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -159,7 +159,7 @@ public:
 
     virtual const TupleDescriptor* tuple_descriptor(RuntimeState* state) const = 0;
 
-    virtual bool always_shared_scan() const { return true; }
+    virtual bool always_shared_scan(TScanRangeParams* scan_range) const { return true; }
 
     virtual void peek_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {}
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -49,6 +49,11 @@ DataSourcePtr HiveDataSourceProvider::create_data_source(const TScanRange& scan_
     return std::make_unique<HiveDataSource>(this, scan_range);
 }
 
+bool HiveDataSourceProvider::always_shared_scan(TScanRangeParams* scan_range) const {
+    return scan_range && !(scan_range->scan_range.hdfs_scan_range.__isset.use_kudu_jni_reader &&
+                           scan_range->scan_range.hdfs_scan_range.use_kudu_jni_reader);
+}
+
 const TupleDescriptor* HiveDataSourceProvider::tuple_descriptor(RuntimeState* state) const {
     return state->desc_tbl().get_tuple_descriptor(_hdfs_scan_node.tuple_id);
 }

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -44,6 +44,7 @@ public:
     HiveDataSourceProvider(ConnectorScanNode* scan_node, const TPlanNode& plan_node);
     DataSourcePtr create_data_source(const TScanRange& scan_range) override;
     const TupleDescriptor* tuple_descriptor(RuntimeState* state) const override;
+    bool always_shared_scan(TScanRangeParams* scan_range) const override;
 
     void peek_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
     void default_data_source_mem_bytes(int64_t* min_value, int64_t* max_value) override;

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -199,7 +199,7 @@ public:
     const TupleDescriptor* tuple_descriptor(RuntimeState* state) const override;
 
     // always enable shared scan for cloud native table
-    bool always_shared_scan() const override { return true; }
+    bool always_shared_scan(TScanRangeParams* scan_range) const override { return true; }
 
     StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
             const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -680,7 +680,11 @@ void ConnectorScanNode::_init_counter() {
 }
 
 bool ConnectorScanNode::always_shared_scan() const {
-    return _data_source_provider->always_shared_scan();
+    TScanRangeParams scan_range;
+    if (_connector_type == connector::HIVE && _scan_ranges.size() > 0) {
+        scan_range = _scan_ranges[0];
+    }
+    return _data_source_provider->always_shared_scan(&scan_range);
 }
 
 StatusOr<pipeline::MorselQueuePtr> ConnectorScanNode::convert_scan_range_to_morsel_queue(

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -163,7 +163,8 @@ TEST_F(LakeDataSourceTest, test_convert_scan_range_to_morsel_queue) {
     auto data_source_provider = dynamic_cast<connector::LakeDataSourceProvider*>(scan_node->data_source_provider());
     data_source_provider->set_lake_tablet_manager(_tablet_mgr.get());
 
-    ASSERT_TRUE(data_source_provider->always_shared_scan());
+    TScanRangeParams scan_range;
+    ASSERT_TRUE(data_source_provider->always_shared_scan(&scan_range));
 
     config::tablet_internal_parallel_max_splitted_scan_bytes = 32;
     config::tablet_internal_parallel_min_splitted_scan_rows = 4;


### PR DESCRIPTION
## Why I'm doing:
For now, all scanners generated by HiveDataSource are not allowed to do non-share scan. It makes sense for file scans since the size of each file might diff a lot. But the sizes of the tablets in kudu are basically the same, so we should try to assign morsel uniformly among operators to avoid data skew (showed below).

Kudu scan:
![image](https://github.com/user-attachments/assets/b52514b7-5dff-4a35-af44-5382729a793c)

the following project:
![image](https://github.com/user-attachments/assets/d87b7d70-a02f-4b0f-a61e-eb547e8aafa9)

## What I'm doing:
Allow non-share scan in kudu connector.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0