### PR TITLE
[BugFix] Fix get compaction status crash

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1348,7 +1348,7 @@ void Tablet::get_compaction_status(std::string* json_result) {
                 version.SetString(version_value.c_str(), version_value.length(), root.GetAllocator());
                 value.AddMember("version", version, root.GetAllocator());
 
-                input_rowset_details.PushBack(value, input_rowset_details.GetAllocator());
+                input_rowset_details.PushBack(value, root.GetAllocator());
             }
             task.AddMember("input_rowset_details", input_rowset_details, root.GetAllocator());
             compaction_detail.AddMember("task", task, root.GetAllocator());

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -474,4 +474,47 @@ TEST_F(CompactionManagerTest, test_compaction_update_thread_pool_num) {
     EXPECT_EQ(5, _engine->compaction_manager()->max_task_num());
 }
 
+TEST_F(CompactionManagerTest, test_get_compaction_status) {
+    auto tablet_meta = std::make_shared<TabletMeta>();
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
+    tablet_meta->set_tablet_schema(schema);
+    DataDir data_dir("./data_dir");
+    auto tablet = Tablet::create_tablet_from_meta(tablet_meta, &data_dir);
+    tablet_meta->set_tablet_id(0);
+    auto compaction_context = std::make_unique<CompactionContext>();
+    compaction_context->policy = std::make_unique<DefaultCumulativeBaseCompactionPolicy>(tablet.get());
+    tablet->set_compaction_context(compaction_context);
+
+    std::vector<RowsetSharedPtr> mock_rowsets;
+    auto rs_meta_pb = std::make_unique<RowsetMetaPB>();
+    rs_meta_pb->set_rowset_id("123");
+    rs_meta_pb->set_start_version(0);
+    rs_meta_pb->set_end_version(1);
+    auto rowset_meta = std::make_shared<RowsetMeta>(rs_meta_pb);
+    auto rowset = std::make_shared<Rowset>(schema, "", rowset_meta);
+    mock_rowsets.emplace_back(rowset);
+
+    // generate compaction task
+    auto task = std::make_shared<MockCompactionTask>();
+    task->set_tablet(tablet);
+    task->set_task_id(1);
+    task->set_compaction_type(CUMULATIVE_COMPACTION);
+    task->set_input_rowsets(std::move(mock_rowsets));
+
+    _engine->compaction_manager()->init_max_task_num(10);
+    bool ret = _engine->compaction_manager()->register_task(task.get());
+    ASSERT_TRUE(ret);
+    ASSERT_EQ(1, _engine->compaction_manager()->running_tasks_num());
+
+    std::string compaction_status;
+    tablet->get_compaction_status(&compaction_status);
+    ASSERT_TRUE(compaction_status.find("\"compaction_status\": \"RUNNING\"") != std::string::npos);
+    ASSERT_TRUE(compaction_status.find("\"rowset_id\": \"123\"") != std::string::npos);
+
+    _engine->compaction_manager()->clear_tasks();
+    ASSERT_EQ(0, _engine->compaction_manager()->running_tasks_num());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
curl `http://be_host:http_port/api/compaction/show?tablet_id=xxx`, be crash
```
tracker:replication consumption: 0
*** Aborted at 1732097972 (unix time) try "date -d @1732097972" if you are using GNU date ***
PC: @          0x358e76d rapidjson::Writer<>::WriteString()
*** SIGSEGV (@0x730cf403d603) received by PID 2820 (TID 0x7fc6bd9fe700) from PID 18446744073508476419; stack trace: ***
    @          0x6d54f22 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fc7a06b2630 (unknown)
    @          0x358e76d rapidjson::Writer<>::WriteString()
    @          0x358e932 rapidjson::GenericValue<>::Accept<>()
    @          0x358eba6 rapidjson::GenericValue<>::Accept<>()
    @          0x358eba6 rapidjson::GenericValue<>::Accept<>()
    @          0x358eba6 rapidjson::GenericValue<>::Accept<>()
    @          0x54432cf starrocks::Tablet::get_compaction_status()
    @          0x3587abe starrocks::CompactionAction::_handle_show_compaction()
    @          0x358cc15 starrocks::CompactionAction::handle()
    @          0x6de7367 evhttp_handle_request
    @          0x6de8013 bufferevent_readcb
    @          0x6dd4752 event_process_active_single_queue
    @          0x6dd4e8f event_base_loop
    @          0x3556ca4 _ZZN9starrocks12EvHttpServer5startEvENKUlvE_clEv
    @          0x91956c0 execute_native_thread_routine
    @     0x7fc7a06aaea5 start_thread
    @     0x7fc79faabb0d __clone
    @                0x0 (unknown)

==2176681==ERROR: AddressSanitizer: heap-use-after-free on address 0x63100030ca5e at pc 0x000013eae4ed bp 0x7f4a1bafffc0 sp 0x7f4a1bafffb8
READ of size 2 at 0x63100030ca5e thread T2187
    #0 0x13eae4ec in rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::GetType() const /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:936:62
    #1 0x13e030bf in bool rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::Accept<rapidjson::PrettyWriter<rapidjson::GenericStringBuffer<rapidjson::UTF8<char>, rapidjson::CrtAllocator>, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator, 0u>>(rapidjson::PrettyWriter<rapidjson::GenericStri
ngBuffer<rapidjson::UTF8<char>, rapidjson::CrtAllocator>, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator, 0u>&) const /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:1769:16
    #2 0x13e03514 in bool rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::Accept<rapidjson::PrettyWriter<rapidjson::GenericStringBuffer<rapidjson::UTF8<char>, rapidjson::CrtAllocator>, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator, 0u>>(rapidjson::PrettyWriter<rapidjson::GenericStri
ngBuffer<rapidjson::UTF8<char>, rapidjson::CrtAllocator>, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator, 0u>&) const /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:1790:21
    #3 0x13e033b1 in bool rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::Accept<rapidjson::PrettyWriter<rapidjson::GenericStringBuffer<rapidjson::UTF8<char>, rapidjson::CrtAllocator>, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator, 0u>>(rapidjson::PrettyWriter<rapidjson::GenericStri
ngBuffer<rapidjson::UTF8<char>, rapidjson::CrtAllocator>, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator, 0u>&) const /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:1781:21
    #4 0x13e033b1 in bool rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::Accept<rapidjson::PrettyWriter<rapidjson::GenericStringBuffer<rapidjson::UTF8<char>, rapidjson::CrtAllocator>, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator, 0u>>(rapidjson::PrettyWriter<rapidjson::GenericStri
ngBuffer<rapidjson::UTF8<char>, rapidjson::CrtAllocator>, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator, 0u>&) const /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:1781:21
    #5 0x13e033b1 in bool rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::Accept<rapidjson::PrettyWriter<rapidjson::GenericStringBuffer<rapidjson::UTF8<char>, rapidjson::CrtAllocator>, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator, 0u>>(rapidjson::PrettyWriter<rapidjson::GenericStri
ngBuffer<rapidjson::UTF8<char>, rapidjson::CrtAllocator>, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator, 0u>&) const /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:1781:21
    #6 0x148b35e8 in starrocks::Tablet::get_compaction_status(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>*) be/build_ASAN/be/src/storage/tablet.cpp:1426:10
    #7 0x22bf3039 in starrocks::CompactionAction::_handle_show_compaction(starrocks::HttpRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>*) be/build_ASAN/be/src/http/action/compaction_action.cpp:95:13
    #8 0x22bfe119 in starrocks::CompactionAction::handle(starrocks::HttpRequest*) be/build_ASAN/be/src/http/action/compaction_action.cpp:350:14
    #9 0x22b0e9bf in starrocks::on_request(evhttp_request*, void*) be/build_ASAN/be/src/http/ev_http_server.cpp:77:25
    #10 0x26232d66 in evhttp_handle_request libevent-24236aed01798303745470e6c498bf606e88724a/http.c:3454:4
    #11 0x26233a76 in bufferevent_trigger_nolock_ libevent-24236aed01798303745470e6c498bf606e88724a/bufferevent-internal.h:411:3
    #12 0x26233a76 in bufferevent_readcb libevent-24236aed01798303745470e6c498bf606e88724a/bufferevent_sock.c:219:2
    #13 0x2621ee31 in event_persist_closure libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1608:9
    #14 0x2621ee31 in event_process_active_single_queue libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1667:4
    #15 0x2621f5be in event_process_active libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1768:9
    #16 0x2621f5be in event_base_loop libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1991:12
    #17 0x22b0e7a1 in starrocks::EvHttpServer::start()::$_0::operator()() const be/build_ASAN/be/src/http/ev_http_server.cpp:146:13
    #18 0x22b0dfa4 in void std::__invoke_impl<void, starrocks::EvHttpServer::start()::$_0>(std::__invoke_other, starrocks::EvHttpServer::start()::$_0&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #19 0x22b0df64 in std::__invoke_result<starrocks::EvHttpServer::start()::$_0>::type std::__invoke<starrocks::EvHttpServer::start()::$_0>(starrocks::EvHttpServer::start()::$_0&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #20 0x22b0df3c in void std::thread::_Invoker<std::tuple<starrocks::EvHttpServer::start()::$_0>>::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:259:13
    #21 0x22b0df14 in std::thread::_Invoker<std::tuple<starrocks::EvHttpServer::start()::$_0>>::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:266:11
    #22 0x22b0de58 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<starrocks::EvHttpServer::start()::$_0>>>::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:211:13
    #23 0x29d2eb93 in execute_native_thread_routine pcre2_xclass.c
    #24 0x7f5411febac2 in start_thread nptl/pthread_create.c:442:8
    #25 0x7f541207d84f  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

0x63100030ca5e is located 606 bytes inside of 65560-byte region [0x63100030c800,0x63100031c818)
freed by thread T2187 here:
    #0 0xfbad7a2 in free (/home/disk3/wyb/workspace/deploy/sr/main/be/lib/starrocks_be+0xfbad7a2) (BuildId: 75a42954781d6f80)
    #1 0x13e379a4 in rapidjson::CrtAllocator::Free(void*) /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/internal/../allocators.h:79:35
    #2 0x13ead342 in rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>::Clear() /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/internal/../allocators.h:148:13
    #3 0x13ead188 in rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>::~MemoryPoolAllocator() /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/internal/../allocators.h:140:9
    #4 0x13ead15f in rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>::Destroy() /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:2391:9
    #5 0x13e03a48 in rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>::~GenericDocument() /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:2073:9
    #6 0x148b160f in starrocks::Tablet::get_compaction_status(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>*) be/build_ASAN/be/src/storage/tablet.cpp:1355:9
    #7 0x22bf3039 in starrocks::CompactionAction::_handle_show_compaction(starrocks::HttpRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>*) be/build_ASAN/be/src/http/action/compaction_action.cpp:95:13
    #8 0x22bfe119 in starrocks::CompactionAction::handle(starrocks::HttpRequest*) be/build_ASAN/be/src/http/action/compaction_action.cpp:350:14
    #9 0x22b0e9bf in starrocks::on_request(evhttp_request*, void*) be/build_ASAN/be/src/http/ev_http_server.cpp:77:25
    #10 0x26232d66 in evhttp_handle_request libevent-24236aed01798303745470e6c498bf606e88724a/http.c:3454:4
    #11 0x26233a76 in bufferevent_trigger_nolock_ libevent-24236aed01798303745470e6c498bf606e88724a/bufferevent-internal.h:411:3
    #12 0x26233a76 in bufferevent_readcb libevent-24236aed01798303745470e6c498bf606e88724a/bufferevent_sock.c:219:2
    #13 0x2621ee31 in event_persist_closure libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1608:9
    #14 0x2621ee31 in event_process_active_single_queue libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1667:4
    #15 0x2621f5be in event_process_active libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1768:9
    #16 0x2621f5be in event_base_loop libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1991:12
    #17 0x22b0e7a1 in starrocks::EvHttpServer::start()::$_0::operator()() const be/build_ASAN/be/src/http/ev_http_server.cpp:146:13
    #18 0x22b0dfa4 in void std::__invoke_impl<void, starrocks::EvHttpServer::start()::$_0>(std::__invoke_other, starrocks::EvHttpServer::start()::$_0&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #19 0x22b0df64 in std::__invoke_result<starrocks::EvHttpServer::start()::$_0>::type std::__invoke<starrocks::EvHttpServer::start()::$_0>(starrocks::EvHttpServer::start()::$_0&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #20 0x22b0df3c in void std::thread::_Invoker<std::tuple<starrocks::EvHttpServer::start()::$_0>>::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:259:13
    #21 0x22b0df14 in std::thread::_Invoker<std::tuple<starrocks::EvHttpServer::start()::$_0>>::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:266:11
    #22 0x22b0de58 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<starrocks::EvHttpServer::start()::$_0>>>::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:211:13
    #23 0x29d2eb93 in execute_native_thread_routine pcre2_xclass.c

previously allocated by thread T2187 here:
    #0 0xfbada4e in malloc (/home/disk3/wyb/workspace/deploy/sr/main/be/lib/starrocks_be+0xfbada4e) (BuildId: 75a42954781d6f80)
    #1 0x100afe43 in rapidjson::CrtAllocator::Malloc(unsigned long) /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/internal/../allocators.h:67:20
    #2 0x100afce7 in rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>::AddChunk(unsigned long) /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/internal/../allocators.h:240:81
    #3 0x100af71a in rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>::Malloc(unsigned long) /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/internal/../allocators.h:182:18
    #4 0x13eade06 in rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::SetStringRaw(rapidjson::GenericStringRef<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>&) /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:1976:47
    #5 0x13e022e4 in rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::SetString(char const*, unsigned int, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>&) /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:1713:106
    #6 0x148b0f08 in starrocks::Tablet::get_compaction_status(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>*) be/build_ASAN/be/src/storage/tablet.cpp:1342:27
    #7 0x22bf3039 in starrocks::CompactionAction::_handle_show_compaction(starrocks::HttpRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>*) be/build_ASAN/be/src/http/action/compaction_action.cpp:95:13
    #8 0x22bfe119 in starrocks::CompactionAction::handle(starrocks::HttpRequest*) be/build_ASAN/be/src/http/action/compaction_action.cpp:350:14
    #9 0x22b0e9bf in starrocks::on_request(evhttp_request*, void*) be/build_ASAN/be/src/http/ev_http_server.cpp:77:25
    #10 0x26232d66 in evhttp_handle_request libevent-24236aed01798303745470e6c498bf606e88724a/http.c:3454:4
    #11 0x26233a76 in bufferevent_trigger_nolock_ libevent-24236aed01798303745470e6c498bf606e88724a/bufferevent-internal.h:411:3
    #12 0x26233a76 in bufferevent_readcb libevent-24236aed01798303745470e6c498bf606e88724a/bufferevent_sock.c:219:2
    #13 0x2621ee31 in event_persist_closure libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1608:9
    #14 0x2621ee31 in event_process_active_single_queue libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1667:4
    #15 0x2621f5be in event_process_active libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1768:9
    #16 0x2621f5be in event_base_loop libevent-24236aed01798303745470e6c498bf606e88724a/event.c:1991:12
    #17 0x22b0e7a1 in starrocks::EvHttpServer::start()::$_0::operator()() const be/build_ASAN/be/src/http/ev_http_server.cpp:146:13
    #18 0x22b0dfa4 in void std::__invoke_impl<void, starrocks::EvHttpServer::start()::$_0>(std::__invoke_other, starrocks::EvHttpServer::start()::$_0&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #19 0x22b0df64 in std::__invoke_result<starrocks::EvHttpServer::start()::$_0>::type std::__invoke<starrocks::EvHttpServer::start()::$_0>(starrocks::EvHttpServer::start()::$_0&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #20 0x22b0df3c in void std::thread::_Invoker<std::tuple<starrocks::EvHttpServer::start()::$_0>>::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:259:13
    #21 0x22b0df14 in std::thread::_Invoker<std::tuple<starrocks::EvHttpServer::start()::$_0>>::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:266:11
    #22 0x22b0de58 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<starrocks::EvHttpServer::start()::$_0>>>::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:211:13
    #23 0x29d2eb93 in execute_native_thread_routine pcre2_xclass.c

Thread T2187 created by T0 here:
    #0 0xfb967dc in pthread_create (/home/disk3/wyb/workspace/deploy/sr/main/be/lib/starrocks_be+0xfb967dc) (BuildId: 75a42954781d6f80)
    #1 0x29d2ec68 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) (/home/disk3/wyb/workspace/deploy/sr/main/be/lib/starrocks_be+0x29d2ec68) (BuildId: 75a42954781d6f80)
    #2 0x22b0db10 in decltype(::new((void*)(0)) std::thread(std::declval<starrocks::EvHttpServer::start()::$_0&>())) std::construct_at<std::thread, starrocks::EvHttpServer::start()::$_0&>(std::thread*, starrocks::EvHttpServer::start()::$_0&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:97:39
    #3 0x22b0d420 in void std::allocator_traits<std::allocator<std::thread>>::construct<std::thread, starrocks::EvHttpServer::start()::$_0&>(std::allocator<std::thread>&, std::thread*, starrocks::EvHttpServer::start()::$_0&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:518:4
    #4 0x22b0ad02 in std::thread& std::vector<std::thread, std::allocator<std::thread>>::emplace_back<starrocks::EvHttpServer::start()::$_0&>(starrocks::EvHttpServer::start()::$_0&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/vector.tcc:115:6
    #5 0x22b092db in starrocks::EvHttpServer::start() be/build_ASAN/be/src/http/ev_http_server.cpp:148:18
    #6 0x2002b3eb in starrocks::HttpServiceBE::start() be/build_ASAN/be/src/service/service_be/http_service.cpp:285:5
    #7 0x1ff27e7c in starrocks::start_be(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath>> const&, bool) be/build_ASAN/be/src/service/service_be/starrocks_be.cpp:303:36
    #8 0xfbebfc9 in main be/build_ASAN/be/src/service/starrocks_main.cpp:258:5
    #9 0x7f5411f80d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

SUMMARY: AddressSanitizer: heap-use-after-free /home/disk3/sr-deps/thirdparty/installed/include/rapidjson/document.h:936:62 in rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::GetType() const
```

## What I'm doing:

`input_rowset_details` allocator is not valid when writing json at the end,
so use `root` allocator

Fixes https://github.com/StarRocks/StarRocksTest/issues/8847

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0