### PR TITLE
[Enhancement] external table adaptation feedback

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1325,11 +1325,14 @@ public class StmtExecutor {
                 context.getState().setOk(statisticsForAuditLog.returnedRows, 0, "");
             }
 
+            if (null != statisticsForAuditLog) {
+                analyzePlanWithExecStats(execPlan);
+            }
+
             if (null == statisticsForAuditLog || null == statisticsForAuditLog.statsItems ||
                     statisticsForAuditLog.statsItems.isEmpty()) {
                 return;
             }
-            analyzePlanWithExecStats(execPlan);
 
             // collect table-level metrics
             Set<Long> tableIds = Sets.newHashSet();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/skeleton/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/skeleton/ScanNode.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.qe.feedback.skeleton;
 
+import com.starrocks.catalog.Table;
 import com.starrocks.qe.feedback.NodeExecStats;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
@@ -22,6 +23,8 @@ import java.util.Objects;
 
 public class ScanNode extends SkeletonNode {
 
+    // The tableId of the external table is monotonically increasing for each instance.
+    // There is no need to compare between hashcode and equals
     private final long tableId;
 
     private final String tableIdentifier;
@@ -30,7 +33,8 @@ public class ScanNode extends SkeletonNode {
                     NodeExecStats nodeExecStats, SkeletonNode parent) {
         super(optExpression, nodeExecStats, parent);
         PhysicalScanOperator scanOperator = (PhysicalScanOperator) optExpression.getOp();
-        tableId = scanOperator.getTable().getId();
+        Table table = scanOperator.getTable();
+        tableId = table.isExternalTableWithFileSystem() ? -1 : table.getId();
         tableIdentifier = scanOperator.getTable().getTableIdentifier();
     }
 

--- a/test/sql/test_feedback/R/test_external_table_join_feedback
+++ b/test/sql/test_feedback/R/test_external_table_join_feedback
@@ -1,0 +1,67 @@
+-- name: test_external_table_join_feedback
+create external catalog iceberg_catalog_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+-- result:
+-- !result
+create database iceberg_catalog_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew (
+  `c0` int(11) NULL COMMENT "",
+  `c1` char(50) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+);
+-- result:
+-- !result
+insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'b', generate_series, generate_series from TABLE(generate_series(3, 4));
+-- result:
+-- !result
+insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'c', generate_series, generate_series from TABLE(generate_series(5, 6));
+-- result:
+-- !result
+insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'd', generate_series, generate_series from TABLE(generate_series(7, 8));
+-- result:
+-- !result
+insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'e', generate_series, generate_series from TABLE(generate_series(9, 10));
+-- result:
+-- !result
+insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'f', generate_series, generate_series from TABLE(generate_series(11, 5050000));
+-- result:
+-- !result
+set enable_plan_advisor=true;
+-- result:
+-- !result
+set enable_plan_analyzer=true;
+-- result:
+-- !result
+use iceberg_catalog_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+function: assert_explain_not_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+add into plan advisor select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t;
+-- result:
+[REGEX]Add query into plan advisor in FE*
+-- !result
+function: assert_explain_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t", "RightChildEstimationErrorTuningGuide")
+-- result:
+None
+-- !result
+clear plan advisor;
+-- result:
+[REGEX]Clear all plan advisor in FE*
+-- !result
+drop table iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew;
+-- result:
+-- !result
+drop database iceberg_catalog_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_catalog_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_feedback/T/test_external_table_join_feedback
+++ b/test/sql/test_feedback/T/test_external_table_join_feedback
@@ -1,0 +1,32 @@
+-- name: test_external_table_join_feedback
+
+create external catalog iceberg_catalog_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+
+create database iceberg_catalog_${uuid0}.iceberg_db_${uuid0};
+CREATE TABLE iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew (
+  `c0` int(11) NULL COMMENT "",
+  `c1` char(50) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+);
+
+insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'b', generate_series, generate_series from TABLE(generate_series(3, 4));
+insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'c', generate_series, generate_series from TABLE(generate_series(5, 6));
+insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'd', generate_series, generate_series from TABLE(generate_series(7, 8));
+insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'e', generate_series, generate_series from TABLE(generate_series(9, 10));
+insert into iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew select generate_series, 'f', generate_series, generate_series from TABLE(generate_series(11, 5050000));
+set enable_plan_advisor=true;
+set enable_plan_analyzer=true;
+use iceberg_catalog_${uuid0}.iceberg_db_${uuid0};
+set catalog default_catalog;
+function: assert_explain_not_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
+
+add into plan advisor select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t;
+
+
+function: assert_explain_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t", "RightChildEstimationErrorTuningGuide")
+
+clear plan advisor;
+drop table iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew;
+drop database iceberg_catalog_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_catalog_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
major changes:
1. feedback doesn't use statsItems in PQueryStatistics. and external table won't collect statsItems.  So analyzePlanWithExecStats ignore the existence of statsItems.
2. The tableId of the external table is monotonically increasing for each instance. There is no need to compare between hashcode and equals.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0