### PR TITLE
[Feature] (Part 3) Support partition_redention_condition property for native tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -447,6 +447,8 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
+                    } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -102,6 +102,10 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
             ttlDuration = PropertyAnalyzer.analyzePartitionTTL(properties, true);
         }
+        String ttlRetentionCondition = null;
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {
+            ttlRetentionCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(properties, true);
+        }
         int partitionRefreshNumber = INVALID;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)) {
             partitionRefreshNumber = PropertyAnalyzer.analyzePartitionRefreshNumber(properties);
@@ -219,6 +223,12 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 materializedView.getTableProperty().getPartitionTTLNumber() != partitionTTL) {
             curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER, String.valueOf(partitionTTL));
             materializedView.getTableProperty().setPartitionTTLNumber(partitionTTL);
+            isChanged = true;
+        } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION) &&
+                ttlRetentionCondition != null &&
+                !ttlRetentionCondition.equalsIgnoreCase(materializedView.getTableProperty().getPartitionRetentionCondition())) {
+            curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION, ttlRetentionCondition);
+            materializedView.getTableProperty().setPartitionRetentionCondition(ttlRetentionCondition);
             isChanged = true;
         } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER) &&
                 materializedView.getTableProperty().getPartitionRefreshNumber() != partitionRefreshNumber) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
@@ -104,7 +105,9 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         }
         String ttlRetentionCondition = null;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {
-            ttlRetentionCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(properties, true);
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(materializedView.getDbId());
+            ttlRetentionCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(db,
+                    materializedView, properties, true);
         }
         int partitionRefreshNumber = INVALID;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
@@ -14,8 +14,8 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Strings;
 import com.starrocks.sql.ast.TableRelation;
-import org.apache.parquet.Strings;
 
 import java.util.List;
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -194,6 +194,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     private PeriodDuration partitionTTL = PeriodDuration.ZERO;
 
+    // This property can be used to specify the retention condition of the partition table or materialized view,
+    // it's a SQL expression, and the partition will be deleted if the condition is not true.
+    private String partitionRetentionCondition = null;
+
     // This property only applies to materialized views
     // It represents the maximum number of partitions that will be refreshed by a TaskRun refresh
     private int partitionRefreshNumber = Config.default_mv_partition_refresh_number;
@@ -387,6 +391,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
             case OperationType.OP_ALTER_TABLE_PROPERTIES:
                 buildPartitionTTL();
                 buildPartitionLiveNumber();
+                buildPartitionRetentionCondition();
                 buildDataCachePartitionDuration();
                 buildLocation();
                 buildStorageCoolDownTTL();
@@ -493,6 +498,11 @@ public class TableProperty implements Writable, GsonPostProcessable {
         partitionRefreshNumber =
                 Integer.parseInt(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER,
                         String.valueOf(INVALID)));
+        return this;
+    }
+
+    public TableProperty buildPartitionRetentionCondition() {
+        partitionRetentionCondition = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION, "");
         return this;
     }
 
@@ -837,6 +847,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return partitionTTL;
     }
 
+    public String getPartitionRetentionCondition() {
+        return partitionRetentionCondition;
+    }
+
+    public void setPartitionRetentionCondition(String partitionRetentionCondition) {
+        this.partitionRetentionCondition = partitionRetentionCondition;
+    }
+
     public int getAutoRefreshPartitionsLimit() {
         return autoRefreshPartitionsLimit;
     }
@@ -1083,6 +1101,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildCompressionType();
         buildWriteQuorum();
         buildPartitionLiveNumber();
+        buildPartitionRetentionCondition();
         buildReplicatedStorage();
         buildBucketSize();
         buildEnableLoadProfile();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/PartitionTTLScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/PartitionTTLScheduler.java
@@ -39,9 +39,11 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AlterTableClauseAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DropPartitionClause;
+import com.starrocks.sql.optimizer.rule.transformation.partition.PartitionSelector;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
 import org.threeten.extra.PeriodDuration;
 
 import java.time.LocalDate;
@@ -140,6 +142,7 @@ public class PartitionTTLScheduler {
                                              PartitionInfo partitionInfo) {
         long dbId = db.getId();
         long tableId = olapTable.getId();
+        String ttlCondition = olapTable.getTableProperty().getPartitionRetentionCondition();
         if (partitionInfo instanceof RangePartitionInfo) {
             RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
             if (rangePartitionInfo.getPartitionColumnsSize() != 1) {
@@ -150,12 +153,15 @@ public class PartitionTTLScheduler {
 
             int ttlNumber = olapTable.getTableProperty().getPartitionTTLNumber();
             PeriodDuration ttlDuration = olapTable.getTableProperty().getPartitionTTL();
-            if (Objects.equals(ttlNumber, INVALID) && ttlDuration.isZero()) {
+            if (Objects.equals(ttlNumber, INVALID) && ttlDuration.isZero() && Strings.isNullOrEmpty(ttlCondition)) {
                 LOG.warn("database={}, table={} have no ttl. remove it from scheduler", dbId, tableId);
                 return false;
             }
         } else if (partitionInfo instanceof ListPartitionInfo) {
-            return false;
+            if (Strings.isNullOrEmpty(ttlCondition)) {
+                LOG.warn("database={}, table={} have no retention condition. remove it from scheduler", dbId, tableId);
+                return false;
+            }
         }
         return true;
     }
@@ -167,16 +173,22 @@ public class PartitionTTLScheduler {
         long tableId = olapTable.getId();
         List<String> dropPartitionNames = null;
         try {
+            String ttlCondition = olapTable.getTableProperty().getPartitionRetentionCondition();
             if (partitionInfo instanceof RangePartitionInfo) {
                 int ttlNumber = olapTable.getTableProperty().getPartitionTTLNumber();
                 PeriodDuration ttlDuration = olapTable.getTableProperty().getPartitionTTL();
-                if (!ttlDuration.isZero()) {
+                // prefer ttlCondition first
+                if (!Strings.isNullOrEmpty(ttlCondition)) {
+                    dropPartitionNames = PartitionSelector.getExpiredPartitionsByRetentionCondition(db, olapTable, ttlCondition);
+                } else if (!ttlDuration.isZero()) {
                     dropPartitionNames = buildDropPartitionClauseByTTLDuration(olapTable, ttlDuration);
-                } else {
+                } else if (ttlNumber != INVALID) {
                     dropPartitionNames = buildDropPartitionClauseByTTLNumber(olapTable, ttlNumber);
                 }
             } else if (partitionInfo instanceof ListPartitionInfo) {
-                return dropPartitionNames;
+                if (!Strings.isNullOrEmpty(ttlCondition)) {
+                    dropPartitionNames = PartitionSelector.getExpiredPartitionsByRetentionCondition(db, olapTable, ttlCondition);
+                }
             }
         } catch (AnalysisException e) {
             LOG.warn("database={}-{}, table={}-{} failed to build drop partition statement.",

--- a/fe/fe-core/src/main/java/com/starrocks/clone/PartitionTTLScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/PartitionTTLScheduler.java
@@ -15,6 +15,7 @@ package com.starrocks.clone;
 
 import com.google.api.client.util.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
@@ -43,7 +44,6 @@ import com.starrocks.sql.optimizer.rule.transformation.partition.PartitionSelect
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.parquet.Strings;
 import org.threeten.extra.PeriodDuration;
 
 import java.time.LocalDate;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -90,7 +91,6 @@ import com.starrocks.sql.plan.ExecPlan;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.parquet.Strings;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -671,7 +671,7 @@ public class OlapTableFactory implements AbstractTableFactory {
 
             // analyze partition retention condition
             if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {
-                String ttlCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(properties, true);
+                String ttlCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(db, table, properties, true);
                 if (ttlCondition == null) {
                     throw new DdlException("Invalid partition retention condition");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -654,21 +654,30 @@ public class OlapTableFactory implements AbstractTableFactory {
             table.setCompressionLevel(compressionLevel);
 
             // partition live number
-            int partitionLiveNumber;
             if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER)) {
-                partitionLiveNumber = PropertyAnalyzer.analyzePartitionLiveNumber(properties, true);
+                int partitionLiveNumber = PropertyAnalyzer.analyzePartitionLiveNumber(properties, true);
                 table.setPartitionLiveNumber(partitionLiveNumber);
             }
 
             // analyze partition ttl duration
-            Pair<String, PeriodDuration> ttlDuration = null;
             if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
-                ttlDuration = PropertyAnalyzer.analyzePartitionTTL(properties, true);
+                Pair<String, PeriodDuration> ttlDuration = PropertyAnalyzer.analyzePartitionTTL(properties, true);
                 if (ttlDuration == null) {
                     throw new DdlException("Invalid partition ttl duration");
                 }
                 table.getTableProperty().getProperties().put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL, ttlDuration.first);
                 table.getTableProperty().setPartitionTTL(ttlDuration.second);
+            }
+
+            // analyze partition retention condition
+            if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {
+                String ttlCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(properties, true);
+                if (ttlCondition == null) {
+                    throw new DdlException("Invalid partition retention condition");
+                }
+                table.getTableProperty().getProperties()
+                        .put(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION, ttlCondition);
+                table.getTableProperty().setPartitionRetentionCondition(ttlCondition);
             }
 
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -105,6 +105,7 @@ import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.transformation.partition.PartitionSelector;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import org.apache.commons.collections4.CollectionUtils;
@@ -118,7 +119,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
-import static com.starrocks.sql.optimizer.rule.transformation.partition.PartitionSelector.getPartitionNamesByExpr;
 
 public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext> {
     private final Table table;
@@ -215,6 +215,8 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
             PropertyAnalyzer.analyzePartitionLiveNumber(properties, false);
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
             PropertyAnalyzer.analyzePartitionTTL(properties, false);
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {
+            PropertyAnalyzer.analyzePartitionRetentionCondition(properties, false);
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
             PropertyAnalyzer.analyzeReplicationNum(properties, false);
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)) {
@@ -1274,7 +1276,8 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
             Database db = context.getGlobalStateMgr().getMetadataMgr()
                     .getDb(context.getCurrentCatalog(), context.getDatabase());
             TableName tableName = new TableName(db.getFullName(), table.getName());
-            List<String> dropPartitionNames = getPartitionNamesByExpr(context, tableName, olapTable, expr, true);
+            List<String> dropPartitionNames = PartitionSelector.getPartitionNamesByExpr(context, tableName,
+                    olapTable, expr, true);
             clause.setResolvedPartitionNames(dropPartitionNames);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -216,7 +216,7 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
             PropertyAnalyzer.analyzePartitionTTL(properties, false);
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {
-            PropertyAnalyzer.analyzePartitionRetentionCondition(properties, false);
+            // do nothing
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
             PropertyAnalyzer.analyzeReplicationNum(properties, false);
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -98,6 +98,23 @@ public class PartitionSelector {
                                                        OlapTable olapTable,
                                                        Expr whereExpr,
                                                        boolean isRecyclingCondition) {
+        List<Long> selectedPartitionIds = getPartitionIdsByExpr(context, tableName, olapTable, whereExpr,
+                isRecyclingCondition);
+        return selectedPartitionIds.stream()
+                .map(p -> olapTable.getPartition(p))
+                .map(Partition::getName)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Return filtered partition ids by whereExpr.
+     * @isRecyclingOrRetention, true for recycling/dropping condition, false for retention condition.
+     */
+    public static List<Long> getPartitionIdsByExpr(ConnectContext context,
+                                                   TableName tableName,
+                                                   OlapTable olapTable,
+                                                   Expr whereExpr,
+                                                   boolean isRecyclingCondition) {
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         if (!partitionInfo.isPartitioned()) {
             throw new SemanticException("Can't drop partitions with where expression since it is not partitioned");
@@ -176,7 +193,7 @@ public class PartitionSelector {
                     columnRefOperatorMap, isRecyclingCondition);
         } else if (partitionInfo.isListPartition()) {
             ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
-            selectedPartitionIds = getListPartitionIdsByExpr(tableName.getDb(), olapTable, listPartitionInfo,
+            selectedPartitionIds = getListPartitionIdsByExpr(tableName.getDb(), olapTable, listPartitionInfo, 
                     whereExpr, scalarOperator, exprToColumnIdxes);
         } else {
             throw new SemanticException("Unsupported partition type: " + partitionInfo.getType());
@@ -184,10 +201,38 @@ public class PartitionSelector {
         if (selectedPartitionIds == null) {
             throw new SemanticException("Failed to prune partitions with where expression: " + whereExpr.toSql());
         }
-        return selectedPartitionIds.stream()
-                .map(p -> olapTable.getPartition(p))
+        return selectedPartitionIds;
+    }
+
+    /**
+     * Get expired partitions by retention condition.
+     * inputCells and isMockPartitionIds are used for mv refresh since the partition is not added into table yet, but
+     * we need to check whether inputCells are expired or created for mv refresh.
+     */
+    public static List<String> getExpiredPartitionsByRetentionCondition(Database db,
+                                                                        OlapTable olapTable,
+                                                                        String ttlCondition) {
+        TableName tableName = new TableName(db.getFullName(), olapTable.getName());
+        ConnectContext context = ConnectContext.get() != null ? ConnectContext.get() : new ConnectContext();
+        // needs to parse the expr each schedule because it can be changed dynamically
+        // TODO: cache the parsed expr to avoid parsing it every time later.
+        Expr whereExpr = SqlParser.parseSqlToExpr(ttlCondition, SqlModeHelper.MODE_DEFAULT);
+        if (whereExpr == null) {
+            LOG.warn("database={}, table={} failed to parse retention condition: {}",
+                    db.getFullName(), olapTable.getName(), ttlCondition);
+            return Lists.newArrayList();
+        }
+        List<Long> retentionPartitionIds = PartitionSelector.getPartitionIdsByExpr(context, tableName, olapTable,
+                whereExpr, false);
+        if (retentionPartitionIds == null) {
+            return null;
+        }
+        Set<Long> retentionPartitionSet = Sets.newHashSet(retentionPartitionIds);
+        List<String> result = olapTable.getVisiblePartitions().stream()
+                .filter(p -> !retentionPartitionSet.contains(p.getId()))
                 .map(Partition::getName)
                 .collect(Collectors.toList());
+        return result;
     }
 
     private static Map<ColumnRefOperator, ScalarOperator> buildReplaceMap(Map<ColumnRefOperator, Integer> colRefIdxMap,
@@ -208,7 +253,8 @@ public class PartitionSelector {
                                                          ScalarOperator predicate,
                                                          Map<Column, ColumnRefOperator> columnRefOperatorMap,
                                                          boolean isRecyclingCondition) {
-        Map<Long, Range<PartitionKey>> keyRangeById = rangePartitionInfo.getIdToRange(false);
+        // clone it to avoid changing the original map
+        Map<Long, Range<PartitionKey>> keyRangeById = Maps.newHashMap(rangePartitionInfo.getIdToRange(false));
         // since partition pruning is false positive which means it may not prune some partitions which should be pruned
         // but it will not prune partitions which should not be pruned.
         ScalarOperator fpPredicate = predicate;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -5057,4 +5057,96 @@ public class CreateMaterializedViewTest {
         starRocksAssert.dropTable("t3");
         starRocksAssert.dropTable("t4");
     }
+
+    @Test
+    public void testCreateMVWithRetentionCondition1() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE t3 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10) not null,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY LIST (province, dt, age) (\n" +
+                "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-01\", \"10\")),\n" +
+                "     PARTITION p2 VALUES IN ((\"guangdong\", \"2024-01-01\", \"20\")), \n" +
+                "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-01-02\", \"30\")),\n" +
+                "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-01-02\", \"40\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n");
+        starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                "partition by (province, dt, age) \n" +
+                "REFRESH DEFERRED MANUAL \n" +
+                "properties (\n" +
+                "'replication_num' = '1',\n" +
+                "'partition_refresh_number' = '-1'," +
+                "'partition_retention_condition' = 'dt > current_date() - interval 1 month'\n" +
+                ") \n" +
+                "as select dt, province, age, sum(id) from t3 group by dt, province, age;");
+        MaterializedView mv = starRocksAssert.getMv("test", "mv1");
+        List<Column> mvPartitionCols = mv.getPartitionColumns();
+        Assert.assertEquals(3, mvPartitionCols.size());
+        Assert.assertEquals("province", mvPartitionCols.get(0).getName());
+        Assert.assertEquals("dt", mvPartitionCols.get(1).getName());
+        Assert.assertEquals("age", mvPartitionCols.get(2).getName());
+        starRocksAssert.dropMaterializedView("mv1");
+        starRocksAssert.dropTable("t3");
+    }
+
+    @Test
+    public void testCreateMVWithRetentionCondition2() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE t3 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10) not null,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "PARTITION BY province, dt, age\n" +
+                "DISTRIBUTED BY RANDOM\n");
+        starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                "partition by (province, dt, age) \n" +
+                "REFRESH DEFERRED MANUAL \n" +
+                "properties (\n" +
+                "'replication_num' = '1',\n" +
+                "'partition_refresh_number' = '-1'," +
+                "'partition_retention_condition' = 'dt > current_date() - interval 1 month'\n" +
+                ") \n" +
+                "as select dt, province, age, sum(id) from t3 group by dt, province, age;");
+        MaterializedView mv = starRocksAssert.getMv("test", "mv1");
+        List<Column> mvPartitionCols = mv.getPartitionColumns();
+        Assert.assertEquals(3, mvPartitionCols.size());
+        Assert.assertEquals("province", mvPartitionCols.get(0).getName());
+        Assert.assertEquals("dt", mvPartitionCols.get(1).getName());
+        Assert.assertEquals("age", mvPartitionCols.get(2).getName());
+        starRocksAssert.dropMaterializedView("mv1");
+        starRocksAssert.dropTable("t3");
+    }
+
+    @Test
+    public void testCreateMVWithRetentionCondition3() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE t3 (\n" +
+                "      id BIGINT,\n" +
+                "      age SMALLINT,\n" +
+                "      dt VARCHAR(10) not null,\n" +
+                "      province VARCHAR(64) not null\n" +
+                ")\n" +
+                "DUPLICATE KEY(id)\n" +
+                "DISTRIBUTED BY RANDOM\n");
+        try {
+            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                    "REFRESH DEFERRED MANUAL \n" +
+                    "properties (\n" +
+                    "'replication_num' = '1',\n" +
+                    "'partition_refresh_number' = '-1'," +
+                    "'partition_retention_condition' = 'dt > current_date() - interval 1 month'\n" +
+                    ") \n" +
+                    "as select dt, province, age, sum(id) from t3 group by dt, province, age;");
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("partition_retention_condition is " +
+                    "only supported by partitioned materialized-view."));
+        }
+        starRocksAssert.dropTable("t3");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithPartitionTest.java
@@ -894,6 +894,7 @@ public class CreateTableWithPartitionTest {
                     "'replication_num' = '1',\n" +
                     "'partition_retention_condition' = 'dt > current_date() - interval 1 month'\n" +
                     ")");
+            starRocksAssert.dropTable("t1");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -981,6 +982,7 @@ public class CreateTableWithPartitionTest {
                     "'replication_num' = '1',\n" +
                     "'partition_retention_condition' = 'dt > current_date() - interval 1 month'\n" +
                     ")");
+            starRocksAssert.dropTable("r1");
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithPartitionTest.java
@@ -878,5 +878,112 @@ public class CreateTableWithPartitionTest {
         Assert.assertFalse(partitionDesc.toString().contains("PARTITION p4 VALUES [('4'), ('5'))"));
 
     }
+
+    @Test
+    public void testAnalyzeRetentionConditionWithListPartition1() {
+        try {
+            starRocksAssert.withTable("CREATE TABLE t1 (\n" +
+                    " id BIGINT,\n" +
+                    " age SMALLINT,\n" +
+                    " dt datetime not null,\n" +
+                    " province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "PARTITION BY (province, dt) \n" +
+                    "DISTRIBUTED BY RANDOM\n" +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1',\n" +
+                    "'partition_retention_condition' = 'dt > current_date() - interval 1 month'\n" +
+                    ")");
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testAnalyzeRetentionConditionWithListPartition2() {
+        try {
+            starRocksAssert.withTable("CREATE TABLE t1 (\n" +
+                    " id BIGINT,\n" +
+                    " age SMALLINT,\n" +
+                    " dt datetime not null,\n" +
+                    " province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "PARTITION BY (province, dt) \n" +
+                    "DISTRIBUTED BY RANDOM\n" +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1',\n" +
+                    "'partition_retention_condition' = 'dt2 > current_date() - interval 1 month'\n" +
+                    ")");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Column 'dt2' cannot be resolved"));
+        }
+    }
+
+    @Test
+    public void testAnalyzeRetentionConditionWithListPartition3() {
+        try {
+            starRocksAssert.withTable("CREATE TABLE t1 (\n" +
+                    " id BIGINT,\n" +
+                    " age SMALLINT,\n" +
+                    " dt datetime not null,\n" +
+                    " province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "PARTITION BY (province, dt) \n" +
+                    "DISTRIBUTED BY RANDOM\n" +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1',\n" +
+                    "'partition_retention_condition' = 'cast(id as date) > current_date() - interval 1 month'\n" +
+                    ")");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Column is not a partition column which can not be " +
+                    "used in where clause for drop partition"));
+        }
+    }
+
+    @Test
+    public void testAnalyzeRetentionConditionWithListPartition4() {
+        try {
+            starRocksAssert.withTable("CREATE TABLE t1 (\n" +
+                    " id BIGINT,\n" +
+                    " age SMALLINT,\n" +
+                    " dt datetime not null,\n" +
+                    " province VARCHAR(64) not null\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY RANDOM\n" +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1',\n" +
+                    "'partition_retention_condition' = 'cast(id as date) > current_date() - interval 1 month'\n" +
+                    ")");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Can't drop partitions with where expression " +
+                    "since it is not partitioned"));
+        }
+    }
+
+    @Test
+    public void testAnalyzeRetentionConditionWithRangePartition1() {
+        try {
+            starRocksAssert.withTable("CREATE TABLE r1 \n" +
+                    "(\n" +
+                    "    dt date,\n" +
+                    "    k2 int,\n" +
+                    "    v1 int \n" +
+                    ")\n" +
+                    "PARTITION BY RANGE(dt)\n" +
+                    "(\n" +
+                    "    PARTITION p0 values [('2024-01-29'),('2024-01-30')),\n" +
+                    "    PARTITION p1 values [('2024-01-30'),('2024-01-31')),\n" +
+                    "    PARTITION p2 values [('2024-01-31'),('2024-02-01')),\n" +
+                    "    PARTITION p3 values [('2024-02-01'),('2024-02-02')) \n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1',\n" +
+                    "'partition_retention_condition' = 'dt > current_date() - interval 1 month'\n" +
+                    ")");
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -1322,7 +1322,7 @@ public class RefreshMaterializedViewTest extends MvRewriteTestBase {
                 .useDatabase("drop_mv_db")
                 .withMaterializedView("CREATE MATERIALIZED VIEW test_mv\n"
                         + "DISTRIBUTED BY HASH(`k2`)\n"
-                        + "REFRESH ASYNC\n"
+                        + "REFRESH DEFERRED ASYNC\n"
                         + "AS select k1, k2, v1  from drop_db.tbl_with_mv;");
 
         executeInsertSql(connectContext, "insert into drop_db.tbl_with_mv partition(p2) values(\"2022-02-20\", 2, 10)");

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
@@ -204,26 +204,26 @@ public class DynamicPartitionSchedulerTest {
     @Test
     public void testPartitionTTLProperties() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.tbl1\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    v1 int \n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values less than('2020-02-01'),\n" +
-                                "    PARTITION p2 values less than('2020-03-01'),\n" +
-                                "    PARTITION p3 values less than('2020-04-01'),\n" +
-                                "    PARTITION p4 values less than('2020-05-01')\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
-                                "PROPERTIES" +
-                                "(" +
-                                "    'replication_num' = '1'\n" +
-                                ");");
+                .withTable("CREATE TABLE test.tbl1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    v1 int \n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2020-02-01'),\n" +
+                        "    PARTITION p2 values less than('2020-03-01'),\n" +
+                        "    PARTITION p3 values less than('2020-04-01'),\n" +
+                        "    PARTITION p4 values less than('2020-05-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
+                        "PROPERTIES" +
+                        "(" +
+                        "    'replication_num' = '1'\n" +
+                        ");");
 
         DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
-                    .getDynamicPartitionScheduler();
+                .getDynamicPartitionScheduler();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "tbl1");
         // Now the table does not actually support partition ttl,
@@ -240,30 +240,30 @@ public class DynamicPartitionSchedulerTest {
     @Test
     public void testPartitionTTLPropertiesZero() throws Exception {
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test.base\n" +
-                                "(\n" +
-                                "    k1 date,\n" +
-                                "    k2 int,\n" +
-                                "    v1 int sum\n" +
-                                ")\n" +
-                                "PARTITION BY RANGE(k1)\n" +
-                                "(\n" +
-                                "    PARTITION p1 values less than('2020-02-01'),\n" +
-                                "    PARTITION p2 values less than('2020-03-01')\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                                "PROPERTIES('replication_num' = '1');");
+                .withTable("CREATE TABLE test.base\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2020-02-01'),\n" +
+                        "    PARTITION p2 values less than('2020-03-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
         String sql = "create materialized view mv1 " +
-                    "partition by k1 " +
-                    "distributed by hash(k2) " +
-                    "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
-                    "PROPERTIES (\n" +
-                    "\"replication_num\" = \"1\",\n" +
-                    "\"partition_ttl_number\" = \"0\"\n" +
-                    ") " +
-                    "as select k1, k2 from test.base;";
+                "partition by k1 " +
+                "distributed by hash(k2) " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"partition_ttl_number\" = \"0\"\n" +
+                ") " +
+                "as select k1, k2 from test.base;";
         CreateMaterializedViewStatement createMaterializedViewStatement =
-                    (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+                (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createMaterializedViewStatement);
             fail();
@@ -282,29 +282,29 @@ public class DynamicPartitionSchedulerTest {
         };
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE site_access(\n" +
-                                "    event_day datetime,\n" +
-                                "    site_id INT DEFAULT '10',\n" +
-                                "    city_code VARCHAR(100),\n" +
-                                "    user_name VARCHAR(32) DEFAULT '',\n" +
-                                "    pv BIGINT DEFAULT '0'\n" +
-                                ")\n" +
-                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                                "PARTITION BY date_trunc('day', event_day)(\n" +
-                                " START (\"2023-03-27\") END (\"2023-03-31\") EVERY (INTERVAL 1 day),\n" +
-                                " START (\"9999-12-30\") END (\"9999-12-31\") EVERY (INTERVAL 1 day)\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
-                                "PROPERTIES(\n" +
-                                "    \"partition_live_number\" = \"3\",\n" +
-                                "    \"replication_num\" = \"1\"\n" +
-                                ");");
+                .withTable("CREATE TABLE site_access(\n" +
+                        "    event_day datetime,\n" +
+                        "    site_id INT DEFAULT '10',\n" +
+                        "    city_code VARCHAR(100),\n" +
+                        "    user_name VARCHAR(32) DEFAULT '',\n" +
+                        "    pv BIGINT DEFAULT '0'\n" +
+                        ")\n" +
+                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                        "PARTITION BY date_trunc('day', event_day)(\n" +
+                        " START (\"2023-03-27\") END (\"2023-03-31\") EVERY (INTERVAL 1 day),\n" +
+                        " START (\"9999-12-30\") END (\"9999-12-31\") EVERY (INTERVAL 1 day)\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32\n" +
+                        "PROPERTIES(\n" +
+                        "    \"partition_live_number\" = \"3\",\n" +
+                        "    \"replication_num\" = \"1\"\n" +
+                        ");");
 
         DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
-                    .getDynamicPartitionScheduler();
+                .getDynamicPartitionScheduler();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl =
-                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access");
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access");
         dynamicPartitionScheduler.registerTtlPartitionTable(db.getId(), tbl.getId());
         dynamicPartitionScheduler.runOnceForTest();
 
@@ -327,29 +327,29 @@ public class DynamicPartitionSchedulerTest {
         };
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE site_access(\n" +
-                                "    event_day datetime,\n" +
-                                "    site_id INT DEFAULT '10',\n" +
-                                "    city_code VARCHAR(100),\n" +
-                                "    user_name VARCHAR(32) DEFAULT '',\n" +
-                                "    pv BIGINT DEFAULT '0'\n" +
-                                ")\n" +
-                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
-                                "PARTITION BY date_trunc('day', event_day)(\n" +
-                                " START (\"2023-03-27\") END (\"2023-03-31\") EVERY (INTERVAL 1 day),\n" +
-                                " START (\"9999-12-30\") END (\"9999-12-31\") EVERY (INTERVAL 1 day)\n" +
-                                ")\n" +
-                                "DISTRIBUTED BY RANDOM BUCKETS 32\n" +
-                                "PROPERTIES(\n" +
-                                "    \"partition_live_number\" = \"3\",\n" +
-                                "    \"replication_num\" = \"1\"\n" +
-                                ");");
+                .withTable("CREATE TABLE site_access(\n" +
+                        "    event_day datetime,\n" +
+                        "    site_id INT DEFAULT '10',\n" +
+                        "    city_code VARCHAR(100),\n" +
+                        "    user_name VARCHAR(32) DEFAULT '',\n" +
+                        "    pv BIGINT DEFAULT '0'\n" +
+                        ")\n" +
+                        "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                        "PARTITION BY date_trunc('day', event_day)(\n" +
+                        " START (\"2023-03-27\") END (\"2023-03-31\") EVERY (INTERVAL 1 day),\n" +
+                        " START (\"9999-12-30\") END (\"9999-12-31\") EVERY (INTERVAL 1 day)\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY RANDOM BUCKETS 32\n" +
+                        "PROPERTIES(\n" +
+                        "    \"partition_live_number\" = \"3\",\n" +
+                        "    \"replication_num\" = \"1\"\n" +
+                        ");");
 
         DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
-                    .getDynamicPartitionScheduler();
+                .getDynamicPartitionScheduler();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl =
-                    (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access");
+                (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "site_access");
         dynamicPartitionScheduler.registerTtlPartitionTable(db.getId(), tbl.getId());
         dynamicPartitionScheduler.runOnceForTest();
 
@@ -372,30 +372,30 @@ public class DynamicPartitionSchedulerTest {
         };
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE test_random_bucket (\n" +
-                                "    uid String,\n" +
-                                "    tdbank_imp_date Date\n" +
-                                ") ENGINE=OLAP \n" +
-                                "DUPLICATE KEY(`uid`) \n" +
-                                "PARTITION BY RANGE(`tdbank_imp_date`) ()\n" +
-                                "DISTRIBUTED BY RANDOM BUCKETS 1\n" +
-                                "PROPERTIES (\n" +
-                                "     \"replication_num\" = \"1\", \n" +
-                                "     \"dynamic_partition.enable\" = \"true\", \n" +
-                                "     \"dynamic_partition.time_unit\" = \"DAY\", \n" +
-                                "     \"dynamic_partition.time_zone\" = \"Asia/Shanghai\", \n" +
-                                "     \"dynamic_partition.start\" = \"-180\", \n" +
-                                "     \"dynamic_partition.end\" = \"3\", \n" +
-                                "     \"dynamic_partition.prefix\" = \"p\", \n" +
-                                "     \"dynamic_partition.buckets\" = \"4\", \n" +
-                                "     \"dynamic_partition.history_partition_num\" = \"0\",\n" +
-                                "     \"compression\" = \"LZ4\" );");
+                .withTable("CREATE TABLE test_random_bucket (\n" +
+                        "    uid String,\n" +
+                        "    tdbank_imp_date Date\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`uid`) \n" +
+                        "PARTITION BY RANGE(`tdbank_imp_date`) ()\n" +
+                        "DISTRIBUTED BY RANDOM BUCKETS 1\n" +
+                        "PROPERTIES (\n" +
+                        "     \"replication_num\" = \"1\", \n" +
+                        "     \"dynamic_partition.enable\" = \"true\", \n" +
+                        "     \"dynamic_partition.time_unit\" = \"DAY\", \n" +
+                        "     \"dynamic_partition.time_zone\" = \"Asia/Shanghai\", \n" +
+                        "     \"dynamic_partition.start\" = \"-180\", \n" +
+                        "     \"dynamic_partition.end\" = \"3\", \n" +
+                        "     \"dynamic_partition.prefix\" = \"p\", \n" +
+                        "     \"dynamic_partition.buckets\" = \"4\", \n" +
+                        "     \"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                        "     \"compression\" = \"LZ4\" );");
 
         DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
-                    .getDynamicPartitionScheduler();
+                .getDynamicPartitionScheduler();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(db.getFullName(), "test_random_bucket");
+                .getTable(db.getFullName(), "test_random_bucket");
         dynamicPartitionScheduler.registerTtlPartitionTable(db.getId(), tbl.getId());
         dynamicPartitionScheduler.runOnceForTest();
 
@@ -416,38 +416,38 @@ public class DynamicPartitionSchedulerTest {
         };
 
         starRocksAssert.withDatabase("test").useDatabase("test")
-                    .withTable("CREATE TABLE `test_hour_partition2` (\n" +
-                                "  `event_day` date NULL COMMENT \"\",\n" +
-                                "  `site_id` int(11) NULL DEFAULT \"10\" COMMENT \"\",\n" +
-                                "  `city_code` varchar(100) NULL COMMENT \"\",\n" +
-                                "  `user_name` varchar(32) NULL DEFAULT \"\" COMMENT \"\",\n" +
-                                "  `pv` bigint(20) NULL DEFAULT \"0\" COMMENT \"\"\n" +
-                                ") ENGINE=OLAP \n" +
-                                "DUPLICATE KEY(`event_day`, `site_id`, `city_code`, `user_name`)\n" +
-                                "PARTITION BY RANGE(`event_day`)\n" +
-                                "()\n" +
-                                "DISTRIBUTED BY HASH(`event_day`, `site_id`) BUCKETS 32 \n" +
-                                "PROPERTIES (\n" +
-                                "\"replication_num\" = \"1\",\n" +
-                                "\"dynamic_partition.enable\" = \"true\",\n" +
-                                "\"dynamic_partition.time_unit\" = \"DAY\",\n" +
-                                "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
-                                "\"dynamic_partition.start\" = \"-1\",\n" +
-                                "\"dynamic_partition.end\" = \"10\",\n" +
-                                "\"dynamic_partition.prefix\" = \"p\",\n" +
-                                "\"dynamic_partition.buckets\" = \"3\",\n" +
-                                "\"dynamic_partition.history_partition_num\" = \"0\",\n" +
-                                "\"in_memory\" = \"false\",\n" +
-                                "\"storage_format\" = \"DEFAULT\",\n" +
-                                "\"enable_persistent_index\" = \"false\",\n" +
-                                "\"compression\" = \"LZ4\"\n" +
-                                ");");
+                .withTable("CREATE TABLE `test_hour_partition2` (\n" +
+                        "  `event_day` date NULL COMMENT \"\",\n" +
+                        "  `site_id` int(11) NULL DEFAULT \"10\" COMMENT \"\",\n" +
+                        "  `city_code` varchar(100) NULL COMMENT \"\",\n" +
+                        "  `user_name` varchar(32) NULL DEFAULT \"\" COMMENT \"\",\n" +
+                        "  `pv` bigint(20) NULL DEFAULT \"0\" COMMENT \"\"\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`event_day`, `site_id`, `city_code`, `user_name`)\n" +
+                        "PARTITION BY RANGE(`event_day`)\n" +
+                        "()\n" +
+                        "DISTRIBUTED BY HASH(`event_day`, `site_id`) BUCKETS 32 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"dynamic_partition.enable\" = \"true\",\n" +
+                        "\"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                        "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
+                        "\"dynamic_partition.start\" = \"-1\",\n" +
+                        "\"dynamic_partition.end\" = \"10\",\n" +
+                        "\"dynamic_partition.prefix\" = \"p\",\n" +
+                        "\"dynamic_partition.buckets\" = \"3\",\n" +
+                        "\"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                        "\"in_memory\" = \"false\",\n" +
+                        "\"storage_format\" = \"DEFAULT\",\n" +
+                        "\"enable_persistent_index\" = \"false\",\n" +
+                        "\"compression\" = \"LZ4\"\n" +
+                        ");");
 
         DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
-                    .getDynamicPartitionScheduler();
+                .getDynamicPartitionScheduler();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(db.getFullName(), "test_hour_partition2");
+                .getTable(db.getFullName(), "test_hour_partition2");
         DynamicPartitionProperty dynamicPartitionProperty = tbl.getTableProperty().getDynamicPartitionProperty();
         dynamicPartitionProperty.setTimeUnit("HOUR");
         boolean result = dynamicPartitionScheduler.executeDynamicPartitionForTable(db.getId(), tbl.getId());
@@ -514,22 +514,18 @@ public class DynamicPartitionSchedulerTest {
                         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                                 .getTable(db.getFullName(), tableName);
-                        try {
-                            scheduler.runOnceForTest();
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
-                            // add a new partition and an expired partition
-                            LocalDateTime now = LocalDateTime.now();
-                            addListPartition(tableName, "p5", "guangdong",
-                                    now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-                            addListPartition(tableName, "p6", "guangdong",
-                                    now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
+                        // add a new partition and an expired partition
+                        LocalDateTime now = LocalDateTime.now();
+                        addListPartition(tableName, "p5", "guangdong",
+                                now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                        addListPartition(tableName, "p6", "guangdong",
+                                now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
 
-                            scheduler.runOnceForTest();
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
-                        } catch (Exception e) {
-                            fail("Should not throw exception: " + e.getMessage());
-                        }
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
                     });
         }
     }
@@ -556,22 +552,18 @@ public class DynamicPartitionSchedulerTest {
                     Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                     OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                             .getTable(db.getFullName(), tableName);
-                    try {
-                        scheduler.runOnceForTest();
-                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
-                        // add a new partition and an expired partition
-                        LocalDateTime now = LocalDateTime.now();
-                        addListPartition(tableName, "p5", "guangdong",
-                                now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-                        addListPartition(tableName, "p6", "guangdong",
-                                now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
+                    scheduler.runOnceForTest();
+                    Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
+                    // add a new partition and an expired partition
+                    LocalDateTime now = LocalDateTime.now();
+                    addListPartition(tableName, "p5", "guangdong",
+                            now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                    addListPartition(tableName, "p6", "guangdong",
+                            now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                    Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
 
-                        scheduler.runOnceForTest();
-                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
-                    } catch (Exception e) {
-                        fail("Should not throw exception: " + e.getMessage());
-                    }
+                    scheduler.runOnceForTest();
+                    Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
                 });
     }
 
@@ -586,9 +578,9 @@ public class DynamicPartitionSchedulerTest {
                         Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
 
                         String dropPartitionSql = String.format("alter table %s set ('partition_retention_condition' = " +
-                                        "'date_trunc(\"day\", dt) >= date_sub(current_date(), 2) or " +
-                                        "date_trunc(\"day\", dt) = (date_trunc(\"month\", dt) " +
-                                        "+ interval 1 month - interval 1 day)');", tableName);
+                                "'date_trunc(\"day\", dt) >= date_sub(current_date(), 2) or " +
+                                "date_trunc(\"day\", dt) = (date_trunc(\"month\", dt) " +
+                                "+ interval 1 month - interval 1 day)');", tableName);
                         starRocksAssert.alterTable(dropPartitionSql);
 
                         DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
@@ -596,22 +588,18 @@ public class DynamicPartitionSchedulerTest {
                         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                                 .getTable(db.getFullName(), tableName);
-                        try {
-                            scheduler.runOnceForTest();
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
-                            // add a new partition and an expired partition
-                            LocalDateTime now = LocalDateTime.now();
-                            addListPartition(tableName, "p5", "guangdong",
-                                    now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-                            addListPartition(tableName, "p6", "guangdong",
-                                    now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 4);
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
+                        // add a new partition and an expired partition
+                        LocalDateTime now = LocalDateTime.now();
+                        addListPartition(tableName, "p5", "guangdong",
+                                now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                        addListPartition(tableName, "p6", "guangdong",
+                                now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 4);
 
-                            scheduler.runOnceForTest();
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 3);
-                        } catch (Exception e) {
-                            fail("Should not throw exception: " + e.getMessage());
-                        }
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 3);
                     });
         }
     }
@@ -636,21 +624,17 @@ public class DynamicPartitionSchedulerTest {
                         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                                 .getTable(db.getFullName(), tableName);
-                        try {
-                            scheduler.runOnceForTest();
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
-                            // add a new partition and an expired partition
-                            LocalDateTime now = LocalDateTime.now();
-                            String currentDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                            String nextDate = now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                            addRangePartition(tableName, "p5", currentDate, nextDate);
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
+                        // add a new partition and an expired partition
+                        LocalDateTime now = LocalDateTime.now();
+                        String currentDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                        String nextDate = now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                        addRangePartition(tableName, "p5", currentDate, nextDate);
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
 
-                            scheduler.runOnceForTest();
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
-                        } catch (Exception e) {
-                            fail("Should not throw exception: " + e.getMessage());
-                        }
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
                     });
         }
     }
@@ -683,22 +667,18 @@ public class DynamicPartitionSchedulerTest {
                     Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                     OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                             .getTable(db.getFullName(), tableName);
-                    try {
-                        scheduler.runOnceForTest();
-                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
+                    scheduler.runOnceForTest();
+                    Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
 
-                        // add a new partition and an expired partition
-                        LocalDateTime now = LocalDateTime.now();
-                        String currentDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                        String nextDate = now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                        addRangePartition(tableName, "p5", currentDate, nextDate);
-                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
+                    // add a new partition and an expired partition
+                    LocalDateTime now = LocalDateTime.now();
+                    String currentDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                    String nextDate = now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                    addRangePartition(tableName, "p5", currentDate, nextDate);
+                    Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
 
-                        scheduler.runOnceForTest();
-                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
-                    } catch (Exception e) {
-                        fail("Should not throw exception: " + e.getMessage());
-                    }
+                    scheduler.runOnceForTest();
+                    Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
                 });
     }
 
@@ -723,22 +703,18 @@ public class DynamicPartitionSchedulerTest {
                         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
                         OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                                 .getTable(db.getFullName(), tableName);
-                        try {
-                            scheduler.runOnceForTest();
-                            // cannot beego
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 4);
-                            // add a new partition and an expired partition
-                            LocalDateTime now = LocalDateTime.now();
-                            String currentDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                            String nextDate = now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                            addRangePartition(tableName, "p5", currentDate, nextDate);
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 5);
+                        scheduler.runOnceForTest();
+                        // cannot beego
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 4);
+                        // add a new partition and an expired partition
+                        LocalDateTime now = LocalDateTime.now();
+                        String currentDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                        String nextDate = now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                        addRangePartition(tableName, "p5", currentDate, nextDate);
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 5);
 
-                            scheduler.runOnceForTest();
-                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 5);
-                        } catch (Exception e) {
-                            fail("Should not throw exception: " + e.getMessage());
-                        }
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 5);
                     });
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
@@ -14,21 +14,30 @@
 
 package com.starrocks.clone;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.DynamicPartitionProperty;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,15 +46,24 @@ import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
 import static org.junit.Assert.fail;
 
 public class DynamicPartitionSchedulerTest {
+    private static final Logger LOG = LogManager.getLogger(DynamicPartitionSchedulerTest.class);
 
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
+    private static String T1;
+    private static String T2;
+    private static List<String> LIST_PARTITION_TABLES;
+
+    private static String R1;
+    private static String R2;
+    private static List<String> RANGE_PARTITION_TABLES;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -58,8 +76,130 @@ public class DynamicPartitionSchedulerTest {
         // set default config for async mvs
         UtFrameUtils.setDefaultConfigForAsyncMVTest(connectContext);
 
+        T1 = "CREATE TABLE t1 (\n" +
+                " id BIGINT,\n" +
+                " age SMALLINT,\n" +
+                " dt VARCHAR(10) not null,\n" +
+                " province VARCHAR(64) not null\n" +
+                ")\n" +
+                "PARTITION BY (province, dt) \n" +
+                "DISTRIBUTED BY RANDOM\n";
+        // table whose partitions have multi columns
+        T2 = "CREATE TABLE t2 (\n" +
+                " id BIGINT,\n" +
+                " age SMALLINT,\n" +
+                " dt VARCHAR(10) not null,\n" +
+                " province VARCHAR(64) not null\n" +
+                ")\n" +
+                "PARTITION BY LIST (province, dt) (\n" +
+                "     PARTITION p1 VALUES IN ((\"beijing\", \"2024-01-31\")),\n" +
+                "     PARTITION p2 VALUES IN ((\"guangdong\", \"2024-01-31\")), \n" +
+                "     PARTITION p3 VALUES IN ((\"beijing\", \"2024-02-01\")),\n" +
+                "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-02-01\")) \n" +
+                ")\n" +
+                "DISTRIBUTED BY RANDOM\n";
+        LIST_PARTITION_TABLES = ImmutableList.of(T1, T2);
+
+        // range partition table
+        R1 = "CREATE TABLE r1 \n" +
+                "(\n" +
+                "    dt date,\n" +
+                "    k2 int,\n" +
+                "    v1 int \n" +
+                ")\n" +
+                "PARTITION BY RANGE(dt)\n" +
+                "(\n" +
+                "    PARTITION p0 values [('2024-01-29'),('2024-01-30')),\n" +
+                "    PARTITION p1 values [('2024-01-30'),('2024-01-31')),\n" +
+                "    PARTITION p2 values [('2024-01-31'),('2024-02-01')),\n" +
+                "    PARTITION p3 values [('2024-02-01'),('2024-02-02')) \n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');";
+        R2 = "CREATE TABLE r2 \n" +
+                "(\n" +
+                "    dt date,\n" +
+                "    k2 int,\n" +
+                "    v1 int \n" +
+                ")\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');";
+        RANGE_PARTITION_TABLES = ImmutableList.of(R1, R2);
+
         starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test").useDatabase("test");
     }
+
+
+    public static void executeInsertSql(String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        StatementBase statement = SqlParser.parseSingleStatement(sql, connectContext.getSessionVariable().getSqlMode());
+        new StmtExecutor(connectContext, statement).execute();
+    }
+
+    private String toPartitionVal(String val) {
+        return val == null ? "NULL" : String.format("'%s'", val);
+    }
+
+    private void addListPartition(String tbl, String pName, String pVal1, String pVal2) {
+        String addPartitionSql = String.format("ALTER TABLE %s ADD PARTITION IF NOT EXISTS %s VALUES IN ((%s, %s))",
+                tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
+        StatementBase stmt = SqlParser.parseSingleStatement(addPartitionSql, connectContext.getSessionVariable().getSqlMode());
+        try {
+            new StmtExecutor(connectContext, stmt).execute();
+        } catch (Exception e) {
+            Assert.fail("add partition failed:" + e);
+        }
+    }
+
+    private void withTableListPartitions(String tableName) {
+        // Automatic partition creation is not supported in FE UTs
+        //String insertSql = String.format("insert into %s values " +
+        //        "(1, 1, '2024-01-01', 'beijing'), (1, 1, '2024-01-01', 'guangdong')," +
+        //        "(2, 1, '2024-01-02', 'beijing'), (2, 1, '2024-01-02', 'guangdong');", tableName);
+        //executeInsertSql(insertSql);
+        addListPartition(tableName, "p1", "beijing", "2024-01-31");
+        addListPartition(tableName, "p2", "guangdong", "2024-01-31");
+        addListPartition(tableName, "p3", "beijing", "2024-02-01");
+        addListPartition(tableName, "p4", "guangdong", "2024-02-01");
+    }
+
+    private void addRangePartition(String tbl, String pName, String pVal1, String pVal2) {
+        // mock the check to ensure test can run
+        new MockUp<ExpressionRangePartitionInfo>() {
+            @Mock
+            public boolean isAutomaticPartition() {
+                return false;
+            }
+        };
+        new MockUp<ExpressionRangePartitionInfoV2>() {
+            @Mock
+            public boolean isAutomaticPartition() {
+                return false;
+            }
+        };
+        try {
+            String addPartitionSql = String.format("ALTER TABLE %s ADD " +
+                    "PARTITION %s VALUES [(%s),(%s))", tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
+            System.out.println(addPartitionSql);
+            starRocksAssert.alterTable(addPartitionSql);
+        } catch (Exception e) {
+            e.printStackTrace();
+            LOG.error("Failed to add partition", e);
+        }
+    }
+
+    private void withTableRangePartitions(String tableName) {
+        if (tableName.equalsIgnoreCase("r1")) {
+            return;
+        }
+        addRangePartition(tableName, "p1", "2024-01-29", "2024-01-30");
+        addRangePartition(tableName, "p2", "2024-01-30", "2024-01-31");
+        addRangePartition(tableName, "p3", "2024-01-31", "2024-02-01");
+        addRangePartition(tableName, "p4", "2024-02-01", "2024-02-02");
+    }
+
 
     @Test
     public void testPartitionTTLProperties() throws Exception {
@@ -353,6 +493,253 @@ public class DynamicPartitionSchedulerTest {
             dynamicPartitionScheduler.executeDynamicPartitionForTable(db.getId(), tbl.getId());
         } catch (Exception e) {
             fail("Should not throw exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testListPartitionTTLCondition1() {
+        for (String t : LIST_PARTITION_TABLES) {
+            starRocksAssert.withTable(t,
+                    (obj) -> {
+                        String tableName = (String) obj;
+                        withTableListPartitions(tableName);
+                        OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                        String dropPartitionSql = String.format("alter table %s set ('partition_retention_condition' = " +
+                                "'dt >= current_date() - interval 1 month');", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+
+                        DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
+                                .getDynamicPartitionScheduler();
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getFullName(), tableName);
+                        try {
+                            scheduler.runOnceForTest();
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
+                            // add a new partition and an expired partition
+                            LocalDateTime now = LocalDateTime.now();
+                            addListPartition(tableName, "p5", "guangdong",
+                                    now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                            addListPartition(tableName, "p6", "guangdong",
+                                    now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
+
+                            scheduler.runOnceForTest();
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
+                        } catch (Exception e) {
+                            fail("Should not throw exception: " + e.getMessage());
+                        }
+                    });
+        }
+    }
+
+    @Test
+    public void testListPartitionTTLCondition2() {
+        starRocksAssert.withTable("CREATE TABLE t1 (\n" +
+                        " id BIGINT,\n" +
+                        " age SMALLINT,\n" +
+                        " dt datetime not null,\n" +
+                        " province VARCHAR(64) not null\n" +
+                        ")\n" +
+                        "PARTITION BY (province, dt) \n" +
+                        "DISTRIBUTED BY RANDOM\n" +
+                        "PROPERTIES ('partition_retention_condition' = 'dt > current_date() - interval 1 month')",
+                (obj) -> {
+                    String tableName = (String) obj;
+                    withTableListPartitions(tableName);
+                    OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                    Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+                    DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
+                            .getDynamicPartitionScheduler();
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                    OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getFullName(), tableName);
+                    try {
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
+                        // add a new partition and an expired partition
+                        LocalDateTime now = LocalDateTime.now();
+                        addListPartition(tableName, "p5", "guangdong",
+                                now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                        addListPartition(tableName, "p6", "guangdong",
+                                now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
+
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
+                    } catch (Exception e) {
+                        fail("Should not throw exception: " + e.getMessage());
+                    }
+                });
+    }
+
+    @Test
+    public void testListPartitionTTLCondition3() {
+        for (String t : LIST_PARTITION_TABLES) {
+            starRocksAssert.withTable(t,
+                    (obj) -> {
+                        String tableName = (String) obj;
+                        withTableListPartitions(tableName);
+                        OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+                        String dropPartitionSql = String.format("alter table %s set ('partition_retention_condition' = " +
+                                        "'date_trunc(\"day\", dt) >= date_sub(current_date(), 2) or " +
+                                        "date_trunc(\"day\", dt) = (date_trunc(\"month\", dt) " +
+                                        "+ interval 1 month - interval 1 day)');", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+
+                        DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
+                                .getDynamicPartitionScheduler();
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getFullName(), tableName);
+                        try {
+                            scheduler.runOnceForTest();
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 2);
+                            // add a new partition and an expired partition
+                            LocalDateTime now = LocalDateTime.now();
+                            addListPartition(tableName, "p5", "guangdong",
+                                    now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                            addListPartition(tableName, "p6", "guangdong",
+                                    now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 4);
+
+                            scheduler.runOnceForTest();
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 3);
+                        } catch (Exception e) {
+                            fail("Should not throw exception: " + e.getMessage());
+                        }
+                    });
+        }
+    }
+
+    @Test
+    public void testRangePartitionTTLCondition1() {
+        for (String t : RANGE_PARTITION_TABLES) {
+            starRocksAssert.withTable(t,
+                    (obj) -> {
+                        String tableName = (String) obj;
+                        System.out.println(tableName);
+                        withTableRangePartitions(tableName);
+
+                        OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                        String dropPartitionSql = String.format("alter table %s set ('partition_retention_condition' = " +
+                                "'dt >= current_date() - interval 1 month');", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+
+                        DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
+                                .getDynamicPartitionScheduler();
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getFullName(), tableName);
+                        try {
+                            scheduler.runOnceForTest();
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
+                            // add a new partition and an expired partition
+                            LocalDateTime now = LocalDateTime.now();
+                            String currentDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                            String nextDate = now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                            addRangePartition(tableName, "p5", currentDate, nextDate);
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
+
+                            scheduler.runOnceForTest();
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
+                        } catch (Exception e) {
+                            fail("Should not throw exception: " + e.getMessage());
+                        }
+                    });
+        }
+    }
+
+    @Test
+    public void testRangePartitionTTLCondition2() {
+        starRocksAssert.withTable("CREATE TABLE r1 \n" +
+                        "(\n" +
+                        "    dt date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int \n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(dt)\n" +
+                        "(\n" +
+                        "    PARTITION p0 values [('2024-01-29'),('2024-01-30')),\n" +
+                        "    PARTITION p1 values [('2024-01-30'),('2024-01-31')),\n" +
+                        "    PARTITION p2 values [('2024-01-31'),('2024-02-01')),\n" +
+                        "    PARTITION p3 values [('2024-02-01'),('2024-02-02')) \n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES ('partition_retention_condition' = 'dt > current_date() - interval 1 month')",
+                (obj) -> {
+                    String tableName = (String) obj;
+                    withTableListPartitions(tableName);
+                    OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                    Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+
+                    DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
+                            .getDynamicPartitionScheduler();
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                    OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getFullName(), tableName);
+                    try {
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 0);
+
+                        // add a new partition and an expired partition
+                        LocalDateTime now = LocalDateTime.now();
+                        String currentDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                        String nextDate = now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                        addRangePartition(tableName, "p5", currentDate, nextDate);
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
+
+                        scheduler.runOnceForTest();
+                        Assert.assertTrue(tbl.getVisiblePartitions().size() == 1);
+                    } catch (Exception e) {
+                        fail("Should not throw exception: " + e.getMessage());
+                    }
+                });
+    }
+
+    @Test
+    public void testRangePartitionTTLCondition3() {
+        for (String t : RANGE_PARTITION_TABLES) {
+            starRocksAssert.withTable(t,
+                    (obj) -> {
+                        String tableName = (String) obj;
+                        System.out.println(tableName);
+                        withTableRangePartitions(tableName);
+
+                        OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+                        Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+                        String dropPartitionSql = String.format("alter table %s set ('partition_retention_condition' = " +
+                                "'dt >= date_sub(current_date(), 2) or dt != (date_trunc(\"month\", dt) + interval 1 month - " +
+                                "interval 1 day)')", tableName);
+                        starRocksAssert.alterTable(dropPartitionSql);
+
+                        DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
+                                .getDynamicPartitionScheduler();
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+                        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .getTable(db.getFullName(), tableName);
+                        try {
+                            scheduler.runOnceForTest();
+                            // cannot beego
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 4);
+                            // add a new partition and an expired partition
+                            LocalDateTime now = LocalDateTime.now();
+                            String currentDate = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                            String nextDate = now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                            addRangePartition(tableName, "p5", currentDate, nextDate);
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 5);
+
+                            scheduler.runOnceForTest();
+                            Assert.assertTrue(tbl.getVisiblePartitions().size() == 5);
+                        } catch (Exception e) {
+                            fail("Should not throw exception: " + e.getMessage());
+                        }
+                    });
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Support `partition_redention_condition` property as common ttl expressions
- Register it into `PartitionTTLScheduler.java` which will drop expired partitions that are not satisfied with `partition_redention_condition` property  for both list or range partition tables.


TODO:
- Support partition_redention_condition for materialized views.

Fixes https://github.com/StarRocks/starrocks/issues/53117

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0