### PR TITLE
[Enhancement] short circuit optimization on `select limit` case (on FE side)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -38,6 +38,9 @@ import com.starrocks.StarRocksFE;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.Replica;
 
+import static java.lang.Math.max;
+import static java.lang.Runtime.getRuntime;
+
 public class Config extends ConfigBase {
 
     /**
@@ -3343,4 +3346,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Defines the maximum balance factor allowed " +
             "between any two nodes before triggering a balance")
     public static double batch_write_be_assigner_balance_factor_threshold = 0.1;
+
+    @ConfField(mutable = false)
+    public static int query_deploy_threadpool_size = max(50, getRuntime().availableProcessors() * 10);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -167,7 +167,7 @@ public class DefaultCoordinator extends Coordinator {
     private boolean isShortCircuit = false;
     private boolean isBinaryRow = false;
 
-    private ExecutionSchedule schedule;
+    private ExecutionSchedule scheduler;
 
     public static class Factory implements Coordinator.Factory {
 
@@ -310,9 +310,9 @@ public class DefaultCoordinator extends Coordinator {
             isShortCircuit = true;
         }
         if (enablePhasedScheduler) {
-            schedule = new PhasedExecutionSchedule(connectContext);
+            scheduler = new PhasedExecutionSchedule(connectContext);
         } else {
-            schedule = new AllAtOnceExecutionSchedule();
+            scheduler = new AllAtOnceExecutionSchedule();
         }
 
         this.queryProfile =
@@ -528,7 +528,7 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     @Override
-    public void startScheduling(boolean needDeploy) throws Exception {
+    public void startScheduling(ScheduleOption option) throws Exception {
         try (Timer timer = Tracers.watchScope(Tracers.Module.SCHEDULER, "Pending")) {
             QueryQueueManager.getInstance().maybeWait(connectContext, this);
         }
@@ -543,11 +543,11 @@ public class DefaultCoordinator extends Coordinator {
         }
 
         try (Timer timer = Tracers.watchScope(Tracers.Module.SCHEDULER, "Deploy")) {
-            deliverExecFragments(needDeploy);
+            deliverExecFragments(option);
         }
 
         // Prevent `explain scheduler` from waiting until the profile timeout.
-        if (!needDeploy) {
+        if (!option.doDeploy) {
             queryProfile.finishAllInstances(Status.OK);
         }
     }
@@ -555,7 +555,7 @@ public class DefaultCoordinator extends Coordinator {
     @Override
     public Status scheduleNextTurn(TUniqueId fragmentInstanceId) {
         try {
-            schedule.tryScheduleNextTurn(fragmentInstanceId);
+            scheduler.tryScheduleNextTurn(fragmentInstanceId);
         } catch (Exception e) {
             LOG.warn("schedule fragment:{} next internal error:", DebugUtil.printId(fragmentInstanceId), e);
             cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, e.getMessage());
@@ -638,14 +638,14 @@ public class DefaultCoordinator extends Coordinator {
         }
     }
 
-    private void deliverExecFragments(boolean needDeploy) throws RpcException, StarRocksException {
+    private void deliverExecFragments(ScheduleOption option) throws RpcException, StarRocksException {
         lock();
         try (Timer ignored = Tracers.watchScope(Tracers.Module.SCHEDULER, "DeployLockInternalTime")) {
             Deployer deployer =
                     new Deployer(connectContext, jobSpec, executionDAG, coordinatorPreprocessor.getCoordAddress(),
-                            this::handleErrorExecution, needDeploy);
-            schedule.prepareSchedule(this, deployer, executionDAG);
-            this.schedule.schedule();
+                            this::handleErrorExecution, option.doDeploy);
+            scheduler.prepareSchedule(this, deployer, executionDAG);
+            this.scheduler.schedule(option);
             queryProfile.attachExecutionProfiles(executionDAG.getExecutions());
         } finally {
             unlock();
@@ -998,7 +998,7 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     private boolean isPhasedSchedule() {
-        return schedule instanceof PhasedExecutionSchedule;
+        return scheduler instanceof PhasedExecutionSchedule;
     }
 
     // For phased schedule execution, we cancel the query context. (BE will cancel the relevant fragment internally)
@@ -1007,6 +1007,7 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     private void cancelRemoteFragmentsAsync(PPlanFragmentCancelReason cancelReason) {
+        scheduler.cancel();
         for (FragmentInstanceExecState execState : executionDAG.getExecutions()) {
             // If the execState fails to be cancelled, and it has been finished or not been deployed,
             // count down the profileDoneSignal of this execState immediately,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1253,12 +1253,12 @@ public class StmtExecutor {
                 new QeProcessorImpl.QueryInfo(context, originStmt.originStmt, coord));
 
         if (isSchedulerExplain) {
-            coord.startSchedulingWithoutDeploy();
+            coord.execWithoutDeploy();
             handleExplainStmt(coord.getSchedulerExplain());
             return;
         }
 
-        coord.exec();
+        coord.execWithQueryDeployExecutor();
         coord.setTopProfileSupplier(this::buildTopLevelProfile);
         coord.setExecPlan(execPlan);
 
@@ -2361,7 +2361,7 @@ public class StmtExecutor {
             QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(), queryInfo);
 
             if (isSchedulerExplain) {
-                coord.startSchedulingWithoutDeploy();
+                coord.execWithoutDeploy();
                 handleExplainStmt(coord.getSchedulerExplain());
                 return;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -89,9 +89,26 @@ public abstract class Coordinator {
     // ------------------------------------------------------------------------------------
     // Common methods for scheduling.
     // ------------------------------------------------------------------------------------
+    public static class ScheduleOption {
+        public boolean doDeploy = true;
+        public boolean useQueryDeployExecutor = false;
+    }
 
     public void exec() throws Exception {
-        startScheduling();
+        ScheduleOption option = new ScheduleOption();
+        startScheduling(option);
+    }
+
+    public void execWithoutDeploy() throws Exception {
+        ScheduleOption option = new ScheduleOption();
+        option.doDeploy = false;
+        startScheduling(option);
+    }
+
+    public void execWithQueryDeployExecutor() throws Exception {
+        ScheduleOption option = new ScheduleOption();
+        option.useQueryDeployExecutor = true;
+        startScheduling(option);
     }
 
     /**
@@ -102,21 +119,11 @@ public abstract class Coordinator {
      *     <li> Deploys them to the related workers, if the parameter {@code needDeploy} is true.
      * </ul>
      * <p>
-     *
-     * @param needDeploy Whether deploying fragment instances to workers.
      */
-    public abstract void startScheduling(boolean needDeploy) throws Exception;
+    public abstract void startScheduling(ScheduleOption option) throws Exception;
 
     public Status scheduleNextTurn(TUniqueId fragmentInstanceId) {
         return Status.OK;
-    }
-
-    public void startScheduling() throws Exception {
-        startScheduling(true);
-    }
-
-    public void startSchedulingWithoutDeploy() throws Exception {
-        startScheduling(false);
     }
 
     public abstract String getSchedulerExplain();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/FeExecuteCoordinator.java
@@ -69,7 +69,7 @@ public class FeExecuteCoordinator extends Coordinator {
         this.execPlan = execPlan;
     }
     @Override
-    public void startScheduling(boolean needDeploy) throws Exception {
+    public void startScheduling(ScheduleOption option) throws Exception {
 
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -19,16 +19,57 @@ import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.Deployer;
 import com.starrocks.qe.scheduler.slot.DeployState;
 import com.starrocks.rpc.RpcException;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TUniqueId;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 // all at once execution schedule only schedule once.
 public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
     private Coordinator coordinator;
     private Deployer deployer;
     private ExecutionDAG dag;
+    private volatile boolean cancelled = false;
+
+    class DeployMoreScanRangesTask implements Runnable {
+        List<DeployState> states;
+        private ExecutorService executorService;
+
+        DeployMoreScanRangesTask(List<DeployState> states, ExecutorService executorService) {
+            this.states = states;
+            this.executorService = executorService;
+        }
+
+        @Override
+        public void run() {
+            if (cancelled) {
+                return;
+            }
+            try {
+                states = coordinator.assignIncrementalScanRangesToDeployStates(deployer, states);
+                if (states.isEmpty()) {
+                    return;
+                }
+                for (DeployState state : states) {
+                    deployer.deployFragments(state);
+                }
+            } catch (StarRocksException | RpcException e) {
+                throw new RuntimeException(e);
+            }
+            // jvm should use tail optimization.
+            start();
+        }
+
+        public void start() {
+            if (executorService != null) {
+                executorService.submit(this);
+            } else {
+                this.run();
+            }
+        }
+    }
 
     @Override
     public void prepareSchedule(Coordinator coordinator, Deployer deployer, ExecutionDAG dag) {
@@ -38,7 +79,7 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
     }
 
     @Override
-    public void schedule() throws RpcException, StarRocksException {
+    public void schedule(Coordinator.ScheduleOption option) throws RpcException, StarRocksException {
         List<DeployState> states = new ArrayList<>();
         for (List<ExecutionFragment> executionFragments : dag.getFragmentsInTopologicalOrderFromRoot()) {
             final DeployState deployState = deployer.createFragmentExecStates(executionFragments);
@@ -46,17 +87,20 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
             states.add(deployState);
         }
 
-        while (true) {
-            states = coordinator.assignIncrementalScanRangesToDeployStates(deployer, states);
-            if (states.isEmpty()) {
-                break;
-            }
-            for (DeployState state : states) {
-                deployer.deployFragments(state);
-            }
+        ExecutorService executorService = null;
+        if (option.useQueryDeployExecutor) {
+            executorService = GlobalStateMgr.getCurrentState().getQueryDeployExecutor();
         }
+
+        DeployMoreScanRangesTask task = new DeployMoreScanRangesTask(states, executorService);
+        task.start();
     }
 
     public void tryScheduleNextTurn(TUniqueId fragmentInstanceId) {
+    }
+
+    @Override
+    public void cancel() {
+        cancelled = true;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionSchedule.java
@@ -23,7 +23,8 @@ import com.starrocks.thrift.TUniqueId;
 public interface ExecutionSchedule {
     void prepareSchedule(Coordinator coordinator, Deployer deployer, ExecutionDAG dag);
 
-    void schedule() throws RpcException, StarRocksException;
+    void schedule(Coordinator.ScheduleOption option) throws RpcException, StarRocksException;
 
     void tryScheduleNextTurn(TUniqueId fragmentInstanceId) throws RpcException, StarRocksException;
+    void cancel();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/PhasedExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/PhasedExecutionSchedule.java
@@ -64,6 +64,8 @@ public class PhasedExecutionSchedule implements ExecutionSchedule {
     private Deployer deployer;
     private ExecutionDAG dag;
 
+    private volatile boolean cancelled = false;
+
     public PhasedExecutionSchedule(ConnectContext context) {
         this.connectContext = context;
         this.maxScheduleConcurrency = context.getSessionVariable().getPhasedSchedulerMaxConcurrency();
@@ -200,7 +202,7 @@ public class PhasedExecutionSchedule implements ExecutionSchedule {
     }
 
     // schedule next
-    public void schedule() throws RpcException, StarRocksException {
+    public void schedule(Coordinator.ScheduleOption option) throws RpcException, StarRocksException {
         buildDeployStates();
         final int oldTaskCnt = inputScheduleTaskNums.getAndIncrement();
         if (oldTaskCnt == 0) {
@@ -210,6 +212,10 @@ public class PhasedExecutionSchedule implements ExecutionSchedule {
                 dec = inputScheduleTaskNums.getAndDecrement();
             } while (dec > 1);
         }
+    }
+
+    public void cancel() {
+        cancelled = true;
     }
 
     private void doDeploy() throws RpcException, StarRocksException {
@@ -234,6 +240,9 @@ public class PhasedExecutionSchedule implements ExecutionSchedule {
     }
 
     public void tryScheduleNextTurn(TUniqueId fragmentInstanceId) throws RpcException, StarRocksException {
+        if (cancelled) {
+            return;
+        }
         final FragmentInstance instance = dag.getInstanceByInstanceId(fragmentInstanceId);
         final PlanFragmentId fragmentId = instance.getFragmentId();
         final AtomicInteger countDowns = schedulingFragmentInstances.get(fragmentId);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -255,6 +255,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
@@ -509,6 +510,7 @@ public class GlobalStateMgr {
     private final Authorizer authorizer;
     private final DDLStmtExecutor ddlStmtExecutor;
     private final ShowExecutor showExecutor;
+    private final ExecutorService queryDeployExecutor;
 
     public NodeMgr getNodeMgr() {
         return nodeMgr;
@@ -807,6 +809,9 @@ public class GlobalStateMgr {
         this.ddlStmtExecutor = new DDLStmtExecutor(DDLStmtExecutor.StmtExecutorVisitor.getInstance());
         this.showExecutor = new ShowExecutor(ShowExecutor.ShowExecutorVisitor.getInstance());
         this.temporaryTableCleaner = new TemporaryTableCleaner();
+        this.queryDeployExecutor =
+                ThreadPoolManager.newDaemonFixedThreadPool(Config.query_deploy_threadpool_size, Integer.MAX_VALUE,
+                        "query-deploy", true);
     }
 
     public static void destroyCheckpoint() {
@@ -1035,6 +1040,10 @@ public class GlobalStateMgr {
 
     public ShowExecutor getShowExecutor() {
         return showExecutor;
+    }
+
+    public ExecutorService getQueryDeployExecutor() {
+        return queryDeployExecutor;
     }
 
     public GtidGenerator getGtidGenerator() {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/StartSchedulingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/StartSchedulingTest.java
@@ -191,7 +191,7 @@ public class StartSchedulingTest extends SchedulerTestBase {
         isFirstFragmentToDeploy.set(true);
         deployFuture.setRef(mockFutureWithException(new InterruptedException("test interrupted exception")));
         DefaultCoordinator scheduler = getScheduler(sql);
-        Assert.assertThrows("test interrupted exception", StarRocksException.class, () -> scheduler.startScheduling());
+        Assert.assertThrows("test interrupted exception", StarRocksException.class, () -> scheduler.exec());
 
         // The deployed executions haven't reported.
         Assert.assertFalse(scheduler.isDone());
@@ -253,7 +253,7 @@ public class StartSchedulingTest extends SchedulerTestBase {
         String sql =
                 "select count(1) from lineitem UNION ALL select count(1) from lineitem UNION ALL select count(1) from lineitem";
         DefaultCoordinator scheduler = getScheduler(sql);
-        Assert.assertThrows("test error message", StarRocksException.class, scheduler::startScheduling);
+        Assert.assertThrows("test error message", StarRocksException.class, scheduler::exec);
 
         // All the deployed fragment instances should be cancelled.
         Assert.assertEquals(successDeployedFragmentCount, cancelledInstanceIds.size());
@@ -288,7 +288,7 @@ public class StartSchedulingTest extends SchedulerTestBase {
 
             String sql = "select count(1) from lineitem t1 JOIN [shuffle] lineitem t2 using(l_orderkey)";
             DefaultCoordinator scheduler = getScheduler(sql);
-            Assert.assertThrows("deploy query timeout", StarRocksException.class, () -> scheduler.startScheduling());
+            Assert.assertThrows("deploy query timeout", StarRocksException.class, () -> scheduler.exec());
         } finally {
             connectContext.getSessionVariable().setQueryDeliveryTimeoutS(prevQueryDeliveryTimeoutSecond);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
@@ -110,7 +110,7 @@ public class ShortCircuitTest extends PlanTestBase {
 
         DefaultCoordinator coord = new DefaultCoordinator.Factory().createQueryScheduler(connectContext,
                 execPlan.getFragments(), ImmutableList.of(scanNode), execPlan.getDescTbl().toThrift());
-        coord.startScheduling();
+        coord.exec();
 
         ExecutionFragment execFragment = coord.getExecutionDAG().getRootFragment();
         Assert.assertEquals(true, execFragment.getPlanFragment().isShortCircuit());
@@ -150,7 +150,7 @@ public class ShortCircuitTest extends PlanTestBase {
 
         DefaultCoordinator coord = new DefaultCoordinator.Factory().createQueryScheduler(connectContext,
                 execPlan.getFragments(), ImmutableList.of(scanNode), execPlan.getDescTbl().toThrift());
-        coord.startScheduling();
+        coord.exec();
         Assert.assertTrue(coord.getNext().isEos());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -585,7 +585,7 @@ public class UtFrameUtils {
                     (context, statementBase, execPlan) -> {
                         DefaultCoordinator scheduler = createScheduler(context, statementBase, execPlan);
 
-                        scheduler.startScheduling();
+                        scheduler.exec();
 
                         return scheduler;
                     });
@@ -597,7 +597,7 @@ public class UtFrameUtils {
                     (context, statementBase, execPlan) -> {
                         DefaultCoordinator scheduler = createScheduler(context, statementBase, execPlan);
 
-                        scheduler.startSchedulingWithoutDeploy();
+                        scheduler.execWithoutDeploy();
                         String plan = scheduler.getSchedulerExplain();
 
                         return Pair.create(plan, scheduler);


### PR DESCRIPTION
## Why I'm doing:

Since we support incremental scan ranges in this PR: https://github.com/StarRocks/starrocks/pull/50189, We can optimize `select limit` pattern query without having to deliver all scan ranges.

![image](https://github.com/user-attachments/assets/ed3b8ffd-73a7-476f-bc37-e2bea28d82e4)

And It's better to know how many rounds of incremental scan ranges deployment. 

## What I'm doing:

This PR works like following:
- put incremental scan ranges delivery in another thread as a task
- and if coord get enough rows, cancel the task

![image](https://github.com/user-attachments/assets/40124dba-f978-4250-8332-9823d32cac81)


Fixes #issue

-----------

I've used following sql to test performance, the dataset is tpcds-1T iceberg table.

```sql
select * from catalog_sales limit 10;
select * from catalog_sales limit 100;
select * from catalog_sales limit 500;
select * from catalog_sales limit 1000;

select * from store_sales limit 10;
select * from store_sales limit 100;
select * from store_sales limit 500;
select * from store_sales limit 1000;
```

  | PR | Base | \+X%
-- | -- | -- | --
Q01 | 136 | 665 | 79.55
Q02 | 148 | 721 | 79.47
Q03 | 161 | 699 | 76.97
Q04 | 166 | 746 | 77.75
Q05 | 202 | 396 | 48.99
Q06 | 225 | 395 | 43.04
Q07 | 234 | 363 | 35.54
Q08 | 209 | 400 | 47.75

</byte-sheet-html-origin><!--EndFragment-->


Table stats:
- catalog_sales
  - 28521 files
  - 32 columns
- store_sales
  - 12030 files
  - 23 columns

So the more files,  the better improvement we have.

---------

We modify code to compare PR and "only deliver 50 files". And there is no big difference.

  | PR | only deliver 50 files
-- | -- | --
Q01 | 136 | 157
Q02 | 148 | 162
Q03 | 161 | 144
Q04 | 166 | 172
Q05 | 202 | 223
Q06 | 225 | 238
Q07 | 234 | 201
Q08 | 209 | 252

</byte-sheet-html-origin><!--EndFragment-->

</byte-sheet-html-origin><!--EndFragment-->


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0