### PR TITLE
[BugFix] fix bad sst when using cloud native pk index

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -503,7 +503,7 @@ Status LakePersistentIndex::major_compact(TabletManager* tablet_mgr, const Table
 }
 
 Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction) {
-    if (op_compaction.input_sstables().empty()) {
+    if (op_compaction.input_sstables().empty() || !op_compaction.has_output_sstable()) {
         return Status::OK();
     }
 

--- a/be/src/storage/sstable/table_builder.cpp
+++ b/be/src/storage/sstable/table_builder.cpp
@@ -15,6 +15,7 @@
 #include "storage/sstable/filter_block.h"
 #include "storage/sstable/filter_policy.h"
 #include "storage/sstable/format.h"
+#include "testutil/sync_point.h"
 #include "util/crc32c.h"
 #include "util/slice.h"
 
@@ -241,6 +242,8 @@ Status TableBuilder::Finish() {
         WriteBlock(&r->index_block, &index_block_handle);
     }
 
+    TEST_SYNC_POINT_CALLBACK("table_builder_footer_error", &r->status);
+
     // Write footer
     if (ok()) {
         Footer footer;
@@ -254,7 +257,9 @@ Status TableBuilder::Finish() {
         }
     }
     // sync file at last
-    r->status = r->file->sync();
+    if (ok()) {
+        r->status = r->file->sync();
+    }
     return r->status;
 }
 


### PR DESCRIPTION
## Why I'm doing:
After PK index compaction, we saw some error like:
```
Fail to publish version: Corruption: not an sstable (bad magic number) 
```
And in ` TableBuilder::Finish()`:
```
Status TableBuilder::Finish() {
...
    // Write footer
    if (ok()) {
        Footer footer;
        footer.set_metaindex_handle(metaindex_block_handle);
        footer.set_index_handle(index_block_handle);
        std::string footer_encoding;
        footer.EncodeTo(&footer_encoding);
        r->status = r->file->append(footer_encoding);
        if (r->status.ok()) {
            r->offset += footer_encoding.size();
        }
    }
    // sync file at last
    r->status = r->file->sync(); <--- cover the status
    return r->status;
}
```
If write footer fail, this failure will be cover by `r->file->sync()`, which will generate a bad sst file with bad footer.

## What I'm doing:
Fix #53227

This pull request includes several changes to the `lake_persistent_index.cpp`, `table_builder.cpp`, and `persistent_index_sstable_test.cpp` files. The most important changes involve adding error handling and testing mechanisms, as well as improving the robustness of the `TableBuilder` class.

Error handling improvements:

* [`be/src/storage/lake/lake_persistent_index.cpp`](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1L506-R506): Modified the `LakePersistentIndex::apply_opcompaction` method to return `Status::OK()` if `op_compaction` has no output sstable, in addition to the existing check for empty input sstables.

Testing enhancements:

* [`be/src/storage/sstable/table_builder.cpp`](diffhunk://#diff-632676454a6529b702fbe5e0e40df1e31ad09b29b851c2d415610732f39e890dR18): Included the `testutil/sync_point.h` header for testing purposes.
* [`be/src/storage/sstable/table_builder.cpp`](diffhunk://#diff-632676454a6529b702fbe5e0e40df1e31ad09b29b851c2d415610732f39e890dR245-R246): Added a sync point callback `TEST_SYNC_POINT_CALLBACK` in the `TableBuilder::Finish` method to simulate footer writing errors during testing.
* [`be/src/storage/sstable/table_builder.cpp`](diffhunk://#diff-632676454a6529b702fbe5e0e40df1e31ad09b29b851c2d415610732f39e890dR260-R262): Added a condition to only sync the file if the status is okay, enhancing the robustness of the `Finish` method.
* [`be/test/storage/lake/persistent_index_sstable_test.cpp`](diffhunk://#diff-5075d8527359a8a36edf4d32868db10575b11ab75150279fd8e912107d7f12aaR441-R473): Added a new test `test_ioerror_inject` in `PersistentIndexSstableTest` to inject IO errors and verify the handling of such errors during the table building process.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0