### PR TITLE
[BugFix] Before deleting a database, check whether any resource groups are bound

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ErrorCode.java
@@ -357,7 +357,11 @@ public enum ErrorCode {
     ERR_INVALID_WAREHOUSE_NAME(10006, new byte[] {'4', '2', '0', '0', '0'}, "Warehouse name can not be null or empty"),
 
     ERR_NOT_SUPPORTED_STATEMENT_IN_SHARED_NOTHING_MODE(10007, new byte[] {'4', '2', '0', '0', '0'},
-            "unsupported statement in shared_nothing mode");
+            "unsupported statement in shared_nothing mode"),
+
+    ERR_DROP_DATABASE(10008, new byte[] {'H', 'Y', '0', '0', '0'},
+            "Deleting the database [%s] failed because the database was bound to a resource group [%s]"),
+    ;
 
     public static final String ERR_ACCESS_DENIED_HINT_MSG_FORMAT = "Please ask the admin to grant permission(s) or" +
             " try activating existing roles using <set [default] role>. Current role(s): %s. Inactivated role(s): %s.";

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -459,12 +459,15 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             if (!db.isExist()) {
                 throw new MetaNotFoundException("Database '" + dbName + "' not found");
             }
-            if (!isForceDrop && stateMgr.getGlobalTransactionMgr().existCommittedTxns(db.getId(), null, null)) {
-                throw new DdlException(
-                        "There are still some transactions in the COMMITTED state waiting to be completed. " +
-                                "The database [" + dbName +
-                                "] cannot be dropped. If you want to forcibly drop(cannot be recovered)," +
-                                " please use \"DROP DATABASE <database> FORCE\".");
+            if (!isForceDrop) {
+                if (stateMgr.getGlobalTransactionMgr().existCommittedTxns(db.getId(), null, null)) {
+                    throw new DdlException(
+                            "There are still some transactions in the COMMITTED state waiting to be completed. " +
+                                    "The database [" + dbName +
+                                    "] cannot be dropped. If you want to forcibly drop(cannot be recovered)," +
+                                    " please use \"DROP DATABASE <database> FORCE\".");
+                }
+                MetaUtils.checkDbExistInResourceGroupAndReport(dbName);
             }
 
             // save table names for recycling

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -63,6 +63,18 @@ public class MetaUtils {
         }
     }
 
+    public static void checkDbExistInResourceGroupAndReport(String dbName) {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        GlobalStateMgr.getCurrentState().getResourceGroupMgr().getAllResourceGroupNames().forEach(rgName -> {
+            GlobalStateMgr.getCurrentState().getResourceGroupMgr().getResourceGroup(rgName).getClassifiers().forEach(classify -> {
+                if (classify.getDatabases().contains(db.getId())) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_DROP_DATABASE, dbName, rgName);
+                }
+            });
+        });
+
+    }
+
     public static void checkDbNullAndReport(Database db, String name) {
         if (db == null) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_DB_ERROR, name);


### PR DESCRIPTION
## Why I'm doing:
If delete a database which was bounded to a resource group, the resource group will become invalid. Therefore, we need to check whether a database was bound to a resource group before deleting it

![image](https://github.com/user-attachments/assets/3f3fc585-ff46-45ed-ab30-84d3e73f7788)

## What I'm doing:
check whether a database was bound to a resource group before deleting database

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0