### PR TITLE
[Enhancement] check tuple id is in Descriptor table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -40,7 +40,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.TupleId;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
@@ -61,8 +60,6 @@ import com.starrocks.thrift.TPlanFragment;
 import com.starrocks.thrift.TResultSinkType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.roaringbitmap.RoaringBitmap;
 
 import java.nio.ByteBuffer;
@@ -113,8 +110,6 @@ import java.util.stream.Stream;
  * fix that
  */
 public class PlanFragment extends TreeNode<PlanFragment> {
-    private static final Logger LOG = LogManager.getLogger(PlanFragment.class);
-
     // id for this plan fragment
     protected final PlanFragmentId fragmentId;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -220,6 +220,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -411,7 +412,23 @@ public class PlanFragmentBuilder {
             }
         }
 
+        if (!checkTupleId(execPlan.getDescTbl(), execPlan.getFragments().get(0))) {
+            throw new StarRocksPlannerException("TupleId check failed", INTERNAL_ERROR);
+        }
+
         return execPlan;
+    }
+
+    private static boolean checkTupleId(DescriptorTable descriptorTable, PlanFragment root) {
+        Queue<PlanFragment> queue = Lists.newLinkedList();
+        queue.add(root);
+        while (!queue.isEmpty()) {
+            PlanFragment planFragment = queue.poll();
+            if (!planFragment.checkFragmentTupleId(descriptorTable)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static class PhysicalPlanTranslator extends OptExpressionVisitor<PlanFragment, ExecPlan> {


### PR DESCRIPTION
## Why I'm doing:
crash like below is because tuple id is not in Descriptor table, so nullptr will be return, and  visit nullptr cause crash
```
@ 0x2d66a6b starrocks::RowDescriptor::init_tuple_idx_map()

 @ 0x2d66cc5 starrocks::RowDescriptor::RowDescriptor()

 @ 0x34ad786 starrocks::ExecNode::ExecNode()

 @ 0x36aa444 starrocks::AssertNumRowsNode::AssertNumRowsNode()

 @ 0x34addbd starrocks::ExecNode::create_vectorized_node()

 @ 0x34aee16 starrocks::ExecNode::create_tree_helper()

 @ 0x34af0fd starrocks::ExecNode::create_tree()

 @ 0x37c8bc2 starrocks::pipeline::FragmentExecutor::_prepare_exec_plan()

 @ 0x37ce80d starrocks::pipeline::FragmentExecutor::prepare()

 @ 0x591422b starrocks::PInternalServiceImplBase<>::_exec_plan_fragment_by_pipeline()

 @ 0x591b819 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()

 @ 0x5926ae5 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()

 @ 0x2cb460d starrocks::PriorityThreadPool::work_thread()
```

## What I'm doing:
check in FE so BE won't crash, make query dump skip this check for debug purpose

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0