### PR TITLE
[BugFix] Support Iceberg multi level namespace and vended-credentials

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.expressions.Projections;
@@ -419,5 +420,9 @@ public class IcebergApiConverter {
             partitionColumns.add(column);
         }
         return partitionColumns;
+    }
+
+    public static Namespace convertDbNameToNamespace(String dbName) {
+        return Namespace.of(dbName.split("\\."));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.StarRocksIcebergTableScan;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.util.StructProjection;
@@ -130,11 +131,11 @@ public interface IcebergCatalog extends MemoryTrackable {
                 srScanContext);
     }
 
-    default String defaultTableLocation(String dbName, String tableName) {
+    default String defaultTableLocation(Namespace ns, String tableName) {
         return "";
     }
 
-    default Map<String, Object> loadNamespaceMetadata(String dbName) {
+    default Map<String, Object> loadNamespaceMetadata(Namespace ns) {
         return new HashMap<>();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -66,7 +66,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     private static final Logger LOG = LogManager.getLogger(IcebergRESTCatalog.class);
 
     public static final String KEY_CREDENTIAL_WITH_PREFIX = ICEBERG_CUSTOM_PROPERTIES_PREFIX + "credential";
-    public static final String KEY_DISABLE_VENDED_CREDENTIAL = "disable_vended_credential";
+    public static final String KEY_VENDED_CREDENTIALS_ENABLED = "vended-credentials-enabled";
 
     private final Configuration conf;
     private final RESTCatalog delegate;
@@ -86,12 +86,12 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         copiedProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
         copiedProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());
 
-        boolean disableVendedCredential =
-                Boolean.parseBoolean(copiedProperties.getOrDefault(KEY_DISABLE_VENDED_CREDENTIAL, "false"));
-        if (disableVendedCredential) {
-            copiedProperties.put(AwsProperties.CLIENT_FACTORY, IcebergAwsClientFactory.class.getName());
-        } else {
+        boolean enableVendedCredentials =
+                Boolean.parseBoolean(copiedProperties.getOrDefault(KEY_VENDED_CREDENTIALS_ENABLED, "true"));
+        if (enableVendedCredentials) {
             copiedProperties.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
+        } else {
+            copiedProperties.put(AwsProperties.CLIENT_FACTORY, IcebergAwsClientFactory.class.getName());
         }
 
         // setup oauth2

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.iceberg.rest;
 
 import com.google.common.base.Strings;
@@ -57,6 +56,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
+import static com.starrocks.connector.iceberg.IcebergApiConverter.convertDbNameToNamespace;
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX;
 import static com.starrocks.connector.iceberg.IcebergMetadata.COMMENT;
 import static com.starrocks.connector.iceberg.IcebergMetadata.LOCATION_PROPERTY;
@@ -65,12 +65,6 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     private static final Logger LOG = LogManager.getLogger(IcebergRESTCatalog.class);
 
-    // Not all RestCatalog is tabular, here just used to handle tabular specifically
-    // If we are using tabular rest catalog, we must use S3FileIO
-    private static final String TABULAR_API = "https://api.tabular.io/ws";
-    // This parameter we don't expose to user, just some people are using docker hosted tabular, it's url may
-    // not the "https://api.tabular.io/ws"
-    public static final String KEY_DISABLE_TABULAR_SUPPORT = "disable_tabular_support";
     public static final String KEY_CREDENTIAL_WITH_PREFIX = ICEBERG_CUSTOM_PROPERTIES_PREFIX + "credential";
     public static final String KEY_DISABLE_VENDED_CREDENTIAL = "disable_vended_credential";
 
@@ -92,16 +86,18 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         copiedProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
         copiedProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());
 
-        if (!copiedProperties.containsKey(KEY_DISABLE_TABULAR_SUPPORT)) {
-            copiedProperties.put("header.x-tabular-s3-access", "vended_credentials");
-        }
-
-        boolean disableVendedCredential = copiedProperties
-                .getOrDefault(KEY_DISABLE_VENDED_CREDENTIAL, "false")
-                .equalsIgnoreCase("true");
+        boolean disableVendedCredential =
+                Boolean.parseBoolean(copiedProperties.getOrDefault(KEY_DISABLE_VENDED_CREDENTIAL, "false"));
         if (disableVendedCredential) {
             copiedProperties.put(AwsProperties.CLIENT_FACTORY, IcebergAwsClientFactory.class.getName());
+        } else {
+            copiedProperties.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
         }
+
+        // setup oauth2
+        OAuth2SecurityConfig securityConfig = OAuth2SecurityConfigBuilder.build(copiedProperties);
+        OAuth2SecurityProperties securityProperties = new OAuth2SecurityProperties(securityConfig);
+        copiedProperties.putAll(securityProperties.get());
 
         delegate = (RESTCatalog) CatalogUtil.loadCatalog(RESTCatalog.class.getName(), name, copiedProperties, conf);
     }
@@ -119,12 +115,12 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
-        return delegate.loadTable(TableIdentifier.of(dbName, tableName));
+        return delegate.loadTable(TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
     }
 
     @Override
     public boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
-        return delegate.tableExists(TableIdentifier.of(dbName, tableName));
+        return delegate.tableExists(TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
     }
 
     @Override
@@ -153,8 +149,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                 throw new IllegalArgumentException("Unrecognized property: " + key);
             }
         }
-        Namespace ns = Namespace.of(dbName);
-        delegate.createNamespace(ns, properties);
+        delegate.createNamespace(convertDbNameToNamespace(dbName), properties);
     }
 
     @Override
@@ -176,24 +171,25 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             throw new MetaNotFoundException("Database location is empty");
         }
 
-        delegate.dropNamespace(Namespace.of(dbName));
+        delegate.dropNamespace(convertDbNameToNamespace(dbName));
     }
 
     @Override
     public Database getDB(String dbName) {
-        Map<String, String> dbMeta = delegate.loadNamespaceMetadata(Namespace.of(dbName));
+        Map<String, String> dbMeta = delegate.loadNamespaceMetadata(convertDbNameToNamespace(dbName));
         return new Database(CONNECTOR_ID_GENERATOR.getNextId().asInt(), dbName, dbMeta.get(LOCATION_PROPERTY));
     }
 
     @Override
     public List<String> listTables(String dbName) {
-        List<TableIdentifier> tableIdentifiers = delegate.listTables(Namespace.of(dbName));
+        Namespace ns = convertDbNameToNamespace(dbName);
+        List<TableIdentifier> tableIdentifiers = delegate.listTables(ns);
         List<TableIdentifier> viewIdentifiers = new ArrayList<>();
         try {
-            viewIdentifiers = delegate.listViews(Namespace.of(dbName));
+            viewIdentifiers = delegate.listViews(ns);
         } catch (BadRequestException e) {
-            LOG.warn("Failed to list views from {} database. Perhaps the server side does not implement the interface. " +
-                    "Ask the user to check it", dbName, e);
+            LOG.warn("Failed to list views from {} namespace. Perhaps the server side does not implement the interface. " +
+                    "Ask the user to check it", ns, e);
         }
         if (!viewIdentifiers.isEmpty()) {
             tableIdentifiers.addAll(viewIdentifiers);
@@ -209,7 +205,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             PartitionSpec partitionSpec,
             String location,
             Map<String, String> properties) {
-        Table nativeTable = delegate.buildTable(TableIdentifier.of(dbName, tableName), schema)
+        Table nativeTable = delegate.buildTable(TableIdentifier.of(convertDbNameToNamespace(dbName), tableName), schema)
                 .withLocation(location)
                 .withPartitionSpec(partitionSpec)
                 .withProperties(properties)
@@ -220,24 +216,26 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public boolean dropTable(String dbName, String tableName, boolean purge) {
-        return delegate.dropTable(TableIdentifier.of(dbName, tableName), purge);
+        return delegate.dropTable(TableIdentifier.of(convertDbNameToNamespace(dbName), tableName), purge);
     }
 
     @Override
     public void renameTable(String dbName, String tblName, String newTblName) throws StarRocksConnectorException {
-        delegate.renameTable(TableIdentifier.of(dbName, tblName), TableIdentifier.of(dbName, newTblName));
+        Namespace ns = convertDbNameToNamespace(dbName);
+        delegate.renameTable(TableIdentifier.of(ns, tblName), TableIdentifier.of(ns, newTblName));
     }
 
     @Override
     public boolean createView(ConnectorViewDefinition definition, boolean replace) {
         Schema schema = IcebergApiConverter.toIcebergApiSchema(definition.getColumns());
-        ViewBuilder viewBuilder = delegate.buildView(TableIdentifier.of(definition.getDatabaseName(), definition.getViewName()));
+        Namespace ns = convertDbNameToNamespace(definition.getDatabaseName());
+        ViewBuilder viewBuilder = delegate.buildView(TableIdentifier.of(ns, definition.getViewName()));
         viewBuilder = viewBuilder.withSchema(schema)
                 .withQuery("starrocks", definition.getInlineViewDef())
-                .withDefaultNamespace(Namespace.of(definition.getDatabaseName()))
+                .withDefaultNamespace(ns)
                 .withDefaultCatalog(definition.getCatalogName())
                 .withProperties(buildProperties(definition))
-                .withLocation(defaultTableLocation(definition.getDatabaseName(), definition.getViewName()));
+                .withLocation(defaultTableLocation(ns, definition.getViewName()));
 
         if (replace) {
             viewBuilder.createOrReplace();
@@ -248,13 +246,13 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         return true;
     }
 
-    public boolean dropView(String dbName, String viewName) {
-        return delegate.dropView(TableIdentifier.of(dbName, viewName));
+    public boolean dropView(Namespace ns, String viewName) {
+        return delegate.dropView(TableIdentifier.of(ns, viewName));
     }
 
     @Override
     public View getView(String dbName, String viewName) {
-        return delegate.loadView(TableIdentifier.of(dbName, viewName));
+        return delegate.loadView(TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
     }
 
     @Override
@@ -280,10 +278,10 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     }
 
     @Override
-    public String defaultTableLocation(String dbName, String tableName) {
-        Map<String, String> properties = delegate.loadNamespaceMetadata(Namespace.of(dbName));
+    public String defaultTableLocation(Namespace ns, String tableName) {
+        Map<String, String> properties = delegate.loadNamespaceMetadata(ns);
         String databaseLocation = properties.get(LOCATION_PROPERTY);
-        checkArgument(databaseLocation != null, "location must be set for %s.%s", dbName, tableName);
+        checkArgument(databaseLocation != null, "location must be set for %s.%s", ns, tableName);
 
         if (databaseLocation.endsWith("/")) {
             return databaseLocation + tableName;
@@ -293,8 +291,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     }
 
     @Override
-    public Map<String, Object> loadNamespaceMetadata(String dbName) {
-        return ImmutableMap.copyOf(delegate.loadNamespaceMetadata(Namespace.of(dbName)));
+    public Map<String, Object> loadNamespaceMetadata(Namespace ns) {
+        return ImmutableMap.copyOf(delegate.loadNamespaceMetadata(ns));
     }
 
     private Map<String, String> buildProperties(ConnectorViewDefinition definition) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
@@ -109,8 +109,11 @@ class OAuth2SecurityConfigBuilder {
         config = config.setSecurity(SecurityEnum.OAUTH2)
                 .setCredential(properties.get(OAuth2SecurityConfig.OAUTH2_CREDENTIAL))
                 .setScope(properties.get(OAuth2SecurityConfig.OAUTH2_SCOPE))
-                .setToken(properties.get(OAuth2SecurityConfig.OAUTH2_TOKEN))
-                .setServerUri(URI.create(properties.get(OAuth2SecurityConfig.SERVER_URI)));
+                .setToken(properties.get(OAuth2SecurityConfig.OAUTH2_TOKEN));
+        String serverUri = properties.get(OAuth2SecurityConfig.SERVER_URI);
+        if (serverUri != null) {
+            config = config.setServerUri(URI.create(serverUri));
+        }
 
         // check OAuth2SecurityConfig is valid
         if (!config.credentialOrTokenPresent() || !config.scopePresentOnlyWithCredential()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
@@ -35,7 +35,7 @@ public class OAuth2SecurityConfig {
     // The Bearer token which will be used for interactions with the server
     public static String OAUTH2_TOKEN = "oauth2.token";
     // The endpoint to retrieve access token from OAuth2 Server
-    public static String SERVER_URI = "server_uri";
+    public static String SERVER_URI = "oauth2.server-uri";
 
     public SecurityEnum getSecurity() {
         return security;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
@@ -1,0 +1,123 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.rest;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+public class OAuth2SecurityConfig {
+    private SecurityEnum security = SecurityEnum.NONE;
+    private String credential;
+    private String scope;
+    private String token;
+    private URI serverUri;
+
+    // The type of security to use (default: NONE). OAUTH2 requires either a token or credential. Example: OAUTH2
+    public static String SECURITY = "security";
+    public static String SECURITY_OAUTH2 = "oauth2";
+    // The credential to exchange for a token in the OAuth2 client credentials flow with the server
+    public static String OAUTH2_CREDENTIAL = "oauth2.credential";
+    // The scope which will be used for interactions with the server
+    public static String OAUTH2_SCOPE = "oauth2.scope";
+    // The Bearer token which will be used for interactions with the server
+    public static String OAUTH2_TOKEN = "oauth2.token";
+    // The endpoint to retrieve access token from OAuth2 Server
+    public static String SERVER_URI = "server_uri";
+
+    public SecurityEnum getSecurity() {
+        return security;
+    }
+
+    public OAuth2SecurityConfig setSecurity(SecurityEnum security) {
+        this.security = security;
+        return this;
+    }
+
+    public Optional<String> getCredential() {
+        return Optional.ofNullable(credential);
+    }
+
+    public OAuth2SecurityConfig setCredential(String credential) {
+        this.credential = credential;
+        return this;
+    }
+
+    public Optional<String> getScope() {
+        return Optional.ofNullable(scope);
+    }
+
+    public OAuth2SecurityConfig setScope(String scope) {
+        this.scope = scope;
+        return this;
+    }
+
+    public Optional<String> getToken() {
+        return Optional.ofNullable(token);
+    }
+
+    public OAuth2SecurityConfig setToken(String token) {
+        this.token = token;
+        return this;
+    }
+
+    public Optional<URI> getServerUri() {
+        return Optional.ofNullable(serverUri);
+    }
+
+    public OAuth2SecurityConfig setServerUri(URI serverUri) {
+        this.serverUri = serverUri;
+        return this;
+    }
+
+    // OAuth2 requires a credential or token
+    public boolean credentialOrTokenPresent() {
+        return credential != null || token != null;
+    }
+
+    // Scope is applicable only when using credential
+    public boolean scopePresentOnlyWithCredential() {
+        return !(token != null && scope != null);
+    }
+}
+
+class OAuth2SecurityConfigBuilder {
+    public static OAuth2SecurityConfig build(final Map<String, String> properties) {
+        SecurityEnum security = SecurityEnum.NONE;
+        String strSecurity = properties.get(OAuth2SecurityConfig.SECURITY);
+        if (strSecurity != null && strSecurity.equalsIgnoreCase(OAuth2SecurityConfig.SECURITY_OAUTH2)) {
+            security = SecurityEnum.OAUTH2;
+        }
+
+        if (security == SecurityEnum.NONE) {
+            return new OAuth2SecurityConfig();
+        }
+
+        OAuth2SecurityConfig config = new OAuth2SecurityConfig();
+        config = config.setSecurity(SecurityEnum.OAUTH2)
+                .setCredential(properties.get(OAuth2SecurityConfig.OAUTH2_CREDENTIAL))
+                .setScope(properties.get(OAuth2SecurityConfig.OAUTH2_SCOPE))
+                .setToken(properties.get(OAuth2SecurityConfig.OAUTH2_TOKEN))
+                .setServerUri(URI.create(properties.get(OAuth2SecurityConfig.SERVER_URI)));
+
+        // check OAuth2SecurityConfig is valid
+        if (!config.credentialOrTokenPresent() || !config.scopePresentOnlyWithCredential()) {
+            return new OAuth2SecurityConfig();
+        }
+
+        return config;
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityProperties.java
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.rest;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.auth.OAuth2Properties;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class OAuth2SecurityProperties {
+    private final Map<String, String> securityProperties;
+
+    public OAuth2SecurityProperties(OAuth2SecurityConfig securityConfig) {
+        requireNonNull(securityConfig, "securityConfig is null");
+
+        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
+        if (securityConfig.getSecurity() == SecurityEnum.OAUTH2) {
+            securityConfig.getCredential().ifPresent(
+                    credential -> {
+                        propertiesBuilder.put(OAuth2Properties.CREDENTIAL, credential);
+                        securityConfig.getScope()
+                                .ifPresent(scope -> propertiesBuilder.put(OAuth2Properties.SCOPE, scope));
+                    });
+            securityConfig.getToken().ifPresent(
+                    value -> propertiesBuilder.put(OAuth2Properties.TOKEN, value));
+            securityConfig.getServerUri().ifPresent(
+                    value -> propertiesBuilder.put(OAuth2Properties.OAUTH2_SERVER_URI, value.toString()));
+        }
+
+        this.securityProperties = propertiesBuilder.buildOrThrow();
+    }
+
+    public Map<String, String> get() {
+        return securityProperties;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/SecurityEnum.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/SecurityEnum.java
@@ -1,0 +1,19 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.rest;
+
+public enum SecurityEnum {
+    NONE, OAUTH2
+}

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
@@ -83,17 +83,19 @@ public class CloudConfigurationFactory {
         return null;
     }
 
-    public static CloudConfiguration buildCloudConfigurationForTabular(Map<String, String> properties) {
+    public static CloudConfiguration buildCloudConfigurationForVendedCredentials(Map<String, String> properties) {
         Map<String, String> copiedProperties = new HashMap<>();
         String sessionAk = properties.getOrDefault(S3FileIOProperties.ACCESS_KEY_ID, null);
         String sessionSk = properties.getOrDefault(S3FileIOProperties.SECRET_ACCESS_KEY, null);
         String sessionToken = properties.getOrDefault(S3FileIOProperties.SESSION_TOKEN, null);
         String region = properties.getOrDefault(AwsClientProperties.CLIENT_REGION, null);
+        String enablePathStyle = properties.getOrDefault(S3FileIOProperties.PATH_STYLE_ACCESS, "false");
         if (sessionAk != null && sessionSk != null && sessionToken != null && region != null) {
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_ACCESS_KEY, sessionAk);
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_SECRET_KEY, sessionSk);
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_SESSION_TOKEN, sessionToken);
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_REGION, region);
+            copiedProperties.put(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS, enablePathStyle);
         }
         return buildCloudConfigurationForStorage(copiedProperties);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -144,11 +144,11 @@ public class IcebergScanNode extends ScanNode {
 
         // Hard coding here
         // Try to get tabular signed temporary credential
-        CloudConfiguration tabularTempCloudConfiguration = CloudConfigurationFactory.
-                buildCloudConfigurationForTabular(icebergTable.getNativeTable().io().properties());
-        if (tabularTempCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
+        CloudConfiguration vendedCredentialsCloudConfiguration = CloudConfigurationFactory.
+                buildCloudConfigurationForVendedCredentials(icebergTable.getNativeTable().io().properties());
+        if (vendedCredentialsCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
             // If we get CloudConfiguration succeed from iceberg FileIO's properties, we just using it.
-            cloudConfiguration = tabularTempCloudConfiguration;
+            cloudConfiguration = vendedCredentialsCloudConfiguration;
         } else {
             CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
             Preconditions.checkState(connector != null,

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
@@ -17,15 +17,12 @@ package com.starrocks.planner;
 import com.google.common.base.Preconditions;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.IcebergTable;
-import com.starrocks.catalog.Type;
 import com.starrocks.connector.CatalogConnector;
-import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.credential.CloudType;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TDataSink;
@@ -33,17 +30,10 @@ import com.starrocks.thrift.TDataSinkType;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TIcebergTableSink;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.aws.AwsProperties;
-
-import java.util.Locale;
 
 import static com.starrocks.analysis.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
-import static org.apache.iceberg.TableProperties.ORC_COMPRESSION;
-import static org.apache.iceberg.TableProperties.ORC_COMPRESSION_DEFAULT;
-import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
-import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION_DEFAULT;
 
 public class IcebergTableSink extends DataSink {
     public final static int ICEBERG_SINK_MAX_DOP = 32;
@@ -79,7 +69,7 @@ public class IcebergTableSink extends DataSink {
 
         // Try to set for tabular
         CloudConfiguration tabularTempCloudConfiguration = CloudConfigurationFactory.
-                buildCloudConfigurationForTabular(icebergTable.getNativeTable().io().properties());
+                buildCloudConfigurationForVendedCredentials(icebergTable.getNativeTable().io().properties());
         if (tabularTempCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
             this.cloudConfiguration = tabularTempCloudConfiguration;
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
@@ -240,5 +241,12 @@ public class IcebergApiConverterTest {
         org.apache.iceberg.types.Type icebergType = Types.TimeType.get();
         Type resType = fromIcebergType(icebergType);
         Assert.assertEquals(resType, timeType);
+    }
+
+    @Test
+    public void testConvertDbNameToNamespace() {
+        Assert.assertEquals(Namespace.of(""), IcebergApiConverter.convertDbNameToNamespace(""));
+        Assert.assertEquals(Namespace.of("a"), IcebergApiConverter.convertDbNameToNamespace("a"));
+        Assert.assertEquals(Namespace.of("a", "b", "c"), IcebergApiConverter.convertDbNameToNamespace("a.b.c"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfigTest.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.rest;
+
+import org.apache.iceberg.rest.auth.OAuth2Properties;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class OAuth2SecurityConfigTest {
+
+    @Test
+    public void testBuild() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("security", "none");
+        OAuth2SecurityConfig config = OAuth2SecurityConfigBuilder.build(properties);
+        Assert.assertEquals(SecurityEnum.NONE, config.getSecurity());
+
+        properties = new HashMap<>();
+        properties.put("security", "oaUth2");
+        properties.put("oauth2.credential", "smith:cruise");
+        properties.put("oauth2.scope", "PRINCIPAL");
+        config = OAuth2SecurityConfigBuilder.build(properties);
+        Assert.assertEquals(SecurityEnum.OAUTH2, config.getSecurity());
+        Assert.assertEquals("smith:cruise", config.getCredential().get());
+        Assert.assertEquals("PRINCIPAL", config.getScope().get());
+
+        properties = new HashMap<>();
+        properties.put("security", "oaUth2");
+        properties.put("oauth2.credential", "smith:cruise");
+        properties.put("oauth2.token", "123456");
+        properties.put("oauth2.scope", "PRINCIPAL");
+        config = OAuth2SecurityConfigBuilder.build(properties);
+        Assert.assertEquals(SecurityEnum.NONE, config.getSecurity());
+    }
+
+    @Test
+    public void testProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("security", "oaUth2");
+        properties.put("oauth2.credential", "smith:cruise");
+        properties.put("oauth2.scope", "PRINCIPAL");
+        properties.put("oauth2.server-uri", "http://localhost:8080");
+        OAuth2SecurityConfig config = OAuth2SecurityConfigBuilder.build(properties);
+        OAuth2SecurityProperties oauth2Properties = new OAuth2SecurityProperties(config);
+        Assert.assertEquals("smith:cruise", oauth2Properties.get().get(OAuth2Properties.CREDENTIAL));
+        Assert.assertEquals("PRINCIPAL", oauth2Properties.get().get(OAuth2Properties.SCOPE));
+        Assert.assertEquals("http://localhost:8080", oauth2Properties.get().get(OAuth2Properties.OAUTH2_SERVER_URI));
+
+        properties = new HashMap<>();
+        config = OAuth2SecurityConfigBuilder.build(properties);
+        oauth2Properties = new OAuth2SecurityProperties(config);
+        Assert.assertEquals(0, oauth2Properties.get().size());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -35,6 +35,7 @@ public class CloudConfigurationFactoryTest {
         map.put(S3FileIOProperties.ACCESS_KEY_ID, "ak");
         map.put(S3FileIOProperties.SECRET_ACCESS_KEY, "sk");
         map.put(S3FileIOProperties.SESSION_TOKEN, "token");
+        map.put(S3FileIOProperties.PATH_STYLE_ACCESS, "true");
         map.put(AwsClientProperties.CLIENT_REGION, "region");
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map);
         Assert.assertNotNull(cloudConfiguration);
@@ -44,7 +45,7 @@ public class CloudConfigurationFactoryTest {
                         "cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, " +
                         "useInstanceProfile=false, accessKey='ak', secretKey='sk', " +
                         "sessionToken='token', iamRoleArn='', stsRegion='', stsEndpoint='', externalId='', " +
-                        "region='region', endpoint=''}, enablePathStyleAccess=false, enableSSL=true}",
+                        "region='region', endpoint=''}, enablePathStyleAccess=true, enableSSL=true}",
                 cloudConfiguration.toConfString());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -30,13 +30,13 @@ import java.util.Map;
 public class CloudConfigurationFactoryTest {
 
     @Test
-    public void testBuildCloudConfigurationForTabular() {
+    public void testBuildCloudConfigurationForVendedCredentials() {
         Map<String, String> map = new HashMap<>();
         map.put(S3FileIOProperties.ACCESS_KEY_ID, "ak");
         map.put(S3FileIOProperties.SECRET_ACCESS_KEY, "sk");
         map.put(S3FileIOProperties.SESSION_TOKEN, "token");
         map.put(AwsClientProperties.CLIENT_REGION, "region");
-        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForTabular(map);
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map);
         Assert.assertNotNull(cloudConfiguration);
         Assert.assertEquals(CloudType.AWS, cloudConfiguration.getCloudType());
         Assert.assertEquals(


### PR DESCRIPTION
## Why I'm doing:
Support nested namespace access, like Polaris.
```sql
mysql> select * from iceberg_rest.`ns1.ns2.tpch_namespace`.tbl;                                                                         
+------+                                                                                                                                
| c1   |                                                                                                                                
+------+                                                                                                                                
| 1    |                                                                                                                                
| 2    |                                                                                                                                
| 3    |                                                                                                                                
+------+                                                                                                                                
3 rows in set (4.55 sec)
```

Support vended-credentials, create catalog like this:
```sql
CREATE EXTERNAL CATALOG iceberg_rest 
PROPERTIES (   
    "iceberg.catalog.uri"  = "http://localhost:8181/api/catalog",   
    "type"  =  "iceberg",   
    "iceberg.catalog.type"  =  "rest",   
    "iceberg.catalog.warehouse" = "starrocks_catalog",
    "iceberg.catalog.credential" = "f7357cfbe9583aa1:7b90fc77e4fbe288a5c41eaa05da3a3b",
    "iceberg.catalog.scope"='PRINCIPAL_ROLE:ALL',
    "iceberg.catalog.client.region" = "us-west-2"
 );
```

You can also disable vended-credentials like this:
```sql
CREATE EXTERNAL CATALOG iceberg_rest 
PROPERTIES (   
    "iceberg.catalog.uri"  = "http://localhost:8181/api/catalog",   
    "type"  =  "iceberg",   
    "iceberg.catalog.type"  =  "rest",   
    "iceberg.catalog.warehouse" = "starrocks_catalog",
    "iceberg.catalog.credential" = "f7357cfbe9583aa1:7b90fc77e4fbe288a5c41eaa05da3a3b",
    "iceberg.catalog.scope"='PRINCIPAL_ROLE:ALL',
    "iceberg.catalog.client.region" = "us-west-2",
    "iceberg.catalog.vended-credentials-enabled"="false"
 );
```

We recommend to use oauth2 to authentication, so add below new parameters

`iceberg.catalog.security`: The type of security to use (default: NONE). OAUTH2 requires either a token or credential. Example: OAUTH2
`iceberg.catalog.oauth2.token`: The bearer token used for interactions with the server. A token or credential is required for OAUTH2 security. Example: AbCdEf123456
`iceberg.catalog.oauth2.credential`:  The credential to exchange for a token in the OAuth2 client credentials flow with the server. A token or credential is required for OAUTH2 security. Example: AbCdEf123456
`iceberg.catalog.oauth2.scope`: Scope to be used when communicating with the REST Catalog. Applicable only when using credential.
`iceberg.catalog.oauth2.server-uri`: The endpoint to retrieve access token from OAuth2 Server.

For example you can create catalog like:
```sql
CREATE EXTERNAL CATALOG new_iceberg_rest 
PROPERTIES (   
    "iceberg.catalog.uri"  = "http://localhost:8181/api/catalog",   
    "type"  =  "iceberg",   
    "iceberg.catalog.type"  =  "rest",   
    "iceberg.catalog.warehouse" = "starrocks_catalog",
    "iceberg.catalog.security" = "oauth2",
    "iceberg.catalog.oauth2.credential" = "f7357cfbe9583aa1:7b90fc77e4fbe288a5c41eaa05da3a3b",
    "iceberg.catalog.oauth2.scope"='PRINCIPAL_ROLE:ALL',
    "iceberg.catalog.client.region" = "us-west-2"
 );
```


## What I'm doing:

Fix #50585 #52451

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0