### PR TITLE
[Enhancement] add partition scan num limit when query internal olap table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -759,6 +759,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String SCAN_HIVE_PARTITION_NUM_LIMIT = "scan_hive_partition_num_limit";
 
+    public static final String SCAN_OLAP_PARTITION_NUM_LIMIT = "scan_olap_partition_num_limit";
+
     public static final String ENABLE_CROSS_JOIN = "enable_cross_join";
 
     public static final String ENABLE_NESTED_LOOP_JOIN = "enable_nested_loop_join";
@@ -2109,6 +2111,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // For the maximum number of partitions allowed to be scanned in a single hive table, 0 means no limit.
     @VarAttr(name = SCAN_HIVE_PARTITION_NUM_LIMIT)
     private int scanHivePartitionNumLimit = 0;
+
+    // For the maximum number of partitions allowed to be scanned in a single olap table, 0 means no limit.
+    @VarAttr(name = SCAN_OLAP_PARTITION_NUM_LIMIT)
+    private int scanOlapPartitionNumLimit = 0;
 
     @VarAttr(name = ENABLE_CROSS_JOIN)
     private boolean enableCrossJoin = true;
@@ -4175,6 +4181,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setScanHivePartitionNumLimit(int scanHivePartitionNumLimit) {
         this.scanHivePartitionNumLimit = scanHivePartitionNumLimit;
+    }
+
+    public int getScanOlapPartitionNumLimit() {
+        return scanOlapPartitionNumLimit;
+    }
+
+    public void setScanOlapPartitionNumLimit(int scanOlapPartitionNumLimit) {
+        this.scanOlapPartitionNumLimit = scanOlapPartitionNumLimit;
     }
 
     public boolean isEnableCrossJoin() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -101,7 +101,7 @@ public class OptOlapPartitionPruner {
             checkScanPartitionLimit(selectedPartitionIds.size());
         } catch (AnalysisException e) {
             LOG.warn("{} queryId: {}", e.getMessage(), DebugUtil.printId(ConnectContext.get().getQueryId()));
-            throw new StarRocksPlannerException(e.getMessage(), ErrorType.INTERNAL_ERROR);
+            throw new StarRocksPlannerException(e.getMessage(), ErrorType.USER_ERROR);
         }
 
         final Pair<ScalarOperator, List<ScalarOperator>> prunePartitionPredicate =
@@ -143,7 +143,7 @@ public class OptOlapPartitionPruner {
             checkScanPartitionLimit(ansPartitionIds.size());
         } catch (AnalysisException e) {
             LOG.warn("{} queryId: {}", e.getMessage(), DebugUtil.printId(ConnectContext.get().getQueryId()));
-            throw new StarRocksPlannerException(e.getMessage(), ErrorType.INTERNAL_ERROR);
+            throw new StarRocksPlannerException(e.getMessage(), ErrorType.USER_ERROR);
         }
 
         final LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
@@ -164,8 +164,10 @@ public class OptOlapPartitionPruner {
             LOG.warn("fail to get variable scan_olap_partition_num_limit, set default value 0, msg: {}", e.getMessage());
         }
         if (scanOlapPartitionNumLimit > 0 && selectedPartitionNum > scanOlapPartitionNumLimit) {
-            String msg = "Exceeded the limit of " + scanOlapPartitionNumLimit + " max scan olap partitions. " +
-                    "Please adjust query or change limit by set session variable scan_olap_partition_num_limit.";
+            String msg = "Exceeded the limit of number of olap table partitions to be scanned. " +
+                         "Number of partitions allowed: " + scanOlapPartitionNumLimit +
+                         ", number of partitions to be scanned: " + selectedPartitionNum +
+                         ". Please adjust the SQL or change the limit by set variable scan_olap_partition_num_limit.";
             throw new AnalysisException(msg);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -161,7 +161,7 @@ public class OptOlapPartitionPruner {
         try {
             scanOlapPartitionNumLimit = ConnectContext.get().getSessionVariable().getScanOlapPartitionNumLimit();
         } catch (Exception e) {
-            LOG.warn("failed to get variable scan_olap_partition_num_limit, set default value 0, msg: {}", e.getMessage());
+            LOG.warn("fail to get variable scan_olap_partition_num_limit, set default value 0, msg: {}", e.getMessage());
         }
         if (scanOlapPartitionNumLimit > 0 && selectedPartitionNum > scanOlapPartitionNumLimit) {
             String msg = "Exceeded the limit of " + scanOlapPartitionNumLimit + " max scan olap partitions. " +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -157,7 +157,12 @@ public class OptOlapPartitionPruner {
     }
 
     private static void checkScanPartitionLimit(int selectedPartitionNum) throws AnalysisException {
-        int scanOlapPartitionNumLimit = ConnectContext.get().getSessionVariable().getScanOlapPartitionNumLimit();
+        int scanOlapPartitionNumLimit = 0;
+        try {
+            scanOlapPartitionNumLimit = ConnectContext.get().getSessionVariable().getScanOlapPartitionNumLimit();
+        } catch (Exception e) {
+            LOG.warn("fail to get variable scan_olap_partition_num_limit, set default value 0, msg: {}", e.getMessage());
+        }
         if (scanOlapPartitionNumLimit > 0 && selectedPartitionNum > scanOlapPartitionNumLimit) {
             String msg = "Exceeded the limit of " + scanOlapPartitionNumLimit + " max scan olap partitions. " +
                     "Please adjust query or change limit by set session variable scan_olap_partition_num_limit.";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -161,7 +161,7 @@ public class OptOlapPartitionPruner {
         try {
             scanOlapPartitionNumLimit = ConnectContext.get().getSessionVariable().getScanOlapPartitionNumLimit();
         } catch (Exception e) {
-            LOG.warn("fail to get variable scan_olap_partition_num_limit, set default value 0, msg: {}", e.getMessage());
+            LOG.warn("failed to get variable scan_olap_partition_num_limit, set default value 0, msg: {}", e.getMessage());
         }
         if (scanOlapPartitionNumLimit > 0 && selectedPartitionNum > scanOlapPartitionNumLimit) {
             String msg = "Exceeded the limit of " + scanOlapPartitionNumLimit + " max scan olap partitions. " +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -99,7 +99,7 @@ public class OptOlapPartitionPruner {
 
         try {
             checkScanPartitionLimit(selectedPartitionIds.size());
-        } catch (AnalysisException e) {
+        } catch (StarRocksPlannerException e) {
             LOG.warn("{} queryId: {}", e.getMessage(), DebugUtil.printId(ConnectContext.get().getQueryId()));
             throw new StarRocksPlannerException(e.getMessage(), ErrorType.USER_ERROR);
         }
@@ -141,7 +141,7 @@ public class OptOlapPartitionPruner {
 
         try {
             checkScanPartitionLimit(ansPartitionIds.size());
-        } catch (AnalysisException e) {
+        } catch (StarRocksPlannerException e) {
             LOG.warn("{} queryId: {}", e.getMessage(), DebugUtil.printId(ConnectContext.get().getQueryId()));
             throw new StarRocksPlannerException(e.getMessage(), ErrorType.USER_ERROR);
         }
@@ -156,7 +156,7 @@ public class OptOlapPartitionPruner {
         return builder.build();
     }
 
-    private static void checkScanPartitionLimit(int selectedPartitionNum) throws AnalysisException {
+    private static void checkScanPartitionLimit(int selectedPartitionNum) throws StarRocksPlannerException {
         int scanOlapPartitionNumLimit = 0;
         try {
             scanOlapPartitionNumLimit = ConnectContext.get().getSessionVariable().getScanOlapPartitionNumLimit();
@@ -168,7 +168,7 @@ public class OptOlapPartitionPruner {
                          "Number of partitions allowed: " + scanOlapPartitionNumLimit +
                          ", number of partitions to be scanned: " + selectedPartitionNum +
                          ". Please adjust the SQL or change the limit by set variable scan_olap_partition_num_limit.";
-            throw new AnalysisException(msg);
+            throw new StarRocksPlannerException(msg, ErrorType.USER_ERROR);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
@@ -501,14 +501,14 @@ public class PartitionPruneRuleTest {
                 String exp = "Exceeded the limit of number of olap table partitions to be scanned. Number of partitions " +
                         "allowed: 3, number of partitions to be scanned: 5. Please adjust the SQL or " +
                         "change the limit by set variable scan_olap_partition_num_limit.";
-                Assert.assertEquals(e.getMessage(), exp);
+                Assert.assertTrue(e.getMessage().contains(exp));
             }
             //check set invalid value abc
             try {
                 stmt.execute("set scan_olap_partition_num_limit=abc;");
             } catch (Exception e) {
                 String exp = "Incorrect argument type to variable 'scan_olap_partition_num_limit'";
-                Assert.assertEquals(e.getMessage(), exp);
+                Assert.assertTrue(e.getMessage().contains(exp));
             }
         } finally {
             stmt.close();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
@@ -34,6 +34,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.optimizer.Memo;
@@ -48,8 +49,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.sql.Connection;
+import java.sql.Statement;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -456,6 +460,61 @@ public class PartitionPruneRuleTest {
         assertEquals(1, selectPartitionIds.size());
         long actual = selectPartitionIds.get(0);
         assertEquals(10001L, actual);
+    }
+
+    @Test
+    public void testOlapPartitionScanLimit() throws Exception {
+        PseudoCluster.getOrCreateWithRandomPort(true, 1);
+        Connection connection = PseudoCluster.getInstance().getQueryConnection();
+        Statement stmt = connection.createStatement();
+        try {
+            stmt.execute("create database olap_partition_scan_limit_test_db");
+            stmt.execute("use olap_partition_scan_limit_test_db");
+            stmt.execute("CREATE TABLE olap_partition_scan_limit_test_table " +
+                    "(`a` varchar(65533),`b` varchar(65533),`ds` date) ENGINE=OLAP " +
+                    "DUPLICATE KEY(`a`) PARTITION BY RANGE(`ds`)" +
+                    "(START (\"2024-09-20\") END (\"2024-09-27\") EVERY (INTERVAL 1 DAY))" +
+                    "DISTRIBUTED BY HASH(`a`)" +
+                    "PROPERTIES (\"replication_num\" = \"1\")");
+            stmt.execute("insert into olap_partition_scan_limit_test_table(a,b,ds) " +
+                    "values('1','a','2024-09-20'),('2','a','2024-09-21')," +
+                    "('3','a','2024-09-22'),('4','a','2024-09-23'),('5','a','2024-09-24')," +
+                    "('6','a','2024-09-25'),('7','a','2024-09-26')");
+            //check default value 0
+            stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
+            if (stmt.getResultSet().next()) {
+                int count = stmt.getResultSet().getInt(1);
+                Assert.assertEquals(count,5);
+            }
+            //check set value -1
+            stmt.execute("set scan_olap_partition_num_limit=-1;");
+            stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
+            if (stmt.getResultSet().next()) {
+                int count = stmt.getResultSet().getInt(1);
+                Assert.assertEquals(count,5);
+            }
+            //check set value 3
+            stmt.execute("set scan_olap_partition_num_limit=3;");
+            try {
+                stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
+            } catch (Exception e) {
+                String exp = "Exceeded the limit of number of olap table partitions to be scanned. Number of partitions " +
+                        "allowed: 3, number of partitions to be scanned: 5. Please adjust the SQL or " +
+                        "change the limit by set variable scan_olap_partition_num_limit.";
+                Assert.assertEquals(e.getMessage(),exp);
+            }
+            //check set invalid value abc
+            try {
+                stmt.execute("set scan_olap_partition_num_limit=abc;");
+            } catch (Exception e) {
+                String exp = "Incorrect argument type to variable 'scan_olap_partition_num_limit'";
+                Assert.assertEquals(e.getMessage(),exp);
+            }
+        } finally {
+            stmt.close();
+            connection.close();
+            PseudoCluster.getInstance().shutdown(true);
+        }
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
@@ -493,7 +493,7 @@ public class PartitionPruneRuleTest {
                 int count = stmt.getResultSet().getInt(1);
                 Assert.assertEquals(count, 5);
             }
-            //check set value 3
+            //check set value 3 
             stmt.execute("set scan_olap_partition_num_limit=3;");
             try {
                 stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
@@ -493,7 +493,7 @@ public class PartitionPruneRuleTest {
                 int count = stmt.getResultSet().getInt(1);
                 Assert.assertEquals(count, 5);
             }
-            //check set value 3 
+            //check set value 3
             stmt.execute("set scan_olap_partition_num_limit=3;");
             try {
                 stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
@@ -484,14 +484,14 @@ public class PartitionPruneRuleTest {
             stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
             if (stmt.getResultSet().next()) {
                 int count = stmt.getResultSet().getInt(1);
-                Assert.assertEquals(count,5);
+                Assert.assertEquals(count, 5);
             }
             //check set value -1
             stmt.execute("set scan_olap_partition_num_limit=-1;");
             stmt.execute("select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';");
             if (stmt.getResultSet().next()) {
                 int count = stmt.getResultSet().getInt(1);
-                Assert.assertEquals(count,5);
+                Assert.assertEquals(count, 5);
             }
             //check set value 3
             stmt.execute("set scan_olap_partition_num_limit=3;");
@@ -501,14 +501,14 @@ public class PartitionPruneRuleTest {
                 String exp = "Exceeded the limit of number of olap table partitions to be scanned. Number of partitions " +
                         "allowed: 3, number of partitions to be scanned: 5. Please adjust the SQL or " +
                         "change the limit by set variable scan_olap_partition_num_limit.";
-                Assert.assertEquals(e.getMessage(),exp);
+                Assert.assertEquals(e.getMessage(), exp);
             }
             //check set invalid value abc
             try {
                 stmt.execute("set scan_olap_partition_num_limit=abc;");
             } catch (Exception e) {
                 String exp = "Incorrect argument type to variable 'scan_olap_partition_num_limit'";
-                Assert.assertEquals(e.getMessage(),exp);
+                Assert.assertEquals(e.getMessage(), exp);
             }
         } finally {
             stmt.close();

--- a/test/sql/test_olap_partition_scan_limit/R/test_olap_partition_scan_limit
+++ b/test/sql/test_olap_partition_scan_limit/R/test_olap_partition_scan_limit
@@ -38,7 +38,7 @@ set scan_olap_partition_num_limit=3;
 -- !result
 select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';
 -- result:
-ERROR 1064 (HY000): Exceeded the limit of 3 max scan olap partitions. Please adjust query or change limit by set session variable scan_olap_partition_num_limit.
+E: (1064, 'Exceeded the limit of 3 max scan olap partitions. Please adjust query or change limit by set session variable scan_olap_partition_num_limit.')
 -- !result
 set scan_olap_partition_num_limit=0;
 -- result:

--- a/test/sql/test_olap_partition_scan_limit/R/test_olap_partition_scan_limit
+++ b/test/sql/test_olap_partition_scan_limit/R/test_olap_partition_scan_limit
@@ -38,7 +38,7 @@ set scan_olap_partition_num_limit=3;
 -- !result
 select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';
 -- result:
-E: (1064, 'Exceeded the limit of 3 max scan olap partitions. Please adjust query or change limit by set session variable scan_olap_partition_num_limit.')
+E: (1064, 'Exceeded the limit of number of olap table partitions to be scanned. Number of partitions allowed: 3, number of partitions to be scanned: 5. Please adjust the SQL or change the limit by set variable scan_olap_partition_num_limit.')
 -- !result
 set scan_olap_partition_num_limit=0;
 -- result:

--- a/test/sql/test_olap_partition_scan_limit/R/test_olap_partition_scan_limit
+++ b/test/sql/test_olap_partition_scan_limit/R/test_olap_partition_scan_limit
@@ -1,0 +1,45 @@
+-- name: test_olap_partition_scan_limit
+create database olap_partition_scan_limit_test_db;
+-- result:
+-- !result
+use olap_partition_scan_limit_test_db;
+-- result:
+-- !result
+CREATE TABLE olap_partition_scan_limit_test_table (
+  `a` varchar(65533),
+  `b` varchar(65533),
+  `ds` date
+) ENGINE=OLAP
+DUPLICATE KEY(`a`)
+PARTITION BY RANGE(`ds`)
+(
+START ("2024-09-20") END ("2024-09-27") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH(`a`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"storage_medium" = "HDD",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into olap_partition_scan_limit_test_table(a,b,ds) values('1','a','2024-09-20'),('2','a','2024-09-21'),('3','a','2024-09-22'),('4','a','2024-09-23'),('5','a','2024-09-24'),('6','a','2024-09-25'),('7','a','2024-09-26');
+-- result:
+-- !result
+select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';
+-- result:
+5
+-- !result
+set scan_olap_partition_num_limit=3;
+-- result:
+-- !result
+select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';
+-- result:
+ERROR 1064 (HY000): Exceeded the limit of 3 max scan olap partitions. Please adjust query or change limit by set session variable scan_olap_partition_num_limit.
+-- !result
+set scan_olap_partition_num_limit=0;
+-- result:
+-- !result

--- a/test/sql/test_olap_partition_scan_limit/T/test_olap_partition_scan_limit
+++ b/test/sql/test_olap_partition_scan_limit/T/test_olap_partition_scan_limit
@@ -1,0 +1,34 @@
+-- name: test_olap_partition_scan_limit
+create database olap_partition_scan_limit_test_db;
+
+use olap_partition_scan_limit_test_db;
+
+CREATE TABLE olap_partition_scan_limit_test_table (
+  `a` varchar(65533),
+  `b` varchar(65533),
+  `ds` date
+) ENGINE=OLAP
+DUPLICATE KEY(`a`)
+PARTITION BY RANGE(`ds`)
+(
+START ("2024-09-20") END ("2024-09-27") EVERY (INTERVAL 1 DAY)
+)
+DISTRIBUTED BY HASH(`a`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"storage_medium" = "HDD",
+"compression" = "LZ4"
+);
+
+insert into olap_partition_scan_limit_test_table(a,b,ds) values('1','a','2024-09-20'),('2','a','2024-09-21'),('3','a','2024-09-22'),('4','a','2024-09-23'),('5','a','2024-09-24'),('6','a','2024-09-25'),('7','a','2024-09-26');
+
+select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';
+
+set scan_olap_partition_num_limit=3;
+
+select count(*) from olap_partition_scan_limit_test_table where ds>='2024-09-22';
+
+set scan_olap_partition_num_limit=0;


### PR DESCRIPTION
## Why I'm doing:
when query big size internal olap table with full table scan or scan too many partitions, would cause BE/CN node high load, lead to cluster instability.

## What I'm doing:
add a new FE session variable `scan_olap_partition_num_limit` to limit partition scan num when query internal olap table.
(default value is 0, means no limitation)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0