### PR TITLE
[Enhancement] Optimize LoadsHistorySyncer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
@@ -284,4 +284,8 @@ public class InsertLoadJob extends LoadJob {
     @Override
     public void replayOnVisible(TransactionState txnState) {
     }
+
+    public long getTableId() {
+        return tableId;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -587,9 +587,7 @@ public class LoadMgr implements MemoryTrackable {
                     continue;
                 }
                 if (loadJob.isFinal()) {
-                    if (loadJob.getFinishTimestamp() > latestFinishTime) {
-                        latestFinishTime = loadJob.getFinishTimestamp();
-                    }
+                    latestFinishTime = Math.max(latestFinishTime, loadJob.getFinishTimestamp());
                 }
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -576,11 +576,16 @@ public class LoadMgr implements MemoryTrackable {
         }
     }
 
-    public long getLatestFinishTime() {
+    public long getLatestFinishTimeExcludeTable(long dbId, long tableId) {
         long latestFinishTime = -1L;
         readLock();
         try {
             for (LoadJob loadJob : idToLoadJob.values()) {
+                if (loadJob instanceof InsertLoadJob
+                        && loadJob.getDbId() == dbId
+                        && ((InsertLoadJob) loadJob).getTableId() == tableId) {
+                    continue;
+                }
                 if (loadJob.isFinal()) {
                     if (loadJob.getFinishTimestamp() > latestFinishTime) {
                         latestFinishTime = loadJob.getFinishTimestamp();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -576,6 +576,24 @@ public class LoadMgr implements MemoryTrackable {
         }
     }
 
+    public long getLatestFinishTime() {
+        long latestFinishTime = -1L;
+        readLock();
+        try {
+            for (LoadJob loadJob : idToLoadJob.values()) {
+                if (loadJob.isFinal()) {
+                    if (loadJob.getFinishTimestamp() > latestFinishTime) {
+                        latestFinishTime = loadJob.getFinishTimestamp();
+                    }
+                }
+            }
+        } finally {
+            readUnlock();
+        }
+
+        return latestFinishTime;
+    }
+
     public List<LoadJob> getLoadJobsByDb(long dbId, String labelValue, boolean accurateMatch) {
         List<LoadJob> loadJobList = Lists.newArrayList();
         readLock();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -15,8 +15,11 @@
 package com.starrocks.load.loadv2;
 
 import com.starrocks.catalog.CatalogUtils;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.scheduler.history.TableKeeper;
@@ -118,7 +121,13 @@ public class LoadsHistorySyncer extends FrontendDaemon {
                 return;
             }
 
-            long latestFinishTime = GlobalStateMgr.getCurrentState().getLoadMgr().getLatestFinishTime();
+            Pair<Long, Long> dbTableId = getTargetDbTableId();
+            if (dbTableId == null) {
+                LOG.warn("failed to get db: {}, table: {}", LOADS_HISTORY_DB_NAME, LOADS_HISTORY_TABLE_NAME);
+                return;
+            }
+            long latestFinishTime = GlobalStateMgr.getCurrentState().getLoadMgr()
+                    .getLatestFinishTimeExcludeTable(dbTableId.first, dbTableId.second);
             if (syncedLoadFinishTime < latestFinishTime) {
                 syncData();
                 // refer to SQL:LOADS_HISTORY_SYNC. Only sync loads that completed more than 1 minute ago
@@ -141,4 +150,16 @@ public class LoadsHistorySyncer extends FrontendDaemon {
         }
     }
 
+    private Pair<Long, Long> getTargetDbTableId() {
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(LOADS_HISTORY_DB_NAME);
+        if (database == null) {
+            return null;
+        }
+        Table table = database.getTable(LOADS_HISTORY_TABLE_NAME);
+        if (table == null) {
+            return null;
+        }
+
+        return Pair.create(database.getId(), table.getId());
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -126,7 +126,8 @@ public class LoadsHistorySyncer extends FrontendDaemon {
                 syncData();
                 // refer to SQL:LOADS_HISTORY_SYNC. Only sync loads that completed more than 1 minute ago
                 long oneMinAgo = System.currentTimeMillis() - 60000;
-                syncedLoadFinishTime = Math.min(latestFinishTime, oneMinAgo);
+                // use (oneMinAgo - 10000) to cover the clock skew between FE and BE
+                syncedLoadFinishTime = Math.min(latestFinishTime, oneMinAgo - 10000);
             }
         } catch (Throwable e) {
             LOG.warn("Failed to process one round of LoadJobScheduler with error message {}", e.getMessage(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -84,7 +84,7 @@ public class LoadsHistorySyncer extends FrontendDaemon {
             new TableKeeper(LOADS_HISTORY_DB_NAME, LOADS_HISTORY_TABLE_NAME, LOADS_HISTORY_TABLE_CREATE,
                     () -> Math.max(1, Config.loads_history_retained_days));
 
-    private long syncedLoadFinishTIme = -1L;
+    private long syncedLoadFinishTime = -1L;
 
     public static TableKeeper createKeeper() {
         return KEEPER;
@@ -119,9 +119,11 @@ public class LoadsHistorySyncer extends FrontendDaemon {
             }
 
             long latestFinishTime = GlobalStateMgr.getCurrentState().getLoadMgr().getLatestFinishTime();
-            if (syncedLoadFinishTIme < latestFinishTime) {
+            if (syncedLoadFinishTime < latestFinishTime) {
                 syncData();
-                syncedLoadFinishTIme = latestFinishTime;
+                // refer to SQL:LOADS_HISTORY_SYNC. Only sync loads that completed more than 1 minute ago
+                long oneMinAgo = System.currentTimeMillis() - 60000;
+                syncedLoadFinishTime = Math.min(latestFinishTime, oneMinAgo);
             }
         } catch (Throwable e) {
             LOG.warn("Failed to process one round of LoadJobScheduler with error message {}", e.getMessage(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -123,9 +123,9 @@ public class LoadsHistorySyncer extends FrontendDaemon {
 
             long latestFinishTime = getLatestFinishTime();
             if (syncedLoadFinishTime < latestFinishTime) {
-                syncData();
                 // refer to SQL:LOADS_HISTORY_SYNC. Only sync loads that completed more than 1 minute ago
                 long oneMinAgo = System.currentTimeMillis() - 60000;
+                syncData();
                 // use (oneMinAgo - 10000) to cover the clock skew between FE and BE
                 syncedLoadFinishTime = Math.min(latestFinishTime, oneMinAgo - 10000);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -700,4 +700,19 @@ public class StreamLoadMgr implements MemoryTrackable {
                 .collect(Collectors.toList());
         return Lists.newArrayList(Pair.create(samples, (long) idToStreamLoadTask.size()));
     }
+
+    public long getLatestFinishTime() {
+        long latestTime = -1L;
+        readLock();
+        try {
+            for (StreamLoadTask task : idToStreamLoadTask.values()) {
+                if (task.isFinal()) {
+                    latestTime = Math.max(latestTime, task.getFinishTimestampMs());
+                }
+            }
+        } finally {
+            readUnlock();
+        }
+        return latestTime;
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
1. If there are no load jobs, LoadsHistorySyncer still runs.
2. LoadsHistorySyncer does not ignore its own load job, so cause Infinite loop.

## What I'm doing:
1. Record the last sync time, if there are no new load jobs, do not run sync SQL.
2. Ignore the LoadsHistorySyncer triggered dml SQL.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0