### PR TITLE
[BugFix] Incorrect isQuery field in auditlog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -515,6 +515,9 @@ public class StmtExecutor {
             if (parsedStmt.isExistQueryScopeHint()) {
                 processQueryScopeHint();
             }
+            if (parsedStmt instanceof QueryStatement) {
+                context.getState().setIsQuery(true);
+            }
 
             // set warehouse for auditLog
             context.getAuditEventBuilder().setWarehouse(context.getCurrentWarehouseName());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #53587 

2024-12-07 23:55:09.326+05:30 [query] |Timestamp=1733595908972|Client=127.0.0.1:45774|User=root|AuthorizedUser='root'@'%'|ResourceGroup=default_wg|Catalog=default_catalog|Db=mydb|State=EOF|ErrorCode=|Time=353|ScanBytes=20|ScanRows=1|ReturnRows=1|CpuCostNs=152932|MemCostBytes=153256|StmtId=3|QueryId=96e36acf-b4c8-11ef-83eb-024246d52f43|IsQuery=true|feIp=127.0.0.1|Stmt=select * from developer|Digest=|PlanCpuCost=20.0|PlanMemCost=0.0|PendingTimeMs=2|Warehouse=default_warehouse|IsForwardToLeader=false

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.4
  - [X] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0