### PR TITLE
[BugFix] Publish time should be update  in shared data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -470,7 +470,7 @@ public class TransactionState implements Writable {
     }
 
     // for test
-    public long getPublishTaskFinishTime() {
+   long getPublishTaskFinishTime() {
         return this.publishVersionFinishTime;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -469,6 +469,12 @@ public class TransactionState implements Writable {
         this.publishVersionFinishTime = System.currentTimeMillis();
     }
 
+    // for test
+    public long getPublishTaskFinishTime() {
+        return this.publishVersionFinishTime;
+    }
+
+
     public long getPublishVersionTime() {
         return this.publishVersionTime;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
@@ -96,6 +96,18 @@ public class TransactionStateBatch implements Writable {
         }
     }
 
+    public void updateSendTaskTime() {
+        for (TransactionState state : transactionStates) {
+            state.updateSendTaskTime();
+        }
+    }
+
+    public void updatePublishTaskFinishTime() {
+        for (TransactionState state : transactionStates) {
+            state.updatePublishTaskFinishTime();
+        }
+    }
+
     // a proxy method
     public void afterVisible(TransactionStatus transactionStatus, boolean txnOperated) {
         for (TransactionState transactionState : transactionStates) {


### PR DESCRIPTION
## Why I'm doing:
`publishVersionFinishTime` and `publishVersionTime` in TransacctionState should be updated when publish in shared data
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0