### PR TITLE
[Enhancement] Add histogram metric and node info metric in json metric

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/JsonMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/JsonMetricVisitor.java
@@ -35,14 +35,31 @@
 package com.starrocks.metric;
 
 import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Snapshot;
 import com.starrocks.monitor.jvm.GcNames;
 import com.starrocks.monitor.jvm.JvmStats;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.system.SystemInfoService;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class JsonMetricVisitor extends MetricVisitor {
     private boolean isFirstElement;
     private final StringBuilder sb;
+
+    private static final String MILLISECONDS = "milliseconds";
+    private static final String QUANTILE = "quantile";
+    private static final String NOUNIT = "nounit";
+    private static final String TYPE = "type";
+    private static final String STATUS = "status";
+    private static final String TOTAL = "total";
+    private static final String FE_NODE_NUM = "fe_node_num";
+    private static final String BE_NODE_NUM = "be_node_num";
+    private static final String CN_NODE_NUM = "cn_node_num";
+    private static final String BROKER_NODE_NUM = "broker_node_num";
 
     public JsonMetricVisitor(String prefix) {
         super(prefix);
@@ -139,10 +156,57 @@ public class JsonMetricVisitor extends MetricVisitor {
 
     @Override
     public void visitHistogram(String name, Histogram histogram) {
+        final String fullName = prefix + "_" + name.replace("\\.", "_");
+        Snapshot snapshot = histogram.getSnapshot();
+
+        buildMetric(fullName, MILLISECONDS, String.valueOf(snapshot.get75thPercentile()),
+                Collections.singletonList(new MetricLabel(QUANTILE, "0.75")));
+        buildMetric(fullName, MILLISECONDS, String.valueOf(snapshot.get95thPercentile()),
+                Collections.singletonList(new MetricLabel(QUANTILE, "0.95")));
+        buildMetric(fullName, MILLISECONDS, String.valueOf(snapshot.get98thPercentile()),
+                Collections.singletonList(new MetricLabel(QUANTILE, "0.98")));
+        buildMetric(fullName, MILLISECONDS, String.valueOf(snapshot.get99thPercentile()),
+                Collections.singletonList(new MetricLabel(QUANTILE, "0.99")));
+        buildMetric(fullName, MILLISECONDS, String.valueOf(snapshot.get999thPercentile()),
+                Collections.singletonList(new MetricLabel(QUANTILE, "0.999")));
+
+        buildMetric(fullName + "_sum", MILLISECONDS, String.valueOf(histogram.getCount() * snapshot.getMean()),
+                null);
+        buildMetric(fullName + "_count", NOUNIT, String.valueOf(histogram.getCount()), null);
     }
 
     @Override
     public void getNodeInfo() {
+        final String NODE_INFO = "node_info";
+        final NodeMgr nodeMgr = GlobalStateMgr.getCurrentState().getNodeMgr();
+        final SystemInfoService systemInfoService = nodeMgr.getClusterInfo();
+
+        buildMetric(NODE_INFO, NOUNIT, String.valueOf(nodeMgr.getFrontends(null).size()),
+                Arrays.asList(new MetricLabel(TYPE, FE_NODE_NUM), new MetricLabel(STATUS, TOTAL)));
+        buildMetric(NODE_INFO, NOUNIT, String.valueOf(systemInfoService.getTotalBackendNumber()),
+                Arrays.asList(new MetricLabel(TYPE, BE_NODE_NUM), new MetricLabel(STATUS, TOTAL)));
+        buildMetric(NODE_INFO, NOUNIT, String.valueOf(systemInfoService.getAliveBackendNumber()),
+                Arrays.asList(new MetricLabel(TYPE, BE_NODE_NUM), new MetricLabel(STATUS, "alive")));
+        buildMetric(NODE_INFO, NOUNIT,
+                String.valueOf(systemInfoService.getDecommissionedBackendIds().size()),
+                Arrays.asList(new MetricLabel(TYPE, BE_NODE_NUM), new MetricLabel(STATUS, "decommissioned")));
+        buildMetric(NODE_INFO, NOUNIT, String.valueOf(
+                        GlobalStateMgr.getCurrentState().getBrokerMgr().getAllBrokers().stream().filter(b -> !b.isAlive)
+                                .count()),
+                Arrays.asList(new MetricLabel(TYPE, BROKER_NODE_NUM), new MetricLabel(STATUS, "dead")));
+
+        buildMetric(NODE_INFO, NOUNIT,
+                String.valueOf(systemInfoService.getTotalComputeNodeNumber()),
+                Arrays.asList(new MetricLabel(TYPE, CN_NODE_NUM), new MetricLabel(STATUS, TOTAL)));
+        buildMetric(NODE_INFO, NOUNIT,
+                String.valueOf(systemInfoService.getAliveComputeNodeNumber()),
+                Arrays.asList(new MetricLabel(TYPE, CN_NODE_NUM), new MetricLabel(STATUS, "alive")));
+
+        // only master FE has this metrics, to help the Grafana knows who is the leader
+        if (GlobalStateMgr.getCurrentState().isLeader()) {
+            buildMetric(NODE_INFO, NOUNIT, String.valueOf(1),
+                    Collections.singletonList(new MetricLabel(TYPE, "is_master")));
+        }
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:
The interface fe_ip:fe_port/metrics?type=json lacks the node metric and the histogram metric.

## What I'm doing:
Add  the node metric and the histogram metric in the interface fe_ip:fe_port/metrics?type=json 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0