### PR TITLE
[Enhancement] interrupt sleep when cancel query

### DIFF
--- a/be/test/exprs/utility_functions_test.cpp
+++ b/be/test/exprs/utility_functions_test.cpp
@@ -21,6 +21,7 @@
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
 #include "exprs/function_context.h"
+#include "runtime/runtime_state.h"
 #include "types/logical_type.h"
 #include "util/random.h"
 #include "util/time.h"
@@ -56,6 +57,8 @@ TEST_F(UtilityFunctionsTest, versionTest) {
 TEST_F(UtilityFunctionsTest, sleepTest) {
     FunctionContext* ctx = FunctionContext::create_test_context();
     auto ptr = std::unique_ptr<FunctionContext>(ctx);
+    RuntimeState state;
+    ptr->set_runtime_state(&state);
 
     // test sleep
     {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Before that, the sleep function will run to complete, cannot be interrupted by cancel/kill.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0