### PR TITLE
[Enhancement] add Type Check for decimal input

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.optimizer.validate;
 
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -195,7 +197,25 @@ public class TypeChecker implements PlanValidator.Checker {
             }
         }
 
+        private boolean checkDecimalType(Type decimalType) {
+            ScalarType type = (ScalarType) decimalType;
+            final int scale = type.getScalarScale();
+            final int precision = type.getScalarPrecision();
+            final PrimitiveType primitiveType = type.getPrimitiveType();
+            return scale >= 0 && scale <= precision && precision <= PrimitiveType.getMaxPrecisionOfDecimal(primitiveType);
+        }
+
         private void checkColType(ScalarOperator arg, ScalarOperator expr, Type defined, Type actual) {
+            if (actual.isDecimalV3()) {
+                checkArgument(checkDecimalType(actual),
+                        "expr '%s' invalid actual type: %s",
+                        PREFIX, expr, actual);
+            }
+            if (defined.isDecimalV3()) {
+                checkArgument(checkDecimalType(actual),
+                        "expr '%s' invalid defined type: %s",
+                        PREFIX, expr, defined);
+            }
             checkArgument(actual.matchesType(defined),
                     "%s the type of arg %s in expr '%s' is defined as %s, but the actual type is %s",
                     PREFIX, arg, expr, defined, actual);


### PR DESCRIPTION
## Why I'm doing:

```
2024-11-26 22:03:42.671+08:00 WARN (starrocks-mysql-nio-pool-0|168) [StmtExecutor.execute():792] execute Exception, sql explain SELECT  SUM((gmv+gmv2)*0.01) FROM test_pt8 WHERE pt = '20241126' AND id IN ( SELECT id FROM test_pt9 WHERE id = '1' )
 com.starrocks.sql.common.StarRocksPlannerException: Invalid plan:
PhysicalHashAggregate {type=GLOBAL, groupBy=[], partitionBy=[] ,aggregations={16: sum=sum(16: sum)}}
->  PhysicalDistributionOperator {distributionSpec=GATHER ,globalDict=[]}
    ->  PhysicalHashAggregate {type=LOCAL, groupBy=[], partitionBy=[] ,aggregations={16: sum=sum(14: sum)}}
        ->  PhysicalHashJoinOperator{joinType=LEFT SEMI JOIN, joinPredicate=1: id = 5: id, limit=-1, predicate=null}
            ->  PhysicalHashAggregate {type=GLOBAL, groupBy=[11: id], partitionBy=[11: id] ,aggregations={15: sum=sum(13: sum_channel_direct_indirect_gmv)}}
                ->  PhysicalOlapScanOperator {table=674355, selectedPartitionId=[674362], selectedIndexId=674356, outputColumns=[11: id, 12: pt, 13: sum_channel_direct_indirect_gmv], projection=null, predicate=null, prunedPartitionPredicates=[12: pt = 2024-11-26], limit=-1}
            ->  PhysicalDistributionOperator {distributionSpec=BUCKET[5(false)] ,globalDict=[]}
                ->  PhysicalOlapScanOperator {table=674341, selectedPartitionId=[674348], selectedIndexId=674342, outputColumns=[5: id], projection=null, predicate=5: id IS NOT NULL AND 5: id = 1, prunedPartitionPredicates=[], limit=-1}expr 'Type check failed.' actual type is 16: sum [DECIMAL128]
        at com.starrocks.sql.optimizer.validate.PlanValidator.validatePlan(PlanValidator.java:65)
        at com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:321)
        at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:205)
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:340)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:146)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:104)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:581)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:367)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:567)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:905)
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0