### PR TITLE
[BugFix] Fix some fragment not recv runtime filter

### DIFF
--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -389,6 +389,10 @@ Status FragmentContext::submit_active_drivers(DriverExecutor* executor) {
     return Status::OK();
 }
 
+void FragmentContext::acquire_runtime_filters() {
+    iterate_pipeline([this](Pipeline* pipeline) { pipeline->acquire_runtime_filter(this->runtime_state()); });
+}
+
 void FragmentContext::_close_stream_load_contexts() {
     for (const auto& context : _stream_load_contexts) {
         context->body_sink->cancel(Status::Cancelled("Close the stream load pipe"));

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -171,6 +171,9 @@ public:
 
     void set_report_when_finish(bool report) { _report_when_finish = report; }
 
+    // acquire runtime filter from cache
+    void acquire_runtime_filters();
+
 private:
     void _close_stream_load_contexts();
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -917,6 +917,7 @@ Status FragmentExecutor::execute(ExecEnv* exec_env) {
     {
         SCOPED_TIMER(prepare_instance_timer);
         SCOPED_TIMER(prepare_driver_timer);
+        _fragment_ctx->acquire_runtime_filters();
         RETURN_IF_ERROR(_fragment_ctx->prepare_active_drivers());
     }
     prepare_success = true;

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -405,6 +405,9 @@ public:
     // Whether it has any runtime filter built by TopN node.
     bool has_topn_filter() const;
 
+    // try to get runtime filter from cache
+    void acquire_runtime_filter(RuntimeState* state);
+
 protected:
     void _prepare_runtime_in_filters(RuntimeState* state);
     void _prepare_runtime_holders(const std::vector<RuntimeFilterHolder*>& holders,

--- a/be/src/exec/pipeline/pipeline.h
+++ b/be/src/exec/pipeline/pipeline.h
@@ -80,6 +80,12 @@ public:
         }
     }
 
+    void acquire_runtime_filter(RuntimeState* state) {
+        for (auto& op : _op_factories) {
+            op->acquire_runtime_filter(state);
+        }
+    }
+
     std::string to_readable_string() const {
         std::stringstream ss;
         ss << "operator-chain: [";

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -18,6 +18,7 @@
 #include <sstream>
 
 #include "column/chunk.h"
+#include "common/status.h"
 #include "common/statusor.h"
 #include "exec/pipeline/adaptive/event.h"
 #include "exec/pipeline/exchange/exchange_sink_operator.h"

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -31,6 +31,7 @@
 #include "exec/pipeline/scan/scan_operator.h"
 #include "exec/pipeline/source_operator.h"
 #include "exec/workgroup/work_group_fwd.h"
+#include "exprs/runtime_filter_bank.h"
 #include "fmt/printf.h"
 #include "runtime/mem_tracker.h"
 #include "util/phmap/phmap.h"

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -23,6 +23,7 @@
 #include "exprs/predicate.h"
 #include "exprs/runtime_filter_bank.h"
 #include "gen_cpp/Types_types.h"
+#include "util/defer_op.h"
 
 namespace starrocks::pipeline {
 class RuntimeFilterHolder;
@@ -145,11 +146,13 @@ public:
     }
 
     void set_collector(TPlanNodeId id, RuntimeFilterCollectorPtr&& collector) {
-        get_holder(id, -1)->set_collector(std::move(collector));
+        auto holder = get_holder(id, -1);
+        holder->set_collector(std::move(collector));
     }
 
     void set_collector(TPlanNodeId id, int32_t sequence_id, RuntimeFilterCollectorPtr&& collector) {
-        get_holder(id, sequence_id)->set_collector(std::move(collector));
+        auto holder = get_holder(id, sequence_id);
+        holder->set_collector(std::move(collector));
     }
 
     void close_all_in_filters(RuntimeState* state) {


### PR DESCRIPTION
## Why I'm doing:

When the runtime filter build side finishes executing, but the fragment prepare on the probe side finishes, but is not added to the query context, the runtime will be ignored. In this PR, the fragment will be retrieved from the runtime filter cache after it is added to the query context.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0