### PR TITLE
[Enhancement] support MySQL `time_format` function

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -3223,7 +3223,7 @@ Status TimeFunctions::last_day_close(FunctionContext* context, FunctionContext::
 }
 
 // Format a time value according to a format string
-StatusOr<ColumnPtr> TimeFunctions::format_time(FunctionContext* context, const starrocks::Columns& columns) {
+StatusOr<ColumnPtr> TimeFunctions::time_format(FunctionContext* context, const starrocks::Columns& columns) {
     if (columns.size() != 2) {
         return Status::InvalidArgument("FORMAT_TIME requires exactly 2 arguments");
     }

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -3231,9 +3231,7 @@ StatusOr<ColumnPtr> TimeFunctions::format_time(FunctionContext* context, const s
     const auto& time_column = columns[0];
     const auto& format_column = columns[1];
 
-    if (time_column->is_nullable() || format_column->is_nullable()) {
-        return Status::InvalidArgument("FORMAT_TIME arguments cannot be NULL");
-    }
+        RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
     auto* time_col = ColumnHelper::cast_to<TYPE_TIME>(time_column);
     auto* format_col = ColumnHelper::cast_to<TYPE_VARCHAR>(format_column);

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -3232,7 +3232,7 @@ StatusOr<ColumnPtr> TimeFunctions::format_time(FunctionContext* context, const s
     const auto& format_column = columns[1];
 
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
-    
+
     auto time_viewer = ColumnViewer<TYPE_TIME>(time_column);
     auto format_viewer = ColumnViewer<TYPE_VARCHAR>(format_column);
 
@@ -3247,7 +3247,7 @@ StatusOr<ColumnPtr> TimeFunctions::format_time(FunctionContext* context, const s
             builder->append_null();
             continue;
         }
-        
+
         // Convert TimeValue to hours, minutes, seconds
         int hours = time_val.hour();
         int minutes = time_val.minute();
@@ -3271,28 +3271,28 @@ StatusOr<ColumnPtr> TimeFunctions::format_time(FunctionContext* context, const s
 
             in_format = false;
             switch (c) {
-                case 'H': // Hour (00-23)
-                    result << std::setfill('0') << std::setw(2) << hours;
-                    break;
-                case 'h': // Hour (01-12)
-                    result << std::setfill('0') << std::setw(2) << (((hours % 12) == 0) ? 12 : (hours % 12));
-                    break;
-                case 'i': // Minutes (00-59)
-                    result << std::setfill('0') << std::setw(2) << minutes;
-                    break;
-                case 'S': // Seconds (00-59)
-                case 's': // Seconds (00-59)
-                    result << std::setfill('0') << std::setw(2) << seconds;
-                    break;
-                case 'f': // Microseconds (000000-999999)
-                    result << std::setfill('0') << std::setw(6) << microseconds;
-                    break;
-                case 'p': // AM or PM
-                    result << (hours < 12 ? "AM" : "PM");
-                    break;
-                default:
-                    result << '%' << c;
-                    break;
+            case 'H': // Hour (00-23)
+                result << std::setfill('0') << std::setw(2) << hours;
+                break;
+            case 'h': // Hour (01-12)
+                result << std::setfill('0') << std::setw(2) << (((hours % 12) == 0) ? 12 : (hours % 12));
+                break;
+            case 'i': // Minutes (00-59)
+                result << std::setfill('0') << std::setw(2) << minutes;
+                break;
+            case 'S': // Seconds (00-59)
+            case 's': // Seconds (00-59)
+                result << std::setfill('0') << std::setw(2) << seconds;
+                break;
+            case 'f': // Microseconds (000000-999999)
+                result << std::setfill('0') << std::setw(6) << microseconds;
+                break;
+            case 'p': // AM or PM
+                result << (hours < 12 ? "AM" : "PM");
+                break;
+            default:
+                result << '%' << c;
+                break;
             }
         }
 

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -805,7 +805,7 @@ public:
      * @paramType columns: [TYPE_TIME, TYPE_VARCHAR]
      * @return ColumnPtr A column holding formatted time strings.
      */
-    DEFINE_VECTORIZED_FN(format_time);
+    DEFINE_VECTORIZED_FN(time_format);
 
 private:
     DEFINE_VECTORIZED_FN_TEMPLATE(_t_from_unix_to_datetime);

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -799,6 +799,14 @@ public:
     // so this value is 253402329599(UTC 9999-12-31 23:59:59) - 24 * 3600(for all timezones)
     constexpr static const int64_t MAX_UNIX_TIMESTAMP = 253402243199L;
 
+    /**
+     * Format a time value according to a format string.
+     * @param: [time_value, format_str]
+     * @paramType columns: [TYPE_TIME, TYPE_VARCHAR]
+     * @return ColumnPtr A column holding formatted time strings.
+     */
+    DEFINE_VECTORIZED_FN(format_time);
+
 private:
     DEFINE_VECTORIZED_FN_TEMPLATE(_t_from_unix_to_datetime);
 

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -3930,12 +3930,12 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
         auto time_builder = ColumnBuilder<TYPE_TIME>(1);
         TimestampValue ts = TimestampValue::create(0, 0, 0, 14, 30, 45);
         time_builder.append(ts.timestamp());
-        auto time_column = time_builder.build();
+        auto time_column = time_builder.build(false);
 
         // Create format column with basic format string
         auto format_builder = ColumnBuilder<TYPE_VARCHAR>(1);
         format_builder.append("%H:%i:%S");
-        auto format_column = format_builder.build();
+        auto format_column = format_builder.build(false);
 
         // Set up columns and function context
         Columns columns;
@@ -3961,7 +3961,7 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
         for (int i = 0; i < 4; i++) {
             time_builder.append(ts.timestamp());
         }
-        auto time_column = time_builder.build();
+        auto time_column = time_builder.build(false);
 
         // Create format column with different format strings
         auto format_builder = ColumnBuilder<TYPE_VARCHAR>(4);
@@ -3969,7 +3969,7 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
         format_builder.append("%H:%i");
         format_builder.append("Time: %H:%i");
         format_builder.append("%H");
-        auto format_column = format_builder.build();
+        auto format_column = format_builder.build(false);
 
         // Set up columns and function context
         Columns columns;

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -25,6 +25,7 @@
 #include "column/binary_column.h"
 #include "column/column_builder.h"
 #include "column/column_helper.h"
+#include "column/column_viewer.h"
 #include "column/const_column.h"
 #include "column/fixed_length_column.h"
 #include "column/vectorized_fwd.h"
@@ -3928,7 +3929,7 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
     {
         // Create time column
         auto time_builder = ColumnBuilder<TYPE_TIME>(1);
-        TimestampValue ts = TimestampValue::create(0, 0, 0, 14, 30, 45);
+        TimestampValue ts = TimestampValue::create(0, 0, 0, 14, 30, 40);
         time_builder.append(ts.timestamp());
         auto time_column = time_builder.build(false);
 
@@ -3950,14 +3951,14 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
         // Verify result
         ASSERT_TRUE(result->is_binary());
         auto result_viewer = ColumnViewer<TYPE_VARCHAR>(result);
-        EXPECT_EQ("14:30:45", std::string(result_viewer.get_slice(0)));
+        EXPECT_EQ("14:30:40", std::string(result_viewer.value(0)));
     }
 
     // Multiple format strings test
     {
         // Create time column with multiple rows
         auto time_builder = ColumnBuilder<TYPE_TIME>(4);
-        TimestampValue ts = TimestampValue::create(0, 0, 0, 14, 30, 45);
+        TimestampValue ts = TimestampValue::create(0, 0, 0, 14, 30, 40);
         for (int i = 0; i < 4; i++) {
             time_builder.append(ts.timestamp());
         }
@@ -3984,10 +3985,10 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
         // Verify results
         ASSERT_TRUE(result->is_binary());
         auto result_viewer = ColumnViewer<TYPE_VARCHAR>(result);
-        EXPECT_EQ("14:30:45", std::string(result_viewer.get_slice(0)));
-        EXPECT_EQ("14:30", std::string(result_viewer.get_slice(1)));
-        EXPECT_EQ("Time: 14:30", std::string(result_viewer.get_slice(2)));
-        EXPECT_EQ("14", std::string(result_viewer.get_slice(3)));
+        EXPECT_EQ("14:30:40", std::string(result_viewer.value(0)));
+        EXPECT_EQ("14:30", std::string(result_viewer.value(1)));
+        EXPECT_EQ("Time: 14:30", std::string(result_viewer.value(2)));
+        EXPECT_EQ("14", std::string(result_viewer.value(3)));
     }
 }
 } // namespace starrocks

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -3944,7 +3944,7 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
 
         // Execute format_time function
         TimeFunctions::format_prepare(_utils->get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
-        ColumnPtr result = TimeFunctions::format_time(_utils->get_fn_ctx(), columns).value();
+        ColumnPtr result = TimeFunctions::time_format(_utils->get_fn_ctx(), columns).value();
         TimeFunctions::format_close(_utils->get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
 
         // Verify result
@@ -3978,7 +3978,7 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
 
         // Execute format_time function
         TimeFunctions::format_prepare(_utils->get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
-        ColumnPtr result = TimeFunctions::format_time(_utils->get_fn_ctx(), columns).value();
+        ColumnPtr result = TimeFunctions::time_format(_utils->get_fn_ctx(), columns).value();
         TimeFunctions::format_close(_utils->get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
 
         // Verify results

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "column/binary_column.h"
+#include "column/column_builder.h"
 #include "column/column_helper.h"
 #include "column/const_column.h"
 #include "column/fixed_length_column.h"
@@ -34,6 +35,7 @@
 #include "runtime/runtime_state.h"
 #include "runtime/time_types.h"
 #include "testutil/function_utils.h"
+#include "types/date_value.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
@@ -3925,13 +3927,13 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
     // Basic format test
     {
         // Create time column
-        auto time_builder = ColumnHelper::get_builder<TYPE_TIME>(1);
-        TimeValue time_val(14, 30, 45, 0);
-        time_builder->append(time_val);
+        auto time_builder = ColumnBuilder<TYPE_TIME>(1);
+        TimestampValue ts = TimestampValue::create(0, 0, 0, 14, 30, 45);
+        time_builder->append(ts.timestamp());
         auto time_column = time_builder->build();
 
         // Create format column with basic format string
-        auto format_builder = ColumnHelper::get_builder<TYPE_VARCHAR>(1);
+        auto format_builder = ColumnBuilder<TYPE_VARCHAR>(1);
         format_builder->append("%H:%i:%S");
         auto format_column = format_builder->build();
 
@@ -3954,15 +3956,15 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
     // Multiple format strings test
     {
         // Create time column with multiple rows
-        auto time_builder = ColumnHelper::get_builder<TYPE_TIME>(4);
-        TimeValue time_val(14, 30, 45, 0);
+        auto time_builder = ColumnBuilder<TYPE_TIME>(4);
+        TimestampValue ts = TimestampValue::create(0, 0, 0, 14, 30, 45);
         for (int i = 0; i < 4; i++) {
-            time_builder->append(time_val);
+            time_builder->append(ts.timestamp());
         }
         auto time_column = time_builder->build();
 
         // Create format column with different format strings
-        auto format_builder = ColumnHelper::get_builder<TYPE_VARCHAR>(4);
+        auto format_builder = ColumnBuilder<TYPE_VARCHAR>(4);
         format_builder->append("%H:%i:%S");
         format_builder->append("%H:%i");
         format_builder->append("Time: %H:%i");

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -3929,13 +3929,13 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
         // Create time column
         auto time_builder = ColumnBuilder<TYPE_TIME>(1);
         TimestampValue ts = TimestampValue::create(0, 0, 0, 14, 30, 45);
-        time_builder->append(ts.timestamp());
-        auto time_column = time_builder->build();
+        time_builder.append(ts.timestamp());
+        auto time_column = time_builder.build();
 
         // Create format column with basic format string
         auto format_builder = ColumnBuilder<TYPE_VARCHAR>(1);
-        format_builder->append("%H:%i:%S");
-        auto format_column = format_builder->build();
+        format_builder.append("%H:%i:%S");
+        auto format_column = format_builder.build();
 
         // Set up columns and function context
         Columns columns;
@@ -3959,17 +3959,17 @@ TEST_F(TimeFunctionsTest, formatTimeTest) {
         auto time_builder = ColumnBuilder<TYPE_TIME>(4);
         TimestampValue ts = TimestampValue::create(0, 0, 0, 14, 30, 45);
         for (int i = 0; i < 4; i++) {
-            time_builder->append(ts.timestamp());
+            time_builder.append(ts.timestamp());
         }
-        auto time_column = time_builder->build();
+        auto time_column = time_builder.build();
 
         // Create format column with different format strings
         auto format_builder = ColumnBuilder<TYPE_VARCHAR>(4);
-        format_builder->append("%H:%i:%S");
-        format_builder->append("%H:%i");
-        format_builder->append("Time: %H:%i");
-        format_builder->append("%H");
-        auto format_column = format_builder->build();
+        format_builder.append("%H:%i:%S");
+        format_builder.append("%H:%i");
+        format_builder.append("Time: %H:%i");
+        format_builder.append("%H");
+        auto format_column = format_builder.build();
 
         // Set up columns and function context
         Columns columns;

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -559,6 +559,7 @@ vectorized_functions = [
     [50403, 'last_day', True, False, 'DATE', ['DATETIME', 'VARCHAR'], 'TimeFunctions::last_day_with_format',
      'TimeFunctions::last_day_prepare', 'TimeFunctions::last_day_close'],
     [50501, 'makedate', True, False, 'DATE', ['INT', 'INT'], 'TimeFunctions::make_date'],
+    [50610, 'makedate', True, False, 'VARCHAR', ['TIME', 'VARCHAR'], 'TimeFunctions::format_time'],
 
     # 60xxx: like predicate
     # important ref: LikePredicate.java, must keep name equals LikePredicate.Operator

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -559,7 +559,7 @@ vectorized_functions = [
     [50403, 'last_day', True, False, 'DATE', ['DATETIME', 'VARCHAR'], 'TimeFunctions::last_day_with_format',
      'TimeFunctions::last_day_prepare', 'TimeFunctions::last_day_close'],
     [50501, 'makedate', True, False, 'DATE', ['INT', 'INT'], 'TimeFunctions::make_date'],
-    [50610, 'format_time', True, False, 'VARCHAR', ['TIME', 'VARCHAR'], 'TimeFunctions::format_time'],
+    [50610, 'time_format', True, False, 'VARCHAR', ['TIME', 'VARCHAR'], 'TimeFunctions::time_format'],
 
     # 60xxx: like predicate
     # important ref: LikePredicate.java, must keep name equals LikePredicate.Operator

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -559,7 +559,7 @@ vectorized_functions = [
     [50403, 'last_day', True, False, 'DATE', ['DATETIME', 'VARCHAR'], 'TimeFunctions::last_day_with_format',
      'TimeFunctions::last_day_prepare', 'TimeFunctions::last_day_close'],
     [50501, 'makedate', True, False, 'DATE', ['INT', 'INT'], 'TimeFunctions::make_date'],
-    [50610, 'makedate', True, False, 'VARCHAR', ['TIME', 'VARCHAR'], 'TimeFunctions::format_time'],
+    [50610, 'format_time', True, False, 'VARCHAR', ['TIME', 'VARCHAR'], 'TimeFunctions::format_time'],
 
     # 60xxx: like predicate
     # important ref: LikePredicate.java, must keep name equals LikePredicate.Operator


### PR DESCRIPTION
## Why I'm doing:
According to Metabase format_time is a must function.
https://github.com/metabase/metabase/issues/50930#issuecomment-2520402223
https://github.com/metabase/metabase/issues/28081
## What I'm doing:
Adding format_time function like MySQL

Fixes https://github.com/StarRocks/starrocks/issues/41951

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0