### PR TITLE
[BugFix] Disable date_trunc equivalent replace if binary type is LE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncEquivalent.java
@@ -34,13 +34,18 @@ public class DateTruncEquivalent extends IPredicateRewriteEquivalent {
 
     /**
      * TODO: we can support this later.
-     * Change date_trunc('month', col) to col = '2023-12-01' will get a wrong result.
-     * MV       : select date_trunc('day', col) as dt from t
-     * Query    : select date_trunc('month, col) from t where date_trunc('month', col) = '2023-11-01'
+     * Change date_trunc('month', dt) to col = '2023-12-01' will get a wrong result.
+     * MV       : select date_trunc('day', dt) as dt from t
+     * Query1   : select date_trunc('month, dt) from t dt = '2023-11-01'
+     * -- cannot be rewritten, rewrite  result will be wrong
+     * Rewritten: select date_trunc('month, dt) from t where date_trunc('month', dt) = '2023-11-01'
+     *
+     * Query2   : select date_trunc('month, dt) from t where dt between '2023-11-01' and '2023-12-01'
+     * -- cannot be rewritten, dt='2023-12-01' doesn't match with date_trunc('month', dt)= '2023-11-01'
+     * Rewritten : select date_trunc('month, dt) from t where date_trunc('month', dt) between '2023-11-01' and '2023-12-01'
      */
     private static Set<BinaryType> SUPPORTED_BINARY_TYPES = ImmutableSet.of(
             BinaryType.GE,
-            BinaryType.LE,
             BinaryType.GT,
             BinaryType.LT
     );
@@ -109,6 +114,9 @@ public class DateTruncEquivalent extends IPredicateRewriteEquivalent {
                 return null;
             }
             BinaryPredicateOperator predicate = (BinaryPredicateOperator) newInput.clone();
+            if (!isSupportedBinaryType(predicate.getBinaryType())) {
+                return null;
+            }
             predicate.setChild(0, replace);
             return predicate;
         } else if (newInput instanceof CallOperator) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.planner;
 
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -239,7 +240,7 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 "PARTITION BY ds \n" +
                 "DISTRIBUTED BY RANDOM \n" +
                 "AS SELECT \n" +
-                "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                "bitmap_union(to_bitmap(`order_id`)) AS `order_num`, \n" +
                 "date_trunc('minute', `dt`) AS ds\n" +
                 "FROM `test_partition_expr_tbl1`\n" +
                 "group by ds;";
@@ -254,8 +255,20 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                     "group by ds")
                     .match("test_partition_expr_mv1");
         }
+        connectContext.getSessionVariable().setEnableMaterializedViewTimeSeriesPushDownRewrite(false);
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('minute', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE `dt` BETWEEN '2023-04-11' AND '2023-04-12'\n" +
+                    "group by ds")
+                    .nonMatch("test_partition_expr_mv1");
+        }
+        connectContext.getSessionVariable().setEnableMaterializedViewTimeSeriesPushDownRewrite(true);
 
         {
+            UtFrameUtils.mockLogicalScanIsEmptyOutputRows(false);
             sql("SELECT \n" +
                     "count(DISTINCT `order_id`) AS `order_num`, \n" +
                     "date_trunc('minute', `dt`) AS ds \n" +
@@ -264,7 +277,6 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                     "group by ds")
                     .match("test_partition_expr_mv1");
         }
-
         starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
         starRocksAssert.dropTable("test_partition_expr_tbl1");
     }
@@ -293,7 +305,6 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 "FROM `test_partition_expr_tbl1`\n" +
                 "group by ds;";
         starRocksAssert.withMaterializedView(mv);
-
         {
             sql("SELECT \n" +
                     "count(DISTINCT `order_id`) AS `order_num`, \n" +
@@ -322,6 +333,121 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                     "WHERE `dt` BETWEEN '2023-04-11' AND '2023-04-12'\n" +
                     "group by ds")
                     .nonMatch("test_partition_expr_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
+        starRocksAssert.dropTable("test_partition_expr_tbl1");
+    }
+
+    @Test
+    public void testDateTruncPartitionColumnExpr3() throws Exception {
+        String tableSQL = "CREATE TABLE `test_partition_expr_tbl1` (\n" +
+                "  `order_id` bigint(20) NOT NULL,\n" +
+                "  `dt` datetime NOT NULL,\n" +
+                "  `value` varchar(256) NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`order_id`, `dt`)\n" +
+                "PARTITION BY RANGE(`dt`)\n" +
+                "(\n" +
+                "PARTITION p2023041017 VALUES [(\"2023-04-10 17:00:00\"), (\"2023-04-10 18:00:00\")),\n" +
+                "PARTITION p2023041021 VALUES [(\"2023-04-10 21:00:00\"), (\"2023-04-10 22:00:00\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`order_id`)";
+        starRocksAssert.withTable(tableSQL);
+        String mv = "CREATE MATERIALIZED VIEW `test_partition_expr_mv1`\n" +
+                "PARTITION BY ds \n" +
+                "DISTRIBUTED BY RANDOM \n" +
+                "AS SELECT \n" +
+                "bitmap_union(to_bitmap(`order_id`)) AS `order_num`, \n" +
+                "date_trunc('hour', `dt`) AS ds\n" +
+                "FROM `test_partition_expr_tbl1`\n" +
+                "group by ds;";
+        starRocksAssert.withMaterializedView(mv);
+
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('day', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE date_trunc('day', `dt`) = '2023-04-01'\n" +
+                    "group by ds")
+                    .nonMatch("test_partition_expr_mv1");
+        }
+        UtFrameUtils.mockLogicalScanIsEmptyOutputRows(false);
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('day', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE date_trunc('day', `dt`) BETWEEN '2023-04-01' AND '2023-05-01'\n" +
+                    "group by ds")
+                    .match("test_partition_expr_mv1");
+        }
+
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('day', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE `dt` BETWEEN '2023-04-11' AND '2023-04-12'\n" +
+                    "group by ds")
+                    .match("test_partition_expr_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
+        starRocksAssert.dropTable("test_partition_expr_tbl1");
+    }
+
+    @Test
+    public void testDateTruncPartitionColumnExpr4() throws Exception {
+        String tableSQL = "CREATE TABLE `test_partition_expr_tbl1` (\n" +
+                "  `order_id` bigint(20) NOT NULL,\n" +
+                "  `dt` datetime NOT NULL,\n" +
+                "  `value` varchar(256) NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`order_id`, `dt`)\n" +
+                "PARTITION BY date_trunc('hour', `dt`)\n" + // with date_trunc partition expression
+                "DISTRIBUTED BY HASH(`order_id`)";
+        starRocksAssert.withTable(tableSQL);
+        String mv = "CREATE MATERIALIZED VIEW `test_partition_expr_mv1`\n" +
+                "PARTITION BY ds \n" +
+                "DISTRIBUTED BY RANDOM \n" +
+                "AS SELECT \n" +
+                "bitmap_union(to_bitmap(`order_id`)) AS `order_num`, \n" +
+                "date_trunc('hour', `dt`) AS ds\n" +
+                "FROM `test_partition_expr_tbl1`\n" +
+                "group by ds;";
+        starRocksAssert.withMaterializedView(mv);
+
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('day', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE date_trunc('day', `dt`) = '2023-04-01'\n" +
+                    "group by ds")
+                    .nonMatch("test_partition_expr_mv1");
+        }
+
+        UtFrameUtils.mockLogicalScanIsEmptyOutputRows(false);
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('day', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE date_trunc('day', `dt`) BETWEEN '2023-04-01' AND '2023-05-01'\n" +
+                    "group by ds")
+                    .match("test_partition_expr_mv1");
+        }
+
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('day', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE `dt` BETWEEN '2023-04-11' AND '2023-04-12'\n" +
+                    "group by ds")
+                    .match("test_partition_expr_mv1");
         }
 
         starRocksAssert.dropMaterializedView("test_partition_expr_mv1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -788,7 +788,7 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
 
         {
             String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
-                    " FROM base_tbl1 where `k1` = '2020-02-11' group by ds";
+                    " FROM base_tbl1 where date_trunc('minute', `k1`) = '2020-02-11' group by ds";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "test_mv1", "ds = '2020-02-11 00:00:00'");
         }
@@ -872,8 +872,8 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
 
         {
             String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
-                    " FROM base_tbl1 where `k1` = '2020-02-11' group by ds";
-            String plan = getFragmentPlan(query);
+                    " FROM base_tbl1 where date_trunc('minute', `k1`)  = '2020-02-11' group by ds";
+            String plan = getFragmentPlan(query, "MV");
             PlanTestBase.assertContains(plan, "test_mv1", "ds = '2020-02-11 00:00:00'");
         }
 


### PR DESCRIPTION
## Why I'm doing:
Query should be rewritten below:
```
 MV       : select date_trunc('day', dt) as dt from t
Query  : select date_trunc('month, dt) from t where dt between '2023-11-01' and '2023-12-01'
```
## What I'm doing:

```
    /**
     * TODO: we can support this later.
     * Change date_trunc('month', dt) to col = '2023-12-01' will get a wrong result.
     * MV       : select date_trunc('day', dt) as dt from t
     * Query1   : select date_trunc('month, dt) from t dt = '2023-11-01'
     * -- cannot be rewritten, rewrite  result will be wrong
     * Rewritten: select date_trunc('month, dt) from t where date_trunc('month', dt) = '2023-11-01'
     *
     * Query2   : select date_trunc('month, dt) from t where dt between '2023-11-01' and '2023-12-01'
     * -- cannot be rewritten, dt='2023-12-01' doesn't match with date_trunc('month', dt)= '2023-11-01'
     * Rewritten : select date_trunc('month, dt) from t where date_trunc('month', dt) between '2023-11-01' and '2023-12-01'
     */
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0