### PR TITLE
[BugFix] fix const pullup problem

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectEmptyRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneProjectEmptyRule.java
@@ -23,6 +23,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.Collections;
@@ -42,6 +43,11 @@ public class PruneProjectEmptyRule extends TransformationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalProjectOperator projectOperator = (LogicalProjectOperator) input.getOp();
+        if (projectOperator.getColumnRefMap().values().stream().allMatch(ScalarOperator::isConstant)) {
+            return Collections.emptyList();
+        }
+
         List<ColumnRefOperator> outputs =
                 Lists.newArrayList(((LogicalProjectOperator) input.getOp()).getColumnRefMap().keySet());
         return Lists.newArrayList(OptExpression.create(new LogicalValuesOperator(outputs, Collections.emptyList())));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -74,6 +74,12 @@ public class SelectConstTest extends PlanTestBase {
                 "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: 1: v1 = 1");
+        assertPlanContains("select t.aaa from (select cast(4/3 as int)as aaa)t", "1:Project\n" +
+                "  |  <slot 3> : CAST(1.3333333333333333 AS INT)\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         NULL");
     }
 
     @Test
@@ -214,6 +220,12 @@ public class SelectConstTest extends PlanTestBase {
                 "78883632:00:00");
         assertFeExecuteResult("select timediff('1000-01-01 01:01:01.000001', '9999-01-02 01:01:01.123456')",
                 "-78883632:00:01");
+    }
+
+    @Test
+    public void testLogicalValueWithProject() throws Exception {
+        String sql = "select t.aaa from (select cast(4/3 as int)as aaa)t;";
+        System.out.println(getVerboseExplain(sql));
     }
 
     private void assertFeExecuteResult(String sql, String expected) throws Exception {


### PR DESCRIPTION
## Why I'm doing:
since https://github.com/StarRocks/starrocks/pull/49724 pull up const column,  we can't prune project with const expr even it's child is empty LogicalValuesOperator

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0