### PR TITLE
[Feature] (Part 4) Support partition_redention_condition property for materialized views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -219,11 +219,17 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         Map<String, String> curProp = materializedView.getTableProperty().getProperties();
         if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL) && ttlDuration != null &&
                 !materializedView.getTableProperty().getPartitionTTL().equals(ttlDuration.second)) {
+            if (!materializedView.getPartitionInfo().isRangePartition()) {
+                throw new SemanticException("partition_ttl is only supported for range partitioned materialized view");
+            }
             curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL, ttlDuration.first);
             materializedView.getTableProperty().setPartitionTTL(ttlDuration.second);
             isChanged = true;
         } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER) &&
                 materializedView.getTableProperty().getPartitionTTLNumber() != partitionTTL) {
+            if (!materializedView.getPartitionInfo().isRangePartition()) {
+                throw new SemanticException("partition_ttl_number is only supported for range partitioned materialized view");
+            }
             curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER, String.valueOf(partitionTTL));
             materializedView.getTableProperty().setPartitionTTLNumber(partitionTTL);
             isChanged = true;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1510,7 +1510,7 @@ public class PropertyAnalyzer {
                 materializedView.getTableProperty().setPartitionRefreshNumber(number);
                 if (isNonPartitioned) {
                     throw new AnalysisException(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER
-                            + " does not support non-range-partitioned materialized view.");
+                            + " does not support non-partitioned materialized view.");
                 }
             }
             // exclude trigger tables

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1486,9 +1486,9 @@ public class PropertyAnalyzer {
                 materializedView.getTableProperty().getProperties()
                         .put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER, String.valueOf(number));
                 materializedView.getTableProperty().setPartitionTTLNumber(number);
-                if (isNonPartitioned) {
+                if (!materializedView.getPartitionInfo().isRangePartition()) {
                     throw new AnalysisException(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER
-                            + " does not support non-partitioned materialized view.");
+                            + " does not support non-range-partitioned materialized view.");
                 }
             }
             // partition auto refresh partitions limit
@@ -1497,9 +1497,9 @@ public class PropertyAnalyzer {
                 materializedView.getTableProperty().getProperties()
                         .put(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT, String.valueOf(limit));
                 materializedView.getTableProperty().setAutoRefreshPartitionsLimit(limit);
-                if (isNonPartitioned) {
+                if (!materializedView.getPartitionInfo().isRangePartition()) {
                     throw new AnalysisException(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT
-                            + " does not support non-partitioned materialized view.");
+                            + " does not support non-range-partitioned materialized view.");
                 }
             }
             // partition refresh number
@@ -1510,7 +1510,7 @@ public class PropertyAnalyzer {
                 materializedView.getTableProperty().setPartitionRefreshNumber(number);
                 if (isNonPartitioned) {
                     throw new AnalysisException(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER
-                            + " does not support non-partitioned materialized view.");
+                            + " does not support non-range-partitioned materialized view.");
                 }
             }
             // exclude trigger tables

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1009,8 +1009,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             throws AnalysisException {
         if (mvRefreshParams.isForceCompleteRefresh()) {
             // Force refresh
-            int partitionTTLNumber = mvContext.getPartitionTTLNumber();
-            return mvRefreshPartitioner.getMVPartitionsToRefreshWithForce(partitionTTLNumber);
+            return mvRefreshPartitioner.getMVPartitionsToRefreshWithForce();
         } else {
             return mvRefreshPartitioner.getMVPartitionsToRefresh(mvPartitionInfo, snapshotBaseTables,
                     mvRefreshParams, mvPotentialPartitionNames);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -50,12 +50,14 @@ import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.ListPartitionDiff;
 import com.starrocks.sql.common.ListPartitionDiffResult;
 import com.starrocks.sql.common.ListPartitionDiffer;
+import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.common.PListCell;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Iterator;
@@ -67,6 +69,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.iceberg.IcebergPartitionUtils.getIcebergTablePartitionPredicateExpr;
+import static com.starrocks.sql.optimizer.rule.transformation.partition.PartitionSelector.getExpiredPartitionsByRetentionCondition;
 
 public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     private static final Logger LOG = LogManager.getLogger(MVPCTRefreshListPartitioner.class);
@@ -113,9 +116,9 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             DistributionDesc distributionDesc = MvUtils.getDistributionDesc(mv);
             Map<String, PListCell> adds = partitionDiff.getAdds();
 
-            // filter by partition_ttl_number
-            int ttlNumber = mv.getTableProperty().getPartitionTTLNumber();
-            filterPartitionsByNumber(adds, ttlNumber);
+            // filter by partition ttl
+            filterPartitionsByTTL(adds, true);
+
             // add partitions for mv
             addListPartitions(db, mv, adds, partitionProperties, distributionDesc);
             LOG.info("The process of synchronizing materialized view [{}] add partitions list [{}]",
@@ -256,8 +259,10 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     }
 
     @Override
-    public Set<String> getMVPartitionsToRefreshWithForce(int partitionTTLNumber) {
-        return mv.getValidListPartitionMap(partitionTTLNumber).keySet();
+    public Set<String> getMVPartitionsToRefreshWithForce() {
+        Map<String, PListCell> mvValidListPartitionMapMap = mv.getValidListPartitionMap(TableProperty.INVALID);
+        filterPartitionsByTTL(mvValidListPartitionMapMap, false);
+        return mvValidListPartitionMapMap.keySet();
     }
 
     @Override
@@ -267,8 +272,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
                                                 Set<String> mvPotentialPartitionNames) {
         // list partitioned materialized view
         boolean isAutoRefresh = mvContext.getTaskType().isAutoRefresh();
-        int partitionTTLNumber = mvContext.getPartitionTTLNumber();
-        Set<String> mvListPartitionNames = getMVPartitionNamesWithTTL(mv, mvRefreshParams, partitionTTLNumber, isAutoRefresh);
+        Set<String> mvListPartitionNames = getMVPartitionNamesWithTTL(mv, mvRefreshParams, isAutoRefresh);
 
         // check non-ref base tables
         if (mvRefreshParams.isForce() || needsRefreshBasedOnNonRefTables(snapshotBaseTables)) {
@@ -317,62 +321,65 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
     }
 
     @Override
-    public Set<String> getMVPartitionNamesWithTTL(MaterializedView materializedView,
+    public Set<String> getMVPartitionNamesWithTTL(MaterializedView mv,
                                                   MVRefreshParams mvRefreshParams,
-                                                  int partitionTTLNumber,
                                                   boolean isAutoRefresh) {
-        int autoRefreshPartitionsLimit = materializedView.getTableProperty().getAutoRefreshPartitionsLimit();
+        int autoRefreshPartitionsLimit = mv.getTableProperty().getAutoRefreshPartitionsLimit();
 
         // if the user specifies the start and end ranges, only refresh the specified partitions
         boolean isCompleteRefresh = mvRefreshParams.isCompleteRefresh();
+        Map<String, PListCell> mvListPartitionMap = Maps.newHashMap();
         if (!isCompleteRefresh) {
             Set<PListCell> pListCells = mvRefreshParams.getListValues();
-            Map<String, PListCell> mvPartitions = materializedView.getListPartitionItems();
-            Set<String> result = Sets.newHashSet();
+            Map<String, PListCell> mvPartitions = mv.getListPartitionItems();
             for (Map.Entry<String, PListCell> e : mvPartitions.entrySet()) {
                 PListCell mvListCell = e.getValue();
                 if (mvListCell.getItemSize() == 1) {
                     // if list value is a single value, check it directly
                     if (pListCells.contains(e.getValue()))  {
-                        result.add(e.getKey());
+                        mvListPartitionMap.put(e.getKey(), e.getValue());
                     }
                 } else {
                     // if list values is multi values, split it into single values and check it then.
                     if (mvListCell.toSingleValueCells().stream().anyMatch(i -> pListCells.contains(i))) {
-                        result.add(e.getKey());
+                        mvListPartitionMap.put(e.getKey(), e.getValue());
                     }
                 }
             }
-            return result;
-        }
-
-        int lastPartitionNum;
-        if (partitionTTLNumber > 0 && isAutoRefresh && autoRefreshPartitionsLimit > 0) {
-            lastPartitionNum = Math.min(partitionTTLNumber, autoRefreshPartitionsLimit);
-        } else if (isAutoRefresh && autoRefreshPartitionsLimit > 0) {
-            lastPartitionNum = autoRefreshPartitionsLimit;
-        } else if (partitionTTLNumber > 0) {
-            lastPartitionNum = partitionTTLNumber;
         } else {
-            lastPartitionNum = TableProperty.INVALID;
+            int lastPartitionNum = TableProperty.INVALID;
+            if (isAutoRefresh && autoRefreshPartitionsLimit > 0) {
+                lastPartitionNum = autoRefreshPartitionsLimit;
+            }
+            mvListPartitionMap = mv.getValidListPartitionMap(lastPartitionNum);
         }
-        return materializedView.getValidListPartitionMap(lastPartitionNum).keySet();
+        // filter all valid partitions by partition_retention_condition
+        filterPartitionsByTTL(mvListPartitionMap, false);
+        return mvListPartitionMap.keySet();
     }
 
-    /**
-     * Filter partitions by partition_ttl_number, save the kept partitions and return the next task run partition values.
-     * @param inputPartitions the partitions to refresh/add
-     * @param filterNumber the number to filter/reserve
-     * @return the next task run partition list cells after the reserved partition_ttl_number
-     */
-    private Set<PListCell> filterPartitionsByNumber(Map<String, PListCell> inputPartitions,
-                                                    int filterNumber) {
-        if (filterNumber <= 0 || filterNumber >= inputPartitions.size()) {
-            return null;
+    @Override
+    public void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh,
+                                               Set<String> mvPotentialPartitionNames, boolean tentative) {
+        Map<String, PListCell> toRefreshPartitions = Maps.newHashMap();
+        Map<String, PListCell> listPartitionMap = mv.getListPartitionItems();
+        for (String partitionName : mvPartitionsToRefresh) {
+            PListCell listCell = listPartitionMap.get(partitionName);
+            if (listCell == null) {
+                LOG.warn("Partition {} is not found in materialized view {}", partitionName, mv.getName());
+                continue;
+            }
+            toRefreshPartitions.put(partitionName, listCell);
         }
+
+        // filter by partition ttl
+        filterPartitionsByTTL(toRefreshPartitions, false);
+
+        // filter by partition refresh number
+        int filterNumber = mv.getTableProperty().getPartitionRefreshNumber();
         // TODO: Sort by List Partition's value is weird because there maybe meaningless or un-sortable,
         // users should take care of `partition_ttl_number` for list partition.
-        LinkedHashMap<String, PListCell> sortedPartition = inputPartitions.entrySet().stream()
+        LinkedHashMap<String, PListCell> sortedPartition = toRefreshPartitions.entrySet().stream()
                 .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue())) // reverse order(max heap)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
         Iterator<Map.Entry<String, PListCell>> iter = sortedPartition.entrySet().iterator();
@@ -382,37 +389,18 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
                 iter.next();
             }
         }
-
         // compute next partition list cells in the next task run
-        Set<PListCell> nextPartitionCells = Sets.newHashSet();
+        Set<PListCell> nextPartitionValues = Sets.newHashSet();
         while (iter.hasNext()) {
             Map.Entry<String, PListCell> entry = iter.next();
-            nextPartitionCells.add(entry.getValue());
+            nextPartitionValues.add(entry.getValue());
             // remove the partition which is not reserved
-            inputPartitions.remove(entry.getKey());
+            toRefreshPartitions.remove(entry.getKey());
         }
         LOG.info("Filter partitions by partition_ttl_number, ttl_number:{}, result:{}, remains:{}",
-                filterNumber, inputPartitions, nextPartitionCells);
-        return nextPartitionCells;
-    }
-
-    @Override
-    public void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh,
-                                               Set<String> mvPotentialPartitionNames, boolean tentative) {
-        Map<String, PListCell> mappedPartitionsToRefresh = Maps.newHashMap();
-        Map<String, PListCell> listPartitionMap = mv.getListPartitionItems();
-        for (String partitionName : mvPartitionsToRefresh) {
-            PListCell listCell = listPartitionMap.get(partitionName);
-            if (listCell == null) {
-                LOG.warn("Partition {} is not found in materialized view {}", partitionName, mv.getName());
-                continue;
-            }
-            mappedPartitionsToRefresh.put(partitionName, listCell);
-        }
-        int refreshNumber = mv.getTableProperty().getPartitionRefreshNumber();
-        Set<PListCell> nextPartitionValues = filterPartitionsByNumber(mappedPartitionsToRefresh, refreshNumber);
+                filterNumber, toRefreshPartitions, nextPartitionValues);
         // do filter input mvPartitionsToRefresh since it's a reference
-        mvPartitionsToRefresh.retainAll(mappedPartitionsToRefresh.keySet());
+        mvPartitionsToRefresh.retainAll(toRefreshPartitions.keySet());
         if (CollectionUtils.isEmpty(nextPartitionValues)) {
             return;
         }
@@ -420,6 +408,31 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
             // partitionNameIter has just been traversed, and endPartitionName is not updated
             // will cause endPartitionName == null
             mvContext.setNextPartitionValues(PListCell.batchSerialize(nextPartitionValues));
+        }
+    }
+
+    /**
+     * Filter partitions by ttl, save the kept partitions and return the next task run partition values.
+     * @param toRefreshPartitions the partitions to refresh/add
+     * @return the next task run partition list cells after the reserved partition_ttl_number
+     */
+    protected void filterPartitionsByTTL(Map<String, ? extends PCell> toRefreshPartitions,
+                                         boolean isMockPartitionIds) {
+        if (CollectionUtils.sizeIsEmpty(toRefreshPartitions)) {
+            return;
+        }
+        // filter partitions by partition_retention_condition
+        String ttlCondition = mv.getTableProperty().getPartitionRetentionCondition();
+        if (!Strings.isNullOrEmpty(ttlCondition)) {
+            List<String> expiredPartitionNames = getExpiredPartitionsByRetentionCondition(db, mv, ttlCondition,
+                    toRefreshPartitions, isMockPartitionIds);
+            // remove the expired partitions
+            if (CollectionUtils.isNotEmpty(expiredPartitionNames)) {
+                LOG.info("Filter partitions by partition_retention_condition, ttl_condition:{}, expired:{}",
+                        ttlCondition, expiredPartitionNames);
+                expiredPartitionNames.stream()
+                        .forEach(toRefreshPartitions::remove);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshNonPartitioner.java
@@ -53,8 +53,9 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
         // do nothing
         return null;
     }
+
     @Override
-    public Set<String> getMVPartitionsToRefreshWithForce(int partitionTTLNumber) {
+    public Set<String> getMVPartitionsToRefreshWithForce() {
         return mv.getVisiblePartitionNames();
     }
 
@@ -73,7 +74,6 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     @Override
     public Set<String> getMVPartitionNamesWithTTL(MaterializedView materializedView,
                                                   MVRefreshParams mvRefreshParams,
-                                                  int partitionTTLNumber,
                                                   boolean isAutoRefresh) {
         return Sets.newHashSet();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -77,11 +77,12 @@ public abstract class MVPCTRefreshPartitioner {
 
     /**
      * Generate partition predicate for mv refresh according ref base table changed partitions.
-     * @param refBaseTable: ref base table to check.
+     *
+     * @param refBaseTable:               ref base table to check.
      * @param refBaseTablePartitionNames: ref base table partition names to check.
-     * @param mvPartitionSlotRefs: mv partition slot ref to generate partition predicate.
-     * @return: Return partition predicate for mv refresh.
+     * @param mvPartitionSlotRefs:        mv partition slot ref to generate partition predicate.
      * @throws AnalysisException
+     * @return: Return partition predicate for mv refresh.
      */
     public abstract Expr generatePartitionPredicate(Table refBaseTable,
                                                     Set<String> refBaseTablePartitionNames,
@@ -89,29 +90,30 @@ public abstract class MVPCTRefreshPartitioner {
 
     /**
      * Get mv partitions to refresh based on the ref base table partitions.
-     * @param mvPartitionInfo: mv partition info to check.
-     * @param snapshotBaseTables: snapshot base tables to check.
+     *
+     * @param mvPartitionInfo:           mv partition info to check.
+     * @param snapshotBaseTables:        snapshot base tables to check.
      * @param mvPotentialPartitionNames: mv potential partition names to check.
-     * @return: Return mv partitions to refresh based on the ref base table partitions.
      * @throws AnalysisException
+     * @return: Return mv partitions to refresh based on the ref base table partitions.
      */
     public abstract Set<String> getMVPartitionsToRefresh(PartitionInfo mvPartitionInfo,
                                                          Map<Long, TableSnapshotInfo> snapshotBaseTables,
                                                          MVRefreshParams mvRefreshParams,
                                                          Set<String> mvPotentialPartitionNames) throws AnalysisException;
-    public abstract Set<String> getMVPartitionsToRefreshWithForce(int partitionTTLNumber) throws AnalysisException;
+
+    public abstract Set<String> getMVPartitionsToRefreshWithForce() throws AnalysisException;
 
     /**
      * Get mv partition names with TTL based on the ref base table partitions.
+     *
      * @param materializedView: materialized view to check.
-     * @param partitionTTLNumber: mv partition TTL number.
-     * @param isAutoRefresh: is auto refresh or not.
-     * @return: mv to refresh partition names with TTL based on the ref base table partitions.
+     * @param isAutoRefresh:    is auto refresh or not.
      * @throws AnalysisException
+     * @return: mv to refresh partition names with TTL based on the ref base table partitions.
      */
     public abstract Set<String> getMVPartitionNamesWithTTL(MaterializedView materializedView,
                                                            MVRefreshParams mvRefreshParams,
-                                                           int partitionTTLNumber,
                                                            boolean isAutoRefresh) throws AnalysisException;
 
     /**
@@ -119,7 +121,7 @@ public abstract class MVPCTRefreshPartitioner {
      *
      * @param mvPartitionsToRefresh     : mv partitions to refresh.
      * @param mvPotentialPartitionNames : mv potential partition names to check.
-     * @param tentative see {@link com.starrocks.scheduler.PartitionBasedMvRefreshProcessor}
+     * @param tentative                 see {@link com.starrocks.scheduler.PartitionBasedMvRefreshProcessor}
      */
     public abstract void filterPartitionByRefreshNumber(Set<String> mvPartitionsToRefresh,
                                                         Set<String> mvPotentialPartitionNames,
@@ -134,7 +136,7 @@ public abstract class MVPCTRefreshPartitioner {
 
     /**
      * Get mv partitions to refresh based on the ref base table partitions and its updated partitions.
-     * @param refBaseTable : ref base table to check.
+     * @param refBaseTable            : ref base table to check.
      * @param baseTablePartitionNames : ref base table partition names to check.
      * @return : Return mv corresponding partition names to the ref base table partition names, null if sync info don't contain.
      */
@@ -144,14 +146,14 @@ public abstract class MVPCTRefreshPartitioner {
         Map<Table, Map<String, Set<String>>> refBaseTableMVPartitionMaps = mvContext.getRefBaseTableMVIntersectedPartitions();
         if (refBaseTableMVPartitionMaps == null || !refBaseTableMVPartitionMaps.containsKey(refBaseTable)) {
             LOG.warn("Cannot find need refreshed ref base table partition from synced partition info: {}, " +
-                            "refBaseTableMVPartitionMaps: {}", refBaseTable, refBaseTableMVPartitionMaps);
+                    "refBaseTableMVPartitionMaps: {}", refBaseTable, refBaseTableMVPartitionMaps);
             return null;
         }
         Map<String, Set<String>> refBaseTableMVPartitionMap = refBaseTableMVPartitionMaps.get(refBaseTable);
         for (String basePartitionName : baseTablePartitionNames) {
             if (!refBaseTableMVPartitionMap.containsKey(basePartitionName)) {
                 LOG.warn("Cannot find need refreshed ref base table partition from synced partition info: {}, " +
-                                "refBaseTableMVPartitionMaps: {}", basePartitionName, refBaseTableMVPartitionMaps);
+                        "refBaseTableMVPartitionMaps: {}", basePartitionName, refBaseTableMVPartitionMaps);
                 return null;
             }
             result.addAll(refBaseTableMVPartitionMap.get(basePartitionName));
@@ -197,7 +199,7 @@ public abstract class MVPCTRefreshPartitioner {
             }
             ans.retainAll(mvPartitionNames);
             LOG.info("The ref base table {} has updated partitions: {}, the corresponding " +
-                    "mv partitions to refresh: {}, " + "mvRangePartitionNames: {}", baseTable.getName(),
+                            "mv partitions to refresh: {}, " + "mvRangePartitionNames: {}", baseTable.getName(),
                     refBaseTablePartitionNames, ans, mvPartitionNames);
             result.addAll(ans);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3667,6 +3667,14 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
             results.put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL, ttlDuration);
         }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER)) {
+            if (!table.getPartitionInfo().isRangePartition()) {
+                throw new DdlException("Table[" + table.getName() + "] is not range partitioned. "
+                        + "no need to set partition live number.");
+            }
+            int partitionTTLNumber = PropertyAnalyzer.analyzePartitionTTLNumber(properties);
+            results.put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER, partitionTTLNumber);
+        }
         // partition retention condition
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {
             if (!table.getPartitionInfo().isPartitioned()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.rewrite;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -88,7 +89,7 @@ public class OptOlapPartitionPruner {
 
         // Do further partition prune if needed
         if (isNeedFurtherPrune(selectedPartitionIds, logicalOlapScanOperator, partitionInfo)) {
-            selectedPartitionIds = doFurtherPartitionPrune(table, partitionInfo, logicalOlapScanOperator.getPredicate(),
+            selectedPartitionIds = doFurtherPartitionPrune(table, logicalOlapScanOperator.getPredicate(),
                     logicalOlapScanOperator.getColumnMetaToColRefMap(), selectedPartitionIds);
         }
 
@@ -332,19 +333,31 @@ public class OptOlapPartitionPruner {
     }
 
     public static List<Long> doFurtherPartitionPrune(OlapTable table,
-                                                     PartitionInfo partitionInfo,
                                                      ScalarOperator predicate,
                                                      Map<Column, ColumnRefOperator> columnRefOperatorMap,
                                                      List<Long> selectedPartitionIds) {
-        List<Column> partitionColumns = partitionInfo.getPartitionColumns(table.getIdToColumn());
+        Preconditions.checkArgument(table.getPartitionInfo() instanceof RangePartitionInfo);
+        RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+        List<Range<PartitionKey>> candidateRanges = selectedPartitionIds.stream()
+                .map(rangePartitionInfo::getRange)
+                .collect(Collectors.toList());
+        return doFurtherPartitionPrune(table, predicate, columnRefOperatorMap, selectedPartitionIds, candidateRanges);
+    }
+
+    /**
+     * Use input candidateRanges to prune partitions rather than all table's partitions.
+     */
+    public static List<Long> doFurtherPartitionPrune(OlapTable table,
+                                                     ScalarOperator predicate,
+                                                     Map<Column, ColumnRefOperator> columnRefOperatorMap,
+                                                     List<Long> selectedPartitionIds,
+                                                     List<Range<PartitionKey>> candidateRanges) {
+        List<Column> partitionColumns = table.getPartitionColumns();
         PartitionColPredicateExtractor extractor = new PartitionColPredicateExtractor(
                 partitionColumns,
-                (RangePartitionInfo) partitionInfo,
                 columnRefOperatorMap);
         PartitionColPredicateEvaluator evaluator = new PartitionColPredicateEvaluator(
-                partitionColumns,
-                (RangePartitionInfo) partitionInfo,
-                selectedPartitionIds);
+                partitionColumns, selectedPartitionIds, candidateRanges);
         return evaluator.prunePartitions(extractor, predicate);
     }
 
@@ -355,27 +368,45 @@ public class OptOlapPartitionPruner {
         if (candidatePartitions.isEmpty() || predicate == null) {
             return false;
         }
+        if (partitionInfo == null || !(partitionInfo instanceof RangePartitionInfo)) {
+            return false;
+        }
+        RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
+        return isNeedFurtherPrune(olapTable, candidatePartitions, predicate, rangePartitionInfo,
+                rangePartitionInfo.getIdToRange(true));
+    }
+
+    /**
+     * Use input idToRange to check whether to further prune partitions rather than all table's partitions.
+     */
+    public static boolean isNeedFurtherPrune(OlapTable olapTable,
+                                             List<Long> candidatePartitions,
+                                             ScalarOperator predicate,
+                                             RangePartitionInfo rangePartitionInfo,
+                                             Map<Long, Range<PartitionKey>> tmpIdToRange) {
+        if (candidatePartitions.isEmpty() || predicate == null) {
+            return false;
+        }
 
         // only support RANGE and EXPR_RANGE
         // EXPR_RANGE_V2 type like partition by RANGE(cast(substring(col, 3)) as int)) is unsupported
-        if (partitionInfo instanceof ExpressionRangePartitionInfo) {
-            ExpressionRangePartitionInfo exprPartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
+        if (rangePartitionInfo instanceof ExpressionRangePartitionInfo) {
+            ExpressionRangePartitionInfo exprPartitionInfo = (ExpressionRangePartitionInfo) rangePartitionInfo;
             List<Expr> partitionExpr = exprPartitionInfo.getPartitionExprs(olapTable.getIdToColumn());
             if (partitionExpr.size() == 1 && partitionExpr.get(0) instanceof FunctionCallExpr) {
                 FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr.get(0);
                 String functionName = functionCallExpr.getFnName().getFunction();
                 return (FunctionSet.DATE_TRUNC.equalsIgnoreCase(functionName)
                         || FunctionSet.TIME_SLICE.equalsIgnoreCase(functionName))
-                        && !exprPartitionInfo.getIdToRange(true).containsKey(candidatePartitions.get(0));
+                        && !tmpIdToRange.containsKey(candidatePartitions.get(0));
             } else if (partitionExpr.size() == 1 && partitionExpr.get(0) instanceof SlotRef) {
-                return !exprPartitionInfo.getIdToRange(true).containsKey(candidatePartitions.get(0));
+                return !tmpIdToRange.containsKey(candidatePartitions.get(0));
             }
-        } else if (partitionInfo instanceof ExpressionRangePartitionInfoV2) {
+        } else if (rangePartitionInfo instanceof ExpressionRangePartitionInfoV2) {
             return false;
-        } else if (partitionInfo instanceof RangePartitionInfo) {
-            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
+        } else if (rangePartitionInfo instanceof RangePartitionInfo) {
             return rangePartitionInfo.getPartitionColumnsSize() == 1
-                    && !rangePartitionInfo.getIdToRange(true).containsKey(candidatePartitions.get(0));
+                    && !tmpIdToRange.containsKey(candidatePartitions.get(0));
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
@@ -30,7 +30,6 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PartitionKeyDiscreteDomain;
 import com.starrocks.catalog.PrimitiveType;
-import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.optimizer.operator.ColumnFilterConverter;
@@ -71,15 +70,13 @@ public class PartitionColPredicateEvaluator {
     private final Column partitionColumn;
 
     public PartitionColPredicateEvaluator(List<Column> partitionColumns,
-                                          RangePartitionInfo rangePartitionInfo, List<Long> candidatePartitions) {
+                                          List<Long> candidatePartitions,
+                                          List<Range<PartitionKey>> candidateRanges) {
         this.candidatePartitions = candidatePartitions;
-        candidateNum = candidatePartitions.size();
-        partitionColumn = partitionColumns.get(0);
-        candidateRanges = Lists.newArrayList();
-        for (long id : candidatePartitions) {
-            candidateRanges.add(rangePartitionInfo.getIdToRange(false).get(id));
-        }
-        exprToCandidateRanges = Maps.newHashMap();
+        this.candidateNum = candidatePartitions.size();
+        this.partitionColumn = partitionColumns.get(0);
+        this.candidateRanges = candidateRanges;
+        this.exprToCandidateRanges = Maps.newHashMap();
     }
 
     public List<Long> prunePartitions(PartitionColPredicateExtractor extractor, ScalarOperator predicates) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateExtractor.java
@@ -16,7 +16,6 @@ package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -52,8 +51,7 @@ public class PartitionColPredicateExtractor extends ScalarOperatorVisitor<Scalar
 
     private final ColumnRefSet partitionColumnSet;
 
-    public PartitionColPredicateExtractor(List<Column> partitionColumns, RangePartitionInfo rangePartitionInfo,
-                                          Map<Column, ColumnRefOperator> columnMetaToColRefMap) {
+    public PartitionColPredicateExtractor(List<Column> partitionColumns, Map<Column, ColumnRefOperator> columnMetaToColRefMap) {
         List<ColumnRefOperator> columnRefOperators = Lists.newArrayList();
         Column partitionColumn = partitionColumns.get(0);
         for (ColumnRefOperator columnRefOperator : columnMetaToColRefMap.values()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -49,6 +49,9 @@ import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.PCell;
+import com.starrocks.sql.common.PListCell;
+import com.starrocks.sql.common.PRangeCell;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.function.MetaFunctions;
@@ -115,6 +118,19 @@ public class PartitionSelector {
                                                    OlapTable olapTable,
                                                    Expr whereExpr,
                                                    boolean isRecyclingCondition) {
+        return getPartitionIdsByExpr(context, tableName, olapTable, whereExpr, isRecyclingCondition, null);
+
+    }
+
+    /**
+     * Return filtered partition ids by whereExpr with extra input cells which are used for mv refresh.
+     */
+    public static List<Long> getPartitionIdsByExpr(ConnectContext context,
+                                                   TableName tableName,
+                                                   OlapTable olapTable,
+                                                   Expr whereExpr,
+                                                   boolean isRecyclingCondition,
+                                                   Map<Long, PCell> inputCells) {
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         if (!partitionInfo.isPartitioned()) {
             throw new SemanticException("Can't drop partitions with where expression since it is not partitioned");
@@ -189,11 +205,11 @@ public class PartitionSelector {
         List<Long> selectedPartitionIds;
         if (partitionInfo.isRangePartition()) {
             RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
-            selectedPartitionIds = getRangePartitionIdsByExpr(olapTable, rangePartitionInfo, scalarOperator,
+            selectedPartitionIds = getRangePartitionIdsByExpr(olapTable, rangePartitionInfo, inputCells, scalarOperator,
                     columnRefOperatorMap, isRecyclingCondition);
         } else if (partitionInfo.isListPartition()) {
             ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
-            selectedPartitionIds = getListPartitionIdsByExpr(tableName.getDb(), olapTable, listPartitionInfo, 
+            selectedPartitionIds = getListPartitionIdsByExpr(tableName.getDb(), olapTable, listPartitionInfo, inputCells,
                     whereExpr, scalarOperator, exprToColumnIdxes);
         } else {
             throw new SemanticException("Unsupported partition type: " + partitionInfo.getType());
@@ -206,12 +222,23 @@ public class PartitionSelector {
 
     /**
      * Get expired partitions by retention condition.
+     */
+    public static List<String> getExpiredPartitionsByRetentionCondition(Database db,
+                                                                        OlapTable olapTable,
+                                                                        String ttlCondition) {
+        return getExpiredPartitionsByRetentionCondition(db, olapTable, ttlCondition, null, false);
+    }
+
+    /**
+     * Get expired partitions by retention condition.
      * inputCells and isMockPartitionIds are used for mv refresh since the partition is not added into table yet, but
      * we need to check whether inputCells are expired or created for mv refresh.
      */
     public static List<String> getExpiredPartitionsByRetentionCondition(Database db,
                                                                         OlapTable olapTable,
-                                                                        String ttlCondition) {
+                                                                        String ttlCondition,
+                                                                        Map<String, ? extends PCell> inputCells,
+                                                                        boolean isMockPartitionIds) {
         TableName tableName = new TableName(db.getFullName(), olapTable.getName());
         ConnectContext context = ConnectContext.get() != null ? ConnectContext.get() : new ConnectContext();
         // needs to parse the expr each schedule because it can be changed dynamically
@@ -227,8 +254,33 @@ public class PartitionSelector {
         } catch (Exception e) {
             throw new SemanticException("Failed to parse retention condition: " + ttlCondition);
         }
+        Map<Long, PCell> inputCellsMap = null;
+        Map<Long, String> inputCellIdToNameMap = null;
+
+        // if isMockPartitionIds is true, we mock partition ids for input cells because the partition is not added into table
+        // yet which may happen in mv's refresh `syncAddOrDropPartitions` process.
+        // TODO: remove this mock partition ids logic if `PartitionPruner` can support to prune partitions by partition name
+        //  rather than by ids.
+        long initialPartitionId = 0;
+        if (!CollectionUtils.sizeIsEmpty(inputCells)) {
+            inputCellsMap = Maps.newHashMap();
+            inputCellIdToNameMap = Maps.newHashMap();
+            if (isMockPartitionIds) {
+                for (Map.Entry<String, ? extends PCell> e : inputCells.entrySet()) {
+                    inputCellsMap.put(initialPartitionId, e.getValue());
+                    inputCellIdToNameMap.put(initialPartitionId, e.getKey());
+                    initialPartitionId--;
+                }
+            } else {
+                for (Map.Entry<String, ? extends PCell> e : inputCells.entrySet()) {
+                    Partition partition = olapTable.getPartition(e.getKey());
+                    inputCellsMap.put(partition.getId(), e.getValue());
+                    inputCellIdToNameMap.put(partition.getId(), e.getKey());
+                }
+            }
+        }
         List<Long> retentionPartitionIds = PartitionSelector.getPartitionIdsByExpr(context, tableName, olapTable,
-                whereExpr, false);
+                whereExpr, false, inputCellsMap);
         if (retentionPartitionIds == null) {
             return null;
         }
@@ -237,6 +289,13 @@ public class PartitionSelector {
                 .filter(p -> !retentionPartitionSet.contains(p.getId()))
                 .map(Partition::getName)
                 .collect(Collectors.toList());
+        // if input cells are not empty, filter out the partitions which are expired too.
+        if (!CollectionUtils.sizeIsEmpty(inputCells)) {
+            Preconditions.checkArgument(inputCellIdToNameMap != null);
+            inputCellIdToNameMap.entrySet().stream()
+                    .filter(e -> !retentionPartitionSet.contains(e.getKey()))
+                    .forEach(e -> result.add(e.getValue()));
+        }
         return result;
     }
 
@@ -253,13 +312,41 @@ public class PartitionSelector {
         return replaceMap;
     }
 
+    private static Map<ColumnRefOperator, ScalarOperator> buildReplaceMapWithCell(Map<ColumnRefOperator, Integer> colRefIdxMap,
+                                                                                  List<String> values) {
+        // columnref -> literal
+        Map<ColumnRefOperator, ScalarOperator> replaceMap = Maps.newHashMap();
+        for (Map.Entry<ColumnRefOperator, Integer> entry : colRefIdxMap.entrySet()) {
+            ColumnRefOperator colRef = entry.getKey();
+            try {
+                LiteralExpr literalExpr = LiteralExpr.create(values.get(entry.getValue()), colRef.getType());
+                ConstantOperator replace = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
+                replaceMap.put(colRef, replace);
+            } catch (Exception e) {
+                LOG.warn("Failed to create literal expr for value: {}", values.get(entry.getValue()));
+                return null;
+            }
+        }
+        return replaceMap;
+    }
+
     private static List<Long> getRangePartitionIdsByExpr(OlapTable olapTable,
                                                          RangePartitionInfo rangePartitionInfo,
+                                                         Map<Long, ? extends PCell> inputCells,
                                                          ScalarOperator predicate,
                                                          Map<Column, ColumnRefOperator> columnRefOperatorMap,
                                                          boolean isRecyclingCondition) {
         // clone it to avoid changing the original map
         Map<Long, Range<PartitionKey>> keyRangeById = Maps.newHashMap(rangePartitionInfo.getIdToRange(false));
+        if (!CollectionUtils.sizeIsEmpty(inputCells)) {
+            // mock partition ids since input cells has not been added into olapTable yet.
+            inputCells.entrySet().stream()
+                    .forEach(e -> {
+                        PRangeCell pRangeCell = (PRangeCell) e.getValue();
+                        keyRangeById.put(e.getKey(), pRangeCell.getRange());
+                    });
+
+        }
         // since partition pruning is false positive which means it may not prune some partitions which should be pruned
         // but it will not prune partitions which should not be pruned.
         ScalarOperator fpPredicate = predicate;
@@ -280,9 +367,13 @@ public class PartitionSelector {
         try {
             selectedPartitionIds = partitionPruner.prune();
             // do more prune if necessary
-            if (isNeedFurtherPrune(olapTable, selectedPartitionIds, fpPredicate, rangePartitionInfo)) {
-                selectedPartitionIds = doFurtherPartitionPrune(olapTable, rangePartitionInfo,
-                        fpPredicate, columnRefOperatorMap, selectedPartitionIds);
+            if (isNeedFurtherPrune(olapTable, selectedPartitionIds, fpPredicate, rangePartitionInfo, Maps.newHashMap())) {
+                List<Range<PartitionKey>> candidateRanges = selectedPartitionIds.stream()
+                        .map(keyRangeById::get)
+                        .filter(range -> range != null)
+                        .collect(Collectors.toList());
+                selectedPartitionIds = doFurtherPartitionPrune(olapTable, fpPredicate,
+                        columnRefOperatorMap, selectedPartitionIds, candidateRanges);
             }
             if (selectedPartitionIds == null) {
                 throw new SemanticException("Failed to prune partitions with where expression: " + predicate.toString());
@@ -304,6 +395,7 @@ public class PartitionSelector {
 
     private static List<Long> getListPartitionIdsByExpr(String dbName, OlapTable olapTable,
                                                         ListPartitionInfo listPartitionInfo,
+                                                        Map<Long, ? extends PCell> inputCells,
                                                         Expr whereExpr,
                                                         ScalarOperator scalarOperator,
                                                         Map<Expr, Integer> exprToColumnIdxes) {
@@ -311,7 +403,7 @@ public class PartitionSelector {
         List<Long> result = null;
         // try to prune partitions by FE's constant evaluation ability
         try {
-            result = getListPartitionIdsByExprV1(olapTable, listPartitionInfo, scalarOperator);
+            result = getListPartitionIdsByExprV1(olapTable, listPartitionInfo, inputCells, scalarOperator);
             if (result != null) {
                 return result;
             }
@@ -332,6 +424,7 @@ public class PartitionSelector {
      */
     private static List<Long> getListPartitionIdsByExprV1(OlapTable olapTable,
                                                           ListPartitionInfo listPartitionInfo,
+                                                          Map<Long, ? extends PCell> inputCells,
                                                           ScalarOperator scalarOperator) {
         // eval for each conjunct
         Map<ColumnRefOperator, Integer> colRefIdxMap = Maps.newHashMap();
@@ -399,6 +492,35 @@ public class PartitionSelector {
             }
             if (isConstTrue) {
                 selectedPartitionIds.add(e.getKey());
+            }
+        }
+        if (!CollectionUtils.sizeIsEmpty(inputCells)) {
+            for (Map.Entry<Long, ? extends PCell> e : inputCells.entrySet()) {
+                boolean isConstTrue = false;
+                PListCell pListCell = (PListCell) e.getValue();
+                for (List<String> values : pListCell.getPartitionItems()) {
+                    Map<ColumnRefOperator, ScalarOperator> replaceMap = buildReplaceMapWithCell(colRefIdxMap, values);
+                    if (replaceMap == null) {
+                        return null;
+                    }
+                    ReplaceColumnRefRewriter replaceColumnRefRewriter = new ReplaceColumnRefRewriter(replaceMap);
+                    ScalarOperator result = replaceColumnRefRewriter.rewrite(scalarOperator);
+                    result = rewriter.rewrite(result, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+                    if (!result.isConstant()) {
+                        return null;
+                    }
+                    if (result.isConstantFalse()) {
+                        isConstTrue = false;
+                        break;
+                    } else if (result.isConstantTrue()) {
+                        isConstTrue = true;
+                    } else {
+                        return null;
+                    }
+                }
+                if (isConstTrue) {
+                    selectedPartitionIds.add(e.getKey());
+                }
             }
         }
         return selectedPartitionIds;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -119,7 +119,6 @@ public class PartitionSelector {
                                                    Expr whereExpr,
                                                    boolean isRecyclingCondition) {
         return getPartitionIdsByExpr(context, tableName, olapTable, whereExpr, isRecyclingCondition, null);
-
     }
 
     /**
@@ -254,13 +253,13 @@ public class PartitionSelector {
         } catch (Exception e) {
             throw new SemanticException("Failed to parse retention condition: " + ttlCondition);
         }
-        Map<Long, PCell> inputCellsMap = null;
-        Map<Long, String> inputCellIdToNameMap = null;
 
         // if isMockPartitionIds is true, we mock partition ids for input cells because the partition is not added into table
         // yet which may happen in mv's refresh `syncAddOrDropPartitions` process.
         // TODO: remove this mock partition ids logic if `PartitionPruner` can support to prune partitions by partition name
         //  rather than by ids.
+        Map<Long, PCell> inputCellsMap = null;
+        Map<Long, String> inputCellIdToNameMap = null;
         long initialPartitionId = 0;
         if (!CollectionUtils.sizeIsEmpty(inputCells)) {
             inputCellsMap = Maps.newHashMap();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
@@ -15,12 +15,18 @@
 package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
+import com.starrocks.clone.DynamicPartitionScheduler;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.scheduler.MVRefreshTestBase;
+import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -33,9 +39,11 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-public class DropPartitionWithExprListTest {
+public class DropPartitionWithExprListTest extends MVRefreshTestBase {
     private static final Logger LOG = LogManager.getLogger(DropPartitionWithExprListTest.class);
     protected static ConnectContext connectContext;
     protected static PseudoCluster cluster;
@@ -46,7 +54,7 @@ public class DropPartitionWithExprListTest {
     private static String T4;
     private static String T5;
     private static String T6;
-    private static List<String> TABLES_WITH_STRING_DT_TYPES;
+    private static List<String> TABLES_WITH_DATE_DT_TYPES;
     private static List<String> TABLES_WITH_DATETIME_DT_TYPES;
 
     @BeforeClass
@@ -69,7 +77,7 @@ public class DropPartitionWithExprListTest {
         T1 = "CREATE TABLE t1 (\n" +
                 " id BIGINT,\n" +
                 " age SMALLINT,\n" +
-                " dt VARCHAR(10) not null,\n" +
+                " dt date not null,\n" +
                 " province VARCHAR(64) not null\n" +
                 ")\n" +
                 "PARTITION BY (province, dt) \n" +
@@ -128,7 +136,7 @@ public class DropPartitionWithExprListTest {
                 ")\n" +
                 "PARTITION BY str2date(dt, '%Y-%m-%d'), date_trunc('day', dt) \n" +
                 "DISTRIBUTED BY RANDOM\n";
-        TABLES_WITH_STRING_DT_TYPES = Lists.newArrayList(T1, T2);
+        TABLES_WITH_DATE_DT_TYPES = Lists.newArrayList(T1, T2);
         TABLES_WITH_DATETIME_DT_TYPES = Lists.newArrayList(T5, T6);
     }
 
@@ -155,11 +163,23 @@ public class DropPartitionWithExprListTest {
     }
 
     private void addListPartition(String tbl, String pName, String pVal1, String pVal2) {
+        addListPartition(tbl, pName, pVal1, pVal2, false);
+    }
+
+    private void addListPartition(String tbl, String pName, String pVal1, String pVal2, boolean isInsertValues) {
         String addPartitionSql = String.format("ALTER TABLE %s ADD PARTITION IF NOT EXISTS %s VALUES IN ((%s, %s))",
                 tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
         StatementBase stmt = SqlParser.parseSingleStatement(addPartitionSql, connectContext.getSessionVariable().getSqlMode());
         try {
+            // add a new partition
             new StmtExecutor(connectContext, stmt).execute();
+
+            // insert values
+            if (isInsertValues) {
+                String insertSql = String.format("insert into %s partition(%s) values(1, 1, '%s', '%s');",
+                        tbl, pName, pVal1, pVal2);
+                executeInsertSql(insertSql);
+            }
         } catch (Exception e) {
             Assert.fail("add partition failed:" + e);
         }
@@ -194,7 +214,7 @@ public class DropPartitionWithExprListTest {
     }
 
     private void withTablesWithStringDtTypes(StarRocksAssert.ExceptionConsumer<OlapTable> runner) {
-        for (String t : TABLES_WITH_STRING_DT_TYPES) {
+        for (String t : TABLES_WITH_DATE_DT_TYPES) {
             System.out.println(t);
             starRocksAssert.withTable(t, (obj) -> {
                 String tableName = (String) obj;
@@ -599,5 +619,125 @@ public class DropPartitionWithExprListTest {
                 Assert.assertEquals("p3", partition.getName());
             }
         });
+    }
+
+    @Test
+    public void testMVRefreshWithTTLCondition1() {
+        for (String table : TABLES_WITH_DATE_DT_TYPES) {
+            starRocksAssert.withTable(table,
+                    (obj) -> {
+                        String tableName = (String) obj;
+                        withTablePartitions(tableName);
+                        String mvCreateDdl = String.format("create materialized view test_mv1\n" +
+                                "partition by (dt) \n" +
+                                "distributed by random \n" +
+                                "REFRESH DEFERRED MANUAL \n" +
+                                "PROPERTIES ('partition_retention_condition' = 'dt >= current_date() - interval 1 month')\n " +
+                                "as select * from %s;", tableName);
+                        starRocksAssert.withMaterializedView(mvCreateDdl,
+                                () -> {
+                                    String mvName = "test_mv1";
+                                    MaterializedView mv = starRocksAssert.getMv("test", mvName);
+                                    {
+                                        // all partitions are expired, no need to create partitions for mv
+                                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                                        Assert.assertEquals(0, mv.getVisiblePartitions().size());
+                                        Assert.assertTrue(processor.getNextTaskRun() == null);
+                                        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+                                        Assert.assertTrue(execPlan == null);
+                                    }
+
+                                    {
+                                        // add new partitions
+                                        LocalDateTime now = LocalDateTime.now();
+                                        addListPartition(tableName, "p5", "guangdong",
+                                                now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), true);
+                                        addListPartition(tableName, "p6", "guangdong",
+                                                now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), true);
+
+                                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                                        Assert.assertTrue(processor != null);
+                                        Assert.assertTrue(processor.getNextTaskRun() == null);
+                                        Assert.assertEquals(2, mv.getVisiblePartitions().size());
+                                        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+                                        Assert.assertTrue(execPlan != null);
+                                        String plan = execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL);
+                                        PlanTestBase.assertContains(plan, "     PREAGGREGATION: ON\n" +
+                                                "     partitions=2/6");
+                                    }
+                                });
+                    });
+        }
+    }
+
+    @Test
+    public void testMVRefreshWithTTLCondition2() {
+        for (String table : TABLES_WITH_DATE_DT_TYPES) {
+            starRocksAssert.withTable(table,
+                    (obj) -> {
+                        String tableName = (String) obj;
+                        withTablePartitions(tableName);
+                        String mvCreateDdl = String.format("create materialized view test_mv1\n" +
+                                "partition by (dt) \n" +
+                                "distributed by random \n" +
+                                "REFRESH DEFERRED MANUAL \n" +
+                                "as select * from %s;", tableName);
+                        starRocksAssert.withMaterializedView(mvCreateDdl,
+                                () -> {
+                                    String mvName = "test_mv1";
+                                    MaterializedView mv = starRocksAssert.getMv("test", mvName);
+                                    {
+                                        // all partitions are expired, no need to create partitions for mv
+                                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                                        Assert.assertEquals(2, mv.getVisiblePartitions().size());
+                                        Assert.assertTrue(processor.getNextTaskRun() == null);
+                                        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+                                        Assert.assertTrue(execPlan == null);
+                                    }
+
+                                    // alter mv ttl condition
+                                    String alterMVSql = String.format("alter materialized view %s set (" +
+                                            "'partition_retention_condition' = 'dt >= current_date() - " +
+                                            "interval 1 month')", mvName);
+                                    starRocksAssert.alterMvProperties(alterMVSql);
+
+                                    {
+                                        // all partitions are expired, no need to create partitions for mv
+                                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                                        Assert.assertEquals(2, mv.getVisiblePartitions().size());
+                                        Assert.assertTrue(processor.getNextTaskRun() == null);
+                                        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+                                        Assert.assertTrue(execPlan == null);
+                                    }
+
+                                    {
+                                        // add new partitions
+                                        LocalDateTime now = LocalDateTime.now();
+                                        addListPartition(tableName, "p5", "guangdong",
+                                                now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), true);
+                                        addListPartition(tableName, "p6", "guangdong",
+                                                now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")), true);
+
+                                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                                        Assert.assertTrue(processor != null);
+                                        Assert.assertTrue(processor.getNextTaskRun() == null);
+                                        Assert.assertEquals(4, mv.getVisiblePartitions().size());
+                                        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+                                        Assert.assertTrue(execPlan != null);
+                                        String plan = execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL);
+                                        PlanTestBase.assertContains(plan, "     PREAGGREGATION: ON\n" +
+                                                "     partitions=2/6");
+                                    }
+
+                                    // run partition ttl scheduler
+                                    {
+                                        DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
+                                                .getDynamicPartitionScheduler();
+                                        scheduler.runOnceForTest();
+                                        Assert.assertEquals(2, mv.getVisiblePartitions().size());
+                                    }
+                                });
+                    });
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprRangeTest.java
@@ -14,12 +14,19 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableList;
+import com.starrocks.clone.DynamicPartitionScheduler;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.scheduler.MVRefreshTestBase;
+import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -34,13 +41,18 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class DropPartitionWithExprRangeTest {
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class DropPartitionWithExprRangeTest extends MVRefreshTestBase  {
     private static final Logger LOG = LogManager.getLogger(DropPartitionWithExprRangeTest.class);
     protected static ConnectContext connectContext;
     protected static PseudoCluster cluster;
     protected static StarRocksAssert starRocksAssert;
     private static String R1;
     private static String R2;
+    private static List<String> RANGE_TABLES;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -80,6 +92,7 @@ public class DropPartitionWithExprRangeTest {
                 "PARTITION BY date_trunc('day', dt)\n" +
                 "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
                 "PROPERTIES('replication_num' = '1');";
+        RANGE_TABLES = ImmutableList.of(R1, R2);
     }
 
     @AfterClass
@@ -105,6 +118,10 @@ public class DropPartitionWithExprRangeTest {
     }
 
     private void addRangePartition(String tbl, String pName, String pVal1, String pVal2) {
+        addRangePartition(tbl, pName, pVal1, pVal2, false);
+    }
+
+    private void addRangePartition(String tbl, String pName, String pVal1, String pVal2, boolean isInsertValue) {
         // mock the check to ensure test can run
         new MockUp<ExpressionRangePartitionInfo>() {
             @Mock
@@ -123,6 +140,13 @@ public class DropPartitionWithExprRangeTest {
                     "PARTITION %s VALUES [(%s),(%s))", tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
             System.out.println(addPartitionSql);
             starRocksAssert.alterTable(addPartitionSql);
+
+            // insert values
+            if (isInsertValue) {
+                String insertSql = String.format("insert into %s partition(%s) values('%s', 1, 1);",
+                        tbl, pName, pVal1);
+                executeInsertSql(insertSql);
+            }
         } catch (Exception e) {
             e.printStackTrace();
             LOG.error("Failed to add partition", e);
@@ -130,6 +154,10 @@ public class DropPartitionWithExprRangeTest {
     }
 
     private void withTablePartitions(String tableName) {
+        if (tableName.equalsIgnoreCase("r1")) {
+            return;
+        }
+
         addRangePartition(tableName, "p1", "2024-01-01", "2024-01-02");
         addRangePartition(tableName, "p2", "2024-01-02", "2024-01-03");
         addRangePartition(tableName, "p3", "2024-01-03", "2024-01-04");
@@ -278,5 +306,131 @@ public class DropPartitionWithExprRangeTest {
                 Assert.assertEquals(2, olapTable.getVisiblePartitions().size());
             }
         });
+    }
+
+    @Test
+    public void testMVRefreshWithTTLCondition1() {
+        for (String table : RANGE_TABLES) {
+            starRocksAssert.withTable(table,
+                    (obj) -> {
+                        String tableName = (String) obj;
+                        withTablePartitions(tableName);
+                        String mvCreateDdl = String.format("create materialized view test_mv1\n" +
+                                "partition by (dt) \n" +
+                                "distributed by random \n" +
+                                "REFRESH DEFERRED MANUAL \n" +
+                                "PROPERTIES ('partition_retention_condition' = 'dt >= current_date() - interval 1 month')\n as" +
+                                " select * from %s;", tableName);
+                        starRocksAssert.withMaterializedView(mvCreateDdl,
+                                () -> {
+                                    String mvName = "test_mv1";
+                                    MaterializedView mv = starRocksAssert.getMv("test", mvName);
+                                    {
+                                        // all partitions are expired, no need to create partitions for mv
+                                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                                        Assert.assertEquals(0, mv.getVisiblePartitions().size());
+                                        Assert.assertTrue(processor.getNextTaskRun() == null);
+                                        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+                                        Assert.assertTrue(execPlan == null);
+                                    }
+
+                                    {
+                                        // add new partitions
+                                        LocalDateTime now = LocalDateTime.now();
+                                        addRangePartition(tableName, "p5",
+                                                now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                                now.minusMonths(1).plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                                true);
+                                        addRangePartition(tableName, "p6",
+                                                now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                                now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                                true);
+                                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                                        Assert.assertTrue(processor != null);
+                                        Assert.assertTrue(processor.getNextTaskRun() == null);
+                                        Assert.assertEquals(2, mv.getVisiblePartitions().size());
+                                        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+                                        Assert.assertTrue(execPlan != null);
+                                        String plan = execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL);
+                                        PlanTestBase.assertContains(plan, "     PREAGGREGATION: ON\n" +
+                                                "     partitions=2/6");
+                                    }
+                                });
+                    });
+        }
+    }
+
+    @Test
+    public void testMVRefreshWithTTLCondition2() {
+        for (String table : RANGE_TABLES) {
+            starRocksAssert.withTable(table,
+                    (obj) -> {
+                        String tableName = (String) obj;
+                        withTablePartitions(tableName);
+                        String mvCreateDdl = String.format("create materialized view test_mv1\n" +
+                                "partition by (dt) \n" +
+                                "distributed by random \n" +
+                                "REFRESH DEFERRED MANUAL \n" +
+                                "AS select * from %s;", tableName);
+                        starRocksAssert.withMaterializedView(mvCreateDdl,
+                                () -> {
+                                    String mvName = "test_mv1";
+                                    MaterializedView mv = starRocksAssert.getMv("test", mvName);
+                                    {
+                                        // all partitions are expired, no need to create partitions for mv
+                                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                                        Assert.assertEquals(4, mv.getVisiblePartitions().size());
+                                        Assert.assertTrue(processor.getNextTaskRun() == null);
+                                        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+                                        Assert.assertTrue(execPlan == null);
+                                    }
+
+                                    // alter mv ttl condition
+                                    String alterMVSql = String.format("alter materialized view %s set (" +
+                                            "'partition_retention_condition' = 'dt >= current_date() " +
+                                            "- interval 1 month')", mvName);
+                                    starRocksAssert.alterMvProperties(alterMVSql);
+
+                                    {
+                                        // all partitions are expired, no need to create partitions for mv
+                                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                                        Assert.assertEquals(4, mv.getVisiblePartitions().size());
+                                        Assert.assertTrue(processor.getNextTaskRun() == null);
+                                        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+                                        Assert.assertTrue(execPlan == null);
+                                    }
+
+                                    {
+                                        // add new partitions
+                                        LocalDateTime now = LocalDateTime.now();
+                                        addRangePartition(tableName, "p5",
+                                                now.minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                                now.minusMonths(1).plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                                true);
+                                        addRangePartition(tableName, "p6",
+                                                now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                                now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                                true);
+                                        PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
+                                        Assert.assertTrue(processor != null);
+                                        Assert.assertTrue(processor.getNextTaskRun() == null);
+                                        Assert.assertEquals(6, mv.getVisiblePartitions().size());
+                                        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+                                        Assert.assertTrue(execPlan != null);
+                                        String plan = execPlan.getExplainString(StatementBase.ExplainLevel.NORMAL);
+                                        PlanTestBase.assertContains(plan, "     PREAGGREGATION: ON\n" +
+                                                "     partitions=2/6");
+                                    }
+
+                                    // run partition ttl scheduler
+                                    {
+                                        DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
+                                                .getDynamicPartitionScheduler();
+                                        scheduler.runOnceForTest();
+                                        Assert.assertEquals(2, mv.getVisiblePartitions().size());
+                                    }
+                                });
+                    });
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -1048,31 +1048,22 @@ public class PCTRefreshListPartitionOlapTest extends MVRefreshTestBase {
 
     @Test
     public void testPartialRefreshSingleColumnMVWithSingleValues2() {
-        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         starRocksAssert.withTable(S2, () -> {
-            starRocksAssert.withMaterializedView("create materialized view mv1\n" +
-                            "partition by dt \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties (" +
-                            "   'partition_refresh_number' = '1'," +
-                            "   'partition_ttl_number' = '1'" +
-                            ")" +
-                            "as select dt, province, sum(age) from s2 group by dt, province;",
-                    (obj) -> {
-                        String mvName = (String) obj;
-                        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState()
-                                .getLocalMetastore().getTable(testDb.getFullName(), mvName));
-                        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-                        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-                        ExecPlan execPlan = getExecPlan(taskRun);
-                        Assert.assertEquals(null, execPlan);
-                        List<String> partitions =
-                                materializedView.getPartitions().stream().map(Partition::getName).sorted()
-                                        .collect(Collectors.toList());
-                        // If mv has partition_ttl_number, ensure only create ttl number partitions.
-                        Assert.assertEquals("[p3]", partitions.toString());
-                    });
+            try {
+                starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                        "partition by dt \n" +
+                        "distributed by random \n" +
+                        "REFRESH DEFERRED MANUAL \n" +
+                        "properties (" +
+                        "   'partition_refresh_number' = '1'," +
+                        "   'partition_ttl_number' = '1'" +
+                        ")" +
+                        "as select dt, province, sum(age) from s2 group by dt, province;");
+                Assert.fail();
+            } catch (Exception e) {
+                Assert.assertTrue(e.getMessage().contains("Invalid parameter partition_ttl_number does not support " +
+                        "non-range-partitioned materialized view"));
+            }
         });
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteListPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteListPartitionTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -290,37 +291,18 @@ public class MvRewriteListPartitionTest extends MvRewriteTestBase {
     @Test
     public void testRewriteMultiColumnsPartitionedMVWithTTLPartitionNumber() {
         starRocksAssert.withTable(T3, () -> {
-            // update base table
-            String insertSql = "insert into t3 partition(p1) values(1, 1, '2021-12-01', 'beijing');";
-            executeInsertSql(connectContext, insertSql);
-            // refresh complete
-            withRefreshedMV("create materialized view mv1\n" +
-                            "partition by province \n" +
-                            "distributed by random \n" +
-                            "REFRESH DEFERRED MANUAL \n" +
-                            "properties ('partition_ttl_number' = '1')" +
-                            "as select dt, province, sum(age) from t3 group by dt, province;",
-                    () -> {
-                        String query = "select dt, province, sum(age) from t3 group by dt, province;";
-                        {
-                            String plan = getFragmentPlan(query);
-                            // assert contains mv1
-                            PlanTestBase.assertContains(plan, "     TABLE: mv1\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=1/1\n" +
-                                    "     rollup: mv1");
-                        }
-                        {
-                            String sql = "insert into t3 partition(p2) values(1, 1, '2024-01-01', 'guangdong');";
-                            executeInsertSql(connectContext, sql);
-                            // mv is ttl outdated, use base table instead
-                            String plan = getFragmentPlan(query);
-                            PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
-                                    "     TABLE: t3\n" +
-                                    "     PREAGGREGATION: ON\n" +
-                                    "     partitions=4/4");
-                        }
-                    });
+            try {
+                starRocksAssert.withMaterializedView("create materialized view mv1\n" +
+                        "partition by province \n" +
+                        "distributed by random \n" +
+                        "REFRESH DEFERRED MANUAL \n" +
+                        "properties ('partition_ttl_number' = '1')" +
+                        "as select dt, province, sum(age) from t3 group by dt, province;");
+                Assert.fail();
+            } catch (Exception e) {
+                Assert.assertTrue(e.getMessage().contains("Invalid parameter partition_ttl_number does not support " +
+                        "non-range-partitioned materialized view"));
+            }
         });
     }
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2723,6 +2723,12 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         else:
             tools.assert_true(False, "clear stale column stats timeout. The number of stale column stats is %s" % num)
 
+    def print_table_partitions_num(self, table_name) -> str:
+        res = self.execute_sql("SHOW PARTITIONS FROM %s" % table_name, True)
+        tools.assert_true(res["status"], "show schema change task error")
+        ans = res["result"]
+        return str(len(ans))
+
     def assert_table_partitions_num(self, table_name, expect_num):
         res = self.execute_sql("SHOW PARTITIONS FROM %s" % table_name, True)
         tools.assert_true(res["status"], "show schema change task error")

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_basic
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_basic
@@ -459,9 +459,9 @@ partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
-'partition_refresh_number' = '-1',
-"replication_num" = "1",
-"partition_ttl_number" = "1"
+      'partition_refresh_number' = '-1',
+      "replication_num" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'"
 ) 
 as select dt, province, sum(age) from t5 group by dt, province;
 -- result:
@@ -471,9 +471,9 @@ select * from test_mv1 order by 1, 2;
 -- result:
 2024-01-02	guangdong	20
 -- !result
-function: assert_table_partitions_num("test_mv1", 1)
+function: print_table_partitions_num("test_mv1")
 -- result:
-None
+1
 -- !result
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 -- result:
@@ -502,25 +502,28 @@ drop materialized view test_mv1;
 -- result:
 -- !result
 create materialized view test_mv1
-partition by province
+partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
-"replication_num" = "1",
-"partition_ttl_number" = "1"
+      "replication_num" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'"
 ) 
 as select dt, province, sum(age) from t5 group by dt, province;
 -- result:
 -- !result
-refresh materialized view  test_mv1 with sync mode;
-select * from test_mv1 order by 1, 2;
--- result:
-2024-01-01	guangdong	20
-2024-01-02	guangdong	20
--- !result
-function: assert_table_partitions_num("test_mv1", 1)
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
 -- result:
 None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+2024-01-02	guangdong	20
+-- !result
+function: print_table_partitions_num("test_mv1")
+-- result:
+1
 -- !result
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 -- result:
@@ -542,56 +545,6 @@ None
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 -- result:
 2024-01-01	beijing	120
-2024-01-01	guangdong	20
-2024-01-02	guangdong	20
--- !result
-drop materialized view test_mv1;
--- result:
--- !result
-create materialized view test_mv1
-partition by dt
-REFRESH DEFERRED MANUAL
-distributed by hash(dt, province) buckets 10 
-PROPERTIES (
-"replication_num" = "1",
-"partition_ttl_number" = "1"
-) 
-as select dt, province, sum(age) from t5 group by dt, province;
--- result:
--- !result
-refresh materialized view  test_mv1;
-function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
--- result:
-None
--- !result
-select * from test_mv1 order by 1, 2;
--- result:
-2024-01-02	guangdong	20
--- !result
-function: assert_table_partitions_num("test_mv1", 1)
--- result:
-None
--- !result
-function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
--- result:
-None
--- !result
-select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
--- result:
-2024-01-01	beijing	120
-2024-01-01	guangdong	20
-2024-01-02	guangdong	20
--- !result
-INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
--- result:
--- !result
-function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
--- result:
-None
--- !result
-select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
--- result:
-2024-01-01	beijing	140
 2024-01-01	guangdong	20
 2024-01-02	guangdong	20
 -- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_partial_refresh
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_partial_refresh
@@ -417,20 +417,21 @@ partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
-'partition_refresh_number' = '-1',
-"replication_num" = "1",
-"partition_ttl_number" = "1"
+      'partition_refresh_number' = '-1',
+      "replication_num" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'"
 ) 
 as select dt, province, sum(age) from t5 group by dt, province;
 -- result:
 -- !result
-refresh materialized view  test_mv1 partition('2024-01-01') with sync mode;
+refresh materialized view test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
 -- result:
+2024-01-02	guangdong	20
 -- !result
-function: assert_table_partitions_num("test_mv1", 1)
+function: print_table_partitions_num("test_mv1")
 -- result:
-None
+1
 -- !result
 function: print_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
 -- result:
@@ -457,70 +458,28 @@ drop materialized view test_mv1;
 -- result:
 -- !result
 create materialized view test_mv1
-partition by province
-REFRESH DEFERRED MANUAL
-distributed by hash(dt, province) buckets 10 
-PROPERTIES (
-"replication_num" = "1",
-"partition_ttl_number" = "1"
-) 
-as select dt, province, sum(age) from t5 group by dt, province;
--- result:
--- !result
-refresh materialized view  test_mv1 partition ('beijing') with sync mode;
-select * from test_mv1 order by 1, 2;
--- result:
--- !result
-function: assert_table_partitions_num("test_mv1", 1)
--- result:
-None
--- !result
-function: print_hit_materialized_view("select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
--- result:
-False
--- !result
-select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;
--- result:
-2024-01-01	beijing	100
--- !result
-INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
--- result:
--- !result
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
--- result:
-None
--- !result
-select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
--- result:
-2024-01-01	beijing	120
-2024-01-01	guangdong	20
-2024-01-02	guangdong	20
--- !result
-drop materialized view test_mv1;
--- result:
--- !result
-create materialized view test_mv1
 partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
-"replication_num" = "1",
-"partition_ttl_number" = "1"
+      "replication_num" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'"
 ) 
 as select dt, province, sum(age) from t5 group by dt, province;
 -- result:
 -- !result
-refresh materialized view  test_mv1 partition('2024-01-01');
+refresh materialized view test_mv1;
 function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
 -- result:
 None
 -- !result
 select * from test_mv1 order by 1, 2;
 -- result:
+2024-01-02	guangdong	20
 -- !result
-function: assert_table_partitions_num("test_mv1", 1)
+function: print_table_partitions_num("test_mv1")
 -- result:
-None
+1
 -- !result
 function: print_hit_materialized_view("select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
 -- result:
@@ -528,7 +487,7 @@ False
 -- !result
 select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
 -- result:
-2024-01-01	beijing	120
+2024-01-01	beijing	100
 2024-01-01	guangdong	20
 -- !result
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
@@ -540,7 +499,7 @@ None
 -- !result
 select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
 -- result:
-2024-01-01	beijing	140
+2024-01-01	beijing	120
 2024-01-01	guangdong	20
 -- !result
 drop materialized view test_mv1;

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_nullable
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_nullable
@@ -445,7 +445,7 @@ REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
       'partition_refresh_number' = '-1',
-      "partition_ttl_number" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'",
       'session.enable_insert_strict' = 'true',
       "replication_num" = "1"
 ) 
@@ -455,11 +455,12 @@ as select dt, province, sum(age) from t5 group by dt, province;
 refresh materialized view  test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
 -- result:
+None	None	None
 2024-01-02	guangdong	20
 -- !result
-function: assert_table_partitions_num("test_mv1", 1)
+function: print_table_partitions_num("test_mv1")
 -- result:
-None
+2
 -- !result
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 -- result:
@@ -490,26 +491,30 @@ drop materialized view test_mv1;
 -- result:
 -- !result
 create materialized view test_mv1
-partition by province
+partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
-      "partition_ttl_number" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'",
       'session.enable_insert_strict' = 'true',
       "replication_num" = "1"
 ) 
 as select dt, province, sum(age) from t5 group by dt, province;
 -- result:
 -- !result
-refresh materialized view  test_mv1 with sync mode;
-select * from test_mv1 order by 1, 2;
--- result:
-2024-01-01	guangdong	20
-2024-01-02	guangdong	20
--- !result
-function: assert_table_partitions_num("test_mv1", 1)
+refresh materialized view  test_mv1;
+function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
 -- result:
 None
+-- !result
+select * from test_mv1 order by 1, 2;
+-- result:
+None	None	None
+2024-01-02	guangdong	20
+-- !result
+function: print_table_partitions_num("test_mv1")
+-- result:
+2
 -- !result
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 -- result:
@@ -533,59 +538,6 @@ select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 -- result:
 None	None	None
 2024-01-01	beijing	120
-2024-01-01	guangdong	20
-2024-01-02	guangdong	20
--- !result
-drop materialized view test_mv1;
--- result:
--- !result
-create materialized view test_mv1
-partition by dt
-REFRESH DEFERRED MANUAL
-distributed by hash(dt, province) buckets 10 
-PROPERTIES (
-      "partition_ttl_number" = "1",
-      'session.enable_insert_strict' = 'true',
-      "replication_num" = "1"
-) 
-as select dt, province, sum(age) from t5 group by dt, province;
--- result:
--- !result
-refresh materialized view  test_mv1;
-function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
--- result:
-None
--- !result
-select * from test_mv1 order by 1, 2;
--- result:
-2024-01-02	guangdong	20
--- !result
-function: assert_table_partitions_num("test_mv1", 1)
--- result:
-None
--- !result
-function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
--- result:
-None
--- !result
-select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
--- result:
-None	None	None
-2024-01-01	beijing	120
-2024-01-01	guangdong	20
-2024-01-02	guangdong	20
--- !result
-INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
--- result:
--- !result
-function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
--- result:
-None
--- !result
-select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
--- result:
-None	None	None
-2024-01-01	beijing	140
 2024-01-01	guangdong	20
 2024-01-02	guangdong	20
 -- !result

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_mv_reuse
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_mv_reuse
@@ -33,7 +33,6 @@ INSERT INTO t1 VALUES
     ('2020-10-24','2020-10-25 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
 -- result:
 -- !result
-    
 CREATE TABLE `t2` (
     `k1`  date not null, 
     `k2`  datetime not null, 
@@ -72,6 +71,10 @@ from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3, a.k4, b.k4;
 -- result:
 -- !result
 refresh materialized view  test_mv0 with sync mode;
+[UC] analyze table test_mv0 with sync mode;
+-- result:
+db_f94db20dc0b44906a3118fe96410cca0.test_mv0	analyze	status	OK
+-- !result
 select * from test_mv0 order by 1, 2, 3, 4, 5, 6;
 -- result:
 2020-10-11	2020-10-11	k3	k3	k4	k4	0	2	3	4
@@ -100,6 +103,10 @@ from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3;
 
 refresh materialized view test_mv1 with sync mode;
 -- result:
+-- !result
+[UC] analyze table test_mv1 with sync mode;
+-- result:
+db_f94db20dc0b44906a3118fe96410cca0.test_mv1	analyze	status	OK
 -- !result
 select * from test_mv1 order by 1, 2, 3, 4;
 -- result:
@@ -140,6 +147,10 @@ refresh materialized view test_mv2 with sync mode;
 2020-10-21	k3	0	2	3
 2020-10-22	k3	1	2	3
 -- !result
+[UC] analyze table test_mv2 with sync mode;
+-- result:
+db_f94db20dc0b44906a3118fe96410cca0.test_mv2	analyze	status	OK
+-- !result
 select * from test_mv2 order by 1, 2, 3, 4;
 -- result:
 2020-10-11	k3	0	2	3
@@ -177,13 +188,21 @@ as
 select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1;
 -- result:
 -- !result
-refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv3 with sync mode;
+[UC] analyze table test_mv3 with sync mode;
+-- result:
+db_f94db20dc0b44906a3118fe96410cca0.test_mv3	analyze	status	OK
+-- !result
 select * from test_mv3 order by 1;
 -- result:
+2020-10-11	0	2
+2020-10-12	1	2
+2020-10-21	0	2
+2020-10-22	1	2
 -- !result
 function: print_hit_materialized_view('select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1;', 'test_mv3')
 -- result:
-False
+True
 -- !result
 select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1 order by 1, 2;
 -- result:
@@ -196,5 +215,17 @@ drop table t1;
 -- result:
 -- !result
 drop table t2;
+-- result:
+-- !result
+drop materialized view test_mv0;
+-- result:
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+drop materialized view test_mv2;
+-- result:
+-- !result
+drop materialized view test_mv3;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_basic
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_basic
@@ -220,14 +220,14 @@ partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
-'partition_refresh_number' = '-1',
-"replication_num" = "1",
-"partition_ttl_number" = "1"
+      'partition_refresh_number' = '-1',
+      "replication_num" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'"
 ) 
 as select dt, province, sum(age) from t5 group by dt, province;
 refresh materialized view  test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
-function: assert_table_partitions_num("test_mv1", 1)
+function: print_table_partitions_num("test_mv1")
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
@@ -235,25 +235,6 @@ function: check_hit_materialized_view("select dt, province, sum(age) from t5 gro
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 drop materialized view test_mv1;
 
--- test sync refresh & partition_refresh_number= 1
-create materialized view test_mv1
-partition by province
-REFRESH DEFERRED MANUAL
-distributed by hash(dt, province) buckets 10 
-PROPERTIES (
-"replication_num" = "1",
-"partition_ttl_number" = "1"
-) 
-as select dt, province, sum(age) from t5 group by dt, province;
-refresh materialized view  test_mv1 with sync mode;
-select * from test_mv1 order by 1, 2;
-function: assert_table_partitions_num("test_mv1", 1)
-function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
-select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
-INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
-function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
-select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
-drop materialized view test_mv1;
 
 -- test async refresh & partition_refresh_number= 1
 create materialized view test_mv1
@@ -261,14 +242,14 @@ partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
-"replication_num" = "1",
-"partition_ttl_number" = "1"
+      "replication_num" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'"
 ) 
 as select dt, province, sum(age) from t5 group by dt, province;
 refresh materialized view  test_mv1;
 function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
 select * from test_mv1 order by 1, 2;
-function: assert_table_partitions_num("test_mv1", 1)
+function: print_table_partitions_num("test_mv1")
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_partial_refresh
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_partial_refresh
@@ -220,39 +220,19 @@ partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
-'partition_refresh_number' = '-1',
-"replication_num" = "1",
-"partition_ttl_number" = "1"
+      'partition_refresh_number' = '-1',
+      "replication_num" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'"
 ) 
 as select dt, province, sum(age) from t5 group by dt, province;
-refresh materialized view  test_mv1 partition('2024-01-01') with sync mode;
+refresh materialized view test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
-function: assert_table_partitions_num("test_mv1", 1)
+function: print_table_partitions_num("test_mv1")
 function: print_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
 function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 where dt='2024-01-01' group by dt, province order by 1, 2;
-drop materialized view test_mv1;
-
--- test sync refresh & partition_refresh_number= 1
-create materialized view test_mv1
-partition by province
-REFRESH DEFERRED MANUAL
-distributed by hash(dt, province) buckets 10 
-PROPERTIES (
-"replication_num" = "1",
-"partition_ttl_number" = "1"
-) 
-as select dt, province, sum(age) from t5 group by dt, province;
-refresh materialized view  test_mv1 partition ('beijing') with sync mode;
-select * from test_mv1 order by 1, 2;
-function: assert_table_partitions_num("test_mv1", 1)
-function: print_hit_materialized_view("select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
-select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;
-INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
-function: check_no_hit_materialized_view("select dt, province, sum(age) from t5 where province='beijing' group by dt, province order by 1, 2;", "test_mv1")
-select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 drop materialized view test_mv1;
 
 -- test async refresh & partition_refresh_number= 1
@@ -261,14 +241,14 @@ partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
-"replication_num" = "1",
-"partition_ttl_number" = "1"
+      "replication_num" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'"
 ) 
 as select dt, province, sum(age) from t5 group by dt, province;
-refresh materialized view  test_mv1 partition('2024-01-01');
+refresh materialized view test_mv1;
 function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
 select * from test_mv1 order by 1, 2;
-function: assert_table_partitions_num("test_mv1", 1)
+function: print_table_partitions_num("test_mv1")
 function: print_hit_materialized_view("select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5  where dt='2024-01-01' group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_nullable
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_nullable
@@ -214,35 +214,14 @@ REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
       'partition_refresh_number' = '-1',
-      "partition_ttl_number" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'",
       'session.enable_insert_strict' = 'true',
       "replication_num" = "1"
 ) 
 as select dt, province, sum(age) from t5 group by dt, province;
 refresh materialized view  test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2;
-function: assert_table_partitions_num("test_mv1", 1)
-function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
-select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
-INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
-function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
-select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
-drop materialized view test_mv1;
-
--- test sync refresh & partition_refresh_number= 1
-create materialized view test_mv1
-partition by province
-REFRESH DEFERRED MANUAL
-distributed by hash(dt, province) buckets 10 
-PROPERTIES (
-      "partition_ttl_number" = "1",
-      'session.enable_insert_strict' = 'true',
-      "replication_num" = "1"
-) 
-as select dt, province, sum(age) from t5 group by dt, province;
-refresh materialized view  test_mv1 with sync mode;
-select * from test_mv1 order by 1, 2;
-function: assert_table_partitions_num("test_mv1", 1)
+function: print_table_partitions_num("test_mv1")
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');
@@ -256,7 +235,7 @@ partition by dt
 REFRESH DEFERRED MANUAL
 distributed by hash(dt, province) buckets 10 
 PROPERTIES (
-      "partition_ttl_number" = "1",
+      "partition_retention_condition" = "dt > '2024-01-01'",
       'session.enable_insert_strict' = 'true',
       "replication_num" = "1"
 ) 
@@ -264,7 +243,7 @@ as select dt, province, sum(age) from t5 group by dt, province;
 refresh materialized view  test_mv1;
 function: wait_async_materialized_view_finish("db_${uuid0}",'test_mv1')
 select * from test_mv1 order by 1, 2;
-function: assert_table_partitions_num("test_mv1", 1)
+function: print_table_partitions_num("test_mv1")
 function: check_hit_materialized_view("select dt, province, sum(age) from t5 group by dt, province order by 1, 2;", "test_mv1")
 select dt, province, sum(age) from t5 group by dt, province order by 1, 2;
 INSERT INTO t5 VALUES (2, 'beijing', 20, '2024-01-01');

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_mv_reuse
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_mv_reuse
@@ -61,6 +61,7 @@ as
 select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, a.k4 as ak4, b.k4 as bk4, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9
 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3, a.k4, b.k4;
 refresh materialized view  test_mv0 with sync mode;
+[UC] analyze table test_mv0 with sync mode;
 select * from test_mv0 order by 1, 2, 3, 4, 5, 6;
 
 ---- test_mv1 refresh should reuse the materialized view test_mv0
@@ -76,6 +77,7 @@ select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, 
 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3; 
 
 refresh materialized view test_mv1 with sync mode;
+[UC] analyze table test_mv1 with sync mode;
 select * from test_mv1 order by 1, 2, 3, 4;
 function: print_hit_materialized_view('select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3;', 'test_mv1')
 select a.k1 as ak1, b.k1 as bk1, a.k3 as ak3, b.k3 as bk3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8, sum(b.k9) as sum_k9 from t1 a join t2 b on a.k1=b.k1 group by a.k1, b.k1, a.k3, b.k3 order by 1, 2, 3, 4;
@@ -93,6 +95,7 @@ select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a
 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3; 
 
 refresh materialized view test_mv2 with sync mode;
+[UC] analyze table test_mv2 with sync mode;
 select * from test_mv2 order by 1, 2, 3, 4;
 function: print_hit_materialized_view('select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3;', 'test_mv2')
 select a.k1 as ak1, a.k3 as ak3, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7, sum(a.k8) as sum_k8 from t1 a join t2 b on a.k1=b.k1 group by a.k1, a.k3 order by 1, 2, 3, 4;
@@ -108,10 +111,15 @@ REFRESH DEFERRED MANUAL
 as 
 select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1;
 
-refresh materialized view test_mv1 with sync mode;
+refresh materialized view test_mv3 with sync mode;
+[UC] analyze table test_mv3 with sync mode;
 select * from test_mv3 order by 1;
 function: print_hit_materialized_view('select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1;', 'test_mv3')
 select a.k1 as ak1, sum(a.k6) as sum_k6, sum(b.k7) as sum_k7 from t1 a join t2 b on a.k1=b.k1 group by a.k1 order by 1, 2;
 
 drop table t1;
 drop table t2;
+drop materialized view test_mv0;
+drop materialized view test_mv1;
+drop materialized view test_mv2;
+drop materialized view test_mv3;


### PR DESCRIPTION
## Why I'm doing:

MV supports multi-level partitioning by internally mapping to NativeTable as List Partition type; to achieve automatic partition management for the purpose of "hot-cold data tiering," it is necessary to clarify the semantics of Partition TTL, especially under the List Partition type.


## What I'm doing:
- Support `partition_redention_condition` property for materialized views 
- Before mv creating/refreshing new partitions,  use `filterPartitionsByTTL` to filter all invalid partitions.

The main differences between mv and native table in `PartitionSelector.java` is that `PartitionSelector` needs to handle extra `inputCells` for mv which the extra `inputCells` are not belong to mv yet but should be considered in mv's creating and refreshing.

Fixes https://github.com/StarRocks/starrocks/issues/53117

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0