### PR TITLE
[Enhancement] Change fe-core compile source/target to 17

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -231,7 +231,7 @@ echo "start time: $(date), server uptime: $(uptime)"
 
 # StarRocksFE java process will write its process id into $pidfile
 if [ ${RUN_DAEMON} -eq 1 ]; then
-    nohup $LIMIT $JAVA $final_java_opt com.starrocks.StarRocksFE ${HELPER} ${HOST_TYPE} ${CLUSTER_SNAPSHOT} "$@" </dev/null &
+    nohup $LIMIT $JAVA $final_java_opt --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED com.starrocks.StarRocksFE ${HELPER} ${HOST_TYPE} ${CLUSTER_SNAPSHOT} "$@" </dev/null &
 else
-    exec $LIMIT $JAVA $final_java_opt com.starrocks.StarRocksFE ${HELPER} ${HOST_TYPE} ${CLUSTER_SNAPSHOT} "$@" </dev/null
+    exec $LIMIT $JAVA $final_java_opt --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED com.starrocks.StarRocksFE ${HELPER} ${HOST_TYPE} ${CLUSTER_SNAPSHOT} "$@" </dev/null
 fi

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -231,7 +231,7 @@ echo "start time: $(date), server uptime: $(uptime)"
 
 # StarRocksFE java process will write its process id into $pidfile
 if [ ${RUN_DAEMON} -eq 1 ]; then
-    nohup $LIMIT $JAVA $final_java_opt --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED com.starrocks.StarRocksFE ${HELPER} ${HOST_TYPE} ${CLUSTER_SNAPSHOT} "$@" </dev/null &
+    nohup $LIMIT $JAVA $final_java_opt com.starrocks.StarRocksFE ${HELPER} ${HOST_TYPE} ${CLUSTER_SNAPSHOT} "$@" </dev/null &
 else
-    exec $LIMIT $JAVA $final_java_opt --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED com.starrocks.StarRocksFE ${HELPER} ${HOST_TYPE} ${CLUSTER_SNAPSHOT} "$@" </dev/null
+    exec $LIMIT $JAVA $final_java_opt com.starrocks.StarRocksFE ${HELPER} ${HOST_TYPE} ${CLUSTER_SNAPSHOT} "$@" </dev/null
 fi

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -37,7 +37,7 @@ under the License.
     <properties>
         <starrocks.home>${basedir}/../../</starrocks.home>
         <fe_ut_parallel>${env.FE_UT_PARALLEL}</fe_ut_parallel>
-        <jacoco.version>0.8.7</jacoco.version>
+        <jacoco.version>0.8.8</jacoco.version>
         <iceberg.version>1.6.0</iceberg.version>
         <paimon.version>0.8.2</paimon.version>
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>
@@ -1134,7 +1134,7 @@ under the License.
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>${jacoco.version}</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -340,18 +340,6 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>de.javakaffee</groupId>
-            <artifactId>kryo-serializers</artifactId>
-            <version>0.45</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.esotericsoftware</groupId>
-                    <artifactId>kryo</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>io.delta</groupId>
             <artifactId>delta-kernel-api</artifactId>
             <version>${delta-kernel.version}</version>

--- a/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/MetadataParser.java
@@ -26,7 +26,6 @@ import com.starrocks.rpc.ConfigurableSerDesFactory;
 import com.starrocks.thrift.TIcebergMetadata;
 import com.starrocks.thrift.TMetadataEntry;
 import com.starrocks.thrift.TResultBatch;
-import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.metrics.ScanMetrics;
 import org.apache.iceberg.metrics.ScanMetricsUtil;

--- a/fe/fe-core/src/main/java/org/apache/iceberg/UnmodifiableCollectionsSerializer.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/UnmodifiableCollectionsSerializer.java
@@ -1,0 +1,173 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.apache.iceberg;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * copy from <a href="https://github.com/opentripplanner/OpenTripPlanner/tree/dev-2.x/application/src/main/java/org/opentripplanner/kryo/UnmodifiableCollectionsSerializer.java">...</a>
+ * A kryo {@link Serializer} for unmodifiable {@link Collection}s and {@link Map}s created via
+ * {@link Collections}.
+ *
+ * @author <a href="mailto:martin.grotzke@javakaffee.de">Martin Grotzke</a>
+ */
+public class UnmodifiableCollectionsSerializer extends Serializer<Object> {
+
+    /**
+     * Creates a new {@link UnmodifiableCollectionsSerializer} and registers its serializer for the
+     * several unmodifiable Collections that can be created via {@link Collections}, including {@link
+     * Map}s.
+     *
+     * @param kryo the {@link Kryo} instance to set the serializer on.
+     * @see Collections#unmodifiableCollection(Collection)
+     * @see Collections#unmodifiableList(List)
+     * @see Collections#unmodifiableSet(Set)
+     * @see Collections#unmodifiableSortedSet(SortedSet)
+     * @see Collections#unmodifiableMap(Map)
+     * @see Collections#unmodifiableSortedMap(SortedMap)
+     */
+    public static void registerSerializers(Kryo kryo) {
+        UnmodifiableCollectionsSerializer serializer = new UnmodifiableCollectionsSerializer();
+        UnmodifiableCollection.values();
+        for (UnmodifiableCollection item : UnmodifiableCollection.values()) {
+            kryo.register(item.type, serializer);
+        }
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output, Object object) {
+        try {
+            UnmodifiableCollection unmodifiableCollection = UnmodifiableCollection.valueOfType(
+                    object.getClass()
+            );
+            // the ordinal could be replaced by s.th. else (e.g. a explicitely managed "id")
+            output.writeInt(unmodifiableCollection.ordinal(), true);
+            kryo.writeClassAndObject(output, getValues(object));
+        } catch (RuntimeException e) {
+            // Don't eat and wrap RuntimeExceptions because the ObjectBuffer.write...
+            // handles SerializationException specifically (resizing the buffer)...
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Object read(Kryo kryo, Input input, Class<Object> clazz) {
+        int ordinal = input.readInt(true);
+        UnmodifiableCollection unmodifiableCollection = UnmodifiableCollection.values()[ordinal];
+        Object sourceCollection = kryo.readClassAndObject(input);
+        return unmodifiableCollection.create(sourceCollection);
+    }
+
+    @Override
+    public Object copy(Kryo kryo, Object original) {
+        try {
+            UnmodifiableCollection unmodifiableCollection = UnmodifiableCollection.valueOfType(
+                    original.getClass()
+            );
+            Object sourceCollectionCopy = kryo.copy(getValues(original));
+            return unmodifiableCollection.create(sourceCollectionCopy);
+        } catch (RuntimeException e) {
+            // Don't eat and wrap RuntimeExceptions
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Collection<?> getValues(Object coll) {
+        return new ArrayList<>((Collection) coll);
+    }
+
+    private enum UnmodifiableCollection {
+        COLLECTION(Collections.unmodifiableCollection(Arrays.asList("")).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableCollection((Collection<?>) sourceCollection);
+            }
+        },
+        RANDOM_ACCESS_LIST(Collections.unmodifiableList(new ArrayList<Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableList((List<?>) sourceCollection);
+            }
+        },
+        LIST(Collections.unmodifiableList(new LinkedList<Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableList((List<?>) sourceCollection);
+            }
+        },
+        SET(Collections.unmodifiableSet(new HashSet<Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableSet((Set<?>) sourceCollection);
+            }
+        },
+        SORTED_SET(Collections.unmodifiableSortedSet(new TreeSet<Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableSortedSet((SortedSet<?>) sourceCollection);
+            }
+        },
+        MAP(Collections.unmodifiableMap(new HashMap<Void, Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableMap((Map<?, ?>) sourceCollection);
+            }
+        },
+        SORTED_MAP(Collections.unmodifiableSortedMap(new TreeMap<Void, Void>()).getClass()) {
+            @Override
+            public Object create(Object sourceCollection) {
+                return Collections.unmodifiableSortedMap((SortedMap<?, ?>) sourceCollection);
+            }
+        };
+
+        private final Class<?> type;
+
+        UnmodifiableCollection(Class<?> type) {
+            this.type = type;
+        }
+
+        public abstract Object create(Object sourceCollection);
+
+        static UnmodifiableCollection valueOfType(Class<?> type) {
+            for (UnmodifiableCollection item : values()) {
+                if (item.type.equals(type)) {
+                    return item;
+                }
+            }
+            throw new IllegalArgumentException("The type " + type + " is not supported.");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeParquetHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeParquetHandlerTest.java
@@ -130,7 +130,7 @@ public class DeltaLakeParquetHandlerTest {
                 .expireAfterWrite(3600, TimeUnit.SECONDS)
                 .weigher((key, value) ->
                         Math.toIntExact(SizeEstimator.estimate(key) + SizeEstimator.estimate(value)))
-                .maximumWeight(1024 * 2)
+                .maximumWeight(400 * 2)
                 .concurrencyLevel(1)
                 .build(new CacheLoader<>() {
                     @NotNull

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -1380,7 +1380,9 @@ public class ScalarOperatorFunctionsTest {
         ConnectContext ctx = new ConnectContext(null);
         ctx.setThreadLocalInfo();
         ctx.setStartTime();
-        LocalDateTime expected = ctx.getStartTimeInstant().atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
+        Instant instant = ctx.getStartTimeInstant();
+        LocalDateTime expected = Instant.ofEpochSecond(instant.getEpochSecond(), instant.getNano() / 1000 * 1000)
+                .atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
         assertEquals(expected, ScalarOperatorFunctions.now(new ConstantOperator(6, Type.INT)).getDatetime());
     }
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -41,8 +41,8 @@ under the License.
     <properties>
         <starrocks.home>${basedir}/../</starrocks.home>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <jprotobuf.version>2.4.23</jprotobuf.version>
         <log4j.version>2.19.0</log4j.version>
         <jackson.version>2.15.2</jackson.version>


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. Change fe-core source/target version to 17, and the others(spark-dpp, hive-udf) still use 8.
2. Copy UnmodifiableCollectionsSerializer.java to our repository to fix compilable issue:
`Unable to make field final java.util.Collection java.util.Collections$UnmodifiableCollection.c accessible: module java.base does not "opens java.util" to unnamed module @61322f9d `
  Refer to https://github.com/magro/kryo-serializers/issues/131
3. Upgrade jacoco to 0.8.8
4. For the arrow flight server, users should add `--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED` to JAVA_OPTS 
  Refer to https://arrow.apache.org/docs/java/install.html
5. Fix some UT


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0