### PR TITLE
[BugFix] fix compression context pool slow down after long running

### DIFF
--- a/be/src/util/compression/compression_context_pool.h
+++ b/be/src/util/compression/compression_context_pool.h
@@ -114,7 +114,7 @@ public:
 
 private:
     void add(InternalRef ptr) {
-        // Use explicit producer token to avoid the overhead of too many sub-ququeues
+        // Use explicit producer token to avoid the overhead of too many sub-queues
         static thread_local std::unique_ptr<::moodycamel::ProducerToken> producer_token;
         if (producer_token == nullptr) {
             producer_token = std::make_unique<::moodycamel::ProducerToken>(_ctx_resources);

--- a/be/src/util/compression/compression_context_pool.h
+++ b/be/src/util/compression/compression_context_pool.h
@@ -115,10 +115,7 @@ public:
 private:
     void add(InternalRef ptr) {
         // Use explicit producer token to avoid the overhead of too many sub-queues
-        static thread_local std::unique_ptr<::moodycamel::ProducerToken> producer_token;
-        if (producer_token == nullptr) {
-            producer_token = std::make_unique<::moodycamel::ProducerToken>(_ctx_resources);
-        }
+        static thread_local ::moodycamel::ProducerToken producer_token(_ctx_resources);
         DCHECK(ptr);
         Status status = _resetter(ptr.get());
         // if reset fail, then delete this context
@@ -126,7 +123,7 @@ private:
             return;
         }
 
-        _ctx_resources.enqueue(*producer_token, std::move(ptr));
+        _ctx_resources.enqueue(producer_token, std::move(ptr));
     }
 
     Creator _creator;

--- a/be/src/util/compression/compression_context_pool.h
+++ b/be/src/util/compression/compression_context_pool.h
@@ -115,7 +115,7 @@ public:
 private:
     void add(InternalRef ptr) {
         // Use explicit producer token to avoid the overhead of too many sub-ququeues
-        static __thread std::unique_ptr<::moodycamel::ProducerToken> producer_token;
+        static thread_local std::unique_ptr<::moodycamel::ProducerToken> producer_token;
         if (producer_token == nullptr) {
             producer_token = std::make_unique<::moodycamel::ProducerToken>(_ctx_resources);
         }

--- a/be/src/util/compression/compression_context_pool.h
+++ b/be/src/util/compression/compression_context_pool.h
@@ -114,6 +114,11 @@ public:
 
 private:
     void add(InternalRef ptr) {
+        // Use explicit producer token to avoid the overhead of too many sub-ququeues
+        static __thread std::unique_ptr<::moodycamel::ProducerToken> producer_token;
+        if (producer_token == nullptr) {
+            producer_token = std::make_unique<::moodycamel::ProducerToken>(_ctx_resources);
+        }
         DCHECK(ptr);
         Status status = _resetter(ptr.get());
         // if reset fail, then delete this context
@@ -121,7 +126,7 @@ private:
             return;
         }
 
-        _ctx_resources.enqueue(std::move(ptr));
+        _ctx_resources.enqueue(*producer_token, std::move(ptr));
     }
 
     Creator _creator;

--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -40,6 +40,7 @@
 #include <thread>
 
 #include "gen_cpp/segment.pb.h"
+#include "util/compression/compression_context_pool_singletons.h"
 #include "util/faststring.h"
 #include "util/random.h"
 #include "util/raw_container.h"
@@ -384,6 +385,22 @@ TEST_F(BlockCompressionTest, LZ4F_compression_LARGE_PAGE_TEST) {
     Slice compressed_slice;
     st = codec->compress(orig_slices, &compressed_slice, true, total_size, nullptr, &compressed);
     ASSERT_TRUE(st.ok());
+}
+
+TEST_F(BlockCompressionTest, test_multi_thread_get_ctx) {
+    for (int j = 0; j < 10; j++) {
+        std::vector<std::thread> workers;
+        for (int cnt = 0; cnt < 30; cnt++) {
+            workers.emplace_back([]() {
+                for (uint64_t i = 1; i < 1000; i++) {
+                    StatusOr<compression::LZ4F_CCtx_Pool::Ref> ref = compression::getLZ4F_CCtx();
+                }
+            });
+        }
+        for (auto& worker : workers) {
+            worker.join();
+        }
+    }
 }
 
 //#define LZ4_BENCHMARK


### PR DESCRIPTION
## Why I'm doing:
In current implementation, we use `moodycamel::concurrentqueue` to reuse compression context, each time we start compress one block, we will try to dequeue ctx from pool, and then return ctx to pool after compression finish.

And now we use implicit enqueue method, which causes an automatically-allocated thread-local producer sub-queue to be allocated, and it won't destroy after thread finish:
```
void add(InternalRef ptr) {
        DCHECK(ptr);
        Status status = _resetter(ptr.get());
        // if reset fail, then delete this context
        if (!status.ok()) {
            return;
        }

        _ctx_resources.enqueue(std::move(ptr));
    }
```

So after long running, sub-queue will keep growing without bound and slow down consumer.

And in doc (https://github.com/cameron314/concurrentqueue?tab=readme-ov-file#basic-use), author recommend to use explicit producer tokens instead. 

## What I'm doing:
Use explicit producer tokens to avoid the overhead of too many sub-ququeues.

This pull request introduces improvements to the compression context pool and adds new tests to ensure the robustness of the multi-threaded context retrieval. The most important changes include the addition of a producer token to optimize the context pool and the introduction of a new multi-threaded test.

Improvements to compression context pool:

* [`be/src/util/compression/compression_context_pool.h`](diffhunk://#diff-56c505a302cfb4718b88f784d710905a228235d6bc5a19062e3cbbcd1152267cR117-R129): Added a thread-local `ProducerToken` to the `add` method to reduce the overhead of multiple sub-queues when enqueuing contexts.

Enhancements to testing:

* [`be/test/util/block_compression_test.cpp`](diffhunk://#diff-efbf78979f0c1ad210cd4bb88ebb3fecd6672af8f64506c0841bc382a0581df4R43): Included the `compression_context_pool_singletons.h` header to support new tests.
* [`be/test/util/block_compression_test.cpp`](diffhunk://#diff-efbf78979f0c1ad210cd4bb88ebb3fecd6672af8f64506c0841bc382a0581df4R390-R405): Added a new test `test_multi_thread_get_ctx` to verify the behavior of multi-threaded context retrieval from the LZ4F context pool.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0