### PR TITLE
[BugFix] Consolidating multiple not likes misses not

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ConsolidateLikesRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ConsolidateLikesRule.java
@@ -215,11 +215,12 @@ public class ConsolidateLikesRule extends TopDownScalarOperatorRewriteRule {
                 .collect(Collectors.groupingBy(likeOp ->
                         Utils.mustCast(likeOp.getChild(0), ColumnRefOperator.class)));
 
-        List<Pair<List<LikePredicateOperator>, Optional<List<ScalarOperator>>>> consolidatedConjuncts =
+        List<Pair<List<ScalarOperator>, Optional<List<ScalarOperator>>>> consolidatedConjuncts =
                 likeOpGroups.values()
                         .stream()
                         .map(likePredicateOperators -> Pair.create(
-                                likePredicateOperators,
+                                likePredicateOperators.stream().map(CompoundPredicateOperator::not)
+                                        .collect(Collectors.toList()),
                                 consolidate(likePredicateOperators, consolidateMin)
                                         .map(ops -> ops.stream().map(CompoundPredicateOperator::not)
                                                 .collect(Collectors.toList()))))

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithMultiLikeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithMultiLikeTest.java
@@ -19,6 +19,8 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -34,6 +36,7 @@ public class SelectStmtWithMultiLikeTest {
     private static StarRocksAssert starRocksAssert;
 
     @BeforeAll
+    @BeforeClass
     public static void setUp()
             throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
@@ -67,6 +70,16 @@ public class SelectStmtWithMultiLikeTest {
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("joinOnMultiLikeTestCases")
     void testJoinOnMultiLikeClause(String sql, List<String> patterns) throws Exception {
+        test(sql, patterns);
+    }
+
+    @Test
+    public void testMultiNotLikes() throws Exception {
+        String sql = "select count(1) from t0 where " +
+                "site not like '%ABC%' and " +
+                "region not like '%ABC%' and region not like '%DEF%'";
+        List<String> patterns = Lists.newArrayList(
+                "Predicates: NOT (1: region REGEXP '^((.*ABC.*)|(.*DEF.*))$'), NOT (3: site LIKE '%ABC%')");
         test(sql, patterns);
     }
 


### PR DESCRIPTION
## Why I'm doing:
query as follows
```
select count(1) from t0 where 
                site not like '%ABC%' and
                region not like '%ABC%' and region not like '%DEF%';
```
After like predicates consolidating, the expect final predicates should be
```
site not like '%ABC%' and region not regexp '^((.*ABC.*)|(.*DEF.*))$'
```
but actually, the final predicates go wrong as follows(not is missing)
```
site like '%ABC%' and region not regexp '^((.*ABC.*)|(.*DEF.*))$'
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0