### PR TITLE
[Enhancement] BE cancels the create tablet task if it has already timed out

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -41,6 +41,7 @@
 #include "storage/task/engine_storage_migration_task.h"
 #include "storage/txn_manager.h"
 #include "storage/update_manager.h"
+#include "testutil/sync_point.h"
 
 namespace starrocks {
 
@@ -229,12 +230,14 @@ void run_create_tablet_task(const std::shared_ptr<CreateTabletAgentTaskRequest>&
 
     if (create_tablet_req.__isset.timeout_ms && create_tablet_req.timeout_ms > 0) {
         if (agent_task_req->isset.recv_time) {
-            int64_t elapsed_seconds = std::difftime(time(nullptr), agent_task_req->recv_time);
+            int64_t current_time = time(nullptr);
+            TEST_SYNC_POINT_CALLBACK("AgentTask::run_create_tablet_task::time", &current_time);
+            int64_t elapsed_seconds = std::difftime(current_time, agent_task_req->recv_time);
             if (elapsed_seconds * 1000 > create_tablet_req.timeout_ms) {
                 create_status =
                         Status::TimedOut(fmt::format("the task waits too long in the queue. "
-                                                     "timeout: {}ms, elapsed: {}s",
-                                                     create_tablet_req.timeout_ms, elapsed_seconds));
+                                                     "timeout: {} ms, elapsed: {} ms",
+                                                     create_tablet_req.timeout_ms, elapsed_seconds * 1000));
             }
         }
     }
@@ -252,7 +255,7 @@ void run_create_tablet_task(const std::shared_ptr<CreateTabletAgentTaskRequest>&
         if (tablet_type == TTabletType::TABLET_TYPE_LAKE) {
             error_msgs.emplace_back(create_status.to_string(false));
         } else {
-            error_msgs.emplace_back(fmt::format("create tablet {}", create_status.message()));
+            error_msgs.emplace_back(fmt::format("create tablet failed. {}", create_status.message()));
         }
     } else if (create_tablet_req.tablet_type != TTabletType::TABLET_TYPE_LAKE) {
         g_report_version.fetch_add(1, std::memory_order_relaxed);

--- a/be/src/agent/finish_task.cpp
+++ b/be/src/agent/finish_task.cpp
@@ -18,6 +18,7 @@
 #include "agent/utils.h"
 #include "common/logging.h"
 #include "runtime/exec_env.h"
+#include "testutil/sync_point.h"
 #include "util/starrocks_metrics.h"
 
 namespace starrocks {
@@ -26,6 +27,8 @@ const uint32_t TASK_FINISH_MAX_RETRY = 3;
 const uint32_t ALTER_FINISH_TASK_MAX_RETRY = 10;
 
 void finish_task(const TFinishTaskRequest& finish_task_request) {
+    TEST_SYNC_POINT_CALLBACK("FinishAgentTask::input",
+                             const_cast<void*>(static_cast<const void*>(&finish_task_request)));
     // Return result to FE
     TMasterResult result;
     uint32_t try_time = 0;

--- a/be/test/agent/agent_task_test.cpp
+++ b/be/test/agent/agent_task_test.cpp
@@ -254,4 +254,35 @@ TEST_F(AgentTaskTest, clone_task_under_dropping) {
     tablet->set_is_dropping(false);
 }
 
+TEST_F(AgentTaskTest, create_tablet_task_timeout) {
+    TCreateTabletReq create_tablet_req = get_create_tablet_request(10010, 368169791, 2);
+    create_tablet_req.__set_timeout_ms(2000);
+
+    TAgentTaskRequest agent_task_request;
+    agent_task_request.__set_task_type(TTaskType::CREATE);
+    agent_task_request.__set_signature(1902);
+    agent_task_request.__set_create_tablet_req(create_tablet_req);
+    auto agent_task =
+            std::make_shared<CreateTabletAgentTaskRequest>(agent_task_request, agent_task_request.create_tablet_req, 1);
+
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("AgentTask::run_create_tablet_task::time");
+        SyncPoint::GetInstance()->ClearCallBack("FinishAgentTask::input");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("AgentTask::run_create_tablet_task::time",
+                                          [](void* arg) { *((int64_t*)arg) = 4; });
+    SyncPoint::GetInstance()->SetCallBack("FinishAgentTask::input", [](void* arg) {
+        TFinishTaskRequest* request = (TFinishTaskRequest*)arg;
+        auto status = request->task_status;
+        EXPECT_EQ(TStatusCode::RUNTIME_ERROR, request->task_status.status_code);
+        EXPECT_EQ(1, request->task_status.error_msgs.size());
+        EXPECT_EQ("create tablet failed. the task waits too long in the queue. timeout: 2000 ms, elapsed: 3000 ms",
+                  request->task_status.error_msgs[0]);
+    });
+    run_create_tablet_task(agent_task, nullptr);
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -84,6 +84,7 @@ public class CreateReplicaTask extends AgentTask {
     private boolean createSchemaFile = true;
     private boolean enableTabletCreationOptimization = false;
     private final TTabletSchema tabletSchema;
+    private long timeoutMs = -1;
 
     private CreateReplicaTask(Builder builder) {
         super(null, builder.getNodeId(), TTaskType.CREATE, builder.getDbId(), builder.getTableId(),
@@ -142,6 +143,10 @@ public class CreateReplicaTask extends AgentTask {
     public void setBaseTablet(long baseTabletId, int baseSchemaHash) {
         this.baseTabletId = baseTabletId;
         this.baseSchemaHash = baseSchemaHash;
+    }
+
+    public void setTimeoutMs(long timeoutMs) {
+        this.timeoutMs = timeoutMs;
     }
 
     public TTabletType getTabletType() {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -118,6 +118,8 @@ struct TCreateTabletReq {
     21: optional i32 compression_level = -1;
     // Whether or not use shared tablet initial metadata.
     22: optional bool enable_tablet_creation_optimization = false;
+    // The timeout FE will wait for the tablet to be created.
+    23: optional i64 timeout_ms = -1;
 }
 
 struct TDropTabletReq {


### PR DESCRIPTION
## Why I'm doing:
The FE will fail if the wait times out for creating tablets , but FE does not cancel the tasks already sent to the BE. These tasks will always be executed by BE although they are useless, and consume many resources. When BE resources are under significant pressure, these abandoned tasks will exacerbate the situation, making it difficult for BE to return to normal, and the user need to restart BE to cancel these tasks. We need a more friendly approach to cancel these tasks.

## What I'm doing:
Set a timeout for the create tablet task. BE will check if the task timeouts before executing it. If the task already timeouts, skip to execute it and return error status. The timeout is calculated from the time the task is received by BE and placed in the queue, to the time it is taken out of the queue and executed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0