### PR TITLE
[BugFix] fix partition min/max prune with null-value partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -626,7 +626,7 @@ public class ListPartitionInfo extends PartitionInfo {
                     .filter(x -> x.getValue().stream().anyMatch(LiteralExpr::isConstantNull))
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toList());
-        } else if (MapUtils.isEmpty(idToMultiLiteralExprValues)) {
+        } else if (MapUtils.isNotEmpty(idToMultiLiteralExprValues)) {
             // only if all partition columns are NULL
             return idToMultiLiteralExprValues.entrySet().stream()
                     .filter(x -> x.getValue().stream().anyMatch(y -> y.stream().allMatch(LiteralExpr::isConstantNull)))

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -615,6 +615,29 @@ public class ListPartitionInfo extends PartitionInfo {
     }
 
     /**
+     * ListPartition would put the NULL value into a real NULL partition, whose partition value is NullLiteral
+     *
+     * @return
+     */
+    @Override
+    public List<Long> getNullValuePartitions() {
+        if (MapUtils.isNotEmpty(idToLiteralExprValues)) {
+            return idToLiteralExprValues.entrySet().stream()
+                    .filter(x -> x.getValue().stream().anyMatch(LiteralExpr::isConstantNull))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
+        } else if (MapUtils.isEmpty(idToMultiLiteralExprValues)) {
+            // only if all partition columns are NULL
+            return idToMultiLiteralExprValues.entrySet().stream()
+                    .filter(x -> x.getValue().stream().anyMatch(y -> y.stream().allMatch(LiteralExpr::isConstantNull)))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
+        } else {
+            return Lists.newArrayList();
+        }
+    }
+
+    /**
      * Compare based on the max/min value in the list
      */
     private static int compareRow(List<LiteralExpr> lhs, List<LiteralExpr> rhs, boolean asc) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -616,24 +616,22 @@ public class ListPartitionInfo extends PartitionInfo {
 
     /**
      * ListPartition would put the NULL value into a real NULL partition, whose partition value is NullLiteral
-     *
-     * @return
      */
     @Override
-    public List<Long> getNullValuePartitions() {
+    public Set<Long> getNullValuePartitions() {
         if (MapUtils.isNotEmpty(idToLiteralExprValues)) {
             return idToLiteralExprValues.entrySet().stream()
                     .filter(x -> x.getValue().stream().anyMatch(LiteralExpr::isConstantNull))
                     .map(Map.Entry::getKey)
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toSet());
         } else if (MapUtils.isNotEmpty(idToMultiLiteralExprValues)) {
             // only if all partition columns are NULL
             return idToMultiLiteralExprValues.entrySet().stream()
                     .filter(x -> x.getValue().stream().anyMatch(y -> y.stream().allMatch(LiteralExpr::isConstantNull)))
                     .map(Map.Entry::getKey)
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toSet());
         } else {
-            return Lists.newArrayList();
+            return Sets.newHashSet();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -254,6 +254,14 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
         throw new NotImplementedException("not reachable");
     }
 
+    /**
+     * Return the partitions that contains NULL partition values
+     * e.g. PARTITION p_null VALUES IN (NULL)
+     */
+    public List<Long> getNullValuePartitions() {
+        throw new NotImplementedException("not reachable");
+    }
+
     @Override
     public void gsonPreProcess() throws IOException {
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -52,6 +52,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.validation.constraints.NotNull;
 
 /*
@@ -258,7 +259,7 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
      * Return the partitions that contains NULL partition values
      * e.g. PARTITION p_null VALUES IN (NULL)
      */
-    public List<Long> getNullValuePartitions() {
+    public Set<Long> getNullValuePartitions() {
         throw new NotImplementedException("not reachable");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -391,11 +391,11 @@ public class RangePartitionInfo extends PartitionInfo {
      * It's a little bit tricky, as that partition might contain NULL, or might not.
      */
     @Override
-    public List<Long> getNullValuePartitions() {
+    public Set<Long> getNullValuePartitions() {
         return idToRange.entrySet().stream()
                 .filter(x -> x.getValue().lowerEndpoint().isMinValue())
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
     // get a sorted range list, exclude partitions which ids are in 'excludePartitionIds'

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -386,6 +386,18 @@ public class RangePartitionInfo extends PartitionInfo {
         return sortedList.stream().map(Map.Entry::getKey).collect(Collectors.toList());
     }
 
+    /**
+     * For RangePartition, NULL value would be put in the MIN_VALUE partition but not a real NULL.
+     * It's a little bit tricky, as that partition might contain NULL, or might not.
+     */
+    @Override
+    public List<Long> getNullValuePartitions() {
+        return idToRange.entrySet().stream()
+                .filter(x -> x.getValue().lowerEndpoint().isMinValue())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
     // get a sorted range list, exclude partitions which ids are in 'excludePartitionIds'
     public List<Range<PartitionKey>> getRangeList(Set<Long> excludePartitionIds, boolean isTemp) {
         Map<Long, Range<PartitionKey>> tmpMap = idToRange;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
@@ -220,11 +220,13 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
         List<Partition> nonEmpty = table.getNonEmptyPartitions();
         Set<Long> nonEmptyPartitionIds = nonEmpty.stream().map(Partition::getId).collect(Collectors.toSet());
         PartitionInfo partitionInfo = table.getPartitionInfo();
+        List<Long> nullPartitions = partitionInfo.getNullValuePartitions();
 
         List<Long> pruned = Lists.newArrayList();
         if (hasMinMax.first) {
             List<Long> sorted = partitionInfo.getSortedPartitions(true);
             sorted.retainAll(nonEmptyPartitionIds);
+            sorted.removeAll(nullPartitions);
             if (CollectionUtils.isEmpty(sorted)) {
                 return null;
             }
@@ -234,6 +236,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
         if (hasMinMax.second) {
             List<Long> sorted = partitionInfo.getSortedPartitions(false);
             sorted.retainAll(nonEmptyPartitionIds);
+            sorted.removeAll(nullPartitions);
             if (CollectionUtils.isEmpty(sorted)) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
@@ -226,8 +226,13 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
         if (hasMinMax.first) {
             List<Long> sorted = partitionInfo.getSortedPartitions(true);
             sorted.retainAll(nonEmptyPartitionIds);
-            sorted.removeAll(nullPartitions);
             if (CollectionUtils.isEmpty(sorted)) {
+                return null;
+            }
+            // TODO: in theory if we can confirm one partition contains only NULL values, we can rule out these
+            //  partitions from sorted. But currently a range-partition can contains both NULL value and regular
+            //  values
+            if (nullPartitions.contains(sorted.get(0))) {
                 return null;
             }
             pruned.add(sorted.get(0));
@@ -238,6 +243,9 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
             sorted.retainAll(nonEmptyPartitionIds);
             sorted.removeAll(nullPartitions);
             if (CollectionUtils.isEmpty(sorted)) {
+                return null;
+            }
+            if (nullPartitions.contains(sorted.get(0))) {
                 return null;
             }
             pruned.add(sorted.get(0));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
@@ -229,26 +229,28 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
             if (CollectionUtils.isEmpty(sorted)) {
                 return null;
             }
-            // TODO: in theory if we can confirm one partition contains only NULL values, we can rule out these
-            //  partitions from sorted. But currently a range-partition can contains both NULL value and regular
-            //  values
-            if (nullPartitions.contains(sorted.get(0))) {
-                return null;
+            for (long partitionId : sorted) {
+                pruned.add(partitionId);
+                // at least reserve one non-null partition, null-partition might be useless
+                if (!nullPartitions.contains(partitionId)) {
+                    break;
+                }
             }
-            pruned.add(sorted.get(0));
         }
 
         if (hasMinMax.second) {
             List<Long> sorted = partitionInfo.getSortedPartitions(false);
             sorted.retainAll(nonEmptyPartitionIds);
-            sorted.removeAll(nullPartitions);
             if (CollectionUtils.isEmpty(sorted)) {
                 return null;
             }
-            if (nullPartitions.contains(sorted.get(0))) {
-                return null;
+            for (long partitionId : sorted) {
+                pruned.add(partitionId);
+                // at least reserve one non-null partition, null-partition might be useless
+                if (!nullPartitions.contains(partitionId)) {
+                    break;
+                }
             }
-            pruned.add(sorted.get(0));
         }
 
         LogicalOlapScanOperator scan = new LogicalOlapScanOperator.Builder()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
@@ -220,7 +220,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
         List<Partition> nonEmpty = table.getNonEmptyPartitions();
         Set<Long> nonEmptyPartitionIds = nonEmpty.stream().map(Partition::getId).collect(Collectors.toSet());
         PartitionInfo partitionInfo = table.getPartitionInfo();
-        List<Long> nullPartitions = partitionInfo.getNullValuePartitions();
+        Set<Long> nullPartitions = partitionInfo.getNullValuePartitions();
 
         List<Long> pruned = Lists.newArrayList();
         if (hasMinMax.first) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -30,7 +30,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertTrue;
 
@@ -366,7 +366,7 @@ public class PartitionPruneTest extends PlanTestBase {
         {
             OlapTable t1 = (OlapTable) starRocksAssert.getTable("test", "t1_list");
             PartitionInfo partitionInfo = t1.getPartitionInfo();
-            List<Long> nullValuePartitions = partitionInfo.getNullValuePartitions();
+            Set<Long> nullValuePartitions = partitionInfo.getNullValuePartitions();
             Assert.assertEquals(1, nullValuePartitions.size());
         }
 
@@ -383,7 +383,7 @@ public class PartitionPruneTest extends PlanTestBase {
             OlapTable t3 = (OlapTable) starRocksAssert.getTable("test", "t3_composite");
             PartitionInfo partitionInfo = t3.getPartitionInfo();
 
-            List<Long> nullValuePartitions = partitionInfo.getNullValuePartitions();
+            Set<Long> nullValuePartitions = partitionInfo.getNullValuePartitions();
             Assert.assertEquals(0, nullValuePartitions.size());
 
             starRocksAssert.ddl("alter table t3_composite add partition pnull values in ((NULL, NULL))");
@@ -402,7 +402,7 @@ public class PartitionPruneTest extends PlanTestBase {
         {
             OlapTable t2 = (OlapTable) starRocksAssert.getTable("test", "t2_range");
             PartitionInfo partitionInfo = t2.getPartitionInfo();
-            List<Long> nullValuePartitions = partitionInfo.getNullValuePartitions();
+            Set<Long> nullValuePartitions = partitionInfo.getNullValuePartitions();
             Assert.assertEquals(1, nullValuePartitions.size());
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -430,11 +430,11 @@ public class PartitionPruneTest extends PlanTestBase {
         starRocksAssert.ddl("alter table t2_dup add partition p20240104 values less than('2024-01-04') ");
         starRocksAssert.ddl("alter table t2_dup add partition p20240105 values less than('2024-01-05') ");
 
-        starRocksAssert.query("select min(c1) from t2_dup").explainContains("partitions=1/5");
+        starRocksAssert.query("select min(c1) from t2_dup").explainContains("partitions=2/5");
         starRocksAssert.query("select max(c1) from t2_dup").explainContains("partitions=1/5");
-        starRocksAssert.query("select min(c1), max(c1) from t2_dup").explainContains("partitions=2/5");
-        starRocksAssert.query("select min(c1)+1, max(c1)-1 from t2_dup").explainContains("partitions=2/5");
-        starRocksAssert.query("select min(c1) from t2_dup limit 10").explainContains("partitions=1/5");
+        starRocksAssert.query("select min(c1), max(c1) from t2_dup").explainContains("partitions=3/5");
+        starRocksAssert.query("select min(c1)+1, max(c1)-1 from t2_dup").explainContains("partitions=3/5");
+        starRocksAssert.query("select min(c1) from t2_dup limit 10").explainContains("partitions=2/5");
 
         // manually specify partition
         starRocksAssert.query("select min(c1) from t2_dup partition p20240101").explainContains("partitions=1/5");

--- a/test/sql/test_list_partition/R/test_list_partition_minmax
+++ b/test/sql/test_list_partition/R/test_list_partition_minmax
@@ -1,0 +1,31 @@
+-- name: test_list_partition_minmax
+create table t1(user_id int, dt datetime) partition by dt;
+-- result:
+-- !result
+insert into t1 values (1, '2024-10-05 01:01:01'), (2, '2024-10-06 02:02:02'), (3, '2024-10-07 03:03:03'), (4, NULL);
+-- result:
+-- !result
+select min(dt), max(dt) from t1;
+-- result:
+2024-10-05 01:01:01	2024-10-07 03:03:03
+-- !result
+create table t2(user_id int, dt datetime) partition by date_trunc('day', dt);
+-- result:
+-- !result
+insert into t2 values (1, '2024-10-05 01:01:01'), (2, '2024-10-06 02:02:02'), (3, '2024-10-07 03:03:03'), (4, NULL);
+-- result:
+-- !result
+select min(dt), max(dt) from t2;
+-- result:
+2024-10-05 01:01:01	2024-10-07 03:03:03
+-- !result
+create table t3(user_id int, dt datetime) partition by (user_id, dt);
+-- result:
+-- !result
+insert into t3 values (1, '2024-10-05 01:01:01'), (2, '2024-10-06 02:02:02'), (3, '2024-10-07 03:03:03'), (4, NULL), (NULL, NULL);
+-- result:
+-- !result
+select min(dt), max(dt) from t3;
+-- result:
+2024-10-05 01:01:01	2024-10-07 03:03:03
+-- !result

--- a/test/sql/test_list_partition/T/test_list_partition_minmax
+++ b/test/sql/test_list_partition/T/test_list_partition_minmax
@@ -1,0 +1,22 @@
+-- name: test_list_partition_minmax
+
+-- 1. column
+create table t1(user_id int, dt datetime) partition by dt;
+
+insert into t1 values (1, '2024-10-05 01:01:01'), (2, '2024-10-06 02:02:02'), (3, '2024-10-07 03:03:03'), (4, NULL);
+
+select min(dt), max(dt) from t1;
+
+-- 2. date_trunc
+create table t2(user_id int, dt datetime) partition by date_trunc('day', dt);
+
+insert into t2 values (1, '2024-10-05 01:01:01'), (2, '2024-10-06 02:02:02'), (3, '2024-10-07 03:03:03'), (4, NULL);
+
+select min(dt), max(dt) from t2;
+
+-- 3. multi-column
+create table t3(user_id int, dt datetime) partition by (user_id, dt);
+
+insert into t3 values (1, '2024-10-05 01:01:01'), (2, '2024-10-06 02:02:02'), (3, '2024-10-07 03:03:03'), (4, NULL), (NULL, NULL);
+
+select min(dt), max(dt) from t3;


### PR DESCRIPTION
## Why I'm doing:

```
create table t2(user_id int, dt datetime) partition by date_trunc('day', dt);
insert into t2 values (1, '2024-10-05 01:01:01'), (2, '2024-10-06 02:02:02'), (3, '2024-10-07 03:03:03'), (4, NULL);
select min(dt), max(dt) from t2;
```

For this case, we need to rule out NULL partition when doing min/max partition pruning, because `min/max` aggregation function itself also rule out NULL values.

## What I'm doing:


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0