### PR TITLE
[Enhancement] check tuple id is in Descriptor table

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -375,6 +375,8 @@ Status ExecNode::create_tree_helper(RuntimeState* state, ObjectPool* pool, const
 
     int num_children = tnodes[*node_idx].num_children;
     ExecNode* node = nullptr;
+    // check tuple ids is in descs before create node
+    RETURN_IF_ERROR(checkTupleIdsInDescs(descs, tnodes[*node_idx]));
     RETURN_IF_ERROR(create_vectorized_node(state, pool, tnodes[*node_idx], descs, &node));
 
     DCHECK((parent != nullptr) || (root != nullptr));
@@ -579,6 +581,28 @@ std::string ExecNode::debug_string() const {
     std::stringstream out;
     this->debug_string(0, &out);
     return out.str();
+}
+
+Status ExecNode::checkTupleIdsInDescs(const DescriptorTbl& descs, const TPlanNode& planNode) {
+    for (auto id : planNode.row_tuples) {
+        if (descs.get_tuple_descriptor(id) == nullptr) {
+            std::stringstream ss;
+            ss << "Plan node id: " << planNode.node_id << ", Tuple ids: ";
+            for (auto id : planNode.row_tuples) {
+                ss << id << ", ";
+            }
+            LOG(ERROR) << ss.str();
+            ss.str("");
+            ss << "DescriptorTbl: " << descs.debug_string();
+            LOG(ERROR) << ss.str();
+            ss.str("");
+            ss << "TPlanNode: " << apache::thrift::ThriftDebugString(planNode);
+            LOG(ERROR) << ss.str();
+            return Status::InternalError("Tuple ids are not in descs");
+        }
+    }
+
+    return Status::OK();
 }
 
 void ExecNode::debug_string(int indentation_level, std::stringstream* out) const {

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -316,6 +316,8 @@ protected:
     Status exec_debug_action(TExecNodePhase::type phase);
 
 private:
+    // TODO: delete this function if removed tupleId
+    Status static checkTupleIdsInDescs(const DescriptorTbl& descs, const TPlanNode& planNode);
     RuntimeState* _runtime_state;
     bool _is_closed;
 };


### PR DESCRIPTION
## Why I'm doing:
crash like below is because tuple id is not in Descriptor table, so nullptr will be return, and  visit nullptr cause crash
```
@ 0x2d66a6b starrocks::RowDescriptor::init_tuple_idx_map()

 @ 0x2d66cc5 starrocks::RowDescriptor::RowDescriptor()

 @ 0x34ad786 starrocks::ExecNode::ExecNode()

 @ 0x36aa444 starrocks::AssertNumRowsNode::AssertNumRowsNode()

 @ 0x34addbd starrocks::ExecNode::create_vectorized_node()

 @ 0x34aee16 starrocks::ExecNode::create_tree_helper()

 @ 0x34af0fd starrocks::ExecNode::create_tree()

 @ 0x37c8bc2 starrocks::pipeline::FragmentExecutor::_prepare_exec_plan()

 @ 0x37ce80d starrocks::pipeline::FragmentExecutor::prepare()

 @ 0x591422b starrocks::PInternalServiceImplBase<>::_exec_plan_fragment_by_pipeline()

 @ 0x591b819 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()

 @ 0x5926ae5 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()

 @ 0x2cb460d starrocks::PriorityThreadPool::work_thread()
```

## What I'm doing:
check  before create node in BE's prepare phase

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0