### PR TITLE
[Enhancement] add add_shard_listener in StarOSWorker

### DIFF
--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -89,7 +89,18 @@ absl::Status StarOSWorker::add_shard(const ShardInfo& shard) {
             return st;
         }
     }
-    _shards.insert_or_assign(shard.id, ShardInfoDetails(shard));
+    auto ret = _shards.insert_or_assign(shard.id, ShardInfoDetails(shard));
+    l.unlock();
+    if (ret.second) {
+        // it is an insert op to the map
+        // NOTE:
+        //  1. Since the following statement is invoked outside the lock, it is possible that
+        //     the shard may be removed when retrieving from the callback.
+        //  2. Expect the callback is as quick and simple as possible, otherwise it will occupy
+        //     the GRPC thread too long and blocking response sent back to StarManager. A better
+        //     choice would be: starting a new thread pool and send callback tasks in the thread pool.
+        on_add_shard_event(shard.id);
+    }
     return absl::OkStatus();
 }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -479,6 +479,7 @@ set(EXEC_FILES
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp
         ./service/service_be/internal_service_test.cpp
+        ./service/staros_worker_test.cpp
         ./storage/metadata_util_test.cpp
         ./storage/delta_writer_test.cpp
         ./storage/compaction_parallelization_test.cpp

--- a/be/test/service/staros_worker_test.cpp
+++ b/be/test/service/staros_worker_test.cpp
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef USE_STAROS
+#include "service/staros_worker.h"
+
+#include <gtest/gtest.h>
+
+#include <functional>
+
+namespace starrocks {
+
+static void add_shard_listener(std::vector<StarOSWorker::ShardId>* shardIds, int* counter, StarOSWorker::ShardId id) {
+    shardIds->push_back(id);
+    ++*counter;
+}
+
+TEST(StarOSWorkerTest, test_add_listener) {
+    int counter = 0;
+    std::vector<StarOSWorker::ShardId> ids;
+
+    auto worker = std::make_unique<StarOSWorker>();
+
+    StarOSWorker::ShardInfo info;
+
+    EXPECT_EQ(0, counter);
+    EXPECT_TRUE(ids.empty());
+
+    info.id = 1;
+    EXPECT_TRUE(worker->add_shard(info).ok());
+
+    // no shard registered, counter and ids will not be modified
+    EXPECT_EQ(0, counter);
+    EXPECT_TRUE(ids.empty());
+
+    // register the counter;
+    worker->register_add_shard_listener(std::bind(&add_shard_listener, &ids, &counter, std::placeholders::_1));
+
+    info.id = 2;
+    EXPECT_TRUE(worker->add_shard(info).ok());
+
+    // shard:2 added
+    EXPECT_EQ(1, counter);
+    EXPECT_EQ(1, ids.size());
+    EXPECT_EQ(2, ids[0]);
+
+    // add it again
+    EXPECT_TRUE(worker->add_shard(info).ok());
+    // no change, the shard:2 is already added
+    EXPECT_EQ(1, counter);
+    EXPECT_EQ(1, ids.size());
+}
+
+} // namespace starrocks
+#endif


### PR DESCRIPTION
* be able to hook callbacks when new shards added to the worker in shared-data mode

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0