### PR TITLE
[Enhancement] smooth the jemalloc memory fragmentation

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -82,7 +82,7 @@ CONF_String(mem_limit, "90%");
 
 // Enable the jemalloc tracker, which is responsible for reserving memory
 CONF_Bool(enable_jemalloc_memory_tracker, "true");
-// Consider part of jemalloc memory as fragmentation: ratio * (RSS-allocated-metadata)
+// Alpha number of jemalloc memory fragmentation ratio, should in range (0, 1)
 CONF_mDouble(jemalloc_fragmentation_ratio, "0.3");
 
 // The port heartbeat service used.

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -216,20 +216,25 @@ void jemalloc_tracker_daemon(void* arg_this) {
         JemallocStats stats;
         retrieve_jemalloc_stats(&stats);
 
-        // metadata
+        // Jemalloc metadata
         if (GlobalEnv::GetInstance()->jemalloc_metadata_traker() && stats.metadata > 0) {
             auto tracker = GlobalEnv::GetInstance()->jemalloc_metadata_traker();
             int64_t delta = stats.metadata - tracker->consumption();
             tracker->consume(delta);
         }
 
-        // fragmentation
+        // Fragmentation and dirty memory:
+        // Jemalloc retains some dirty memory and gradually returns it to the OS, which cannot be reused by the application.
+        // Failing to account for this memory in the MemoryTracker may lead to memory allocation failures or even process
+        // termination by the OS; however, retaining excessive memory in the tracker is also wasteful.
+        // To address this, we employ a smoothing formula to track fragmentation and dirty memory, which also mitigates
+        // the impact of sudden memory releases, such as those occurring when a large query is executed:
+        // S_t = \exp\left(\alpha \cdot \log(1 + x_t) + (1 - \alpha) \cdot \log(1 + S_{t-1})\right) - 1
         if (GlobalEnv::GetInstance()->jemalloc_fragmentation_traker()) {
             if (stats.resident > 0 && stats.allocated > 0 && stats.metadata > 0) {
                 double fragmentation = stats.resident - stats.allocated - stats.metadata;
                 if (fragmentation < 0) fragmentation = 0;
 
-                // S_t = \exp\left(\alpha \cdot \log(1 + x_t) + (1 - \alpha) \cdot \log(1 + S_{t-1})\right) - 1
                 // log transformation
                 double alpha = std::clamp(config::jemalloc_fragmentation_ratio, 0.1, 0.9);
                 fragmentation = std::log1p(fragmentation);

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -211,6 +211,7 @@ static void retrieve_jemalloc_stats(JemallocStats* stats) {
 // Tracker the memory usage of jemalloc
 void jemalloc_tracker_daemon(void* arg_this) {
     auto* daemon = static_cast<Daemon*>(arg_this);
+    double smoothed_fragmentation = 0;
     while (!daemon->stopped()) {
         JemallocStats stats;
         retrieve_jemalloc_stats(&stats);
@@ -225,14 +226,18 @@ void jemalloc_tracker_daemon(void* arg_this) {
         // fragmentation
         if (GlobalEnv::GetInstance()->jemalloc_fragmentation_traker()) {
             if (stats.resident > 0 && stats.allocated > 0 && stats.metadata > 0) {
-                int64_t fragmentation = stats.resident - stats.allocated - stats.metadata;
-                fragmentation *= config::jemalloc_fragmentation_ratio;
+                double fragmentation = stats.resident - stats.allocated - stats.metadata;
+                if (fragmentation < 0) fragmentation = 0;
 
-                // In case that released a lot of memory but not get purged, we would not consider it as fragmentation
-                bool released_a_lot = stats.allocated < (stats.resident * 0.5);
-                if (released_a_lot) {
-                    fragmentation = 0;
-                }
+                // S_t = \exp\left(\alpha \cdot \log(1 + x_t) + (1 - \alpha) \cdot \log(1 + S_{t-1})\right) - 1
+                // log transformation
+                double alpha = std::clamp(config::jemalloc_fragmentation_ratio, 0.1, 0.9);
+                fragmentation = std::log1p(fragmentation);
+                // smoothing
+                fragmentation = alpha * fragmentation + smoothed_fragmentation * (1 - alpha);
+                // restore the log value
+                smoothed_fragmentation = fragmentation;
+                fragmentation = std::expm1(fragmentation);
 
                 if (fragmentation >= 0) {
                     auto tracker = GlobalEnv::GetInstance()->jemalloc_fragmentation_traker();


### PR DESCRIPTION
## Why I'm doing:

Introduced by https://github.com/StarRocks/starrocks/pull/51382.

Jemalloc memory fragmentation can be affected by jitter, in which it will mistakenly take more memory than expected. So here we introduce a transformation to make it more smooth.

formula: $S_t = \exp\left(\alpha \cdot \log(1 + x_t) + (1 - \alpha) \cdot \log(1 + S_{t-1})\right) - 1$

<img width="902" alt="image" src="https://github.com/user-attachments/assets/b4348ccb-7235-4b02-a0c1-84a832560a34" />

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0