### PR TITLE
[BugFix] Release the starcache instance before the block cache instance being destructed to avoid some unexpected issues when stopping.

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -189,6 +189,7 @@ Status BlockCache::shutdown() {
         _disk_space_monitor->stop();
     }
     _initialized.store(false, std::memory_order_relaxed);
+    _kv_cache.reset();
     return st;
 }
 


### PR DESCRIPTION
## Why I'm doing:
Release the starcache instance during the block cache destructor is not a good choice, because the block cache is a global singleton instance and at that time some resources have been released. As the starcache destructor also include some shutdown works, which may depend some resources that have been released.

## What I'm doing:
Release the starcache instance before the block cache instance being destructed to avoid some unexpected issues when stopping.

[Fixes #8886](https://github.com/StarRocks/StarRocksTest/issues/8886)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0