### PR TITLE
[Enhancement] Use comma as default fieldDelim for OpenCSVSerde

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveClassNames.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveClassNames.java
@@ -50,4 +50,6 @@ public class HiveClassNames {
     public static final String SEQUENCE_OUTPUT_FORMAT_CLASS =
             "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat";
 
+    public static final String OPEN_CSV_SERDE_CLASS = "org.apache.hadoop.hive.serde2.OpenCSVSerde";
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.opencsv.CSVWriter;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
@@ -602,7 +603,7 @@ public class HiveMetastoreApiConverter {
         if (fieldDelim.isEmpty()) {
             // Support for hive org.apache.hadoop.hive.serde2.OpenCSVSerde
             // https://cwiki.apache.org/confluence/display/hive/csv+serde
-            fieldDelim = parameters.getOrDefault(OpenCSVSerde.SEPARATORCHAR, ",");
+            fieldDelim = parameters.getOrDefault(OpenCSVSerde.SEPARATORCHAR, String.valueOf(CSVWriter.DEFAULT_SEPARATOR));
         }
         String lineDelim = parameters.getOrDefault(serdeConstants.LINE_DELIM, "");
         String mapkeyDelim = parameters.getOrDefault(serdeConstants.MAPKEY_DELIM, "");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -356,6 +356,7 @@ public class HiveMetastoreApiConverter {
         textFileParameters.putAll(sd.getSerdeInfo().getParameters());
         // "skip.header.line.count" is set in TBLPROPERTIES
         textFileParameters.putAll(params);
+        textFileParameters.put(HIVE_TABLE_SERDE_LIB, sd.getSerdeInfo().getSerializationLib());
         Partition.Builder partitionBuilder = Partition.builder()
                 .setParams(params)
                 .setFullPath(sd.getLocation())
@@ -603,7 +604,9 @@ public class HiveMetastoreApiConverter {
         if (fieldDelim.isEmpty()) {
             // Support for hive org.apache.hadoop.hive.serde2.OpenCSVSerde
             // https://cwiki.apache.org/confluence/display/hive/csv+serde
-            fieldDelim = parameters.getOrDefault(OpenCSVSerde.SEPARATORCHAR, String.valueOf(CSVWriter.DEFAULT_SEPARATOR));
+            if (parameters.getOrDefault(HIVE_TABLE_SERDE_LIB, null).equals(HiveClassNames.OPEN_CSV_SERDE_CLASS)) {
+                fieldDelim = parameters.getOrDefault(OpenCSVSerde.SEPARATORCHAR, String.valueOf(CSVWriter.DEFAULT_SEPARATOR));
+            }
         }
         String lineDelim = parameters.getOrDefault(serdeConstants.LINE_DELIM, "");
         String mapkeyDelim = parameters.getOrDefault(serdeConstants.MAPKEY_DELIM, "");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -604,7 +604,7 @@ public class HiveMetastoreApiConverter {
         if (fieldDelim.isEmpty()) {
             // Support for hive org.apache.hadoop.hive.serde2.OpenCSVSerde
             // https://cwiki.apache.org/confluence/display/hive/csv+serde
-            if (parameters.getOrDefault(HIVE_TABLE_SERDE_LIB, null).equals(HiveClassNames.OPEN_CSV_SERDE_CLASS)) {
+            if (HiveClassNames.OPEN_CSV_SERDE_CLASS.equals(parameters.getOrDefault(HIVE_TABLE_SERDE_LIB, null))) {
                 fieldDelim = parameters.getOrDefault(OpenCSVSerde.SEPARATORCHAR, String.valueOf(CSVWriter.DEFAULT_SEPARATOR));
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -602,7 +602,7 @@ public class HiveMetastoreApiConverter {
         if (fieldDelim.isEmpty()) {
             // Support for hive org.apache.hadoop.hive.serde2.OpenCSVSerde
             // https://cwiki.apache.org/confluence/display/hive/csv+serde
-            fieldDelim = parameters.getOrDefault(OpenCSVSerde.SEPARATORCHAR, "");
+            fieldDelim = parameters.getOrDefault(OpenCSVSerde.SEPARATORCHAR, ",");
         }
         String lineDelim = parameters.getOrDefault(serdeConstants.LINE_DELIM, "");
         String mapkeyDelim = parameters.getOrDefault(serdeConstants.MAPKEY_DELIM, "");


### PR DESCRIPTION
## Why I'm doing:
With csv table without config any Serde properties
```sql
CREATE TABLE `dev_hotel.city_licheng_new`(
  `city` string COMMENT 'from deserializer', 
  `star_type` string COMMENT 'from deserializer', 
  `city2` string COMMENT 'from deserializer')
COMMENT ''
ROW FORMAT SERDE 
  'org.apache.hadoop.hive.serde2.OpenCSVSerde' 
STORED AS INPUTFORMAT 
  'org.apache.hadoop.mapred.TextInputFormat' 
OUTPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
LOCATION
```
Now will use empty fieldDelim and return wrong result 

![image](https://github.com/user-attachments/assets/e13a409f-4fea-46fe-ad31-685ecd84aecd)

## What I'm doing:

Use comma as default fieldDelim for OpenCSVSerde

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0