### PR TITLE
[BugFix] Add warehouse column in show load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LoadProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LoadProcDir.java
@@ -52,7 +52,7 @@ public class LoadProcDir implements ProcDirInterface {
             .add("Type").add("Priority").add("ScanRows").add("FilteredRows").add("UnselectedRows")
             .add("SinkRows").add("EtlInfo").add("TaskInfo").add("ErrorMsg").add("CreateTime")
             .add("EtlStartTime").add("EtlFinishTime").add("LoadStartTime").add("LoadFinishTime")
-            .add("TrackingSQL").add("JobDetails")
+            .add("TrackingSQL").add("JobDetails").add("Warehouse")
             .build();
 
     // label and state column index of result

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowLoadStmtTest.java
@@ -60,7 +60,7 @@ public class ShowLoadStmtTest {
         ShowLoadStmt stmt = (ShowLoadStmt) analyzeSuccess("SHOW LOAD FROM test");
         ShowResultSetMetaData metaData = stmt.getMetaData();
         Assert.assertNotNull(metaData);
-        Assert.assertEquals(20, metaData.getColumnCount());
+        Assert.assertEquals(21, metaData.getColumnCount());
         Assert.assertEquals("JobId", metaData.getColumn(0).getName());
         Assert.assertEquals("Label", metaData.getColumn(1).getName());
         Assert.assertEquals("State", metaData.getColumn(2).getName());
@@ -81,6 +81,7 @@ public class ShowLoadStmtTest {
         Assert.assertEquals("LoadFinishTime", metaData.getColumn(17).getName());
         Assert.assertEquals("TrackingSQL", metaData.getColumn(18).getName());
         Assert.assertEquals("JobDetails", metaData.getColumn(19).getName());
+        Assert.assertEquals("Warehouse", metaData.getColumn(20).getName());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
`show load` meta is not consistent with the result, and `warehouse` column is missing.

## What I'm doing:
add `warehouse` into `show load` meta, and the value is `default_warehouse` in shared-nothing mode

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0