### PR TITLE
[Enhancement] support async list hive partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -43,6 +43,16 @@ public class GetRemoteFilesParams {
         this.checkPartitionExistence = builder.checkPartitionExistence;
     }
 
+    public int getPartitionSize() {
+        if (partitionKeys != null) {
+            return partitionKeys.size();
+        }
+        if (partitionNames != null) {
+            return partitionNames.size();
+        }
+        return 0;
+    }
+
     public GetRemoteFilesParams copy() {
         return GetRemoteFilesParams.newBuilder()
                 .setPartitionKeys(partitionKeys)
@@ -186,8 +196,9 @@ public class GetRemoteFilesParams {
         List<GetRemoteFilesParams> result = new ArrayList<>();
         int currentSize = minSize;
         int start = 0;
-        while (start < partitionKeys.size()) {
-            int end = Math.min(start + currentSize, partitionKeys.size());
+        int partitionSize = getPartitionSize();
+        while (start < partitionSize) {
+            int end = Math.min(start + currentSize, partitionSize);
             result.add(sub(start, end));
             start = end;
             currentSize = Math.min(currentSize * 2, maxSize);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -17,6 +17,7 @@ package com.starrocks.connector;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class GetRemoteFilesParams {
@@ -56,8 +57,22 @@ public class GetRemoteFilesParams {
                 .build();
     }
 
+    public GetRemoteFilesParams sub(int start, int end) {
+        GetRemoteFilesParams p = copy();
+        if (p.partitionKeys != null) {
+            p.partitionKeys = p.partitionKeys.subList(start, end);
+        }
+        if (p.partitionNames != null) {
+            p.partitionNames = p.partitionNames.subList(start, end);
+        }
+        if (p.partitionAttachments != null) {
+            p.partitionAttachments = p.partitionAttachments.subList(start, end);
+        }
+        return p;
+    }
+
     @SuppressWarnings("unchecked")
-    public  <T extends GetRemoteFilesParams> T cast() {
+    public <T extends GetRemoteFilesParams> T cast() {
         return (T) this;
     }
 
@@ -165,5 +180,18 @@ public class GetRemoteFilesParams {
 
     public static Builder newBuilder() {
         return new Builder();
+    }
+
+    public List<GetRemoteFilesParams> partitionExponentially(int minSize, int maxSize) {
+        List<GetRemoteFilesParams> result = new ArrayList<>();
+        int currentSize = minSize;
+        int start = 0;
+        while (start < partitionKeys.size()) {
+            int end = Math.min(start + currentSize, partitionKeys.size());
+            result.add(sub(start, end));
+            start = end;
+            currentSize = Math.min(currentSize * 2, maxSize);
+        }
+        return result;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/HMSPartitionBasedRemoteInfoSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/HMSPartitionBasedRemoteInfoSource.java
@@ -1,0 +1,119 @@
+package com.starrocks.connector;
+
+import autovalue.shaded.com.google.common.common.base.Preconditions;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
+import com.starrocks.connector.hive.Partition;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+public class HMSPartitionBasedRemoteInfoSource extends AsyncTaskQueue<RemoteFileInfo> implements RemoteFileInfoSource {
+    public static final String HMS_PARTITIONS_LIST_FIES_ASYNC_GET = "HMS.PARTITIONS.LIST_FS_ASYNC.GET";
+    public static final String HMS_PARTITIONS_LIST_FILES_ASYNC_WAIT = "HMS.PARTITIONS.LIST_FS_ASYNC.WAIT";
+    public static final int HMS_PARTITION_BATCH_SIZE_MIN = 16;
+    public static final int HMS_PARTITION_BATCH_SIZE_MAX = 128;
+
+    private GetRemoteFilesParams params = null;
+    private Function<GetRemoteFilesParams, List<Partition>> fnGetPartitionValues = null;
+
+    private Function<Partition, RemoteFileInfo> fnGetRemoteFileInfo = null;
+
+    public HMSPartitionBasedRemoteInfoSource(Executor executor, GetRemoteFilesParams params,
+                                             Function<Partition, RemoteFileInfo> fnGetRemoteFileInfo,
+                                             Function<GetRemoteFilesParams, List<Partition>> fnGetPartitionValues) {
+        super(executor);
+        this.params = params;
+        this.fnGetPartitionValues = fnGetPartitionValues;
+        this.fnGetRemoteFileInfo = fnGetRemoteFileInfo;
+    }
+
+    @Override
+    public List<RemoteFileInfo> getOutputs(int maxSize) {
+        try (Timer ignored = Tracers.watchScope(Tracers.Module.EXTERNAL, HMS_PARTITIONS_LIST_FIES_ASYNC_GET)) {
+            return super.getOutputs(maxSize);
+        }
+    }
+
+    @Override
+    public boolean hasMoreOutput() {
+        // `hasMoreOutput` will trigger tasks to generate output.
+        try (Timer ignored = Tracers.watchScope(Tracers.Module.EXTERNAL, HMS_PARTITIONS_LIST_FILES_ASYNC_WAIT)) {
+            return super.hasMoreOutput();
+        }
+    }
+
+    @Override
+    public int computeOutputSize(RemoteFileInfo output) {
+        List<RemoteFileDesc> files = (output.getFiles());
+        int size = 1;
+        if (files != null) {
+            size = Math.max(size, files.size());
+        }
+        return size;
+    }
+
+    @Override
+    public RemoteFileInfo getOutput() {
+        List<RemoteFileInfo> res = getOutputs(1);
+        Preconditions.checkArgument(res.size() == 1);
+        return res.get(0);
+    }
+
+    class ListPartitionFilesTask implements AsyncTaskQueue.Task {
+        Partition partition;
+        Object attachment;
+
+        @Override
+        public List run() throws InterruptedException {
+            RemoteFileInfo remoteFileInfo = fnGetRemoteFileInfo.apply(partition);
+            remoteFileInfo.setAttachment(attachment);
+            return List.of(remoteFileInfo);
+        }
+    }
+
+    class GetPartitionValuesTask implements AsyncTaskQueue.Task<RemoteFileInfo> {
+        List<GetRemoteFilesParams> requests;
+        int usedIndex = 0;
+
+        @Override
+        public List<RemoteFileInfo> run() throws InterruptedException {
+            if (requests == null) {
+                requests = params.partitionExponentially(HMS_PARTITION_BATCH_SIZE_MIN, HMS_PARTITION_BATCH_SIZE_MAX);
+                usedIndex = 0;
+            }
+            return null;
+        }
+
+        @Override
+        public boolean isDone() {
+            return usedIndex >= requests.size();
+        }
+
+        @Override
+        public List subTasks() {
+            GetRemoteFilesParams params = requests.get(usedIndex);
+            usedIndex += 1;
+
+            List<Partition> partitions = fnGetPartitionValues.apply(params);
+            List attachments = params.getPartitionAttachments();
+
+            List<ListPartitionFilesTask> tasks = new ArrayList<>();
+            for (int i = 0; i < partitions.size(); i++) {
+                Partition p = partitions.get(i);
+                ListPartitionFilesTask t = new ListPartitionFilesTask();
+                t.partition = p;
+                t.attachment = (attachments != null) ? attachments.get(i) : null;
+                tasks.add(t);
+            }
+            return tasks;
+        }
+    }
+
+    public void run() {
+        GetPartitionValuesTask task = new GetPartitionValuesTask();
+        start(List.of(task));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/HMSPartitionBasedRemoteInfoSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/HMSPartitionBasedRemoteInfoSource.java
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.starrocks.connector;
 
 import autovalue.shaded.com.google.common.common.base.Preconditions;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/HMSPartitionBasedRemoteInfoSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/HMSPartitionBasedRemoteInfoSource.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.connector;
 
-import autovalue.shaded.com.google.common.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.hive.Partition;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -279,8 +279,7 @@ public class HiveMetadata implements ConnectorMetadata {
 
     @Override
     public RemoteFileInfoSource getRemoteFilesAsync(Table table, GetRemoteFilesParams params) {
-        List<Partition> partitions = buildGetRemoteFilesPartitions(table, params);
-        return fileOps.getRemoteFilesAsync(table, partitions, params);
+        return fileOps.getRemoteFilesAsync(table, params, (p) -> this.buildGetRemoteFilesPartitions(table, p));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -180,8 +180,7 @@ public class HudiMetadata implements ConnectorMetadata {
 
     @Override
     public RemoteFileInfoSource getRemoteFilesAsync(Table table, GetRemoteFilesParams params) {
-        List<Partition> partitions = buildGetRemoteFilesPartitions(table, params);
-        return fileOps.getRemoteFilesAsync(table, partitions, params);
+        return fileOps.getRemoteFilesAsync(table, params, (p) -> this.buildGetRemoteFilesPartitions(table, p));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/HMSPartitionBasedRemoteInfoSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/HMSPartitionBasedRemoteInfoSourceTest.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.starrocks.connector.hive.Partition;
+import com.starrocks.connector.hive.RemoteFileInputFormat;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class HMSPartitionBasedRemoteInfoSourceTest {
+    @Test
+    public void testGetHiveRemoteFiles() {
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        int partitionCount = 1024;
+        List<String> partitionNames = new ArrayList<>();
+        for (int i = 0; i < partitionCount; i++) {
+            partitionNames.add("dt=" + String.valueOf(i));
+        }
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder().
+                setPartitionNames(partitionNames).build();
+
+        String hdfsPath = "hdfs://hadoop01/tmp/";
+        class Counter {
+            int getRemoteFiles = 0;
+            int getPartitionValues = 0;
+        }
+        final Counter counter = new Counter();
+
+        HMSPartitionBasedRemoteInfoSource source = new HMSPartitionBasedRemoteInfoSource(executorService, params,
+                partition -> {
+                    counter.getRemoteFiles++;
+                    // a single file under a partition.
+                    RemoteFileInfo remoteFileInfo =
+                            new RemoteFileInfo(RemoteFileInputFormat.PARQUET,
+                                    List.of(new RemoteFileDesc("aa", "lz4", 0, 0, null)),
+                                    partition.getFullPath());
+                    return remoteFileInfo;
+                },
+                ps -> {
+                    counter.getPartitionValues++;
+                    System.out.println("getPartitionValues: " + String.join(",", ps.getPartitionNames()));
+                    List<Partition> res = new ArrayList<>();
+                    for (String name : ps.getPartitionNames()) {
+                        Partition partition =
+                                new Partition(null, RemoteFileInputFormat.PARQUET, null,
+                                        hdfsPath + name, false);
+                        res.add(partition);
+                    }
+                    return res;
+                });
+
+        source.setMaxOutputQueueSize(HMSPartitionBasedRemoteInfoSource.HMS_PARTITION_BATCH_SIZE_MIN);
+        source.setMaxRunningTaskCount(4);
+        source.run();
+        // we fetch MIN files(partitions) + buffer MIN files(partitions), and getPartitionValues should be only 2.
+        for (int i = 0; i < HMSPartitionBasedRemoteInfoSource.HMS_PARTITION_BATCH_SIZE_MIN; i++) {
+            RemoteFileInfo remoteFileInfo = source.getOutput();
+            System.out.println(remoteFileInfo.getFullPath());
+        }
+        Assert.assertEquals(2, counter.getPartitionValues);
+        Assert.assertTrue(HMSPartitionBasedRemoteInfoSource.HMS_PARTITION_BATCH_SIZE_MIN <= counter.getRemoteFiles);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Since we have incremental scan ranges delivery: https://github.com/StarRocks/starrocks/pull/50189, we can also do async list hive partitions to improve the pipeline of FE and BE.

## What I'm doing:

If we have 1000 partitions to list files:
- we exponentially split those partitions into groups, 16,32,64, 128. Max value is 128.
- for each group, we call hive rpc to get pattition values, and put those partition values into task queue
- then call `listFiles` on each partition to get files.

In way, we avoid a single rpc of large partitions which probably takes a long time. Instead if we call multiples rpc on a small group of pattitions, we can get partition values fatser, then we can get files faster, then we can send those files to BE ASAP. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0