### PR TITLE
[BugFix] Fix files() load counter NPE in coordinator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -196,7 +196,7 @@ public class Coordinator {
     private final boolean isBlockQuery;
     private int numReceivedRows = 0;
     private List<String> deltaUrls;
-    private Map<String, String> loadCounters;
+    private final Map<String, String> loadCounters = new HashMap<>();
     private String trackingUrl;
     private final Set<String> rejectedRecordPaths = new HashSet<>();
     // for export
@@ -246,7 +246,6 @@ public class Coordinator {
         attachInstanceProfileToFragmentProfile();
 
         deltaUrls = Lists.newArrayList();
-        loadCounters = Maps.newHashMap();
         this.connectContext = planner.getConnectContext();
 
         // for complie
@@ -715,7 +714,6 @@ public class Coordinator {
                 queryOptions.setRuntime_profile_report_interval(30);
             }
             deltaUrls = Lists.newArrayList();
-            loadCounters = Maps.newHashMap();
             List<Long> relatedBackendIds = Lists.newArrayList(coordinatorPreprocessor.getAddressToBackendID().values());
             GlobalStateMgr.getCurrentState().getLoadMgr()
                     .initJobProgress(jobId, queryId, coordinatorPreprocessor.getInstanceIds(),


### PR DESCRIPTION
## Why I'm doing:

```
2024-12-10 16:23:31.574+08:00 WARN (thrift-server-pool-0|151) [QeProcessorImpl.reportExecStatus():197] ReportExecStatus() failed, fragment_instance_id=054d9d51-b6d0-11ef-b3f7-8a0601efeedd, query_id=054d9d51-b6d0-11ef-b3f7-8a0601efeedc, error: null
2024-12-10 16:23:31.575+08:00 WARN (thrift-server-pool-0|151) [QeProcessorImpl.reportExecStatus():199] stack:
java.lang.NullPointerException: null
        at com.starrocks.qe.Coordinator.updateLoadCounters(Coordinator.java:1411) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.Coordinator.updateFragmentExecStatus(Coordinator.java:1704) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.QeProcessorImpl.reportExecStatus(QeProcessorImpl.java:195) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.reportExecStatus(FrontendServiceImpl.java:1065) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$reportExecStatus.getResult(FrontendService.java:3546) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$reportExecStatus.getResult(FrontendService.java:3526) ~[starrocks-fe.jar:?]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) ~[libthrift-0.13.0.jar:0.13.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) ~[libthrift-0.13.0.jar:0.13.0]
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8906

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [x] 3.1
  - [x] 3.1.16
  - [ ] 3.0
