### PR TITLE
[BugFix] fix query timeout behavior when using query queue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.qe;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -586,6 +587,12 @@ public class ConnectContext {
 
     public void setStartTime() {
         startTime = Instant.now();
+        returnRows = 0;
+    }
+
+    @VisibleForTesting
+    public void setStartTime(Instant start) {
+        startTime = start;
         returnRows = 0;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -65,12 +65,12 @@ public class QueryQueueManager {
             MetricRepo.COUNTER_QUERY_QUEUE_TOTAL.increase(1L);
             ResourceGroupMetricMgr.increaseQueuedQuery(context, 1L);
 
-            long timeoutMs = slotRequirement.getExpiredPendingTimeMs();
+            long deadlineEpochMs = slotRequirement.getExpiredPendingTimeMs();
             LogicalSlot allocatedSlot = null;
             while (allocatedSlot == null) {
                 // Check timeout.
                 long currentMs = System.currentTimeMillis();
-                if (currentMs >= timeoutMs) {
+                if (currentMs >= deadlineEpochMs) {
                     MetricRepo.COUNTER_QUERY_QUEUE_TIMEOUT.increase(1L);
                     slotProvider.cancelSlotRequirement(slotRequirement);
                     String errMsg = String.format(PENDING_TIMEOUT_ERROR_MSG_FORMAT,
@@ -84,7 +84,7 @@ public class QueryQueueManager {
 
                 // Wait for slot allocated.
                 try {
-                    allocatedSlot = slotFuture.get(timeoutMs - currentMs, TimeUnit.MILLISECONDS);
+                    allocatedSlot = slotFuture.get(deadlineEpochMs - currentMs, TimeUnit.MILLISECONDS);
                 } catch (ExecutionException e) {
                     LOG.warn("[Slot] failed to allocate resource to query [slot={}]", slotRequirement, e);
                     if (e.getCause() instanceof RecoverableException) {
@@ -94,7 +94,13 @@ public class QueryQueueManager {
                 } catch (TimeoutException e) {
                     // Check timeout in the next loop.
                 } catch (CancellationException e) {
-                    throw new StarRocksException("Cancelled");
+                    // There are two threads checking timeout, one is there, the other is CheckTimer.
+                    // So this thread can get be cancelled by CheckTimer
+                    if (System.currentTimeMillis() >= deadlineEpochMs) {
+                        MetricRepo.COUNTER_QUERY_QUEUE_TIMEOUT.increase(1L);
+                        ResourceGroupMetricMgr.increaseTimeoutQueuedQuery(context, 1L);
+                    }
+                    throw new StarRocksException(e);
                 }
             }
         } finally {
@@ -117,7 +123,7 @@ public class QueryQueueManager {
         TWorkGroup group = coord.getJobSpec().getResourceGroup();
         long groupId = group == null ? LogicalSlot.ABSENT_GROUP_ID : group.getId();
 
-        long nowMs = System.currentTimeMillis();
+        long nowMs = context.getStartTime();
         long queryTimeoutSecond = coord.getJobSpec().getQueryOptions().getQuery_timeout();
         long expiredPendingTimeMs =
                 nowMs + Math.min(GlobalVariable.getQueryQueuePendingTimeoutSecond(), queryTimeoutSecond) * 1000L;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/LogicalSlot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/LogicalSlot.java
@@ -138,8 +138,8 @@ public class LogicalSlot {
         return expiredAllocatedTimeMs;
     }
 
-    public boolean isPendingExpired(long nowMs) {
-        return nowMs >= expiredPendingTimeMs;
+    public boolean isPendingTimeout() {
+        return System.currentTimeMillis() >= expiredPendingTimeMs;
     }
 
     public boolean isAllocatedExpired(long nowMs) {


### PR DESCRIPTION
## Why I'm doing:

For a particular case that a query takes hundreds of seconds in the optimizer then pend in the query queue:
1. The real timeout can be longer than expected, because query queue pending timeout count from creating slot, but not from command start
2. The counter `query_queue_timeout` is not changed, since that pending request received a cancel request

## What I'm doing:

1. Query queue pending deadline should count from `command start`, instead of the time when create slot
3. The pending can be cancelled by other thread, so it also need to deal with the `CancellationException`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0