### PR TITLE
[BugFix] Fix retry upload failure when backup files using HDFS filesystem interface

### DIFF
--- a/be/test/fs/fs_hdfs_test.cpp
+++ b/be/test/fs/fs_hdfs_test.cpp
@@ -76,4 +76,24 @@ TEST_F(HdfsFileSystemTest, create_file_and_destroy) {
     thread.join();
 }
 
+TEST_F(HdfsFileSystemTest, create_file_with_open_after_delete) {
+    auto fs = new_fs_hdfs(FSOptions());
+    std::string filepath = "file://" + _root_path + "/create_file_with_open_truncate";
+    auto st = fs->path_exists(filepath);
+    EXPECT_TRUE(st.is_not_found());
+
+    WritableFileOptions opts{.sync_on_close = false,
+                             .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    auto wfile_1 = fs->new_writable_file(opts, filepath);
+    EXPECT_TRUE(wfile_1.ok());
+    (*wfile_1)->close();
+
+    auto wfile_2 = fs->new_writable_file(opts, filepath);
+    EXPECT_TRUE(wfile_2.ok());
+    (*wfile_2)->close();
+
+    (*wfile_1).reset();
+    (*wfile_2).reset();
+}
+
 } // namespace starrocks

--- a/be/test/fs/fs_hdfs_test.cpp
+++ b/be/test/fs/fs_hdfs_test.cpp
@@ -78,21 +78,49 @@ TEST_F(HdfsFileSystemTest, create_file_and_destroy) {
 
 TEST_F(HdfsFileSystemTest, create_file_with_open_truncate) {
     auto fs = new_fs_hdfs(FSOptions());
-    std::string filepath = "file://" + _root_path + "/create_file_with_open_truncate";
+    const std::string filepath = "file://" + _root_path + "/create_file_with_open_truncate";
     auto st = fs->path_exists(filepath);
     EXPECT_TRUE(st.is_not_found());
+    std::string str1 = "123";
+    std::string str2 = "456";
+    Slice data1(str1);
+    Slice data2(str2);
 
     WritableFileOptions opts{.sync_on_close = false, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+
     auto wfile_1 = fs->new_writable_file(opts, filepath);
     EXPECT_TRUE(wfile_1.ok());
+    EXPECT_TRUE((*wfile_1)->append(data1).ok());
+    EXPECT_TRUE((*wfile_1)->flush(WritableFile::FlushMode::FLUSH_SYNC).ok());
+    EXPECT_TRUE((*wfile_1)->sync().ok());
     (*wfile_1)->close();
 
     st = fs->path_exists(filepath);
     EXPECT_TRUE(st.ok());
 
+    auto open_res1 = fs->new_random_access_file(filepath);
+    EXPECT_TRUE(open_res1.ok());
+    auto rfile1 = std::move(open_res1.value());
+    auto read_res_1 = rfile1->read_all();
+    EXPECT_TRUE(read_res_1.ok());
+    EXPECT_TRUE(read_res_1.value() == str1);
+
     auto wfile_2 = fs->new_writable_file(opts, filepath);
     EXPECT_TRUE(wfile_2.ok());
+    EXPECT_TRUE((*wfile_2)->append(data2).ok());
+    EXPECT_TRUE((*wfile_2)->flush(WritableFile::FlushMode::FLUSH_SYNC).ok());
+    EXPECT_TRUE((*wfile_2)->sync().ok());
     (*wfile_2)->close();
+
+    st = fs->path_exists(filepath);
+    EXPECT_TRUE(st.ok());
+
+    auto open_res2 = fs->new_random_access_file(filepath);
+    EXPECT_TRUE(open_res2.ok());
+    auto rfile2 = std::move(open_res2.value());
+    auto read_res_2 = rfile2->read_all();
+    EXPECT_TRUE(read_res_2.ok());
+    EXPECT_TRUE(read_res_2.value() == str2);
 
     (*wfile_1).reset();
     (*wfile_2).reset();

--- a/be/test/fs/fs_hdfs_test.cpp
+++ b/be/test/fs/fs_hdfs_test.cpp
@@ -76,17 +76,19 @@ TEST_F(HdfsFileSystemTest, create_file_and_destroy) {
     thread.join();
 }
 
-TEST_F(HdfsFileSystemTest, create_file_with_open_after_delete) {
+TEST_F(HdfsFileSystemTest, create_file_with_open_truncate) {
     auto fs = new_fs_hdfs(FSOptions());
     std::string filepath = "file://" + _root_path + "/create_file_with_open_truncate";
     auto st = fs->path_exists(filepath);
     EXPECT_TRUE(st.is_not_found());
 
-    WritableFileOptions opts{.sync_on_close = false,
-                             .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    WritableFileOptions opts{.sync_on_close = false, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
     auto wfile_1 = fs->new_writable_file(opts, filepath);
     EXPECT_TRUE(wfile_1.ok());
     (*wfile_1)->close();
+
+    st = fs->path_exists(filepath);
+    EXPECT_TRUE(st.ok());
 
     auto wfile_2 = fs->new_writable_file(opts, filepath);
     EXPECT_TRUE(wfile_2.ok());


### PR DESCRIPTION
## Why I'm doing:
HDFS filesystem interface does not support file mode with CREATE_OR_OPEN_WITH_TRUNCATE. If we want to new writable file but it has already existed, it will fail in this case. It means that it is impossible to retry upload in many cases in backup process.

## What I'm doing:
Use `O_WRONLY` flag for `hdfsOpenFile` which implies `O_TRUNCAT`.

Fixes #53631

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0