### PR TITLE
[BugFix] Generate the same digest because column names of HashJoin RHS is neglected during query cache digest computation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1333,6 +1333,8 @@ public class OlapScanNode extends ScanNode {
     @Override
     public void normalizeConjuncts(FragmentNormalizer normalizer, TNormalPlanNode planNode, List<Expr> conjuncts) {
         if (!normalizer.isProcessingLeftNode()) {
+            // take column names of HashJoin RHS into cache digest computation
+            associateSlotIdsWithColumns(normalizer, planNode, Optional.empty());
             normalizeConjunctsNonLeft(normalizer, planNode);
             return;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
@@ -27,7 +27,9 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.util.Util;
 import com.starrocks.statistic.StatsConstants;
+import com.starrocks.thrift.TCacheParam;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import kotlin.text.Charsets;
@@ -46,6 +48,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.starrocks.sql.optimizer.statistics.CachedStatisticStorageTest.DEFAULT_CREATE_TABLE_TEMPLATE;
 
@@ -1529,5 +1532,29 @@ public class QueryCacheTest {
         Optional<PlanFragment> frag1 = getCachedFragment(sql1);
         Assert.assertTrue(frag0.isPresent() && frag1.isPresent());
         Assert.assertNotEquals(frag0.get().getCacheParam().digest, frag1.get().getCacheParam().digest);
+    }
+
+    @Test
+    public void testDigestsVaryAsDifferentColumnNames() {
+        String sqlFmt = "select %s, count(distinct lo_custkey) \n" +
+                "from lineorder left outer join[broadcast] \n" +
+                "     part on lo_custkey = p_partkey group by %s";
+
+        String[] columnNames = new String[]
+                {"p_mfgr", "p_color", "p_category", "p_brand", "p_type", "p_container"};
+
+        List<Optional<PlanFragment>> planFragments = Stream.of(columnNames)
+                .map(col -> String.format(sqlFmt, col, col))
+                .map(this::getCachedFragment)
+                .collect(Collectors.toList());
+        Assert.assertTrue(planFragments.stream().allMatch(Optional::isPresent));
+        Set<String> digests = planFragments.stream().map(optFrag -> optFrag
+                        .map(PlanFragment::getCacheParam)
+                        .map(TCacheParam::getDigest)
+                        .map(Util::toHexString))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+        Assert.assertEquals(digests.size(), columnNames.length);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0