### PR TITLE
[BugFix] ScanNode of SkeletonNode compare operation adapt to external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanAdvisorExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanAdvisorExecutor.java
@@ -85,7 +85,6 @@ public class PlanAdvisorExecutor {
             String result = String.format("Clear all plan advisor in FE(%s) successfully. Advisor size: %d",
                     GlobalStateMgr.getCurrentState().getNodeMgr().getNodeName(), size);
             return new ShowResultSet(COLUMN_META, List.of(List.of(result)));
-
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanTuningAdvisor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanTuningAdvisor.java
@@ -76,8 +76,6 @@ public class PlanTuningAdvisor {
         optimizedQueryRecords.clear();
     }
 
-
-
     public void deleteTuningGuides(UUID queryId) {
         for (Map.Entry<PlanTuningCacheKey, OperatorTuningGuides> entry : cache.asMap().entrySet()) {
             if (entry.getValue().getOriginalQueryId().equals(queryId)) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/skeleton/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/skeleton/ScanNode.java
@@ -24,19 +24,22 @@ public class ScanNode extends SkeletonNode {
 
     private final long tableId;
 
-    private final String tableName;
+    private final String tableIdentifier;
 
     public ScanNode(OptExpression optExpression,
                     NodeExecStats nodeExecStats, SkeletonNode parent) {
         super(optExpression, nodeExecStats, parent);
         PhysicalScanOperator scanOperator = (PhysicalScanOperator) optExpression.getOp();
         tableId = scanOperator.getTable().getId();
-        tableName = scanOperator.getTable().getName();
+        tableIdentifier = scanOperator.getTable().getTableIdentifier();
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), tableId);
+    public long getTableId() {
+        return tableId;
+    }
+
+    public String getTableIdentifier() {
+        return tableIdentifier;
     }
 
     @Override
@@ -45,14 +48,18 @@ public class ScanNode extends SkeletonNode {
             return true;
         }
 
-        if (!super.equals(o)) {
-            return false;
-        }
-
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        if (!super.equals(o)) {
+            return false;
+        }
         ScanNode scanNode = (ScanNode) o;
-        return tableId == scanNode.tableId;
+        return tableId == scanNode.tableId && Objects.equals(tableIdentifier, scanNode.tableIdentifier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), tableId, tableIdentifier);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
The `table_id` of the external table may start from 1 for each query and is not guaranteed to be unique. Therefore, add a table identifier to the scan node for comparison.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0