### PR TITLE
[Refactor] OlapRuntimeScanRangePruner use object pool to manager the life cycle of predicate

### DIFF
--- a/be/src/storage/olap_runtime_range_pruner.h
+++ b/be/src/storage/olap_runtime_range_pruner.h
@@ -44,18 +44,15 @@ struct UnarrivedRuntimeFilterList {
 
 class OlapRuntimeScanRangePruner {
 public:
-    using PredicatesPtrs = std::vector<std::unique_ptr<ColumnPredicate>>;
     using PredicatesRawPtrs = std::vector<const ColumnPredicate*>;
     using RuntimeFilterArrivedCallBack = std::function<Status(int, const PredicatesRawPtrs&)>;
-    static constexpr auto rf_update_threhold = 4096 * 10;
+    static constexpr auto rf_update_threshold = 4096 * 10;
 
     OlapRuntimeScanRangePruner() = default;
     OlapRuntimeScanRangePruner(PredicateParser* parser, const UnarrivedRuntimeFilterList& params) {
         _parser = parser;
         _init(params);
     }
-
-    void set_predicate_parser(PredicateParser* parser) { _parser = parser; }
 
     Status update_range_if_arrived(const ColumnIdToGlobalDictMap* global_dictmaps,
                                    RuntimeFilterArrivedCallBack&& updater, size_t raw_read_rows) {
@@ -72,10 +69,9 @@ private:
     PredicateParser* _parser = nullptr;
     size_t _raw_read_rows = 0;
 
-    // get predicate
-    StatusOr<PredicatesPtrs> _get_predicates(const ColumnIdToGlobalDictMap* global_dictmaps, size_t idx);
-
-    PredicatesRawPtrs _as_raw_predicates(const std::vector<std::unique_ptr<ColumnPredicate>>& predicates);
+    // get predicates
+    StatusOr<PredicatesRawPtrs> _get_predicates(const ColumnIdToGlobalDictMap* global_dictmaps, size_t idx,
+                                                ObjectPool* pool);
 
     Status _update(const ColumnIdToGlobalDictMap* global_dictmaps, RuntimeFilterArrivedCallBack&& updater,
                    size_t raw_read_rows);

--- a/be/src/storage/olap_runtime_range_pruner.hpp
+++ b/be/src/storage/olap_runtime_range_pruner.hpp
@@ -30,18 +30,18 @@ namespace starrocks {
 namespace detail {
 struct RuntimeColumnPredicateBuilder {
     template <LogicalType ltype>
-    StatusOr<std::vector<std::unique_ptr<ColumnPredicate>>> operator()(const ColumnIdToGlobalDictMap* global_dictmaps,
-                                                                       PredicateParser* parser,
-                                                                       const RuntimeFilterProbeDescriptor* desc,
-                                                                       const SlotDescriptor* slot,
-                                                                       int32_t driver_sequence) {
+    StatusOr<std::vector<const ColumnPredicate*>> operator()(const ColumnIdToGlobalDictMap* global_dictmaps,
+                                                             PredicateParser* parser,
+                                                             const RuntimeFilterProbeDescriptor* desc,
+                                                             const SlotDescriptor* slot, int32_t driver_sequence,
+                                                             ObjectPool* pool) {
         // keep consistent with ColumnRangeBuilder
         if constexpr (ltype == TYPE_TIME || ltype == TYPE_NULL || ltype == TYPE_JSON || lt_is_float<ltype> ||
                       lt_is_binary<ltype>) {
             DCHECK(false) << "unreachable path";
             return Status::NotSupported("unreachable path");
         } else {
-            std::vector<std::unique_ptr<ColumnPredicate>> preds;
+            std::vector<const ColumnPredicate*> preds;
 
             // Treat tinyint and boolean as int
             constexpr LogicalType limit_type = ltype == TYPE_TINYINT || ltype == TYPE_BOOLEAN ? TYPE_INT : ltype;
@@ -86,10 +86,10 @@ struct RuntimeColumnPredicateBuilder {
             }
 
             for (auto& f : filters) {
-                std::unique_ptr<ColumnPredicate> p(parser->parse_thrift_cond(f));
+                ColumnPredicate* p = pool->add(parser->parse_thrift_cond(f));
                 VLOG(2) << "build runtime predicate:" << p->debug_string();
                 p->set_index_filter_only(f.is_index_filter_only);
-                preds.emplace_back(std::move(p));
+                preds.emplace_back(p);
             }
 
             return preds;
@@ -179,12 +179,13 @@ inline Status OlapRuntimeScanRangePruner::_update(const ColumnIdToGlobalDictMap*
         // we will filter by index
         if (auto rf = _unarrived_runtime_filters[i]->runtime_filter(_driver_sequence)) {
             size_t rf_version = rf->rf_version();
-            if (_arrived_runtime_filters_masks[i] == 0 ||
-                (rf_version > _rf_versions[i] && raw_read_rows - _raw_read_rows > rf_update_threhold)) {
-                ASSIGN_OR_RETURN(auto predicates, _get_predicates(global_dictmaps, i));
-                auto raw_predicates = _as_raw_predicates(predicates);
-                if (!raw_predicates.empty()) {
-                    RETURN_IF_ERROR(updater(raw_predicates.front()->column_id(), raw_predicates));
+            if (!_arrived_runtime_filters_masks[i] ||
+                (rf_version > _rf_versions[i] && raw_read_rows - _raw_read_rows > rf_update_threshold)) {
+                ObjectPool pool;
+
+                ASSIGN_OR_RETURN(auto predicates, _get_predicates(global_dictmaps, i, &pool));
+                if (!predicates.empty()) {
+                    RETURN_IF_ERROR(updater(predicates.front()->column_id(), predicates));
                 }
                 _arrived_runtime_filters_masks[i] = true;
                 _rf_versions[i] = rf_version;
@@ -196,24 +197,15 @@ inline Status OlapRuntimeScanRangePruner::_update(const ColumnIdToGlobalDictMap*
     return Status::OK();
 }
 
-inline auto OlapRuntimeScanRangePruner::_get_predicates(const ColumnIdToGlobalDictMap* global_dictmaps, size_t idx)
-        -> StatusOr<PredicatesPtrs> {
+inline auto OlapRuntimeScanRangePruner::_get_predicates(const ColumnIdToGlobalDictMap* global_dictmaps, size_t idx,
+                                                        ObjectPool* pool) -> StatusOr<PredicatesRawPtrs> {
     auto rf = _unarrived_runtime_filters[idx]->runtime_filter(_driver_sequence);
-    if (rf->has_null()) return PredicatesPtrs{};
+    if (rf->has_null()) return PredicatesRawPtrs{};
     // convert to olap filter
     auto slot_desc = _slot_descs[idx];
-    return type_dispatch_predicate<StatusOr<PredicatesPtrs>>(
+    return type_dispatch_predicate<StatusOr<PredicatesRawPtrs>>(
             slot_desc->type().type, false, detail::RuntimeColumnPredicateBuilder(), global_dictmaps, _parser,
-            _unarrived_runtime_filters[idx], slot_desc, _driver_sequence);
-}
-
-inline auto OlapRuntimeScanRangePruner::_as_raw_predicates(
-        const std::vector<std::unique_ptr<ColumnPredicate>>& predicates) -> PredicatesRawPtrs {
-    PredicatesRawPtrs res;
-    for (auto& predicate : predicates) {
-        res.push_back(predicate.get());
-    }
-    return res;
+            _unarrived_runtime_filters[idx], slot_desc, _driver_sequence, pool);
 }
 
 inline void OlapRuntimeScanRangePruner::_init(const UnarrivedRuntimeFilterList& params) {

--- a/be/src/testutil/exprs_test_helper.h
+++ b/be/src/testutil/exprs_test_helper.h
@@ -35,6 +35,18 @@ namespace starrocks {
 
 class ExprsTestHelper {
 public:
+    template <LogicalType Type>
+    static TExpr create_column_ref_t_expr(SlotId slot_id, bool is_nullable) {
+        TExpr expr;
+        expr.nodes.emplace_back(TExprNode());
+        expr.nodes[0].__set_type(TypeDescriptor(Type).to_thrift());
+        expr.nodes[0].__set_node_type(TExprNodeType::SLOT_REF);
+        expr.nodes[0].__set_is_nullable(is_nullable);
+        expr.nodes[0].__set_slot_ref(TSlotRef());
+        expr.nodes[0].slot_ref.__set_slot_id(slot_id);
+        return expr;
+    }
+
     static TTypeDesc create_scalar_type_desc(const TPrimitiveType::type t_type) {
         TTypeDesc type;
 

--- a/be/src/testutil/schema_test_helper.cpp
+++ b/be/src/testutil/schema_test_helper.cpp
@@ -26,7 +26,7 @@ TabletSchemaPB SchemaTestHelper::gen_schema_pb_of_dup(TabletSchema::SchemaId sch
     for (size_t i = 0; i < num_cols; i++) {
         auto c0 = schema_pb.add_column();
         c0->set_unique_id(i);
-        c0->set_name("c0");
+        c0->set_name("c" + std::to_string(i));
         c0->set_type("INT");
         c0->set_is_nullable(true);
         c0->set_index_length(4);
@@ -36,6 +36,12 @@ TabletSchemaPB SchemaTestHelper::gen_schema_pb_of_dup(TabletSchema::SchemaId sch
     }
 
     return schema_pb;
+}
+
+TabletSchemaSPtr SchemaTestHelper::gen_schema_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
+                                                     size_t num_key_cols) {
+    TabletSchemaPB schema_pb = SchemaTestHelper::gen_schema_pb_of_dup(1, 3, 1);
+    return std::make_shared<TabletSchema>(schema_pb);
 }
 
 TColumn SchemaTestHelper::gen_key_column(const std::string& col_name, TPrimitiveType::type type) {

--- a/be/src/testutil/schema_test_helper.h
+++ b/be/src/testutil/schema_test_helper.h
@@ -21,6 +21,7 @@ namespace starrocks {
 class SchemaTestHelper {
 public:
     static TabletSchemaPB gen_schema_pb_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols, size_t num_key_cols);
+    static TabletSchemaSPtr gen_schema_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols, size_t num_key_cols);
     static TColumn gen_key_column(const std::string& col_name, TPrimitiveType::type type);
     static TColumn gen_value_column_for_dup_table(const std::string& col_name, TPrimitiveType::type type);
     static TColumn gen_value_column_for_agg_table(const std::string& col_name, TPrimitiveType::type type);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -359,6 +359,7 @@ set(EXEC_FILES
         ./storage/dictionary_cache_manager_test.cpp
         ./storage/column_or_predicate_test.cpp
         ./storage/column_and_predicate_test.cpp
+        ./storage/olap_runtime_range_pruner_test.cpp
         ./runtime/agg_state_desc_test.cpp
         ./runtime/buffer_control_block_test.cpp
         ./runtime/data_stream_mgr_test.cpp

--- a/be/test/storage/olap_runtime_range_pruner_test.cpp
+++ b/be/test/storage/olap_runtime_range_pruner_test.cpp
@@ -1,0 +1,131 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/olap_runtime_range_pruner.h"
+
+#include <gtest/gtest.h>
+
+#include "exprs/runtime_filter_bank.h"
+#include "gen_cpp/RuntimeFilter_types.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
+#include "storage/column_predicate.h"
+#include "storage/predicate_parser.h"
+#include "testutil/exprs_test_helper.h"
+#include "testutil/schema_test_helper.h"
+
+namespace starrocks {
+
+class OlapRuntimeRangePrunerTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _tablet_schema = SchemaTestHelper::gen_schema_of_dup(1, 3, 1);
+        _predicate_parser = std::make_unique<PredicateParser>(_tablet_schema);
+    }
+
+    static StatusOr<std::shared_ptr<RuntimeFilterProbeDescriptor>> gen_runtime_filter_desc(TPlanNodeId node_id,
+                                                                                           ObjectPool* pool,
+                                                                                           RuntimeState* runtime_state);
+
+protected:
+    ObjectPool _pool;
+    RuntimeState _runtime_state;
+    TPlanNodeId _node_id;
+    TabletSchemaSPtr _tablet_schema;
+    std::unique_ptr<PredicateParser> _predicate_parser;
+};
+
+StatusOr<std::shared_ptr<RuntimeFilterProbeDescriptor>> OlapRuntimeRangePrunerTest::gen_runtime_filter_desc(
+        TPlanNodeId node_id, ObjectPool* pool, RuntimeState* runtime_state) {
+    TRuntimeFilterDescription tRuntimeFilterDescription;
+    tRuntimeFilterDescription.__set_filter_id(1);
+    tRuntimeFilterDescription.__set_has_remote_targets(false);
+    tRuntimeFilterDescription.__set_build_plan_node_id(node_id);
+    tRuntimeFilterDescription.__set_build_join_mode(TRuntimeFilterBuildJoinMode::BORADCAST);
+    tRuntimeFilterDescription.__set_filter_type(TRuntimeFilterBuildType::TOPN_FILTER);
+
+    TExpr col_ref = ExprsTestHelper::create_column_ref_t_expr<TYPE_INT>(1, true);
+    tRuntimeFilterDescription.__isset.plan_node_id_to_target_expr = true;
+    tRuntimeFilterDescription.plan_node_id_to_target_expr.emplace(node_id, col_ref);
+
+    auto runtime_filter_desc = std::make_shared<RuntimeFilterProbeDescriptor>();
+    RETURN_IF_ERROR(runtime_filter_desc->init(pool, tRuntimeFilterDescription, node_id, runtime_state));
+
+    return runtime_filter_desc;
+}
+
+TEST_F(OlapRuntimeRangePrunerTest, update_1) {
+    SlotDescriptor slot(0, "c0", TypeDescriptor(TYPE_INT));
+
+    auto ret = gen_runtime_filter_desc(_node_id, &_pool, &_runtime_state);
+    ASSERT_TRUE(ret.ok());
+    auto runtime_filter_desc = ret.value();
+
+    UnarrivedRuntimeFilterList unarrivedRuntimeFilterList;
+    unarrivedRuntimeFilterList.add_unarrived_rf(runtime_filter_desc.get(), &slot, 1);
+    OlapRuntimeScanRangePruner pruner(_predicate_parser.get(), unarrivedRuntimeFilterList);
+
+    size_t pred_size = 0;
+    std::string pred_1;
+    std::string pred_2;
+
+    // init
+    Status st = pruner.update_range_if_arrived(
+            nullptr,
+            [&pred_size](auto vid, const PredicateList& predicates) {
+                pred_size = predicates.size();
+                return Status::OK();
+            },
+            100000);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(pred_size, 0);
+
+    // version 1
+    RuntimeBloomFilter<TYPE_INT> _rf;
+    _rf.insert(10);
+    _rf.insert(20);
+    runtime_filter_desc->set_runtime_filter(&_rf);
+
+    st = pruner.update_range_if_arrived(
+            nullptr,
+            [&pred_size, &pred_1, &pred_2](auto vid, const PredicateList& predicates) {
+                pred_size = predicates.size();
+                pred_1 = predicates[0]->debug_string();
+                pred_2 = predicates[1]->debug_string();
+                return Status::OK();
+            },
+            200000);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(pred_size, 2);
+    ASSERT_EQ(pred_1, "(columnId(0)>=10)");
+    ASSERT_EQ(pred_2, "(columnId(0)<=20)");
+
+    // version 2 & 3
+    _rf.update_min_max<true>(11);
+    _rf.update_min_max<false>(15);
+    st = pruner.update_range_if_arrived(
+            nullptr,
+            [&pred_size, &pred_1, &pred_2](auto vid, const PredicateList& predicates) {
+                pred_size = predicates.size();
+                pred_1 = predicates[0]->debug_string();
+                pred_2 = predicates[1]->debug_string();
+                return Status::OK();
+            },
+            300000);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(pred_size, 2);
+    ASSERT_EQ(pred_1, "(columnId(0)>=11)");
+    ASSERT_EQ(pred_2, "(columnId(0)<=15)");
+}
+} // namespace starrocks

--- a/be/test/storage/olap_runtime_range_pruner_test.cpp
+++ b/be/test/storage/olap_runtime_range_pruner_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "storage/olap_runtime_range_pruner.h"
+#include "storage/olap_runtime_range_pruner.hpp"
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
## Why I'm doing:

The child of `ColumnAndPredicate` is raw ptr,  making it hard to manage the life cycle of child predicate, so i will use object pool to manage the life cycle of predicate.

```
class ColumnAndPredicate final : public ColumnPredicate {
    std::vector<const ColumnPredicate*> _child;
}
```

The column predicate generated by runtime filter will be used to filter the zonemaps and then released, so it's safe here.

## What I'm doing:

OlapRuntimeScanRangePruner use object pool to manager the life cycle of predicate


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0