### PR TITLE
[Enhancement] Append LIST partition info when list table partitions by rest api.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -34,7 +34,6 @@
 
 package com.starrocks.http.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
@@ -127,7 +126,6 @@ public class TableQueryPlanAction extends RestBaseAction {
                     || Strings.isNullOrEmpty(tableName)) {
                 throw new StarRocksHttpException(HttpResponseStatus.BAD_REQUEST, "{database}/{table} must be selected");
             }
-            String sql;
             if (Strings.isNullOrEmpty(postContent)) {
                 throw new StarRocksHttpException(HttpResponseStatus.BAD_REQUEST,
                         "POST body must contains [sql] root object");
@@ -139,7 +137,7 @@ public class TableQueryPlanAction extends RestBaseAction {
                 throw new StarRocksHttpException(HttpResponseStatus.BAD_REQUEST,
                         "malformed json [ " + postContent + " ]");
             }
-            sql = jsonObject.optString("sql");
+            String sql = jsonObject.optString("sql");
             if (Strings.isNullOrEmpty(sql)) {
                 throw new StarRocksHttpException(HttpResponseStatus.BAD_REQUEST,
                         "POST body must contains [sql] root object");
@@ -180,11 +178,11 @@ public class TableQueryPlanAction extends RestBaseAction {
             resultMap.put("status", e.getCode().code());
             resultMap.put("exception", e.getMessage());
         }
-        ObjectMapper mapper = new ObjectMapper();
+
         try {
             String result = mapper.writeValueAsString(resultMap);
             // send result with extra information
-            response.setContentType("application/json");
+            response.setContentType(JSON_CONTENT_TYPE);
             response.getContent().append(result);
             sendResult(request, response,
                     HttpResponseStatus.valueOf(Integer.parseInt(String.valueOf(resultMap.get("status")))));
@@ -222,9 +220,10 @@ public class TableQueryPlanAction extends RestBaseAction {
             context.getSessionVariable().setSingleNodeExecPlan(false);
             context.getSessionVariable().setSqlSelectLimit(limit);
         } catch (Exception e) {
-            LOG.error("error occurred when optimizing queryId: {}", context.getQueryId(), e);
-            throw new StarRocksHttpException(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                    "The Sql is invalid");
+            LOG.error("Get query plan for sql[{}] error, queryId: {}", sql, context.getQueryId(), e);
+            throw new StarRocksHttpException(
+                    HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                    "Invalid SQL: " + sql);
         }
 
         // only process select semantic
@@ -245,13 +244,13 @@ public class TableQueryPlanAction extends RestBaseAction {
         if (AnalyzerUtils.collectAllTable(statementBase).size() != 1) {
             if (stmt.getRelation() instanceof TableRelation) {
                 throw new StarRocksHttpException(HttpResponseStatus.BAD_REQUEST,
-                        "Select statement must have only one table");
+                        "Select statement must have only one table: " + sql);
             }
         }
 
         if (stmt.getRelation() instanceof SubqueryRelation) {
             throw new StarRocksHttpException(HttpResponseStatus.BAD_REQUEST,
-                    "Select statement must not embed another statement");
+                    "Select statement must not embed another statement: " + sql);
         }
 
         // check consistent http requested resource with sql referenced
@@ -259,14 +258,14 @@ public class TableQueryPlanAction extends RestBaseAction {
         TableName tableAndDb = stmt.getRelation().getResolveTableName();
         if (!(tableAndDb.getDb().equals(requestDb) && tableAndDb.getTbl().equals(requestTable))) {
             throw new StarRocksHttpException(HttpResponseStatus.BAD_REQUEST,
-                    "requested database and table must consistent with sql: request [ "
-                            + requestDb + "." + requestTable + "]" + "and sql [" + tableAndDb.toString() + "]");
+                    "Requested database and table must consistent with sql: request [ "
+                            + requestDb + "." + requestTable + "]" + "and sql [" + tableAndDb + "]");
         }
 
         if (execPlan == null) {
-            LOG.error("plan is null for queryId: {}", context.getQueryId());
+            LOG.error("Null exec plan for sql[{}], queryId: {}", sql, context.getQueryId());
             throw new StarRocksHttpException(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                    "The Sql is invalid");
+                    "Invalid SQL: " + sql);
         }
 
         if (execPlan.getScanNodes().isEmpty() && FeConstants.enablePruneEmptyOutputScan) {
@@ -280,7 +279,7 @@ public class TableQueryPlanAction extends RestBaseAction {
         // in this way, just retrieve only one scannode
         if (execPlan.getScanNodes().size() != 1) {
             throw new StarRocksHttpException(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                    "Planner should plan just only one ScanNode but found [ " + execPlan.getScanNodes().size() + "]");
+                    "Planner should plan just only 1 ScanNode but found " + execPlan.getScanNodes().size() + ", sql is " + sql);
         }
         List<TScanRangeLocations> scanRangeLocations =
                 execPlan.getScanNodes().get(0).getScanRangeLocations(0);
@@ -288,7 +287,7 @@ public class TableQueryPlanAction extends RestBaseAction {
         List<PlanFragment> fragments = execPlan.getFragments();
         if (fragments.size() != 1) {
             throw new StarRocksHttpException(HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                    "Planner should plan just only one PlanFragment but found [ " + fragments.size() + "]");
+                    "Planner should plan just only 1 PlanFragment but found " + fragments.size() + ", sql is " + sql);
         }
 
         TQueryPlanInfo tQueryPlanInfo = new TQueryPlanInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
@@ -40,7 +40,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.BrokerDesc;
-import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.LiteralExpr;
@@ -94,7 +93,6 @@ import com.starrocks.transaction.TransactionState;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -393,19 +391,10 @@ public class SparkLoadPendingTask extends LoadTask {
             // bucket num
             int bucketNum = partition.getDistributionInfo().getBucketNum();
             // list partition values
-            List<List<LiteralExpr>> multiValueList = multiLiteralExprValues.get(partitionId);
-            List<List<Object>> inKeys = Lists.newArrayList();
-            if (multiValueList != null && !multiValueList.isEmpty()) {
-                for (List<LiteralExpr> list : multiValueList) {
-                    inKeys.add(initItemOfInKeys(list));
-                }
-            }
-            List<LiteralExpr> valueList = literalExprValues.get(partitionId);
-            if (valueList != null && !valueList.isEmpty()) {
-                for (LiteralExpr literalExpr : valueList) {
-                    inKeys.add(initItemOfInKeys(Lists.newArrayList(literalExpr)));
-                }
-            }
+            List<List<Object>> inKeys = PartitionUtils.calListPartitionKeys(
+                    multiLiteralExprValues.get(partitionId),
+                    literalExprValues.get(partitionId)
+            );
 
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                 long physicalPartitionId = physicalPartition.getId();
@@ -413,20 +402,6 @@ public class SparkLoadPendingTask extends LoadTask {
             }
         }
         return etlPartitions;
-    }
-
-    private List<Object> initItemOfInKeys(List<LiteralExpr> list) {
-        List<Object> curList = new ArrayList<>();
-        for (LiteralExpr literalExpr : list) {
-            Object keyValue;
-            if (literalExpr instanceof DateLiteral) {
-                keyValue = PartitionUtils.convertDateLiteralToNumber((DateLiteral) literalExpr);
-            } else {
-                keyValue = literalExpr.getRealObjectValue();
-            }
-            curList.add(keyValue);
-        }
-        return curList;
     }
 
     private List<EtlPartition> initEtlRangePartition(


### PR DESCRIPTION
## Why I'm doing:

You can learn about the background from PR [#52682](https://github.com/StarRocks/starrocks/issues/52682).

## What I'm doing:

This PR is a supplement to [#41938](https://github.com/StarRocks/starrocks/pull/41938), and append LIST partition info when list table's partitions by RESTful API. For example, for the following LIST partition table:

```sql
CREATE TABLE `tb_list_partition` (
  `c0` bigint(20) NOT NULL COMMENT "cc0",
  `c1` datetime NOT NULL COMMENT "cc1",
  `c2` varchar(32) NOT NULL COMMENT "cc2",
  `c3` decimal(32, 8) NULL DEFAULT "0" COMMENT "cc3",
  `c4` array<int(11)> NULL COMMENT "cc4",
  `c5` struct<C4_a int(11), c4_b struct<c4_b_1 varchar(65533)>> NULL COMMENT "cc5",
  `c6` map<bigint(20),map<int(11),varchar(65533)>> NOT NULL COMMENT "cc6",
  `c7` json NOT NULL COMMENT "cc7",
  `c8` bitmap NOT NULL COMMENT "cc8",
  `c9` hll NOT NULL COMMENT "cc9",
  INDEX idx_bitmap (`c9`) USING BITMAP COMMENT ''
) ENGINE=OLAP
PRIMARY KEY(`c0`, `c1`, `c2`)
PARTITION BY LIST(`c2`)(
  PARTITION p1 VALUES IN ('beijing'),
  PARTITION p2 VALUES IN ('shanghai', 'hangzhou'),
  PARTITION p3 VALUES IN ('guangzhou', 'shenzhen'),
  PARTITION p4 VALUES IN ('chengdu', 'chongqing')
)
DISTRIBUTED BY HASH(`c0`) BUCKETS 8
PROPERTIES (
"enable_persistent_index" = "true",
"replication_num" = "3"
);
```

The `/api/v2/catalogs/{catalog}/databases/{db}/tables/{table}/partition` API will return the LIST partition information through the `inKeys` field:

```json
{
    "result": {
        "pageNum": 0,
        "pageSize": 100,
        "pages": 1,
        "total": 4,
        "items": [
            {
                "id": 10321,
                "name": "p1",
                "bucketNum": 8,
                "distributionType": "HASH",
                "visibleVersion": 1,
                "visibleVersionTime": 1732870030714,
                "nextVersion": 2,
                "inKeys": [
                    [
                        "beijing"
                    ]
                ],
                "tablets": [
                    ...
                ]
            },
            {
                "id": 10322,
                "name": "p2",
                "bucketNum": 8,
                "distributionType": "HASH",
                "visibleVersion": 1,
                "visibleVersionTime": 1732870030715,
                "nextVersion": 2,
                "inKeys": [
                    [
                        "shanghai"
                    ],
                    [
                        "hangzhou"
                    ]
                ],
                "tablets": [
                    ...
                ]
            },
            {
                "id": 10323,
                "name": "p3",
                "bucketNum": 8,
                "distributionType": "HASH",
                "visibleVersion": 1,
                "visibleVersionTime": 1732870030715,
                "nextVersion": 2,
                "inKeys": [
                    [
                        "guangzhou"
                    ],
                    [
                        "shenzhen"
                    ]
                ],
                "tablets": [
                    ...
                ]
            },
            {
                "id": 10324,
                "name": "p4",
                "bucketNum": 8,
                "distributionType": "HASH",
                "visibleVersion": 1,
                "visibleVersionTime": 1732870030715,
                "nextVersion": 2,
                "inKeys": [
                    [
                        "chengdu"
                    ],
                    [
                        "chongqing"
                    ]
                ],
                "tablets": [
                    ...
                ]
            }
        ]
    },
    "code": "0",
    "message": "OK"
}
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0