### PR TITLE
[BugFix] With a high streamload frequency and too many tablets involved, TabletCommitInfos will take up too much memory.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1177,7 +1177,6 @@ public class DatabaseTransactionMgr {
                     transactionState.clearErrorMsg();
                     transactionState.setTransactionStatus(TransactionStatus.VISIBLE);
                     unprotectUpsertTransactionState(transactionState, false);
-                    transactionState.resetTabletCommitInfos();
                     txnOperated = true;
                     // TODO(cmy): We found a very strange problem. When delete-related transactions are processed here,
                     // subsequent `updateCatalogAfterVisible()` is called, but it does not seem to be executed here
@@ -1206,6 +1205,13 @@ public class DatabaseTransactionMgr {
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE);
             finishSpan.end();
+        }
+
+        writeLock();
+        try {
+            transactionState.resetTabletCommitInfos();
+        } finally {
+            writeUnlock();
         }
 
         transactionState.notifyVisible();
@@ -1886,7 +1892,6 @@ public class DatabaseTransactionMgr {
                     transactionState.setNewFinish();
                     transactionState.setTransactionStatus(TransactionStatus.VISIBLE);
                     unprotectUpsertTransactionState(transactionState, false);
-                    transactionState.resetTabletCommitInfos();
                     transactionState.notifyVisible();
                     txnOperated = true;
                 } finally {
@@ -1907,6 +1912,13 @@ public class DatabaseTransactionMgr {
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE);
             finishSpan.end();
+        }
+
+        writeLock();
+        try {
+            transactionState.resetTabletCommitInfos();
+        } finally {
+            writeUnlock();
         }
 
         // do after transaction finish

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1177,6 +1177,7 @@ public class DatabaseTransactionMgr {
                     transactionState.clearErrorMsg();
                     transactionState.setTransactionStatus(TransactionStatus.VISIBLE);
                     unprotectUpsertTransactionState(transactionState, false);
+                    transactionState.resetTabletCommitInfos();
                     txnOperated = true;
                     // TODO(cmy): We found a very strange problem. When delete-related transactions are processed here,
                     // subsequent `updateCatalogAfterVisible()` is called, but it does not seem to be executed here
@@ -1885,6 +1886,7 @@ public class DatabaseTransactionMgr {
                     transactionState.setNewFinish();
                     transactionState.setTransactionStatus(TransactionStatus.VISIBLE);
                     unprotectUpsertTransactionState(transactionState, false);
+                    transactionState.resetTabletCommitInfos();
                     transactionState.notifyVisible();
                     txnOperated = true;
                 } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1207,13 +1207,7 @@ public class DatabaseTransactionMgr {
             finishSpan.end();
         }
 
-        writeLock();
-        try {
-            transactionState.resetTabletCommitInfos();
-        } finally {
-            writeUnlock();
-        }
-
+        resetTransactionStateTabletCommitInfos(transactionState);
         transactionState.notifyVisible();
         // do after transaction finish
         GlobalStateMgr.getCurrentState().getOperationListenerBus().onStreamJobTransactionFinish(transactionState);
@@ -1914,13 +1908,7 @@ public class DatabaseTransactionMgr {
             finishSpan.end();
         }
 
-        writeLock();
-        try {
-            transactionState.resetTabletCommitInfos();
-        } finally {
-            writeUnlock();
-        }
-
+        resetTransactionStateTabletCommitInfos(transactionState);
         // do after transaction finish
         GlobalStateMgr.getCurrentState().getOperationListenerBus().onStreamJobTransactionFinish(transactionState);
         GlobalStateMgr.getCurrentState().getLocalMetastore().handleMVRepair(transactionState);
@@ -2080,6 +2068,15 @@ public class DatabaseTransactionMgr {
             return new ArrayList<>();
         } finally {
             readUnlock();
+        }
+    }
+
+    public void resetTransactionStateTabletCommitInfos(TransactionState transactionState) {
+        writeLock();
+        try {
+            transactionState.resetTabletCommitInfos();
+        } finally {
+            writeUnlock();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -427,6 +427,12 @@ public class TransactionState implements Writable {
         this.tabletCommitInfos.addAll(infos);
     }
 
+    public void resetTabletCommitInfos() {
+        // With a high streamload frequency and too many tablets involved,
+        // TabletCommitInfos will take up too much memory.
+        tabletCommitInfos = null;
+    }
+
     public boolean tabletCommitInfosContainsReplica(long tabletId, long backendId, ReplicaState state) {
         TabletCommitInfo info = new TabletCommitInfo(tabletId, backendId);
         if (this.tabletCommitInfos == null) {


### PR DESCRIPTION
## Why I'm doing:
Upgrading from 3.1.2 to 3.1.15, the memory grows too fast.
Version 3.1.2 memory didn't grow too fast because of [35115](https://github.com/StarRocks/starrocks/pull/35115) refactoring here.
dump info:
<img width="1282" alt="Clipboard_Screenshot_1732785322" src="https://github.com/user-attachments/assets/ce3e8494-262c-479a-adca-b2e7c88bdcfd">
<img width="1659" alt="企业微信截图_4fe6b993-d882-4695-bf36-b232d3856a8f" src="https://github.com/user-attachments/assets/6b11c04d-5d43-4ff8-bfa8-d438118f671c">
<img width="1671" alt="企业微信截图_dd7af068-781e-43fb-a5c8-5f4f51bd0528" src="https://github.com/user-attachments/assets/87394f11-e9b8-4d8c-b115-107774dd4b75">

## What I'm doing:
Fixes #53330

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0