### PR TITLE
[BugFix] Fix MVPCTRefreshPlanBuilder generate plan bug if output contains complex expressions

### DIFF
--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_union
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_union
@@ -35,7 +35,6 @@ INSERT INTO t1 VALUES
     ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
 -- result:
 -- !result
-    
 CREATE TABLE `t2` (
     `k1`  date not null, 
     `k2`  datetime not null, 
@@ -70,7 +69,6 @@ INSERT INTO t2 VALUES
     ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
 -- result:
 -- !result
-    
 CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
 PARTITION BY `k1`
 DISTRIBUTED BY HASH(`k1`)
@@ -197,7 +195,6 @@ INSERT INTO t1 VALUES
     ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
 -- result:
 -- !result
-    
 CREATE TABLE `t2` (
     `k1`  date not null, 
     `k2`  datetime not null, 
@@ -225,7 +222,6 @@ INSERT INTO t2 VALUES
     ('2020-10-22','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
 -- result:
 -- !result
-    
 CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
 PARTITION BY date_trunc('day', `k1`)
 DISTRIBUTED BY HASH(`k1`)
@@ -317,6 +313,112 @@ select k1, count(1) from test_mv1 group by k1 order by k1;
 -- result:
 2020-10-21	1
 2020-10-22	2
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH DEFERRED ASYNC
+as 
+    select t1.k1, t1.k2 as k12, concat(t1.k3, '[', t1.k4, ']') as v1, t1.k9 as k19 from t1 join t2 on t1.k1=t2.k1
+    union all
+    select t1.k1, t1.k2 as k12, concat(t1.k3, '[', t1.k4, ']') as v1, t1.k9 as k19 from t1 join t2 on t1.k1=t2.k1;
+-- result:
+-- !result
+refresh materialized view  test_mv1 partition start('2020-10-21') end ('2020-10-23') force with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+-- result:
+2020-10-22	2
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+CREATE TABLE if not EXISTS `s1` (
+  `k1` int(11) NULL,
+  `k2` bigint(20) NULL,
+  `k3` varchar(255) NULL,
+  `k4` varchar(65533) NULL,
+  `k5` varchar(65533) NULL,
+  `k6` varchar(65533) NULL,
+  `v1` varchar(65533) NULL,
+  `v2` datetime NULL
+) ENGINE=OLAP 
+UNIQUE KEY(`k1`, `k2`, `k3`, `k4`, `k5`, `k6`)
+DISTRIBUTED BY HASH(`k1`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE if not EXISTS `s2` (
+  `dt` int(11) NOT NULL,
+  `_k2_` int(11) NOT NULL,
+  `c1` varchar(65533) NOT NULL,
+  `c2` varchar(65533) NOT NULL,
+  `k3` varchar(65533) NULL,
+  `k3_val` varchar(65533) NULL,
+  `k4` varchar(65533) NULL,
+  `k4_val` varchar(65533) NULL,
+  `status` varchar(65533) NULL,
+  `status_val` varchar(65533) NULL,
+  `c1_val` varchar(65533) NULL,
+  `k5` varchar(65533) NULL,
+  `c4` int(11) NULL,
+  `c5` int(11) NULL,
+  `diff` decimal(20, 2) NULL,
+  `c6` varchar(65533) NULL,
+  `c7` varchar(65533) NULL,
+  `v2` datetime NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`dt`, `_k2_`, `c1`, `c2`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p20241120 VALUES [("20241120"), ("20241121")),
+    PARTITION p20241121 VALUES [("20241121"), ("20241122")),
+    PARTITION p20241122 VALUES [("20241122"), ("20241123")),
+    PARTITION p20241123 VALUES [("20241123"), ("20241124")),
+    PARTITION p20241124 VALUES [("20241124"), ("20241125")),
+    PARTITION p20241125 VALUES [("20241125"), ("20241126")))
+DISTRIBUTED BY HASH(`dt`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `s1` (
+  `k1`, 
+  `k2`, 
+  `k3`, 
+  `k4`, 
+  `k5`, 
+  `k6`, 
+  `v1`, 
+  `v2`
+) VALUES
+(101, 100001, 'ODS', 'financial_report', 'Annual Financial Report', 'Rule 1: Validate totals', 'John Doe', '2024-11-26 10:00:00');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `test_mv1` 
+PARTITION BY (`dt`)
+DISTRIBUTED BY HASH(`v2`)
+REFRESH DEFERRED ASYNC START("2024-08-10 00:00:00") EVERY(INTERVAL 1 MINUTE)
+PROPERTIES (
+"replication_num" = "1"
+)
+AS 
+SELECT `t1`.`k3`, `t1`.`k3_val`, `t1`.`k4`, `t1`.`k4_val`, `t1`.`status`, `t1`.`status_val`, `t1`.`c1`, `t1`.`c1_val`, `t1`.`k5`, `t1`.`c2`, `t1`.`c4`, `t1`.`c5`, `t1`.`diff`, `t1`.`c6`, `t1`.`_k2_`, `t1`.`c7`, `t1`.`v2`, `t1`.`dt`, concat(`t2`.`v1`, '[', `t2`.`k1`, ']') AS `responsible_person`
+FROM `s2` AS `t1` LEFT OUTER JOIN `s1` AS `t2` ON `t1`.`k3` = `t2`.`k3` AND `t1`.`k4` = `t2`.`k4` AND `t1`.`c1` = `t2`.`k6` AND `t1`.`k5` = `t2`.`k5`
+UNION ALL 
+SELECT `t1`.`k3`, `t1`.`k3_val`, `t1`.`k4`, `t1`.`k4_val`, `t1`.`status`, `t1`.`status_val`, `t1`.`c1`, `t1`.`c1_val`, `t1`.`k5`, `t1`.`c2`, `t1`.`c4`, `t1`.`c5`, `t1`.`diff`, `t1`.`c6`, `t1`.`_k2_`, `t1`.`c7`, `t1`.`v2`, `t1`.`dt`, concat(`t2`.`v1`, '[', `t2`.`k1`, ']') AS `responsible_person`
+FROM `s2` AS `t1` LEFT OUTER JOIN `s1` AS `t2` ON `t1`.`k3` = `t2`.`k3` AND `t1`.`k4` = `t2`.`k4` AND `t1`.`c1` = `t2`.`k6`;
+-- result:
+-- !result
+refresh materialized view  test_mv1 with sync mode;
+select count(1) from test_mv1;
+-- result:
+0
 -- !result
 drop materialized view test_mv1;
 -- result:

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_union
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_union
@@ -211,5 +211,97 @@ refresh materialized view  test_mv1 partition start('2020-10-21') end ('2020-10-
 select k1, count(1) from test_mv1 group by k1 order by k1;
 drop materialized view test_mv1;
 
+CREATE MATERIALIZED VIEW IF NOT EXISTS test_mv1
+PARTITION BY `k1`
+DISTRIBUTED BY HASH(`k1`)
+REFRESH DEFERRED ASYNC
+as 
+    select t1.k1, t1.k2 as k12, concat(t1.k3, '[', t1.k4, ']') as v1, t1.k9 as k19 from t1 join t2 on t1.k1=t2.k1
+    union all
+    select t1.k1, t1.k2 as k12, concat(t1.k3, '[', t1.k4, ']') as v1, t1.k9 as k19 from t1 join t2 on t1.k1=t2.k1;
+refresh materialized view  test_mv1 partition start('2020-10-21') end ('2020-10-23') force with sync mode;
+select k1, count(1) from test_mv1 group by k1 order by k1;
+drop materialized view test_mv1;
+
+CREATE TABLE if not EXISTS `s1` (
+  `k1` int(11) NULL,
+  `k2` bigint(20) NULL,
+  `k3` varchar(255) NULL,
+  `k4` varchar(65533) NULL,
+  `k5` varchar(65533) NULL,
+  `k6` varchar(65533) NULL,
+  `v1` varchar(65533) NULL,
+  `v2` datetime NULL
+) ENGINE=OLAP 
+UNIQUE KEY(`k1`, `k2`, `k3`, `k4`, `k5`, `k6`)
+DISTRIBUTED BY HASH(`k1`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+CREATE TABLE if not EXISTS `s2` (
+  `dt` int(11) NOT NULL,
+  `_k2_` int(11) NOT NULL,
+  `c1` varchar(65533) NOT NULL,
+  `c2` varchar(65533) NOT NULL,
+  `k3` varchar(65533) NULL,
+  `k3_val` varchar(65533) NULL,
+  `k4` varchar(65533) NULL,
+  `k4_val` varchar(65533) NULL,
+  `status` varchar(65533) NULL,
+  `status_val` varchar(65533) NULL,
+  `c1_val` varchar(65533) NULL,
+  `k5` varchar(65533) NULL,
+  `c4` int(11) NULL,
+  `c5` int(11) NULL,
+  `diff` decimal(20, 2) NULL,
+  `c6` varchar(65533) NULL,
+  `c7` varchar(65533) NULL,
+  `v2` datetime NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`dt`, `_k2_`, `c1`, `c2`)
+PARTITION BY RANGE(`dt`)
+(
+    PARTITION p20241120 VALUES [("20241120"), ("20241121")),
+    PARTITION p20241121 VALUES [("20241121"), ("20241122")),
+    PARTITION p20241122 VALUES [("20241122"), ("20241123")),
+    PARTITION p20241123 VALUES [("20241123"), ("20241124")),
+    PARTITION p20241124 VALUES [("20241124"), ("20241125")),
+    PARTITION p20241125 VALUES [("20241125"), ("20241126")))
+DISTRIBUTED BY HASH(`dt`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO `s1` (
+  `k1`, 
+  `k2`, 
+  `k3`, 
+  `k4`, 
+  `k5`, 
+  `k6`, 
+  `v1`, 
+  `v2`
+) VALUES
+(101, 100001, 'ODS', 'financial_report', 'Annual Financial Report', 'Rule 1: Validate totals', 'John Doe', '2024-11-26 10:00:00');
+
+CREATE MATERIALIZED VIEW `test_mv1` 
+PARTITION BY (`dt`)
+DISTRIBUTED BY HASH(`v2`)
+REFRESH DEFERRED ASYNC START("2024-08-10 00:00:00") EVERY(INTERVAL 1 MINUTE)
+PROPERTIES (
+"replication_num" = "1"
+)
+AS 
+SELECT `t1`.`k3`, `t1`.`k3_val`, `t1`.`k4`, `t1`.`k4_val`, `t1`.`status`, `t1`.`status_val`, `t1`.`c1`, `t1`.`c1_val`, `t1`.`k5`, `t1`.`c2`, `t1`.`c4`, `t1`.`c5`, `t1`.`diff`, `t1`.`c6`, `t1`.`_k2_`, `t1`.`c7`, `t1`.`v2`, `t1`.`dt`, concat(`t2`.`v1`, '[', `t2`.`k1`, ']') AS `responsible_person`
+FROM `s2` AS `t1` LEFT OUTER JOIN `s1` AS `t2` ON `t1`.`k3` = `t2`.`k3` AND `t1`.`k4` = `t2`.`k4` AND `t1`.`c1` = `t2`.`k6` AND `t1`.`k5` = `t2`.`k5`
+UNION ALL 
+SELECT `t1`.`k3`, `t1`.`k3_val`, `t1`.`k4`, `t1`.`k4_val`, `t1`.`status`, `t1`.`status_val`, `t1`.`c1`, `t1`.`c1_val`, `t1`.`k5`, `t1`.`c2`, `t1`.`c4`, `t1`.`c5`, `t1`.`diff`, `t1`.`c6`, `t1`.`_k2_`, `t1`.`c7`, `t1`.`v2`, `t1`.`dt`, concat(`t2`.`v1`, '[', `t2`.`k1`, ']') AS `responsible_person`
+FROM `s2` AS `t1` LEFT OUTER JOIN `s1` AS `t2` ON `t1`.`k3` = `t2`.`k3` AND `t1`.`k4` = `t2`.`k4` AND `t1`.`c1` = `t2`.`k6`;
+
+refresh materialized view  test_mv1 with sync mode;
+select count(1) from test_mv1;
+drop materialized view test_mv1;
+
 drop table t1;
 drop table t2;


### PR DESCRIPTION
## Why I'm doing:

```
 2024-11-26 15:41:02.857+08:00 WARN (starrocks-taskrun-pool-0|772) [TaskRunExecutor.lambda$executeTaskRun$0():64] failed to execute TaskRun.
 com.starrocks.sql.common.DmlException: Refresh materialized view mv_ads_pub_gov_asset_quality_details failed after retrying 1 times(try-lock 0 times), error-msg : Getting analyzing error. Detail message: Column '`test_db`.`test_tbl`.`test_col`' cannot be resolved.
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:395)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:326)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:200)
        at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:257)
        at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:57)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Column '`test_db`.`test_tbl`.`test_col`' cannot be resolved.
        at com.starrocks.sql.analyzer.Scope.resolveField(Scope.java:96)
        at com.starrocks.sql.analyzer.Scope.resolveField(Scope.java:90)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer$Visitor.visitSlot(ExpressionAnalyzer.java:443)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer$Visitor.visitSlot(ExpressionAnalyzer.java:385)
        at com.starrocks.analysis.SlotRef.accept(SlotRef.java:517)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:71)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.bottomUpAnalyze(ExpressionAnalyzer.java:381)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.bottomUpAnalyze(ExpressionAnalyzer.java:379)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.analyze(ExpressionAnalyzer.java:145)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.analyzeExpression(ExpressionAnalyzer.java:2090)
        at com.starrocks.sql.analyzer.SelectAnalyzer.analyzeExpression(SelectAnalyzer.java:704)
        at com.starrocks.sql.analyzer.SelectAnalyzer.analyzeSelect(SelectAnalyzer.java:248)
        at com.starrocks.sql.analyzer.SelectAnalyzer.analyze(SelectAnalyzer.java:77)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitSelect(QueryAnalyzer.java:238)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitSelect(QueryAnalyzer.java:130)
        at com.starrocks.sql.ast.SelectRelation.accept(SelectRelation.java:242)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.process(QueryAnalyzer.java:135)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitQueryRelation(QueryAnalyzer.java:150)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitQueryStatement(QueryAnalyzer.java:140)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitQueryStatement(QueryAnalyzer.java:130)
        at com.starrocks.sql.ast.QueryStatement.accept(QueryStatement.java:70)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.process(QueryAnalyzer.java:135)
        at com.starrocks.sql.analyzer.QueryAnalyzer.analyze(QueryAnalyzer.java:123)
        at com.starrocks.scheduler.mv.MVPCTRefreshPlanBuilder.buildInsertPlan(MVPCTRefreshPlanBuilder.java:205)
        at com.starrocks.scheduler.mv.MVPCTRefreshPlanBuilder.analyzeAndBuildInsertPlan(MVPCTRefreshPlanBuilder.java:78)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.prepareRefreshPlan(PartitionBasedMvRefreshProcessor.java:513)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:464)
        at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:367)
        ... 8 more
```


## What I'm doing:
-  use `getColumnOutputNames` rather than `getOutputExpression` to avoid `getOutputExpression` referring original queryStatement's  output expressions which may cause column missing if the original queryStatement's output contains alias.

Fixes https://github.com/StarRocks/starrocks/issues/53208


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0