### PR TITLE
[Enhancement] Add ColumnAndPredicate

### DIFF
--- a/be/src/exprs/min_max_predicate.h
+++ b/be/src/exprs/min_max_predicate.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/type_traits.h"

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -136,6 +136,7 @@ set(STORAGE_FILES
     column_not_in_predicate.cpp
     column_null_predicate.cpp
     column_or_predicate.cpp
+    column_and_predicate.cpp
     column_expr_predicate.cpp
     conjunctive_predicates.cpp
     predicate_tree/predicate_tree.cpp

--- a/be/src/storage/column_and_predicate.cpp
+++ b/be/src/storage/column_and_predicate.cpp
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/column_and_predicate.h"
+
+namespace starrocks {
+Status ColumnAndPredicate::evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const {
+    return _evaluate(column, selection, from, to);
+}
+
+Status ColumnAndPredicate::evaluate_and(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const {
+    for (const ColumnPredicate* child : _child) {
+        RETURN_IF_ERROR(child->evaluate_and(column, selection, from, to));
+    }
+    return Status::OK();
+}
+
+Status ColumnAndPredicate::evaluate_or(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const {
+    _buff.resize(column->size());
+    RETURN_IF_ERROR(_evaluate(column, _buff.data(), from, to));
+    const uint8_t* p = _buff.data();
+    for (uint16_t i = from; i < to; i++) {
+        selection[i] |= p[i];
+    }
+    return Status::OK();
+}
+
+std::string ColumnAndPredicate::debug_string() const {
+    std::stringstream ss;
+    ss << "AND(";
+    for (size_t i = 0; i < _child.size(); i++) {
+        if (i != 0) {
+            ss << ", ";
+        }
+        ss << i << ":" << _child[i]->debug_string();
+    }
+    ss << ")";
+    return ss.str();
+}
+
+Status ColumnAndPredicate::_evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const {
+    RETURN_IF_ERROR(_child[0]->evaluate(column, selection, from, to));
+    for (size_t i = 1; i < _child.size(); i++) {
+        RETURN_IF_ERROR(_child[i]->evaluate_and(column, selection, from, to));
+    }
+    return Status::OK();
+}
+
+// return false if page not satisfied
+bool ColumnAndPredicate::zone_map_filter(const ZoneMapDetail& detail) const {
+    for (const ColumnPredicate* child : _child) {
+        RETURN_IF(!child->zone_map_filter(detail), false);
+    }
+    return true;
+}
+
+Status ColumnAndPredicate::convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_ptr,
+                                      ObjectPool* obj_pool) const {
+    ColumnAndPredicate* new_pred =
+            obj_pool->add(new ColumnAndPredicate(get_type_info(target_type_ptr.get()), _column_id));
+    for (auto pred : _child) {
+        const ColumnPredicate* new_child = nullptr;
+        RETURN_IF_ERROR(pred->convert_to(&new_child, get_type_info(target_type_ptr.get()), obj_pool));
+        new_pred->_child.emplace_back(new_child);
+    }
+    *output = new_pred;
+    return Status::OK();
+}
+} // namespace starrocks

--- a/be/src/storage/column_and_predicate.h
+++ b/be/src/storage/column_and_predicate.h
@@ -14,21 +14,18 @@
 
 #pragma once
 
-#include <vector>
-
 #include "storage/column_predicate.h"
 
 namespace starrocks {
 
-class ColumnOrPredicate : public ColumnPredicate {
+class ColumnAndPredicate final : public ColumnPredicate {
 public:
-    explicit ColumnOrPredicate(const TypeInfoPtr& type_info, ColumnId cid) : ColumnPredicate(type_info, cid) {}
+    explicit ColumnAndPredicate(const TypeInfoPtr& type_info, ColumnId cid) : ColumnPredicate(type_info, cid) {}
 
     template <typename Container>
-    ColumnOrPredicate(const TypeInfoPtr& type_info, ColumnId cid, const Container& c)
+    ColumnAndPredicate(const TypeInfoPtr& type_info, ColumnId cid, const Container& c)
             : ColumnPredicate(type_info, cid), _child(c.begin(), c.end()) {}
 
-    // Does NOT take the ownership of |child|.
     void add_child(ColumnPredicate* child) { _child.emplace_back(child); }
 
     template <typename Iterator>
@@ -37,36 +34,25 @@ public:
     }
 
     Status evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const override;
-
     Status evaluate_and(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const override;
-
     Status evaluate_or(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const override;
 
     bool filter(const BloomFilter& bf) const override { return true; }
-
     bool zone_map_filter(const ZoneMapDetail& detail) const override;
 
     bool can_vectorized() const override { return false; }
-
-    PredicateType type() const override { return PredicateType::kOr; }
-
-    // Always return `NULL`.
+    PredicateType type() const override { return PredicateType::kAnd; }
     Datum value() const override { return {}; }
-
-    // Always return an empty set.
     std::vector<Datum> values() const override { return std::vector<Datum>{}; }
 
     Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,
                       ObjectPool* obj_pool) const override;
-
     std::string debug_string() const override;
 
 private:
     Status _evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const;
 
-    // TODO: reorder child predicates based on their cost.
     std::vector<const ColumnPredicate*> _child;
     mutable std::vector<uint8_t> _buff;
 };
-
 } // namespace starrocks

--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -30,7 +30,7 @@ class Column;
 // And this class has a big limitation that it does not support range evaluatation. In another word, `from` supposed to be 0 always.
 // The fundamental reason is `ExprContext` requires `Column*` as a total piece, unless we can create a class to represent `ColumnSlice`.
 // And that task is almost impossible.
-class ColumnExprPredicate : public ColumnPredicate {
+class ColumnExprPredicate final : public ColumnPredicate {
 public:
     static StatusOr<ColumnExprPredicate*> make_column_expr_predicate(TypeInfoPtr type_info, ColumnId column_id,
                                                                      RuntimeState* state, ExprContext* expr_ctx,
@@ -86,7 +86,7 @@ private:
     mutable std::vector<uint8_t> _tmp_select;
 };
 
-class ColumnTruePredicate : public ColumnPredicate {
+class ColumnTruePredicate final : public ColumnPredicate {
 public:
     ColumnTruePredicate(TypeInfoPtr type_info, ColumnId column_id) : ColumnPredicate(std::move(type_info), column_id) {}
     ~ColumnTruePredicate() override = default;

--- a/be/src/storage/column_in_predicate.cpp
+++ b/be/src/storage/column_in_predicate.cpp
@@ -29,7 +29,7 @@
 namespace starrocks {
 
 template <LogicalType field_type, typename ItemSet>
-class ColumnInPredicate : public ColumnPredicate {
+class ColumnInPredicate final : public ColumnPredicate {
     using ValueType = typename CppTypeTraits<field_type>::CppType;
     static_assert(std::is_same_v<ValueType, typename ItemSet::value_type>);
 
@@ -195,7 +195,7 @@ private:
 
 // Template specialization for binary column
 template <LogicalType field_type>
-class BinaryColumnInPredicate : public ColumnPredicate {
+class BinaryColumnInPredicate final : public ColumnPredicate {
 public:
     BinaryColumnInPredicate(const TypeInfoPtr& type_info, ColumnId id, std::vector<std::string> strings)
             : ColumnPredicate(type_info, id), _zero_padded_strs(std::move(strings)) {
@@ -368,7 +368,7 @@ private:
     ItemHashSet<Slice> _slices;
 };
 
-class DictionaryCodeInPredicate : public ColumnPredicate {
+class DictionaryCodeInPredicate final : public ColumnPredicate {
 private:
     enum LogicOp { ASSIGN, AND, OR };
 

--- a/be/src/storage/column_not_in_predicate.cpp
+++ b/be/src/storage/column_not_in_predicate.cpp
@@ -25,7 +25,7 @@
 namespace starrocks {
 
 template <LogicalType field_type>
-class ColumnNotInPredicate : public ColumnPredicate {
+class ColumnNotInPredicate final : public ColumnPredicate {
     using ValueType = typename CppTypeTraits<field_type>::CppType;
 
 public:
@@ -177,7 +177,7 @@ private:
 
 // Template specialization for binary column
 template <LogicalType field_type>
-class BinaryColumnNotInPredicate : public ColumnPredicate {
+class BinaryColumnNotInPredicate final : public ColumnPredicate {
 public:
     BinaryColumnNotInPredicate(const TypeInfoPtr& type_info, ColumnId id, std::vector<std::string> strings)
             : ColumnPredicate(type_info, id), _zero_padded_strs(std::move(strings)) {

--- a/be/src/storage/column_null_predicate.cpp
+++ b/be/src/storage/column_null_predicate.cpp
@@ -23,7 +23,7 @@
 
 namespace starrocks {
 
-class ColumnIsNullPredicate : public ColumnPredicate {
+class ColumnIsNullPredicate final : public ColumnPredicate {
 public:
     explicit ColumnIsNullPredicate(const TypeInfoPtr& type_info, ColumnId id) : ColumnPredicate(type_info, id) {}
 
@@ -103,7 +103,7 @@ public:
     std::string debug_string() const override { return strings::Substitute("(ColumnId($0) IS NULL)", _column_id); }
 };
 
-class ColumnNotNullPredicate : public ColumnPredicate {
+class ColumnNotNullPredicate final : public ColumnPredicate {
 public:
     explicit ColumnNotNullPredicate(const TypeInfoPtr& type_info, ColumnId id) : ColumnPredicate(type_info, id) {}
 

--- a/be/src/storage/column_or_predicate.cpp
+++ b/be/src/storage/column_or_predicate.cpp
@@ -68,4 +68,17 @@ Status ColumnOrPredicate::convert_to(const ColumnPredicate** output, const TypeI
     return Status::OK();
 }
 
+std::string ColumnOrPredicate::debug_string() const {
+    std::stringstream ss;
+    ss << "OR(";
+    for (size_t i = 0; i < _child.size(); i++) {
+        if (i != 0) {
+            ss << ", ";
+        }
+        ss << i << ":" << _child[i]->debug_string();
+    }
+    ss << ")";
+    return ss.str();
+}
+
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -357,6 +357,8 @@ set(EXEC_FILES
         ./storage/persistent_index_consistency_test.cpp
         ./storage/meta_reader_test.cpp
         ./storage/dictionary_cache_manager_test.cpp
+        ./storage/column_or_predicate_test.cpp
+        ./storage/column_and_predicate_test.cpp
         ./runtime/agg_state_desc_test.cpp
         ./runtime/buffer_control_block_test.cpp
         ./runtime/data_stream_mgr_test.cpp

--- a/be/test/storage/column_and_predicate_test.cpp
+++ b/be/test/storage/column_and_predicate_test.cpp
@@ -1,0 +1,121 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/column_and_predicate.h"
+
+#include <gtest/gtest.h>
+
+#include "storage/rowset/block_split_bloom_filter.h"
+#include "testutil/column_test_helper.h"
+
+namespace starrocks {
+class ColumnAndPredicateTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _left.reset(new_column_ge_predicate(get_type_info(TYPE_INT), 0, "10"));
+        _right.reset(new_column_le_predicate(get_type_info(TYPE_INT), 0, "20"));
+        _pred = std::make_unique<ColumnAndPredicate>(get_type_info(TYPE_INT), 0);
+        _pred->add_child(_left.get());
+        _pred->add_child(_right.get());
+
+        std::vector<int32_t> values = {5, 15, 17, 25, 0, 0};
+        std::vector<uint8_t> null_values = {0, 0, 0, 0, 1, 1};
+        _col = ColumnTestHelper::build_nullable_column<int32_t>(values, null_values);
+    }
+
+protected:
+    std::unique_ptr<ColumnPredicate> _left;
+    std::unique_ptr<ColumnPredicate> _right;
+    std::unique_ptr<ColumnAndPredicate> _pred;
+    ColumnPtr _col;
+    BlockSplitBloomFilter _bf;
+    ObjectPool _pool;
+};
+
+TEST_F(ColumnAndPredicateTest, basic) {
+    ASSERT_TRUE(_pred->filter(_bf));
+    ASSERT_FALSE(_pred->can_vectorized());
+    ASSERT_EQ(_pred->type(), PredicateType::kAnd);
+    ASSERT_TRUE(_pred->value().is_null());
+    ASSERT_EQ(_pred->values().size(), 0);
+    ASSERT_EQ(_pred->debug_string(), "AND(0:(columnId(0)>=10), 1:(columnId(0)<=20))");
+}
+
+TEST_F(ColumnAndPredicateTest, evaluate) {
+    std::vector<uint8_t> buff = {0, 0, 0, 0, 0, 0};
+    auto st = _pred->evaluate(_col.get(), buff.data(), 0, 6);
+    ASSERT_TRUE(st.ok());
+
+    std::vector<uint8_t> result = {0, 1, 1, 0, 0, 0};
+    ASSERT_EQ(buff, result);
+}
+
+TEST_F(ColumnAndPredicateTest, evaluate_and) {
+    std::vector<uint8_t> buff = {1, 1, 0, 1, 1, 1};
+    auto st = _pred->evaluate_and(_col.get(), buff.data(), 0, 6);
+    ASSERT_TRUE(st.ok());
+
+    std::vector<uint8_t> result = {0, 1, 0, 0, 0, 0};
+    ASSERT_EQ(buff, result);
+}
+
+TEST_F(ColumnAndPredicateTest, evaluate_or) {
+    std::vector<uint8_t> buff = {0, 0, 0, 0, 1, 0};
+    auto st = _pred->evaluate_or(_col.get(), buff.data(), 0, 6);
+    ASSERT_TRUE(st.ok());
+
+    std::vector<uint8_t> result = {0, 1, 1, 0, 1, 0};
+    ASSERT_EQ(buff, result);
+}
+
+TEST_F(ColumnAndPredicateTest, zonemap_filter) {
+    Datum min_value_1((int32_t)10);
+    Datum max_value_1((int32_t)20);
+    ZoneMapDetail zone_map_1(min_value_1, max_value_1, false);
+    ASSERT_TRUE(_pred->zone_map_filter(zone_map_1));
+
+    Datum min_value_2((int32_t)5);
+    Datum max_value_2((int32_t)25);
+    ZoneMapDetail zone_map_2(min_value_2, max_value_2, false);
+    ASSERT_TRUE(_pred->zone_map_filter(zone_map_2));
+
+    Datum min_value_3((int32_t)1);
+    Datum max_value_3((int32_t)5);
+    ZoneMapDetail zone_map_3(min_value_3, max_value_3, false);
+    ASSERT_FALSE(_pred->zone_map_filter(zone_map_3));
+
+    Datum min_value_4((int32_t)30);
+    Datum max_value_4((int32_t)40);
+    ZoneMapDetail zone_map_4(min_value_4, max_value_4, false);
+    ASSERT_FALSE(_pred->zone_map_filter(zone_map_4));
+
+    Datum min_value_5((int32_t)5);
+    Datum max_value_5((int32_t)25);
+    ZoneMapDetail zone_map_5(min_value_5, max_value_5, false);
+    ASSERT_TRUE(_pred->zone_map_filter(zone_map_5));
+
+    Datum min_value_6((int32_t)15);
+    Datum max_value_6((int32_t)40);
+    ZoneMapDetail zone_map_6(min_value_6, max_value_6, false);
+    ASSERT_TRUE(_pred->zone_map_filter(zone_map_6));
+}
+
+TEST_F(ColumnAndPredicateTest, convert_to) {
+    const ColumnPredicate* new_pred = nullptr;
+    Status st = _pred->convert_to(&new_pred, get_type_info(TYPE_INT), &_pool);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(new_pred->debug_string(), "AND(0:(columnId(0)>=10), 1:(columnId(0)<=20))");
+}
+
+} // namespace starrocks

--- a/be/test/storage/column_or_predicate_test.cpp
+++ b/be/test/storage/column_or_predicate_test.cpp
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/column_or_predicate.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/column_test_helper.h"
+
+namespace starrocks {
+class ColumnOrPredicateTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _left.reset(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "100"));
+        _right.reset(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "200"));
+        _pred = std::make_unique<ColumnOrPredicate>(get_type_info(TYPE_INT), 0);
+        _pred->add_child(_left.get());
+        _pred->add_child(_right.get());
+
+        std::vector<int32_t> values = {10, 100, 200, 0, 0};
+        std::vector<uint8_t> null_values = {0, 0, 0, 1, 1};
+        _col = ColumnTestHelper::build_nullable_column<int32_t>(values, null_values);
+    }
+
+protected:
+    std::unique_ptr<ColumnPredicate> _left;
+    std::unique_ptr<ColumnPredicate> _right;
+    std::unique_ptr<ColumnOrPredicate> _pred;
+    ColumnPtr _col;
+};
+
+TEST_F(ColumnOrPredicateTest, basic) {
+    ASSERT_EQ(PredicateType::kOr, _pred->type());
+    ASSERT_FALSE(_pred->can_vectorized());
+    ASSERT_EQ(_pred->debug_string(), "OR(0:(columnId(0)=100), 1:(columnId(0)=200))");
+}
+
+TEST_F(ColumnOrPredicateTest, evaluate) {
+    std::vector<uint8_t> buff = {0, 0, 0, 0, 0};
+    auto st = _pred->evaluate(_col.get(), buff.data(), 0, 5);
+    ASSERT_TRUE(st.ok());
+
+    std::vector<uint8_t> result = {0, 1, 1, 0, 0};
+    ASSERT_EQ(buff, result);
+}
+
+TEST_F(ColumnOrPredicateTest, evaluate_and) {
+    std::vector<uint8_t> buff = {1, 1, 0, 1, 1};
+    auto st = _pred->evaluate_and(_col.get(), buff.data(), 0, 5);
+    ASSERT_TRUE(st.ok());
+
+    std::vector<uint8_t> result = {0, 1, 0, 0, 0};
+    ASSERT_EQ(buff, result);
+}
+
+TEST_F(ColumnOrPredicateTest, evaluate_or) {
+    std::vector<uint8_t> buff = {1, 1, 1, 1, 0};
+    auto st = _pred->evaluate_or(_col.get(), buff.data(), 0, 5);
+    ASSERT_TRUE(st.ok());
+
+    std::vector<uint8_t> result = {1, 1, 1, 1, 0};
+    ASSERT_EQ(buff, result);
+}
+
+} // namespace starrocks

--- a/be/test/storage/column_predicate_test.cpp
+++ b/be/test/storage/column_predicate_test.cpp
@@ -18,7 +18,6 @@
 
 #include "gtest/gtest.h"
 #include "storage/chunk_helper.h"
-#include "storage/column_or_predicate.h"
 #include "testutil/assert.h"
 
 namespace starrocks {
@@ -1947,75 +1946,6 @@ TEST(ColumnPredicateTest, test_not_null) {
 
         p->evaluate_or(c.get(), buff.data(), 2, 4);
         ASSERT_EQ("1,1,1,0,1", to_string(buff));
-
-        buff.assign(5, 1);
-        p->evaluate_or(c.get(), buff.data(), 0, 5);
-        ASSERT_EQ("1,1,1,1,1", to_string(buff));
-
-        p->evaluate_or(c.get(), buff.data(), 2, 4);
-        ASSERT_EQ("1,1,1,1,1", to_string(buff));
-    }
-}
-
-// NOLINTNEXTLINE
-TEST(ColumnPredicateTest, test_or) {
-    {
-        std::unique_ptr<ColumnPredicate> p1(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "100"));
-        std::unique_ptr<ColumnPredicate> p2(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "200"));
-
-        auto p = std::make_unique<ColumnOrPredicate>(get_type_info(TYPE_INT), 0);
-        p->add_child(p1.get());
-        p->add_child(p2.get());
-
-        auto c = ChunkHelper::column_from_field_type(TYPE_INT, true);
-        c->append_datum(10);
-        c->append_datum(100);
-        c->append_datum(200);
-        (void)c->append_nulls(2);
-
-        ASSERT_EQ(PredicateType::kOr, p->type());
-        ASSERT_FALSE(p->can_vectorized());
-
-        // ---------------------------------------------
-        // evaluate()
-        // ---------------------------------------------
-        std::vector<uint8_t> buff(5);
-        p->evaluate(c.get(), buff.data(), 0, 5);
-        ASSERT_EQ("0,1,1,0,0", to_string(buff));
-
-        p->evaluate(c.get(), buff.data(), 1, 3);
-        ASSERT_EQ("0,1,1,0,0", to_string(buff));
-
-        // ---------------------------------------------
-        // evaluate_and()
-        // ---------------------------------------------
-        buff.assign(5, 1);
-        p->evaluate_and(c.get(), buff.data(), 0, 5);
-        ASSERT_EQ("0,1,1,0,0", to_string(buff));
-
-        p->evaluate_and(c.get(), buff.data(), 1, 3);
-        ASSERT_EQ("0,1,1,0,0", to_string(buff));
-
-        buff.assign(5, 0);
-        p->evaluate_and(c.get(), buff.data(), 0, 5);
-        ASSERT_EQ("0,0,0,0,0", to_string(buff));
-
-        buff[2] = 1;
-        p->evaluate_and(c.get(), buff.data(), 0, 5);
-        ASSERT_EQ("0,0,1,0,0", to_string(buff));
-
-        p->evaluate_and(c.get(), buff.data(), 2, 4);
-        ASSERT_EQ("0,0,1,0,0", to_string(buff));
-
-        // ---------------------------------------------
-        // evaluate_or()
-        // ---------------------------------------------
-        buff.assign(5, 0);
-        p->evaluate_or(c.get(), buff.data(), 0, 5);
-        ASSERT_EQ("0,1,1,0,0", to_string(buff));
-
-        p->evaluate_or(c.get(), buff.data(), 2, 4);
-        ASSERT_EQ("0,1,1,0,0", to_string(buff));
 
         buff.assign(5, 1);
         p->evaluate_or(c.get(), buff.data(), 0, 5);


### PR DESCRIPTION
## Why I'm doing:

Later storage engine will dynamic transfer `runtime filter(min=5, max=10, has_null)` to `(xxx>=5 and xxx<10) or (xxx has null)` , so i need support `ColumnAndPredicate` first.

## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0