### PR TITLE
[Enhancement] MinMaxPredicate support handing null

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -230,11 +230,13 @@ void ScanOperator::_detach_chunk_sources() {
 
 void ScanOperator::update_exec_stats(RuntimeState* state) {
     auto ctx = state->query_ctx();
-    ctx->update_pull_rows_stats(_plan_node_id, _pull_row_num_counter->value());
-    if (ctx != nullptr && _bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
-        int64_t input_rows = _bloom_filter_eval_context.join_runtime_filter_input_counter->value();
-        int64_t output_rows = _bloom_filter_eval_context.join_runtime_filter_output_counter->value();
-        ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
+    if (ctx != nullptr) {
+        ctx->update_pull_rows_stats(_plan_node_id, _pull_row_num_counter->value());
+        if (_bloom_filter_eval_context.join_runtime_filter_input_counter != nullptr) {
+            int64_t input_rows = _bloom_filter_eval_context.join_runtime_filter_input_counter->value();
+            int64_t output_rows = _bloom_filter_eval_context.join_runtime_filter_output_counter->value();
+            ctx->update_rf_filter_stats(_plan_node_id, input_rows - output_rows);
+        }
     }
 }
 

--- a/be/src/exprs/min_max_predicate.h
+++ b/be/src/exprs/min_max_predicate.h
@@ -86,7 +86,8 @@ public:
                 }
             }
         } else {
-            const CppType* __restrict__ data = ColumnHelper::get_data_column_by_type<Type>(col.get())->get_data().data();
+            const CppType* __restrict__ data =
+                    ColumnHelper::get_data_column_by_type<Type>(col.get())->get_data().data();
             for (int i = 0; i < size; i++) {
                 res[i] = (data[i] >= _min_value && data[i] <= _max_value);
             }

--- a/be/src/exprs/min_max_predicate.h
+++ b/be/src/exprs/min_max_predicate.h
@@ -20,7 +20,6 @@
 #include "types/large_int_value.h"
 
 namespace starrocks {
-// ========================================================
 template <LogicalType Type>
 class MinMaxPredicate : public Expr {
 public:

--- a/be/src/exprs/min_max_predicate.h
+++ b/be/src/exprs/min_max_predicate.h
@@ -1,0 +1,148 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/type_traits.h"
+#include "exprs/expr.h"
+#include "exprs/runtime_filter.h"
+#include "types/large_int_value.h"
+
+namespace starrocks {
+// ========================================================
+template <LogicalType Type>
+class MinMaxPredicate : public Expr {
+public:
+    using CppType = RunTimeCppType<Type>;
+    MinMaxPredicate(SlotId slot_id, const CppType& min_value, const CppType& max_value, bool has_null)
+            : Expr(TypeDescriptor(Type), false),
+              _slot_id(slot_id),
+              _min_value(min_value),
+              _max_value(max_value),
+              _has_null(has_null) {
+        _node_type = TExprNodeType::RUNTIME_FILTER_MIN_MAX_EXPR;
+    }
+    ~MinMaxPredicate() override = default;
+    Expr* clone(ObjectPool* pool) const override {
+        return pool->add(new MinMaxPredicate<Type>(_slot_id, _min_value, _max_value, _has_null));
+    }
+
+    bool is_constant() const override { return false; }
+    bool is_bound(const std::vector<TupleId>& tuple_ids) const override { return false; }
+    bool has_null() const { return _has_null; }
+
+    StatusOr<ColumnPtr> evaluate_with_filter(ExprContext* context, Chunk* ptr, uint8_t* filter) override {
+        const ColumnPtr col = ptr->get_column_by_slot_id(_slot_id);
+        size_t size = col->size();
+
+        std::shared_ptr<BooleanColumn> result(new BooleanColumn(size, 1));
+        uint8_t* res = result->get_data().data();
+
+        if (col->only_null()) {
+            if (!_has_null) {
+                memset(res, 0x0, size);
+            }
+            return result;
+        }
+
+        if (col->is_constant()) {
+            CppType value = ColumnHelper::get_const_value<Type>(col);
+            if (!(value >= _min_value && value <= _max_value)) {
+                memset(res, 0x0, size);
+            }
+            return result;
+        }
+
+        // NOTE(yan): make sure following code can be compiled into SIMD instructions:
+        // in original version, we use
+        //   1. memcpy filter -> res
+        //   2. res[i] = res[i] && (null_data[i] || (data[i] >= _min_value && data[i] <= _max_value));
+        // but they can not be compiled into SIMD instructions.
+        if (col->is_nullable() && col->has_null()) {
+            auto tmp = ColumnHelper::as_raw_column<NullableColumn>(col);
+            uint8_t* __restrict__ null_data = tmp->null_column_data().data();
+            CppType* __restrict__ data = ColumnHelper::cast_to_raw<Type>(tmp->data_column())->get_data().data();
+            for (int i = 0; i < size; i++) {
+                res[i] = (data[i] >= _min_value && data[i] <= _max_value);
+            }
+
+            if (_has_null) {
+                for (int i = 0; i < size; i++) {
+                    res[i] = res[i] | null_data[i];
+                }
+            } else {
+                for (int i = 0; i < size; i++) {
+                    res[i] = res[i] & !null_data[i];
+                }
+            }
+        } else {
+            const CppType* __restrict__ data = ColumnHelper::get_data_column_by_type<Type>(col.get())->get_data().data();
+            for (int i = 0; i < size; i++) {
+                res[i] = (data[i] >= _min_value && data[i] <= _max_value);
+            }
+        }
+
+        // NOTE(yan): filter can be used optionally.
+        // if (filter != nullptr) {
+        //     for (int i = 0; i < size; i++) {
+        //         res[i] = res[i] & filter[i];
+        //     }
+        // }
+
+        return result;
+    }
+
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
+        return evaluate_with_filter(context, ptr, nullptr);
+    }
+
+    int get_slot_ids(std::vector<SlotId>* slot_ids) const override {
+        slot_ids->emplace_back(_slot_id);
+        return 1;
+    }
+
+    std::string debug_string() const override {
+        std::stringstream out;
+        auto expr_debug_string = Expr::debug_string();
+        out << "MinMaxPredicate (type=" << Type << ", slot_id=" << _slot_id << ", has_null=" << _has_null
+            << ", min=" << _min_value << ", max=" << _max_value << ", expr(" << expr_debug_string << "))";
+        return out.str();
+    }
+
+private:
+    SlotId _slot_id;
+    const CppType _min_value;
+    const CppType _max_value;
+    bool _has_null = false;
+};
+
+class MinMaxPredicateBuilder {
+public:
+    MinMaxPredicateBuilder(ObjectPool* pool, SlotId slot_id, const JoinRuntimeFilter* filter)
+            : _pool(pool), _slot_id(slot_id), _filter(filter) {}
+
+    template <LogicalType ltype>
+    Expr* operator()() {
+        auto* bloom_filter = (RuntimeBloomFilter<ltype>*)(_filter);
+        return _pool->add(new MinMaxPredicate<ltype>(_slot_id, bloom_filter->min_value(), bloom_filter->max_value(),
+                                                     bloom_filter->has_null()));
+    }
+
+private:
+    ObjectPool* _pool;
+    SlotId _slot_id;
+    const JoinRuntimeFilter* _filter;
+};
+
+} // namespace starrocks

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -22,6 +22,7 @@
 #include "exprs/dictmapping_expr.h"
 #include "exprs/in_const_predicate.hpp"
 #include "exprs/literal.h"
+#include "exprs/min_max_predicate.h"
 #include "exprs/runtime_filter.h"
 #include "exprs/runtime_filter_layout.h"
 #include "gen_cpp/RuntimeFilter_types.h"
@@ -778,113 +779,10 @@ void RuntimeFilterProbeDescriptor::set_shared_runtime_filter(const std::shared_p
     }
 }
 
-// ========================================================
-template <LogicalType Type>
-class MinMaxPredicate : public Expr {
-public:
-    using CppType = RunTimeCppType<Type>;
-    MinMaxPredicate(SlotId slot_id, const CppType& min_value, const CppType& max_value)
-            : Expr(TypeDescriptor(Type), false), _slot_id(slot_id), _min_value(min_value), _max_value(max_value) {
-        _node_type = TExprNodeType::RUNTIME_FILTER_MIN_MAX_EXPR;
-    }
-    ~MinMaxPredicate() override = default;
-    Expr* clone(ObjectPool* pool) const override {
-        return pool->add(new MinMaxPredicate<Type>(_slot_id, _min_value, _max_value));
-    }
-
-    bool is_constant() const override { return false; }
-    bool is_bound(const std::vector<TupleId>& tuple_ids) const override { return false; }
-
-    StatusOr<ColumnPtr> evaluate_with_filter(ExprContext* context, Chunk* ptr, uint8_t* filter) override {
-        const ColumnPtr col = ptr->get_column_by_slot_id(_slot_id);
-        size_t size = col->size();
-
-        std::shared_ptr<BooleanColumn> result(new BooleanColumn(size, 1));
-        uint8_t* res = result->get_data().data();
-
-        if (col->only_null()) {
-            return result;
-        }
-
-        if (col->is_constant()) {
-            CppType value = ColumnHelper::get_const_value<Type>(col);
-            if (!(value >= _min_value && value <= _max_value)) {
-                memset(res, 0x0, size);
-            }
-            return result;
-        }
-
-        // NOTE(yan): make sure following code can be compiled into SIMD instructions:
-        // in original version, we use
-        //   1. memcpy filter -> res
-        //   2. res[i] = res[i] && (null_data[i] || (data[i] >= _min_value && data[i] <= _max_value));
-        // but they can not be compiled into SIMD instructions.
-        if (col->is_nullable()) {
-            auto tmp = ColumnHelper::as_raw_column<NullableColumn>(col);
-            uint8_t* __restrict__ null_data = tmp->null_column_data().data();
-            CppType* __restrict__ data = ColumnHelper::cast_to_raw<Type>(tmp->data_column())->get_data().data();
-            for (int i = 0; i < size; i++) {
-                res[i] = (data[i] >= _min_value && data[i] <= _max_value);
-            }
-            // we take null as true value.
-            for (int i = 0; i < size; i++) {
-                res[i] = res[i] | null_data[i];
-            }
-        } else {
-            CppType* data = ColumnHelper::cast_to_raw<Type>(col)->get_data().data();
-            for (int i = 0; i < size; i++) {
-                res[i] = (data[i] >= _min_value && data[i] <= _max_value);
-            }
-        }
-
-        // NOTE(yan): filter can be used optionally.
-        // if (filter != nullptr) {
-        //     for (int i = 0; i < size; i++) {
-        //         res[i] = res[i] & filter[i];
-        //     }
-        // }
-
-        return result;
-    }
-
-    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
-        return evaluate_with_filter(context, ptr, nullptr);
-    }
-
-    int get_slot_ids(std::vector<SlotId>* slot_ids) const override {
-        slot_ids->emplace_back(_slot_id);
-        return 1;
-    }
-
-private:
-    SlotId _slot_id;
-    const CppType _min_value;
-    const CppType _max_value;
-};
-
-class MinMaxPredicateBuilder {
-public:
-    MinMaxPredicateBuilder(ObjectPool* pool, SlotId slot_id, const JoinRuntimeFilter* filter)
-            : _pool(pool), _slot_id(slot_id), _filter(filter) {}
-
-    template <LogicalType ltype>
-    Expr* operator()() {
-        auto* bloom_filter = (RuntimeBloomFilter<ltype>*)(_filter);
-        MinMaxPredicate<ltype>* p =
-                _pool->add(new MinMaxPredicate<ltype>(_slot_id, bloom_filter->min_value(), bloom_filter->max_value()));
-        return p;
-    }
-
-private:
-    ObjectPool* _pool;
-    SlotId _slot_id;
-    const JoinRuntimeFilter* _filter;
-};
-
 void RuntimeFilterHelper::create_min_max_value_predicate(ObjectPool* pool, SlotId slot_id, LogicalType slot_type,
                                                          const JoinRuntimeFilter* filter, Expr** min_max_predicate) {
     *min_max_predicate = nullptr;
-    if (filter == nullptr || filter->has_null()) return;
+    if (filter == nullptr) return;
     if (slot_type == TYPE_CHAR || slot_type == TYPE_VARCHAR) return;
     auto res = type_dispatch_filter(slot_type, (Expr*)nullptr, MinMaxPredicateBuilder(pool, slot_id, filter));
     *min_max_predicate = res;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -154,6 +154,7 @@ set(EXEC_FILES
         ./exprs/runtime_filter_test.cpp
         ./exprs/subfield_expr_test.cpp
         ./exprs/vectorized_literal_test.cpp
+        ./exprs/min_max_predicate_test.cpp
         ./formats/csv/array_converter_test.cpp
         ./formats/csv/boolean_converter_test.cpp
         ./formats/csv/csv_file_writer_test.cpp

--- a/be/test/exprs/min_max_predicate_test.cpp
+++ b/be/test/exprs/min_max_predicate_test.cpp
@@ -228,6 +228,11 @@ TEST_F(MinMaxPredicateTest, other) {
     auto* expr2 = reinterpret_cast<MinMaxPredicate<TYPE_INT>*>(
             MinMaxPredicateBuilder(&_pool, _slot_id, &_nullable_rf).operator()<TYPE_INT>());
     ASSERT_TRUE(expr2->has_null());
+
+    std::vector<SlotId> slot_ids;
+    auto ret = expr2->get_slot_ids(&slot_ids);
+    ASSERT_EQ(ret, 1);
+    ASSERT_EQ(slot_ids, std::vector<SlotId>{1});
 }
 
 } // namespace starrocks

--- a/be/test/exprs/min_max_predicate_test.cpp
+++ b/be/test/exprs/min_max_predicate_test.cpp
@@ -210,4 +210,24 @@ TEST_F(MinMaxPredicateTest, debug_string) {
               "node-type=RUNTIME_FILTER_MIN_MAX_EXPR codegen=false))");
 }
 
+TEST_F(MinMaxPredicateTest, clone) {
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_rf).operator()<TYPE_INT>();
+    Expr* clone_expr = expr->clone(&_pool);
+    ASSERT_EQ(clone_expr->debug_string(),
+              "MinMaxPredicate (type=5, slot_id=1, has_null=0, min=10, max=20, expr( type=INT "
+              "node-type=RUNTIME_FILTER_MIN_MAX_EXPR codegen=false))");
+}
+
+TEST_F(MinMaxPredicateTest, other) {
+    auto* expr1 = reinterpret_cast<MinMaxPredicate<TYPE_INT>*>(
+            MinMaxPredicateBuilder(&_pool, _slot_id, &_rf).operator()<TYPE_INT>());
+    ASSERT_FALSE(expr1->is_constant());
+    ASSERT_FALSE(expr1->is_bound({}));
+    ASSERT_FALSE(expr1->has_null());
+
+    auto* expr2 = reinterpret_cast<MinMaxPredicate<TYPE_INT>*>(
+            MinMaxPredicateBuilder(&_pool, _slot_id, &_nullable_rf).operator()<TYPE_INT>());
+    ASSERT_TRUE(expr2->has_null());
+}
+
 } // namespace starrocks

--- a/be/test/exprs/min_max_predicate_test.cpp
+++ b/be/test/exprs/min_max_predicate_test.cpp
@@ -1,0 +1,213 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/min_max_predicate.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/column_test_helper.h"
+
+namespace starrocks {
+
+class MinMaxPredicateTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _rf.init(100);
+        _rf.insert(10);
+        _rf.insert(20);
+
+        _nullable_rf.init(100);
+        _nullable_rf.insert(10);
+        _nullable_rf.insert(20);
+        _nullable_rf.insert_null();
+
+        _chunk = std::make_shared<Chunk>();
+        _slot_id = 1;
+    }
+
+protected:
+    RuntimeBloomFilter<TYPE_INT> _rf;
+    RuntimeBloomFilter<TYPE_INT> _nullable_rf;
+    ObjectPool _pool;
+    ChunkPtr _chunk;
+    ColumnPtr _column;
+    SlotId _slot_id;
+};
+
+// rt has no null, col is not nullable
+TEST_F(MinMaxPredicateTest, rt_has_no_null_1) {
+    std::vector<int32_t> values = {1, 10, 15, 20, 25};
+    _column = ColumnTestHelper::build_column<int32_t>(values);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[0, 1, 1, 1, 0]");
+}
+
+// rt has no null, col is nullable, there is no null in column
+TEST_F(MinMaxPredicateTest, rt_has_no_null_2) {
+    std::vector<int32_t> values = {1, 10, 15, 20, 25};
+    std::vector<uint8_t> null_values = {0, 0, 0, 0, 0};
+    _column = ColumnTestHelper::build_nullable_column<int32_t>(values, null_values);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[0, 1, 1, 1, 0]");
+}
+
+// rt has no null, col is nullable, there is null in column
+TEST_F(MinMaxPredicateTest, rt_has_no_null_3) {
+    std::vector<int32_t> values = {1, 10, 15, 20, 25};
+    std::vector<uint8_t> null_values = {0, 0, 0, 1, 0};
+    _column = ColumnTestHelper::build_nullable_column<int32_t>(values, null_values);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[0, 1, 1, 0, 0]");
+}
+
+// rt has no null, col is only null
+TEST_F(MinMaxPredicateTest, rt_has_no_null_4) {
+    _column = ColumnHelper::create_const_null_column(5);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[0, 0, 0, 0, 0]");
+}
+
+// rt has no null, col is const not null value, and exist in rt
+TEST_F(MinMaxPredicateTest, rt_has_no_null_5) {
+    _column = ColumnHelper::create_const_column<TYPE_INT>(15, 5);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[1, 1, 1, 1, 1]");
+}
+
+// rt has no null, col is const not null value, and not exist in rt
+TEST_F(MinMaxPredicateTest, rt_has_no_null_6) {
+    _column = ColumnHelper::create_const_column<TYPE_INT>(30, 5);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[0, 0, 0, 0, 0]");
+}
+
+// rt has null, col is not nullable
+TEST_F(MinMaxPredicateTest, rt_has_null_1) {
+    std::vector<int32_t> values = {1, 10, 15, 20, 25};
+    _column = ColumnTestHelper::build_column<int32_t>(values);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_nullable_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[0, 1, 1, 1, 0]");
+}
+
+// rt has null, col is nullable, there is no null in col
+TEST_F(MinMaxPredicateTest, rt_has_null_2) {
+    std::vector<int32_t> values = {1, 10, 15, 20, 25};
+    std::vector<uint8_t> null_values = {0, 0, 0, 0, 0};
+    _column = ColumnTestHelper::build_nullable_column<int32_t>(values, null_values);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_nullable_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[0, 1, 1, 1, 0]");
+}
+
+// rt has null, col is nullable, there is null in col
+TEST_F(MinMaxPredicateTest, rt_has_null_3) {
+    std::vector<int32_t> values = {1, 10, 15, 20, 25};
+    std::vector<uint8_t> null_values = {0, 0, 0, 0, 1};
+    _column = ColumnTestHelper::build_nullable_column<int32_t>(values, null_values);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_nullable_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[0, 1, 1, 1, 1]");
+}
+
+// rt has null, col is only null
+TEST_F(MinMaxPredicateTest, rt_has_null_4) {
+    _column = ColumnHelper::create_const_null_column(5);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_nullable_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[1, 1, 1, 1, 1]");
+}
+
+// rt has null, col is const not null value, and exist in rt
+TEST_F(MinMaxPredicateTest, rt_has_null_5) {
+    _column = ColumnHelper::create_const_column<TYPE_INT>(15, 5);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_nullable_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[1, 1, 1, 1, 1]");
+}
+
+// rt has null, col is const not null value, and not exist in rt
+TEST_F(MinMaxPredicateTest, rt_has_null_6) {
+    _column = ColumnHelper::create_const_column<TYPE_INT>(30, 5);
+    _chunk->append_column(_column, _slot_id);
+
+    Expr* expr = MinMaxPredicateBuilder(&_pool, _slot_id, &_nullable_rf).operator()<TYPE_INT>();
+    auto st = expr->evaluate_checked(nullptr, _chunk.get());
+
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(st.value()->debug_string(), "[0, 0, 0, 0, 0]");
+}
+
+TEST_F(MinMaxPredicateTest, debug_string) {
+    Expr* expr1 = MinMaxPredicateBuilder(&_pool, _slot_id, &_rf).operator()<TYPE_INT>();
+    Expr* expr2 = MinMaxPredicateBuilder(&_pool, _slot_id, &_nullable_rf).operator()<TYPE_INT>();
+    ASSERT_EQ(expr1->debug_string(),
+              "MinMaxPredicate (type=5, slot_id=1, has_null=0, min=10, max=20, expr( type=INT "
+              "node-type=RUNTIME_FILTER_MIN_MAX_EXPR codegen=false))");
+    ASSERT_EQ(expr2->debug_string(),
+              "MinMaxPredicate (type=5, slot_id=1, has_null=1, min=10, max=20, expr( type=INT "
+              "node-type=RUNTIME_FILTER_MIN_MAX_EXPR codegen=false))");
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`MinMaxPredicate` is generated by runtime filter and then push down to `scanner`, but if runtime filter has null, the `MinMaxPredicate` will not be generated.

This PR will remove this `not null` restriction.

## What I'm doing:

* Put `MinMaxPredicate` into a separate file.
* `MinMaxPredicate` support handing null.
* Add more unit test for `MinMaxPredicate`
* remove this `not null` restriction for generate `MinMaxPredicate`.
* Fix the bug of checking `ctx!=nullptr`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0