### PR TITLE
[Enhancement] add `DeployRound` in FE profile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/PhasedExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/PhasedExecutionSchedule.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.UnionFind;
 import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.qe.ConnectContext;
@@ -217,6 +218,7 @@ public class PhasedExecutionSchedule implements ExecutionSchedule {
             return;
         }
         List<DeployState> deployState = deployStates.poll();
+        int deployRound = 1;
         Preconditions.checkState(deployState != null);
         for (DeployState state : deployState) {
             deployer.deployFragments(state);
@@ -227,10 +229,12 @@ public class PhasedExecutionSchedule implements ExecutionSchedule {
             if (deployState.isEmpty()) {
                 break;
             }
+            deployRound += 1;
             for (DeployState state : deployState) {
                 deployer.deployFragments(state);
             }
         }
+        Tracers.count(Tracers.Module.SCHEDULER, "DeployRound", deployRound);
     }
 
     public void tryScheduleNextTurn(TUniqueId fragmentInstanceId) throws RpcException, StarRocksException {


### PR DESCRIPTION
## Why I'm doing:

Since we support incremental scan ranges in this PR: https://github.com/StarRocks/starrocks/pull/50189 , It's bette to kno how many rounds of incremental scan ranges deployment. 

## What I'm doing:

Add a metric `DeployRound` to see how many rounds of deployments.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0