### PR TITLE
[Enhancement] can set priority when refresh mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Constants.java
@@ -85,7 +85,7 @@ public class Constants {
     // Used to determine the scheduling order of Pending TaskRun to Running TaskRun
     // The bigger the priority, the higher the priority, the default value is LOWEST
     public enum TaskRunPriority {
-        LOWEST(0), LOW(20), NORMAL(50), HIGH(80), HIGHEST(100);
+        LOWEST(0), LOW(20), NORMAL(50), HIGH(80), HIGHER(90), HIGHEST(100);
 
         private final int value;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -711,12 +711,14 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             extraMessage.setNextPartitionValues(mvContext.getNextPartitionValues());
         });
 
-        // Partition refreshing task run should have the HIGHEST priority, and be scheduled before other tasks
+        // Partition refreshing task run should have the HIGHER priority, and be scheduled before other tasks
         // Otherwise this round of partition refreshing would be staved and never got finished
-        ExecuteOption option = new ExecuteOption(Constants.TaskRunPriority.HIGHEST.value(), true, newProperties);
-        LOG.info("[MV] Generate a task to refresh next batches of partitions for MV {}-{}, start={}, end={}",
-                materializedView.getName(), materializedView.getId(),
-                mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd());
+        int priority = mvContext.executeOption.getPriority() > Constants.TaskRunPriority.LOWEST.value() ?
+                mvContext.executeOption.getPriority() : Constants.TaskRunPriority.HIGHER.value();
+        ExecuteOption option = new ExecuteOption(priority, true, newProperties);
+        LOG.info("[MV] Generate a task to refresh next batches of partitions for MV {}-{}, start={}, end={}, " +
+                        "priority={}", materializedView.getName(), materializedView.getId(),
+                mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd(), priority);
 
         if (properties.containsKey(TaskRun.IS_TEST) && properties.get(TaskRun.IS_TEST).equalsIgnoreCase("true")) {
             // for testing

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3246,7 +3246,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         String mvName = refreshMaterializedViewStatement.getMvName().getTbl();
         boolean force = refreshMaterializedViewStatement.isForceRefresh();
         EitherOr<PartitionRangeDesc, Set<PListCell>> partitionDesc = refreshMaterializedViewStatement.getPartitionDesc();
-        return refreshMaterializedView(dbName, mvName, force, partitionDesc, Constants.TaskRunPriority.HIGH.value(),
+        int priority = refreshMaterializedViewStatement.getPriority() != null ?
+                refreshMaterializedViewStatement.getPriority() : Constants.TaskRunPriority.HIGH.value();
+        return refreshMaterializedView(dbName, mvName, force, partitionDesc, priority,
                 Config.enable_mv_refresh_sync_refresh_mergeable, true, refreshMaterializedViewStatement.isSync());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshMaterializedViewStatement.java
@@ -30,6 +30,7 @@ public class RefreshMaterializedViewStatement extends DdlStmt {
     private EitherOr<PartitionRangeDesc, Set<PListCell>> partitionDesc;
     private final boolean forceRefresh;
     private final boolean isSync;
+    private final Integer priority;
 
     public static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()
@@ -38,12 +39,13 @@ public class RefreshMaterializedViewStatement extends DdlStmt {
 
     public RefreshMaterializedViewStatement(TableName mvName,
                                             EitherOr<PartitionRangeDesc, Set<PListCell>> partitionDesc,
-                                            boolean forceRefresh, boolean isSync, NodePosition pos) {
+                                            boolean forceRefresh, boolean isSync, Integer priority, NodePosition pos) {
         super(pos);
         this.mvName = mvName;
         this.partitionDesc = partitionDesc;
         this.forceRefresh = forceRefresh;
         this.isSync = isSync;
+        this.priority = priority;
     }
 
     public TableName getMvName() {
@@ -79,5 +81,9 @@ public class RefreshMaterializedViewStatement extends DdlStmt {
 
     public boolean isSync() {
         return isSync;
+    }
+
+    public Integer getPriority() {
+        return priority;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2111,7 +2111,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             }
         }
         return new RefreshMaterializedViewStatement(mvName, new EitherOr(rangePartitionDesc, cells),
-                context.FORCE() != null, context.SYNC() != null, createPos(context));
+                context.FORCE() != null, context.SYNC() != null,
+                context.priority != null ? Integer.parseInt(context.priority.getText()) : null,
+                createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -675,7 +675,7 @@ alterMaterializedViewStatement
     ;
 
 refreshMaterializedViewStatement
-    : REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION (partitionRangeDesc | listPartitionValues))? FORCE? (WITH (SYNC | ASYNC) MODE)?
+    : REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION (partitionRangeDesc | listPartitionValues))? FORCE? (WITH (SYNC | ASYNC) MODE)? (WITH PRIORITY priority=INTEGER_VALUE)?
     ;
 
 cancelRefreshMaterializedViewStatement

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -408,6 +408,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                     }
                     Assert.assertEquals(1, statuses.size());
                     TaskRunStatus status = statuses.get(0);
+                    // default priority for next refresh batch is Constants.TaskRunPriority.HIGHER.value()
                     Assert.assertEquals(Constants.TaskRunPriority.HIGHER.value(), status.getPriority());
                     starRocksAssert.dropMaterializedView("mv_refresh_priority");
                 }
@@ -449,16 +450,31 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                                 MaterializedView mv = ((MaterializedView) testDb.getTable(mvName));
                                 executeInsertSql(connectContext,
                                         "insert into tbl6 partition(p1) values('2022-01-02',2,10);");
+                                executeInsertSql(connectContext, "insert into tbl6 partition(p2) values('2022-02-02',2,10);");
 
                                 HashMap<String, String> taskRunProperties = new HashMap<>();
                                 taskRunProperties.put(TaskRun.FORCE, Boolean.toString(true));
                                 Task task = TaskBuilder.buildMvTask(mv, testDb.getFullName());
-                                TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                ExecuteOption executeOption = new ExecuteOption(70, false, new HashMap<>());
+                                TaskRun taskRun = TaskRunBuilder.newBuilder(task).setExecuteOption(executeOption).build();
                                 initAndExecuteTaskRun(taskRun);
+                                TGetTasksParams params = new TGetTasksParams();
+                                params.setTask_name(task.getName());
+                                TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+                                List<TaskRunStatus> statuses = tm.getMatchedTaskRunStatus(params);
+                                while (statuses.size() != 1) {
+                                    statuses = tm.getMatchedTaskRunStatus(params);
+                                    Thread.sleep(100);
+                                }
+                                Assert.assertEquals(1, statuses.size());
+                                TaskRunStatus status = statuses.get(0);
+                                // the priority for next refresh batch is 70 which is specified in executeOption
+                                Assert.assertEquals(70, status.getPriority());
 
                                 PartitionBasedMvRefreshProcessor processor =
                                         (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
                                 MvTaskRunContext mvTaskRunContext = processor.getMvContext();
+                                Assert.assertEquals(70, mvTaskRunContext.getExecuteOption().getPriority());
                                 Map<String, String> properties = mvTaskRunContext.getProperties();
                                 Assert.assertEquals(1, properties.size());
                                 Assert.assertTrue(properties.containsKey(MV_ID));
@@ -470,6 +486,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                                 // Ensure that session properties are set
                                 Assert.assertTrue(sessionVariable.isEnableMaterializedViewRewrite());
                                 Assert.assertTrue(sessionVariable.isEnableMaterializedViewRewriteForInsert());
+                                starRocksAssert.dropMaterializedView(mvName);
                             });
                 }
         );

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -408,7 +408,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVRefreshTest
                     }
                     Assert.assertEquals(1, statuses.size());
                     TaskRunStatus status = statuses.get(0);
-                    Assert.assertEquals(Constants.TaskRunPriority.HIGHEST.value(), status.getPriority());
+                    Assert.assertEquals(Constants.TaskRunPriority.HIGHER.value(), status.getPriority());
                     starRocksAssert.dropMaterializedView("mv_refresh_priority");
                 }
         );


### PR DESCRIPTION
## Why I'm doing:

I want periodically scheduled async materialize view task run be more prior than task run that is triggerred manually

## What I'm doing:

`refresh MATERIALIZED VIEW test_mv with priority 80;`

The default priority for mv task run is 90, and the default priority for manual refreshed task run is 80.

User can specify priority smaller than 90, which is the **default** behavior, to make periodically scheduled async materialize view task run prior to manual refresh mv task run.

Or user can specify priority larger than 90 to make manual refresh mv task run prior to periodically scheduled async materialize view task run.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0