### PR TITLE
[Enhancement] improve sql digest for massive compound predicates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -40,6 +40,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarType;
@@ -82,6 +83,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Queue;
 import java.util.stream.Collectors;
 
 /**
@@ -439,63 +441,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
             throw new IllegalStateException(e);
         }
     }
-
-    /**
-     * Gather conjuncts from this expr and return them in a list.
-     * A conjunct is an expr that returns a boolean, e.g., Predicates, function calls,
-     * SlotRefs, etc. Hence, this method is placed here and not in Predicate.
-     */
-    public static List<Expr> extractConjuncts(Expr root) {
-        List<Expr> conjuncts = Lists.newArrayList();
-        if (null == root) {
-            return conjuncts;
-        }
-
-        extractConjunctsImpl(root, conjuncts);
-        return conjuncts;
-    }
-
-    private static void extractConjunctsImpl(Expr root, List<Expr> conjuncts) {
-        if (!(root instanceof CompoundPredicate)) {
-            conjuncts.add(root);
-            return;
-        }
-
-        CompoundPredicate cpe = (CompoundPredicate) root;
-        if (!CompoundPredicate.Operator.AND.equals(cpe.getOp())) {
-            conjuncts.add(root);
-            return;
-        }
-
-        extractConjunctsImpl(cpe.getChild(0), conjuncts);
-        extractConjunctsImpl(cpe.getChild(1), conjuncts);
-    }
-
-    public static List<Expr> flattenPredicate(Expr root) {
-        List<Expr> children = Lists.newArrayList();
-        if (null == root) {
-            return children;
-        }
-
-        flattenPredicate(root, children);
-        return children;
-    }
-
-    private static void flattenPredicate(Expr root, List<Expr> children) {
-        if (!(root instanceof CompoundPredicate)) {
-            children.add(root);
-            return;
-        }
-
-        CompoundPredicate cpe = (CompoundPredicate) root;
-        if (CompoundPredicate.Operator.AND.equals(cpe.getOp()) || CompoundPredicate.Operator.OR.equals(cpe.getOp())) {
-            extractConjunctsImpl(cpe.getChild(0), children);
-            extractConjunctsImpl(cpe.getChild(1), children);
-        } else {
-            children.add(root);
-        }
-    }
-
 
     public static Expr compoundAnd(Collection<Expr> conjuncts) {
         return createCompound(CompoundPredicate.Operator.AND, conjuncts);
@@ -1218,14 +1163,22 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     }
 
     public List<SlotRef> collectAllSlotRefs() {
-        List<SlotRef> result = Lists.newArrayList();
-        if (this instanceof SlotRef) {
-            result.add((SlotRef) this);
+        return collectAllSlotRefs(false);
+    }
+
+    public List<SlotRef> collectAllSlotRefs(boolean distinct) {
+        Collection<SlotRef> result = distinct ? Sets.newHashSet() : Lists.newArrayList();
+        Queue<Expr> q = Lists.newLinkedList();
+        q.add(this);
+        while (!q.isEmpty()) {
+            Expr head = q.poll();
+            if (head instanceof SlotRef) {
+                result.add((SlotRef) head);
+            }
+            q.addAll(head.getChildren());
         }
-        for (Expr child : children) {
-            result.addAll(child.collectAllSlotRefs());
-        }
-        return result;
+
+        return distinct ? Lists.newArrayList(result) : (List<SlotRef>) result;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -310,6 +310,10 @@ public class SlotRef extends Expr {
         }
     }
 
+    public boolean isColumnRef() {
+        return tblName != null && !isFromLambda();
+    }
+
     @Override
     public String explainImpl() {
         if (label != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/LoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/LoadScanNode.java
@@ -45,6 +45,7 @@ import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -86,7 +87,7 @@ public abstract class LoadScanNode extends ScanNode {
         if (!whereExpr.getType().isBoolean()) {
             throw new UserException("where statement is not a valid statement return bool");
         }
-        addConjuncts(Expr.extractConjuncts(whereExpr));
+        addConjuncts(AnalyzerUtils.extractConjuncts(whereExpr));
     }
 
     protected void checkBitmapCompatibility(Analyzer analyzer, SlotDescriptor slotDesc, Expr expr)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlDigestBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SqlDigestBuilder.java
@@ -15,24 +15,19 @@
 package com.starrocks.sql.common;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.InPredicate;
 import com.starrocks.analysis.LimitElement;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotRef;
-import com.starrocks.common.Pair;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.ValuesRelation;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
-import java.util.Queue;
-import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -47,37 +42,6 @@ public class SqlDigestBuilder {
     }
 
     private static class SqlDigestBuilderVisitor extends AstToStringBuilder.AST2StringBuilderVisitor {
-
-        private Pair<Integer, Integer> countCompound(CompoundPredicate node) {
-            int andCount = 0;
-            int orCount = 0;
-            Queue<Expr> q = Lists.newLinkedList();
-            q.add(node);
-            while (!q.isEmpty()) {
-                Expr head = q.poll();
-                if (head instanceof CompoundPredicate) {
-                    CompoundPredicate.Operator op = ((CompoundPredicate) head).getOp();
-                    if (op == CompoundPredicate.Operator.AND) {
-                        andCount++;
-                    } else if (op == CompoundPredicate.Operator.OR) {
-                        orCount++;
-                    }
-                }
-                q.addAll(head.getChildren());
-            }
-
-            return Pair.create(andCount, orCount);
-        }
-
-        private void traverse(CompoundPredicate node, Consumer<Expr> consumer) {
-            Queue<Expr> q = Lists.newLinkedList();
-            q.add(node);
-            while (!q.isEmpty()) {
-                Expr head = q.poll();
-                consumer.accept(head);
-                q.addAll(head.getChildren());
-            }
-        }
 
         @Override
         public String visitInPredicate(InPredicate node, Void context) {
@@ -94,20 +58,19 @@ public class SqlDigestBuilder {
 
         @Override
         public String visitCompoundPredicate(CompoundPredicate node, Void context) {
-            Pair<Integer, Integer> pair = countCompound(node);
-            if (pair.first + pair.second >= MASSIVE_COMPOUND_LIMIT) {
+            List<Expr> flatten = AnalyzerUtils.flattenPredicate(node);
+            if (flatten.size() >= MASSIVE_COMPOUND_LIMIT) {
                 // Only record de-duplicated slots if there are too many compounds
-                Set<SlotRef> exprs = Sets.newHashSet();
-                traverse(node, x -> {
-                    if (x instanceof SlotRef) {
-                        exprs.add((SlotRef) x);
-                    }
-                });
-                return "$massive_compounds[" + exprs.stream().map(SlotRef::toSqlImpl)
-                        .collect(Collectors.joining(",")) + "]$";
+                List<SlotRef> exprs = node.collectAllSlotRefs(true);
+                String sortedSlots = exprs.stream()
+                        .filter(SlotRef::isColumnRef)
+                        .map(SlotRef::toSqlImpl)
+                        .sorted()
+                        .collect(Collectors.joining(","));
+                return "$massive_compounds[" + sortedSlots + "]$";
             } else {
-                // TODO: it will introduce a little bit overhead in top-down visiting, in which the countCompound is
-                //  duplicated. it's better to eliminate this overhead
+                // TODO: it will introduce a little bit overhead in top-down visiting, in which the
+                //  flattenPredicate is duplicated revoked. it's better to eliminate this overhead
                 return super.visitCompoundPredicate(node, context);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -48,6 +48,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.FieldId;
@@ -1129,7 +1130,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
             List<ColumnRefOperator> leftOutputColumns, List<ColumnRefOperator> rightOutputColumns,
             ExpressionMapping expressionMapping) {
         // Step1
-        List<Expr> exprConjuncts = Expr.extractConjuncts(node.getOnPredicate());
+        List<Expr> exprConjuncts = AnalyzerUtils.extractConjuncts(node.getOnPredicate());
 
         List<ScalarOperator> scalarConjuncts = Lists.newArrayList();
         Map<ScalarOperator, SubqueryOperator> allSubqueryPlaceholders = Maps.newHashMap();
@@ -1206,7 +1207,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
     private boolean isJoinLeftRelatedSubquery(JoinRelation node, Expr joinOnConjunct) {
         List<Subquery> subqueries = Lists.newArrayList();
 
-        List<Expr> elements = Expr.flattenPredicate(joinOnConjunct);
+        List<Expr> elements = AnalyzerUtils.flattenPredicate(joinOnConjunct);
         List<Expr> predicateWithSubquery = Lists.newArrayList();
         for (Expr element : elements) {
             int oldSize = subqueries.size();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SqlDigestBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SqlDigestBuilderTest.java
@@ -72,11 +72,16 @@ public class SqlDigestBuilderTest extends PlanTestBase {
                     "or v4=11 or v4=12 or v4=13 or v4=14 or v4=15 or v4=16 or v4=17 or v4=18 " +
                     "or v4=19 or v4=20| " +
                     "SELECT * FROM test.t1 WHERE $massive_compounds[`test`.`t1`.`v4`]$",
+            "select * from t1 where v4+v5=1 or v4+v5=2 or v4+v5=3 or v4=4 or v4=5 or v4=6 or v4=7 or v4=8 or v4=9 or " +
+                    "v4=10 " +
+                    "or v4=11 or v4=12 or v4=13 or v4=14 or v4=15 or v4=16 or v4=17 or v4=18 " +
+                    "or v4=19 or v4=20| " +
+                    "SELECT * FROM test.t1 WHERE $massive_compounds[`test`.`t1`.`v4`,`test`.`t1`.`v5`]$",
             "select * from t1 where v5 = 123 and (v4=1 or v4=2 or v4=3 or v4=4 or v4=5 or v4=6 or v4=7 or v4=8 or " +
                     "v4=9 or v4=10 " +
                     "or v4=11 or v4=12 or v4=13 or v4=14 or v4=15 or v4=16 or v4=17 or v4=18 " +
                     "or v4=19 or v4=20)| " +
-                    "SELECT * FROM test.t1 WHERE $massive_compounds[`test`.`t1`.`v5`,`test`.`t1`.`v4`]$",
+                    "SELECT * FROM test.t1 WHERE $massive_compounds[`test`.`t1`.`v4`,`test`.`t1`.`v5`]$",
     })
     public void testBuild(String sql, String expectedDigest) throws Exception {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SqlDigestBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SqlDigestBuilderTest.java
@@ -66,6 +66,17 @@ public class SqlDigestBuilderTest extends PlanTestBase {
                     "|INSERT INTO `test`.`part_t1` PARTITION (p1) VALUES(?, ?, ?)",
             "insert overwrite part_t1 partition (p1) values(1,2,3) " +
                     "|INSERT OVERWRITE `test`.`part_t1` PARTITION (p1) VALUES(?, ?, ?)",
+
+            // massive compounds
+            "select * from t1 where v4=1 or v4=2 or v4=3 or v4=4 or v4=5 or v4=6 or v4=7 or v4=8 or v4=9 or v4=10 " +
+                    "or v4=11 or v4=12 or v4=13 or v4=14 or v4=15 or v4=16 or v4=17 or v4=18 " +
+                    "or v4=19 or v4=20| " +
+                    "SELECT * FROM test.t1 WHERE $massive_compounds[`test`.`t1`.`v4`]$",
+            "select * from t1 where v5 = 123 and (v4=1 or v4=2 or v4=3 or v4=4 or v4=5 or v4=6 or v4=7 or v4=8 or " +
+                    "v4=9 or v4=10 " +
+                    "or v4=11 or v4=12 or v4=13 or v4=14 or v4=15 or v4=16 or v4=17 or v4=18 " +
+                    "or v4=19 or v4=20)| " +
+                    "SELECT * FROM test.t1 WHERE $massive_compounds[`test`.`t1`.`v5`,`test`.`t1`.`v4`]$",
     })
     public void testBuild(String sql, String expectedDigest) throws Exception {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

In cases where an OR predicate is dynamically constructed with a fixed column, the SQL digest varies due to a differing number of predicates. To address this, we consolidate extensive compound predicates into a compact format, ensuring consistent SQL digests.

```sql
where c_code like 'a%';
where c_code like 'a%' or c_code like 'b%';
where c_code like 'a%' or c_code like 'b%' or c_code like 'c%';

=> 

where $massive_compounds[c_code]$
```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0