### PR TITLE
[BugFix] Use latest collects stats job columns as stats meta columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalBasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalBasicStatsMeta.java
@@ -121,6 +121,10 @@ public class ExternalBasicStatsMeta implements Writable {
         this.type = analyzeType;
     }
 
+    public void setColumns(List<String> columns) {
+        this.columns = columns;
+    }
+
     public void addColumnStatsMeta(ColumnStatsMeta columnStatsMeta) {
         this.columnStatsMetaMap.put(columnStatsMeta.getColumnName(), columnStatsMeta);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -447,6 +447,8 @@ public class StatisticExecutor {
                     externalBasicStatsMeta.setUpdateTime(analyzeStatus.getEndTime());
                     externalBasicStatsMeta.setProperties(statsJob.getProperties());
                     externalBasicStatsMeta.setAnalyzeType(statsJob.getType());
+                    // set columns to the latest collect job's columns
+                    externalBasicStatsMeta.setColumns(Lists.newArrayList(statsJob.getColumnNames()));
                 }
 
                 Set<Long> sampledPartitions = new HashSet<>();

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -261,6 +261,7 @@ public class StatisticsExecutorTest extends PlanTestBase {
         statisticExecutor.collectStatistics(connectContext, statisticsCollectJob, status, false);
         externalBasicStatsMeta = GlobalStateMgr.getCurrentState().getAnalyzeMgr().
                 getExternalTableBasicStatsMeta("test_catalog", "test_db", "test_table");
+        Assert.assertEquals(externalBasicStatsMeta.getColumns(), Lists.newArrayList("col1", "col3"));
         Assert.assertEquals(externalBasicStatsMeta.getColumnStatsMetaMap().size(), 3);
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Use latest collects stats job columns as stats meta columns
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0