### PR TITLE
[BugFix] Add lock to prevent concurrency issue in committed_rs_map

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -633,7 +633,7 @@ bool Tablet::add_committed_rowset(const RowsetSharedPtr& rowset) {
     //   2. Removing from _committed_rs_map when publishing a transaction.
     //   3. Clear _committed_rs_map during a schema update.
     // Add and Delete from _committed_rs_map is thread safe but there are concurrent issue between
-    // add(delete) and clear operation. 
+    // add(delete) and clear operation.
     // So we use schema_lock to prevent the concurrent issue.
     std::shared_lock l(_schema_lock);
     if (_committed_rs_map.size() >= config::max_committed_without_schema_rowset) {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -628,6 +628,14 @@ Status Tablet::add_inc_rowset(const RowsetSharedPtr& rowset, int64_t version) {
 }
 
 bool Tablet::add_committed_rowset(const RowsetSharedPtr& rowset) {
+    // There are several scenarios where _committed_rs_map might be modified:
+    //   1. Adding to _committed_rs_map when committing a transaction.
+    //   2. Removing from _committed_rs_map when publishing a transaction.
+    //   3. Removing from _committed_rs_map during a schema update.
+    // To avoid concurrency issues, the _schema_lock is used. While the meta_lock might involve I/O operations, _schema_lock
+    // only involves I/O during schema updates, which occur after an alter operation and are relatively infrequent.
+    // Therefore, _schema_lock is used instead of meta_lock.
+    std::lock_guard l1(_schema_lock);
     if (_committed_rs_map.size() >= config::max_committed_without_schema_rowset) {
         VLOG(2) << "tablet: " << tablet_id()
                 << " too many committed without schema rowset : " << _committed_rs_map.size();
@@ -642,6 +650,7 @@ bool Tablet::add_committed_rowset(const RowsetSharedPtr& rowset) {
 }
 
 void Tablet::erase_committed_rowset(const RowsetSharedPtr& rowset) {
+    std::lock_guard l1(_schema_lock);
     if (rowset != nullptr) {
         _committed_rs_map.erase(rowset->rowset_id());
     }

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -278,9 +278,6 @@ Status TxnManager::commit_txn(KVStore* meta, TPartitionId partition_id, TTransac
                            !rowset_ptr->rowset_meta()->get_meta_pb_without_schema().has_txn_meta() &&
                            !tablet->is_update_schema_running();
         if (skip_schema) {
-            // avoid `update_max_version_schema` and `commit_txn` run concurrency, so hold a read
-            // lock for `schema_lock` is enough
-            std::shared_lock l(tablet->get_schema_lock());
             skip_schema = tablet->add_committed_rowset(rowset_ptr);
             if (skip_schema) {
                 rowset_ptr->rowset_meta()->set_skip_tablet_schema(true);


### PR DESCRIPTION
## Why I'm doing:
There are several scenarios where _committed_rs_map might be modified:
1. Adding to _committed_rs_map when committing a transaction.
2. Removing from _committed_rs_map when publishing a transaction.
3. Clear _committed_rs_map during a schema update.

Add and Delete from _committed_rs_map is thread safe but there are concurrent issue between add(delete) and clear operation. 

## What I'm doing:
Add `schema_lock` to prevent concurrency issue.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0