### PR TITLE
[Enhancement] Make region is optional in iceberg rest catalog vended credentials

### DIFF
--- a/docs/en/data_source/catalog/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg_catalog.md
@@ -322,7 +322,7 @@ The following example creates an Iceberg catalog named `smith_polaris` that uses
 ```sql
 CREATE EXTERNAL CATALOG smith_polaris 
 PROPERTIES (   
-    "iceberg.catalog.uri"  = "http://localhost:8181/api/catalog",   
+    "iceberg.catalog.uri"  = "http://xxx.xx.xx.xxx:8181/api/catalog", 
     "type"  =  "iceberg",   
     "iceberg.catalog.type"  =  "rest",   
     "iceberg.catalog.warehouse" = "starrocks_catalog",

--- a/docs/en/data_source/catalog/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg_catalog.md
@@ -283,7 +283,7 @@ Description: The credential to exchange for a token in the OAuth2 client credent
 
 Required: No
 
-Description: Scope to be used when communicating with the REST Catalog. Applicable only when using `credential`.
+Description: Scope to be used when communicating with the REST Catalog. Applicable only when `credential` is used.
 
 ###### iceberg.catalog.oauth2.server-uri
 

--- a/docs/en/data_source/catalog/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg_catalog.md
@@ -295,7 +295,7 @@ Description: The endpoint to retrieve access token from OAuth2 Server.
 
 Required: No
 
-Description: Support querying objects under nested namespace. Defaults to `true`.
+Description: Whether to support querying objects under nested namespace. Default: `true`.
 
 ###### iceberg.catalog.warehouse
 

--- a/docs/en/data_source/catalog/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg_catalog.md
@@ -276,6 +276,7 @@ Description: The bearer token used for interactions with the server. A `token` o
 ###### iceberg.catalog.oauth2.credential
 
 Required: No
+
 Description: The credential to exchange for a token in the OAuth2 client credentials flow with the server. A `token` or `credential` is required for `OAUTH2` security. Example: `AbCdEf123456`.
 
 ###### iceberg.catalog.oauth2.scope

--- a/docs/en/data_source/catalog/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg_catalog.md
@@ -277,7 +277,7 @@ Description: The bearer token used for interactions with the server. A `token` o
 
 Required: No
 
-Description: The credential to exchange for a token in the OAuth2 client credentials flow with the server. A `token` or `credential` is required for `OAUTH2` security. Example: `AbCdEf123456`.
+Description: The credential to exchange for a token in the OAuth2 client credentials flow with the server. A `token` or `credential` is required for `OAUTH2` authorization protocol. Example: `AbCdEf123456`.
 
 ###### iceberg.catalog.oauth2.scope
 

--- a/docs/en/data_source/catalog/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg_catalog.md
@@ -271,7 +271,7 @@ Description: The type of authorization protocol to use. Default: `NONE`. Valid v
 
 Required: No
 
-Description: The bearer token used for interactions with the server. A `token` or `credential` is required for `OAUTH2` security. Example: `AbCdEf123456`.
+Description: The bearer token used for interactions with the server. A `token` or `credential` is required for `OAUTH2` authorization protocol. Example: `AbCdEf123456`.
 
 ###### iceberg.catalog.oauth2.credential
 

--- a/docs/en/data_source/catalog/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg_catalog.md
@@ -235,20 +235,21 @@ Description: The secret key of your AWS IAM user. If you use the IAM user-based 
 For information about how to choose an authentication method for accessing AWS Glue and how to configure an access control policy in the AWS IAM Console, see [Authentication parameters for accessing AWS Glue](../../integrations/authenticate_to_aws_resources.md#authentication-parameters-for-accessing-aws-glue).
 
 </TabItem>
-<TabItem value="TABULAR" label="Tabular">
+<TabItem value="REST" label="REST">
 
-##### Tabular
+##### REST
 
-If you use Tabular as metastore, you must specify the metastore type as REST (`"iceberg.catalog.type" = "rest"`). Configure `MetastoreParams` as follows:
+If you use REST as metastore, you must specify the metastore type as REST (`"iceberg.catalog.type" = "rest"`). Configure `MetastoreParams` as follows:
 
 ```SQL
 "iceberg.catalog.type" = "rest",
 "iceberg.catalog.uri" = "<rest_server_api_endpoint>",
-"iceberg.catalog.credential" = "<credential>",
+"iceberg.catalog.security" = "oauth2",
+"iceberg.catalog.oauth2.credential" = "<credential>",
 "iceberg.catalog.warehouse" = "<identifier_or_path_to_warehouse>"
 ```
 
-`MetastoreParams` for Tabular:
+`MetastoreParams` for REST catalog:
 
 ###### iceberg.catalog.type
 
@@ -258,17 +259,49 @@ Description: The type of metastore that you use for your Iceberg cluster. Set th
 ###### iceberg.catalog.uri
 
 Required: Yes
-Description: The URI of the Tabular service endpoint. Example: `https://api.tabular.io/ws`.      
+Description: The URI of the REST service endpoint. Example: `https://api.tabular.io/ws`. 
 
-###### iceberg.catalog.credential
+###### iceberg.catalog.security
 
-Required: Yes
-Description: The authentication information of the Tabular service.
+Required: No
+
+Description: The type of security to use (default: `NONE`). `OAUTH2` requires either a `token` or `credential`. Example: `OAUTH2`.
+
+###### iceberg.catalog.oauth2.token
+
+Required: No
+
+Description: The bearer token used for interactions with the server. A `token` or `credential` is required for `OAUTH2` security. Example: `AbCdEf123456`.
+
+###### iceberg.catalog.oauth2.credential
+
+Required: No
+Description: The credential to exchange for a token in the OAuth2 client credentials flow with the server. A `token` or `credential` is required for `OAUTH2` security. Example: `AbCdEf123456`.
+
+###### iceberg.catalog.oauth2.scope
+
+Required: No
+
+Description: Scope to be used when communicating with the REST Catalog. Applicable only when using `credential`.
+
+###### iceberg.catalog.oauth2.server-uri
+
+Required: No
+
+Description: The endpoint to retrieve access token from OAuth2 Server.
+
+###### iceberg.catalog.vended-credentials-enabled
+
+Required: No
+
+Description: Support querying objects under nested namespace. Defaults to `true`.
 
 ###### iceberg.catalog.warehouse
 
 Required: No
 Description: The warehouse location or identifier of the Iceberg catalog. Example: `s3://my_bucket/warehouse_location` or `sandbox`.
+
+
 
 The following example creates an Iceberg catalog named `tabular` that uses Tabular as metastore:
 
@@ -283,6 +316,34 @@ PROPERTIES
     "iceberg.catalog.warehouse" = "sandbox"
 );
 ```
+The following example creates an Iceberg catalog named `smith_polaris` that uses Polaris as metastore:
+
+```sql
+CREATE EXTERNAL CATALOG smith_polaris 
+PROPERTIES (   
+    "iceberg.catalog.uri"  = "http://localhost:8181/api/catalog",   
+    "type"  =  "iceberg",   
+    "iceberg.catalog.type"  =  "rest",   
+    "iceberg.catalog.warehouse" = "starrocks_catalog",
+    "iceberg.catalog.security" = "oauth2",
+    "iceberg.catalog.oauth2.credential" = "f7357cfbe9583aa1:7b90fc77e4fbe288a5c41eaa05da3a3b",
+    "iceberg.catalog.oauth2.scope"='PRINCIPAL_ROLE:ALL'
+ );
+
+# `ns1.ns2.tpch_namespace` is a nested namespace
+create table smith_polaris.`ns1.ns2.tpch_namespace`.tbl (c1 string);
+
+mysql> select * from smith_polaris.`ns1.ns2.tpch_namespace`.tbl;
++------+
+| c1   |
++------+
+| 1    |
+| 2    |
+| 3    |
++------+
+3 rows in set (0.34 sec)
+```
+
 </TabItem>
 
 </Tabs>

--- a/docs/en/data_source/catalog/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg_catalog.md
@@ -265,7 +265,7 @@ Description: The URI of the REST service endpoint. Example: `https://api.tabular
 
 Required: No
 
-Description: The type of security to use (default: `NONE`). `OAUTH2` requires either a `token` or `credential`. Example: `OAUTH2`.
+Description: The type of authorization protocol to use. Default: `NONE`. Valid value: `OAUTH2`, which requires either a `token` or `credential`.
 
 ###### iceberg.catalog.oauth2.token
 

--- a/docs/en/data_source/catalog/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg_catalog.md
@@ -327,7 +327,7 @@ PROPERTIES (
     "iceberg.catalog.type"  =  "rest",   
     "iceberg.catalog.warehouse" = "starrocks_catalog",
     "iceberg.catalog.security" = "oauth2",
-    "iceberg.catalog.oauth2.credential" = "f7357cfbe9583aa1:7b90fc77e4fbe288a5c41eaa05da3a3b",
+    "iceberg.catalog.oauth2.credential" = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "iceberg.catalog.oauth2.scope"='PRINCIPAL_ROLE:ALL'
  );
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
@@ -89,13 +89,17 @@ public class CloudConfigurationFactory {
         String sessionSk = properties.getOrDefault(S3FileIOProperties.SECRET_ACCESS_KEY, null);
         String sessionToken = properties.getOrDefault(S3FileIOProperties.SESSION_TOKEN, null);
         String region = properties.getOrDefault(AwsClientProperties.CLIENT_REGION, null);
-        String enablePathStyle = properties.getOrDefault(S3FileIOProperties.PATH_STYLE_ACCESS, "false");
-        if (sessionAk != null && sessionSk != null && sessionToken != null && region != null) {
+        String enablePathStyle = properties.getOrDefault(S3FileIOProperties.PATH_STYLE_ACCESS, null);
+        if (sessionAk != null && sessionSk != null && sessionToken != null) {
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_ACCESS_KEY, sessionAk);
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_SECRET_KEY, sessionSk);
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_SESSION_TOKEN, sessionToken);
-            copiedProperties.put(CloudConfigurationConstants.AWS_S3_REGION, region);
-            copiedProperties.put(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS, enablePathStyle);
+            if (region != null) {
+                copiedProperties.put(CloudConfigurationConstants.AWS_S3_REGION, region);
+            }
+            if (enablePathStyle != null) {
+                copiedProperties.put(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS, enablePathStyle);
+            }
         }
         return buildCloudConfigurationForStorage(copiedProperties);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -47,6 +47,19 @@ public class CloudConfigurationFactoryTest {
                         "sessionToken='token', iamRoleArn='', stsRegion='', stsEndpoint='', externalId='', " +
                         "region='region', endpoint=''}, enablePathStyleAccess=true, enableSSL=true}",
                 cloudConfiguration.toConfString());
+
+        map.remove(AwsClientProperties.CLIENT_REGION);
+        map.remove(S3FileIOProperties.PATH_STYLE_ACCESS);
+        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(map);
+        Assert.assertNotNull(cloudConfiguration);
+        Assert.assertEquals(CloudType.AWS, cloudConfiguration.getCloudType());
+        Assert.assertEquals(
+                "AWSCloudConfiguration{resources='', jars='', hdpuser='', " +
+                        "cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, " +
+                        "useInstanceProfile=false, accessKey='ak', secretKey='sk', " +
+                        "sessionToken='token', iamRoleArn='', stsRegion='', stsEndpoint='', externalId='', " +
+                        "region='us-east-1', endpoint=''}, enablePathStyleAccess=false, enableSSL=true}",
+                cloudConfiguration.toConfString());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
For Polaris's vended-credentials, it will not return aws's region, we can't treat it as required.

## What I'm doing:
Fix it and also add doc.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0