### PR TITLE
[Enhancement] Record builded tuning guide to query profile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1366,6 +1366,9 @@ public class StmtExecutor {
                 PlanTuningAnalyzer.getInstance().analyzePlan(execPlan.getPhysicalPlan(), pair.second, tuningGuides);
                 PlanTuningAdvisor.getInstance()
                         .putTuningGuides(parsedStmt.getOrigStmt().getOrigStmt(), pair.first, tuningGuides);
+                if (!tuningGuides.isEmpty()) {
+                    Tracers.record(Tracers.Module.BASE, "BuildTuningGuides", tuningGuides.getFullTuneGuidesInfo());
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/OperatorTuningGuides.java
@@ -98,12 +98,20 @@ public class OperatorTuningGuides {
         return originalTimeCost;
     }
 
-    public String getTuneGuidesInfo() {
+    public String getFullTuneGuidesInfo() {
+        return getTuneGuidesInfo(true);
+    }
+
+    public String getTuneGuidesInfo(boolean isFull) {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<Integer, List<TuningGuide>> entry : tuningGuides.entrySet()) {
             sb.append("PlanNode ").append(entry.getKey()).append(":").append("\n");
             for (TuningGuide guide : entry.getValue()) {
                 sb.append(guide.getClass().getSimpleName()).append("\n");
+                if (isFull) {
+                    sb.append(guide.getDescription()).append("\n");
+                    sb.append(guide.getAdvice()).append("\n");
+                }
             }
             sb.append("\n");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanTuningAdvisor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/PlanTuningAdvisor.java
@@ -108,7 +108,7 @@ public class PlanTuningAdvisor {
             row.add(entry.getValue().getOriginalQueryId().toString());
             row.add(entry.getKey().getSql());
             row.add(String.valueOf(entry.getValue().getOriginalTimeCost()));
-            row.add(entry.getValue().getTuneGuidesInfo());
+            row.add(entry.getValue().getTuneGuidesInfo(false));
             row.add(String.valueOf(entry.getValue().getAvgTunedTimeCost()));
             row.add(String.valueOf(entry.getValue().optimizedQueryCount()));
             row.add(String.valueOf(entry.getValue().isUseful()));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -972,7 +972,7 @@ public class Optimizer {
         OperatorTuningGuides.OptimizedRecord optimizedRecord = PlanTuningAdvisor.getInstance()
                 .getOptimizedRecord(context.getQueryId());
         if (optimizedRecord != null) {
-            Tracers.record(Tracers.Module.BASE, "DynamicTuningGuides", optimizedRecord.getExplainString());
+            Tracers.record(Tracers.Module.BASE, "DynamicApplyTuningGuides", optimizedRecord.getExplainString());
         }
         return result;
     }


### PR DESCRIPTION
## Why I'm doing:
If a certain SQL build a tuning guide after execution, record it in the current query profile.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0