### PR TITLE
[Enhancement] change default setting of monitor queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -63,7 +63,9 @@ import org.apache.logging.log4j.Logger;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.starrocks.mysql.MysqlCommand.COM_STMT_EXECUTE;
@@ -71,15 +73,16 @@ import static com.starrocks.mysql.MysqlCommand.COM_STMT_EXECUTE;
 public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(QeProcessorImpl.class);
     private static final int MEMORY_QUERY_SAMPLES = 10;
-    private static final long ONE_MINUTE = 60 * 1000L;
     private final Map<TUniqueId, QueryInfo> coordinatorMap = Maps.newConcurrentMap();
     private final Map<TUniqueId, Long> monitorQueryMap = Maps.newConcurrentMap();
-    private final AtomicLong lastCheckTime = new AtomicLong();
 
-    public static final QeProcessor INSTANCE;
+    public static final QeProcessorImpl INSTANCE;
+    private static final ScheduledExecutorService MONITOR_EXECUTOR;
 
     static {
         INSTANCE = new QeProcessorImpl();
+        MONITOR_EXECUTOR = Executors.newSingleThreadScheduledExecutor();
+        MONITOR_EXECUTOR.scheduleAtFixedRate(INSTANCE::scanMonitorQueries, 0, 1, TimeUnit.SECONDS);
     }
 
     private QeProcessorImpl() {
@@ -115,19 +118,18 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
         if (result != null) {
             throw new StarRocksException("queryId " + queryId + " already exists");
         }
-        scanMonitorQueries();
     }
 
+    /**
+     * Scan all monitored queries, cleanup them if expired
+     */
     private void scanMonitorQueries() {
         long now = System.currentTimeMillis();
-        long lastCheckTime = this.lastCheckTime.get();
-        if (now - lastCheckTime > ONE_MINUTE && this.lastCheckTime.compareAndSet(lastCheckTime, now)) {
-            for (Map.Entry<TUniqueId, Long> entry : monitorQueryMap.entrySet()) {
-                if (now > entry.getValue()) {
-                    LOG.warn("monitor expired, query id = {}", DebugUtil.printId(entry.getKey()));
-                    unregisterQuery(entry.getKey());
-                    monitorQueryMap.remove(entry.getKey());
-                }
+        for (Map.Entry<TUniqueId, Long> entry : monitorQueryMap.entrySet()) {
+            if (now > entry.getValue()) {
+                LOG.warn("monitor expired, query id = {}", DebugUtil.printId(entry.getKey()));
+                unregisterQuery(entry.getKey());
+                monitorQueryMap.remove(entry.getKey());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1155,7 +1155,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int maxPipelineDop = 64;
 
     @VariableMgr.VarAttr(name = PROFILE_TIMEOUT, flag = VariableMgr.INVISIBLE)
-    private int profileTimeout = 2;
+    private int profileTimeout = 10;
 
     @VariableMgr.VarAttr(name = RUNTIME_PROFILE_REPORT_INTERVAL)
     private int runtimeProfileReportInterval = 10;


### PR DESCRIPTION
## Why I'm doing:

The async-profile query use a `profileTimeout=2s, checkInterval=1m`, which doesn't make sense.
In particular cases, it would either expire the query very quickly, or leave a lot of queries in memory.

## What I'm doing:

1. change default value of `profileTimeout` to `10s`
2. use a dedicated thread to monitor queries, whose interval is `1s`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0