### PR TITLE
[BugFix] Fix TaskRunHistoryTable's lookup api output order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.util.Strings;
 
 import java.text.MessageFormat;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -201,7 +202,10 @@ public class TaskRunHistoryTable {
         sql += Joiner.on(" AND ").join(predicates);
 
         List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
-        return TaskRunStatus.fromResultBatch(batch);
+        List<TaskRunStatus> result = TaskRunStatus.fromResultBatch(batch);
+        // sort results by create time desc to make the result more stable.
+        Collections.sort(result, TaskRunStatus.COMPARATOR_BY_CREATE_TIME_DESC);
+        return result;
     }
 
     public List<TaskRunStatus> lookupByTaskNames(String dbName, Set<String> taskNames) {
@@ -217,6 +221,9 @@ public class TaskRunHistoryTable {
 
         String sql = LOOKUP + Joiner.on(" AND ").join(predicates);
         List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
-        return TaskRunStatus.fromResultBatch(batch);
+        List<TaskRunStatus> result = TaskRunStatus.fromResultBatch(batch);
+        // sort results by create time desc to make the result more stable.
+        Collections.sort(result, TaskRunStatus.COMPARATOR_BY_CREATE_TIME_DESC);
+        return result;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -42,12 +42,17 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class TaskRunStatus implements Writable {
     private static final Logger LOG = LogManager.getLogger(TaskRun.class);
+
+    // Sort task run status by create time in descending order
+    public static final Comparator<TaskRunStatus> COMPARATOR_BY_CREATE_TIME_DESC =
+            Comparator.comparingLong(TaskRunStatus::getCreateTime).reversed();
 
     // A refresh may contain a batch of task runs, startTaskRunId is to mark the unique id of the batch task run status.
     // You can use the startTaskRunId to find the batch of task runs.


### PR DESCRIPTION
## Why I'm doing:
> multiple fields are missing randomly. Run command multiple time will give random null values.
> There are no obvious pattern of it.


## What I'm doing:
- Sort `look`/`lookupByTaskNames` results by `create_time desc` to make result stable.

Fixes https://github.com/StarRocks/starrocks/issues/48649

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0