### PR TITLE
[BugFix] fix partial update failure due to column name case

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
@@ -50,7 +50,7 @@ public class UpdateStmt extends DmlStmt {
         this.fromRelations = fromRelations;
         this.wherePredicate = wherePredicate;
         this.commonTableExpressions = commonTableExpressions;
-        this.assignmentColumns = Sets.newHashSet();
+        this.assignmentColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         for (ColumnAssignment each : assignments) {
             this.assignmentColumns.add(each.getColumn());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -50,6 +50,18 @@ public class UpdatePlanTest extends PlanTestBase {
         testExplain("explain costs update tprimary set v2 = v2 + 1 where v1 = 'aaa'");
     }
 
+    @Test
+    public void testColumnPartialUpdate() throws Exception {
+        String oldVal = connectContext.getSessionVariable().getPartialUpdateMode();
+        connectContext.getSessionVariable().setPartialUpdateMode("column");
+        testExplain("explain update tprimary set v2 = v2 + 1 where v1 = 'aaa'");
+        testExplain("explain update tprimary set v2 = DEFAULT where v1 = 'aaa'");
+        testExplain("explain update tprimary_auto_increment set v2 = DEFAULT where v1 = '123'");
+        testExplain("explain verbose update tprimary set v2 = v2 + 1 where v1 = 'aaa'");
+        testExplain("explain costs update tprimary set v2 = v2 + 1 where v1 = 'aaa'");
+        connectContext.getSessionVariable().setPartialUpdateMode(oldVal);
+    }
+
     private void testExplain(String explainStmt) throws Exception {
         connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));

--- a/test/sql/test_partial_update_column_mode/R/test_upper_case_partial_update
+++ b/test/sql/test_partial_update_column_mode/R/test_upper_case_partial_update
@@ -1,0 +1,49 @@
+-- name: test_upper_case_partial_update
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      V1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
+-- !result
+set partial_update_mode = 'column';
+-- result:
+-- !result
+update tab1 set V1 = 101 where k1 = 100 and k2 = "k2_100";
+-- result:
+-- !result
+update tab1 set v1 = 202 where k1 = 200 and k2 = "k2_200";
+-- result:
+-- !result
+select * from tab1;
+-- result:
+300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	101	100	100	v4_100	v5_100
+200	k2_200	202	200	200	v4_200	v5_200
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_upper_case_partial_update
+++ b/test/sql/test_partial_update_column_mode/T/test_upper_case_partial_update
@@ -1,0 +1,27 @@
+-- name: test_upper_case_partial_update
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      V1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+select * from tab1;
+
+set partial_update_mode = 'column';
+update tab1 set V1 = 101 where k1 = 100 and k2 = "k2_100";
+update tab1 set v1 = 202 where k1 = 200 and k2 = "k2_200";
+select * from tab1;


### PR DESCRIPTION
## Why I'm doing:
Partial update fail in this case: #53655
This is because in UpdatePlaner.java:
```
for (Column column : targetTable.getFullSchema()) {
                if (updateStmt.usePartialUpdate() && !column.isGeneratedColumn() &&
                        !updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {
                    // When using partial update, skip columns which aren't key column and not be assign, except for
                    // generated column
                    continue;
                }
```
`!updateStmt.isAssignmentColumn(column.getName())` is case-sensitively, so if the update column name are not same as which it was defined when create table, it will generate wrong plan. E.g.
```
CREATE TABLE employees (
    EmployeeID INT,
    Name VARCHAR(50),
    Salary DECIMAL(10, 2)
)
```
If you update `salary` instead of `Salary`, it will fail with `number of exprs is not same with slots  backend`.

## What I'm doing:
Update planner treats column names case-sensitively, which can lead to incorrect execution plans.

This pull request introduces improvements to the handling of column updates in SQL statements and adds corresponding test cases. The most important changes include modifying how assignment columns are stored, adding a new test method for partial updates, and creating new test scripts for upper-case partial updates.

Enhancements to column updates:

* [`fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java`](diffhunk://#diff-2718aa7803d7bf117a77c446b5878b51a4c7d277fe7893ac9f0043975fdb32d1L53-R53): Changed the `assignmentColumns` from a `HashSet` to a `TreeSet` with case-insensitive ordering to ensure consistent handling of column names.

New test cases for partial updates:

* [`fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java`](diffhunk://#diff-b6d4863b6a921adf8eb1fbb09a054ea99308a284f4cec62c1dd34e87caac33b6R53-R64): Added a new test method `testColumnPartialUpdate` to verify the behavior of partial updates in different scenarios.

New test scripts for upper-case partial updates:

* [`test/sql/test_partial_update_column_mode/R/test_upper_case_partial_update`](diffhunk://#diff-dc92785ae33c3f02544932c62da0c0bfe0bb5769641f15f95c6afcae0169ebccR1-R49): Added a new test script to validate partial updates with upper-case column names. This script includes table creation, data insertion, and update operations.
* [`test/sql/test_partial_update_column_mode/T/test_upper_case_partial_update`](diffhunk://#diff-c90be84a07d182a7895a8a1685d5c9a2d4c340cb0eebc2944e4d974d68b73eb9R1-R27): Added another test script with the same purpose as the previous one, ensuring thorough testing of partial updates with upper-case column names.

Fixes #53655

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0