### PR TITLE
[Enhancement] short circuit optimization on `select limit` case (on Scan Node)

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -976,7 +976,8 @@ void FragmentExecutor::_fail_cleanup(bool fragment_has_registed) {
     }
 }
 
-Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const TExecPlanFragmentParams& request) {
+Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const TExecPlanFragmentParams& request,
+                                                        TExecPlanFragmentResult* response) {
     DCHECK(!request.__isset.fragment);
     DCHECK(request.__isset.params);
     const TPlanFragmentExecParams& params = request.params;
@@ -997,7 +998,8 @@ Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const
     RuntimeState* runtime_state = fragment_ctx->runtime_state();
 
     std::unordered_set<int> notify_ids;
-
+    std::vector<int32_t> closed_scan_nodes;
+    
     for (const auto& [node_id, scan_ranges] : params.per_node_scan_ranges) {
         if (scan_ranges.size() == 0) continue;
         auto iter = fragment_ctx->morsel_queue_factories().find(node_id);
@@ -1020,6 +1022,10 @@ Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const
         RETURN_IF_ERROR(morsel_queue_factory->append_morsels(0, std::move(morsels)));
         morsel_queue_factory->set_has_more(has_more_morsel);
         notify_ids.insert(node_id);
+
+        if (morsel_queue_factory->reach_limit()) {
+            closed_scan_nodes.push_back(node_id);
+        }
     }
 
     if (params.__isset.node_to_per_driver_seq_scan_ranges) {
@@ -1048,6 +1054,14 @@ Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const
             }
             morsel_queue_factory->set_has_more(has_more_morsel);
             notify_ids.insert(node_id);
+
+            if (morsel_queue_factory->reach_limit()) {
+                closed_scan_nodes.push_back(node_id);
+            }
+        }
+        
+        if (closed_scan_nodes.size() > 0) {
+            response->__set_closed_scan_nodes(closed_scan_nodes);
         }
     }
 

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -107,7 +107,8 @@ public:
                    const TExecPlanFragmentParams& unique_request);
     Status execute(ExecEnv* exec_env);
 
-    static Status append_incremental_scan_ranges(ExecEnv* exec_env, const TExecPlanFragmentParams& request);
+    static Status append_incremental_scan_ranges(ExecEnv* exec_env, const TExecPlanFragmentParams& request,
+                                                 TExecPlanFragmentResult* response);
 
 private:
     void _fail_cleanup(bool fragment_has_registed);

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -150,6 +150,15 @@ void IndividualMorselQueueFactory::set_has_more(bool v) {
     }
 }
 
+bool IndividualMorselQueueFactory::reach_limit() const {
+    for (const auto& p : _queue_per_driver_seq) {
+        if (p->reach_limit()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 BucketSequenceMorselQueueFactory::BucketSequenceMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq,
                                                                    bool could_local_shuffle)
         : _could_local_shuffle(could_local_shuffle) {
@@ -180,6 +189,15 @@ void BucketSequenceMorselQueueFactory::set_has_more(bool v) {
     for (auto& q : _queue_per_driver_seq) {
         q->set_has_more(v);
     }
+}
+
+bool BucketSequenceMorselQueueFactory::reach_limit() const {
+    for (const auto& p : _queue_per_driver_seq) {
+        if (p->reach_limit()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 size_t BucketSequenceMorselQueueFactory::num_original_morsels() const {

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -191,15 +191,6 @@ void BucketSequenceMorselQueueFactory::set_has_more(bool v) {
     }
 }
 
-bool BucketSequenceMorselQueueFactory::reach_limit() const {
-    for (const auto& p : _queue_per_driver_seq) {
-        if (p->reach_limit()) {
-            return true;
-        }
-    }
-    return false;
-}
-
 size_t BucketSequenceMorselQueueFactory::num_original_morsels() const {
     size_t total = 0;
     for (const auto& queue : _queue_per_driver_seq) {

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -90,6 +90,10 @@ void SharedMorselQueueFactory::set_has_more(bool v) {
     _queue->set_has_more(v);
 }
 
+bool SharedMorselQueueFactory::reach_limit() const {
+    return _queue->reach_limit();
+}
+
 size_t IndividualMorselQueueFactory::num_original_morsels() const {
     size_t total = 0;
     for (const auto& queue : _queue_per_driver_seq) {

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -322,7 +322,6 @@ public:
 
     Status append_morsels(int driver_seq, Morsels&& morsels) override;
     void set_has_more(bool v) override;
-    bool reach_limit() const override;
 
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -252,6 +252,7 @@ public:
 
     virtual Status append_morsels(int driver_seq, Morsels&& morsels);
     virtual void set_has_more(bool v) {}
+    virtual bool reach_limit() const { return false; }
 };
 
 class SharedMorselQueueFactory final : public MorselQueueFactory {
@@ -268,6 +269,7 @@ public:
 
     Status append_morsels(int driver_seq, Morsels&& morsels) override;
     void set_has_more(bool v) override;
+    bool reach_limit() const override;
 
 private:
     MorselQueuePtr _queue;
@@ -369,11 +371,16 @@ public:
         DCHECK(tablet_schema != nullptr);
         _tablet_schema = tablet_schema;
     }
+    // is there any more scan ranges delivered from FE to be processed?
     bool has_more() const { return _has_more; }
     void set_has_more(bool v) { _has_more = v; }
+    // do scan operator emit enough rows that we can stop processing scan ranges?
+    void set_reach_limit(bool v) { _reach_limit = v; }
+    bool reach_limit() const { return _reach_limit; }
 
 protected:
     std::atomic<bool> _has_more = false;
+    std::atomic<bool> _reach_limit = false;
     Morsels _morsels;
     size_t _num_morsels = 0;
     MorselPtr _unget_morsel = nullptr;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -295,6 +295,7 @@ public:
 
     Status append_morsels(int driver_seq, Morsels&& morsels) override;
     void set_has_more(bool v) override;
+    bool reach_limit() const override;
 
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;
@@ -321,6 +322,7 @@ public:
 
     Status append_morsels(int driver_seq, Morsels&& morsels) override;
     void set_has_more(bool v) override;
+    bool reach_limit() const override;
 
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -297,6 +297,10 @@ StatusOr<ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
         res->owner_info().set_owner_id(owner_id, is_eos);
     }
 
+    if (_scan_node->limit() != -1 && _op_pull_rows >= _scan_node->limit()) {
+        _morsel_queue->set_reach_limit(true);
+    }
+
     return res;
 }
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -306,7 +306,7 @@ void PInternalServiceImplBase<T>::_exec_plan_fragment(google::protobuf::RpcContr
         return;
     }
 
-    auto st = _exec_plan_fragment(cntl, request);
+    auto st = _exec_plan_fragment(cntl, request, response);
     if (!st.ok()) {
         LOG(WARNING) << "exec plan fragment failed, errmsg=" << st.message();
     }
@@ -422,6 +422,15 @@ void PInternalServiceImplBase<T>::tablet_writer_cancel(google::protobuf::RpcCont
                                                        PTabletWriterCancelResult* response,
                                                        google::protobuf::Closure* done) {}
 
+static void copy_result_from_thrift_to_protobuf(const TExecPlanFragmentResult& t_response,
+                                                PExecPlanFragmentResult* p_response) {
+    if (t_response.__isset.closed_scan_nodes) {
+        for (auto v : t_response.closed_scan_nodes) {
+            p_response->add_closed_scan_nodes(v);
+        }
+    }
+}
+
 template <typename T>
 void PInternalServiceImplBase<T>::get_load_replica_status(google::protobuf::RpcController* controller,
                                                           const PLoadReplicaStatusRequest* request,
@@ -434,8 +443,8 @@ void PInternalServiceImplBase<T>::load_diagnose(google::protobuf::RpcController*
                                                 google::protobuf::Closure* done) {}
 
 template <typename T>
-Status PInternalServiceImplBase<T>::_exec_plan_fragment(brpc::Controller* cntl,
-                                                        const PExecPlanFragmentRequest* request) {
+Status PInternalServiceImplBase<T>::_exec_plan_fragment(brpc::Controller* cntl, const PExecPlanFragmentRequest* request,
+                                                        PExecPlanFragmentResult* response) {
     auto ser_request = cntl->request_attachment().to_string();
     TExecPlanFragmentParams t_request;
     {
@@ -445,7 +454,10 @@ Status PInternalServiceImplBase<T>::_exec_plan_fragment(brpc::Controller* cntl,
     }
     // incremental scan ranges deployment.
     if (!t_request.__isset.fragment) {
-        return pipeline::FragmentExecutor::append_incremental_scan_ranges(_exec_env, t_request);
+        TExecPlanFragmentResult t_result;
+        Status code = pipeline::FragmentExecutor::append_incremental_scan_ranges(_exec_env, t_request, &t_result);
+        copy_result_from_thrift_to_protobuf(t_result, response);
+        return code;
     }
 
     if (UNLIKELY(!t_request.query_options.__isset.batch_size)) {

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -233,7 +233,8 @@ private:
     void _get_file_schema(google::protobuf::RpcController* controller, const PGetFileSchemaRequest* request,
                           PGetFileSchemaResult* response, google::protobuf::Closure* done);
 
-    Status _exec_plan_fragment(brpc::Controller* cntl, const PExecPlanFragmentRequest* request);
+    Status _exec_plan_fragment(brpc::Controller* cntl, const PExecPlanFragmentRequest* request,
+                               PExecPlanFragmentResult* response);
     Status _exec_plan_fragment_by_pipeline(const TExecPlanFragmentParams& t_common_request,
                                            const TExecPlanFragmentParams& t_unique_request);
     Status _exec_plan_fragment_by_non_pipeline(const TExecPlanFragmentParams& t_request);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -53,6 +53,7 @@ public class DeltaLakeScanNode extends ScanNode {
     private final HDFSScanNodePredicates scanNodePredicates = new HDFSScanNodePredicates();
     private CloudConfiguration cloudConfiguration = null;
     private DeltaConnectorScanRangeSource scanRangeSource = null;
+    private volatile boolean reachLimit = false;
     private int selectedPartitionCount = -1;
 
     public DeltaLakeScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
@@ -100,7 +101,12 @@ public class DeltaLakeScanNode extends ScanNode {
 
     @Override
     public boolean hasMoreScanRanges() {
-        return scanRangeSource.hasMoreOutput();
+        return !reachLimit && scanRangeSource.hasMoreOutput();
+    }
+
+    @Override
+    public void setReachLimit() {
+        reachLimit = true;
     }
 
     public void setupScanRangeSource(ScalarOperator predicate, List<String> fieldNames, boolean enableIncrementalScanRanges)

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -59,6 +59,7 @@ import static com.starrocks.thrift.TExplainLevel.VERBOSE;
  * TODO: Dictionary pruning
  */
 public class HdfsScanNode extends ScanNode {
+    private volatile boolean reachLimit = false;
     private HiveConnectorScanRangeSource scanRangeSource = null;
 
     private HiveTable hiveTable = null;
@@ -115,7 +116,12 @@ public class HdfsScanNode extends ScanNode {
 
     @Override
     public boolean hasMoreScanRanges() {
-        return scanRangeSource.hasMoreOutput();
+        return !reachLimit && scanRangeSource.hasMoreOutput();
+    }
+
+    @Override
+    public void setReachLimit() {
+        reachLimit = true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -138,6 +138,9 @@ public abstract class ScanNode extends PlanNode {
         return false;
     }
 
+    public void setReachLimit() {
+    }
+
     /**
      * cast expr to SlotDescriptor type
      */

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -83,7 +83,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
 
     @Override
     public void schedule(Coordinator.ScheduleOption option) throws RpcException, StarRocksException {
-        List<DeployState> states = new ArrayList<>();
+        List<DeployState> states = new ArrayList<>();        
         for (List<ExecutionFragment> executionFragments : dag.getFragmentsInTopologicalOrderFromRoot()) {
             final DeployState deployState = deployer.createFragmentExecStates(executionFragments);
             deployer.deployFragments(deployState);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -21,6 +21,8 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.planner.PlanFragmentId;
+import com.starrocks.planner.PlanNodeId;
+import com.starrocks.planner.ScanNode;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.proto.StatusPB;
@@ -273,12 +275,15 @@ public class FragmentInstanceExecState {
         TStatusCode code;
         String errMsg = null;
         Throwable failure = null;
+        List<Integer> closedScanNodes = null;
         try {
             PExecPlanFragmentResult result = deployFuture.get(deployTimeoutMs, TimeUnit.MILLISECONDS);
+            closedScanNodes = result.getClosedScanNodes();
             code = TStatusCode.findByValue(result.status.statusCode);
             if (!CollectionUtils.isEmpty(result.status.errorMsgs)) {
                 errMsg = result.status.errorMsgs.get(0);
             }
+
         } catch (ExecutionException e) {
             LOG.warn("catch a execute exception", e);
             code = TStatusCode.THRIFT_RPC_ERROR;
@@ -308,6 +313,15 @@ public class FragmentInstanceExecState {
 
             LOG.warn("exec plan fragment failed, errmsg={}, code={}, fragmentId={}, backend={}:{}",
                     errMsg, code, getFragmentId(), address.hostname, address.port);
+        }
+
+        if (closedScanNodes != null) {
+            for (int id : closedScanNodes) {
+                ScanNode scanNode = fragmentInstance.getExecFragment().getScanNode(new PlanNodeId(id));
+                if (scanNode != null) {
+                    scanNode.setReachLimit();
+                }
+            }
         }
 
         requestToDeploy = null;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/DeltaLakeScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/DeltaLakeScanNodeTest.java
@@ -49,6 +49,7 @@ public class DeltaLakeScanNodeTest {
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);
         DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "XXX");
+        scanNode.setReachLimit();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HdfsScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HdfsScanNodeTest.java
@@ -47,5 +47,6 @@ public class HdfsScanNodeTest {
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);
         HdfsScanNode scanNode = new HdfsScanNode(new PlanNodeId(0), desc, "XXX");
+        scanNode.setReachLimit();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HudiScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HudiScanNodeTest.java
@@ -47,5 +47,6 @@ public class HudiScanNodeTest {
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);
         HudiScanNode scanNode = new HudiScanNode(new PlanNodeId(0), desc, "XXX");
+        scanNode.setReachLimit();
     }
 }

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -362,7 +362,7 @@ message PLoadDiagnoseResult {
 
 message PExecPlanFragmentRequest {
     // describe attachment protocol: binary, compact, json
-    optional string attachment_protocol = 1;
+    optional string attachment_protocol = 1;    
 };
 
 message PTabletReaderOpenRequest {
@@ -424,13 +424,17 @@ message PTabletReaderScanGetNextResult {
 
 message PExecPlanFragmentResult {
     required StatusPB status = 1;
+
+    // short circuit optimization on `select limit`
+    // scan nodes that don't need any scan ranges.
+    repeated int32 closed_scan_nodes = 2;
 };
 
 message PExecBatchPlanFragmentsRequest {
 };
 
 message PExecBatchPlanFragmentsResult {
-    optional StatusPB status = 1;
+    optional StatusPB status = 1;    
 };
 
 enum PPlanFragmentCancelReason {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -362,7 +362,7 @@ message PLoadDiagnoseResult {
 
 message PExecPlanFragmentRequest {
     // describe attachment protocol: binary, compact, json
-    optional string attachment_protocol = 1;    
+    optional string attachment_protocol = 1;
 };
 
 message PTabletReaderOpenRequest {
@@ -434,7 +434,7 @@ message PExecBatchPlanFragmentsRequest {
 };
 
 message PExecBatchPlanFragmentsResult {
-    optional StatusPB status = 1;    
+    optional StatusPB status = 1;
 };
 
 enum PPlanFragmentCancelReason {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -519,6 +519,10 @@ struct TExecPlanFragmentParams {
 struct TExecPlanFragmentResult {
   // required in V1
   1: optional Status.TStatus status
+
+  // short circuit optimization on `select limit`
+  // scan nodes that don't need any scan ranges.
+  2: optional list<i32> closed_scan_nodes;
 }
 
 struct TExecBatchPlanFragmentsParams {


### PR DESCRIPTION
## Why I'm doing:

Since we support incremental scan ranges in this PR: https://github.com/StarRocks/starrocks/pull/50189, We can optimize `select limit` pattern query without having to deliver all scan ranges.

![image](https://github.com/user-attachments/assets/ed3b8ffd-73a7-476f-bc37-e2bea28d82e4)

And It's better to know how many rounds of incremental scan ranges deployment. 


## What I'm doing:

This PR works like following:
- add `closed_scan_ndoes` in rpc response. this field means which scan node has reached limit and does not need scan ranges any mode.
- if scan node does not need scan ranges any more, it's marked as `reach_limit` state.
- and in next delivery round, we don't deliver scan ranges to this node any more.

![image](https://github.com/user-attachments/assets/3fc7c372-1921-484b-869c-8f481eb14882)

And also add a metric `DeployRound` to see how many rounds of deployments.

Fixes #issue

-----------

I've used following sql to test performance, the dataset is tpcds-1T iceberg table.

```sql
select * from catalog_sales limit 10;
select * from catalog_sales limit 100;
select * from catalog_sales limit 500;
select * from catalog_sales limit 1000;

select * from store_sales limit 10;
select * from store_sales limit 100;
select * from store_sales limit 500;
select * from store_sales limit 1000;
```

  | PR | Base | \+X%
-- | -- | -- | --
Q01 | 164 | 665 | 75.34
Q02 | 143 | 721 | 80.17
Q03 | 179 | 699 | 74.39
Q04 | 166 | 746 | 77.75
Q05 | 277 | 396 | 30.05
Q06 | 230 | 395 | 41.77
Q07 | 231 | 363 | 36.36
Q08 | 271 | 400 | 32.25

Table stats:
- catalog_sales
  - 28521 files
  - 32 columns
- store_sales
  - 12030 files
  - 23 columns

So the more files,  the better improvement we have.

---------

We modify code to compare PR and "only deliver 50 files". And there is no big difference.

  | PR | only deliver 50 files
-- | -- | --
Q01 | 164 | 157
Q02 | 143 | 162
Q03 | 179 | 144
Q04 | 166 | 172
Q05 | 277 | 223
Q06 | 230 | 238
Q07 | 231 | 201
Q08 | 271 | 252

</byte-sheet-html-origin><!--EndFragment-->


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0