### PR TITLE
[Refactor] adjust plan advisor syntax

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4919,7 +4919,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     // ------------------------------------------- Plan Tuning Statement -----------------------------------------------
-    public ParseNode visitAddPlanAdvisorStatement(StarRocksParser.AddPlanAdvisorStatementContext context) {
+    public ParseNode visitAlterPlanAdvisorAddStatement(StarRocksParser.AlterPlanAdvisorAddStatementContext context) {
         QueryStatement queryStmt = (QueryStatement) visitQueryStatement(context.queryStatement());
         int start = context.queryStatement().start.getStartIndex();
         int end = context.queryStatement().stop.getStopIndex();
@@ -4933,11 +4933,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         return new AddPlanAdvisorStmt(createPos(context), queryStmt);
     }
 
-    public ParseNode visitClearPlanAdvisorStatement(StarRocksParser.ClearPlanAdvisorStatementContext context) {
+    public ParseNode visitTruncatePlanAdvisorStatement(StarRocksParser.TruncatePlanAdvisorStatementContext context) {
         return new ClearPlanAdvisorStmt(createPos(context));
     }
 
-    public ParseNode visitDelPlanAdvisorStatement(StarRocksParser.DelPlanAdvisorStatementContext context) {
+    public ParseNode visitAlterPlanAdvisorDropStatement(StarRocksParser.AlterPlanAdvisorDropStatementContext context) {
         String advisorId = ((StringLiteral) visit(context.string())).getStringValue();
         return new DelPlanAdvisorStmt(createPos(context), advisorId);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -302,9 +302,9 @@ statement
     | cancelRefreshDictionaryStatement
 
     // Plan advisor statement
-    | addPlanAdvisorStatement
-    | clearPlanAdvisorStatement
-    | delPlanAdvisorStatement
+    | alterPlanAdvisorAddStatement
+    | truncatePlanAdvisorStatement
+    | alterPlanAdvisorDropStatement
     | showPlanAdvisorStatement
 
     // Warehouse Statement
@@ -1991,14 +1991,14 @@ lock_type
     ;
 
 // ------------------------------------------- Plan Tuning Statement ---------------------------------------------------
-addPlanAdvisorStatement
-    : ADD INTO PLAN ADVISOR queryStatement;
+alterPlanAdvisorAddStatement
+    : ALTER PLAN ADVISOR ADD queryStatement;
 
-clearPlanAdvisorStatement
-    : CLEAR PLAN ADVISOR;
+truncatePlanAdvisorStatement
+    : TRUNCATE PLAN ADVISOR;
 
-delPlanAdvisorStatement
-    : DELETE PLAN ADVISOR string;
+alterPlanAdvisorDropStatement
+    : ALTER PLAN ADVISOR DROP string;
 
 showPlanAdvisorStatement
     : SHOW PLAN ADVISOR;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -59,7 +59,7 @@ class ParserTest {
 
     @Test
     void test() {
-        String sql = "add into plan advisor  " +
+        String sql = "alter plan advisor add " +
                 "select count(*) from customer join " +
                 "(select * from skew_tbl where c_custkey_skew = 100) t on abs(c_custkey) = c_custkey_skew;";
         SqlParser.parse(sql, new SessionVariable());

--- a/test/sql/test_feedback/R/test_agg_feedback
+++ b/test/sql/test_feedback/R/test_agg_feedback
@@ -129,7 +129,7 @@ function: assert_explain_not_contains("select count(*) from pre_agg_case group b
 -- result:
 None
 -- !result
-add into plan advisor select count(*) from pre_agg_case group by c3;
+alter plan advisor add select count(*) from pre_agg_case group by c3;
 -- result:
 [REGEX]Add query into plan advisor in FE
 -- !result
@@ -137,7 +137,7 @@ function: assert_explain_contains("select count(*) from pre_agg_case group by c3
 -- result:
 None
 -- !result
-clear plan advisor;
+truncate plan advisor;
 -- result:
 [REGEX]Clear all plan advisor in FE
 -- !result

--- a/test/sql/test_feedback/R/test_external_table_join_feedback
+++ b/test/sql/test_feedback/R/test_external_table_join_feedback
@@ -44,7 +44,7 @@ function: assert_explain_not_contains("select count(*) from (select * from icebe
 -- result:
 None
 -- !result
-add into plan advisor select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t;
+alter plan advisor add select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t;
 -- result:
 [REGEX]Add query into plan advisor in FE*
 -- !result
@@ -52,7 +52,7 @@ function: assert_explain_contains("select count(*) from (select * from iceberg_c
 -- result:
 None
 -- !result
-clear plan advisor;
+truncate plan advisor;
 -- result:
 [REGEX]Clear all plan advisor in FE*
 -- !result

--- a/test/sql/test_feedback/R/test_join_feedback
+++ b/test/sql/test_feedback/R/test_join_feedback
@@ -45,7 +45,7 @@ function: assert_explain_not_contains("select count(*) from (select * from c1_sk
 -- result:
 None
 -- !result
-add into plan advisor select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t;
+alter plan advisor add select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t;
 -- result:
 [REGEX]Add query into plan advisor in FE.*
 -- !result
@@ -57,7 +57,7 @@ function: assert_trace_values_contains("select count(*) from (select * from c1_s
 -- result:
 None
 -- !result
-clear plan advisor;
+truncate plan advisor;
 -- result:
 [REGEX]Clear all plan advisor in FE.*
 -- !result

--- a/test/sql/test_feedback/T/test_agg_feedback
+++ b/test/sql/test_feedback/T/test_agg_feedback
@@ -53,6 +53,6 @@ set enable_plan_advisor=true;
 set enable_plan_analyzer=true;
 set enable_global_runtime_filter = false;
 function: assert_explain_not_contains("select count(*) from pre_agg_case group by c3", "StreamingAggTuningGuide")
-add into plan advisor select count(*) from pre_agg_case group by c3;
+alter plan advisor add select count(*) from pre_agg_case group by c3;
 function: assert_explain_contains("select count(*) from pre_agg_case group by c3", "StreamingAggTuningGuide")
-clear plan advisor;
+truncate plan advisor;

--- a/test/sql/test_feedback/T/test_external_table_join_feedback
+++ b/test/sql/test_feedback/T/test_external_table_join_feedback
@@ -21,12 +21,12 @@ use iceberg_catalog_${uuid0}.iceberg_db_${uuid0};
 set catalog default_catalog;
 function: assert_explain_not_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
 
-add into plan advisor select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t;
+alter plan advisor add select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t;
 
 
 function: assert_explain_contains("select count(*) from (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew t1 join (select * from iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2 where t1.c1 = 'a') t", "RightChildEstimationErrorTuningGuide")
 
-clear plan advisor;
+truncate plan advisor;
 drop table iceberg_catalog_${uuid0}.iceberg_db_${uuid0}.c1_skew;
 drop database iceberg_catalog_${uuid0}.iceberg_db_${uuid0};
 drop catalog iceberg_catalog_${uuid0};

--- a/test/sql/test_feedback/T/test_join_feedback
+++ b/test/sql/test_feedback/T/test_join_feedback
@@ -24,7 +24,7 @@ insert into c1_skew values(50001, 'f', 50001, 50001);
 analyze full table c1_skew with sync mode;
 set enable_global_runtime_filter = false;
 function: assert_explain_not_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
-add into plan advisor select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t;
+alter plan advisor add select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t;
 function: assert_explain_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
 function: assert_trace_values_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "RightChildEstimationErrorTuningGuide")
-clear plan advisor;
+truncate plan advisor;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. `ADD INTO PLAN ADVISOR queryStatement;` -> `ALTER PLAN ADVISOR ADD queryStatement;`
2. `CLEAR PLAN ADVISOR;` -> `TRUNCATE PLAN ADVISOR`
3. `DELETE PLAN ADVISOR string;` -> `ALTER PLAN ADVISOR DROP string;`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0