### PR TITLE
[BugFix] Fix ExecuteOption may change task's taskRunProperties bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
@@ -50,7 +50,10 @@ public class ExecuteOption {
     public ExecuteOption(int priority, boolean isMergeRedundant, Map<String, String> taskRunProperties) {
         this.priority = priority;
         this.isMergeRedundant = isMergeRedundant;
-        this.taskRunProperties = taskRunProperties;
+        // clone the taskRunProperties to avoid modifying the original map because `mergeProperties` may change it.
+        if (taskRunProperties != null) {
+            this.taskRunProperties = Maps.newHashMap(taskRunProperties);
+        }
     }
 
     public static ExecuteOption makeMergeRedundantOption() {


### PR DESCRIPTION
## Why I'm doing:
`ExecuteOption` should be created for each `TaskRun` and it should not refer `Task`'s properties which may cause some trick bugs if it pollute it.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0