### PR TITLE
[BugFix] Fix Left Anti join null_array UAF

### DIFF
--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -228,6 +228,8 @@ void SerializedJoinProbeFunc::_probe_column(const JoinHashTableItems& table_item
         ptr += probe_state->probe_slice[i].size;
     }
 
+    probe_state->null_array = nullptr;
+
     for (uint32_t i = 0; i < row_count; i++) {
         probe_state->next[i] = table_items.first[probe_state->buckets[i]];
     }

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -351,7 +351,7 @@ void FixedSizeJoinProbeFunc<LT>::_probe_column(const JoinHashTableItems& table_i
                                                            row_count);
     const auto& data = get_key_data(*probe_state);
     JoinHashMapHelper::calc_bucket_nums<CppType>(data, table_items.bucket_size, &probe_state->buckets, 0, row_count);
-
+    probe_state->null_array = nullptr;
     for (uint32_t i = 0; i < row_count; i++) {
         probe_state->next[i] = table_items.first[probe_state->buckets[i]];
     }

--- a/test/sql/test_join/R/test_null_aware_anti_join
+++ b/test/sql/test_join/R/test_null_aware_anti_join
@@ -70,3 +70,14 @@ None	None	None
 2	3	None
 2	3	2
 -- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+select count(*) from (SELECT * from (SELECT if (generate_series <= 1000, null, generate_series) x0 FROM TABLE(generate_series(1,  8192))) t where (x0, x0 + 1) not in  ( select l3.l_orderkey, l3.l_orderkey + 1 from lineitem l3 ) order by 1) t;
+-- result:
+7192
+-- !result
+select count(*) from (SELECT * from (SELECT if (generate_series <= 1000, null, generate_series) x0 FROM TABLE(generate_series(1,  8192))) t where (x0, concat("l", x0)) not in  ( select l3.l_orderkey, concat("l", l_orderkey) from lineitem l3 ) order by 1) t;
+-- result:
+7192
+-- !result

--- a/test/sql/test_join/T/test_null_aware_anti_join
+++ b/test/sql/test_join/T/test_null_aware_anti_join
@@ -39,3 +39,9 @@ select * from lineitem_nullable l1 where l1.l_orderkey not in ( select l3.l_orde
 select * from lineitem_nullable l1 where l1.l_orderkey in ( select l3.l_orderkey from lineitem_nullable l3 ) order by 1,2,3;
 select * from lineitem_nullable l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem_nullable l3 where  l3.l_suppkey = l1.l_suppkey ) order by 1,2,3;
 select * from lineitem_nullable l1 where l1.l_orderkey not in ( select l3.l_orderkey from lineitem_nullable l3 where  l3.l_suppkey != l1.l_suppkey ) order by 1,2,3;
+
+set pipeline_dop = 1;
+-- branch fixed size keys
+select count(*) from (SELECT * from (SELECT if (generate_series <= 1000, null, generate_series) x0 FROM TABLE(generate_series(1,  8192))) t where (x0, x0 + 1) not in  ( select l3.l_orderkey, l3.l_orderkey + 1 from lineitem l3 ) order by 1) t;
+-- branch serialized keys
+select count(*) from (SELECT * from (SELECT if (generate_series <= 1000, null, generate_series) x0 FROM TABLE(generate_series(1,  8192))) t where (x0, concat("l", x0)) not in  ( select l3.l_orderkey, concat("l", l_orderkey) from lineitem l3 ) order by 1) t;


### PR DESCRIPTION
## Why I'm doing:

null_array should be reset when input has not null.

## What I'm doing:

Fixes 
```
<pre style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; widows: auto; word-spacing: 0px; -webkit-tap-highlight-color: rgba(26, 26, 26, 0.3); -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; overflow-wrap: break-word; white-space: pre-wrap;">3.2.12-ee RELEASE (build f1496f5)
query_id:c0a108e5-b23e-11ef-b7ce-58a2e1bc0436, fragment_instance:c0a108e5-b23e-11ef-b7ce-58a2e1bc0438
tracker:process consumption: 549134011440
tracker:jemalloc_metadata consumption: 17448843280
tracker:jemalloc_fragmentation consumption: 10592096488
tracker:query_pool consumption: 3081171264
tracker:query_pool/connector_scan consumption: 0
tracker:load consumption: 1528657726
tracker:metadata consumption: 93686169928
tracker:tablet_metadata consumption: 166203468
tracker:rowset_metadata consumption: 538173983
tracker:segment_metadata consumption: 6659708510
tracker:column_metadata consumption: 86322083967
tracker:tablet_schema consumption: 5117364
tracker:segment_zonemap consumption: 1124249792
tracker:short_key_index consumption: 5461168904
tracker:column_zonemap_index consumption: 28078810943
tracker:ordinal_index consumption: 51134061536
tracker:bitmap_index consumption: 0
tracker:bloom_filter_index consumption: 7025888
tracker:compaction consumption: 2457592920
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 263771320960
tracker:update consumption: 110879673908
tracker:chunk_allocator consumption: 2137550840
tracker:clone consumption: 0
tracker:consistency consumption: 24890424
tracker:datacache consumption: 0
tracker:replication consumption: 0
*** Aborted at 1733316816 (unix time) try "date -d @1733316816" if you are using GNU date ***
PC: @          0x37bacdb starrocks::JoinHashMap&lt;&gt;::_ZN9starrocks11JoinHashMapILNS_11LogicalTypeE17ENS_23SerializedJoinBuildFuncENS_23SerializedJoinProbeFuncEE33_probe_from_ht_for_left_anti_joinEPNS_12RuntimeStateERKSt6vectorINS_5SliceESaIS8_EESC_.actor()
*** SIGSEGV (@0x0) received by PID 44699 (TID 0x1465a04da640) from PID 0; stack trace: ***
    @          0x6cb5a62 google::(anonymous namespace)::FailureSignalHandler()
    @     0x14691162b9b9 os::Linux::chained_handler()
    @     0x146911631c7a JVM_handle_linux_signal
    @     0x146911623a4c signalHandler()
    @     0x14691063e6f0 (unknown)
    @          0x37bacdb starrocks::JoinHashMap&lt;&gt;::_ZN9starrocks11JoinHashMapILNS_11LogicalTypeE17ENS_23SerializedJoinBuildFuncENS_23SerializedJoinProbeFuncEE33_probe_from_ht_for_left_anti_joinEPNS_12RuntimeStateERKSt6vectorINS_5SliceESaIS8_EESC_.actor()
    @          0x37a9e5c starrocks::JoinHashMap&lt;&gt;::_probe_coroutine&lt;&gt;()
    @          0x3860e84 starrocks::JoinHashMap&lt;&gt;::probe()
    @          0x37a3d46 starrocks::JoinHashTable::probe()
    @          0x3ce25ca starrocks::HashJoinProber::probe_chunk()
    @          0x3cddad4 starrocks::HashJoiner::_pull_probe_output_chunk()
    @          0x3cddd32 starrocks::HashJoiner::pull_chunk()
    @          0x3b16aa9 starrocks::pipeline::HashJoinProbeOperator::pull_chunk()
    @          0x3ac36e6 starrocks::pipeline::PipelineDriver::process()
    @          0x3ab55bf starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x302f5ec starrocks::ThreadPool::dispatch_thread()
    @          0x3028b6a starrocks::Thread::supervise_thread()</pre>
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0