### PR TITLE
[BugFix] Fix compaction task cannot be disabled while in the execution queue

### DIFF
--- a/be/src/storage/compaction_candidate.h
+++ b/be/src/storage/compaction_candidate.h
@@ -28,7 +28,6 @@ struct CompactionCandidate {
     TabletSharedPtr tablet;
     CompactionType type;
     double score = 0;
-    bool force_cumulative = false;
 
     CompactionCandidate() : tablet(nullptr), type(INVALID_COMPACTION) {}
 
@@ -41,14 +40,12 @@ struct CompactionCandidate {
         tablet = other.tablet;
         type = other.type;
         score = other.score;
-        force_cumulative = other.force_cumulative;
     }
 
     CompactionCandidate& operator=(const CompactionCandidate& rhs) {
         tablet = rhs.tablet;
         type = rhs.type;
         score = rhs.score;
-        force_cumulative = rhs.force_cumulative;
         return *this;
     }
 
@@ -56,14 +53,12 @@ struct CompactionCandidate {
         tablet = std::move(other.tablet);
         type = other.type;
         score = other.score;
-        force_cumulative = other.force_cumulative;
     }
 
     CompactionCandidate& operator=(CompactionCandidate&& rhs) {
         tablet = std::move(rhs.tablet);
         type = rhs.type;
         score = rhs.score;
-        force_cumulative = rhs.force_cumulative;
         return *this;
     }
 
@@ -75,7 +70,6 @@ struct CompactionCandidate {
             ss << "nullptr tablet";
         }
         ss << ", type:" << starrocks::to_string(type);
-        ss << ", force_cumulative:" << force_cumulative;
         ss << ", score:" << score;
         return ss.str();
     }

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -55,6 +55,8 @@ public:
 
     bool pick_candidate(CompactionCandidate* candidate);
 
+    void submit_compaction_task(const CompactionCandidate& compaction_candidate);
+
     void update_tablet_async(const TabletSharedPtr& tablet);
 
     void update_tablet(const TabletSharedPtr& tablet);
@@ -131,6 +133,8 @@ public:
 
     void stop_compaction(const TabletSharedPtr& tablet);
 
+    bool check_compaction_disabled(const CompactionCandidate& candidate);
+
     std::unordered_set<CompactionTask*> get_running_task(const TabletSharedPtr& tablet);
 
     int get_waiting_task_num();
@@ -146,8 +150,8 @@ private:
     CompactionManager& operator=(CompactionManager&& compaction_manager) = delete;
 
     void _dispatch_worker();
-    bool _check_compaction_disabled(const CompactionCandidate& candidate);
     bool _check_precondition(const CompactionCandidate& candidate);
+    bool _check_compaction_disabled(const CompactionCandidate& candidate);
     void _set_force_cumulative(CompactionCandidate* candidate);
     void _schedule();
     void _notify();

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -137,7 +137,11 @@ public:
     }
     ~CompactionTask() override;
 
+#ifdef BE_TEST
+    virtual void run();
+#else
     void run() override;
+#endif
 
     bool should_stop() const override;
 

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -274,7 +274,11 @@ public:
 
     void set_compaction_context(std::unique_ptr<CompactionContext>& context);
 
+#ifdef BE_TEST
+    virtual std::shared_ptr<CompactionTask> create_compaction_task();
+#else
     std::shared_ptr<CompactionTask> create_compaction_task();
+#endif
 
     bool has_compaction_task();
 


### PR DESCRIPTION
## Why I'm doing:

where the compaction task cannot be disabled while in the execution queue.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0