### PR TITLE
[Enhancement] add tuning guides to query profile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
@@ -120,6 +120,7 @@ public class OperatorTuningGuides {
         public OperatorTuningGuides getOperatorTuningGuides() {
             return operatorTuningGuides;
         }
+
         public String getExplainString() {
             StringBuilder sb = new StringBuilder();
             sb.append("Plan had been tuned by Plan Advisor.").append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanTuningAdvisor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanTuningAdvisor.java
@@ -58,6 +58,9 @@ public class PlanTuningAdvisor {
     }
 
     public OperatorTuningGuides.OptimizedRecord getOptimizedRecord(UUID queryId) {
+        if (queryId == null) {
+            return null;
+        }
         return optimizedQueryRecords.get(queryId);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -25,6 +25,8 @@ import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.feedback.OperatorTuningGuides;
+import com.starrocks.qe.feedback.PlanTuningAdvisor;
 import com.starrocks.sql.Explain;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -962,6 +964,12 @@ public class Optimizer {
         // if we can change the distribution to adjust the plan because of skew data, bad statistics or something else.
         result = new MarkParentRequiredDistributionRule().rewrite(result, rootTaskContext);
         result = new ApplyTuningGuideRule(connectContext).rewrite(result, rootTaskContext);
+
+        OperatorTuningGuides.OptimizedRecord optimizedRecord = PlanTuningAdvisor.getInstance()
+                .getOptimizedRecord(context.getQueryId());
+        if (optimizedRecord != null) {
+            Tracers.record(Tracers.Module.BASE, "DynamicTuningGuides", optimizedRecord.getExplainString());
+        }
         return result;
     }
 

--- a/test/sql/test_feedback/R/test_feedback
+++ b/test/sql/test_feedback/R/test_feedback
@@ -53,6 +53,10 @@ function: assert_explain_contains("select count(*) from (select * from c1_skew t
 -- result:
 None
 -- !result
+function: assert_trace_values_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
 clear plan advisor;
 -- result:
 [REGEX]Clear all plan advisor in FE.*

--- a/test/sql/test_feedback/T/test_feedback
+++ b/test/sql/test_feedback/T/test_feedback
@@ -26,4 +26,6 @@ set enable_global_runtime_filter = false;
 function: assert_explain_not_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
 add into plan advisor select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t;
 function: assert_explain_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
+function: assert_trace_values_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
+
 clear plan advisor;


### PR DESCRIPTION
## Why I'm doing:
if user's plan has been rewritten by the plan advisor of the feedback, and we need to get relevant information through the query profile
![image](https://github.com/user-attachments/assets/749ca3d8-5f02-4023-a443-2ebb9405c936)

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0