### PR TITLE
[BugFix] Fix column pruning for mv transparent union rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -450,6 +450,7 @@ public class Optimizer {
             tree = new SeparateProjectRule().rewrite(tree, rootTaskContext);
             deriveLogicalProperty(tree);
             ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PUSH_DOWN_PREDICATE);
+            ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PRUNE_COLUMNS);
             // It's necessary for external table since its predicate is not used directly after push down.
             ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PARTITION_PRUNE);
             ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PRUNE_EMPTY_OPERATOR);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -428,7 +428,8 @@ public class Optimizer {
     }
 
     private void ruleBasedMaterializedViewRewrite(OptExpression tree,
-                                                  TaskContext rootTaskContext) {
+                                                  TaskContext rootTaskContext,
+                                                  ColumnRefSet requiredColumns) {
         if (!mvRewriteStrategy.enableMaterializedViewRewrite || context.getQueryMaterializationContext() == null ||
                 context.getQueryMaterializationContext().hasRewrittenSuccess()) {
             return;
@@ -439,6 +440,7 @@ public class Optimizer {
 
         // NOTE: Since union rewrite will generate Filter -> Union -> OlapScan -> OlapScan, need to push filter below Union
         // and do partition predicate again.
+        // TODO: move this into doRuleBasedMaterializedViewRewrite
         // TODO: Do it in CBO if needed later.
         boolean isNeedFurtherPartitionPrune = Utils.isOptHasAppliedRule(tree, op -> op.isOpRuleBitSet(OP_MV_UNION_REWRITE));
         if (isNeedFurtherPartitionPrune && context.getQueryMaterializationContext().hasRewrittenSuccess()) {
@@ -449,8 +451,10 @@ public class Optimizer {
             // Do predicate push down if union rewrite successes.
             tree = new SeparateProjectRule().rewrite(tree, rootTaskContext);
             deriveLogicalProperty(tree);
-            ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PUSH_DOWN_PREDICATE);
+            // Do partition prune again to avoid unnecessary scan.
+            rootTaskContext.setRequiredColumns(requiredColumns.clone());
             ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PRUNE_COLUMNS);
+            ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PUSH_DOWN_PREDICATE);
             // It's necessary for external table since its predicate is not used directly after push down.
             ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PARTITION_PRUNE);
             ruleRewriteIterative(tree, rootTaskContext, RuleSetType.PRUNE_EMPTY_OPERATOR);
@@ -679,7 +683,7 @@ public class Optimizer {
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownTopNBelowUnionRule());
 
         // rule based materialized view rewrite
-        ruleBasedMaterializedViewRewrite(tree, rootTaskContext);
+        ruleBasedMaterializedViewRewrite(tree, rootTaskContext, requiredColumns);
 
         // this rewrite rule should be after mv.
         ruleRewriteIterative(tree, rootTaskContext, RewriteSimpleAggToHDFSScanRule.HIVE_SCAN_NO_PROJECT);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.schema.MTable;
 import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
 import org.junit.After;
 import org.junit.Assert;
@@ -976,6 +977,68 @@ public class MvTransparentRewriteWithOlapTableTest extends MvRewriteTestBase {
                         {
                             String plan = getFragmentPlan("select * from mv0");
                             PlanTestBase.assertContains(plan, "UNION", "mv0", "t3");
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testTransparentMVWithListPartitionsPartialColumns1() {
+        starRocksAssert.withTable(t3, () -> {
+            String insertSql = "insert into t3 values(1, 1, '2024-01-01', 'beijing')," +
+                    "(1, 1, '2022-01-01', 'hangzhou');";
+            cluster.runSql("test", insertSql);
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0 " +
+                            " PARTITION BY (province, dt) " +
+                            " DISTRIBUTED BY HASH(province) " +
+                            " REFRESH DEFERRED MANUAL " +
+                            " AS select * from t3;",
+                    () -> {
+                        cluster.runSql("test", String.format("REFRESH MATERIALIZED VIEW mv0 PARTITION (('%s', '%s')) " +
+                                "with sync mode", "beijing", "2024-01-01"));
+                        MaterializedView mv1 = getMv("test", "mv0");
+                        Set<String> mvNames = mv1.getPartitionNames();
+                        Assert.assertEquals("[p1, p2, p3, p4]", mvNames.toString());
+                        // transparent mv
+                        {
+                            String plan = getFragmentPlan("select dt from t3", TExplainLevel.COSTS, "");
+                            PlanTestBase.assertContains(plan, "UNION", "mv0", "t3");
+                            PlanTestBase.assertContains(plan, "  0:UNION\n" +
+                                    "  |  output exprs:\n" +
+                                    "  |      [7, VARCHAR(10), false]\n" +
+                                    "  |  child exprs:\n" +
+                                    "  |      [11: dt, VARCHAR, false]\n" +
+                                    "  |      [15: dt, VARCHAR, false]");
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testTransparentMVWithListPartitionsPartialColumns2() {
+        starRocksAssert.withTable(t3, () -> {
+            String insertSql = "insert into t3 values(1, 1, '2024-01-01', 'beijing')," +
+                    "(1, 1, '2022-01-01', 'hangzhou');";
+            cluster.runSql("test", insertSql);
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0 " +
+                            " PARTITION BY (province, dt) " +
+                            " REFRESH DEFERRED MANUAL " +
+                            " AS select province, dt, min(age) from t3 group by province, dt;",
+                    () -> {
+                        cluster.runSql("test", String.format("REFRESH MATERIALIZED VIEW mv0 PARTITION (('%s', '%s')) " +
+                                "with sync mode", "beijing", "2024-01-01"));
+                        MaterializedView mv1 = getMv("test", "mv0");
+                        Set<String> mvNames = mv1.getPartitionNames();
+                        Assert.assertEquals("[p1, p2, p3, p4]", mvNames.toString());
+                        // transparent mv
+                        {
+                            String plan = getFragmentPlan("select min(age) from t3 group by province;", TExplainLevel.COSTS, "");
+                            PlanTestBase.assertContains(plan, "UNION", "mv0", "t3");
+                            PlanTestBase.assertContains(plan, "  |  output exprs:\n" +
+                                    "  |      [6, VARCHAR(64), false] | [8, SMALLINT, true]\n" +
+                                    "  |  child exprs:\n" +
+                                    "  |      [9: province, VARCHAR, false] | [11: min(age), SMALLINT, true]\n" +
+                                    "  |      [14: province, VARCHAR, false] | [16: min, SMALLINT, true]");
                         }
                     });
         });


### PR DESCRIPTION
## Why I'm doing:
- `MVColumnPruner` cannot prune `LogicalUnionOperator`'s output columns. It will output all mv columns if mv transparent mv rewrite has successed.

## What I'm doing:
- Support to prune `LogicalUnionOperator`'s output columns in `MVColumnPruner`
- Add `PRUNE_COLUMNS` rules after `union rewrite success

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0