### PR TITLE
[BugFix]Dictionary drop operations and refresh operations collide, resulting in inconsistent metadata.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -504,7 +504,8 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
                     if (dictionariesMapById.containsKey(dictionary.getDictionaryId())) {
                         dictionariesMapById.put(dictionary.getDictionaryId(), dictionary);
                     } else {
-                        LOG.warn("dictionary {}, id {} has been deleted", dictionary.getDictionaryName(), dictionary.getDictionaryId());
+                        LOG.warn("dictionary {}, id {} has been deleted",
+                                dictionary.getDictionaryName(), dictionary.getDictionaryId());
                     }
                 }
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -501,7 +501,11 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
             try {
                 for (Dictionary dictionary : dictionaries) {
                     // update dictionary object state
-                    dictionariesMapById.put(dictionary.getDictionaryId(), dictionary);
+                    if (dictionariesMapById.containsKey(dictionary.getDictionaryId())) {
+                        dictionariesMapById.put(dictionary.getDictionaryId(), dictionary);
+                    } else {
+                        LOG.warn("dictionary {}, id {} has been deleted", dictionary.getDictionaryName(), dictionary.getDictionaryId());
+                    }
                 }
             } finally {
                 lock.unlock();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #53549

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0