### PR TITLE
[BugFix] CastOperator skips predicate pushdown for KuduConnector

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduPredicateConverter.java
@@ -202,7 +202,7 @@ public class KuduPredicateConverter extends ScalarOperatorVisitor<List<KuduPredi
     }
 
     private String getColumnName(ScalarOperator operator) {
-        if (operator == null) {
+        if (operator == null || operator instanceof CastOperator) {
             return null;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduPredicateConverterTest.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.kudu;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -49,6 +50,8 @@ public class KuduPredicateConverterTest {
     private static final ColumnRefOperator F1 = new ColumnRefOperator(0, Type.VARCHAR, "f1", true, false);
     private static final ColumnRefOperator F3 = new ColumnRefOperator(0, Type.DATE, "f3", true, false);
     private static final ColumnRefOperator F4 = new ColumnRefOperator(0, Type.DATETIME, "f4", true, false);
+    private static final CastOperator F0_CAST = new CastOperator(
+            Type.VARCHAR, new ColumnRefOperator(0, Type.INT, "f0", true, false));
 
     private static final KuduPredicateConverter CONVERTER = new KuduPredicateConverter(SCHEMA);
 
@@ -71,6 +74,14 @@ public class KuduPredicateConverterTest {
         ScalarOperator op = new BinaryPredicateOperator(BinaryType.EQ, F0, value);
         List<KuduPredicate> result = CONVERTER.convert(op);
         Assert.assertEquals(result.get(0).toString(), "`f0` = 5");
+    }
+
+    @Test
+    public void testEqCast() {
+        ConstantOperator value = ConstantOperator.createInt(5);
+        ScalarOperator op = new BinaryPredicateOperator(BinaryType.EQ, F0_CAST, value);
+        List<KuduPredicate> result = CONVERTER.convert(op);
+        Assert.assertEquals(result.size(), 0);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #53424 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0