### PR TITLE
[UT][BugFix] fix PullUpScanPredicateRule

### DIFF
--- a/be/src/exprs/map_apply_expr.cpp
+++ b/be/src/exprs/map_apply_expr.cpp
@@ -150,15 +150,17 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
                                                  map_col->keys_column()->size()));
     }
 
-    auto res_map =
-            std::make_shared<MapColumn>(map_col->keys_column(), map_col->values_column(), input_map->offsets_column());
+    auto res_map = std::make_shared<MapColumn>(
+            map_col->keys_column(), map_col->values_column(),
+            ColumnHelper::as_column<UInt32Column>(input_map->offsets_column()->clone_shared()));
 
     if (_maybe_duplicated_keys && res_map->size() > 0) {
         res_map->remove_duplicated_keys();
     }
     // attach null info
     if (input_null_map != nullptr) {
-        return NullableColumn::create(std::move(res_map), input_null_map);
+        return NullableColumn::create(std::move(res_map),
+                                      ColumnHelper::as_column<NullColumn>(input_null_map->clone_shared()));
     }
     return res_map;
 }

--- a/be/src/exprs/map_apply_expr.cpp
+++ b/be/src/exprs/map_apply_expr.cpp
@@ -80,7 +80,7 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
                 input_null_map =
                         FunctionHelper::union_null_column(nullable->null_column(), input_null_map); // merge null
             } else {
-                input_null_map = nullable->null_column();
+                input_null_map = ColumnHelper::as_column<NullColumn>(nullable->null_column()->clone_shared());
             }
         }
         DCHECK(data_column->is_map());
@@ -159,8 +159,7 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
     }
     // attach null info
     if (input_null_map != nullptr) {
-        return NullableColumn::create(std::move(res_map),
-                                      ColumnHelper::as_column<NullColumn>(input_null_map->clone_shared()));
+        return NullableColumn::create(std::move(res_map), input_null_map);
     }
     return res_map;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -702,7 +702,9 @@ public class Optimizer {
         ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.VECTOR_REWRITE);
         // this rule should be after mv
         // @TODO: it can also be applied to other table scan operator
-        ruleRewriteOnlyOnce(tree, rootTaskContext, PullUpScanPredicateRule.OLAP_SCAN);
+        if (context.getSessionVariable().isEnableScanPredicateExprReuse()) {
+            ruleRewriteOnlyOnce(tree, rootTaskContext, PullUpScanPredicateRule.OLAP_SCAN);
+        }
 
         tree = SimplifyCaseWhenPredicateRule.INSTANCE.rewrite(tree, rootTaskContext);
         deriveLogicalProperty(tree);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/TableScanPredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/TableScanPredicateExtractor.java
@@ -105,6 +105,7 @@ public class TableScanPredicateExtractor {
     // currently, we only allow single-column predicates that not contain lambda expressions to be pushed down.
     private class CanFullyPushDownVisitor extends ScalarOperatorVisitor<Boolean, CanFullyPushDownVisitorContext> {
         private final Map<ColumnRefOperator, Column> columnRefOperatorColumnMap;
+
         public CanFullyPushDownVisitor(Map<ColumnRefOperator, Column> columnRefOperatorColumnMap) {
             this.columnRefOperatorColumnMap = columnRefOperatorColumnMap;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
@@ -258,6 +259,11 @@ public class PullUpScanPredicateRule extends TransformationRule {
                 }
                 return true;
             }
+            return false;
+        }
+
+        @Override
+        public Boolean visitLambdaFunctionOperator(LambdaFunctionOperator op, Void context) {
             return false;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
@@ -17,6 +17,8 @@ package com.starrocks.sql.optimizer.rule.transformation;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -24,10 +26,15 @@ import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.sql.optimizer.rewrite.TableScanPredicateExtractor;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.tree.prunesubfield.PruneSubfieldRule;
 
 import java.util.HashMap;
 import java.util.List;
@@ -79,6 +86,12 @@ public class PullUpScanPredicateRule extends TransformationRule {
             return Lists.newArrayList();
         }
 
+        Operator.Builder builder = OperatorBuilderFactory.build(logicalScanOperator);
+        LogicalScanOperator newScanOperator = (LogicalScanOperator) builder.withOperator(logicalScanOperator)
+                .setPredicate(pushedPredicates).build();
+        // these columns must keep in the final projections
+        List<ColumnRefOperator> outputColumns = newScanOperator.getOutputColumns();
+
         // After applying some rules, the ScanOperator may generate some projection columns, e.g. `RemoveAggregationFromAggTableRule`
         // In order to reuse existing columns as much as possible,
         // we need to replace the expressions in the predicate with the column that appears in the projection.
@@ -89,17 +102,33 @@ public class PullUpScanPredicateRule extends TransformationRule {
                     translatingMap.put(v, k);
                 }
             });
-            if (!translatingMap.isEmpty()) {
-                reservedPredicates = replaceScalarOperator(reservedPredicates, translatingMap);
-            }
         }
 
-        Operator.Builder builder = OperatorBuilderFactory.build(logicalScanOperator);
-        LogicalScanOperator newScanOperator = (LogicalScanOperator) builder.withOperator(logicalScanOperator)
-                .setPredicate(pushedPredicates).build();
+        Map<ColumnRefOperator, ScalarOperator> newProjections = new HashMap();
+        // collect all expressions that can be used to prune subfield,
+        // we should replace these expressions in the predicate so that subfield pruning still works.
+        // for example, `cardinality(col1) + cardinality(col2) > 10`,
+        // we should make `cardinality(col1)` and `cardinality(col2)` appear in the scan projections
+        // instead of `col1` and `col2` so that we can have a correct column access path.
+        SubfieldCollector collector = new SubfieldCollector(context.getColumnRefFactory());
+        collector.visit(reservedPredicates, null);
+
+        collector.getExpressionMapping().forEach((k, v) -> {
+            if (!translatingMap.containsKey(k)) {
+                translatingMap.put(k, v);
+                newProjections.put(v, k);
+            }
+        });
+
+
+        if (!translatingMap.isEmpty()) {
+            reservedPredicates = replaceScalarOperator(reservedPredicates, translatingMap);
+        }
+
+        ColumnRefSet predicateUsedColumnRefSet = reservedPredicates.getUsedColumns();
         newScanOperator.buildColumnFilters(pushedPredicates);
 
-        List<ColumnRefOperator> predicateUsedColumns = reservedPredicates.getUsedColumns()
+        List<ColumnRefOperator> predicateUsedColumns = predicateUsedColumnRefSet
                 .getColumnRefOperators(context.getColumnRefFactory());
         boolean allPredicatesColumnFromTableColumn = predicateUsedColumns.stream().allMatch(
                 columnRefOperator -> newScanOperator.getColRefToColumnMetaMap().containsKey(columnRefOperator));
@@ -115,22 +144,111 @@ public class PullUpScanPredicateRule extends TransformationRule {
             }
         }
 
-        if (newScanOperator.getProjection() == null && allPredicatesColumnFromTableColumn) {
+        if (newScanOperator.getProjection() == null && newProjections.isEmpty() && allPredicatesColumnFromTableColumn) {
             // if all predicate used columns are table columns and projection is null, we don't need to set projection too
         } else {
             if (newScanOperator.getProjection() == null) {
                 newScanOperator.setProjection(new Projection(new HashMap<>()));
             }
             scanProjectionMap = newScanOperator.getProjection().getColumnRefMap();
+            for (Map.Entry<ScalarOperator, ColumnRefOperator> entry : translatingMap.entrySet()) {
+                if (!scanProjectionMap.containsKey(entry.getValue())) {
+                    scanProjectionMap.put(entry.getValue(), entry.getKey());
+                }
+            }
             for (ColumnRefOperator columnRefOperator : predicateUsedColumns) {
                 if (!scanProjectionMap.containsKey(columnRefOperator)) {
                     scanProjectionMap.put(columnRefOperator, columnRefOperator);
                 }
             }
+            for (ColumnRefOperator columnRefOperator : outputColumns) {
+                if (!scanProjectionMap.containsKey(columnRefOperator)) {
+                    scanProjectionMap.put(columnRefOperator, columnRefOperator);
+                }
+            }
+
         }
 
         LogicalFilterOperator newFilterOperator = new LogicalFilterOperator(reservedPredicates);
+        if (newScanOperator.hasLimit()) {
+            newFilterOperator.setLimit(newScanOperator.getLimit());
+            newScanOperator.setLimit(Operator.DEFAULT_LIMIT);
+        }
+
         OptExpression filter = OptExpression.create(newFilterOperator, OptExpression.create(newScanOperator));
         return Lists.newArrayList(filter);
+    }
+
+    // collect all expressions that can be used to prune subfield and record them in expressionMap
+    private static class SubfieldCollector extends ScalarOperatorVisitor<Boolean, Void> {
+        private ColumnRefFactory columnRefFactory;
+        private Map<ScalarOperator, ColumnRefOperator> expressionMapping = new HashMap();
+        public SubfieldCollector(ColumnRefFactory columnRefFactory) {
+            this.columnRefFactory = columnRefFactory;
+        }
+        public Map<ScalarOperator, ColumnRefOperator> getExpressionMapping() {
+            return expressionMapping;
+        }
+
+        @Override
+        public Boolean visit(ScalarOperator scalarOperator, Void context) {
+            boolean result = true;
+            for (ScalarOperator child : scalarOperator.getChildren()) {
+                if (!child.accept(this, context)) {
+                    result = false;
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public Boolean visitVariableReference(ColumnRefOperator op, Void context) {
+            if (op.getType().isComplexType() || op.getType().isJsonType()) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public Boolean visitCollectionElement(CollectionElementOperator op, Void context) {
+            return visit(op, context);
+        }
+
+        @Override
+        public Boolean visitSubfield(SubfieldOperator op, Void context) {
+            if (op.getUsedColumns().isEmpty()) {
+                return false;
+            }
+            if (visit(op.getChild(0), context)) {
+                if (!expressionMapping.containsKey(op)) {
+                    ColumnRefOperator columnRefOperator = columnRefFactory.create("subfield", op.getType(), op.isNullable());
+                    expressionMapping.put(op, columnRefOperator);
+                }
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public Boolean visitCall(CallOperator op, Void context) {
+            if (!PruneSubfieldRule.PRUNE_FUNCTIONS.contains(op.getFnName())) {
+                visit(op, context);
+                return false;
+            }
+            List<ScalarOperator> children = op.getChildren();
+            boolean allConstArgs = true;
+            for (int i = 1; i < children.size() && allConstArgs; i++) {
+                allConstArgs &= children.get(i).isConstant();
+            }
+            if (allConstArgs && visit(children.get(0), context)) {
+                if (!expressionMapping.containsKey(op)) {
+                    ColumnRefOperator columnRefOperator =
+                            columnRefFactory.create(op.getFnName(), op.getType(), op.isNullable());
+                    expressionMapping.put(op, columnRefOperator);
+                }
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
@@ -211,7 +211,17 @@ public class PullUpScanPredicateRule extends TransformationRule {
 
         @Override
         public Boolean visitCollectionElement(CollectionElementOperator op, Void context) {
-            return visit(op, context);
+            if (op.getUsedColumns().isEmpty()) {
+                return false;
+            }
+            if (op.getChild(1).isConstant() && visit(op.getChild(0), context)) {
+                if (!expressionMapping.containsKey(op)) {
+                    ColumnRefOperator columnRefOperator = columnRefFactory.create("element_at", op.getType(), op.isNullable());
+                    expressionMapping.put(op, columnRefOperator);
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -320,6 +320,4 @@ public class SubfieldAccessPathNormalizer {
                 scalarOperators.stream().map(op -> collector.process(op, allAccessPaths)).collect(Collectors.toList());
         paths.forEach(p -> p.ifPresent(allAccessPaths::add));
     }
-
-    // translater access path to sub field operator
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -320,4 +320,6 @@ public class SubfieldAccessPathNormalizer {
                 scalarOperators.stream().map(op -> collector.process(op, allAccessPaths)).collect(Collectors.toList());
         paths.forEach(p -> p.ifPresent(allAccessPaths::add));
     }
+
+    // translater access path to sub field operator
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ScanPredicateExprReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ScanPredicateExprReuseTest.java
@@ -116,4 +116,189 @@ public class ScanPredicateExprReuseTest extends PlanTestBase {
                     "  |  <slot 10> : array_min(9: array_map)");
         }
     }
+
+    @Test
+    public void testLimit() throws Exception {
+        {
+            String sql = "select * from tarray where all_match(x->x>10, v3) limit 10";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  1:SELECT\n" +
+                    "  |  predicates: all_match(array_map(<slot 4> -> <slot 4> > 10, 3: v3))\n" +
+                    "  |  limit: 10");
+        }
+        {
+            String sql = "select * from t0 where v1 + v2 > 10 and v1 + v2 + v3 > 20 and v1 = 5 limit 10";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "  1:SELECT\n" +
+                    "  |  predicates: 4: add > 10, 4: add + 3: v3 > 20\n" +
+                    "  |    common sub expr:\n" +
+                    "  |    <slot 4> : 1: v1 + 2: v2\n" +
+                    "  |  limit: 10\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: t0\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 1: v1 = 5");
+        }
+    }
+
+    @Test
+    public void testComplexType() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `complex_t` (\n" +
+                "  `k` bigint(20) NOT NULL COMMENT \"\",\n" +
+                "  `v1` array<bigint(20)> NULL COMMENT \"\",\n" +
+                "  `v2` array<bigint(20)> NULL COMMENT \"\",\n" +
+                "  `v3` array<bigint(20)> NULL COMMENT \"\",\n" +
+                "  `v4` struct<a int(11), b struct<a int(11)>> NULL COMMENT \"\",\n" +
+                "  `v5` struct<a int(11), b struct<a array<bigint(20)>>> NULL COMMENT \"\",\n" +
+                "  `v6` map<int(11),int(11)> NULL COMMENT \"\",\n" +
+                "  `v7` map<int(11),int(11)> NULL COMMENT \"\",\n" +
+                "  `v8` json NULL COMMENT \"\",\n" +
+                "  `v9` json NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY(`k`)\n" +
+                "DISTRIBUTED BY HASH(`k`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"compression\" = \"LZ4\",\n" +
+                "\"enable_persistent_index\" = \"true\",\n" +
+                "\"fast_schema_evolution\" = \"true\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")");
+        // for complex type predicates, column pruning can still be used after pull up predicates from scan node
+        {
+            String sql = "select k from complex_t where v1[0] > v2[3]";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  2:SELECT\n" +
+                    "  |  predicates: 2: v1[0] > 3: v2[3]\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  1 <-> [1: k, BIGINT, false]\n" +
+                    "  |  2 <-> [2: v1, ARRAY<BIGINT>, true]\n" +
+                    "  |  3 <-> [3: v2, ARRAY<BIGINT>, true]\n" +
+                    "  |  cardinality: 1");
+            assertContains(plan, "     Pruned type: 2 <-> [ARRAY<BIGINT>]\n" +
+                    "     Pruned type: 3 <-> [ARRAY<BIGINT>]\n" +
+                    "     ColumnAccessPath: [/v1/INDEX, /v2/INDEX]");
+        }
+        {
+            String sql = "select k from complex_t where array_length(v1) > array_length(v3)";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  2:SELECT\n" +
+                    "  |  predicates: 11: array_length > 12: array_length\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  1 <-> [1: k, BIGINT, false]\n" +
+                    "  |  11 <-> array_length[([2: v1, ARRAY<BIGINT>, true]); args: INVALID_TYPE; " +
+                    "result: INT; args nullable: true; result nullable: true]\n" +
+                    "  |  12 <-> array_length[([4: v3, ARRAY<BIGINT>, true]); args: INVALID_TYPE; " +
+                    "result: INT; args nullable: true; result nullable: true]\n" +
+                    "  |  cardinality: 1");
+            assertContains(plan, "     Pruned type: 2 <-> [ARRAY<BIGINT>]\n" +
+                    "     Pruned type: 4 <-> [ARRAY<BIGINT>]\n" +
+                    "     ColumnAccessPath: [/v1/OFFSET, /v3/OFFSET]");
+        }
+        {
+            String sql = "select k from complex_t where array_length(array_map(x->x+10, v5.b.a)) > 10";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  2:SELECT\n" +
+                    "  |  predicates: array_length(array_map(<slot 11> -> <slot 11> + 10, 12: subfield)) > 10\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  1 <-> [1: k, BIGINT, false]\n" +
+                    "  |  12 <-> 6: v5.b.a[false]\n" +
+                    "  |  cardinality: 1");
+            assertContains(plan, "ColumnAccessPath: [/v5/b/a]");
+        }
+        {
+            // json
+            String sql = "select k from complex_t where v8->'$.a.b' > v9->'$.a.c'";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  2:SELECT\n" +
+                    "  |  predicates: 11: json_query > 12: json_query\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  1 <-> [1: k, BIGINT, false]\n" +
+                    "  |  11 <-> json_query[([9: v8, JSON, true], '$.a.b'); args: JSON,VARCHAR; " +
+                    "result: JSON; args nullable: true; result nullable: true]\n" +
+                    "  |  12 <-> json_query[([10: v9, JSON, true], '$.a.c'); args: JSON,VARCHAR; " +
+                    "result: JSON; args nullable: true; result nullable: true]\n" +
+                    "  |  cardinality: 1");
+            assertContains(plan, "ColumnAccessPath: [/v8/a/b(json), /v9/a/c(json)]");
+        }
+        {
+            String sql = "select k from complex_t where json_length(v8, '$.k1') > json_length(v9->'$.k1.k2')";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  2:SELECT\n" +
+                    "  |  predicates: 11: json_length > 12: json_length\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  1 <-> [1: k, BIGINT, false]\n" +
+                    "  |  11 <-> json_length[([9: v8, JSON, true], '$.k1'); args: JSON,VARCHAR; " +
+                    "result: INT; args nullable: true; result nullable: true]\n" +
+                    "  |  12 <-> json_length[(json_query[([10: v9, JSON, true], '$.k1.k2'); " +
+                    "args: JSON,VARCHAR; result: JSON; args nullable: true; result nullable: true]); " +
+                    "args: JSON; result: INT; args nullable: true; result nullable: true]");
+            assertContains(plan, "ColumnAccessPath: [/v8/k1(json), /v9/k1/k2(json)]");
+        }
+        {
+            // map
+            String sql = "select k from complex_t where array_max(array_map((x,y)->x+y+k, map_keys(v6),map_keys(v7)))>10";
+            String plan = getVerboseExplain(sql);
+            assertContains("  2:SELECT\n" +
+                    "  |  predicates: array_max(array_map((<slot 11>, <slot 12>) -> " +
+                    "CAST(<slot 11> AS BIGINT) + CAST(<slot 12> AS BIGINT) + 1: k, 13: map_keys, 14: map_keys)) > 10\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  1 <-> [1: k, BIGINT, false]\n" +
+                    "  |  13 <-> map_keys[([7: v6, MAP<INT,INT>, true]); args: INVALID_TYPE; " +
+                    "result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                    "  |  14 <-> map_keys[([8: v7, MAP<INT,INT>, true]); args: INVALID_TYPE; " +
+                    "result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                    "  |  cardinality: 1");
+            assertContains(plan, "     Pruned type: 7 <-> [MAP<INT,INT>]\n" +
+                    "     Pruned type: 8 <-> [MAP<INT,INT>]\n" +
+                    "     ColumnAccessPath: [/v6/KEY, /v7/KEY]");
+        }
+        {
+            String sql = "select k from complex_t where cardinality(v1) + cardinality(v5.b.a) > 3 and " +
+                    "cardinality(v1) + cardinality(v5.b.a) + cardinality(v6) >5";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  2:SELECT\n" +
+                    "  |  predicates: 16: add > 3, 16: add + CAST(13: cardinality AS BIGINT) > 5\n" +
+                    "  |    common sub expr:\n" +
+                    "  |    <slot 16> : 14: cast + 15: cast\n" +
+                    "  |    <slot 14> : CAST(11: cardinality AS BIGINT)\n" +
+                    "  |    <slot 15> : CAST(12: cardinality AS BIGINT)\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  1 <-> [1: k, BIGINT, false]\n" +
+                    "  |  11 <-> cardinality[([2: v1, ARRAY<BIGINT>, true]); args: INVALID_TYPE; " +
+                    "result: INT; args nullable: true; result nullable: true]\n" +
+                    "  |  12 <-> cardinality[(6: v5.b.a[true]); args: INVALID_TYPE; result: INT; " +
+                    "args nullable: true; result nullable: true]\n" +
+                    "  |  13 <-> cardinality[([7: v6, MAP<INT,INT>, true]); args: INVALID_TYPE; " +
+                    "result: INT; args nullable: true; result nullable: true]\n" +
+                    "  |  cardinality: 1");
+            assertContains(plan, "     Pruned type: 2 <-> [ARRAY<BIGINT>]\n" +
+                    "     Pruned type: 6 <-> [struct<a int(11), b struct<a array<bigint(20)>>>]\n" +
+                    "     Pruned type: 7 <-> [MAP<INT,INT>]\n" +
+                    "     ColumnAccessPath: [/v1/OFFSET, /v5/b/a/OFFSET, /v6/OFFSET]");
+        }
+
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ScanPredicateExprReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ScanPredicateExprReuseTest.java
@@ -170,15 +170,14 @@ public class ScanPredicateExprReuseTest extends PlanTestBase {
             String sql = "select k from complex_t where v1[0] > v2[3]";
             String plan = getVerboseExplain(sql);
             assertContains(plan, "  2:SELECT\n" +
-                    "  |  predicates: 2: v1[0] > 3: v2[3]\n" +
+                    "  |  predicates: 11: element_at > 12: element_at\n" +
                     "  |  cardinality: 1\n" +
                     "  |  \n" +
                     "  1:Project\n" +
                     "  |  output columns:\n" +
                     "  |  1 <-> [1: k, BIGINT, false]\n" +
-                    "  |  2 <-> [2: v1, ARRAY<BIGINT>, true]\n" +
-                    "  |  3 <-> [3: v2, ARRAY<BIGINT>, true]\n" +
-                    "  |  cardinality: 1");
+                    "  |  11 <-> 2: v1[0]\n" +
+                    "  |  12 <-> 3: v2[3]");
             assertContains(plan, "     Pruned type: 2 <-> [ARRAY<BIGINT>]\n" +
                     "     Pruned type: 3 <-> [ARRAY<BIGINT>]\n" +
                     "     ColumnAccessPath: [/v1/INDEX, /v2/INDEX]");
@@ -271,6 +270,22 @@ public class ScanPredicateExprReuseTest extends PlanTestBase {
             assertContains(plan, "     Pruned type: 7 <-> [MAP<INT,INT>]\n" +
                     "     Pruned type: 8 <-> [MAP<INT,INT>]\n" +
                     "     ColumnAccessPath: [/v6/KEY, /v7/KEY]");
+        }
+        {
+            String sql = "select k from complex_t where v6[0] > v7[1]";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  2:SELECT\n" +
+                    "  |  predicates: 11: element_at > 12: element_at\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  1 <-> [1: k, BIGINT, false]\n" +
+                    "  |  11 <-> 7: v6[0]\n" +
+                    "  |  12 <-> 8: v7[1]");
+            assertContains(plan, "     Pruned type: 7 <-> [MAP<INT,INT>]\n" +
+                    "     Pruned type: 8 <-> [MAP<INT,INT>]\n" +
+                    "     ColumnAccessPath: [/v6/INDEX, /v7/INDEX]");
         }
         {
             String sql = "select k from complex_t where cardinality(v1) + cardinality(v5.b.a) > 3 and " +

--- a/test/sql/test_expr_reuese/R/test_scan_predicate_expr_reuse
+++ b/test/sql/test_expr_reuese/R/test_scan_predicate_expr_reuse
@@ -1,0 +1,201 @@
+-- name: test_scan_predicate_expr_reuse
+CREATE TABLE `t` (
+  `v1` bigint NOT NULL COMMENT "",
+  `v2` bigint NULL COMMENT "",
+  `v3` bigint NULL COMMENT "",
+  `v4` array<string> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t select generate_series, generate_series, generate_series, array_repeat(cast(generate_series as string), 5) from table(generate_series(1, 100));
+-- result:
+-- !result
+select * from t where v1 = 10 and v2 = v3;
+-- result:
+10	10	10	["10","10","10","10","10"]
+-- !result
+select * from t where v1 = 10 or v2 = v3 order by v1 limit 3;
+-- result:
+1	1	1	["1","1","1","1","1"]
+2	2	2	["2","2","2","2","2"]
+3	3	3	["3","3","3","3","3"]
+-- !result
+select * from t where v1 = v3 and (v2 = 5 or v3 = 10) order by v1;
+-- result:
+5	5	5	["5","5","5","5","5"]
+10	10	10	["10","10","10","10","10"]
+-- !result
+select * from t where v1 < 10 and array_max(array_map(x->length(x) + v2, v4)) > 0 order by v1;
+-- result:
+1	1	1	["1","1","1","1","1"]
+2	2	2	["2","2","2","2","2"]
+3	3	3	["3","3","3","3","3"]
+4	4	4	["4","4","4","4","4"]
+5	5	5	["5","5","5","5","5"]
+6	6	6	["6","6","6","6","6"]
+7	7	7	["7","7","7","7","7"]
+8	8	8	["8","8","8","8","8"]
+9	9	9	["9","9","9","9","9"]
+-- !result
+set enable_scan_predicate_expr_reuse = false;
+-- result:
+-- !result
+select * from t where v1 = 10 and v2 = v3;
+-- result:
+10	10	10	["10","10","10","10","10"]
+-- !result
+select * from t where v1 = 10 or v2 = v3 order by v1 limit 3;
+-- result:
+1	1	1	["1","1","1","1","1"]
+2	2	2	["2","2","2","2","2"]
+3	3	3	["3","3","3","3","3"]
+-- !result
+select * from t where v1 = v3 and (v2 = 5 or v3 = 10) order by v1;
+-- result:
+5	5	5	["5","5","5","5","5"]
+10	10	10	["10","10","10","10","10"]
+-- !result
+select * from t where v1 < 10 and array_max(array_map(x->length(x) + v2, v4)) > 0 order by v1;
+-- result:
+1	1	1	["1","1","1","1","1"]
+2	2	2	["2","2","2","2","2"]
+3	3	3	["3","3","3","3","3"]
+4	4	4	["4","4","4","4","4"]
+5	5	5	["5","5","5","5","5"]
+6	6	6	["6","6","6","6","6"]
+7	7	7	["7","7","7","7","7"]
+8	8	8	["8","8","8","8","8"]
+9	9	9	["9","9","9","9","9"]
+-- !result
+CREATE TABLE `t0` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v1` array<bigint(20)> NULL COMMENT "",
+  `v2` array<bigint(20)> NULL COMMENT "",
+  `v3` array<bigint(20)> NULL COMMENT "",
+  `v4` struct<a int(11), b struct<a int(11)>> NULL COMMENT "",
+  `v5` struct<a int(11), b struct<a array<bigint(20)>>> NULL COMMENT "",
+  `v6` map<int(11),int(11)> NULL COMMENT "",
+  `v7` map<int(11),int(11)> NULL COMMENT "",
+  `v8` json NULL COMMENT "",
+  `v9` json NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 values 
+(1,[1],[1],[1],row(1,row(1)),row(1,row([1])),map{1:1},map{1:1,2:2},parse_json('{"a":{"b":1}}'),parse_json('{"a":1,"b":[1]}')),
+(2,[2],[2],[2],row(2,row(2)),row(2,row([2])),map{1:1},map{1:2,2:2},parse_json('{"a":{"b":2}}'),parse_json('{"a":1,"b":[1]}')),
+(3,[3],[3],[3],row(3,row(3)),row(3,row([3])),map{1:1},map{1:3,2:2},parse_json('{"a":{"b":3}}'),parse_json('{"a":1,"b":[1]}')),
+(4,[4],[4],[4],row(4,row(4)),row(4,row([4])),map{1:1},map{1:4,2:2},parse_json('{"a":{"b":4}}'),parse_json('{"a":1,"b":[1]}')),
+(5,[5],[5],[5],row(5,row(5)),row(5,row([5])),map{1:1},map{1:5,2:2},parse_json('{"a":{"b":5}}'),parse_json('{"a":1,"b":[1]}'));
+-- result:
+-- !result
+select k from t0 where v1[1] = v2[1] order by k;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+select k from t0 where v1[1] = v2[1] order by k limit 1;
+-- result:
+1
+-- !result
+select k,v1 from t0 where v1[1] = v2[1] order by k;
+-- result:
+1	[1]
+2	[2]
+3	[3]
+4	[4]
+5	[5]
+-- !result
+select k,v2 from t0 where v1[1] = v2[1] order by k;
+-- result:
+1	[1]
+2	[2]
+3	[3]
+4	[4]
+5	[5]
+-- !result
+select k from t0 where array_length(v1) = array_length(v2) order by k;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+select k from t0 where array_length(v1) = array_length(v5.b.a) order by k;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+select k,v5 from t0 where array_length(v1) = array_length(v5.b.a) order by k;
+-- result:
+1	{"a":1,"b":{"a":[1]}}
+2	{"a":2,"b":{"a":[2]}}
+3	{"a":3,"b":{"a":[3]}}
+4	{"a":4,"b":{"a":[4]}}
+5	{"a":5,"b":{"a":[5]}}
+-- !result
+select k,v5.a from t0 where array_length(v1) = array_length(v5.b.a) order by k;
+-- result:
+1	1
+2	2
+3	3
+4	4
+5	5
+-- !result
+select k from t0 where array_max(array_map(x->x+k, v5.b.a)) > 0 order by k;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+select k from t0 where array_max(array_map((x,y,z)->x+y+z, v5.b.a, map_keys(v6), v1)) > 0 order by k;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+select k,v5.a from t0 where array_max(array_map((x,y,z)->x+y+z, v5.b.a, map_keys(v6), v1)) > 0 order by k;
+-- result:
+1	1
+2	2
+3	3
+4	4
+5	5
+-- !result
+select k from t0 where v8->'$.a.b' = v9->'$.a' order by k;
+-- result:
+1
+-- !result
+select k,v9->'$.b' from t0 where v8->'$.a.b' = v9->'$.a' order by k;
+-- result:
+1	[1]
+-- !result
+select k from t0 where cardinality(v1) + cardinality(v5.b.a) > 0 and cardinality(v1) + cardinality(v5.b.a) + cardinality(v6) > 0 order by k;
+-- result:
+1
+2
+3
+4
+5
+-- !result

--- a/test/sql/test_expr_reuese/T/test_scan_predicate_expr_reuse
+++ b/test/sql/test_expr_reuese/T/test_scan_predicate_expr_reuse
@@ -1,0 +1,64 @@
+-- name: test_scan_predicate_expr_reuse
+CREATE TABLE `t` (
+  `v1` bigint NOT NULL COMMENT "",
+  `v2` bigint NULL COMMENT "",
+  `v3` bigint NULL COMMENT "",
+  `v4` array<string> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into t select generate_series, generate_series, generate_series, array_repeat(cast(generate_series as string), 5) from table(generate_series(1, 100));
+
+select * from t where v1 = 10 and v2 = v3;
+select * from t where v1 = 10 or v2 = v3 order by v1 limit 3;
+select * from t where v1 = v3 and (v2 = 5 or v3 = 10) order by v1;
+select * from t where v1 < 10 and array_max(array_map(x->length(x) + v2, v4)) > 0 order by v1;
+
+set enable_scan_predicate_expr_reuse = false;
+select * from t where v1 = 10 and v2 = v3;
+select * from t where v1 = 10 or v2 = v3 order by v1 limit 3;
+select * from t where v1 = v3 and (v2 = 5 or v3 = 10) order by v1;
+select * from t where v1 < 10 and array_max(array_map(x->length(x) + v2, v4)) > 0 order by v1;
+
+CREATE TABLE `t0` (
+  `k` bigint(20) NOT NULL COMMENT "",
+  `v1` array<bigint(20)> NULL COMMENT "",
+  `v2` array<bigint(20)> NULL COMMENT "",
+  `v3` array<bigint(20)> NULL COMMENT "",
+  `v4` struct<a int(11), b struct<a int(11)>> NULL COMMENT "",
+  `v5` struct<a int(11), b struct<a array<bigint(20)>>> NULL COMMENT "",
+  `v6` map<int(11),int(11)> NULL COMMENT "",
+  `v7` map<int(11),int(11)> NULL COMMENT "",
+  `v8` json NULL COMMENT "",
+  `v9` json NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 values 
+(1,[1],[1],[1],row(1,row(1)),row(1,row([1])),map{1:1},map{1:1,2:2},parse_json('{"a":{"b":1}}'),parse_json('{"a":1,"b":[1]}')),
+(2,[2],[2],[2],row(2,row(2)),row(2,row([2])),map{1:1},map{1:2,2:2},parse_json('{"a":{"b":2}}'),parse_json('{"a":1,"b":[1]}')),
+(3,[3],[3],[3],row(3,row(3)),row(3,row([3])),map{1:1},map{1:3,2:2},parse_json('{"a":{"b":3}}'),parse_json('{"a":1,"b":[1]}')),
+(4,[4],[4],[4],row(4,row(4)),row(4,row([4])),map{1:1},map{1:4,2:2},parse_json('{"a":{"b":4}}'),parse_json('{"a":1,"b":[1]}')),
+(5,[5],[5],[5],row(5,row(5)),row(5,row([5])),map{1:1},map{1:5,2:2},parse_json('{"a":{"b":5}}'),parse_json('{"a":1,"b":[1]}'));
+
+select k from t0 where v1[1] = v2[1] order by k;
+select k from t0 where v1[1] = v2[1] order by k limit 1;
+select k,v1 from t0 where v1[1] = v2[1] order by k;
+select k,v2 from t0 where v1[1] = v2[1] order by k;
+select k from t0 where array_length(v1) = array_length(v2) order by k;
+select k from t0 where array_length(v1) = array_length(v5.b.a) order by k;
+select k,v5 from t0 where array_length(v1) = array_length(v5.b.a) order by k;
+select k,v5.a from t0 where array_length(v1) = array_length(v5.b.a) order by k;
+select k from t0 where array_max(array_map(x->x+k, v5.b.a)) > 0 order by k;
+select k from t0 where array_max(array_map((x,y,z)->x+y+z, v5.b.a, map_keys(v6), v1)) > 0 order by k;
+select k,v5.a from t0 where array_max(array_map((x,y,z)->x+y+z, v5.b.a, map_keys(v6), v1)) > 0 order by k;
+select k from t0 where v8->'$.a.b' = v9->'$.a' order by k;
+select k,v9->'$.b' from t0 where v8->'$.a.b' = v9->'$.a' order by k;
+select k from t0 where cardinality(v1) + cardinality(v5.b.a) > 0 and cardinality(v1) + cardinality(v5.b.a) + cardinality(v6) > 0 order by k;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8896

Fix some bugs in `PullUpScanPredicateRule`:
1. Limit is not handled correctly.

when there is a limit on ScanOperator, we need to extract the limit from ScanOperator to FilterOperator

2. semi-structured data is not handled correctly, it will cause the optimization of subfield column pruning to fail.

for this problem, we cannot directly give up extracting related expressions from scan predicates, otherwise we will lose many opportunities to reuse expressions.
my solution: after extracting the reserved predicate in FilterOperator, we also need to collect the expressions that can be used for subfield column pruning, then add them to the scan projection and replace them with column ref in the final predicate.


taking this query as an example, before fixing, we need read the whole json column since json columns are in project node.

```sql
mysql> desc t1;
+----------------------+------+------+-------+---------+-------+
| Field                | Type | Null | Key   | Default | Extra |
+----------------------+------+------+-------+---------+-------+
| k1                   | int  | YES  | true  | NULL    |       |
| no_match_flat_json   | json | YES  | false | NULL    |       |
| one_layer_flat_json  | json | YES  | false | NULL    |       |
| many_layer_flat_json | json | YES  | false | NULL    |       |
+----------------------+------+------+-------+---------+-------+
4 rows in set (0.00 sec)
mysql> explain select k1 from t1 where no_match_flat_json->'$.k9.k0.k3' = one_layer_flat_json->'$.k5';
+---------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                |
+---------------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                               |
|  OUTPUT EXPRS:1: k1                                                                                           |
|   PARTITION: UNPARTITIONED                                                                                    |
|                                                                                                               |
|   RESULT SINK                                                                                                 |
|                                                                                                               |
|   3:EXCHANGE                                                                                                  |
|                                                                                                               |
| PLAN FRAGMENT 1                                                                                               |
|  OUTPUT EXPRS:                                                                                                |
|   PARTITION: RANDOM                                                                                           |
|                                                                                                               |
|   STREAM DATA SINK                                                                                            |
|     EXCHANGE ID: 03                                                                                           |
|     UNPARTITIONED                                                                                             |
|                                                                                                               |
|   2:SELECT                                                                                                    |
|   |  predicates: json_query(2: no_match_flat_json, '$.k9.k0.k3') = json_query(3: one_layer_flat_json, '$.k5') |
|   |                                                                                                           |
|   1:Project                                                                                                   |
|   |  <slot 1> : 1: k1                                                                                         |
|   |  <slot 2> : 2: no_match_flat_json                                                                         |
|   |  <slot 3> : 3: one_layer_flat_json                                                                        |
|   |                                                                                                           |
|   0:OlapScanNode                                                                                              |
|      TABLE: t1                                                                                                |
|      PREAGGREGATION: ON                                                                                       |
|      partitions=1/4                                                                                           |
|      rollup: t1                                                                                               |
|      tabletRatio=2/2                                                                                          |
|      tabletList=48051,48053                                                                                   |
|      cardinality=7                                                                                            |
|      avgRowSize=2052.0                                                                                        |
+---------------------------------------------------------------------------------------------------------------+
33 rows in set (0.01 sec)
```

after fixing, only json_query(xx) in project node, we don't need read the whole column
```sql
mysql> explain verbose select k1 from t1 where no_match_flat_json->'$.k9.k0.k3' = one_layer_flat_json->'$.k5';
+----------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                           |
+----------------------------------------------------------------------------------------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                                                                                               |
|                                                                                                                                                          |
| PLAN COST                                                                                                                                                |
|   CPU: 20500.0                                                                                                                                           |
|   Memory: 0.0                                                                                                                                            |
|                                                                                                                                                          |
| PLAN FRAGMENT 0(F01)                                                                                                                                     |
|   Fragment Cost: 0.0                                                                                                                                     |
|   Output Exprs:1: k1                                                                                                                                     |
|   Input Partition: UNPARTITIONED                                                                                                                         |
|   RESULT SINK                                                                                                                                            |
|                                                                                                                                                          |
|   3:EXCHANGE                                                                                                                                             |
|      cardinality: 5                                                                                                                                      |
|                                                                                                                                                          |
| PLAN FRAGMENT 1(F00)                                                                                                                                     |
|   Fragment Cost: 10250.0                                                                                                                                 |
|                                                                                                                                                          |
|   Input Partition: RANDOM                                                                                                                                |
|   OutPut Partition: UNPARTITIONED                                                                                                                        |
|   OutPut Exchange Id: 03                                                                                                                                 |
|                                                                                                                                                          |
|   2:SELECT                                                                                                                                               |
|   |  predicates: 5: json_query = 6: json_query                                                                                                           |
|   |  cardinality: 5                                                                                                                                      |
|   |                                                                                                                                                      |
|   1:Project                                                                                                                                              |
|   |  output columns:                                                                                                                                     |
|   |  1 <-> [1: k1, INT, true]                                                                                                                            |
|   |  5 <-> json_query[([2: no_match_flat_json, JSON, true], '$.k9.k0.k3'); args: JSON,VARCHAR; result: JSON; args nullable: true; result nullable: true] |
|   |  6 <-> json_query[([3: one_layer_flat_json, JSON, true], '$.k5'); args: JSON,VARCHAR; result: JSON; args nullable: true; result nullable: true]      |
|   |  cardinality: 5                                                                                                                                      |
|   |                                                                                                                                                      |
|   0:OlapScanNode                                                                                                                                         |
|      table: t1, rollup: t1                                                                                                                               |
|      preAggregation: on                                                                                                                                  |
|      partitionsRatio=1/4, tabletsRatio=2/2                                                                                                               |
|      tabletList=48051,48053                                                                                                                              |
|      actualRows=7, avgRowSize=2054.0                                                                                                                     |
|      ColumnAccessPath: [/no_match_flat_json/k9/k0/k3(json), /one_layer_flat_json/k5(json)]                                                               |
|      cardinality: 5                                                                                                                                      |
+----------------------------------------------------------------------------------------------------------------------------------------------------------+
41 rows in set (0.01 sec)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0