### PR TITLE
[BugFix] Fix getNextWorker overflow

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -42,8 +42,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
+
+import static com.starrocks.qe.WorkerProviderHelper.getNextWorker;
 
 /**
  * WorkerProvider for SHARED_DATA mode. Compared to its counterpart for SHARED_NOTHING mode:
@@ -271,13 +272,9 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
         return NEXT_COMPUTE_NODE_INDEX.getAndIncrement();
     }
 
-    private static ComputeNode getNextWorker(ImmutableMap<Long, ComputeNode> workers,
-                                             IntSupplier getNextWorkerNodeIndex) {
-        if (workers.isEmpty()) {
-            return null;
-        }
-        int index = getNextWorkerNodeIndex.getAsInt() % workers.size();
-        return workers.values().asList().get(index);
+    @VisibleForTesting
+    static AtomicInteger getNextComputeNodeIndexer() {
+        return NEXT_COMPUTE_NODE_INDEX;
     }
 
     private static ImmutableMap<Long, ComputeNode> filterAvailableWorkers(ImmutableMap<Long, ComputeNode> workers) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/WorkerProviderHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/WorkerProviderHelper.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.system.ComputeNode;
+
+import java.util.function.IntSupplier;
+
+public class WorkerProviderHelper {
+    public static <C extends ComputeNode> C getNextWorker(ImmutableMap<Long, C> workers,
+                                                          IntSupplier getNextWorkerNodeIndex) {
+        if (workers.isEmpty()) {
+            return null;
+        }
+        int index = getNextWorkerNodeIndex.getAsInt();
+        if (index < 0) {
+            if (index == Integer.MIN_VALUE) {
+                index = 0;
+            } else {
+                index = -index;
+            }
+        }
+        index %= workers.size();
+        return workers.values().asList().get(index);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/WorkerProviderHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/WorkerProviderHelper.java
@@ -25,15 +25,10 @@ public class WorkerProviderHelper {
         if (workers.isEmpty()) {
             return null;
         }
-        int index = getNextWorkerNodeIndex.getAsInt();
+        int index = getNextWorkerNodeIndex.getAsInt() % workers.size();
         if (index < 0) {
-            if (index == Integer.MIN_VALUE) {
-                index = 0;
-            } else {
-                index = -index;
-            }
+            index = -index;
         }
-        index %= workers.size();
         return workers.values().asList().get(index);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -663,7 +663,8 @@ public class DefaultSharedDataWorkerProviderTest {
 
     @Test
     public void testNextWorkerOverflow() throws NonRecoverableException {
-        WorkerProvider provider = new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes), ImmutableMap.copyOf(id2AllNodes));
+        WorkerProvider provider =
+                new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes), ImmutableMap.copyOf(id2AllNodes));
         for (int i = 0; i < 100; i++) {
             Long workerId = provider.selectNextWorker();
             assertThat(workerId).isNotNegative();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -67,6 +67,8 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class DefaultSharedDataWorkerProviderTest {
     private Map<Long, ComputeNode> id2Backend;
     private Map<Long, ComputeNode> id2ComputeNode;
@@ -656,6 +658,20 @@ public class DefaultSharedDataWorkerProviderTest {
             ColocatedBackendSelector selector =
                     new ColocatedBackendSelector(scanNode, assignment, colAssignment, false, providerNoAvailNode, 1);
             Assert.assertThrows(NonRecoverableException.class, selector::computeScanRangeAssignment);
+        }
+    }
+
+    @Test
+    public void testNextWorkerOverflow() throws NonRecoverableException {
+        WorkerProvider provider = new DefaultSharedDataWorkerProvider(ImmutableMap.copyOf(id2AllNodes), ImmutableMap.copyOf(id2AllNodes));
+        for (int i = 0; i < 100; i++) {
+            Long workerId = provider.selectNextWorker();
+            assertThat(workerId).isNotNegative();
+        }
+        DefaultSharedDataWorkerProvider.getNextComputeNodeIndexer().set(Integer.MAX_VALUE);
+        for (int i = 0; i < 100; i++) {
+            Long workerId = provider.selectNextWorker();
+            assertThat(workerId).isNotNegative();
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -80,7 +80,6 @@ public class DefaultWorkerProviderTest {
         return ImmutableMap.copyOf(res);
     }
 
-
     @Test
     public void testCaptureAvailableWorkers() {
 
@@ -129,7 +128,7 @@ public class DefaultWorkerProviderTest {
 
             workerProvider =
                     workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY, 
+                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY,
                             WarehouseManager.DEFAULT_WAREHOUSE_ID);
 
             int numAvailableComputeNodes = 0;
@@ -176,7 +175,7 @@ public class DefaultWorkerProviderTest {
         for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
             workerProvider =
                     workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY, 
+                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY,
                             WarehouseManager.DEFAULT_WAREHOUSE_ID);
             List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
             for (Long selectedWorkerId : selectedWorkerIdsList) {
@@ -188,7 +187,7 @@ public class DefaultWorkerProviderTest {
         for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
             workerProvider =
                     workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            false, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY, 
+                            false, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY,
                             WarehouseManager.DEFAULT_WAREHOUSE_ID);
             List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
             Assert.assertEquals(availableId2Backend.size(), selectedWorkerIdsList.size());
@@ -201,7 +200,7 @@ public class DefaultWorkerProviderTest {
         for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
             workerProvider =
                     workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.ALL_NODES, 
+                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.ALL_NODES,
                             WarehouseManager.DEFAULT_WAREHOUSE_ID);
             List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
             Collections.reverse(selectedWorkerIdsList); //put ComputeNode id to the front,Backend id to the back
@@ -375,6 +374,21 @@ public class DefaultWorkerProviderTest {
                 new DefaultWorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode,
                         true);
         Assert.assertThrows(SchedulerException.class, workerProvider::reportDataNodeNotFoundException);
+    }
+
+    @Test
+    public void testNextWorkerOverflow() throws NonRecoverableException {
+        DefaultWorkerProvider workerProvider =
+                new DefaultWorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, true);
+        for (int i = 0; i < 100; i++) {
+            Long workerId = workerProvider.selectNextWorker();
+            assertThat(workerId).isNotNegative();
+        }
+        DefaultWorkerProvider.getNextComputeNodeIndexer().set(Integer.MAX_VALUE);
+        for (int i = 0; i < 100; i++) {
+            Long workerId = workerProvider.selectNextWorker();
+            assertThat(workerId).isNotNegative();
+        }
     }
 
     public static void testUsingWorkerHelper(DefaultWorkerProvider workerProvider, Long workerId) {


### PR DESCRIPTION
## Why I'm doing:

The `getNextWorker()` method uses a global `AtomicInteger nextIndexId`, which increments by one with each call to `getNextWorker()`. As a result, it may overflow into a negative value.

```
java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 3
        at com.google.common.collect.RegularImmutableMap$Values.get(RegularImmutableMap.java:384) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.qe.scheduler.DefaultWorkerProvider.getNextWorker(DefaultWorkerProvider.java:354) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.DefaultWorkerProvider.selectNextWorker(DefaultWorkerProvider.java:141) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.assignment.RemoteFragmentAssignmentStrategy.assignGatherFragmentToWorker(RemoteFragmentAssignmentStrategy.java:91) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.assignment.RemoteFragmentAssignmentStrategy.assignFragmentToWorker(RemoteFragmentAssignmentStrategy.java:76) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.CoordinatorPreprocessor.computeFragmentInstances(CoordinatorPreprocessor.java:244) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.CoordinatorPreprocessor.prepareExec(CoordinatorPreprocessor.java:200) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.prepareExec(DefaultCoordinator.java:456) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.startScheduling(DefaultCoordinator.java:501) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.Coordinator.startScheduling(Coordinator.java:105) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.Coordinator.exec(Coordinator.java:88) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:1119) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:633) ~[starrocks-fe.jar:?]
```

## What I'm doing:



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0