### PR TITLE
[Enhancement] Support only deleting shard meta from fe for shared-data cluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.staros.proto.ShardGroupInfo;
+import com.staros.proto.ShardInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -43,6 +44,7 @@ import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.warehouse.Warehouse;
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -123,7 +125,6 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             DeleteTabletRequest request = new DeleteTabletRequest();
             request.tabletIds = Lists.newArrayList(shards);
 
-            boolean forceDelete = Config.meta_sync_force_delete_shard_meta;
             try {
                 LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
                 DeleteTabletResponse response = lakeService.deleteTablet(request).get();
@@ -132,7 +133,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                     LOG.info("Fail to delete tablet. StatusCode: {}, failedTablets: {}", stCode, response.failedTablets);
 
                     // ignore INVALID_ARGUMENT error, treat it as success
-                    if (stCode != TStatusCode.INVALID_ARGUMENT && !forceDelete) {
+                    if (stCode != TStatusCode.INVALID_ARGUMENT) {
                         response.failedTablets.forEach(shards::remove);
                     }
                 }
@@ -140,9 +141,6 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                 LOG.error(e.getMessage(), e);
                 if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
-                }
-                if (!forceDelete) {
-                    continue;
                 }
             }
 
@@ -153,7 +151,6 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                 }
             } catch (DdlException e) {
                 LOG.warn("failed to delete shard from starMgr");
-                continue;
             }
         }
     }
@@ -198,22 +195,59 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         List<Long> emptyShardGroup = new ArrayList<>();
         for (long groupId : diffList) {
             if (Config.shard_group_clean_threshold_sec * 1000L + Long.parseLong(groupToCreateTimeMap.get(groupId)) < nowMs) {
-                try {
-                    List<Long> shardIds = starOSAgent.listShard(groupId);
-                    if (shardIds.isEmpty()) {
-                        emptyShardGroup.add(groupId);
-                    } else {
-                        dropTabletAndDeleteShard(shardIds, starOSAgent);
-                    }
-                } catch (Exception e) {
-                    continue;
-                }
+                cleanOneGroup(groupId, starOSAgent, emptyShardGroup);
             }
         }
 
         LOG.debug("emptyShardGroup.size is {}", emptyShardGroup.size());
         if (!emptyShardGroup.isEmpty()) {
             starOSAgent.deleteShardGroup(emptyShardGroup);
+        }
+    }
+
+    private void cleanOneGroup(long groupId, StarOSAgent starOSAgent, List<Long> emptyShardGroup) {
+        try {
+            List<Long> shardIds = starOSAgent.listShard(groupId);
+            if (shardIds.isEmpty()) {
+                emptyShardGroup.add(groupId);
+                return;
+            }
+            // delete shard from star manager only, not considering tablet data on be/cn
+            if (Config.meta_sync_force_delete_shard_meta) {
+                forceDeleteShards(groupId, starOSAgent, shardIds);
+            } else {
+                // drop meta and data
+                long start = System.currentTimeMillis();
+                dropTabletAndDeleteShard(shardIds, starOSAgent);
+                LOG.debug("delete shards from starMgr and FE, shard group: {}, cost: {} ms",
+                        groupId, (System.currentTimeMillis() - start));
+            }
+        } catch (Exception e) {
+            LOG.warn("delete shards from starMgr and FE failed, shard group: {}, {}", groupId, e.getMessage());
+        }
+    }
+
+    private static void forceDeleteShards(long groupId, StarOSAgent starOSAgent, List<Long> shardIds)
+            throws DdlException {
+        LOG.debug("delete shards from starMgr only, shard group: {}", groupId);
+        // before deleting shardIds, let's record the root directory of this shard group first
+        // root directory has the format like `s3://bucket/xx/db15570/15648/15944`
+        String rootDirectory = null;
+        long shardId = shardIds.get(0);
+        try {
+            // all shards have the same root directory
+            ShardInfo shardInfo = starOSAgent.getShardInfo(shardId, StarOSAgent.DEFAULT_WORKER_GROUP_ID);
+            if (shardInfo != null) {
+                rootDirectory = shardInfo.getFilePath().getFullPath();
+            }
+        } catch (Exception e) {
+            LOG.warn("failed to get shard root directory from starMgr, shard id: {}, group id: {}, {}", shardId,
+                    groupId, e.getMessage());
+        }
+        starOSAgent.deleteShards(new HashSet<>(shardIds));
+        if (StringUtils.isNotEmpty(rootDirectory)) {
+            LOG.info("shard group {} deleted from starMgr only, you may need to delete remote file path manually," +
+                    " file path is: {}", groupId, rootDirectory);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -17,7 +17,13 @@ package com.starrocks.lake;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.staros.client.StarClientException;
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
 import com.staros.proto.ShardGroupInfo;
+import com.staros.proto.ShardInfo;
+import com.staros.proto.StatusCode;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.ColocateTableIndex.GroupId;
 import com.starrocks.catalog.Column;
@@ -485,7 +491,7 @@ public class StarMgrMetaSyncerTest {
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
         for (long groupId : allShardGroupId) {
             ShardGroupInfo info = ShardGroupInfo.newBuilder()
-                    .setGroupId(groupIdToClear)
+                    .setGroupId(groupId)
                     .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
                     .addAllShardIds(allShardIds)
                     .build();
@@ -558,29 +564,210 @@ public class StarMgrMetaSyncerTest {
     }
 
     @Test
-    public void testForceDelete() {
+    public void testDeleteShardAndShardGroupWithForceAndGetShardException() {
+        boolean oldValue = Config.meta_sync_force_delete_shard_meta;
         Config.meta_sync_force_delete_shard_meta = true;
         Config.shard_group_clean_threshold_sec = 0;
         long groupIdToClear = shardGroupId + 1;
-        List<Long> allShardGroupId = Lists.newArrayList(groupIdToClear);
+        // build shardGroupInfos
+        List<Long> allShardIds = Stream.of(1000L, 1001L, 1002L, 1003L).collect(Collectors.toList());
+        List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
+        ShardGroupInfo info = ShardGroupInfo.newBuilder()
+                .setGroupId(groupIdToClear)
+                .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
+                .addAllShardIds(allShardIds)
+                .build();
+        shardGroupInfos.add(info);
+
+        // case get shard info failed, should also delete shards
+        {
+            new MockUp<StarOSAgent>() {
+                @Mock
+                public List<ShardGroupInfo> listShardGroup() {
+                    return shardGroupInfos;
+                }
+
+                @Mock
+                public List<Long> listShard(long groupId) {
+                    return allShardIds;
+                }
+
+                @Mock
+                public void deleteShards(Set<Long> shardIds) {
+                    allShardIds.removeAll(shardIds);
+                }
+
+                @Mock
+                public ShardInfo getShardInfo(long shardId, long workerGroupId) throws StarClientException {
+                    throw new StarClientException(StatusCode.INTERNAL, "failed to get shard info");
+                }
+            };
+
+            Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
+            Assert.assertEquals(0, allShardIds.size());
+        }
+    }
+
+    @Test
+    public void testDeleteShardAndShardGroupWithForceAndDeleteException() {
+        boolean oldValue = Config.meta_sync_force_delete_shard_meta;
+        Config.meta_sync_force_delete_shard_meta = true;
+        Config.shard_group_clean_threshold_sec = 0;
+        long groupIdToClear = shardGroupId + 1;
+        // build shardGroupInfos
+        List<Long> allShardIds = Stream.of(1000L, 1001L, 1002L, 1003L).collect(Collectors.toList());
+        List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
+        ShardGroupInfo info = ShardGroupInfo.newBuilder()
+                .setGroupId(groupIdToClear)
+                .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
+                .addAllShardIds(allShardIds)
+                .build();
+        shardGroupInfos.add(info);
+        // case: delete shards failed, should also delete shards
+        {
+            new MockUp<StarOSAgent>() {
+                @Mock
+                public List<ShardGroupInfo> listShardGroup() {
+                    return shardGroupInfos;
+                }
+
+                @Mock
+                public List<Long> listShard(long groupId) {
+                    return allShardIds;
+                }
+
+                @Mock
+                public void deleteShards(Set<Long> shardIds) throws DdlException {
+                    throw new DdlException("delete shard failed..");
+                }
+
+                @Mock
+                public ShardInfo getShardInfo(long shardId, long workerGroupId) throws StarClientException {
+                    ShardInfo.Builder builder = ShardInfo.newBuilder();
+                    builder.setShardId(1000L);
+
+                    FilePathInfo.Builder filePathBuilder = FilePathInfo.newBuilder();
+                    FileStoreInfo.Builder fsBuilder = filePathBuilder.getFsInfoBuilder();
+
+                    S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+                    s3FsBuilder.setBucket("test-bucket");
+                    s3FsBuilder.setRegion("test-region");
+
+                    fsBuilder.setFsType(FileStoreType.S3);
+                    fsBuilder.setFsKey("test-bucket");
+                    fsBuilder.setS3FsInfo(s3FsBuilder.build());
+                    FileStoreInfo fsInfo = fsBuilder.build();
+
+                    filePathBuilder.setFsInfo(fsInfo);
+                    filePathBuilder.setFullPath("s3://test-bucket/1/");
+
+                    builder.setFilePath(filePathBuilder);
+                    return builder.build();
+                }
+            };
+
+            Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
+            Assert.assertEquals(4, allShardIds.size());
+        }
+        Config.meta_sync_force_delete_shard_meta = oldValue;
+    }
+
+    @Test
+    public void testDeleteShardAndShardGroupWithForce() {
+        boolean oldValue = Config.meta_sync_force_delete_shard_meta;
+        Config.meta_sync_force_delete_shard_meta = true;
+        Config.shard_group_clean_threshold_sec = 0;
+        long groupIdToClear = shardGroupId + 1;
+        // build shardGroupInfos
+        List<Long> allShardIds = Stream.of(1000L, 1001L, 1002L, 1003L).collect(Collectors.toList());
+        List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
+        ShardGroupInfo info = ShardGroupInfo.newBuilder()
+                .setGroupId(groupIdToClear)
+                .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
+                .addAllShardIds(allShardIds)
+                .build();
+        shardGroupInfos.add(info);
+        // iterate 1: delete all shards
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardGroupInfo> listShardGroup() {
+                return shardGroupInfos;
+            }
+
+            @Mock
+            public List<Long> listShard(long groupId) {
+                return allShardIds;
+            }
+
+            @Mock
+            public void deleteShards(Set<Long> shardIds) {
+                allShardIds.removeAll(shardIds);
+            }
+
+            @Mock
+            public ShardInfo getShardInfo(long shardId, long workerGroupId) throws StarClientException {
+                ShardInfo.Builder builder = ShardInfo.newBuilder();
+                builder.setShardId(1000L);
+
+                FilePathInfo.Builder filePathBuilder = FilePathInfo.newBuilder();
+                FileStoreInfo.Builder fsBuilder = filePathBuilder.getFsInfoBuilder();
+
+                S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+                s3FsBuilder.setBucket("test-bucket");
+                s3FsBuilder.setRegion("test-region");
+
+                fsBuilder.setFsType(FileStoreType.S3);
+                fsBuilder.setFsKey("test-bucket");
+                fsBuilder.setS3FsInfo(s3FsBuilder.build());
+                FileStoreInfo fsInfo = fsBuilder.build();
+
+                filePathBuilder.setFsInfo(fsInfo);
+                filePathBuilder.setFullPath("s3://test-bucket/1/");
+
+                builder.setFilePath(filePathBuilder);
+                return builder.build();
+            }
+        };
+
+        Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
+        Assert.assertEquals(0, allShardIds.size());
+
+
+        // iterate 2: delete empty group (shards has been deleted by iterate 1)
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void deleteShardGroup(List<Long> groupIds) throws StarClientException {
+                for (long groupId : groupIds) {
+                    shardGroupInfos.removeIf(item -> item.getGroupId() == groupId);
+                }
+            }
+        };
+        Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
+        Assert.assertEquals(0, shardGroupInfos.size());
+
+        Config.meta_sync_force_delete_shard_meta = oldValue;
+    }
+
+    @Test
+    public void testDeleteShardAndShardGroupWithoutForce() {
+        boolean oldValue = Config.meta_sync_force_delete_shard_meta;
+        Config.meta_sync_force_delete_shard_meta = false;
+        Config.shard_group_clean_threshold_sec = 0;
+        long groupIdToClear = shardGroupId + 1;
         // build shardGroupInfos
         List<Long> allShardIds = Stream.of(1000L, 1001L, 1002L, 1003L).collect(Collectors.toList());
         int numOfShards = allShardIds.size();
         List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
-        for (long groupId : allShardGroupId) {
-            ShardGroupInfo info = ShardGroupInfo.newBuilder()
-                    .setGroupId(groupIdToClear)
-                    .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
-                    .addAllShardIds(allShardIds)
-                    .build();
-            shardGroupInfos.add(info);
-        }
+        ShardGroupInfo info = ShardGroupInfo.newBuilder()
+                .setGroupId(groupIdToClear)
+                .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
+                .addAllShardIds(allShardIds)
+                .build();
+        shardGroupInfos.add(info);
 
         new MockUp<StarOSAgent>() {
             @Mock
-            public void deleteShardGroup(List<Long> groupIds) throws
-                    StarClientException {
-                allShardGroupId.removeAll(groupIds);
+            public void deleteShardGroup(List<Long> groupIds) {
                 for (long groupId : groupIds) {
                     shardGroupInfos.removeIf(item -> item.getGroupId() == groupId);
                 }
@@ -591,7 +778,7 @@ public class StarMgrMetaSyncerTest {
             }
 
             @Mock
-            public List<Long> listShard(long groupId) throws DdlException {
+            public List<Long> listShard(long groupId) {
                 if (groupId == groupIdToClear) {
                     return allShardIds;
                 } else {
@@ -600,7 +787,7 @@ public class StarMgrMetaSyncerTest {
             }
 
             @Mock
-            public void deleteShards(Set<Long> shardIds) throws DdlException {
+            public void deleteShards(Set<Long> shardIds) {
                 allShardIds.removeAll(shardIds);
             }
         };
@@ -614,19 +801,19 @@ public class StarMgrMetaSyncerTest {
 
         new MockUp<PseudoBackend.PseudoLakeService>() {
             @Mock
-            Future<DeleteTabletResponse> deleteTablet(DeleteTabletRequest request) throws Exception {
-                throw new Exception("testForceDelete");
+            Future<DeleteTabletResponse> deleteTablet(DeleteTabletRequest request) {
+                DeleteTabletResponse resp = new DeleteTabletResponse();
+                resp.status = new StatusPB();
+                resp.status.statusCode = TStatusCode.INTERNAL_ERROR.getValue();
+                resp.failedTablets = new ArrayList<>(request.tabletIds);
+                return CompletableFuture.completedFuture(resp);
             }
         };
-        Config.meta_sync_force_delete_shard_meta = false;
         Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
+        // No shards deleted
         Assert.assertEquals(numOfShards, allShardIds.size());
 
-        Config.meta_sync_force_delete_shard_meta = true;
-        Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
-        Assert.assertEquals(0, allShardIds.size());
-
-        Config.meta_sync_force_delete_shard_meta = false;
+        Config.meta_sync_force_delete_shard_meta = oldValue;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -606,6 +606,7 @@ public class StarMgrMetaSyncerTest {
             Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
             Assert.assertEquals(0, allShardIds.size());
         }
+        Config.meta_sync_force_delete_shard_meta = oldValue;
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Add an option to delete staros meta from FE quickly

## What I'm doing:

Fixes #53554 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0