### PR TITLE
[Enhancement] ColumnValueRange::add_range supports less than or equal to max and great than or equal to min

### DIFF
--- a/be/src/exec/olap_common.cpp
+++ b/be/src/exec/olap_common.cpp
@@ -462,8 +462,8 @@ Status ColumnValueRange<T>::add_range(SQLFilterOp op, T value) {
                 if (value > _low_value) {
                     _low_value = value;
                     _low_op = op;
-                } else if (value <= _type_min) {
-                    return Status::NotSupported("reject value smaller than or equals to type min");
+                } else if (value < _type_min) {
+                    return Status::NotSupported("reject value smaller than type min");
                 } else {
                     // accept this value, but keep range unchanged.
                 }
@@ -484,8 +484,8 @@ Status ColumnValueRange<T>::add_range(SQLFilterOp op, T value) {
                 if (value < _high_value) {
                     _high_value = value;
                     _high_op = op;
-                } else if (value >= _type_max) {
-                    return Status::NotSupported("reject value larger than or equals to type max");
+                } else if (value > _type_max) {
+                    return Status::NotSupported("reject value larger than type max");
                 } else {
                     // accept this value, but keep range unchanged.
                 }
@@ -654,6 +654,18 @@ ColumnValueRange<T>::ColumnValueRange(std::string col_name, LogicalType type, T 
           _column_type(type),
           _type_min(min),
           _type_max(max),
+          _low_value(min),
+          _high_value(max),
+          _low_op(FILTER_LARGER_OR_EQUAL),
+          _high_op(FILTER_LESS_OR_EQUAL),
+          _fixed_op(FILTER_IN) {}
+
+template <class T>
+ColumnValueRange<T>::ColumnValueRange(std::string col_name, LogicalType type, T type_min, T type_max, T min, T max)
+        : _column_name(std::move(col_name)),
+          _column_type(type),
+          _type_min(type_min),
+          _type_max(type_max),
           _low_value(min),
           _high_value(max),
           _low_op(FILTER_LARGER_OR_EQUAL),

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -72,6 +72,7 @@ public:
     typedef typename std::set<T>::iterator iterator_type;
     ColumnValueRange();
     ColumnValueRange(std::string col_name, LogicalType type, T min, T max);
+    ColumnValueRange(std::string col_name, LogicalType type, T type_min, T type_max, T min, T max);
 
     Status add_fixed_values(SQLFilterOp op, const std::set<T>& values);
 

--- a/be/test/exec/column_value_range_test.cpp
+++ b/be/test/exec/column_value_range_test.cpp
@@ -118,7 +118,7 @@ TEST(NormalizeRangeTest, RangeTest) {
         // where range >= -limit and range in (1, 2, 3)
         ColumnValueRange<CppType> range("test", Type, std::numeric_limits<CppType>::lowest(),
                                         std::numeric_limits<CppType>::max());
-        ASSERT_ERROR(range.add_range(SQLFilterOp::FILTER_LARGER_OR_EQUAL, std::numeric_limits<CppType>::lowest()));
+        ASSERT_OK(range.add_range(SQLFilterOp::FILTER_LARGER_OR_EQUAL, std::numeric_limits<CppType>::lowest()));
         ASSERT_OK(range.add_fixed_values(SQLFilterOp::FILTER_IN, {1, 2, 3}));
         ASSERT_EQ(range._fixed_values.size(), 3);
         ASSERT_TRUE(range._fixed_values.count(1));

--- a/be/test/exec/column_value_range_test.cpp
+++ b/be/test/exec/column_value_range_test.cpp
@@ -19,6 +19,43 @@
 #include "types/logical_type.h"
 
 namespace starrocks {
+
+class ColumnValueRangeTest : public ::testing::Test {
+public:
+    void SetUp() override {}
+
+protected:
+    std::stringstream _ss;
+    static const auto _int32_min_value = RunTimeTypeLimits<TYPE_INT>::min_value();
+    static const auto _int32_max_value = RunTimeTypeLimits<TYPE_INT>::max_value();
+};
+
+TEST_F(ColumnValueRangeTest, add_range_le_max) {
+    ColumnValueRange<int32_t> range("c_int32", TYPE_INT, _int32_min_value, _int32_max_value, 5, _int32_max_value);
+
+    ASSERT_OK(range.add_range(SQLFilterOp::FILTER_LESS_OR_EQUAL, _int32_max_value));
+    std::vector<TCondition> filters;
+    range.to_olap_filter<false>(filters);
+
+    ASSERT_EQ(filters.size(), 1);
+    _ss << filters[0];
+    ASSERT_EQ(_ss.str(),
+              "TCondition(column_name=c_int32, condition_op=>=, condition_values=[5], is_index_filter_only=0)");
+}
+
+TEST_F(ColumnValueRangeTest, add_range_ge_min) {
+    ColumnValueRange<int32_t> range("c_int32", TYPE_INT, _int32_min_value, _int32_max_value, _int32_min_value, 100);
+
+    ASSERT_OK(range.add_range(SQLFilterOp::FILTER_LARGER_OR_EQUAL, _int32_min_value));
+    std::vector<TCondition> filters;
+    range.to_olap_filter<false>(filters);
+
+    ASSERT_EQ(filters.size(), 1);
+    _ss << filters[0];
+    ASSERT_EQ(_ss.str(),
+              "TCondition(column_name=c_int32, condition_op=<=, condition_values=[100], is_index_filter_only=0)");
+}
+
 TEST(NormalizeRangeTest, RangeTest) {
     const constexpr LogicalType Type = TYPE_INT;
     using CppType = RunTimeCppType<Type>;


### PR DESCRIPTION
## Why I'm doing:

Before the pr

```
Range range [5, max]
range.add_range(<=, max);  // fail
```

After the pr

```
Range range [5, max]
range.add_range(<=, max);  // success, the result is range [5, max];
```

RuntimeFilter (>=5) will be normailzed to (>=5 and <=max).

If `add_range` not support that, normalized runtime_filter will be failed, and the predicate generated by runtime_filter will not push down to storage engine.

## What I'm doing:

ColumnValueRange::add_range supports less than or equal to max and great than or equal to min

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0