### PR TITLE
[Enhancement] Support push down min/max to scanner for runtime filter with null

### DIFF
--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -1158,4 +1158,5 @@ const UnarrivedRuntimeFilterList& ScanConjunctsManager::unarrived_runtime_filter
     return _root_builder.unarrived_runtime_filters();
 }
 
+template class ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND>;
 } // namespace starrocks

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -17,9 +17,12 @@
 #include <variant>
 
 #include "column/type_traits.h"
+#include "exprs/binary_predicate.h"
+#include "exprs/compound_predicate.h"
 #include "exprs/dictmapping_expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/in_const_predicate.hpp"
+#include "exprs/is_null_predicate.h"
 #include "gutil/map_util.h"
 #include "runtime/descriptors.h"
 #include "storage/column_predicate.h"
@@ -541,13 +544,50 @@ Status ChunkPredicateBuilder<E, Type>::normalize_binary_predicate(const SlotDesc
 }
 
 template <BoxedExprType E, CompoundNodeType Type>
+template <LogicalType SlotType, LogicalType MappingType, template <class> class Decoder, class... Args>
+void ChunkPredicateBuilder<E, Type>::normalized_rf_with_null(const JoinRuntimeFilter* rf, Expr* col_ref,
+                                                             Args&&... args) {
+    DCHECK(Type == CompoundNodeType::AND);
+
+    ObjectPool* pool = _opts.obj_pool;
+
+    const auto* filter = down_cast<const RuntimeBloomFilter<MappingType>*>(rf);
+    using DecoderType = Decoder<typename RunTimeTypeTraits<MappingType>::CppType>;
+    DecoderType decoder(std::forward<Args>(args)...);
+    detail::RuntimeColumnPredicateBuilder::MinMaxParser<RuntimeBloomFilter<MappingType>, DecoderType> parser(filter,
+                                                                                                             &decoder);
+    const TypeDescriptor& col_type = col_ref->type();
+
+    ColumnPtr const_min_col = parser.template min_const_column<SlotType>(col_type);
+    ColumnPtr const_max_col = parser.template max_const_column<SlotType>(col_type);
+    VectorizedLiteral* min_literal = pool->add(new VectorizedLiteral(std::move(const_min_col), col_type));
+    VectorizedLiteral* max_literal = pool->add(new VectorizedLiteral(std::move(const_max_col), col_type));
+
+    Expr* left_expr = _gen_min_binary_pred(col_ref, min_literal, filter->left_close_interval());
+    Expr* right_expr = _gen_max_binary_pred(col_ref, max_literal, filter->right_close_interval());
+    Expr* is_null_expr = _gen_is_null_pred(col_ref);
+    Expr* and_expr = _gen_and_pred(left_expr, right_expr);
+
+    std::vector<BoxedExpr> containers;
+    containers.emplace_back(and_expr);
+    containers.emplace_back(is_null_expr);
+    ChunkPredicateBuilder<BoxedExpr, CompoundNodeType::OR> child_builder(_opts, containers, false);
+
+    auto normalized = child_builder.parse_conjuncts();
+    if (!normalized.ok()) {
+    } else if (normalized.value()) {
+        _child_builders.emplace_back(child_builder);
+    }
+}
+
+template <BoxedExprType E, CompoundNodeType Type>
 template <LogicalType SlotType, typename RangeValueType, bool Negative>
 Status ChunkPredicateBuilder<E, Type>::normalize_join_runtime_filter(const SlotDescriptor& slot,
                                                                      ColumnValueRange<RangeValueType>* range) {
-    // TODO(lzh): OR preidcate with runtime filters is not supported yet.
-    if constexpr (Negative) {
+    if (!_is_root_builder) {
         return Status::OK();
     }
+    DCHECK(!Negative);
 
     // in runtime filter
     for (size_t i = 0; i < _exprs.size(); i++) {
@@ -588,7 +628,7 @@ Status ChunkPredicateBuilder<E, Type>::normalize_join_runtime_filter(const SlotD
 
     // bloom runtime filter
     for (const auto& it : _opts.runtime_filters->descriptors()) {
-        const RuntimeFilterProbeDescriptor* desc = it.second;
+        RuntimeFilterProbeDescriptor* desc = it.second;
         const JoinRuntimeFilter* rf = desc->runtime_filter(_opts.driver_sequence);
         using RangeType = ColumnValueRange<RangeValueType>;
         using ValueType = typename RunTimeTypeTraits<SlotType>::CppType;
@@ -603,8 +643,6 @@ Status ChunkPredicateBuilder<E, Type>::normalize_join_runtime_filter(const SlotD
             continue;
         }
 
-        if (rf->has_null()) continue;
-
         // If this column doesn't have other filter, we use join runtime filter
         // to fast comput row range in storage engine
         if (range->is_init_state()) {
@@ -618,18 +656,35 @@ Status ChunkPredicateBuilder<E, Type>::normalize_join_runtime_filter(const SlotD
         auto& global_dicts = _opts.runtime_state->get_query_global_dict_map();
         if constexpr (SlotType == TYPE_VARCHAR) {
             if (auto iter = global_dicts.find(slot_id); iter != global_dicts.end()) {
-                detail::RuntimeColumnPredicateBuilder::build_minmax_range<
-                        RangeType, ValueType, LowCardDictType,
-                        detail::RuntimeColumnPredicateBuilder::GlobalDictCodeDecoder>(*range, rf, &iter->second.first);
+                if (rf->has_null()) {
+                    normalized_rf_with_null<SlotType, LowCardDictType,
+                                            detail::RuntimeColumnPredicateBuilder::GlobalDictCodeDecoder>(
+                            rf, desc->probe_expr_ctx()->root(), &iter->second.first);
+                } else {
+                    detail::RuntimeColumnPredicateBuilder::build_minmax_range<
+                            RangeType, SlotType, LowCardDictType,
+                            detail::RuntimeColumnPredicateBuilder::GlobalDictCodeDecoder>(*range, rf,
+                                                                                          &iter->second.first);
+                }
             } else {
-                detail::RuntimeColumnPredicateBuilder::build_minmax_range<
-                        RangeType, ValueType, SlotType, detail::RuntimeColumnPredicateBuilder::DummyDecoder>(*range, rf,
-                                                                                                             nullptr);
+                if (rf->has_null()) {
+                    normalized_rf_with_null<SlotType, SlotType, detail::RuntimeColumnPredicateBuilder::DummyDecoder>(
+                            rf, desc->probe_expr_ctx()->root(), nullptr);
+                } else {
+                    detail::RuntimeColumnPredicateBuilder::build_minmax_range<
+                            RangeType, SlotType, SlotType, detail::RuntimeColumnPredicateBuilder::DummyDecoder>(
+                            *range, rf, nullptr);
+                }
             }
         } else {
-            detail::RuntimeColumnPredicateBuilder::build_minmax_range<
-                    RangeType, ValueType, SlotType, detail::RuntimeColumnPredicateBuilder::DummyDecoder>(*range, rf,
-                                                                                                         nullptr);
+            if (rf->has_null()) {
+                normalized_rf_with_null<SlotType, SlotType, detail::RuntimeColumnPredicateBuilder::DummyDecoder>(
+                        rf, desc->probe_expr_ctx()->root(), nullptr);
+            } else {
+                detail::RuntimeColumnPredicateBuilder::build_minmax_range<
+                        RangeType, SlotType, SlotType, detail::RuntimeColumnPredicateBuilder::DummyDecoder>(*range, rf,
+                                                                                                            nullptr);
+            }
         }
     }
 
@@ -974,6 +1029,79 @@ Status ChunkPredicateBuilder<E, Type>::build_column_expr_predicates() {
     }
 
     return Status::OK();
+}
+
+template <BoxedExprType E, CompoundNodeType Type>
+Expr* ChunkPredicateBuilder<E, Type>::_gen_min_binary_pred(Expr* col_ref, VectorizedLiteral* min_literal,
+                                                           bool is_close_interval) {
+    TExprNode node;
+    node.node_type = TExprNodeType::BINARY_PRED;
+    node.type = TypeDescriptor(TYPE_BOOLEAN).to_thrift();
+    node.child_type = to_thrift(col_ref->type().type);
+    if (is_close_interval) {
+        node.__set_opcode(TExprOpcode::GE);
+    } else {
+        node.__set_opcode(TExprOpcode::GT);
+    }
+
+    Expr* expr = _opts.obj_pool->add(VectorizedBinaryPredicateFactory::from_thrift(node));
+    expr->add_child(col_ref);
+    expr->add_child(min_literal);
+    return expr;
+}
+
+template <BoxedExprType E, CompoundNodeType Type>
+Expr* ChunkPredicateBuilder<E, Type>::_gen_max_binary_pred(Expr* col_ref, VectorizedLiteral* max_literal,
+                                                           bool is_close_interval) {
+    TExprNode node;
+    node.node_type = TExprNodeType::BINARY_PRED;
+    node.type = TypeDescriptor(TYPE_BOOLEAN).to_thrift();
+    node.child_type = to_thrift(col_ref->type().type);
+    if (is_close_interval) {
+        node.__set_opcode(TExprOpcode::LE);
+    } else {
+        node.__set_opcode(TExprOpcode::LT);
+    }
+
+    Expr* expr = _opts.obj_pool->add(VectorizedBinaryPredicateFactory::from_thrift(node));
+    expr->add_child(col_ref);
+    expr->add_child(max_literal);
+    return expr;
+}
+
+template <BoxedExprType E, CompoundNodeType Type>
+Expr* ChunkPredicateBuilder<E, Type>::_gen_is_null_pred(Expr* col_ref) {
+    TExprNode null_pred_node;
+    null_pred_node.node_type = TExprNodeType::FUNCTION_CALL;
+    TFunction fn;
+    fn.name.function_name = "is_null_pred";
+    null_pred_node.__set_fn(fn);
+    TTypeNode type_node;
+    type_node.type = TTypeNodeType::SCALAR;
+    TScalarType scalar_type;
+    scalar_type.__set_type(TPrimitiveType::BOOLEAN);
+    type_node.__set_scalar_type(scalar_type);
+    null_pred_node.type.types.emplace_back(type_node);
+
+    Expr* expr = _opts.obj_pool->add(VectorizedIsNullPredicateFactory::from_thrift(null_pred_node));
+    expr->add_child(col_ref);
+    return expr;
+}
+
+template <BoxedExprType E, CompoundNodeType Type>
+Expr* ChunkPredicateBuilder<E, Type>::_gen_and_pred(Expr* left, Expr* right) {
+    TExprNode and_pred_node;
+    and_pred_node.node_type = TExprNodeType::COMPOUND_PRED;
+    and_pred_node.num_children = 2;
+    and_pred_node.is_nullable = true;
+    and_pred_node.__set_opcode(TExprOpcode::COMPOUND_AND);
+    and_pred_node.__set_child_type(TPrimitiveType::BOOLEAN);
+    and_pred_node.__set_type(TypeDescriptor(TYPE_BOOLEAN).to_thrift());
+
+    Expr* expr = _opts.obj_pool->add(VectorizedCompoundPredicateFactory::from_thrift(and_pred_node));
+    expr->add_child(left);
+    expr->add_child(right);
+    return expr;
 }
 
 // ------------------------------------------------------------------------------------

--- a/be/src/exec/olap_scan_prepare.h
+++ b/be/src/exec/olap_scan_prepare.h
@@ -138,11 +138,11 @@ private:
     Status normalize_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
 
     template <LogicalType SlotType, typename RangeValueType, bool Negative>
-        requires(!lt_is_date<SlotType>)
-    Status normalize_in_or_equal_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
+    requires(!lt_is_date<SlotType>) Status
+            normalize_in_or_equal_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
     template <LogicalType SlotType, typename RangeValueType, bool Negative>
-        requires lt_is_date<SlotType>
-    Status normalize_in_or_equal_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
+    requires lt_is_date<SlotType> Status normalize_in_or_equal_predicate(const SlotDescriptor& slot,
+                                           ColumnValueRange<RangeValueType>* range);
 
     template <LogicalType SlotType, typename RangeValueType, bool Negative>
     Status normalize_binary_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);

--- a/be/src/exec/olap_scan_prepare.h
+++ b/be/src/exec/olap_scan_prepare.h
@@ -142,7 +142,7 @@ private:
             normalize_in_or_equal_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
     template <LogicalType SlotType, typename RangeValueType, bool Negative>
     requires lt_is_date<SlotType> Status normalize_in_or_equal_predicate(const SlotDescriptor& slot,
-                                           ColumnValueRange<RangeValueType>* range);
+                                                                         ColumnValueRange<RangeValueType>* range);
 
     template <LogicalType SlotType, typename RangeValueType, bool Negative>
     Status normalize_binary_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -363,6 +363,8 @@ private:
     void to_protobuf(PTypeDesc* proto_type) const;
 };
 
+static const TypeDescriptor TYPE_INT_DESC = TypeDescriptor(LogicalType::TYPE_INT);
+
 inline std::ostream& operator<<(std::ostream& os, const TypeDescriptor& type) {
     os << type.debug_string();
     return os;

--- a/be/src/testutil/schema_test_helper.cpp
+++ b/be/src/testutil/schema_test_helper.cpp
@@ -38,9 +38,39 @@ TabletSchemaPB SchemaTestHelper::gen_schema_pb_of_dup(TabletSchema::SchemaId sch
     return schema_pb;
 }
 
+TabletSchemaPB SchemaTestHelper::gen_varchar_schema_pb_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
+                                                              size_t num_key_cols) {
+    TabletSchemaPB schema_pb;
+
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(num_key_cols);
+    schema_pb.set_id(schema_id);
+
+    for (size_t i = 0; i < num_cols; i++) {
+        auto c0 = schema_pb.add_column();
+        c0->set_unique_id(i);
+        c0->set_name("c" + std::to_string(i));
+        c0->set_type("VARCHAR");
+        c0->set_is_nullable(true);
+        c0->set_index_length(4);
+        c0->set_length(100);
+        if (i < num_key_cols) {
+            c0->set_is_key(true);
+        }
+    }
+
+    return schema_pb;
+}
+
 TabletSchemaSPtr SchemaTestHelper::gen_schema_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
                                                      size_t num_key_cols) {
     TabletSchemaPB schema_pb = SchemaTestHelper::gen_schema_pb_of_dup(1, 3, 1);
+    return std::make_shared<TabletSchema>(schema_pb);
+}
+
+TabletSchemaSPtr SchemaTestHelper::gen_varchar_schema_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
+                                                             size_t num_key_cols) {
+    TabletSchemaPB schema_pb = SchemaTestHelper::gen_varchar_schema_pb_of_dup(1, 3, 1);
     return std::make_shared<TabletSchema>(schema_pb);
 }
 

--- a/be/src/testutil/schema_test_helper.h
+++ b/be/src/testutil/schema_test_helper.h
@@ -21,7 +21,11 @@ namespace starrocks {
 class SchemaTestHelper {
 public:
     static TabletSchemaPB gen_schema_pb_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols, size_t num_key_cols);
+    static TabletSchemaPB gen_varchar_schema_pb_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
+                                                       size_t num_key_cols);
     static TabletSchemaSPtr gen_schema_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols, size_t num_key_cols);
+    static TabletSchemaSPtr gen_varchar_schema_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
+                                                      size_t num_key_cols);
     static TColumn gen_key_column(const std::string& col_name, TPrimitiveType::type type);
     static TColumn gen_value_column_for_dup_table(const std::string& col_name, TPrimitiveType::type type);
     static TColumn gen_value_column_for_agg_table(const std::string& col_name, TPrimitiveType::type type);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -91,6 +91,7 @@ set(EXEC_FILES
         ./exec/repeat_node_test.cpp
         ./exec/sorting_test.cpp
         ./exec/table_function_node_test.cpp
+        ./exec/olap_scan_prepare_test.cpp
         ./exprs/agg/json_each_test.cpp
         ./exprs/agg/aggregate_test.cpp
         ./exprs/arithmetic_expr_test.cpp

--- a/be/test/exec/olap_scan_prepare_test.cpp
+++ b/be/test/exec/olap_scan_prepare_test.cpp
@@ -1,0 +1,280 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/olap_scan_prepare.h"
+
+#include <gtest/gtest.h>
+
+#include "exec/tablet_scanner.h"
+#include "formats/parquet/parquet_test_util/util.h"
+#include "storage/predicate_parser.h"
+#include "testutil/exprs_test_helper.h"
+#include "testutil/schema_test_helper.h"
+
+namespace starrocks {
+class ChunkPredicateBuilderTest : public testing::Test {
+public:
+    void SetUp() override {
+        _int_tablet_schema = SchemaTestHelper::gen_schema_of_dup(1, 3, 1);
+        _int_pred_parser = _pool.add(new OlapPredicateParser(_int_tablet_schema));
+        _varchar_tablet_schema = SchemaTestHelper::gen_varchar_schema_of_dup(1, 3, 1);
+        _varchar_pred_parser = _pool.add(new OlapPredicateParser(_varchar_tablet_schema));
+        _type_varchar = TypeDescriptor::create_varchar_type(100);
+        _opts.runtime_state = &_runtime_state;
+        _opts.obj_pool = &_pool;
+        _opts.pred_tree_params.enable_or = true;
+    }
+
+protected:
+    template <LogicalType Type>
+    StatusOr<RuntimeFilterProbeDescriptor*> _gen_runtime_filter_desc(SlotId slot_id);
+    StatusOr<RuntimeFilterProbeCollector*> _gen_runtime_filter_collector(SlotId slot_id, bool has_null);
+    StatusOr<RuntimeFilterProbeCollector*> _gen_varchar_runtime_filter_collector(SlotId slot_id, bool has_null);
+    template <bool IsMin>
+    StatusOr<RuntimeFilterProbeCollector*> _gen_range_runtime_filter_collector(SlotId slot_id, bool has_null);
+
+    ScanConjunctsManagerOptions _opts;
+    RuntimeState _runtime_state;
+    ObjectPool _pool;
+    std::vector<std::string> _key_column_names;
+
+    TabletSchemaSPtr _int_tablet_schema;
+    OlapPredicateParser* _int_pred_parser;
+    TabletSchemaSPtr _varchar_tablet_schema;
+    OlapPredicateParser* _varchar_pred_parser;
+
+    ColumnPredicatePtrs _predicate_free_pool;
+    TypeDescriptor _type_varchar;
+};
+
+template <LogicalType Type>
+StatusOr<RuntimeFilterProbeDescriptor*> ChunkPredicateBuilderTest::_gen_runtime_filter_desc(SlotId slot_id) {
+    TRuntimeFilterDescription tRuntimeFilterDescription;
+    tRuntimeFilterDescription.__set_filter_id(1);
+    tRuntimeFilterDescription.__set_has_remote_targets(false);
+    tRuntimeFilterDescription.__set_build_plan_node_id(1);
+    tRuntimeFilterDescription.__set_build_join_mode(TRuntimeFilterBuildJoinMode::BORADCAST);
+    tRuntimeFilterDescription.__set_filter_type(TRuntimeFilterBuildType::JOIN_FILTER);
+
+    TExpr col_ref = ExprsTestHelper::create_column_ref_t_expr<Type>(slot_id, true);
+    tRuntimeFilterDescription.__isset.plan_node_id_to_target_expr = true;
+    tRuntimeFilterDescription.plan_node_id_to_target_expr.emplace(1, col_ref);
+
+    auto* runtime_filter_desc = _pool.add(new RuntimeFilterProbeDescriptor());
+    RETURN_IF_ERROR(runtime_filter_desc->init(&_pool, tRuntimeFilterDescription, 1, &_runtime_state));
+
+    return runtime_filter_desc;
+}
+
+StatusOr<RuntimeFilterProbeCollector*> ChunkPredicateBuilderTest::_gen_runtime_filter_collector(SlotId slot_id,
+                                                                                                bool has_null) {
+    auto* rf = _pool.add(new RuntimeBloomFilter<TYPE_INT>());
+    rf->insert(10);
+    rf->insert(20);
+    if (has_null) {
+        rf->insert_null();
+    }
+
+    ASSIGN_OR_RETURN(auto* rf_desc, _gen_runtime_filter_desc<TYPE_INT>(slot_id));
+    rf_desc->set_runtime_filter(rf);
+
+    auto* rf_collector = _pool.add(new RuntimeFilterProbeCollector());
+    rf_collector->add_descriptor(rf_desc);
+
+    return rf_collector;
+}
+
+StatusOr<RuntimeFilterProbeCollector*> ChunkPredicateBuilderTest::_gen_varchar_runtime_filter_collector(SlotId slot_id,
+                                                                                                        bool has_null) {
+    auto* rf = _pool.add(new RuntimeBloomFilter<TYPE_VARCHAR>());
+    rf->insert(Slice("111"));
+    rf->insert(Slice("222"));
+    if (has_null) {
+        rf->insert_null();
+    }
+
+    ASSIGN_OR_RETURN(auto* rf_desc, _gen_runtime_filter_desc<TYPE_VARCHAR>(slot_id));
+    rf_desc->set_runtime_filter(rf);
+
+    auto* rf_collector = _pool.add(new RuntimeFilterProbeCollector());
+    rf_collector->add_descriptor(rf_desc);
+
+    return rf_collector;
+}
+
+template <bool IsMin>
+StatusOr<RuntimeFilterProbeCollector*> ChunkPredicateBuilderTest::_gen_range_runtime_filter_collector(SlotId slot_id,
+                                                                                                      bool has_null) {
+    auto* rf = RuntimeBloomFilter<TYPE_INT>::create_with_range<IsMin>(&_pool, 10, false);
+    if (has_null) {
+        rf->insert_null();
+    }
+
+    ASSIGN_OR_RETURN(auto* rf_desc, _gen_runtime_filter_desc<TYPE_INT>(slot_id));
+    rf_desc->set_runtime_filter(rf);
+
+    auto* rf_collector = _pool.add(new RuntimeFilterProbeCollector());
+    rf_collector->add_descriptor(rf_desc);
+
+    return rf_collector;
+}
+
+TEST_F(ChunkPredicateBuilderTest, rt_has_no_null) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    auto ret1 = _gen_runtime_filter_collector(slot_id, false);
+    ASSERT_TRUE(ret1.ok());
+
+    _opts.runtime_filters = ret1.value();
+    _opts.key_column_names = &_key_column_names;
+
+    std::vector<BoxedExprContext> containers;
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, containers, true);
+
+    auto ret2 = builder.parse_conjuncts();
+    ASSERT_TRUE(ret1.ok());
+    ASSERT_TRUE(ret2.value());
+
+    auto ret3 = builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool);
+    ASSERT_TRUE(ret3.ok());
+    ASSERT_EQ(ret3.value().debug_string(),
+              "{\"and\":[{\"pred\":\"(columnId(1)>=10)\"},{\"pred\":\"(columnId(1)<=20)\"}]}");
+}
+
+TEST_F(ChunkPredicateBuilderTest, rt_has_null) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    auto ret1 = _gen_runtime_filter_collector(slot_id, true);
+    ASSERT_TRUE(ret1.ok());
+
+    _opts.runtime_filters = ret1.value();
+    _opts.key_column_names = &_key_column_names;
+
+    std::vector<BoxedExprContext> containers;
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, containers, true);
+
+    auto ret2 = builder.parse_conjuncts();
+    ASSERT_TRUE(ret1.ok());
+    ASSERT_TRUE(ret2.value());
+
+    auto ret3 = builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool);
+    ASSERT_TRUE(ret3.ok());
+    ASSERT_EQ(ret3.value().debug_string(),
+              "{\"and\":[{\"or\":[{\"pred\":\"(ColumnId(1) IS "
+              "NULL)\"},{\"and\":[{\"pred\":\"(columnId(1)>=10)\"},{\"pred\":\"(columnId(1)<=20)\"}]}]}]}");
+}
+
+TEST_F(ChunkPredicateBuilderTest, varchar_rt_has_no_null) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", _type_varchar, 1}, {"c2", _type_varchar, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    auto ret1 = _gen_varchar_runtime_filter_collector(slot_id, false);
+    ASSERT_TRUE(ret1.ok());
+
+    _opts.runtime_filters = ret1.value();
+    _opts.key_column_names = &_key_column_names;
+
+    std::vector<BoxedExprContext> containers;
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, containers, true);
+
+    auto ret2 = builder.parse_conjuncts();
+    ASSERT_TRUE(ret1.ok());
+    ASSERT_TRUE(ret2.value());
+
+    auto ret3 = builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool);
+    ASSERT_TRUE(ret3.ok());
+    ASSERT_EQ(ret3.value().debug_string(),
+              "{\"and\":[{\"pred\":\"(columnId(1)>=111)\"},{\"pred\":\"(columnId(1)<=222)\"}]}");
+}
+
+TEST_F(ChunkPredicateBuilderTest, varchar_rt_has_null) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", _type_varchar, 1}, {"c2", _type_varchar, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    auto ret1 = _gen_varchar_runtime_filter_collector(slot_id, true);
+    ASSERT_TRUE(ret1.ok());
+
+    _opts.runtime_filters = ret1.value();
+    _opts.key_column_names = &_key_column_names;
+
+    std::vector<BoxedExprContext> containers;
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, containers, true);
+
+    auto ret2 = builder.parse_conjuncts();
+    ASSERT_TRUE(ret1.ok());
+    ASSERT_TRUE(ret2.value());
+
+    auto ret3 = builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool);
+    ASSERT_TRUE(ret3.ok());
+    ASSERT_EQ(ret3.value().debug_string(),
+              "{\"and\":[{\"or\":[{\"pred\":\"(ColumnId(1) IS "
+              "NULL)\"},{\"and\":[{\"pred\":\"(columnId(1)>=111)\"},{\"pred\":\"(columnId(1)<=222)\"}]}]}]}");
+}
+
+TEST_F(ChunkPredicateBuilderTest, range_rt_has_null_min) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    auto ret1 = _gen_range_runtime_filter_collector<true>(slot_id, true);
+    ASSERT_TRUE(ret1.ok());
+
+    _opts.runtime_filters = ret1.value();
+    _opts.key_column_names = &_key_column_names;
+
+    std::vector<BoxedExprContext> containers;
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, containers, true);
+
+    auto ret2 = builder.parse_conjuncts();
+    ASSERT_TRUE(ret1.ok());
+    ASSERT_TRUE(ret2.value());
+
+    auto ret3 = builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool);
+    ASSERT_TRUE(ret3.ok());
+    ASSERT_EQ(
+            ret3.value().debug_string(),
+            "{\"and\":[{\"or\":[{\"pred\":\"(ColumnId(1) IS NULL)\"},{\"and\":[{\"pred\":\"(columnId(1)>10)\"}]}]}]}");
+}
+
+TEST_F(ChunkPredicateBuilderTest, range_rt_has_null_max) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    auto ret1 = _gen_range_runtime_filter_collector<false>(slot_id, true);
+    ASSERT_TRUE(ret1.ok());
+
+    _opts.runtime_filters = ret1.value();
+    _opts.key_column_names = &_key_column_names;
+
+    std::vector<BoxedExprContext> containers;
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, containers, true);
+
+    auto ret2 = builder.parse_conjuncts();
+    ASSERT_TRUE(ret1.ok());
+    ASSERT_TRUE(ret2.value());
+
+    auto ret3 = builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool);
+    ASSERT_TRUE(ret3.ok());
+    ASSERT_EQ(
+            ret3.value().debug_string(),
+            "{\"and\":[{\"or\":[{\"pred\":\"(ColumnId(1) IS NULL)\"},{\"and\":[{\"pred\":\"(columnId(1)<10)\"}]}]}]}");
+}
+} // namespace starrocks

--- a/be/test/exec/olap_scan_prepare_test.cpp
+++ b/be/test/exec/olap_scan_prepare_test.cpp
@@ -23,6 +23,8 @@
 #include "testutil/schema_test_helper.h"
 
 namespace starrocks {
+template class ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND>;
+
 class ChunkPredicateBuilderTest : public testing::Test {
 public:
     void SetUp() override {

--- a/be/test/exec/olap_scan_prepare_test.cpp
+++ b/be/test/exec/olap_scan_prepare_test.cpp
@@ -23,8 +23,6 @@
 #include "testutil/schema_test_helper.h"
 
 namespace starrocks {
-template class ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND>;
-
 class ChunkPredicateBuilderTest : public testing::Test {
 public:
     void SetUp() override {


### PR DESCRIPTION
## Why I'm doing:

RuntimeBloomFilter (1, 2, 3, 5, null) will generate one predicate ((xxx>=1 and xxx<=5) or (xxx is null)) and then push down to storage engine.

## What I'm doing:

Support push down min/max to scanner for runtime filter with null

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0