### PR TITLE
[Enhancement] GetCommonStructType returns the non-null struct while an argument is struct<null>.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -168,6 +168,10 @@ public class StructType extends Type {
         return fields;
     }
 
+    public boolean isAllNull() {
+        return getFields().stream().allMatch(field -> field.getType().isNull());
+    }
+
     public StructField getField(String fieldName) {
         return fieldMap.get(StringUtils.lowerCase(fieldName));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -104,6 +104,10 @@ public class TypeManager {
     }
 
     private static Type getCommonStructType(StructType t1, StructType t2) {
+        if (t2.isAllNull() || t1.isAllNull()) {
+            return t2.isAllNull() ? t1 : t2;
+        }
+
         if (t1.getFields().size() != t2.getFields().size()) {
             return Type.INVALID;
         }


### PR DESCRIPTION
## Why I'm doing:
Getting common type of a struct type with more than 1 arguments and null type returns invalid for now, so the sql below raises an error.
`StarRocks > select if(a = 2, row(1, 2), null)  from tt4;`
ERROR 1064 (HY000): Getting analyzing error from line 1, column 7 to line 1, column 32. Detail message: No matching function with signature: if(boolean, struct<col1 tinyint(4), col2 tinyint(4)>, NULL_TYPE).

## What I'm doing:
Returns the non-null struct while the other struct's arguments are all null


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0