### PR TITLE
[Enhancement]support java style datetime formatter

### DIFF
--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -1240,10 +1240,12 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetimeWithFormat) {
         tc1->append(24 * 60 * 60);
         tc1->append(61 + 24 * 60 * 60);
         tc1->append(3789 + 24 * 60 * 60);
+        tc1->append(3789 + 24 * 60 * 60);
         auto tc2 = BinaryColumn::create();
         tc2->append("%Y-%m-%d %H:%i:%S");
         tc2->append("%Y-%m-%d %H:%i:%S");
         tc2->append("%Y-%m-%d %H:%i:%S");
+        tc2->append("yyyy/MM/dd %H:%i:%S");
 
         columns.emplace_back(tc1);
         columns.emplace_back(tc2);
@@ -1262,6 +1264,7 @@ TEST_F(TimeFunctionsTest, fromUnixToDatetimeWithFormat) {
         ASSERT_EQ("1970-01-01 16:00:00", v->get_data()[0]);
         ASSERT_EQ("1970-01-01 16:01:01", v->get_data()[1]);
         ASSERT_EQ("1970-01-01 17:03:09", v->get_data()[2]);
+        ASSERT_EQ("1970/01/01 17:03:09", v->get_data()[3]);
 
         ASSERT_TRUE(TimeFunctions::from_unix_close(_utils->get_fn_ctx(),
                                                    FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
@@ -3919,4 +3922,17 @@ TEST_F(TimeFunctionsTest, MakeDateTest) {
     ASSERT_TRUE(nullable_col->is_null(8));
     ASSERT_TRUE(nullable_col->is_null(9));
 }
+
+TEST_F(TimeFunctionsTest, ConvertFormatTest) {
+    ASSERT_EQ(TimeFunctions::convert_format(Slice("yyyy-MM-dd")), "%Y-%m-%d");
+    EXPECT_EQ(TimeFunctions::convert_format(Slice("yyyyMMdd")), "%Y%m%d");
+    EXPECT_EQ(TimeFunctions::convert_format(Slice("yyyy/MM/dd")), "%Y/%m/%d");
+    EXPECT_EQ(TimeFunctions::convert_format(Slice("yyyy#MM#dd")), "%Y#%m#%d");
+    EXPECT_EQ(TimeFunctions::convert_format(Slice("yyyy")), "%Y");
+    EXPECT_EQ(TimeFunctions::convert_format(Slice("MM")), "%m");
+    EXPECT_EQ(TimeFunctions::convert_format(Slice("dd")), "%d");
+    EXPECT_EQ(TimeFunctions::convert_format(Slice("HH:mm:ss")), "%H:%i:%s");
+    EXPECT_EQ(TimeFunctions::convert_format(Slice("yyyy-MM-dd HH:mm:ss")), "%Y-%m-%d %H:%i:%s");
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -36,6 +36,8 @@ import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.WeekFields;
+import java.util.HashMap;
+import java.util.Map;
 
 public class DateUtils {
     // These are marked as deprecated because they don't support year 0000 parsing
@@ -237,6 +239,46 @@ public class DateUtils {
 
     private static DateTimeFormatter unixDatetimeStrictFormatter(String pattern, boolean isOutputFormat) {
         return unixDatetimeFormatBuilder(pattern, isOutputFormat).toFormatter().withResolverStyle(ResolverStyle.STRICT);
+    }
+
+
+    public static String convertJavaStyleDateTimeFormat(String format) {
+        // Defining mapping rules
+        Map<String, String> formatMap = new HashMap<>();
+        formatMap.put("yyyy", "%Y");
+        formatMap.put("MM", "%m");
+        formatMap.put("dd", "%d");
+        formatMap.put("HH", "%H");
+        formatMap.put("mm", "%i");
+        formatMap.put("ss", "%s");
+
+        StringBuilder result = new StringBuilder();
+        int pos = 0;
+
+        while (pos < format.length()) {
+            boolean matched = false;
+
+            // Try to match the longest keyword
+            for (Map.Entry<String, String> entry : formatMap.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+
+                if (format.startsWith(key, pos)) {
+                    result.append(value);
+                    pos += key.length();
+                    matched = true;
+                    break;
+                }
+            }
+
+            // If no keyword is matched, keep the original character
+            if (!matched) {
+                result.append(format.charAt(pos));
+                pos++;
+            }
+        }
+
+        return result.toString();
     }
 
     public static DateTimeFormatterBuilder unixDatetimeFormatBuilder(String pattern, boolean isOutputFormat) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -405,14 +405,11 @@ public class ScalarOperatorFunctions {
         if (format.isEmpty()) {
             return ConstantOperator.createNull(Type.VARCHAR);
         }
-        // unix style
-        if (!SUPPORT_JAVA_STYLE_DATETIME_FORMATTER.contains(format.trim())) {
-            DateTimeFormatter builder = DateUtils.unixDatetimeFormatter(fmtLiteral.getVarchar());
-            return ConstantOperator.createVarchar(builder.format(date.getDatetime()));
-        } else {
-            String result = date.getDatetime().format(DateTimeFormatter.ofPattern(fmtLiteral.getVarchar()));
-            return ConstantOperator.createVarchar(result);
-        }
+        // format java datetime style
+        String javaStyleFormatter = DateUtils.convertJavaStyleDateTimeFormat(format);
+        // change to unix datetime style
+        DateTimeFormatter builder = DateUtils.unixDatetimeFormatter(javaStyleFormatter);
+        return ConstantOperator.createVarchar(builder.format(date.getDatetime()));
     }
 
     @ConstantFunction.List(list = {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -133,6 +133,10 @@ public class ConstantExpressionTest extends PlanTestBase {
                 "'20180808'");
 
         testFragmentPlanContainsConstExpr(
+                "select date_format('2018-08-08 07:16:19', 'yyyy/MM/dd');",
+                "'2018/08/08'");
+
+        testFragmentPlanContainsConstExpr(
                 "select date_format('2018-08-08 07:16:19', 'yyyy-MM-dd HH:mm:ss');",
                 "'2018-08-08 07:16:19'");
 


### PR DESCRIPTION
## Why I'm doing:
```
mysql> select from_unixtime(1733328215, 'yyyy');
+-----------------------------------+
| from_unixtime(1733328215, 'yyyy') |
+-----------------------------------+
| yyyy                              |
+-----------------------------------+
1 row in set (15.58 sec)

```
## What I'm doing:
```
mysql> select from_unixtime(1733328215, 'yyyy');
+-----------------------------------+
| from_unixtime(1733328215, 'yyyy') |
+-----------------------------------+
| 2024                              |
+-----------------------------------+
1 row in set (0.02 sec)

mysql> select from_unixtime(1733328215, 'yyyy-MM-dd');
+-----------------------------------------+
| from_unixtime(1733328215, 'yyyy-MM-dd') |
+-----------------------------------------+
| 2024-12-05                              |
+-----------------------------------------+
1 row in set (0.01 sec)

mysql> select from_unixtime(1196440219, 'yyyy-MM-dd');
+-----------------------------------------+
| from_unixtime(1196440219, 'yyyy-MM-dd') |
+-----------------------------------------+
| 2007-12-01                              |
+-----------------------------------------+
1 row in set (0.01 sec)

mysql> select from_unixtime(1196440219, 'MM-dd');
+------------------------------------+
| from_unixtime(1196440219, 'MM-dd') |
+------------------------------------+
| 12-01                              |
+------------------------------------+
1 row in set (0.02 sec)

mysql> select from_unixtime(1196440219, 'MMdd');
+-----------------------------------+
| from_unixtime(1196440219, 'MMdd') |
+-----------------------------------+
| 1201                              |
+-----------------------------------+
1 row in set (0.01 sec)

mysql> select from_unixtime(1196440219, 'MM:dd');
+------------------------------------+
| from_unixtime(1196440219, 'MM:dd') |
+------------------------------------+
| 12:01                              |
+------------------------------------+
1 row in set (0.01 sec)

mysql> select from_unixtime(1196440219, 'MM');
+---------------------------------+
| from_unixtime(1196440219, 'MM') |
+---------------------------------+
| 12                              |
+---------------------------------+
1 row in set (0.02 sec)
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0