### PR TITLE
[BugFix] Fix connection pool leak in JDBC connector

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -65,7 +65,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-public interface ConnectorMetadata {
+public interface ConnectorMetadata extends AutoCloseable {
     /**
      * Use connector type as a hint of table type.
      * Caveat: there are exceptions that hive connector may have non-hive(e.g. iceberg) tables.
@@ -343,6 +343,10 @@ public interface ConnectorMetadata {
     default Set<DeleteFile> getDeleteFiles(IcebergTable icebergTable, Long snapshotId,
                                            ScalarOperator predicate, FileContent fileContent) {
         throw new StarRocksConnectorException("This connector doesn't support getting delete files");
+    }
+
+    @Override
+    default void close() {
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCConnector.java
@@ -103,4 +103,11 @@ public class JDBCConnector implements Connector {
         }
         return metadata;
     }
+
+    @Override
+    public void shutdown() {
+        if (metadata != null) {
+            metadata.close();
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -58,7 +58,7 @@ public class JDBCMetadata implements ConnectorMetadata {
     private JDBCMetaCache<JDBCTableName, Table> tableInstanceCache;
     private JDBCMetaCache<JDBCTableName, List<Partition>> partitionInfoCache;
 
-    private HikariDataSource dataSource;
+    private final HikariDataSource dataSource;
 
     public JDBCMetadata(Map<String, String> properties, String catalogName) {
         this(properties, catalogName, null);
@@ -301,5 +301,10 @@ public class JDBCMetadata implements ConnectorMetadata {
 
     public void refreshCache(Map<String, String> properties) {
         createMetaAsyncCacheInstances(properties);
+    }
+
+    @Override
+    public void close() {
+        this.dataSource.close();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
@@ -102,8 +102,7 @@ public class ClickhouseSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("clickhouse", "template1", "test");
             Assert.assertEquals(expectResult, result);
@@ -125,8 +124,7 @@ public class ClickhouseSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
@@ -152,8 +150,7 @@ public class ClickhouseSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "t1", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "t1", dataSource)) {
             List<String> result = jdbcMetadata.listTableNames("test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
@@ -181,10 +178,11 @@ public class ClickhouseSchemaResolverTest {
             }
         };
 
-        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        List<String> result = jdbcMetadata.listTableNames("test");
-        List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
-        Assert.assertEquals(expectResult, result);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+            List<String> result = jdbcMetadata.listTableNames("test");
+            List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
+            Assert.assertEquals(expectResult, result);
+        }
 
     }
 
@@ -205,8 +203,7 @@ public class ClickhouseSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());
@@ -237,9 +234,10 @@ public class ClickhouseSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        List<String> result = jdbcMetadata.listDbNames();
-        List<String> expectResult = Lists.newArrayList("clickhouse", "template1", "test");
-        Assert.assertEquals(expectResult, result);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+            List<String> result = jdbcMetadata.listDbNames();
+            List<String> expectResult = Lists.newArrayList("clickhouse", "template1", "test");
+            Assert.assertEquals(expectResult, result);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
@@ -129,8 +129,7 @@ public class JDBCMetaCacheTest {
 
     @Test
     public void testListDatabaseNames() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             dbResult.beforeFirst();
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("test");
@@ -142,8 +141,7 @@ public class JDBCMetaCacheTest {
 
     @Test
     public void testGetDb() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             dbResult.beforeFirst();
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
@@ -154,8 +152,7 @@ public class JDBCMetaCacheTest {
 
     @Test
     public void testListTableNames() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             List<String> result = jdbcMetadata.listTableNames("test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
@@ -166,8 +163,7 @@ public class JDBCMetaCacheTest {
 
     @Test
     public void testGetTable() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Table table2 = jdbcMetadata.getTable("test", "tbl1");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -117,8 +117,7 @@ public class JDBCMetadataTest {
 
     @Test
     public void testListDatabaseNames() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             dbResult.beforeFirst();
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("test");
@@ -130,8 +129,7 @@ public class JDBCMetadataTest {
 
     @Test
     public void testGetDb() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             dbResult.beforeFirst();
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
@@ -142,8 +140,7 @@ public class JDBCMetadataTest {
 
     @Test
     public void testListTableNames() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             List<String> result = jdbcMetadata.listTableNames("test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
@@ -161,8 +158,7 @@ public class JDBCMetadataTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertTrue(table.getPartitionColumns().isEmpty());
@@ -187,8 +183,7 @@ public class JDBCMetadataTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertFalse(table.getPartitionColumns().isEmpty());
@@ -200,25 +195,26 @@ public class JDBCMetadataTest {
 
     @Test
     public void testColumnTypes() {
-        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        Table table = jdbcMetadata.getTable("test", "tbl1");
-        List<Column> columns = table.getColumns();
-        Assert.assertEquals(columns.size(), columnResult.getRowCount());
-        Assert.assertTrue(columns.get(0).getType().equals(ScalarType.createType(PrimitiveType.INT)));
-        Assert.assertTrue(columns.get(1).getType().equals(ScalarType.createUnifiedDecimalType(10, 2)));
-        Assert.assertTrue(columns.get(2).getType().equals(ScalarType.createCharType(10)));
-        Assert.assertTrue(columns.get(3).getType().equals(ScalarType.createVarcharType(10)));
-        Assert.assertTrue(columns.get(4).getType().equals(ScalarType.createType(PrimitiveType.SMALLINT)));
-        Assert.assertTrue(columns.get(5).getType().equals(ScalarType.createType(PrimitiveType.INT)));
-        Assert.assertTrue(columns.get(6).getType().equals(ScalarType.createType(PrimitiveType.BIGINT)));
-        Assert.assertTrue(columns.get(7).getType().equals(ScalarType.createType(PrimitiveType.LARGEINT)));
-        Assert.assertTrue(columns.get(8).getType().equals(ScalarType.createType(PrimitiveType.TINYINT)));
-        Assert.assertTrue(columns.get(9).getType().equals(ScalarType.createType(PrimitiveType.SMALLINT)));
-        Assert.assertTrue(columns.get(10).getType().equals(ScalarType.createType(PrimitiveType.INT)));
-        Assert.assertTrue(columns.get(11).getType().equals(ScalarType.createType(PrimitiveType.BIGINT)));
-        Assert.assertTrue(columns.get(12).getType().equals(ScalarType.createType(PrimitiveType.DATE)));
-        Assert.assertTrue(columns.get(13).getType().equals(ScalarType.createType(PrimitiveType.TIME)));
-        Assert.assertTrue(columns.get(14).getType().equals(ScalarType.createType(PrimitiveType.DATETIME)));
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+            Table table = jdbcMetadata.getTable("test", "tbl1");
+            List<Column> columns = table.getColumns();
+            Assert.assertEquals(columns.size(), columnResult.getRowCount());
+            Assert.assertTrue(columns.get(0).getType().equals(ScalarType.createType(PrimitiveType.INT)));
+            Assert.assertTrue(columns.get(1).getType().equals(ScalarType.createUnifiedDecimalType(10, 2)));
+            Assert.assertTrue(columns.get(2).getType().equals(ScalarType.createCharType(10)));
+            Assert.assertTrue(columns.get(3).getType().equals(ScalarType.createVarcharType(10)));
+            Assert.assertTrue(columns.get(4).getType().equals(ScalarType.createType(PrimitiveType.SMALLINT)));
+            Assert.assertTrue(columns.get(5).getType().equals(ScalarType.createType(PrimitiveType.INT)));
+            Assert.assertTrue(columns.get(6).getType().equals(ScalarType.createType(PrimitiveType.BIGINT)));
+            Assert.assertTrue(columns.get(7).getType().equals(ScalarType.createType(PrimitiveType.LARGEINT)));
+            Assert.assertTrue(columns.get(8).getType().equals(ScalarType.createType(PrimitiveType.TINYINT)));
+            Assert.assertTrue(columns.get(9).getType().equals(ScalarType.createType(PrimitiveType.SMALLINT)));
+            Assert.assertTrue(columns.get(10).getType().equals(ScalarType.createType(PrimitiveType.INT)));
+            Assert.assertTrue(columns.get(11).getType().equals(ScalarType.createType(PrimitiveType.BIGINT)));
+            Assert.assertTrue(columns.get(12).getType().equals(ScalarType.createType(PrimitiveType.DATE)));
+            Assert.assertTrue(columns.get(13).getType().equals(ScalarType.createType(PrimitiveType.TIME)));
+            Assert.assertTrue(columns.get(14).getType().equals(ScalarType.createType(PrimitiveType.DATETIME)));
+        }
     }
 
     @Test
@@ -226,15 +222,15 @@ public class JDBCMetadataTest {
         // user/password are optional fields for jdbc.
         properties.put(JDBCResource.USER, "");
         properties.put(JDBCResource.PASSWORD, "");
-        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        Table table = jdbcMetadata.getTable("test", "tbl1");
-        Assert.assertNotNull(table);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+            Table table = jdbcMetadata.getTable("test", "tbl1");
+            Assert.assertNotNull(table);
+        }
     }
 
     @Test
     public void testCacheTableId() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Table table1 = jdbcMetadata.getTable("test", "tbl1");
             columnResult.beforeFirst();
             Table table2 = jdbcMetadata.getTable("test", "tbl1");
@@ -248,11 +244,13 @@ public class JDBCMetadataTest {
     @Test
     public void testGetJdbcUrl() {
         properties.put(JDBCResource.URI, "jdbc:mysql://127.0.0.1:3306");
-        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
-        Assert.assertEquals("jdbc:mariadb://127.0.0.1:3306", jdbcMetadata.getJdbcUrl());
-        properties.put(JDBCResource.URI, "jdbc:mysql://abc.mysql.com:3306");
-        jdbcMetadata = new JDBCMetadata(properties, "catalog");
-        Assert.assertEquals("jdbc:mariadb://abc.mysql.com:3306", jdbcMetadata.getJdbcUrl());
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog")) {
+            Assert.assertEquals("jdbc:mariadb://127.0.0.1:3306", jdbcMetadata.getJdbcUrl());
+            properties.put(JDBCResource.URI, "jdbc:mysql://abc.mysql.com:3306");
+        }
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog")) {
+            Assert.assertEquals("jdbc:mariadb://abc.mysql.com:3306", jdbcMetadata.getJdbcUrl());
+        }
     }
 
     @Test
@@ -264,6 +262,8 @@ public class JDBCMetadataTest {
         properties.put(JDBCResource.PASSWORD, "123456");
         properties.put(JDBCResource.CHECK_SUM, "xxxx");
         properties.put(JDBCResource.DRIVER_URL, "xxxx");
-        new JDBCMetadata(properties, "catalog");
+        try (JDBCMetadata ignored = new JDBCMetadata(properties, "catalog")) {
+            ;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -146,8 +146,7 @@ public class MysqlSchemaResolverTest {
 
     @Test
     public void testListPartitionNames() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
             Assert.assertFalse(partitionNames.isEmpty());
         } catch (Exception e) {
@@ -159,19 +158,20 @@ public class MysqlSchemaResolverTest {
     public void testListPartitionNamesWithCache() {
         try {
             JDBCCacheTestUtil.openCacheEnable(connectContext);
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1",
-                    ConnectorMetadatRequestContext.DEFAULT);
-            Assert.assertFalse(partitionNames.isEmpty());
-            List<String> partitionNamesWithCache =
-                    jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
-            Assert.assertFalse(partitionNamesWithCache.isEmpty());
-            JDBCCacheTestUtil.closeCacheEnable(connectContext);
-            Map<String, String> properties = new HashMap<>();
-            jdbcMetadata.refreshCache(properties);
-            List<String> partitionNamesWithOutCache =
-                    jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
-            Assert.assertTrue(partitionNamesWithOutCache.isEmpty());
+            try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+                List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1",
+                        ConnectorMetadatRequestContext.DEFAULT);
+                Assert.assertFalse(partitionNames.isEmpty());
+                List<String> partitionNamesWithCache =
+                        jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
+                Assert.assertFalse(partitionNamesWithCache.isEmpty());
+                JDBCCacheTestUtil.closeCacheEnable(connectContext);
+                Map<String, String> properties = new HashMap<>();
+                jdbcMetadata.refreshCache(properties);
+                List<String> partitionNamesWithOutCache =
+                        jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
+                Assert.assertTrue(partitionNamesWithOutCache.isEmpty());
+            }
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -187,9 +187,14 @@ public class MysqlSchemaResolverTest {
                     minTimes = 0;
                 }
             };
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1", ConnectorMetadatRequestContext.DEFAULT);
-            Assert.assertTrue(partitionNames.size() == 0);
+            try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+                List<String> partitionNames = jdbcMetadata.listPartitionNames(
+                        "test",
+                        "tbl1",
+                        ConnectorMetadatRequestContext.DEFAULT
+                );
+                Assert.assertTrue(partitionNames.size() == 0);
+            }
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -197,8 +202,7 @@ public class MysqlSchemaResolverTest {
 
     @Test
     public void testListPartitionColumns() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Integer size = jdbcMetadata.listPartitionColumns("test", "tbl1",
                     Arrays.asList(new Column("d", Type.VARCHAR))).size();
             Assert.assertTrue(size > 0);
@@ -217,10 +221,11 @@ public class MysqlSchemaResolverTest {
                     minTimes = 0;
                 }
             };
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            Integer size = jdbcMetadata.listPartitionColumns("test", "tbl1",
-                    Arrays.asList(new Column("d", Type.VARCHAR))).size();
-            Assert.assertTrue(size == 0);
+            try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+                Integer size = jdbcMetadata.listPartitionColumns("test", "tbl1",
+                        Arrays.asList(new Column("d", Type.VARCHAR))).size();
+                Assert.assertTrue(size == 0);
+            }
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -228,8 +233,7 @@ public class MysqlSchemaResolverTest {
 
     @Test
     public void testGetPartitions() {
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", Type.VARCHAR)),
                     Arrays.asList(new Column("d", Type.VARCHAR)), "test", "catalog", properties);
             Integer size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
@@ -243,18 +247,19 @@ public class MysqlSchemaResolverTest {
     public void testGetPartitionsWithCache() {
         try {
             JDBCCacheTestUtil.openCacheEnable(connectContext);
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", Type.VARCHAR)),
-                    Arrays.asList(new Column("d", Type.VARCHAR)), "test", "catalog", properties);
-            int size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
-            Assert.assertTrue(size > 0);
-            int sizeWithCache = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
-            Assert.assertTrue(sizeWithCache > 0);
-            JDBCCacheTestUtil.closeCacheEnable(connectContext);
-            Map<String, String> properties = new HashMap<>();
-            jdbcMetadata.refreshCache(properties);
-            int sizeWithOutCache = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
-            Assert.assertEquals(0, sizeWithOutCache);
+            try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+                JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", Type.VARCHAR)),
+                        Arrays.asList(new Column("d", Type.VARCHAR)), "test", "catalog", properties);
+                int size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
+                Assert.assertTrue(size > 0);
+                int sizeWithCache = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
+                Assert.assertTrue(sizeWithCache > 0);
+                JDBCCacheTestUtil.closeCacheEnable(connectContext);
+                Map<String, String> properties = new HashMap<>();
+                jdbcMetadata.refreshCache(properties);
+                int sizeWithOutCache = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
+                Assert.assertEquals(0, sizeWithOutCache);
+            }
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -262,14 +267,15 @@ public class MysqlSchemaResolverTest {
 
     @Test
     public void testGetPartitions_NonPartitioned() throws DdlException {
-        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-        List<Column> columns = Arrays.asList(new Column("d", Type.VARCHAR));
-        JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
-                "test", "catalog", properties);
-        int size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
-        Assert.assertEquals(1, size);
-        List<String> partitionNames = PartitionUtil.getPartitionNames(jdbcTable);
-        Assert.assertEquals(Arrays.asList("tbl1"), partitionNames);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+            List<Column> columns = Arrays.asList(new Column("d", Type.VARCHAR));
+            JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
+                    "test", "catalog", properties);
+            int size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
+            Assert.assertEquals(1, size);
+            List<String> partitionNames = PartitionUtil.getPartitionNames(jdbcTable);
+            Assert.assertEquals(Arrays.asList("tbl1"), partitionNames);
+        }
     }
 
     @Test
@@ -282,11 +288,12 @@ public class MysqlSchemaResolverTest {
                     minTimes = 0;
                 }
             };
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", Type.VARCHAR)),
-                    Arrays.asList(new Column("d", Type.VARCHAR)), "test", "catalog", properties);
-            Integer size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
-            Assert.assertTrue(size == 0);
+            try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+                JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", Type.VARCHAR)),
+                        Arrays.asList(new Column("d", Type.VARCHAR)), "test", "catalog", properties);
+                Integer size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
+                Assert.assertTrue(size == 0);
+            }
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -307,12 +314,13 @@ public class MysqlSchemaResolverTest {
                     minTimes = 0;
                 }
             };
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
-            List<Column> columns = Arrays.asList(new Column("d", Type.VARCHAR));
-            JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
-                    "test", "catalog", properties);
-            jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
-            Assert.fail();
+            try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
+                List<Column> columns = Arrays.asList(new Column("d", Type.VARCHAR));
+                JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
+                        "test", "catalog", properties);
+                jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
+                Assert.fail();
+            }
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Timestamp format must be yyyy-mm-dd hh:mm:ss"));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/OracleSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/OracleSchemaResolverTest.java
@@ -86,8 +86,7 @@ public class OracleSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("oracle", "template1", "test");
             Assert.assertEquals(expectResult, result);
@@ -109,8 +108,7 @@ public class OracleSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
@@ -136,8 +134,7 @@ public class OracleSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             List<String> result = jdbcMetadata.listTableNames("test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
@@ -163,8 +160,7 @@ public class OracleSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -84,8 +84,7 @@ public class PostgresSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("postgres", "template1", "test");
             Assert.assertEquals(expectResult, result);
@@ -107,8 +106,7 @@ public class PostgresSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
@@ -134,8 +132,7 @@ public class PostgresSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             List<String> result = jdbcMetadata.listTableNames("test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
@@ -161,8 +158,7 @@ public class PostgresSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/SqlServerSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/SqlServerSchemaResolverTest.java
@@ -110,8 +110,7 @@ public class SqlServerSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("sqlserver", "template1", "test");
             Assert.assertEquals(expectResult, result);
@@ -133,8 +132,7 @@ public class SqlServerSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
@@ -160,8 +158,7 @@ public class SqlServerSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             List<String> result = jdbcMetadata.listTableNames("test");
             List<String> expectResult = Lists.newArrayList("tbl1", "tbl2", "tbl3");
             Assert.assertEquals(expectResult, result);
@@ -187,8 +184,7 @@ public class SqlServerSchemaResolverTest {
                 minTimes = 0;
             }
         };
-        try {
-            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+        try (JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource)) {
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());


### PR DESCRIPTION
## Why I'm doing:

JDBC connection pool won't closed even though connector is removed.

## What I'm doing:

Fix connection pool leak in JDBC connector.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0