### PR TITLE
[Doc] Fixed SHOW DATA command syntax in documentation.

### DIFF
--- a/docs/en/sql-reference/sql-statements/Database/SHOW_DATA.md
+++ b/docs/en/sql-reference/sql-statements/Database/SHOW_DATA.md
@@ -11,7 +11,7 @@ This statement is used to display the amount of data, the number of copies, and 
 Syntax:
 
 ```sql
-SHOW DATA [FROM <db_name>[.<table_name>]]
+SHOW DATA [FROM [<db_name>.]<table_name>]
 ```
 
 Note:


### PR DESCRIPTION
## Why I'm doing:
The documentation seemed to show that the table name is optional even when the FROM clause was used. I think that's an error. When the FROM clause is used, I think the table name is required. The database name is optional.

## What I'm doing:
Changing the line that shows the syntax of the SHOW DATA command.
Its a minor change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [X] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0