### PR TITLE
[UT] fix TestPipelineControlFlow

### DIFF
--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -302,8 +302,11 @@ ChunkPtr PipelineTestBase::_create_and_fill_chunk(size_t row_num) {
     CHECK(deserialize_thrift_msg(buf, &len, TProtocolType::JSON, &tbl).ok());
 
     std::vector<SlotDescriptor> slots;
+    phmap::flat_hash_set<SlotId> seen_slots;
     for (auto& t_slot : tbl.slotDescriptors) {
-        slots.emplace_back(t_slot);
+        if (auto [_, is_new] = seen_slots.insert(t_slot.id); is_new) {
+            slots.emplace_back(t_slot);
+        }
     }
 
     std::vector<SlotDescriptor*> p_slots;


### PR DESCRIPTION
## Why I'm doing:

these test cases always crash on the following stack
```
*** SIGABRT (@0x3ed003004c6) received by PID 3146950 (TID 0x7f05627b1e00) from PID 3146950; stack trace: ***
    @         0x2da5c156 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f056286fee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x2da5b999 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f0562818520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f056286c9fc pthread_kill
    @     0x7f0562818476 raise
    @     0x7f05627fe7f3 abort
    @         0x1c6a774a starrocks::failure_function()
    @         0x2da4f12e google::LogMessage::Fail()
    @         0x2da503a9 google::LogMessageFatal::~LogMessageFatal()
    @         0x1c78aa9f starrocks::Chunk::append_column(std::shared_ptr<starrocks::Column>, int)
    @         0x275f09a6 starrocks::ChunkHelper::new_chunk(std::vector<starrocks::SlotDescriptor*, std::allocator<starrocks::SlotDescriptor*> > const&, unsigned long)
    @         0x16c1081a starrocks::pipeline::PipelineTestBase::_create_and_fill_chunk(std::vector<starrocks::SlotDescriptor*, std::allocator<starrocks::SlotDescriptor*> > const&, unsigned long)
    @         0x16c126f1 starrocks::pipeline::PipelineTestBase::_create_and_fill_chunk(unsigned long)
    @         0x16b28c41 starrocks::pipeline::TestSourceOperator::TestSourceOperator(starrocks::pipeline::OperatorFactory*, int, int, int, unsigned long, unsigned long, std::shared_ptr<starrocks::pipeline::Counter>, int)
    @         0x16b3fa0b decltype (::new ((void*)(0)) starrocks::pipeline::TestSourceOperator((declval<starrocks::pipeline::TestSourceOperatorFactory*>)(), (declval<int const&>)(), (declval<int const&>)(), (declval<int&>)(), (declval<unsigned long&>)(), (declval<unsigned long&>)()
    @         0x16b3fb80 void std::allocator_traits<std::allocator<starrocks::pipeline::TestSourceOperator> >::construct<starrocks::pipeline::TestSourceOperator, starrocks::pipeline::TestSourceOperatorFactory*, int const&, int const&, int&, unsigned long&, unsigned long&, std::sha
    @         0x16b3cccb std::_Sp_counted_ptr_inplace<starrocks::pipeline::TestSourceOperator, std::allocator<starrocks::pipeline::TestSourceOperator>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<starrocks::pipeline::TestSourceOperatorFactory*, int const&, int const&, int
    @         0x16b3a05b std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<starrocks::pipeline::TestSourceOperator, std::allocator<starrocks::pipeline::TestSourceOperator>, starrocks::pipeline::TestSourceOperatorFactory*, int const&, int const&, int&, unsigned long&,
    @         0x16b37800 std::__shared_ptr<starrocks::pipeline::TestSourceOperator, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<starrocks::pipeline::TestSourceOperator>, starrocks::pipeline::TestSourceOperatorFactory*, int const&, int const&, int&, unsigned long&, uns
    @         0x16b34881 std::shared_ptr<starrocks::pipeline::TestSourceOperator>::shared_ptr<std::allocator<starrocks::pipeline::TestSourceOperator>, starrocks::pipeline::TestSourceOperatorFactory*, int const&, int const&, int&, unsigned long&, unsigned long&, std::shared_ptr<sta
    @         0x16b31c61 std::shared_ptr<starrocks::pipeline::TestSourceOperator> std::allocate_shared<starrocks::pipeline::TestSourceOperator, std::allocator<starrocks::pipeline::TestSourceOperator>, starrocks::pipeline::TestSourceOperatorFactory*, int const&, int const&, int&, u
    @         0x16b2dac9 std::shared_ptr<starrocks::pipeline::TestSourceOperator> std::make_shared<starrocks::pipeline::TestSourceOperator, starrocks::pipeline::TestSourceOperatorFactory*, int const&, int const&, int&, unsigned long&, unsigned long&, std::shared_ptr<starrocks::pip
    @         0x16b29b35 starrocks::pipeline::TestSourceOperatorFactory::create(int, int)
    @         0x16d014d0 starrocks::pipeline::Pipeline::create_operators(int, int)
    @         0x1f24eb4c starrocks::pipeline::Pipeline::instantiate_drivers(starrocks::RuntimeState*)
    @         0x16c0df80 starrocks::pipeline::PipelineTestBase::_prepare()::{lambda(starrocks::pipeline::Pipeline*)#1}::operator()(starrocks::pipeline::Pipeline*) const
    @         0x16c14048 void std::__invoke_impl<void, starrocks::pipeline::PipelineTestBase::_prepare()::{lambda(starrocks::pipeline::Pipeline*)#1}&, starrocks::pipeline::Pipeline*>(std::__invoke_other, starrocks::pipeline::PipelineTestBase::_prepare()::{lambda(starrocks::pipelin
    @         0x16c13bfe std::enable_if<is_invocable_r_v<void, starrocks::pipeline::PipelineTestBase::_prepare()::{lambda(starrocks::pipeline::Pipeline*)#1}&, starrocks::pipeline::Pipeline*>, void>::type std::__invoke_r<void, starrocks::pipeline::PipelineTestBase::_prepare()::{lam
    @         0x16c1377e std::_Function_handler<void (starrocks::pipeline::Pipeline*), starrocks::pipeline::PipelineTestBase::_prepare()::{lambda(starrocks::pipeline::Pipeline*)#1}>::_M_invoke(std::_Any_data const&, starrocks::pipeline::Pipeline*&&)
    @         0x1ef28b0a std::function<void (starrocks::pipeline::Pipeline*)>::operator()(starrocks::pipeline::Pipeline*) const
    @         0x1ef27229 auto starrocks::pipeline::ExecutionGroup::for_each_pipeline<std::function<void (starrocks::pipeline::Pipeline*)> const&>(std::function<void (starrocks::pipeline::Pipeline*)> const&)
```

this is because we don't allow duplicated slot id when appending column, we should make sure all slot_ids are different in chunk.
<img width="1018" alt="image" src="https://github.com/user-attachments/assets/6cee7e9b-6495-490b-b11a-5cab7f329c17">


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0