### PR TITLE
[Enhancement] reduce min/max counters from query profile

### DIFF
--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -970,9 +970,11 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
 
                 if (!counter->skip_min_max()) {
                     if (counter->_min_value.has_value()) {
+                        already_merged = true;
                         min_value = counter->_min_value.value();
                     }
                     if (counter->_max_value.has_value()) {
+                        already_merged = true;
                         max_value = counter->_max_value.value();
                     }
                 }

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -971,11 +971,11 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
                 if (!counter->skip_min_max()) {
                     if (counter->_min_value.has_value()) {
                         already_merged = true;
-                        min_value = counter->_min_value.value();
+                        min_value = std::min(counter->_min_value.value(), min_value);
                     }
                     if (counter->_max_value.has_value()) {
                         already_merged = true;
-                        max_value = counter->_max_value.value();
+                        max_value = std::max(counter->_max_value.value(), max_value);
                     }
                 }
 
@@ -1007,10 +1007,10 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
 
                 if (!merged_counter->skip_min_max()) {
                     if (min_value != std::numeric_limits<int64_t>::max()) {
-                        merged_counter->_max_value.emplace(max_value);
+                        merged_counter->_min_value.emplace(min_value);
                     }
                     if (max_value != std::numeric_limits<int64_t>::min()) {
-                        merged_counter->_min_value.emplace(min_value);
+                        merged_counter->_max_value.emplace(max_value);
                     }
                 }
             }

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -1004,8 +1004,12 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
                 merged_counter->set(merged_value);
 
                 if (!merged_counter->skip_min_max()) {
-                    merged_counter->_max_value.emplace(max_value);
-                    merged_counter->_min_value.emplace(min_value);
+                    if (min_value != std::numeric_limits<int64_t>::max()) {
+                        merged_counter->_max_value.emplace(max_value);
+                    }
+                    if (max_value != std::numeric_limits<int64_t>::min()) {
+                        merged_counter->_min_value.emplace(min_value);
+                    }
                 }
             }
         }

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -181,6 +181,11 @@ public:
 
         virtual double double_value() const { return bit_cast<double>(_value.load(std::memory_order_relaxed)); }
 
+        virtual void set_min(int64_t min) { _min_value.emplace(min); }
+        virtual void set_max(int64_t max) { _max_value.emplace(max); }
+        virtual std::optional<int64_t> min_value() const { return _min_value; }
+        virtual std::optional<int64_t> max_value() const { return _max_value; }
+
         TUnit::type type() const { return _type; }
 
         const TCounterStrategy& strategy() const { return _strategy; }

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -40,6 +40,7 @@
 #include <atomic>
 #include <functional>
 #include <iostream>
+#include <optional>
 #include <thread>
 #include <unordered_set>
 #include <utility>
@@ -212,6 +213,8 @@ public:
         std::atomic<int64_t> _value;
         const TUnit::type _type;
         const TCounterStrategy _strategy;
+        std::optional<int64_t> _min_value;
+        std::optional<int64_t> _max_value;
     };
 
     class ConcurrentTimerCounter;

--- a/be/test/util/runtime_profile_test.cpp
+++ b/be/test/util/runtime_profile_test.cpp
@@ -62,30 +62,18 @@ TEST(TestRuntimeProfile, testMergeIsomorphicProfiles1) {
 
     auto* merged_time1 = merged_profile->get_counter("time1");
     ASSERT_EQ(2000000000L, merged_time1->value());
-    auto* merged_min_of_time1 = merged_profile->get_counter("__MIN_OF_time1");
-    auto* merged_max_of_time1 = merged_profile->get_counter("__MAX_OF_time1");
-    ASSERT_TRUE(merged_min_of_time1);
-    ASSERT_TRUE(merged_max_of_time1);
-    ASSERT_EQ(2000000000L, merged_min_of_time1->value());
-    ASSERT_EQ(2000000000L, merged_max_of_time1->value());
+    ASSERT_EQ(2000000000L, merged_time1->min_value().value());
+    ASSERT_EQ(2000000000L, merged_time1->max_value().value());
 
     auto* merged_time2 = merged_profile->get_counter("time2");
     ASSERT_EQ(1000000000L, merged_time2->value());
-    auto* merged_min_of_time2 = merged_profile->get_counter("__MIN_OF_time2");
-    auto* merged_max_of_time2 = merged_profile->get_counter("__MAX_OF_time2");
-    ASSERT_TRUE(merged_min_of_time2);
-    ASSERT_TRUE(merged_max_of_time2);
-    ASSERT_EQ(0, merged_min_of_time2->value());
-    ASSERT_EQ(2000000000L, merged_max_of_time2->value());
+    ASSERT_EQ(0, merged_time2->min_value().value());
+    ASSERT_EQ(2000000000L, merged_time2->max_value().value());
 
     auto* merged_count1 = merged_profile->get_counter("count1");
     ASSERT_EQ(2, merged_count1->value());
-    auto* merged_min_of_count1 = merged_profile->get_counter("__MIN_OF_count1");
-    auto* merged_max_of_count1 = merged_profile->get_counter("__MAX_OF_count1");
-    ASSERT_TRUE(merged_min_of_count1);
-    ASSERT_TRUE(merged_max_of_count1);
-    ASSERT_EQ(1, merged_min_of_count1->value());
-    ASSERT_EQ(1, merged_max_of_count1->value());
+    ASSERT_EQ(1, merged_count1->min_value().value());
+    ASSERT_EQ(1, merged_count1->min_value().value());
 }
 
 TEST(TestRuntimeProfile, testMergeIsomorphicProfiles2) {
@@ -96,21 +84,13 @@ TEST(TestRuntimeProfile, testMergeIsomorphicProfiles2) {
     {
         auto* time1 = profile1->add_counter("time1", TUnit::TIME_NS, create_strategy(TUnit::TIME_NS));
         time1->set(2000000000L);
-        auto* min_of_time1 =
-                profile1->add_child_counter("__MIN_OF_time1", TUnit::TIME_NS, create_strategy(TUnit::TIME_NS), "time1");
-        min_of_time1->set(1500000000L);
-        auto* max_of_time1 =
-                profile1->add_child_counter("__MAX_OF_time1", TUnit::TIME_NS, create_strategy(TUnit::TIME_NS), "time1");
-        max_of_time1->set(5000000000L);
+        time1->set_min(1500000000L);
+        time1->set_max(5000000000L);
 
         auto* count1 = profile1->add_counter("count1", TUnit::UNIT, create_strategy(TUnit::UNIT));
         count1->set(6L);
-        auto* min_of_count1 =
-                profile1->add_child_counter("__MIN_OF_count1", TUnit::UNIT, create_strategy(TUnit::UNIT), "count1");
-        min_of_count1->set(1L);
-        auto* max_of_count1 =
-                profile1->add_child_counter("__MAX_OF_count1", TUnit::UNIT, create_strategy(TUnit::UNIT), "count1");
-        max_of_count1->set(3L);
+        count1->set_min(1L);
+        count1->set_max(3L);
 
         profiles.push_back(profile1.get());
     }
@@ -119,21 +99,13 @@ TEST(TestRuntimeProfile, testMergeIsomorphicProfiles2) {
     {
         auto* time1 = profile2->add_counter("time1", TUnit::TIME_NS, create_strategy(TUnit::TIME_NS));
         time1->set(3000000000L);
-        auto* min_of_time1 =
-                profile2->add_child_counter("__MIN_OF_time1", TUnit::TIME_NS, create_strategy(TUnit::TIME_NS), "time1");
-        min_of_time1->set(100000000L);
-        auto* max_of_time1 =
-                profile2->add_child_counter("__MAX_OF_time1", TUnit::TIME_NS, create_strategy(TUnit::TIME_NS), "time1");
-        max_of_time1->set(4000000000L);
+        time1->set_min(100000000L);
+        time1->set_max(4000000000L);
 
         auto* count1 = profile2->add_counter("count1", TUnit::UNIT, create_strategy(TUnit::UNIT));
         count1->set(15L);
-        auto* min_of_count1 =
-                profile2->add_child_counter("__MIN_OF_count1", TUnit::UNIT, create_strategy(TUnit::UNIT), "count1");
-        min_of_count1->set(4L);
-        auto* max_of_count1 =
-                profile2->add_child_counter("__MAX_OF_count1", TUnit::UNIT, create_strategy(TUnit::UNIT), "count1");
-        max_of_count1->set(6L);
+        count1->set_min(4L);
+        count1->set_max(6L);
 
         profiles.push_back(profile2.get());
     }
@@ -141,21 +113,13 @@ TEST(TestRuntimeProfile, testMergeIsomorphicProfiles2) {
     auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(obj_pool.get(), profiles);
     auto* merged_time1 = merged_profile->get_counter("time1");
     ASSERT_EQ(2500000000L, merged_time1->value());
-    auto* merged_min_of_time1 = merged_profile->get_counter("__MIN_OF_time1");
-    auto* merged_max_of_time1 = merged_profile->get_counter("__MAX_OF_time1");
-    ASSERT_TRUE(merged_min_of_time1);
-    ASSERT_TRUE(merged_max_of_time1);
-    ASSERT_EQ(100000000L, merged_min_of_time1->value());
-    ASSERT_EQ(5000000000L, merged_max_of_time1->value());
+    ASSERT_EQ(100000000L, merged_time1->min_value().value());
+    ASSERT_EQ(5000000000L, merged_time1->max_value().value());
 
     auto* merged_count1 = merged_profile->get_counter("count1");
     ASSERT_EQ(21, merged_count1->value());
-    auto* merged_min_of_count1 = merged_profile->get_counter("__MIN_OF_count1");
-    auto* merged_max_of_count1 = merged_profile->get_counter("__MAX_OF_count1");
-    ASSERT_TRUE(merged_min_of_count1);
-    ASSERT_TRUE(merged_max_of_count1);
-    ASSERT_EQ(1, merged_min_of_count1->value());
-    ASSERT_EQ(6, merged_max_of_count1->value());
+    ASSERT_EQ(1, merged_count1->min_value().value());
+    ASSERT_EQ(6, merged_count1->max_value().value());
 }
 
 TEST(TestRuntimeProfile, testProfileMergeStrategy) {
@@ -216,35 +180,23 @@ TEST(TestRuntimeProfile, testProfileMergeStrategy) {
 
         auto* merged_time1 = merged_profile->get_counter("time1");
         ASSERT_EQ(2000000000L, merged_time1->value());
-        auto* merged_min_of_time1 = merged_profile->get_counter("__MIN_OF_time1");
-        auto* merged_max_of_time1 = merged_profile->get_counter("__MAX_OF_time1");
-        ASSERT_TRUE(merged_min_of_time1);
-        ASSERT_TRUE(merged_max_of_time1);
-        ASSERT_EQ(1000000000L, merged_min_of_time1->value());
-        ASSERT_EQ(1000000000L, merged_max_of_time1->value());
+        ASSERT_EQ(1000000000L, merged_time1->min_value().value());
+        ASSERT_EQ(1000000000L, merged_time1->max_value().value());
 
         auto* merged_time2 = merged_profile->get_counter("time2");
         ASSERT_EQ(2000000000L, merged_time2->value());
-        auto* merged_min_of_time2 = merged_profile->get_counter("__MIN_OF_time2");
-        auto* merged_max_of_time2 = merged_profile->get_counter("__MAX_OF_time2");
-        ASSERT_FALSE(merged_min_of_time2);
-        ASSERT_FALSE(merged_max_of_time2);
+        ASSERT_FALSE(merged_time2->min_value().has_value());
+        ASSERT_FALSE(merged_time2->max_value().has_value());
 
         auto* merged_count1 = merged_profile->get_counter("count1");
         ASSERT_EQ(6, merged_count1->value());
-        auto* merged_min_of_count1 = merged_profile->get_counter("__MIN_OF_count1");
-        auto* merged_max_of_count1 = merged_profile->get_counter("__MAX_OF_count1");
-        ASSERT_FALSE(merged_min_of_count1);
-        ASSERT_FALSE(merged_max_of_count1);
+        ASSERT_FALSE(merged_count1->min_value().has_value());
+        ASSERT_FALSE(merged_count1->max_value().has_value());
 
         auto* merged_count2 = merged_profile->get_counter("count2");
         ASSERT_EQ(8, merged_count2->value());
-        auto* merged_min_of_count2 = merged_profile->get_counter("__MIN_OF_count2");
-        auto* merged_max_of_count2 = merged_profile->get_counter("__MAX_OF_count2");
-        ASSERT_TRUE(merged_min_of_count2);
-        ASSERT_TRUE(merged_max_of_count2);
-        ASSERT_EQ(8, merged_min_of_count2->value());
-        ASSERT_EQ(8, merged_max_of_count2->value());
+        ASSERT_EQ(8, merged_count2->min_value().value());
+        ASSERT_EQ(8, merged_count2->max_value().value());
     };
 
     do_test(TCounterAggregateType::SUM, TCounterAggregateType::AVG);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -42,12 +42,15 @@ import com.starrocks.thrift.TUnit;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 // Counter means indicators field. The counter's name is key, the counter itself is value.  
 public class Counter {
     private volatile int type;
     private volatile TCounterStrategy strategy;
     private volatile long value;
+    private volatile Optional<Long> minValue;
+    private volatile Optional<Long> maxValue;
 
     public long getValue() {
         return value;
@@ -55,6 +58,22 @@ public class Counter {
 
     public void setValue(long newValue) {
         value = newValue;
+    }
+
+    public Optional<Long> getMinValue() {
+        return minValue;
+    }
+
+    public Optional<Long> getMaxValue() {
+        return maxValue;
+    }
+
+    public void setMinValue(long minValue) {
+        this.minValue = Optional.of(minValue);
+    }
+
+    public void setMaxValue(long maxValue) {
+        this.maxValue = Optional.of(maxValue);
     }
 
     public void update(long increment) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -49,8 +49,8 @@ public class Counter {
     private volatile int type;
     private volatile TCounterStrategy strategy;
     private volatile long value;
-    private volatile Optional<Long> minValue;
-    private volatile Optional<Long> maxValue;
+    private volatile Optional<Long> minValue = Optional.empty();
+    private volatile Optional<Long> maxValue = Optional.empty();
 
     public long getValue() {
         return value;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -765,7 +765,7 @@ public class RuntimeProfile {
                             }
                         }
                     }
-                    if (counter.getMinValue().isPresent()) {
+                    if (counter.getMaxValue().isPresent()) {
                         alreadyMerged = true;
                         maxValue = Math.max(counter.getMinValue().get(), maxValue);
                     } else {
@@ -805,16 +805,20 @@ public class RuntimeProfile {
                 mergedCounter.setValue(mergedValue);
 
                 if (!mergedCounter.isSkipMinMax()) {
-                    mergedCounter.setMinValue(minValue);
-                    mergedCounter.setMaxValue(maxValue);
                     Counter minCounter =
                             mergedProfile.addCounter(MERGED_INFO_PREFIX_MIN + name, type, mergedCounter.getStrategy(),
                                     name);
                     Counter maxCounter =
                             mergedProfile.addCounter(MERGED_INFO_PREFIX_MAX + name, type, mergedCounter.getStrategy(),
                                     name);
-                    minCounter.setValue(minValue);
-                    maxCounter.setValue(maxValue);
+                    if (minValue != Integer.MAX_VALUE) {
+                        mergedCounter.setMinValue(minValue);
+                        minCounter.setValue(minValue);
+                    }
+                    if (maxValue != Integer.MIN_VALUE) {
+                        mergedCounter.setMaxValue(maxValue);
+                        maxCounter.setValue(maxValue);
+                    }
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -324,6 +324,12 @@ public class RuntimeProfile {
                     Counter counter = addCounter(tcounter.name, tcounter.type, tcounter.strategy);
                     counter.setValue(tcounter.value);
                     counter.setStrategy(tcounter.strategy);
+                    if (tcounter.isSetMin_value()) {
+                        counter.setMinValue(tcounter.getMin_value());
+                    }
+                    if (tcounter.isSetMax_value()) {
+                        counter.setMaxValue(tcounter.getMax_value());
+                    }
                 } else {
                     if (pair.first.getType() != tcounter.type) {
                         LOG.error("Cannot update counters with the same name but different types"
@@ -687,7 +693,8 @@ public class RuntimeProfile {
                     TUnit existType = levelCounters.get(name).first;
                     if (!existType.equals(counter.getType())) {
                         LOG.warn(
-                                "find non-isomorphic counter, profileName={}, counterName={}, existType={}, anotherType={}",
+                                "find non-isomorphic counter, profileName={}, counterName={}, existType={}, " +
+                                        "anotherType={}",
                                 mergedProfile.name, name, existType.name(), counter.getType().name());
                         continue;
                     }
@@ -745,20 +752,33 @@ public class RuntimeProfile {
                 }
 
                 if (!counter.isSkipMinMax()) {
-                    Counter minCounter = profile.getCounter(MERGED_INFO_PREFIX_MIN + name);
-                    if (minCounter != null) {
+                    if (counter.getMinValue().isPresent()) {
                         alreadyMerged = true;
-                        if (minCounter.getValue() < minValue) {
-                            minValue = minCounter.getValue();
+                        minValue = Math.min(counter.getMinValue().get(), minValue);
+                    } else {
+                        // TODO: keep compatible with older version backend, can be removed in next version
+                        Counter minCounter = profile.getCounter(MERGED_INFO_PREFIX_MIN + name);
+                        if (minCounter != null) {
+                            alreadyMerged = true;
+                            if (minCounter.getValue() < minValue) {
+                                minValue = minCounter.getValue();
+                            }
                         }
                     }
-                    Counter maxCounter = profile.getCounter(MERGED_INFO_PREFIX_MAX + name);
-                    if (maxCounter != null) {
+                    if (counter.getMinValue().isPresent()) {
                         alreadyMerged = true;
-                        if (maxCounter.getValue() > maxValue) {
-                            maxValue = maxCounter.getValue();
+                        maxValue = Math.max(counter.getMinValue().get(), maxValue);
+                    } else {
+                        // TODO: keep compatible with older version backend, can be removed in next version
+                        Counter maxCounter = profile.getCounter(MERGED_INFO_PREFIX_MAX + name);
+                        if (maxCounter != null) {
+                            alreadyMerged = true;
+                            if (maxCounter.getValue() > maxValue) {
+                                maxValue = maxCounter.getValue();
+                            }
                         }
                     }
+
                 }
 
                 counters.add(counter);
@@ -785,6 +805,8 @@ public class RuntimeProfile {
                 mergedCounter.setValue(mergedValue);
 
                 if (!mergedCounter.isSkipMinMax()) {
+                    mergedCounter.setMinValue(minValue);
+                    mergedCounter.setMaxValue(maxValue);
                     Counter minCounter =
                             mergedProfile.addCounter(MERGED_INFO_PREFIX_MIN + name, type, mergedCounter.getStrategy(),
                                     name);

--- a/gensrc/thrift/RuntimeProfile.thrift
+++ b/gensrc/thrift/RuntimeProfile.thrift
@@ -56,6 +56,10 @@ struct TCounter {
   2: required Metrics.TUnit type
   3: required i64 value 
   5: optional TCounterStrategy strategy 
+  
+  // Added to reduce the total number of counters
+  6: optional i64 min_value
+  7: optional i64 max_value
 }
 
 // A single runtime profile


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Replace the `MIN_OF/MAX_OF` counters in query profile with `min/max` value, which can reduce the number of counters into 1/3. It will benefit the performance of profile merging both in frontend and backend.

Compatibility:
- we didn't change the final representation of query profile, which still contains `MIN_OF/MAX_OF` counters
- So it's compatible with previous version

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0