### PR TITLE
[BugFix] Fix cannot insert into overwrite a hive partition when files are written by hive

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveWriteUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveWriteUtils.java
@@ -110,8 +110,11 @@ public class HiveWriteUtils {
     }
 
     public static boolean fileCreatedByQuery(String fileName, String queryId) {
-        Preconditions.checkState(fileName.length() > queryId.length() && queryId.length() > 8,
-                "file name or query id is invalid");
+        Preconditions.checkState(queryId.length() > 8, "file name or query id is invalid");
+        if (fileName.length() <= queryId.length()) {
+            // file is created by other engine like hive
+            return false;
+        }
         String checkQueryId = queryId.substring(0, queryId.length() - 8);
         return fileName.startsWith(checkQueryId) || fileName.endsWith(checkQueryId);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveWriteUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveWriteUtilsTest.java
@@ -96,4 +96,9 @@ public class HiveWriteUtilsTest {
                 "Failed to create directory",
                 () -> HiveWriteUtils.createDirectory(path, new Configuration()));
     }
+
+    @Test
+    public void testFileCreateByQuery() {
+        Assert.assertFalse(HiveWriteUtils.fileCreatedByQuery("000000_0", "aaaa-bbbb"));
+    }
 }


### PR DESCRIPTION

## Why I'm doing:
When executing insert overwrite a partition into a hive table, if the table is created by hive, it's file name may be like `000000_0`, which is shorter than a query id. It will throws `file name or query id is invalid` as a result.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0