### PR TITLE
[Enhancement] Add pendingTime/netTime/netComputeTime to queryDetail

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TimeWatcher.java
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -40,6 +41,10 @@ public class TimeWatcher {
         }
         t.start();
         return t;
+    }
+
+    public Optional<Timer> getTimer(String name) {
+        return Optional.ofNullable(timers.get(name));
     }
 
     public List<Timer> getAllTimerWithOrder() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracer.java
@@ -18,6 +18,7 @@ import com.starrocks.common.util.RuntimeProfile;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 public abstract class Tracer {
@@ -70,5 +71,9 @@ public abstract class Tracer {
     }
 
     public void toRuntimeProfile(RuntimeProfile parent) {
+    }
+
+    public Optional<Timer> getSpecifiedTimer(String name) {
+        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TracerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TracerImpl.java
@@ -20,6 +20,7 @@ import com.starrocks.common.util.RuntimeProfile;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -241,5 +242,10 @@ class TracerImpl extends Tracer {
         buildTimers(parent);
         buildVars(parent);
         buildReasons(parent);
+    }
+
+    @Override
+    public Optional<Timer> getSpecifiedTimer(String name) {
+        return watcher.getTimer(name);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -20,6 +20,7 @@ import com.starrocks.qe.ConnectContext;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 public class Tracers {
@@ -256,6 +257,11 @@ public class Tracers {
     public static void toRuntimeProfile(RuntimeProfile profile) {
         Tracers tracers = THREAD_LOCAL.get();
         tracers.allTracer[1].toRuntimeProfile(profile);
+    }
+
+    public static Optional<Timer> getSpecifiedTimer(String name) {
+        Tracers tracers = THREAD_LOCAL.get();
+        return tracers.allTracer[1].getSpecifiedTimer(name);
     }
 
     public static String getTrace(Mode mode) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -65,6 +65,10 @@ public class QueryDetail implements Serializable {
     // default value will set to be minus one(-1).
     private long endTime;
     private long latency;
+
+    private long pendingTime = -1;
+    private long netTime = -1;
+    private long netComputeTime = -1;
     private QueryMemState state;
     private String database;
     private String sql;
@@ -205,6 +209,30 @@ public class QueryDetail implements Serializable {
 
     public long getLatency() {
         return latency;
+    }
+
+    public long getPendingTime() {
+        return pendingTime;
+    }
+
+    public void setPendingTime(long pendingTime) {
+        this.pendingTime = pendingTime;
+    }
+
+    public long getNetTime() {
+        return netTime;
+    }
+
+    public void setNetTime(long netTime) {
+        this.netTime = netTime;
+    }
+
+    public long getNetComputeTime() {
+        return netComputeTime;
+    }
+
+    public void setNetComputeTime(long netComputeTime) {
+        this.netComputeTime = netComputeTime;
     }
 
     public void setState(QueryMemState state) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2855,6 +2855,15 @@ public class StmtExecutor {
         }
         queryDetail.setEndTime(endTime);
         queryDetail.setLatency(elapseMs);
+        long pendingTime = ctx.getAuditEventBuilder().build().pendingTimeMs;
+        pendingTime = pendingTime < 0 ? 0 : pendingTime;
+        queryDetail.setPendingTime(pendingTime);
+        queryDetail.setNetTime(elapseMs - pendingTime);
+        long parseTime = Tracers.getSpecifiedTimer("Parser").map(Timer::getTotalTime).orElse(0L);
+        long planTime = Tracers.getSpecifiedTimer("Total").map(Timer::getTotalTime).orElse(0L);
+        long prepareTime = Tracers.getSpecifiedTimer("Prepare").map(Timer::getTotalTime).orElse(0L);
+        long deployTime = Tracers.getSpecifiedTimer("Deploy").map(Timer::getTotalTime).orElse(0L);
+        queryDetail.setNetComputeTime(elapseMs - parseTime - planTime - prepareTime - pendingTime - deployTime);
         queryDetail.setResourceGroupName(ctx.getResourceGroup() != null ? ctx.getResourceGroup().getName() : "");
         // add execution statistics into queryDetail
         queryDetail.setReturnRows(ctx.getReturnRows());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -63,24 +63,29 @@ public class QueryDetailQueueTest extends PlanTestBase {
 
         Gson gson = new Gson();
         String jsonString = gson.toJson(queryDetails);
-        String queryDetailString = "[{\"eventTime\":" + startQueryDetail.getEventTime() + ","
-                + "\"queryId\":\"219a2d5443c542d4-8fc938db37c892e3\","
-                + "\"isQuery\":false,"
-                + "\"remoteIP\":\"127.0.0.1\","
-                + "\"connId\":1,"
-                + "\"startTime\":" + startQueryDetail.getStartTime() + ",\"endTime\":-1,\"latency\":-1,"
-                + "\"state\":\"RUNNING\",\"database\":\"testDb\","
-                + "\"sql\":\"select * from table1 limit 1\","
-                + "\"user\":\"root\","
-                + "\"scanRows\":100,"
-                + "\"scanBytes\":10001,"
-                + "\"returnRows\":1,"
-                + "\"cpuCostNs\":1002,"
-                + "\"memCostBytes\":100003,"
-                + "\"spillBytes\":-1,"
-                + "\"warehouse\":\"default_warehouse\","
-                + "\"catalog\":\"default_catalog\""
-                + "}]";
+        String queryDetailString = "[{\"eventTime\":" + startQueryDetail.getEventTime() + "," +
+                "\"queryId\":\"219a2d5443c542d4-8fc938db37c892e3\"," +
+                "\"isQuery\":false," +
+                "\"remoteIP\":\"127.0.0.1\"," +
+                "\"connId\":1," +
+                "\"startTime\":" + startQueryDetail.getStartTime() + "," +
+                "\"endTime\":-1," +
+                "\"latency\":-1," +
+                "\"pendingTime\":-1," +
+                "\"netTime\":-1," +
+                "\"netComputeTime\":-1," +
+                "\"state\":\"RUNNING\"," +
+                "\"database\":\"testDb\"," +
+                "\"sql\":\"select * from table1 limit 1\"," +
+                "\"user\":\"root\"," +
+                "\"scanRows\":100," +
+                "\"scanBytes\":10001," +
+                "\"returnRows\":1," +
+                "\"cpuCostNs\":1002," +
+                "\"memCostBytes\":100003," +
+                "\"spillBytes\":-1," +
+                "\"warehouse\":\"default_warehouse\"," +
+                "\"catalog\":\"default_catalog\"}]";
         Assert.assertEquals(jsonString, queryDetailString);
 
         queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(startQueryDetail.getEventTime());


### PR DESCRIPTION
## Why I'm doing:
Add pendingTime, netTime, netComputeTime to QueryDetail, so we can sort history query list by netTime or netComputeTime in byoc-admin to find out real top-N slow queries.
1. netTime = latency - pendingTime;
2. netComputeTime = latency - parseTime - planTime - prepareTime(MPP) - pendingTime - deployTime.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0