### PR TITLE
[BugFix] Fix mv agg push down rewrite decimal type bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
@@ -274,7 +274,7 @@ public class AggregatePushDownUtils {
             }
             // ensure argument types are correct
             // clone function to avoid changing the original function
-            Function cloned = newFunc.clone();
+            Function cloned = newFunc.copy();
             cloned.setArgsType(argTypes);
             cloned.setRetType(aggCall.getType());
             newAggregate = new CallOperator(rollupFuncName, aggCall.getType(), newArgs, cloned);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
@@ -266,13 +266,16 @@ public class AggregatePushDownUtils {
                 return null;
             }
             Type[] argTypes = newArgs.stream().map(ScalarOperator::getType).toArray(Type[]::new);
+            // ensure argument types are correct
             Function newFunc = Expr.getBuiltinFunction(rollupFuncName, argTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             if (newFunc == null) {
                 logMVRewrite(mvRewriteContext, "Get rollup function is null, rollupFuncName:", rollupFuncName);
                 return null;
             }
-            newAggregate = new CallOperator(rollupFuncName, newFunc.getReturnType(), newArgs, newFunc);
+            newFunc.setArgsType(argTypes);
+            newFunc.setRetType(aggCall.getType());
+            newAggregate = new CallOperator(rollupFuncName, aggCall.getType(), newArgs, newFunc);
         }
         if (newAggregate == null) {
             logMVRewrite(mvRewriteContext, "realAggregate is null");
@@ -282,8 +285,8 @@ public class AggregatePushDownUtils {
     }
 
     public static CallOperator getRollupPartialAggregate(MvRewriteContext mvRewriteContext,
-                                                          AggregatePushDownContext ctx,
-                                                          CallOperator aggCall) {
+                                                         AggregatePushDownContext ctx,
+                                                         CallOperator aggCall) {
         if (!ctx.isRewrittenByEquivalent(aggCall)) {
             return aggCall;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
@@ -266,16 +266,18 @@ public class AggregatePushDownUtils {
                 return null;
             }
             Type[] argTypes = newArgs.stream().map(ScalarOperator::getType).toArray(Type[]::new);
-            // ensure argument types are correct
             Function newFunc = Expr.getBuiltinFunction(rollupFuncName, argTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             if (newFunc == null) {
                 logMVRewrite(mvRewriteContext, "Get rollup function is null, rollupFuncName:", rollupFuncName);
                 return null;
             }
-            newFunc.setArgsType(argTypes);
-            newFunc.setRetType(aggCall.getType());
-            newAggregate = new CallOperator(rollupFuncName, aggCall.getType(), newArgs, newFunc);
+            // ensure argument types are correct
+            // clone function to avoid changing the original function
+            Function cloned = newFunc.clone();
+            cloned.setArgsType(argTypes);
+            cloned.setRetType(aggCall.getType());
+            newAggregate = new CallOperator(rollupFuncName, aggCall.getType(), newArgs, cloned);
         }
         if (newAggregate == null) {
             logMVRewrite(mvRewriteContext, "realAggregate is null");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -338,10 +338,14 @@ public class MaterializedViewTestBase extends PlanTestBase {
     }
 
     public String getQueryPlan(String query) {
+        return getQueryPlan(query, TExplainLevel.NORMAL);
+    }
+
+    public String getQueryPlan(String query, TExplainLevel level) {
         try {
             Pair<ExecPlan, String> planAndTrace =
                     UtFrameUtils.getFragmentPlanWithTrace(connectContext, query, traceLogModule).second;
-            return planAndTrace.first.getExplainString(TExplainLevel.NORMAL);
+            return planAndTrace.first.getExplainString(level);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }

--- a/test/sql/test_materialized_view/R/test_materialized_view_agg_pushdown_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_agg_pushdown_rewrite
@@ -543,3 +543,61 @@ select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE),  avg(LO_
 1993-01-01	180	90	90	90.0	1.0	1	1	90.0	90.0	90	1
 1994-01-01	175	175	175	175.0	2.0	1	1	175.0	175.0	175	1
 -- !result
+CREATE TABLE `test_pt8` (
+  `id` bigint(20) NULL COMMENT "id",
+  `pt` date NOT NULL COMMENT "",
+  `gmv` bigint(20) NULL COMMENT "gmv",
+  `gmv2` bigint(20) NULL COMMENT "gmv2"
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+PARTITION BY date_trunc('day', pt)
+DISTRIBUTED BY HASH(`pt`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into test_pt8 values(1,'20241126',1,2);
+-- result:
+-- !result
+CREATE TABLE `test_pt9` (
+  `id` bigint(20) NULL COMMENT "id",
+  `pt` date NOT NULL COMMENT "",
+  `name` varchar(20) NULL COMMENT "gmv"
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+PARTITION BY date_trunc('day', pt)
+DISTRIBUTED BY HASH(`pt`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into test_pt9 values(1,'20241126','a');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `test_mv1` 
+PARTITION BY (`pt`)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+REFRESH DEFERRED ASYNC START("2024-11-22 17:34:45") EVERY(INTERVAL 1 MINUTE)
+PROPERTIES (
+    "query_rewrite_consistency" = "LOOSE",
+    "replication_num" = "1"
+)
+AS
+SELECT  `id`,`pt`,SUM((`gmv` + `gmv2`) * 0.01) AS `sum_channel_direct_indirect_gmv`
+FROM `test_pt8`
+GROUP BY  `id`,`pt`;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW `test_mv1` WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT SUM((gmv+gmv2)*0.01) FROM test_pt8 WHERE pt = '20241126' AND id IN ( SELECT id FROM test_pt9 WHERE id = '1');", "test_mv1")
+-- result:
+None
+-- !result
+SELECT SUM((gmv+gmv2)*0.01) FROM test_pt8 WHERE pt = '20241126' AND id IN ( SELECT id FROM test_pt9 WHERE id = '1');
+-- result:
+0.03
+-- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_agg_pushdown_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_agg_pushdown_rewrite
@@ -270,3 +270,50 @@ select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), avg(LO_REVENUE) from line
 select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), sum(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), max(LO_REVENUE) , sum(LO_REVENUE), max(LO_REVENUE), count(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE order by LO_ORDERDATE;
 select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE), avg(LO_REVENUE), avg(lo_suppkey), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE order by LO_ORDERDATE;
 select LO_ORDERDATE, sum(LO_REVENUE), max(LO_REVENUE), min(LO_REVENUE),  avg(LO_REVENUE), avg(lo_suppkey), bitmap_union_count(to_bitmap(LO_REVENUE)), approx_count_distinct(LO_REVENUE), PERCENTILE_APPROX(LO_REVENUE, 0.5), PERCENTILE_APPROX(LO_REVENUE, 0.7), sum(distinct LO_REVENUE), count(distinct LO_REVENUE) from lineorder l join dates d on l.LO_ORDERDATE = d.d_date group by LO_ORDERDATE HAVING sum(LO_REVENUE) > 1 order by LO_ORDERDATE;
+
+-- test push down with decimal types
+CREATE TABLE `test_pt8` (
+  `id` bigint(20) NULL COMMENT "id",
+  `pt` date NOT NULL COMMENT "",
+  `gmv` bigint(20) NULL COMMENT "gmv",
+  `gmv2` bigint(20) NULL COMMENT "gmv2"
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+PARTITION BY date_trunc('day', pt)
+DISTRIBUTED BY HASH(`pt`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into test_pt8 values(1,'20241126',1,2);
+
+CREATE TABLE `test_pt9` (
+  `id` bigint(20) NULL COMMENT "id",
+  `pt` date NOT NULL COMMENT "",
+  `name` varchar(20) NULL COMMENT "gmv"
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+PARTITION BY date_trunc('day', pt)
+DISTRIBUTED BY HASH(`pt`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into test_pt9 values(1,'20241126','a');
+
+CREATE MATERIALIZED VIEW `test_mv1` 
+PARTITION BY (`pt`)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+REFRESH DEFERRED ASYNC START("2024-11-22 17:34:45") EVERY(INTERVAL 1 MINUTE)
+PROPERTIES (
+    "query_rewrite_consistency" = "LOOSE",
+    "replication_num" = "1"
+)
+AS
+SELECT  `id`,`pt`,SUM((`gmv` + `gmv2`) * 0.01) AS `sum_channel_direct_indirect_gmv`
+FROM `test_pt8`
+GROUP BY  `id`,`pt`;
+REFRESH MATERIALIZED VIEW `test_mv1` WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT SUM((gmv+gmv2)*0.01) FROM test_pt8 WHERE pt = '20241126' AND id IN ( SELECT id FROM test_pt9 WHERE id = '1');", "test_mv1")
+SELECT SUM((gmv+gmv2)*0.01) FROM test_pt8 WHERE pt = '20241126' AND id IN ( SELECT id FROM test_pt9 WHERE id = '1');


### PR DESCRIPTION
## Why I'm doing:

![img_v3_02h0_6318682c-9f6a-4d94-b9ca-88de82d8716g](https://github.com/user-attachments/assets/e786e537-dcdb-4057-86ad-c886a5eac312)

## What I'm doing:
- Use arguments' type and return type as the final rollup aggregate's types.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0