### PR TITLE
[Enhancement] support collecting array/map type column statistics

### DIFF
--- a/be/src/runtime/statistic_result_writer.cpp
+++ b/be/src/runtime/statistic_result_writer.cpp
@@ -424,7 +424,6 @@ Status StatisticResultWriter::_fill_full_statistic_data_v4(int version, const Co
     return Status::OK();
 }
 
-
 Status StatisticResultWriter::_fill_full_statistic_data_v5(int version, const Columns& columns, const Chunk* chunk,
                                                            TFetchDataResult* result) {
     SCOPED_TIMER(_serialize_timer);

--- a/be/src/runtime/statistic_result_writer.cpp
+++ b/be/src/runtime/statistic_result_writer.cpp
@@ -25,6 +25,7 @@
 namespace starrocks {
 
 const int STATISTIC_DATA_VERSION1 = 1;
+const int STATISTIC_DATA_VERSION2 = 10;
 const int STATISTIC_HISTOGRAM_VERSION = 2;
 const int DICT_STATISTIC_DATA_VERSION = 101;
 const int STATISTIC_TABLE_VERSION = 3;
@@ -34,6 +35,7 @@ const int STATISTIC_EXTERNAL_VERSION = 5;
 const int STATISTIC_EXTERNAL_QUERY_VERSION = 6;
 const int STATISTIC_EXTERNAL_HISTOGRAM_VERSION = 7;
 const int STATISTIC_EXTERNAL_QUERY_VERSION_V2 = 8;
+const int STATISTIC_BATCH_V5_VERSION = 9;
 
 StatisticResultWriter::StatisticResultWriter(BufferControlBlock* sinker,
                                              const std::vector<ExprContext*>& output_expr_ctxs,
@@ -120,6 +122,9 @@ StatusOr<TFetchDataResultPtr> StatisticResultWriter::_process_chunk(Chunk* chunk
     if (version == STATISTIC_DATA_VERSION1) {
         RETURN_IF_ERROR_WITH_WARN(_fill_statistic_data_v1(version, result_columns, chunk, result.get()),
                                   "Fill statistic data failed");
+    } else if (version == STATISTIC_DATA_VERSION2) {
+        RETURN_IF_ERROR_WITH_WARN(_fill_statistic_data_v2(version, result_columns, chunk, result.get()),
+                                  "Fill statistic data failed");
     } else if (version == DICT_STATISTIC_DATA_VERSION) {
         RETURN_IF_ERROR_WITH_WARN(_fill_dict_statistic_data(version, result_columns, chunk, result.get()),
                                   "Fill dict statistic data failed");
@@ -134,6 +139,9 @@ StatusOr<TFetchDataResultPtr> StatisticResultWriter::_process_chunk(Chunk* chunk
                                   "Fill partition statistic data failed");
     } else if (version == STATISTIC_BATCH_VERSION) {
         RETURN_IF_ERROR_WITH_WARN(_fill_full_statistic_data_v4(version, result_columns, chunk, result.get()),
+                                  "Fill table statistic data failed");
+    } else if (version == STATISTIC_BATCH_V5_VERSION) {
+        RETURN_IF_ERROR_WITH_WARN(_fill_full_statistic_data_v5(version, result_columns, chunk, result.get()),
                                   "Fill table statistic data failed");
     } else if (version == STATISTIC_EXTERNAL_VERSION) {
         RETURN_IF_ERROR_WITH_WARN(_fill_full_statistic_data_external(version, result_columns, chunk, result.get()),
@@ -215,6 +223,55 @@ Status StatisticResultWriter::_fill_statistic_data_v1(int version, const Columns
         data_list[i].__set_nullCount(nullCounts->get(i).get_int64());
         data_list[i].__set_max(maxColumn->get_slice(i).to_string());
         data_list[i].__set_min(minColumn->get_slice(i).to_string());
+    }
+
+    result->result_batch.rows.resize(num_rows);
+    result->result_batch.__set_statistic_version(version);
+
+    ThriftSerializer serializer(true, chunk->memory_usage());
+    for (int i = 0; i < num_rows; ++i) {
+        RETURN_IF_ERROR(serializer.serialize(&data_list[i], &result->result_batch.rows[i]));
+    }
+    return Status::OK();
+}
+
+// Added collection size compared to `_fill_statistic_data_v1`
+Status StatisticResultWriter::_fill_statistic_data_v2(int version, const Columns& columns, const Chunk* chunk,
+                                                      TFetchDataResult* result) {
+    SCOPED_TIMER(_serialize_timer);
+
+    // mapping with Data.thrift.TStatisticData
+    DCHECK(columns.size() == 12);
+
+    // skip read version
+    auto& updateTimes = ColumnHelper::cast_to_raw<TYPE_DATETIME>(columns[1])->get_data();
+    auto& dbIds = ColumnHelper::cast_to_raw<TYPE_BIGINT>(columns[2])->get_data();
+    auto& tableIds = ColumnHelper::cast_to_raw<TYPE_BIGINT>(columns[3])->get_data();
+    BinaryColumn* nameColumn = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(columns[4]);
+    auto* rowCounts = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[5].get()));
+    auto* dataSizes = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[6].get()));
+    auto* countDistincts = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[7].get()));
+    auto* nullCounts = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[8].get()));
+    auto* maxColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[9].get()));
+    auto* minColumn = down_cast<BinaryColumn*>(ColumnHelper::get_data_column(columns[10].get()));
+    auto* collectionSize = down_cast<Int64Column*>(ColumnHelper::get_data_column(columns[11].get()));
+
+    std::vector<TStatisticData> data_list;
+    int num_rows = chunk->num_rows();
+
+    data_list.resize(num_rows);
+    for (int i = 0; i < num_rows; ++i) {
+        data_list[i].__set_updateTime(updateTimes[i].to_string());
+        data_list[i].__set_dbId(dbIds[i]);
+        data_list[i].__set_tableId(tableIds[i]);
+        data_list[i].__set_columnName(nameColumn->get_slice(i).to_string());
+        data_list[i].__set_rowCount(rowCounts->get(i).get_int64());
+        data_list[i].__set_dataSize(dataSizes->get(i).get_int64());
+        data_list[i].__set_countDistinct(countDistincts->get(i).get_int64());
+        data_list[i].__set_nullCount(nullCounts->get(i).get_int64());
+        data_list[i].__set_max(maxColumn->get_slice(i).to_string());
+        data_list[i].__set_min(minColumn->get_slice(i).to_string());
+        data_list[i].__set_collectionSize(collectionSize->get(i).get_int64());
     }
 
     result->result_batch.rows.resize(num_rows);
@@ -355,6 +412,51 @@ Status StatisticResultWriter::_fill_full_statistic_data_v4(int version, const Co
         data_list[i].__set_nullCount(nullCounts.value(i));
         data_list[i].__set_max(max.value(i).to_string());
         data_list[i].__set_min(min.value(i).to_string());
+    }
+
+    result->result_batch.rows.resize(num_rows);
+    result->result_batch.__set_statistic_version(version);
+
+    ThriftSerializer serializer(true, chunk->memory_usage());
+    for (int i = 0; i < num_rows; ++i) {
+        RETURN_IF_ERROR(serializer.serialize(&data_list[i], &result->result_batch.rows[i]));
+    }
+    return Status::OK();
+}
+
+
+Status StatisticResultWriter::_fill_full_statistic_data_v5(int version, const Columns& columns, const Chunk* chunk,
+                                                           TFetchDataResult* result) {
+    SCOPED_TIMER(_serialize_timer);
+
+    // mapping with Data.thrift.TStatisticData
+    DCHECK(columns.size() == 10);
+
+    // skip read version
+    auto pid = ColumnViewer<TYPE_BIGINT>(columns[1]);
+    auto name = ColumnViewer<TYPE_VARCHAR>(columns[2]);
+    auto rowCounts = ColumnViewer<TYPE_BIGINT>(columns[3]);
+    auto dataSizes = ColumnViewer<TYPE_BIGINT>(columns[4]);
+    auto hll = ColumnViewer<TYPE_VARCHAR>(columns[5]);
+    auto nullCounts = ColumnViewer<TYPE_BIGINT>(columns[6]);
+    auto max = ColumnViewer<TYPE_VARCHAR>(columns[7]);
+    auto min = ColumnViewer<TYPE_VARCHAR>(columns[8]);
+    auto collection_size = ColumnViewer<TYPE_BIGINT>(columns[9]);
+
+    std::vector<TStatisticData> data_list;
+    int num_rows = chunk->num_rows();
+
+    data_list.resize(num_rows);
+    for (int i = 0; i < num_rows; ++i) {
+        data_list[i].__set_partitionId(pid.value(i));
+        data_list[i].__set_columnName(name.value(i).to_string());
+        data_list[i].__set_rowCount(rowCounts.value(i));
+        data_list[i].__set_dataSize(dataSizes.value(i));
+        data_list[i].__set_hll(hll.value(i).to_string());
+        data_list[i].__set_nullCount(nullCounts.value(i));
+        data_list[i].__set_max(max.value(i).to_string());
+        data_list[i].__set_min(min.value(i).to_string());
+        data_list[i].__set_collectionSize(collection_size.value(i));
     }
 
     result->result_batch.rows.resize(num_rows);

--- a/be/src/runtime/statistic_result_writer.h
+++ b/be/src/runtime/statistic_result_writer.h
@@ -42,6 +42,9 @@ private:
     StatusOr<TFetchDataResultPtr> _process_chunk(Chunk* chunk);
 
     Status _fill_statistic_data_v1(int version, const Columns& columns, const Chunk* chunk, TFetchDataResult* result);
+
+    Status _fill_statistic_data_v2(int version, const Columns& columns, const Chunk* chunk, TFetchDataResult* result);
+
     Status _fill_dict_statistic_data(int version, const Columns& columns, const Chunk* chunk, TFetchDataResult* result);
 
     Status _fill_statistic_histogram(int version, const Columns& columns, const Chunk* chunk, TFetchDataResult* result);
@@ -52,6 +55,9 @@ private:
                                           TFetchDataResult* result);
 
     Status _fill_full_statistic_data_v4(int version, const Columns& columns, const Chunk* chunk,
+                                        TFetchDataResult* result);
+
+    Status _fill_full_statistic_data_v5(int version, const Columns& columns, const Chunk* chunk,
                                         TFetchDataResult* result);
 
     Status _fill_full_statistic_data_external(int version, const Columns& columns, const Chunk* chunk,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -845,7 +845,7 @@ public abstract class Type implements Cloneable {
 
     public boolean canStatistic() {
         // TODO(mofei) support statistic by for JSON
-        return !isOnlyMetricType() && !isJsonType() && !isComplexType() && !isFunctionType()
+        return !isOnlyMetricType() && !isJsonType() && !isStructType() && !isFunctionType()
                 && !isBinaryType();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
@@ -47,6 +47,7 @@ import java.util.concurrent.Executor;
 
 import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
 import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
+import static com.starrocks.sql.optimizer.statistics.ColumnStatistic.DEFAULT_COLLECTION_SIZE;
 
 public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStatsCacheKey, Optional<ColumnStatistic>> {
     private static final Logger LOG = LogManager.getLogger(ColumnBasicStatsCacheLoader.class);
@@ -201,10 +202,15 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
             distinctValues = 1;
         }
 
+        double collectionSize = statisticData.isSetCollectionSize() ? statisticData.getCollectionSize() :
+                DEFAULT_COLLECTION_SIZE;
+
         return builder.setMinValue(minValue).
                 setMaxValue(maxValue).
                 setDistinctValuesCount(distinctValues).
                 setAverageRowSize(statisticData.dataSize / Math.max(statisticData.rowCount, 1)).
-                setNullsFraction(statisticData.nullCount * 1.0 / Math.max(statisticData.rowCount, 1)).build();
+                setNullsFraction(statisticData.nullCount * 1.0 / Math.max(statisticData.rowCount, 1))
+                .setCollectionSize(collectionSize)
+                .build();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -31,6 +31,8 @@ public class ColumnStatistic {
     private static final ColumnStatistic UNKNOWN =
             new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 1, 1, null, StatisticType.UNKNOWN);
 
+    public static final double DEFAULT_COLLECTION_SIZE = -1.0;
+
     // For time types, including Date, DateTime, Timestamp. They all represented as timestamp in ColumnStatistic,
     // regardless of their different storage format
     private final double minValue;
@@ -45,6 +47,28 @@ public class ColumnStatistic {
     // @todo refactor this!
     private String minString = null;
     private String maxString = null;
+
+
+    private double collectionSize = DEFAULT_COLLECTION_SIZE;
+
+    public ColumnStatistic(
+            double minValue,
+            double maxValue,
+            double nullsFraction,
+            double averageRowSize,
+            double distinctValuesCount,
+            double collectionSize,
+            Histogram histogram,
+            StatisticType type) {
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+        this.nullsFraction = nullsFraction;
+        this.averageRowSize = averageRowSize;
+        this.distinctValuesCount = distinctValuesCount;
+        this.histogram = histogram;
+        this.collectionSize = collectionSize;
+        this.type = type;
+    }
 
     // TODO deal with string max, min
     public ColumnStatistic(
@@ -108,6 +132,10 @@ public class ColumnStatistic {
         return distinctValuesCount;
     }
 
+    public double getCollectionSize() {
+        return collectionSize;
+    }
+
     public Histogram getHistogram() {
         return histogram;
     }
@@ -149,14 +177,16 @@ public class ColumnStatistic {
                 + maxValue + separator
                 + nullsFraction + separator
                 + averageRowSize + separator
-                + distinctValuesCount + "] "
+                + distinctValuesCount + separator
+                + collectionSize + "] "
                 + (histogram == null ? "" : histogram.getMcvString() + " ")
                 + type;
     }
 
     public static Builder buildFrom(ColumnStatistic other) {
         return new Builder(other.minString, other.maxString, other.minValue, other.maxValue,
-                other.nullsFraction, other.averageRowSize, other.distinctValuesCount, other.histogram, other.type);
+                other.nullsFraction, other.averageRowSize, other.distinctValuesCount, other.histogram,
+                other.collectionSize, other.type);
     }
 
     public static Builder buildFrom(String columnStatistic) {
@@ -206,20 +236,20 @@ public class ColumnStatistic {
         private StatisticType type = StatisticType.ESTIMATE;
         private String minString = null;
         private String maxString = null;
+        private double collectionSize = DEFAULT_COLLECTION_SIZE;
 
         private Builder() {
         }
 
         private Builder(double minValue, double maxValue, double nullsFraction, double averageRowSize,
-                        double distinctValuesCount, Histogram histogram,
-                        StatisticType type) {
+                        double distinctValuesCount, double collectionSize, Histogram histogram, StatisticType type) {
             this(null, null, minValue, maxValue, nullsFraction,
-                    averageRowSize, distinctValuesCount, histogram, type);
+                    averageRowSize, distinctValuesCount, histogram, collectionSize, type);
         }
 
         private Builder(String minString, String maxString, double minValue, double maxValue,
                         double nullsFraction, double averageRowSize,
-                        double distinctValuesCount, Histogram histogram,
+                        double distinctValuesCount, Histogram histogram, double collectionSize,
                         StatisticType type) {
             this.minString = minString;
             this.maxString = maxString;
@@ -230,11 +260,13 @@ public class ColumnStatistic {
             this.distinctValuesCount = distinctValuesCount;
             this.histogram = histogram;
             this.type = type;
+            this.collectionSize = collectionSize;
         }
 
         private Builder(double minValue, double maxValue, double nullsFraction, double averageRowSize,
                         double distinctValuesCount) {
-            this(minValue, maxValue, nullsFraction, averageRowSize, distinctValuesCount, null, StatisticType.ESTIMATE);
+            this(minValue, maxValue, nullsFraction, averageRowSize, distinctValuesCount,
+                    DEFAULT_COLLECTION_SIZE, null, StatisticType.ESTIMATE);
         }
 
         public Builder setMinValue(double minValue) {
@@ -262,6 +294,11 @@ public class ColumnStatistic {
             return this;
         }
 
+        public Builder setCollectionSize(double collectionSize) {
+            this.collectionSize = collectionSize;
+            return this;
+        }
+
         public Builder setHistogram(Histogram histogram) {
             this.histogram = histogram;
             return this;
@@ -284,7 +321,7 @@ public class ColumnStatistic {
 
         public ColumnStatistic build() {
             ColumnStatistic columnStatistic = new ColumnStatistic(
-                    minValue, maxValue, nullsFraction, averageRowSize, distinctValuesCount, histogram, type);
+                    minValue, maxValue, nullsFraction, averageRowSize, distinctValuesCount, collectionSize, histogram, type);
             columnStatistic.setMaxString(maxString);
             columnStatistic.setMinString(minString);
             return columnStatistic;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -177,8 +177,8 @@ public class ColumnStatistic {
                 + maxValue + separator
                 + nullsFraction + separator
                 + averageRowSize + separator
-                + distinctValuesCount + separator
-                + collectionSize + "] "
+                + distinctValuesCount + "] "
+                + (collectionSize == DEFAULT_COLLECTION_SIZE ? "" : "COS: " + collectionSize + " ")
                 + (histogram == null ? "" : histogram.getMcvString() + " ")
                 + type;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1464,6 +1464,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         Statistics.Builder builder = Statistics.builder();
 
         Statistics inputStatistics = context.getChildStatistics(0);
+        double rowCount = inputStatistics.getOutputRowCount();
         Map<ColumnRefOperator, ColumnStatistic> columnStats = inputStatistics.getColumnStatistics();
 
         for (ColumnRefOperator col : outputColumns) {
@@ -1474,7 +1475,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             }
         }
 
-        builder.setOutputRowCount(inputStatistics.getOutputRowCount());
+        builder.setOutputRowCount(rowCount);
 
         context.setStatistics(builder.build());
         return visitOperator(context.getOp(), context);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -166,7 +166,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         context.put("tableName", table.getName());
         context.put("catalogName", this.catalogName);
 
-        if (!columnType.canStatistic()) {
+        if (!columnType.canStatistic() || columnType.isCollectionType()) {
             context.put("hllFunction", "hex(hll_serialize(hll_empty()))");
             context.put("countNullFunction", "0");
             context.put("maxFunction", "''");

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -90,7 +90,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
                     .collect(Collectors.joining(", ")) + ") " + "\n" +
                     "SELECT " +
                     "   table_id, $targetPartitionId, column_name, db_id, table_name, \n" +
-                    "   partition_name, row_count, data_size, ndv, null_count, max, min, update_time \n" +
+                    "   partition_name, row_count, data_size, ndv, null_count, max, min, update_time, collection_size \n" +
                     "FROM " + TABLE_NAME + "\n" +
                     "WHERE `table_id`=$tableId AND `partition_id`=$sourcePartitionId";
     private static final String DELETE_PARTITION_TEMPLATE =

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -20,7 +20,9 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MapType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
@@ -70,6 +72,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
     //| max            | varchar(1048576) | NO   | false | <null>  |       |
     //| min            | varchar(1048576) | NO   | false | <null>  |       |
     //| update_time    | datetime         | NO   | false | <null>  |       |
+    //| collection_size| bigint           | NO   | false | <null>  |       |
     private static final String TABLE_NAME = "column_statistics";
     private static final String BATCH_FULL_STATISTIC_TEMPLATE = "SELECT cast($version as INT)" +
             ", cast($partitionId as BIGINT)" + // BIGINT
@@ -80,6 +83,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             ", cast($countNullFunction as BIGINT)" + // BIGINT
             ", $maxFunction" + // VARCHAR
             ", $minFunction " + // VARCHAR
+            ", cast($collectionSizeFunction as BIGINT)" + // BIGINT
             " FROM (select $quoteColumnName as column_key from `$dbName`.`$tableName` partition `$partitionName`) tt";
     private static final String OVERWRITE_PARTITION_TEMPLATE =
             "INSERT INTO " + TABLE_NAME + "(" + StatisticUtils.buildStatsColumnDef(TABLE_NAME).stream().map(ColumnDef::getName)
@@ -178,9 +182,10 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         flushInsertStatisticsData(context, true);
     }
 
-    // INSERT INTO column_statistics values
+    // INSERT INTO column_statistics(table_id, partition_id, column_name, db_id, table_name,
+    // partition_name, row_count, data_size, ndv, null_count, max, min, update_time, collection_size) values
     // ($tableId, $partitionId, '$columnName', $dbId, '$dbName.$tableName', '$partitionName',
-    //  $count, $dataSize, hll_deserialize('$hll'), $countNull, $maxFunction, $minFunction, NOW());
+    //  $count, $dataSize, hll_deserialize('$hll'), $countNull, $maxFunction, $minFunction, NOW(), $collectionSizeFunction);
     @Override
     public void collectStatisticSync(String sql, ConnectContext context) throws Exception {
         LOG.debug("statistics collect sql : " + sql);
@@ -215,6 +220,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             params.add("'" + data.getMax() + "'");
             params.add("'" + data.getMin() + "'");
             params.add("now()");
+            params.add(String.valueOf(data.getCollectionSize() <= 0 ? -1 : data.getCollectionSize()));
             // int
             row.add(new IntLiteral(table.getId(), Type.BIGINT)); // table id, 8 byte
             row.add(new IntLiteral(data.getPartitionId(), Type.BIGINT)); // partition id, 8 byte
@@ -229,6 +235,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             row.add(new StringLiteral(data.getMax())); // max, 200 byte
             row.add(new StringLiteral(data.getMin())); // min, 200 byte
             row.add(nowFn()); // update time, 8 byte
+            row.add(new IntLiteral(data.getCollectionSize() <= 0 ? -1 : data.getCollectionSize())); // collection size, 8 byte
 
             rowsBuffer.add(row);
             sqlBuffer.add("(" + String.join(", ", params) + ")");
@@ -323,7 +330,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
         String quoteColumnName = StatisticUtils.quoting(table, columnName);
         String quoteColumnKey = "`column_key`";
 
-        context.put("version", StatsConstants.STATISTIC_BATCH_VERSION);
+        context.put("version", StatsConstants.STATISTIC_BATCH_VERSION_V5);
         context.put("partitionId", partition.getId());
         context.put("columnNameStr", columnNameStr);
         context.put("dataSize", fullAnalyzeGetDataSize(quoteColumnKey, columnType));
@@ -337,11 +344,25 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             context.put("countNullFunction", "0");
             context.put("maxFunction", "''");
             context.put("minFunction", "''");
+            context.put("collectionSizeFunction", "-1");
+        } else if (columnType.isCollectionType()) {
+            String collectionSizeFunction = "AVG(" + (columnType.isArrayType() ? "ARRAY_LENGTH" : "MAP_SIZE") +
+                    "(" + quoteColumnKey + ")) ";
+            long elementTypeSize = columnType.isArrayType() ? ((ArrayType) columnType).getItemType().getTypeSize() :
+                    ((MapType) columnType).getKeyType().getTypeSize() + ((MapType) columnType).getValueType().getTypeSize();
+            String dataSizeFunction =  "COUNT(*) * " + elementTypeSize + " * " + collectionSizeFunction;
+            context.put("hllFunction", "'00'");
+            context.put("countNullFunction", "0");
+            context.put("maxFunction", "''");
+            context.put("minFunction", "''");
+            context.put("collectionSizeFunction", collectionSizeFunction);
+            context.put("dataSize", dataSizeFunction);
         } else {
             context.put("hllFunction", "hex(hll_serialize(IFNULL(hll_raw(" + quoteColumnKey + "), hll_empty())))");
             context.put("countNullFunction", "COUNT(1) - COUNT(" + quoteColumnKey + ")");
             context.put("maxFunction", getMinMaxFunction(columnType, quoteColumnKey, true));
             context.put("minFunction", getMinMaxFunction(columnType, quoteColumnKey, false));
+            context.put("collectionSizeFunction", "-1");
         }
 
         builder.append(build(context, BATCH_FULL_STATISTIC_TEMPLATE));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -148,8 +148,7 @@ public class StatisticExecutor {
                             .map(x -> StatisticUtils.getQueryStatisticsColumnType(table, x.getColumnName()))
                             .collect(Collectors.toList());
 
-            String statsSql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(
-                    dbId, tableId, columnNamesForStats, columnTypesForStats);
+            String statsSql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(tableId, columnNamesForStats, columnTypesForStats);
             List<TStatisticData> tStatisticData = executeStatisticDQL(context, statsSql);
             columnStats.addAll(tStatisticData);
         }
@@ -161,7 +160,7 @@ public class StatisticExecutor {
                         .map(x -> StatisticUtils.getQueryStatisticsColumnType(table, x.getColumnName()))
                         .collect(Collectors.toList());
                 String statsSql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(
-                        dbId, tableId, columnNamesForStats, columnTypesForStats);
+                        tableId, columnNamesForStats, columnTypesForStats);
                 List<TStatisticData> tStatisticData = executeStatisticDQL(context, statsSql);
                 columnStats.addAll(tStatisticData);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -34,6 +34,7 @@ import static com.starrocks.statistic.StatsConstants.EXTERNAL_FULL_STATISTICS_TA
 import static com.starrocks.statistic.StatsConstants.FULL_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.SAMPLE_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_DATA_VERSION;
+import static com.starrocks.statistic.StatsConstants.STATISTIC_DATA_VERSION_V2;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_EXTERNAL_HISTOGRAM_VERSION;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_EXTERNAL_QUERY_V2_VERSION;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_HISTOGRAM_VERSION;
@@ -61,9 +62,18 @@ public class StatisticSQLBuilder {
                     + " WHERE $predicate";
 
     private static final String QUERY_FULL_STATISTIC_TEMPLATE =
-            "SELECT cast(" + STATISTIC_DATA_VERSION + " as INT), $updateTime, db_id, table_id, column_name,"
+            "SELECT cast(" + STATISTIC_DATA_VERSION_V2 + " as INT), $updateTime, db_id, table_id, column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
-                    + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string)"
+                    + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string), "
+                    + " cast(avg(collection_size) as bigint)"
+                    + " FROM " + StatsConstants.FULL_STATISTICS_TABLE_NAME
+                    + " WHERE $predicate"
+                    + " GROUP BY db_id, table_id, column_name";
+
+    private static final String QUERY_COLLECTION_FULL_STATISTIC_TEMPLATE =
+            "SELECT cast(" + STATISTIC_DATA_VERSION_V2 + " as INT), $updateTime, db_id, table_id, column_name,"
+                    + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
+                    + " any_value(''), any_value(''), cast(avg(collection_size) as bigint) "
                     + " FROM " + StatsConstants.FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"
                     + " GROUP BY db_id, table_id, column_name";
@@ -149,8 +159,7 @@ public class StatisticSQLBuilder {
         return build(context, QUERY_SAMPLE_STATISTIC_TEMPLATE);
     }
 
-    public static String buildQueryFullStatisticsSQL(Long dbId, Long tableId, List<String> columnNames,
-                                                     List<Type> columnTypes) {
+    public static String buildQueryFullStatisticsSQL(Long tableId, List<String> columnNames, List<Type> columnTypes) {
         Map<String, List<String>> nameGroups = groupByTypes(columnNames, columnTypes);
 
         List<String> querySQL = new ArrayList<>();
@@ -160,7 +169,12 @@ public class StatisticSQLBuilder {
             context.put("type", type);
             context.put("predicate", "table_id = " + tableId + " and column_name in (" +
                     names.stream().map(c -> "\"" + c + "\"").collect(Collectors.joining(", ")) + ")");
-            querySQL.add(build(context, QUERY_FULL_STATISTIC_TEMPLATE));
+
+            if (type.startsWith("array") || type.startsWith("map")) {
+                querySQL.add(build(context, QUERY_COLLECTION_FULL_STATISTIC_TEMPLATE));
+            } else {
+                querySQL.add(build(context, QUERY_FULL_STATISTIC_TEMPLATE));
+            }
         });
         return Joiner.on(" UNION ALL ").join(querySQL);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -64,7 +64,7 @@ public class StatisticSQLBuilder {
     private static final String QUERY_FULL_STATISTIC_TEMPLATE =
             "SELECT cast(" + STATISTIC_DATA_VERSION_V2 + " as INT), $updateTime, db_id, table_id, column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
-                    + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string), "
+                    + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string),"
                     + " cast(avg(collection_size) as bigint)"
                     + " FROM " + StatsConstants.FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -22,6 +22,7 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.SubfieldExpr;
 import com.starrocks.analysis.TypeDef;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
@@ -46,10 +47,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.ConnectorPartitionTraits;
-import com.starrocks.load.EtlStatus;
-import com.starrocks.load.loadv2.LoadJobFinalOperation;
 import com.starrocks.load.pipe.filelist.RepoExecutor;
-import com.starrocks.load.streamload.StreamLoadTxnCommitAttachment;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
@@ -59,9 +57,7 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
 import com.starrocks.transaction.InsertOverwriteJobStats;
-import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TransactionState;
-import com.starrocks.transaction.TxnCommitAttachment;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -83,7 +79,6 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Maps.immutableEntry;
 import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
-import static com.starrocks.statistic.StatsConstants.AnalyzeType.SAMPLE;
 
 public class StatisticUtils {
     private static final Logger LOG = LogManager.getLogger(StatisticUtils.class);
@@ -122,23 +117,6 @@ public class StatisticUtils {
         context.setStartTime();
 
         return context;
-    }
-
-    private static StatsConstants.AnalyzeType parseAnalyzeType(TransactionState txnState, Table table) {
-        Long loadRows = null;
-        TxnCommitAttachment attachment = txnState.getTxnCommitAttachment();
-        if (attachment instanceof LoadJobFinalOperation) {
-            EtlStatus loadingStatus = ((LoadJobFinalOperation) attachment).getLoadingStatus();
-            loadRows = loadingStatus.getLoadedRows(table.getId());
-        } else if (attachment instanceof InsertTxnCommitAttachment) {
-            loadRows = ((InsertTxnCommitAttachment) attachment).getLoadedRows();
-        } else if (attachment instanceof StreamLoadTxnCommitAttachment) {
-            loadRows = ((StreamLoadTxnCommitAttachment) attachment).getNumRowsNormal();
-        }
-        if (loadRows != null && loadRows > Config.statistic_sample_collect_rows) {
-            return SAMPLE;
-        }
-        return StatsConstants.AnalyzeType.FULL;
     }
 
     public static void triggerCollectionOnInsertOverwrite(InsertOverwriteJobStats stats,
@@ -298,7 +276,9 @@ public class StatisticUtils {
                     new ColumnDef("null_count", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("max", new TypeDef(maxType)),
                     new ColumnDef("min", new TypeDef(minType)),
-                    new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME)))
+                    new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME))),
+                    new ColumnDef("collection_size", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT)), false, null,
+                            null, true, new ColumnDef.DefaultValueDef(true, new StringLiteral("-1")), "")
             );
         } else if (tableName.equals(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
             return ImmutableList.of(

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -95,7 +95,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
     }
 
     // Add collection_size field to `column_statistics` table to collect array/map type columns
-    private boolean checkTableCompatible(String tableName) {
+    public boolean checkTableCompatible(String tableName) {
         if (!tableName.equalsIgnoreCase(FULL_STATISTICS_TABLE_NAME)) {
             return true;
         }
@@ -339,7 +339,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
         }
     }
 
-    private boolean alterTable(String tableName) {
+    public boolean alterTable(String tableName) {
         ConnectContext context = StatisticUtils.buildConnectContext();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(STATISTICS_DB_NAME);
         Table table =  GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
@@ -352,7 +352,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
         }
     }
 
-    private boolean alterFullStatisticsTable(ConnectContext context, Table table) {
+    public boolean alterFullStatisticsTable(ConnectContext context, Table table) {
         for (String columnName : FULL_STATISTICS_COMPATIBLE_COLUMNS) {
             if (table.getColumn(columnName) == null) {
                 if (columnName.equalsIgnoreCase("collection_size")) {
@@ -361,7 +361,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
                             false, null, null, true, defaultValueDef, "");
                     AddColumnClause addColumnClause = new AddColumnClause(columnDef, null, null, new HashMap<>());
                     AlterTableStmt alterTableStmt = new AlterTableStmt(
-                            new TableName(DEFAULT_INTERNAL_CATALOG_NAME, STATISTICS_DB_NAME, FULL_STATISTICS_TABLE_NAME),
+                            new TableName(DEFAULT_INTERNAL_CATALOG_NAME, STATISTICS_DB_NAME, table.getName()),
                             Lists.newArrayList(addColumnClause));
 
                     try {
@@ -467,4 +467,5 @@ public class StatisticsMetaManager extends FrontendDaemon {
             trySleep(1);
         }
     }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -16,10 +16,17 @@ package com.starrocks.statistic;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.alter.AlterJobV2;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.TypeDef;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
@@ -31,6 +38,9 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.ast.AddColumnClause;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.HashDistributionDesc;
@@ -42,8 +52,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.starrocks.catalog.InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+import static com.starrocks.statistic.StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME;
+import static com.starrocks.statistic.StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME;
+import static com.starrocks.statistic.StatsConstants.FULL_STATISTICS_TABLE_NAME;
+import static com.starrocks.statistic.StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME;
+import static com.starrocks.statistic.StatsConstants.SAMPLE_STATISTICS_TABLE_NAME;
+import static com.starrocks.statistic.StatsConstants.STATISTICS_DB_NAME;
 
 public class StatisticsMetaManager extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(StatisticsMetaManager.class);
@@ -53,12 +72,12 @@ public class StatisticsMetaManager extends FrontendDaemon {
     }
 
     private boolean checkDatabaseExist() {
-        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(StatsConstants.STATISTICS_DB_NAME) != null;
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(STATISTICS_DB_NAME) != null;
     }
 
     private boolean createDatabase() {
         LOG.info("create statistics db start");
-        CreateDbStmt dbStmt = new CreateDbStmt(false, StatsConstants.STATISTICS_DB_NAME);
+        CreateDbStmt dbStmt = new CreateDbStmt(false, STATISTICS_DB_NAME);
         try {
             GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(dbStmt.getFullDbName());
         } catch (StarRocksException e) {
@@ -70,9 +89,24 @@ public class StatisticsMetaManager extends FrontendDaemon {
     }
 
     private boolean checkTableExist(String tableName) {
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(StatsConstants.STATISTICS_DB_NAME);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(STATISTICS_DB_NAME);
         Preconditions.checkState(db != null);
         return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName) != null;
+    }
+
+    // Add collection_size field to `column_statistics` table to collect array/map type columns
+    private boolean checkTableCompatible(String tableName) {
+        if (!tableName.equalsIgnoreCase(FULL_STATISTICS_TABLE_NAME)) {
+            return true;
+        }
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(STATISTICS_DB_NAME);
+        Table table =  GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
+        for (String columnName : FULL_STATISTICS_COMPATIBLE_COLUMNS) {
+            if (table.getColumn(columnName) == null) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static final List<String> KEY_COLUMN_NAMES = ImmutableList.of(
@@ -95,10 +129,13 @@ public class StatisticsMetaManager extends FrontendDaemon {
             "table_uuid", "column_name"
     );
 
+    private static final List<String> FULL_STATISTICS_COMPATIBLE_COLUMNS = ImmutableList.of(
+            "collection_size"
+    );
+
     private boolean createSampleStatisticsTable(ConnectContext context) {
         LOG.info("create sample statistics table start");
-        TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
-                StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
+        TableName tableName = new TableName(STATISTICS_DB_NAME, SAMPLE_STATISTICS_TABLE_NAME);
         Map<String, String> properties = Maps.newHashMap();
         try {
             int defaultReplicationNum = AutoInferUtil.calDefaultReplicationNum();
@@ -106,7 +143,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             KeysType keysType = KeysType.UNIQUE_KEYS;
             CreateTableStmt stmt = new CreateTableStmt(false, false,
                     tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME),
+                    StatisticUtils.buildStatsColumnDef(SAMPLE_STATISTICS_TABLE_NAME),
                     EngineType.defaultEngine().name(),
                     new KeysDesc(keysType, KEY_COLUMN_NAMES),
                     null,
@@ -123,13 +160,13 @@ public class StatisticsMetaManager extends FrontendDaemon {
         }
         LOG.info("create sample statistics table done");
         refreshAnalyzeJob();
-        return checkTableExist(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
+        return checkTableExist(SAMPLE_STATISTICS_TABLE_NAME);
     }
 
     private boolean createFullStatisticsTable(ConnectContext context) {
         LOG.info("create full statistics table start");
-        TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
-                StatsConstants.FULL_STATISTICS_TABLE_NAME);
+        TableName tableName = new TableName(STATISTICS_DB_NAME,
+                FULL_STATISTICS_TABLE_NAME);
         KeysType keysType = RunMode.isSharedDataMode() ? KeysType.UNIQUE_KEYS : KeysType.PRIMARY_KEYS;
         Map<String, String> properties = Maps.newHashMap();
 
@@ -138,7 +175,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
             CreateTableStmt stmt = new CreateTableStmt(false, false,
                     tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.FULL_STATISTICS_TABLE_NAME),
+                    StatisticUtils.buildStatsColumnDef(FULL_STATISTICS_TABLE_NAME),
                     EngineType.defaultEngine().name(),
                     new KeysDesc(keysType, FULL_STATISTICS_KEY_COLUMNS),
                     null,
@@ -155,13 +192,12 @@ public class StatisticsMetaManager extends FrontendDaemon {
         }
         LOG.info("create full statistics table done");
         refreshAnalyzeJob();
-        return checkTableExist(StatsConstants.FULL_STATISTICS_TABLE_NAME);
+        return checkTableExist(FULL_STATISTICS_TABLE_NAME);
     }
 
     private boolean createHistogramStatisticsTable(ConnectContext context) {
         LOG.info("create histogram statistics table start");
-        TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
-                StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME);
+        TableName tableName = new TableName(STATISTICS_DB_NAME, HISTOGRAM_STATISTICS_TABLE_NAME);
         KeysType keysType = RunMode.isSharedDataMode() ? KeysType.UNIQUE_KEYS : KeysType.PRIMARY_KEYS;
         Map<String, String> properties = Maps.newHashMap();
         try {
@@ -169,7 +205,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
             CreateTableStmt stmt = new CreateTableStmt(false, false,
                     tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME),
+                    StatisticUtils.buildStatsColumnDef(HISTOGRAM_STATISTICS_TABLE_NAME),
                     EngineType.defaultEngine().name(),
                     new KeysDesc(keysType, HISTOGRAM_KEY_COLUMNS),
                     null,
@@ -192,13 +228,12 @@ public class StatisticsMetaManager extends FrontendDaemon {
                     histogramStatsMeta.getDbId(), histogramStatsMeta.getTableId(), histogramStatsMeta.getColumn(),
                     histogramStatsMeta.getType(), LocalDateTime.MIN, histogramStatsMeta.getProperties()));
         }
-        return checkTableExist(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME);
+        return checkTableExist(HISTOGRAM_STATISTICS_TABLE_NAME);
     }
 
     private boolean createExternalFullStatisticsTable(ConnectContext context) {
         LOG.info("create external full statistics table start");
-        TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
-                StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME);
+        TableName tableName = new TableName(STATISTICS_DB_NAME, EXTERNAL_FULL_STATISTICS_TABLE_NAME);
         KeysType keysType = RunMode.isSharedDataMode() ? KeysType.UNIQUE_KEYS : KeysType.PRIMARY_KEYS;
         Map<String, String> properties = Maps.newHashMap();
 
@@ -207,7 +242,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
             CreateTableStmt stmt = new CreateTableStmt(false, false,
                     tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME),
+                    StatisticUtils.buildStatsColumnDef(EXTERNAL_FULL_STATISTICS_TABLE_NAME),
                     EngineType.defaultEngine().name(),
                     new KeysDesc(keysType, EXTERNAL_FULL_STATISTICS_KEY_COLUMNS),
                     null,
@@ -223,13 +258,12 @@ public class StatisticsMetaManager extends FrontendDaemon {
             return false;
         }
         LOG.info("create external full statistics table done");
-        return checkTableExist(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME);
+        return checkTableExist(EXTERNAL_FULL_STATISTICS_TABLE_NAME);
     }
 
     private boolean createExternalHistogramStatisticsTable(ConnectContext context) {
         LOG.info("create external histogram statistics table start");
-        TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
-                StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME);
+        TableName tableName = new TableName(STATISTICS_DB_NAME, EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME);
         KeysType keysType = RunMode.isSharedDataMode() ? KeysType.UNIQUE_KEYS : KeysType.PRIMARY_KEYS;
         Map<String, String> properties = Maps.newHashMap();
         try {
@@ -237,7 +271,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
             CreateTableStmt stmt = new CreateTableStmt(false, false,
                     tableName,
-                    StatisticUtils.buildStatsColumnDef(StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME),
+                    StatisticUtils.buildStatsColumnDef(EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME),
                     EngineType.defaultEngine().name(),
                     new KeysDesc(keysType, EXTERNAL_HISTOGRAM_KEY_COLUMNS),
                     null,
@@ -261,7 +295,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
                             histogramStatsMeta.getTableName(), histogramStatsMeta.getColumn(),
                             histogramStatsMeta.getType(), LocalDateTime.MIN, histogramStatsMeta.getProperties()));
         }
-        return checkTableExist(StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME);
+        return checkTableExist(EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME);
     }
 
     private void refreshAnalyzeJob() {
@@ -289,20 +323,81 @@ public class StatisticsMetaManager extends FrontendDaemon {
     private boolean createTable(String tableName) {
         ConnectContext context = StatisticUtils.buildConnectContext();
         try (ConnectContext.ScopeGuard guard = context.bindScope()) {
-            if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
+            if (tableName.equals(SAMPLE_STATISTICS_TABLE_NAME)) {
                 return createSampleStatisticsTable(context);
-            } else if (tableName.equals(StatsConstants.FULL_STATISTICS_TABLE_NAME)) {
+            } else if (tableName.equals(FULL_STATISTICS_TABLE_NAME)) {
                 return createFullStatisticsTable(context);
-            } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
+            } else if (tableName.equals(HISTOGRAM_STATISTICS_TABLE_NAME)) {
                 return createHistogramStatisticsTable(context);
-            } else if (tableName.equals(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
+            } else if (tableName.equals(EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
                 return createExternalFullStatisticsTable(context);
-            } else if (tableName.equals(StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME)) {
+            } else if (tableName.equals(EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME)) {
                 return createExternalHistogramStatisticsTable(context);
             } else {
                 throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
             }
         }
+    }
+
+    private boolean alterTable(String tableName) {
+        ConnectContext context = StatisticUtils.buildConnectContext();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(STATISTICS_DB_NAME);
+        Table table =  GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
+        try (ConnectContext.ScopeGuard guard = context.bindScope()) {
+            if (tableName.equals(FULL_STATISTICS_TABLE_NAME)) {
+                return alterFullStatisticsTable(context, table);
+            } else {
+                throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
+            }
+        }
+    }
+
+    private boolean alterFullStatisticsTable(ConnectContext context, Table table) {
+        for (String columnName : FULL_STATISTICS_COMPATIBLE_COLUMNS) {
+            if (table.getColumn(columnName) == null) {
+                if (columnName.equalsIgnoreCase("collection_size")) {
+                    ColumnDef.DefaultValueDef defaultValueDef = new ColumnDef.DefaultValueDef(true, new StringLiteral("-1"));
+                    ColumnDef columnDef = new ColumnDef(columnName, new TypeDef(ScalarType.createType(PrimitiveType.BIGINT)),
+                            false, null, null, true, defaultValueDef, "");
+                    AddColumnClause addColumnClause = new AddColumnClause(columnDef, null, null, new HashMap<>());
+                    AlterTableStmt alterTableStmt = new AlterTableStmt(
+                            new TableName(DEFAULT_INTERNAL_CATALOG_NAME, STATISTICS_DB_NAME, FULL_STATISTICS_TABLE_NAME),
+                            Lists.newArrayList(addColumnClause));
+
+                    try {
+                        Analyzer.analyze(alterTableStmt, context);
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(context, alterTableStmt);
+                    } catch (Exception e) {
+                        LOG.warn("Failed to add column {} on full statistics table", columnName, e);
+                        return false;
+                    }
+
+                    while (table.getColumn(columnName) == null) {
+                        // `alter table` may be sync in the shared-nothing cluster. So we need to check if job is done.
+                        // TODO(stephen): This check is not robust because we can't get job handle here.
+                        List<AlterJobV2> unfinishedAlterJobs = GlobalStateMgr.getCurrentState().getAlterJobMgr()
+                                .getSchemaChangeHandler().getUnfinishedAlterJobV2ByTableId(table.getId());
+                        if (unfinishedAlterJobs.isEmpty()) {
+                            if (table.getColumn(columnName) != null) {
+                                break;
+                            } else {
+                                LOG.warn("Failed to add column {} on full statistics table", columnName);
+                                return false;
+                            }
+                        } else {
+                            trySleep(5000);
+                        }
+                    }
+
+                    LOG.info("Finished to add column {} to table {}", columnName, FULL_STATISTICS_TABLE_NAME);
+                } else {
+                    throw new StarRocksPlannerException("Error compatible column name " + columnName, ErrorType.INTERNAL_ERROR);
+                }
+            }
+        }
+
+        LOG.info("alter full statistics table done");
+        return true;
     }
 
     private void refreshStatisticsTable(String tableName) {
@@ -315,6 +410,14 @@ public class StatisticsMetaManager extends FrontendDaemon {
         }
         if (checkTableExist(tableName)) {
             StatisticUtils.alterSystemTableReplicationNumIfNecessary(tableName);
+        }
+
+        while (!checkTableCompatible(tableName)) {
+            if (alterTable(tableName)) {
+                break;
+            }
+            LOG.warn("alter statistics table " + tableName + " failed");
+            trySleep(10000);
         }
     }
 
@@ -329,11 +432,11 @@ public class StatisticsMetaManager extends FrontendDaemon {
             trySleep(10000);
         }
 
-        refreshStatisticsTable(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
-        refreshStatisticsTable(StatsConstants.FULL_STATISTICS_TABLE_NAME);
-        refreshStatisticsTable(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME);
-        refreshStatisticsTable(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME);
-        refreshStatisticsTable(StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME);
+        refreshStatisticsTable(SAMPLE_STATISTICS_TABLE_NAME);
+        refreshStatisticsTable(FULL_STATISTICS_TABLE_NAME);
+        refreshStatisticsTable(HISTOGRAM_STATISTICS_TABLE_NAME);
+        refreshStatisticsTable(EXTERNAL_FULL_STATISTICS_TABLE_NAME);
+        refreshStatisticsTable(EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME);
 
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().clearStatisticFromDroppedPartition();
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().clearStatisticFromDroppedTable();
@@ -353,13 +456,13 @@ public class StatisticsMetaManager extends FrontendDaemon {
         boolean existsSample = false;
         boolean existsFull = false;
         while (!existsSample || !existsFull) {
-            existsSample = checkTableExist(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
-            existsFull = checkTableExist(StatsConstants.FULL_STATISTICS_TABLE_NAME);
+            existsSample = checkTableExist(SAMPLE_STATISTICS_TABLE_NAME);
+            existsFull = checkTableExist(FULL_STATISTICS_TABLE_NAME);
             if (!existsSample) {
-                createTable(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
+                createTable(SAMPLE_STATISTICS_TABLE_NAME);
             }
             if (!existsFull) {
-                createTable(StatsConstants.FULL_STATISTICS_TABLE_NAME);
+                createTable(FULL_STATISTICS_TABLE_NAME);
             }
             trySleep(1);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -33,6 +33,8 @@ public class StatsConstants {
     public static final int STATISTIC_EXTERNAL_HISTOGRAM_VERSION = 7;
     public static final int STATISTIC_EXTERNAL_QUERY_V2_VERSION = 8;
     public static final int STATISTIC_PARTITION_VERSION = 11;
+    public static final int STATISTIC_BATCH_VERSION_V5 = 9;
+    public static final int STATISTIC_DATA_VERSION_V2 = 10;
 
     public static final ImmutableSet<Integer> STATISTIC_SUPPORTED_VERSION =
             ImmutableSet.<Integer>builder()
@@ -46,6 +48,8 @@ public class StatsConstants {
                     .add(STATISTIC_EXTERNAL_HISTOGRAM_VERSION)
                     .add(STATISTIC_EXTERNAL_QUERY_V2_VERSION)
                     .add(STATISTIC_PARTITION_VERSION)
+                    .add(STATISTIC_BATCH_VERSION_V5)
+                    .add(STATISTIC_DATA_VERSION_V2)
                     .build();
 
     public static final int STATISTICS_PARTITION_UPDATED_THRESHOLD = 10;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/CollectionTypeColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/CollectionTypeColumnStats.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic.base;
+
+import com.starrocks.catalog.ArrayType;
+import com.starrocks.catalog.MapType;
+import com.starrocks.catalog.Type;
+import com.starrocks.statistic.sample.SampleInfo;
+
+public class CollectionTypeColumnStats extends ColumnStats {
+    public CollectionTypeColumnStats(String columnName, Type columnType) {
+        super(columnName, columnType);
+    }
+
+    @Override
+    public String getFullDateSize() {
+        long elementTypeSize = columnType.isArrayType() ? ((ArrayType) columnType).getItemType().getTypeSize() :
+                ((MapType) columnType).getKeyType().getTypeSize() + ((MapType) columnType).getValueType().getTypeSize();
+        return "COUNT(*) * " + elementTypeSize + " * " + getCollectionSize();
+    }
+
+    @Override
+    public String getSampleDateSize(SampleInfo info) {
+        return columnType.getTypeSize() + " * " + info.getTotalRowCount();
+    }
+
+    @Override
+    public String getSampleNullCount(SampleInfo info) {
+        return "0";
+    }
+
+    @Override
+    public String getFullNullCount() {
+        return "0";
+    }
+
+    @Override
+    public String getCollectionSize() {
+        String collectionSizeFunction = columnType.isArrayType() ? "ARRAY_LENGTH" : "MAP_SIZE";
+        return "AVG(" + collectionSizeFunction + "(" + getQuotedColumnName() + ")) ";
+    }
+
+    @Override
+    public String getMax() {
+        return "''";
+    }
+
+    @Override
+    public String getMin() {
+        return "''";
+    }
+
+    @Override
+    public String getNDV() {
+        return "'00'";
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/ColumnClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/ColumnClassifier.java
@@ -45,7 +45,11 @@ public class ColumnClassifier {
 
             if (table.getColumn(columnName) != null) {
                 if (columnType.canStatistic()) {
-                    columnStats.add(new PrimitiveTypeColumnStats(columnName, columnType));
+                    if (!columnType.isCollectionType()) {
+                        columnStats.add(new PrimitiveTypeColumnStats(columnName, columnType));
+                    } else {
+                        columnStats.add(new CollectionTypeColumnStats(columnName, columnType));
+                    }
                 } else {
                     unSupportStats.add(new ComplexTypeColumnStats(columnName, columnType));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/ColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/ColumnStats.java
@@ -18,6 +18,8 @@ import com.starrocks.catalog.Type;
 import com.starrocks.statistic.sample.SampleInfo;
 import org.apache.commons.lang.StringEscapeUtils;
 
+import static com.starrocks.sql.optimizer.statistics.ColumnStatistic.DEFAULT_COLLECTION_SIZE;
+
 /*
  * For describe how to collect statistics on different column type
  */
@@ -55,6 +57,10 @@ public abstract class ColumnStats {
     public abstract String getMax();
 
     public abstract String getMin();
+
+    public String getCollectionSize() {
+        return String.valueOf(DEFAULT_COLLECTION_SIZE);
+    }
 
     public abstract String getFullDateSize();
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/SubFieldColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/SubFieldColumnStats.java
@@ -30,9 +30,11 @@ public class SubFieldColumnStats extends PrimitiveTypeColumnStats {
     public SubFieldColumnStats(List<String> names, Type columnType) {
         super(String.join(".", names), columnType);
         this.names = names;
-        this.isComplexType = !columnType.canStatistic();
+        this.isComplexType = !columnType.canStatistic() || columnType.isCollectionType();
         if (!columnType.canStatistic()) {
             complexStats = new ComplexTypeColumnStats("name", columnType);
+        } else if (columnType.isCollectionType()) {
+            complexStats = new CollectionTypeColumnStats("name", columnType);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/ConstQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/ConstQueryJob.java
@@ -71,6 +71,7 @@ public class ConstQueryJob extends HyperQueryJob {
                 data.setDataSize(column.getTypeSize() * rowCount);
                 data.setMax("");
                 data.setMin("");
+                data.setCollectionSize(-1);
                 sqlBuffer.add(createInsertValueSQL(data, tableName, partitionName));
                 rowsBuffer.add(createInsertValueExpr(data, tableName, partitionName));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/FullQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/FullQueryJob.java
@@ -50,6 +50,7 @@ public class FullQueryJob extends HyperQueryJob {
                 context.put("hllFunction", columnStat.getNDV());
                 context.put("maxFunction", columnStat.getMax());
                 context.put("minFunction", columnStat.getMin());
+                context.put("collectionSizeFunction", columnStat.getCollectionSize());
                 String sql = HyperStatisticSQLs.build(context, HyperStatisticSQLs.BATCH_FULL_STATISTIC_TEMPLATE);
                 metaSQL.add(sql);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperQueryJob.java
@@ -42,6 +42,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.optimizer.statistics.ColumnStatistic.DEFAULT_COLLECTION_SIZE;
+
 public abstract class HyperQueryJob {
     private static final Logger LOG = LogManager.getLogger(HyperQueryJob.class);
 
@@ -151,6 +153,7 @@ public abstract class HyperQueryJob {
         params.add("'" + data.getMax() + "'");
         params.add("'" + data.getMin() + "'");
         params.add("now()");
+        params.add(String.valueOf(data.getCollectionSize() <= 0 ? DEFAULT_COLLECTION_SIZE : data.getCollectionSize()));
         return "(" + String.join(", ", params) + ")";
     }
 
@@ -169,6 +172,7 @@ public abstract class HyperQueryJob {
         row.add(new StringLiteral(data.getMax())); // max, 200 byte
         row.add(new StringLiteral(data.getMin())); // min, 200 byte
         row.add(nowFn()); // update time, 8 byte
+        row.add(new IntLiteral(data.getCollectionSize() <= 0 ? -1 : data.getCollectionSize(), Type.BIGINT)); // collection size 8 byte
         return row;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
@@ -63,7 +63,7 @@ public class HyperStatisticSQLs {
             ", $hllFunction" + // VARBINARY
             ", cast($countNullFunction as BIGINT)" + // BIGINT
             ", $maxFunction" + // VARCHAR
-            ", $minFunction " + // VARCHAR
+            ", $minFunction" + // VARCHAR
             ", cast($collectionSizeFunction as BIGINT)" + // BIGINT
             " FROM `$dbName`.`$tableName` partition `$partitionName`";
 
@@ -99,7 +99,7 @@ public class HyperStatisticSQLs {
             ", $hllFunction" + // VARBINARY
             ", cast($countNullFunction as BIGINT)" + // BIGINT
             ", $maxFunction" + // VARCHAR
-            ", $minFunction " + // VARCHAR
+            ", $minFunction" + // VARCHAR
             ", cast($collectionSizeFunction as BIGINT)" + // BIGINT, collection_size
             " FROM base_cte_table ";
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
@@ -54,6 +54,7 @@ public class HyperStatisticSQLs {
     //| max            | varchar(1048576) | NO   | false | <null>  |       |
     //| min            | varchar(1048576) | NO   | false | <null>  |       |
     //| update_time    | datetime         | NO   | false | <null>  |       |
+    //| collection_size| bigint           | NO   | false | <null>  |       |
     public static final String BATCH_FULL_STATISTIC_TEMPLATE = "SELECT cast($version as INT)" +
             ", cast($partitionId as BIGINT)" + // BIGINT
             ", '$columnNameStr'" + // VARCHAR
@@ -63,6 +64,7 @@ public class HyperStatisticSQLs {
             ", cast($countNullFunction as BIGINT)" + // BIGINT
             ", $maxFunction" + // VARCHAR
             ", $minFunction " + // VARCHAR
+            ", cast($collectionSizeFunction as BIGINT)" + // BIGINT
             " FROM `$dbName`.`$tableName` partition `$partitionName`";
 
     public static final String BATCH_META_STATISTIC_TEMPLATE = "SELECT cast($version as INT)" +
@@ -74,6 +76,7 @@ public class HyperStatisticSQLs {
             ", cast(0 as BIGINT)" + // BIGINT, null_count
             ", $maxFunction" + // VARCHAR, max
             ", $minFunction " + // VARCHAR, min
+            ", cast(-1 as BIGINT) " + // BIGINT, collection_size
             " FROM `$dbName`.`$tableName` partitions(`$partitionName`) [_META_]";
 
     public static final String BATCH_DATA_STATISTIC_SELECT_TEMPLATE = "SELECT cast($version as INT)" +
@@ -84,7 +87,8 @@ public class HyperStatisticSQLs {
             ", $hllFunction" + // VARBINARY, ndv
             ", cast($countNullFunction as BIGINT)" + // BIGINT, null_count
             ", ''" + // VARCHAR, max
-            ", '' " + // VARCHAR, min
+            ", ''" + // VARCHAR, min
+            ", cast($collectionSizeFunction as BIGINT)" + // BIGINT, collection_size
             " FROM base_cte_table ";
 
     public static final String BATCH_SAMPLE_STATISTIC_SELECT_TEMPLATE = "SELECT cast($version as INT)" +
@@ -96,6 +100,7 @@ public class HyperStatisticSQLs {
             ", cast($countNullFunction as BIGINT)" + // BIGINT
             ", $maxFunction" + // VARCHAR
             ", $minFunction " + // VARCHAR
+            ", cast($collectionSizeFunction as BIGINT)" + // BIGINT, collection_size
             " FROM base_cte_table ";
 
     public static String build(VelocityContext context, String template) {
@@ -108,7 +113,7 @@ public class HyperStatisticSQLs {
         VelocityContext context = new VelocityContext();
         String columnNameStr = stats.getColumnNameStr();
         String quoteColumnName = stats.getQuotedColumnName();
-        context.put("version", StatsConstants.STATISTIC_BATCH_VERSION);
+        context.put("version", StatsConstants.STATISTIC_BATCH_VERSION_V5);
         context.put("partitionId", p.getId());
         context.put("columnNameStr", columnNameStr);
         context.put("partitionName", p.getName());
@@ -150,6 +155,7 @@ public class HyperStatisticSQLs {
             context.put("countNullFunction", stat.getSampleNullCount(info));
             context.put("maxFunction", stat.getMax());
             context.put("minFunction", stat.getMin());
+            context.put("collectionSizeFunction", stat.getCollectionSize());
             groupSQLs.add(HyperStatisticSQLs.build(context, template));
         }
         sqlBuilder.append(String.join(" UNION ALL ", groupSQLs));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/MetaQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/MetaQueryJob.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 /*
  * Split sample statistics query:
  * 1. max/max/count(1) to meta query
- * 2. length/count null/ndv to data query
+ * 2. length/count null/ndv/collection size to data query
  */
 public class MetaQueryJob extends HyperQueryJob {
     // column_partition -> rows index, for find row
@@ -121,6 +121,7 @@ public class MetaQueryJob extends HyperQueryJob {
                 tempData.setNullCount(data.getNullCount()); // real null count
                 tempData.setDataSize(data.getDataSize()); // real data size
                 tempData.setHll(data.getHll()); // real hll
+                tempData.setCollectionSize(data.getCollectionSize() <= 0 ? -1 : data.getCollectionSize());
                 sqlBuffer.add(createInsertValueSQL(tempData, tableName, partitionName));
                 rowsBuffer.add(createInsertValueExpr(tempData, tableName, partitionName));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/ColumnSampleManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/ColumnSampleManager.java
@@ -48,7 +48,7 @@ public class ColumnSampleManager {
             Type columnType = columnTypes.get(i);
 
             if (table.getColumn(columnName) != null) {
-                if (columnType.canStatistic()) {
+                if (columnType.canStatistic() && !columnType.isCollectionType()) {
                     if (onlyOneDistributionCol && table.getDistributionColumnNames().contains(columnName)) {
                         primitiveTypeStats.add(new DistributionColumnStats(columnName, columnType, sampleInfo));
                         onlyOneDistributionCol = false;
@@ -91,7 +91,7 @@ public class ColumnSampleManager {
                     }
                 }
                 if (!names.isEmpty()) {
-                    if (columnType.canStatistic()) {
+                    if (columnType.canStatistic() && !columnType.isCollectionType()) {
                         primitiveTypeStats.add(new SubFieldColumnStats(names, columnType));
                     } else {
                         complexTypeStats.add(new SubFieldColumnStats(names, columnType));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -295,7 +295,7 @@ public class AnalyzeStmtTest {
                         "cast(min(cast(min as bigint)) as string) FROM column_statistics " +
                         "WHERE table_id = %d and column_name in (\"v1\", \"v2\") " +
                         "GROUP BY db_id, table_id, column_name", table.getId()),
-                StatisticSQLBuilder.buildQueryFullStatisticsSQL(database.getId(), table.getId(),
+                StatisticSQLBuilder.buildQueryFullStatisticsSQL(table.getId(),
                         Lists.newArrayList("v1", "v2"), Lists.newArrayList(v1.getType(), v2.getType())));
 
         Assert.assertEquals(String.format(
@@ -442,7 +442,7 @@ public class AnalyzeStmtTest {
                 "cast(max(cast(max as bigint)) as string), cast(min(cast(min as bigint)) as string) " +
                 "FROM column_statistics WHERE table_id = %d and column_name in (\"kk1\") " +
                 "GROUP BY db_id, table_id, column_name", table.getId(), table.getId());
-        String content = StatisticSQLBuilder.buildQueryFullStatisticsSQL(database.getId(), table.getId(),
+        String content = StatisticSQLBuilder.buildQueryFullStatisticsSQL(table.getId(),
                 Lists.newArrayList("kk1", "kk2"), Lists.newArrayList(kk1.getType(), kk2.getType()));
         Assert.assertEquals(pattern, content);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -278,7 +278,7 @@ public class AnalyzeStmtTest {
     }
 
     @Test
-    public void testStatisticsSqlBuilder() throws Exception {
+    public void testStatisticsSqlBuilder() {
         Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(database.getFullName(), "t0");
         System.out.println(table.getPartitions());
@@ -287,12 +287,12 @@ public class AnalyzeStmtTest {
         Column v1 = table.getColumn("v1");
         Column v2 = table.getColumn("v2");
 
-        Assert.assertEquals(String.format("SELECT cast(1 as INT), now(), " +
+        Assert.assertEquals(String.format("SELECT cast(10 as INT), now(), " +
                         "db_id, table_id, column_name," +
                         " sum(row_count), " +
                         "cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count),  " +
                         "cast(max(cast(max as bigint)) as string), " +
-                        "cast(min(cast(min as bigint)) as string) FROM column_statistics " +
+                        "cast(min(cast(min as bigint)) as string), cast(avg(collection_size) as bigint) FROM column_statistics " +
                         "WHERE table_id = %d and column_name in (\"v1\", \"v2\") " +
                         "GROUP BY db_id, table_id, column_name", table.getId()),
                 StatisticSQLBuilder.buildQueryFullStatisticsSQL(table.getId(),
@@ -432,14 +432,16 @@ public class AnalyzeStmtTest {
         Column kk1 = table.getColumn("kk1");
         Column kk2 = table.getColumn("kk2");
 
-        String pattern = String.format("SELECT cast(1 as INT), now(), db_id, table_id, column_name, sum(row_count), " +
+        String pattern = String.format("SELECT cast(10 as INT), now(), db_id, table_id, column_name, sum(row_count), " +
                 "cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count),  " +
-                "cast(max(cast(max as string)) as string), cast(min(cast(min as string)) as string) " +
+                "cast(max(cast(max as string)) as string), cast(min(cast(min as string)) as string), " +
+                "cast(avg(collection_size) as bigint) " +
                 "FROM column_statistics WHERE table_id = %d and column_name in (\"kk2\") " +
                 "GROUP BY db_id, table_id, column_name " +
-                "UNION ALL SELECT cast(1 as INT), now(), db_id, table_id, column_name, " +
+                "UNION ALL SELECT cast(10 as INT), now(), db_id, table_id, column_name, " +
                 "sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count),  " +
-                "cast(max(cast(max as bigint)) as string), cast(min(cast(min as bigint)) as string) " +
+                "cast(max(cast(max as bigint)) as string), cast(min(cast(min as bigint)) as string), " +
+                "cast(avg(collection_size) as bigint) " +
                 "FROM column_statistics WHERE table_id = %d and column_name in (\"kk1\") " +
                 "GROUP BY db_id, table_id, column_name", table.getId(), table.getId());
         String content = StatisticSQLBuilder.buildQueryFullStatisticsSQL(table.getId(),

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsMetaMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsMetaMgrTest.java
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.TypeDef;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.HashDistributionDesc;
+import com.starrocks.sql.ast.KeysDesc;
+import com.starrocks.sql.common.EngineType;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.starrocks.statistic.StatsConstants.FULL_STATISTICS_TABLE_NAME;
+import static com.starrocks.statistic.StatsConstants.STATISTICS_DB_NAME;
+
+
+public class StatisticsMetaMgrTest extends PlanTestBase  {
+    @Test
+    public void alterMetaTable() throws Exception {
+        PlanTestBase.beforeClass();
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        StatisticsMetaManager m = new StatisticsMetaManager();
+        String tblName = "test_alter_name";
+        m.createStatisticsTablesForTest();
+        TableName tableName = new TableName(STATISTICS_DB_NAME, tblName);
+        Map<String, String> properties = Maps.newHashMap();
+
+        properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, "1");
+        CreateTableStmt stmt = new CreateTableStmt(false, false,
+                tableName,
+                ImmutableList.of(
+                        new ColumnDef("table_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                        new ColumnDef("partition_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                        new ColumnDef("column_name", new TypeDef(ScalarType.createVarcharType(65530))),
+                        new ColumnDef("db_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                        new ColumnDef("table_name", new TypeDef(ScalarType.createVarcharType(65530)))),
+                EngineType.defaultEngine().name(),
+                new KeysDesc(KeysType.UNIQUE_KEYS, ImmutableList.of("table_id", "partition_id", "column_name")),
+                null,
+                new HashDistributionDesc(10, ImmutableList.of("table_id", "partition_id", "column_name")),
+                properties,
+                null,
+                "");
+        Analyzer.analyze(stmt, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(stmt);
+        Table table = globalStateMgr.getLocalMetastore().getTable("_statistics_", tblName);
+        m.alterFullStatisticsTable(connectContext, table);
+        Assert.assertTrue(m.checkTableCompatible(tblName));
+        Assert.assertTrue(m.alterTable(FULL_STATISTICS_TABLE_NAME));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -339,19 +339,19 @@ public class StatisticsSQLTest extends PlanTestBase {
 
     @Test
     public void testCacheQueryColumnStatics() {
-        String sql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(1L, 2L, Lists.newArrayList("col1", "col2"),
+        String sql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(2L, Lists.newArrayList("col1", "col2"),
                 Lists.newArrayList(Type.INT, Type.INT));
         assertContains(sql, "table_id = 2 and column_name in (\"col1\", \"col2\")");
         Assert.assertEquals(0, StringUtils.countMatches(sql, "UNION ALL"));
 
-        sql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(1L, 2L,
+        sql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(2L,
                 Lists.newArrayList("col1", "col2", "col3"),
                 Lists.newArrayList(Type.INT, Type.BIGINT, Type.LARGEINT));
         assertContains(sql, "table_id = 2 and column_name in (\"col1\", \"col2\")");
         assertContains(sql, "table_id = 2 and column_name in (\"col3\")");
         Assert.assertEquals(1, StringUtils.countMatches(sql, "UNION ALL"));
 
-        sql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(1L, 2L,
+        sql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(2L,
                 Lists.newArrayList("col1", "col2", "col3", "col4", "col5", "col6", "col7"),
                 Lists.newArrayList(Type.INT, Type.BIGINT, Type.LARGEINT, Type.STRING, Type.VARCHAR, Type.ARRAY_DATE,
                         Type.DATE));
@@ -361,7 +361,7 @@ public class StatisticsSQLTest extends PlanTestBase {
         assertContains(sql, "table_id = 2 and column_name in (\"col7\")");
         Assert.assertEquals(3, StringUtils.countMatches(sql, "UNION ALL"));
 
-        sql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(1L, 2L,
+        sql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(2L,
                 Lists.newArrayList("col1", "col2", "col3", "col4", "col5", "col6", "col7"),
                 Lists.newArrayList(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3),
                         ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3),

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -357,9 +357,10 @@ public class StatisticsSQLTest extends PlanTestBase {
                         Type.DATE));
         assertContains(sql, "table_id = 2 and column_name in (\"col1\", \"col2\")");
         assertContains(sql, "table_id = 2 and column_name in (\"col3\")");
-        assertContains(sql, "table_id = 2 and column_name in (\"col4\", \"col5\", \"col6\")");
+        assertContains(sql, "table_id = 2 and column_name in (\"col4\", \"col5\")");
         assertContains(sql, "table_id = 2 and column_name in (\"col7\")");
-        Assert.assertEquals(3, StringUtils.countMatches(sql, "UNION ALL"));
+        assertContains(sql, "table_id = 2 and column_name in (\"col6\")");
+        Assert.assertEquals(4, StringUtils.countMatches(sql, "UNION ALL"));
 
         sql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(2L,
                 Lists.newArrayList("col1", "col2", "col3", "col4", "col5", "col6", "col7"),
@@ -395,9 +396,10 @@ public class StatisticsSQLTest extends PlanTestBase {
                         Type.DATE));
         assertContains(sql, "column_name in (\"col1\", \"col2\")");
         assertContains(sql, "column_name in (\"col3\")");
-        assertContains(sql, "column_name in (\"col4\", \"col5\", \"col6\")");
+        assertContains(sql, "column_name in (\"col4\", \"col5\")");
         assertContains(sql, "column_name in (\"col7\")");
-        Assert.assertEquals(3, StringUtils.countMatches(sql, "UNION ALL"));
+        assertContains(sql, "column_name in (\"col6\")");
+        Assert.assertEquals(4, StringUtils.countMatches(sql, "UNION ALL"));
 
         sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL("a",
                 Lists.newArrayList("col1", "col2", "col3", "col4", "col5", "col6", "col7"),

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/hyper/HyperJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/hyper/HyperJobTest.java
@@ -132,7 +132,7 @@ public class HyperJobTest extends DistributedEnvPlanTestBase {
                 .collect(Collectors.toList());
         String sql = HyperStatisticSQLs.buildSampleSQL(db, table, table.getPartition(pid), columnStat, sampler,
                 HyperStatisticSQLs.BATCH_SAMPLE_STATISTIC_SELECT_TEMPLATE);
-        Assert.assertEquals(1, columnStat.size());
+        Assert.assertEquals(2, columnStat.size());
         List<StatementBase> stmt = SqlParser.parse(sql, connectContext.getSessionVariable());
         Assert.assertTrue(stmt.get(0) instanceof QueryStatement);
     }
@@ -206,7 +206,7 @@ public class HyperJobTest extends DistributedEnvPlanTestBase {
         assertContains(sql.get(0), "cast(IFNULL(SUM(CHAR_LENGTH(`c2`)) * 0/ COUNT(*), 0) as BIGINT), " +
                 "hex(hll_serialize(IFNULL(hll_raw(`c2`), hll_empty())))," +
                 " cast((COUNT(*) - COUNT(`c2`)) * 0 / COUNT(*) as BIGINT), " +
-                "IFNULL(MAX(LEFT(`c2`, 200)), ''), IFNULL(MIN(LEFT(`c2`, 200)), '')  " +
+                "IFNULL(MAX(LEFT(`c2`, 200)), ''), IFNULL(MIN(LEFT(`c2`, 200)), ''), cast(-1.0 as BIGINT) " +
                 "FROM base_cte_table ");
     }
 
@@ -218,17 +218,17 @@ public class HyperJobTest extends DistributedEnvPlanTestBase {
         List<HyperQueryJob> jobs = HyperQueryJob.createSampleQueryJobs(connectContext, db, table, columnNames,
                 columnTypes, List.of(pid), 1, sampler);
 
-        Assert.assertEquals(2, jobs.size());
+        Assert.assertEquals(1, jobs.size());
         Assert.assertTrue(jobs.get(0) instanceof SampleQueryJob);
 
         List<String> sql = jobs.get(0).buildQuerySQL();
-        Assert.assertEquals(1, sql.size());
+        Assert.assertEquals(2, sql.size());
 
-        assertContains(sql.get(0), "with base_cte_table as (SELECT * FROM `test`.`t_struct` LIMIT 200000) ");
-        assertContains(sql.get(0), "'c6.c.b', cast(0 as BIGINT), cast(4 * 0 as BIGINT), ");
-        assertContains(sql.get(0), "hex(hll_serialize(IFNULL(hll_raw(`c6`.`c`.`b`), hll_empty()))), ");
-        assertContains(sql.get(0), "cast((COUNT(*) - COUNT(`c6`.`c`.`b`)) * 0 / COUNT(*) as BIGINT), " +
-                "IFNULL(MAX(`c6`.`c`.`b`), ''), IFNULL(MIN(`c6`.`c`.`b`), '')  FROM base_cte_table ");
+        assertContains(sql.get(1), "with base_cte_table as (SELECT * FROM `test`.`t_struct` LIMIT 200000) ");
+        assertContains(sql.get(1), "'c6.c.b', cast(0 as BIGINT), cast(4 * 0 as BIGINT), ");
+        assertContains(sql.get(1), "hex(hll_serialize(IFNULL(hll_raw(`c6`.`c`.`b`), hll_empty()))), ");
+        assertContains(sql.get(1), "cast((COUNT(*) - COUNT(`c6`.`c`.`b`)) * 0 / COUNT(*) as BIGINT), " +
+                "IFNULL(MAX(`c6`.`c`.`b`), ''), IFNULL(MIN(`c6`.`c`.`b`), ''), cast(-1.0 as BIGINT) FROM base_cte_table");
     }
 
     @AfterClass

--- a/gensrc/thrift/Data.thrift
+++ b/gensrc/thrift/Data.thrift
@@ -120,6 +120,7 @@ struct TStatisticData {
     // the batch load version
     15: optional binary hll
     16: optional string partitionName
+    17: optional i64 collectionSize
 }
 
 // Result data for user variable

--- a/test/sql/test_refresh_statistics/R/test_clear_stats
+++ b/test/sql/test_refresh_statistics/R/test_clear_stats
@@ -30,7 +30,7 @@ test_clear_stats.tbl	analyze	status	OK
 -- !result
 insert into _statistics_.column_statistics
 select
-table_id, 1 , column_name, db_id, table_name, partition_name, row_count, data_size, ndv, null_count,max, min, '2024-05-01'
+table_id, 1 , column_name, db_id, table_name, partition_name, row_count, data_size, ndv, null_count,max, min, '2024-05-01', collection_size  
 from _statistics_.column_statistics where table_name = 'test_clear_stats.tbl' limit 1;
 -- result:
 -- !result

--- a/test/sql/test_refresh_statistics/T/test_clear_stats
+++ b/test/sql/test_refresh_statistics/T/test_clear_stats
@@ -20,7 +20,7 @@ insert into tbl values (1, 1);
 analyze table test_clear_stats.tbl WITH SYNC MODE;
 insert into _statistics_.column_statistics
 select
-table_id, 1 , column_name, db_id, table_name, partition_name, row_count, data_size, ndv, null_count,max, min, '2024-05-01'
+table_id, 1 , column_name, db_id, table_name, partition_name, row_count, data_size, ndv, null_count,max, min, '2024-05-01', collection_size
 from _statistics_.column_statistics where table_name = 'test_clear_stats.tbl' limit 1;
 select sleep(2);
 select count(*) > 2 from _statistics_.column_statistics where table_name = 'test_clear_stats.tbl';


### PR DESCRIPTION
## Why I'm doing:
Currently, statistics of array/map types are all mock. When executing analyze table, no actual analyze job is executed to scan the real data. Therefore, if users use table functions like unnest, we are currently unable to estimate the number of rows after array/map expansion, which may cause join order errors in some cases.

## What I'm doing:
This patch support collecting array/map type column statistics. And I will support to calculate unnest table function in the next pr base on this patch.

For unnest estimation, we only need to record the average size of the array/map. For example, the average size of `[1,2,3], [1,7], [5]` is 2. 
We added a new field `collection_size` to `column_statistics` of `_statistics_` to record the average size of the collection type. 

Collection type statistics implement</div><div>
  | base | optimized
-- | -- | --
Row count | From olap partition in the fe | count(*)
ndv | 0 | 0
null_count | 0 |   0
data_size | 16 * row_count |  element_type_size * count(*) * collection_size()
min | NAN | NAN
max | NAN | NAN
collection_size |   | Array: avg(array_length(arr_col))   </div><div> Map:   avg(map_size(map_col)) </div><div> Others: -1

collect statistics performance test
Mainly compare the collection of primitive types and array/map types of different collection_size
case with 1000000000 rows

  | collection_size = 1 | collection_size = 2 | collection_size = 3 | collection_size = 4 | collection_size = 5 | collection_size = 6 | collection_size = 8
-- | -- | -- | -- | -- | -- | -- | --
bigint | 4.6
array<bigint> | 4.1 | 5.4 | 5.3 | 5.4 | 5.6 | 5.6 | 5.2
map<bigint, bigint> | 5.05 | 7.6 | 7.6 | 7.6 | 7.6 | 7.6 | 7.55


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0