### PR TITLE
[Enhancement] reuse column stats on TableFunctionNode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTableFunctionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTableFunctionOperator.java
@@ -122,8 +122,6 @@ public class LogicalTableFunctionOperator extends LogicalOperator {
         return inputs.get(0).getDomainProperty();
     }
 
-
-
     @Override
     public <R, C> R accept(OperatorVisitor<R, C> visitor, C context) {
         return visitor.visitLogicalTableFunction(this, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1447,11 +1447,17 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     private Void computeTableFunctionNode(ExpressionContext context, List<ColumnRefOperator> outputColumns) {
         Statistics.Builder builder = Statistics.builder();
 
+        Statistics inputStatistics = context.getChildStatistics(0);
+        Map<ColumnRefOperator, ColumnStatistic> columnStats = inputStatistics.getColumnStatistics();
+
         for (ColumnRefOperator col : outputColumns) {
-            builder.addColumnStatistic(col, ColumnStatistic.unknown());
+            if (columnStats.containsKey(col)) {
+                builder.addColumnStatistic(col, columnStats.get(col));
+            } else {
+                builder.addColumnStatistic(col, ColumnStatistic.unknown());
+            }
         }
 
-        Statistics inputStatistics = context.getChildStatistics(0);
         builder.setOutputRowCount(inputStatistics.getOutputRowCount());
 
         context.setStatistics(builder.build());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UDFTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UDFTest.java
@@ -101,11 +101,14 @@ public class UDFTest extends PlanTestBase {
     @Test
     public void testMultiUnnest() throws Exception {
         String sql = "with t as (select [1,2,3] as a, [4,5,6] as b, [4,5,6] as c) select * from t,unnest(a,b,c)";
-        PhysicalTableFunctionOperator tp = (PhysicalTableFunctionOperator) getExecPlan(sql).getPhysicalPlan().getOp();
+        ExecPlan execPlan = getExecPlan(sql);
+        PhysicalTableFunctionOperator tp = (PhysicalTableFunctionOperator) execPlan.getPhysicalPlan().getOp();
 
         Assert.assertEquals(3, tp.getFnParamColumnRefs().size());
         Assert.assertEquals("[8, 9, 10]",
                 tp.getFnParamColumnRefs().stream().map(ColumnRefOperator::getId).collect(Collectors.toList()).toString());
+        Assert.assertTrue(execPlan.getOptExpression(2).getStatistics().getColumnStatistics().values()
+                .stream().anyMatch(x -> !x.isUnknown()));
 
         sql = "select * from tarray, unnest(v3, v3)";
         tp = (PhysicalTableFunctionOperator) getExecPlan(sql).getPhysicalPlan().getOp();


### PR DESCRIPTION
## Why I'm doing:
When calculating the TableFunction Node, all output columns are set to UNKNOWN. In fact, we could reuse some calculated column statistics  in this node.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0