### PR TITLE
[BugFix] (Part 6) Fix partition_retention_condition for iceberg with partition transforms

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -16,6 +16,7 @@ package com.starrocks.alter;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
@@ -43,6 +44,7 @@ import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.SetStmtAnalyzer;
 import com.starrocks.sql.ast.AlterMaterializedViewStatusClause;
@@ -106,8 +108,11 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         String ttlRetentionCondition = null;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(materializedView.getDbId());
+            TableName mvTableName = new TableName(db.getFullName(), materializedView.getName());
+            Map<Expr, Expr> mvPartitionByExprToAdjustMap =
+                    MaterializedViewAnalyzer.getMVPartitionByExprToAdjustMap(mvTableName, materializedView);
             ttlRetentionCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(db,
-                    materializedView, properties, true);
+                    materializedView, properties, true, mvPartitionByExprToAdjustMap);
         }
         int partitionRefreshNumber = INVALID;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -2125,30 +2125,4 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
         return this.defineQueryParseNode;
     }
-
-    /**
-     * For MV, its schema has relations with defined query's schema.`getBaseSchema` should not return the generated columns
-     * since they are inner columns and not visible to users.
-     * For now, the generated columns of mv can be created when mv's partition expression is not slot ref and its partition type
-     * is LIST.
-     */
-    @Override
-    public List<Column> getBaseSchema() {
-        if (!hasGeneratedColumn()) {
-            return getSchemaByIndexId(baseIndexId);
-        }
-
-        List<Column> schema = Lists.newArrayList(getSchemaByIndexId(baseIndexId));
-        while (schema.size() > 0) {
-            // check last column is whether is a generated column or not
-            if (schema.get(schema.size() - 1).isGeneratedColumn()) {
-                schema.remove(schema.size() - 1);
-            } else {
-                break;
-            }
-        }
-        return schema;
-    }
-
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -277,6 +277,7 @@ public abstract class MVTimelinessArbiter {
                     mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName));
         }
         addEmptyPartitionsToRefresh(mvUpdateInfo);
+        collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo);
         collectMVToBaseTablePartitionNames(refBaseTablePartitionMap, diff, mvUpdateInfo);
         return mvUpdateInfo;
     }
@@ -313,6 +314,28 @@ public abstract class MVTimelinessArbiter {
             return null;
         }
         return Sets.newHashSet(retentionPartitionNames);
+    }
+
+    /**
+     * TODO: Optimize performance in loos/force_mv mode
+     */
+    protected void collectBaseTableUpdatePartitionNamesInLoose(MvUpdateInfo mvUpdateInfo) {
+        Map<Table, List<Column>> refBaseTableAndColumns = mv.getRefBaseTablePartitionColumns();
+        // collect & update mv's to refresh partitions based on base table's partition changes
+        collectBaseTableUpdatePartitionNames(refBaseTableAndColumns, mvUpdateInfo);
+        Set<Table> refBaseTables = mv.getRefBaseTablePartitionColumns().keySet();
+        MaterializedView.AsyncRefreshContext context = mv.getRefreshScheme().getAsyncRefreshContext();
+        for (Table table : refBaseTables) {
+            Map<String, MaterializedView.BasePartitionInfo> mvBaseTableVisibleVersionMap =
+                    context.getBaseTableVisibleVersionMap()
+                            .computeIfAbsent(table.getId(), k -> Maps.newHashMap());
+            for (String partitionName : mvBaseTableVisibleVersionMap.keySet()) {
+                if (mvUpdateInfo.getBaseTableToRefreshPartitionNames(table) != null) {
+                    // in loose mode, ignore partition that both exists in baseTable and mv
+                    mvUpdateInfo.getBaseTableToRefreshPartitionNames(table).remove(partitionName);
+                }
+            }
+        }
     }
 
     /**
@@ -356,6 +379,7 @@ public abstract class MVTimelinessArbiter {
         if (CollectionUtils.isEmpty(mvUpdateInfo.getMvToRefreshPartitionNames())) {
             return mvUpdateInfo;
         }
+        collectBaseTableUpdatePartitionNamesInLoose(mvUpdateInfo);
         // collect base table's partition infos
         collectMVToBaseTablePartitionNames(refBaseTablePartitionMap, diff, mvUpdateInfo);
         return mvUpdateInfo;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -426,7 +426,8 @@ public class PropertyAnalyzer {
     public static String analyzePartitionRetentionCondition(Database db,
                                                             OlapTable olapTable,
                                                             Map<String, String> properties,
-                                                            boolean removeProperties) {
+                                                            boolean removeProperties,
+                                                            Map<Expr, Expr> exprToAdjustMap) {
         String partitionRetentionCondition = "";
         if (properties != null && properties.containsKey(PROPERTIES_PARTITION_RETENTION_CONDITION)) {
             partitionRetentionCondition = properties.get(PROPERTIES_PARTITION_RETENTION_CONDITION);
@@ -446,8 +447,9 @@ public class PropertyAnalyzer {
             // validate retention condition
             TableName tableName = new TableName(db.getFullName(), olapTable.getName());
             ConnectContext connectContext = ConnectContext.get() == null ? new ConnectContext(null) : ConnectContext.get();
+
             try {
-                PartitionSelector.getPartitionIdsByExpr(connectContext, tableName, olapTable, whereExpr, false);
+                PartitionSelector.getPartitionIdsByExpr(connectContext, tableName, olapTable, whereExpr, false, exprToAdjustMap);
             } catch (Exception e) {
                 throw new SemanticException("Failed to validate retention condition: " + e.getMessage());
             }
@@ -1410,7 +1412,8 @@ public class PropertyAnalyzer {
     public static void analyzeMVProperties(Database db,
                                            MaterializedView materializedView,
                                            Map<String, String> properties,
-                                           boolean isNonPartitioned) throws DdlException {
+                                           boolean isNonPartitioned,
+                                           Map<Expr, Expr> exprAdjustedMap) throws DdlException {
         try {
             // replicated storage
             materializedView.setEnableReplicatedStorage(
@@ -1474,7 +1477,7 @@ public class PropertyAnalyzer {
                             + " is only supported by partitioned materialized-view");
                 }
                 String ttlRetentionCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(db, materializedView,
-                        properties, true);
+                        properties, true, exprAdjustedMap);
                 materializedView.getTableProperty().getProperties()
                         .put(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION, ttlRetentionCondition);
                 materializedView.getTableProperty().setPartitionRetentionCondition(ttlRetentionCondition);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1034,7 +1034,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         // may be different from the defined query's output.
         // so set materialized view's defined outputs as target columns.
         List<Integer> queryOutputIndexes = materializedView.getQueryOutputIndices();
-        List<Column> baseSchema = materializedView.getBaseSchema();
+        List<Column> baseSchema = materializedView.getBaseSchemaWithoutGeneratedColumn();
         if (queryOutputIndexes != null && baseSchema.size() == queryOutputIndexes.size()) {
             List<String> targetColumnNames = queryOutputIndexes.stream()
                     .map(baseSchema::get)

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2981,7 +2981,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         boolean isNonPartitioned = partitionInfo.isUnPartitioned();
         DataProperty dataProperty = PropertyAnalyzer.analyzeMVDataProperty(materializedView, properties);
-        PropertyAnalyzer.analyzeMVProperties(db, materializedView, properties, isNonPartitioned);
+        PropertyAnalyzer.analyzeMVProperties(db, materializedView, properties, isNonPartitioned,
+                stmt.getPartitionByExprToAdjustExprMap());
         try {
             Set<Long> tabletIdSet = new HashSet<>();
             // process single partition info
@@ -3063,12 +3064,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 for (int i = 0; i < partitionByExprs.size(); i++) {
                     Expr partitionByExpr = partitionByExprs.get(i);
                     Column mvPartitionColumn = mvPartitionColumns.get(i);
-                    if (!(partitionByExpr instanceof SlotRef || MvUtils.isFuncCallExpr(partitionByExpr,
-                            FunctionSet.DATE_TRUNC))) {
-                        throw new DdlException("List partition only support partition by slot ref column or date_trunc:"
-                                + partitionByExpr.toSql());
-                    }
-                    if (!(partitionByExpr instanceof SlotRef)) {
+                    // generate column can be any partition expression.
+                    if (generatedPartitionCols.containsKey(i)) {
                         Column generatedCol = generatedPartitionCols.get(i);
                         if (generatedCol == null) {
                             throw new DdlException("Partition expression for list must be a generated column: "
@@ -3077,6 +3074,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         baseSchema.add(generatedCol);
                         newPartitionColumns.add(generatedCol);
                     } else {
+                        if (!(partitionByExpr instanceof SlotRef || MvUtils.isFuncCallExpr(partitionByExpr,
+                                FunctionSet.DATE_TRUNC))) {
+                            throw new DdlException("List partition expression can only be ref-base-table's partition " +
+                                    "expression but contains: " + partitionByExpr.toSql());
+                        }
                         newPartitionColumns.add(mvPartitionColumn);
                     }
                 }
@@ -3684,7 +3686,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         + "no need to set partition retention condition.");
             }
             String partitionRetentionCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(
-                    db, table, properties, true);
+                    db, table, properties, true, null);
             if (Strings.isNullOrEmpty(partitionRetentionCondition)) {
                 throw new DdlException("Invalid partition retention condition");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -671,7 +671,8 @@ public class OlapTableFactory implements AbstractTableFactory {
 
             // analyze partition retention condition
             if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_RETENTION_CONDITION)) {
-                String ttlCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(db, table, properties, true);
+                String ttlCondition = PropertyAnalyzer.analyzePartitionRetentionCondition(db, table, properties,
+                        true, null);
                 if (ttlCondition == null) {
                     throw new DdlException("Invalid partition retention condition");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.ExprSubstitutionMap;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.SlotDescriptor;
@@ -358,18 +359,21 @@ public class MaterializedViewAnalyzer {
                 // check partition expression all in column list and
                 // write the expr into partitionExpDesc if partition expression exists
                 checkExpInColumn(statement);
+                // replace partition by expr with resolved partition by expr
+                Map<Integer, Expr> changedPartitionByExprs = getBaseTableExprToGeneratedColumnMap(context,
+                        aliasTableMap, statement.getPartitionByExprs(), statement.getQueryStatement());
                 // check partition expression is supported
-                checkPartitionColumnExprs(statement, columnExprMap, context);
+                checkPartitionColumnExprs(statement, columnExprMap, changedPartitionByExprs, aliasTableMap, context);
                 // check whether partition expression functions are allowed if it exists
                 checkPartitionExpPatterns(statement);
                 // check partition column must be base table's partition column
-                checkPartitionColumnWithBaseTable(statement, aliasTableMap);
+                checkPartitionColumnWithBaseTable(statement, changedPartitionByExprs, aliasTableMap);
                 // check window function can be used in partitioned mv
                 checkWindowFunctions(statement, columnExprMap);
                 // determine mv partition 's type: list or range
                 checkMVPartitionInfoType(statement, aliasTableMap);
                 // deduce generate partition infos for list partition expressions
-                checkMVGeneratedPartitionColumns(statement, aliasTableMap);
+                checkMVGeneratedPartitionColumns(statement, changedPartitionByExprs, aliasTableMap);
             }
             // check and analyze distribution
             checkDistribution(statement, aliasTableMap);
@@ -688,6 +692,8 @@ public class MaterializedViewAnalyzer {
 
         private void checkPartitionColumnExprs(CreateMaterializedViewStatement statement,
                                                Map<Column, Expr> columnExprMap,
+                                               Map<Integer, Expr> changedPartitionByExprs,
+                                               Map<TableName, Table> aliasTableMap,
                                                ConnectContext connectContext) throws SemanticException {
             List<Expr> partitionByExprs = statement.getPartitionByExprs();
             if (CollectionUtils.isEmpty(partitionByExprs)) {
@@ -701,15 +707,22 @@ public class MaterializedViewAnalyzer {
 
             // partition column expr from input query
             List<Expr> refTablePartitionExprs = new ArrayList<>();
+            List<Expr> newPartitionByExprs = new ArrayList<>();
             for (int i = 0; i < partitionByExprs.size(); i++) {
-                Column partitionColumn = partitionColumns.get(i);
                 // mv's defined partition by expr
                 Expr mvPartitionByExpr = partitionByExprs.get(i);
+                // for generated column partition expression, use generated column instead
+                if (changedPartitionByExprs.containsKey(i)) {
+                    newPartitionByExprs.add(changedPartitionByExprs.get(i));
+                } else {
+                    newPartitionByExprs.add(mvPartitionByExpr);
+                }
+                Column partitionColumn = partitionColumns.get(i);
                 // mv's resolved partition by expr which can be used to check
                 Expr partitionColumnExpr = columnExprMap.get(partitionColumn);
                 try {
                     partitionColumnExpr = resolvePartitionExpr(partitionColumnExpr, connectContext,
-                            statement.getQueryStatement());
+                            statement.getQueryStatement(), aliasTableMap);
                 } catch (Exception e) {
                     LOG.warn("resolve partition column failed", e);
                     throw new SemanticException("Resolve partition column failed:" + e.getMessage(),
@@ -752,6 +765,32 @@ public class MaterializedViewAnalyzer {
                 }
             }
             statement.setPartitionRefTableExpr(refTablePartitionExprs);
+            statement.setPartitionByExprs(newPartitionByExprs);
+        }
+
+        private Expr getResolvedPartitionByExpr(Expr partitionColumnExpr,
+                                                QueryStatement queryStatement) {
+            Expr expr = MVPartitionSlotRefResolver.resolveExpr(partitionColumnExpr, queryStatement);
+            if (expr == null) {
+                throw new SemanticException("Cannot resolve materialized view's partition expression:%s",
+                        partitionColumnExpr.toSql());
+            }
+            return expr;
+        }
+
+        private Table getPartitionByExprRefBaseTable(ConnectContext connectContext,
+                                                     Map<TableName, Table> aliasTableMap,
+                                                     SlotRef slot) {
+            TableName tableName = slot.getTblNameWithoutAnalyzed();
+            tableName.normalization(connectContext);
+            Table table = aliasTableMap.get(tableName);
+            if (table == null) {
+                String catalog = tableName.getCatalog() == null ?
+                        InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME : tableName.getCatalog();
+                table = connectContext.getGlobalStateMgr()
+                        .getMetadataMgr().getTable(catalog, tableName.getDb(), tableName.getTbl());
+            }
+            return table;
         }
 
         /**
@@ -764,36 +803,23 @@ public class MaterializedViewAnalyzer {
          */
         private Expr resolvePartitionExpr(Expr partitionColumnExpr,
                                           ConnectContext connectContext,
-                                          QueryStatement queryStatement) {
-            Expr expr = MVPartitionSlotRefResolver.resolveExpr(partitionColumnExpr, queryStatement);
-            if (expr == null) {
-                throw new SemanticException("Cannot resolve materialized view's partition expression:%s",
+                                          QueryStatement queryStatement,
+                                          Map<TableName, Table> aliasTableMap) {
+            Expr expr = getResolvedPartitionByExpr(partitionColumnExpr, queryStatement);
+            List<SlotRef> slotRefs = expr.collectAllSlotRefs();
+            if (slotRefs.size() != 1) {
+                throw new SemanticException("Materialized view partition expression %s must ref to one column",
                         partitionColumnExpr.toSql());
             }
-            SlotRef slot;
-            if (expr instanceof SlotRef) {
-                slot = (SlotRef) expr;
-            } else {
-                slot = getSlotRef(expr);
-            }
-            Map<TableName, Table> aliasTableMap = getNormalizedBaseTables(queryStatement, connectContext);
-            TableName tableName = slot.getTblNameWithoutAnalyzed();
-            tableName.normalization(connectContext);
-
-            Table table = aliasTableMap.get(tableName);
+            SlotRef slotRef = slotRefs.get(0);
+            Table table = getPartitionByExprRefBaseTable(connectContext, aliasTableMap, slotRef);
             if (table == null) {
-                String catalog = tableName.getCatalog() == null ?
-                        InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME : tableName.getCatalog();
-                table = connectContext.getGlobalStateMgr()
-                        .getMetadataMgr().getTable(catalog, tableName.getDb(), tableName.getTbl());
-                if (table == null) {
-                    throw new SemanticException("Materialized view partition expression %s could only ref to base table",
-                            slot.toSql());
-                }
+                throw new SemanticException("Materialized view partition expression %s could only ref to base table",
+                        slotRef.toSql());
             }
             // TableName's catalog may be null, so normalization it
-            slot.getTblNameWithoutAnalyzed().normalization(connectContext);
-            slot.setType(table.getColumn(slot.getColumnName()).getType());
+            slotRef.getTblNameWithoutAnalyzed().normalization(connectContext);
+            slotRef.setType(table.getColumn(slotRef.getColumnName()).getType());
             return expr;
         }
 
@@ -817,18 +843,95 @@ public class MaterializedViewAnalyzer {
             }
         }
 
+        private Map<Integer, Expr> getBaseTableExprToGeneratedColumnMap(ConnectContext session,
+                                                                        Map<TableName, Table> tableNameTableMap,
+                                                                        List<Expr> partitionByExprs,
+                                                                        QueryStatement queryStatement) {
+            Map<Integer, Expr> changedPartitionByExprs = new HashMap<>();
+            if (CollectionUtils.isEmpty(partitionByExprs)) {
+                return changedPartitionByExprs;
+            }
+            Expr partitionByExpr = partitionByExprs.get(0);
+            Expr resolvedPartitionByExpr = getResolvedPartitionByExpr(partitionByExpr, queryStatement);
+            List<SlotRef> slotRefs = resolvedPartitionByExpr.collectAllSlotRefs();
+            if (slotRefs.size() != 1) {
+                throw new SemanticException("Materialized view partition expression %s must ref to one column",
+                        partitionByExpr.toSql());
+            }
+            SlotRef slotRef = slotRefs.get(0);
+            Table table = getPartitionByExprRefBaseTable(session, tableNameTableMap, slotRef);
+            if (table == null) {
+                throw new SemanticException("Materialized view partition expression %s could only ref to base table",
+                        slotRef.toSql());
+            }
+            if (!table.isNativeTableOrMaterializedView()) {
+                return changedPartitionByExprs;
+            }
+            // if expr is generated column expression, replace with generated column
+            OlapTable olapTable = (OlapTable) table;
+            if (!olapTable.getPartitionInfo().isListPartition() || !olapTable.hasGeneratedColumn()) {
+                return changedPartitionByExprs;
+            }
+            TableName tableName = slotRef.getTblNameWithoutAnalyzed();
+            Scope scope = new Scope(RelationId.anonymous(), new RelationFields(
+                    olapTable.getBaseSchema().stream()
+                            .map(col -> new Field(col.getName(), col.getType(), tableName, null))
+                            .collect(Collectors.toList())));
+            Map<Expr, Expr> generatedExprToColumnRef = new HashMap<>();
+            for (Column column : olapTable.getBaseSchema()) {
+                Expr generatedColumnExpression = column.getGeneratedColumnExpr(olapTable.getIdToColumn());
+                if (generatedColumnExpression != null) {
+                    SlotRef gcSlotRef = new SlotRef(null, column.getName());
+                    ExpressionAnalyzer.analyzeExpression(generatedColumnExpression, new AnalyzeState(),
+                            scope, session);
+                    ExpressionAnalyzer.analyzeExpression(slotRef, new AnalyzeState(), scope, session);
+                    generatedExprToColumnRef.put(generatedColumnExpression, gcSlotRef);
+                }
+            }
+            for (int i = 0; i < partitionByExprs.size(); i++) {
+                Expr expr = partitionByExprs.get(i);
+                Expr newExpr = substituteExprByGeneratedColumn(session, scope, expr, generatedExprToColumnRef);
+                // record the ith partition expr and its resolved expr
+                if (!expr.equals(newExpr)) {
+                    changedPartitionByExprs.put(i, newExpr);
+                }
+            }
+            return changedPartitionByExprs;
+        }
+
+        private Expr substituteExprByGeneratedColumn(ConnectContext session,
+                                                     Scope scope,
+                                                     Expr expr,
+                                                     Map<Expr, Expr> generatedExprToColumnRef) {
+            ExpressionAnalyzer.analyzeExpression(expr, new AnalyzeState(), scope, session);
+            return adjustWhereExprIfNeeded(generatedExprToColumnRef, expr, scope, session);
+        }
+
         private void checkPartitionColumnWithBaseTable(CreateMaterializedViewStatement statement,
+                                                       Map<Integer, Expr> changedPartitionByExprs,
                                                        Map<TableName, Table> tableNameTableMap) {
             List<Expr> partitionRefTableExprs = statement.getPartitionRefTableExpr();
-            for (Expr expr : partitionRefTableExprs) {
+            for (int i = 0; i < partitionRefTableExprs.size(); i++) {
+                Expr expr = partitionRefTableExprs.get(i);
                 SlotRef slotRef = getSlotRef(expr);
-                Table table = tableNameTableMap.get(slotRef.getTblNameWithoutAnalyzed());
-
+                TableName tableName = slotRef.getTblNameWithoutAnalyzed();
+                Table table = tableNameTableMap.get(tableName);
                 if (table == null) {
                     throw new SemanticException("Materialized view partition expression %s could only ref to base table",
                             slotRef.toSql());
-                } else if (table.isNativeTableOrMaterializedView()) {
-                    checkPartitionColumnWithBaseOlapTable(slotRef, (OlapTable) table);
+                }
+                if (table.isNativeTableOrMaterializedView()) {
+                    OlapTable olapTable = (OlapTable) table;
+                    if (changedPartitionByExprs.containsKey(i)) {
+                        // if generated column has changed partition by expr, use the new partition by expr
+                        Expr newPartitionByExpr = changedPartitionByExprs.get(i);
+                        if (!(newPartitionByExpr instanceof SlotRef)) {
+                            throw new SemanticException("Materialized view partition expression %s could only ref base table's " +
+                                    "partition expression without any change", slotRef.toSql());
+                        }
+                        slotRef = (SlotRef) newPartitionByExpr;
+                    }
+                    checkPartitionColumnWithBaseOlapTable(slotRef, olapTable);
                 } else if (table.isHiveTable() || table.isHudiTable() || table.isOdpsTable()) {
                     checkPartitionColumnWithBaseHMSTable(slotRef, table);
                 } else if (table.isIcebergTable()) {
@@ -932,6 +1035,7 @@ public class MaterializedViewAnalyzer {
         }
 
         private void checkMVGeneratedPartitionColumns(CreateMaterializedViewStatement statement,
+                                                      Map<Integer, Expr> changedPartitionByExprs,
                                                       Map<TableName, Table> tableNameTableMap) {
             PartitionType partitionType = statement.getPartitionType();
             if (partitionType != PartitionType.LIST) {
@@ -943,19 +1047,26 @@ public class MaterializedViewAnalyzer {
             TableName mvTableName = statement.getTableName();
             List<Column> mvColumns = statement.getMvColumnItems();
             List<Expr> partitionRefTableExprs = statement.getPartitionRefTableExpr();
+            Map<Expr, Expr> partitionByExprToAdjustExprMap = statement.getPartitionByExprToAdjustExprMap();
             for (int i = 0; i < partitionRefTableExprs.size(); i++) {
                 Expr expr = partitionRefTableExprs.get(i);
-                if (expr instanceof SlotRef) {
+                if (!(expr instanceof FunctionCallExpr)) {
                     continue;
                 }
                 FunctionCallExpr partitionByExpr = (FunctionCallExpr) expr;
                 FunctionCallExpr cloned = (FunctionCallExpr) partitionByExpr.clone();
-                Column generatedCol = getGeneratedPartitionColumn(mvColumns, mvTableName,
-                        cloned, tableNameTableMap, placeholder);
+                Expr adjustedPartitionByExpr = getMVAdjustedPartitionByExpr(i, cloned, mvColumns,
+                        mvTableName, tableNameTableMap, changedPartitionByExprs, partitionByExprToAdjustExprMap);
+                // if partition by expr is not changed, skip
+                if (adjustedPartitionByExpr == null || adjustedPartitionByExpr.equals(expr)) {
+                    continue;
+                }
+                Column generatedCol = getGeneratedPartitionColumn(adjustedPartitionByExpr, placeholder);
                 if (generatedCol == null) {
                     throw new SemanticException("Create generated partition expression column failed:",
                             partitionByExpr.toSql());
                 }
+                placeholder += 1;
                 generatedPartitionColumns.put(i, generatedCol);
             }
         }
@@ -990,7 +1101,7 @@ public class MaterializedViewAnalyzer {
                 Set<String> partitionColumns = listPartitionInfo.getPartitionColumns(table.getIdToColumn()).stream()
                         .map(col -> col.getName())
                         .collect(Collectors.toSet());
-                // mv's partition columns should be subset of the base table's partition columns
+                // mv's partition columns should be a subset of the base table's partition columns
                 if (!partitionColumns.contains(slotRef.getColumnName())) {
                     throw new SemanticException("Materialized view partition column in partition exp " +
                             "must be base table partition column");
@@ -1432,45 +1543,9 @@ public class MaterializedViewAnalyzer {
      * - Iceberg table's timestamp-with-zone's default timezone is UTC
      * - Starrocks table's timestamp type is no timezone and its time is converted to local timezone.
      */
-    private static Column getGeneratedPartitionColumn(List<Column> mvColumns,
-                                                      TableName mvTableName,
-                                                      FunctionCallExpr partitionByExpr,
-                                                      Map<TableName, Table> tableNameTableMap,
+    private static Column getGeneratedPartitionColumn(Expr adjustedPartitionByExpr,
                                                       int placeHolderSlotId) {
-        List<SlotRef> slotRefs = partitionByExpr.collectAllSlotRefs();
-        if (slotRefs.size() != 1) {
-            throw new SemanticException("Partition expr only can ref one slot refs:",
-                    partitionByExpr.toSql());
-        }
-        SlotRef slotRef = slotRefs.get(0);
-        TableName refTableName = slotRef.getTblNameWithoutAnalyzed();
-        Table refBaseTable = tableNameTableMap.get(refTableName);
-        if (refBaseTable == null) {
-            throw new SemanticException("Materialized view partition expression %s could only ref to base table",
-                    slotRef.toSql());
-        }
-        if (!(refBaseTable instanceof IcebergTable)) {
-            throw new SemanticException("Partition expression with function is not supported yet:"
-                    + partitionByExpr.toSqlImpl());
-        }
 
-        // why resolve slot ref to mv columns?
-        // generated column should refer mv's defined column, but partitionByExpr is ref to base table's column,
-        // so resolve slot ref to mv columns.
-        resolveRefToMVColumns(mvColumns, slotRef, mvTableName);
-
-        // change timezone, date_trunc('day', dt) -> date_trunc('day', date_sub(dt, interval 8 hour))
-        IcebergTable icebergTable = (IcebergTable) refBaseTable;
-        int zoneHourOffset = getIcebergPartitionColumnTimeZoneOffset(icebergTable, slotRef);
-        Expr adjustedPartitionByExpr = partitionByExpr;
-        if (MvUtils.isFuncCallExpr(partitionByExpr, FunctionSet.DATE_TRUNC)) {
-            adjustedPartitionByExpr = getAdjustPartitionExpr(partitionByExpr, slotRef, zoneHourOffset);
-        }
-        ExpressionAnalyzer.analyzeExpression(adjustedPartitionByExpr, new AnalyzeState(), new Scope(RelationId.anonymous(),
-                        new RelationFields(mvColumns.stream().map(col -> new Field(col.getName(),
-                                col.getType(), mvTableName, null)).collect(Collectors.toList()))),
-                new ConnectContext());
-        String columnName = FeConstants.GENERATED_PARTITION_COLUMN_PREFIX + placeHolderSlotId;
         Type type = adjustedPartitionByExpr.getType();
         if (type.isScalarType()) {
             ScalarType scalarType = (ScalarType) type;
@@ -1480,6 +1555,7 @@ public class MaterializedViewAnalyzer {
                 type = ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
             }
         }
+        String columnName = FeConstants.GENERATED_PARTITION_COLUMN_PREFIX + placeHolderSlotId;
         TypeDef typeDef = new TypeDef(type);
         try {
             typeDef.analyze();
@@ -1493,8 +1569,177 @@ public class MaterializedViewAnalyzer {
         return generatedPartitionColumn.toColumn(null);
     }
 
-    private static int getIcebergPartitionColumnTimeZoneOffset(IcebergTable icebergTable,
-                                                               SlotRef slotRef) {
+    /**
+     * Support to adjust partition-by-expression if ref-base-table is an Iceberg Table or OlapTable
+     * - Adjust partition expr timezone for iceberg table with timestamp-with-zone type.
+     * - Adjust partition expr if olap table's with common partition expression.
+     */
+    public static Expr getMVAdjustedPartitionByExpr(Integer i,
+                                                    Expr partitionByExpr,
+                                                    List<Column> mvColumns,
+                                                    TableName mvTableName,
+                                                    Map<TableName, Table> refTableNameTableMap,
+                                                    Map<Integer, Expr> changedPartitionByExprs,
+                                                    Map<Expr, Expr> partitionByExprToAdjustExprMap) {
+        List<SlotRef> slotRefs = partitionByExpr.collectAllSlotRefs();
+        if (slotRefs.size() != 1) {
+            throw new SemanticException("Partition expr only can ref one slot refs:",
+                    partitionByExpr.toSql());
+        }
+        SlotRef slotRef = slotRefs.get(0);
+        TableName refTableName = slotRef.getTblNameWithoutAnalyzed();
+        Table refBaseTable = refTableNameTableMap.get(refTableName);
+        if (refBaseTable == null) {
+            throw new SemanticException("Materialized view partition expression %s could only ref to base table",
+                    slotRef.toSql());
+        }
+        return getMVAdjustedPartitionByExpr(i, partitionByExpr, mvColumns, mvTableName, slotRef, refBaseTable,
+                changedPartitionByExprs, partitionByExprToAdjustExprMap);
+    }
+
+    /**
+     * Why need to maintain partitionByExprToAdjustExprMap?
+     * If a mv has `partition_retention_condition` property, since the partition expr is changed, we need to
+     * adjust the partition expr in `partition_retention_condition` to the new partition expr.
+     */
+    public static Expr getMVAdjustedPartitionByExpr(Integer i,
+                                                    Expr partitionByExpr,
+                                                    List<Column> mvColumns,
+                                                    TableName mvTableName,
+                                                    SlotRef slotRef,
+                                                    Table refBaseTable,
+                                                    Map<Integer, Expr> changedPartitionByExprs,
+                                                    Map<Expr, Expr> partitionByExprToAdjustExprMap) {
+        Expr originalPartitionByExpr = partitionByExpr.clone();
+        // change timezone, date_trunc('day', dt) -> date_trunc('day', date_sub(dt, interval 8 hour))
+        Expr adjustedPartitionByExpr;
+        if (refBaseTable instanceof IcebergTable) {
+            IcebergTable icebergTable = (IcebergTable) refBaseTable;
+            adjustedPartitionByExpr = getAdjustedIcebergPartitionExpr(mvColumns, mvTableName, slotRef, icebergTable,
+                    partitionByExpr);
+        } else if (refBaseTable instanceof OlapTable) {
+            adjustedPartitionByExpr = getAdjustedOlapTablePartitionExpr(changedPartitionByExprs, i, mvColumns, mvTableName,
+                    slotRef, partitionByExpr);
+        } else {
+            return partitionByExpr;
+        }
+        if (adjustedPartitionByExpr.equals(partitionByExpr)) {
+            return adjustedPartitionByExpr;
+        }
+        ExpressionAnalyzer.analyzeExpression(adjustedPartitionByExpr, new AnalyzeState(), new Scope(RelationId.anonymous(),
+                        new RelationFields(mvColumns.stream().map(col -> new Field(col.getName(),
+                                col.getType(), mvTableName, null)).collect(Collectors.toList()))),
+                new ConnectContext());
+        // update partitionByExprToAdjustExprMap
+        recordPartitionByExprToAdjustExprMap(mvColumns, mvTableName, originalPartitionByExpr, adjustedPartitionByExpr,
+                partitionByExprToAdjustExprMap);
+        return adjustedPartitionByExpr;
+    }
+
+    /**
+     * Use mv's partition column to adjust original partition expr to new partition expr which is used for
+     * `partition_retention_condition` property that partition expression refs to mv's partition column.
+     */
+    private static void recordPartitionByExprToAdjustExprMap(List<Column> mvColumns,
+                                                             TableName mvTableName,
+                                                             Expr originalPartitionByExpr,
+                                                             Expr adjustedPartitionByExpr,
+                                                             Map<Expr, Expr> partitionByExprToAdjustExprMap) {
+        List<SlotRef> slotRefs = originalPartitionByExpr.collectAllSlotRefs();
+        if (slotRefs.size() != 1) {
+            throw new SemanticException("Partition expr only can ref one slot refs:",
+                    originalPartitionByExpr.toSql());
+        }
+        SlotRef slotRef = slotRefs.get(0);
+        resolveRefToMVColumns(mvColumns, slotRef, mvTableName);
+        partitionByExprToAdjustExprMap.put(originalPartitionByExpr, adjustedPartitionByExpr);
+    }
+
+    /**
+     * For generated column, change its referred slot ref from original ref-base-table's output columns to
+     * MV's output columns.
+     */
+    public static void resolveRefToMVColumns(List<Column> columns, SlotRef slotRef, TableName mvTableName) {
+        Column mvPartitionColumn = null;
+        int columnId = 0;
+        for (Column column : columns) {
+            if (slotRef.getColumnName().equalsIgnoreCase(column.getName())) {
+                mvPartitionColumn = column;
+                break;
+            }
+            columnId++;
+        }
+        if (mvPartitionColumn == null) {
+            throw new SemanticException("Materialized view partition exp column:"
+                    + slotRef.getColumnName() + " is not found in query statement");
+        }
+        SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(columnId), slotRef.getColumnName(),
+                mvPartitionColumn.getType(), mvPartitionColumn.isAllowNull());
+        slotRef.setDesc(slotDescriptor);
+        slotRef.setType(mvPartitionColumn.getType());
+        slotRef.setNullable(mvPartitionColumn.isAllowNull());
+        slotRef.setType(mvPartitionColumn.getType());
+        slotRef.setColumnName(mvPartitionColumn.getName());
+        slotRef.setTblName(mvTableName);
+    }
+
+    public static Map<Expr, Expr> getMVPartitionByExprToAdjustMap(TableName mvTableName,
+                                                                  MaterializedView mv) {
+        PartitionInfo partitionInfo = mv.getPartitionInfo();
+        if (!partitionInfo.isListPartition()) {
+            return null;
+        }
+
+        Map<Table, List<Expr>> refBaseTablePartitionExprMap = mv.getRefBaseTablePartitionExprs();
+        if (refBaseTablePartitionExprMap.size() != 1) {
+            return null;
+        }
+        Map.Entry<Table, List<Expr>> entry = refBaseTablePartitionExprMap.entrySet().iterator().next();
+        Table refBaseTable = entry.getKey();
+        List<Expr> refBaseTablePartitionExprs = entry.getValue();
+        Map<Expr, Expr> mvPartitionByExprToAdjustMap = Maps.newHashMap();
+        for (int i = 0; i < refBaseTablePartitionExprs.size(); i++) {
+            Expr expr = refBaseTablePartitionExprs.get(i);
+            Expr cloned = expr.clone();
+            List<SlotRef> slotRefs = cloned.collectAllSlotRefs();
+            if (slotRefs.size() != 1) {
+                continue;
+            }
+            SlotRef slotRef = slotRefs.get(0);
+            MaterializedViewAnalyzer.getMVAdjustedPartitionByExpr(i, cloned, mv.getColumns(),
+                    mvTableName, slotRef, refBaseTable, Maps.newHashMap(), mvPartitionByExprToAdjustMap);
+        }
+
+        return mvPartitionByExprToAdjustMap;
+    }
+
+    /**
+     * If partition by expression has changed (eg. timezone offset changed), adjust where expr to new partition expr.
+     */
+    public static Expr adjustWhereExprIfNeeded(Map<Expr, Expr> partitionByExprMap,
+                                               Expr expr,
+                                               Scope scope,
+                                               ConnectContext context) {
+        if (CollectionUtils.sizeIsEmpty(partitionByExprMap)) {
+            return expr;
+        }
+        ExprSubstitutionMap exprSubstitutionMap = new ExprSubstitutionMap(false);
+        partitionByExprMap.entrySet().forEach(e -> {
+            Expr lExpr = e.getKey();
+            Expr rExpr = e.getValue();
+            ExpressionAnalyzer.analyzeExpression(lExpr, new AnalyzeState(), scope, context);
+            ExpressionAnalyzer.analyzeExpression(rExpr, new AnalyzeState(), scope, context);
+            exprSubstitutionMap.put(lExpr, rExpr);
+        });
+        return expr.substitute(exprSubstitutionMap);
+    }
+
+    /**
+     * IcebergTable partition column is timestamp with UTC time zone, adjust partition-by-expression's timezone to local timezone,
+     * otherwise MV refresh cannot match target partition by referring specific Iceberg input partition.
+     */
+    public static int getIcebergPartitionColumnTimeZoneOffset(IcebergTable icebergTable,
+                                                              SlotRef slotRef) {
         List<Column> refPartitionCols = icebergTable.getPartitionColumns();
         Optional<Column> refPartitionColOpt = refPartitionCols.stream()
                 .filter(col -> col.getName().equals(slotRef.getColumnName()))
@@ -1508,7 +1753,7 @@ public class MaterializedViewAnalyzer {
             org.apache.iceberg.Schema icebegSchema = icebergTable.getNativeTable().schema();
             if (icebegSchema.findType(partitionField.sourceId()).equals(Types.TimestampType.withZone())) {
                 ZoneId zoneId = TimeUtils.getTimeZone().toZoneId();
-                return getZoneHourOffset(ZoneOffset.UTC, zoneId);
+                return getZoneHourOffset(java.time.ZoneOffset.UTC, zoneId);
             } else {
                 return 0;
             }
@@ -1528,9 +1773,9 @@ public class MaterializedViewAnalyzer {
      * For mv's partition function experssion with timezone, adjust timezone to local timezone; otherwise MV refresh
      * cannot match target partition by referring specific Iceberg input partition.
      */
-    private static Expr getAdjustPartitionExpr(Expr partitionByExpr,
-                                               SlotRef slotRef,
-                                               int zoneHourOffset) {
+    public static Expr getIcebergAdjustPartitionExpr(Expr partitionByExpr,
+                                                     SlotRef slotRef,
+                                                     int zoneHourOffset) {
         if (zoneHourOffset == 0) {
             return partitionByExpr;
         }
@@ -1565,30 +1810,38 @@ public class MaterializedViewAnalyzer {
     }
 
     /**
-     * For generated column, change its referred slot ref from original ref-base-table's output columns to
-     * MV's output columns.
+     * If iceberg table partition column is timestamp with time zone, adjust timezone to local timezone.
      */
-    private static void resolveRefToMVColumns(List<Column> columns, SlotRef slotRef, TableName mvTableName) {
-        Column mvPartitionColumn = null;
-        int columnId = 0;
-        for (Column column : columns) {
-            if (slotRef.getColumnName().equalsIgnoreCase(column.getName())) {
-                mvPartitionColumn = column;
-                break;
-            }
-            columnId++;
+    public static Expr getAdjustedIcebergPartitionExpr(List<Column> mvColumns, TableName mvTableName,
+                                                       SlotRef slotRef, IcebergTable icebergTable,
+                                                       Expr partitionByExpr) {
+        if (!MvUtils.isFuncCallExpr(partitionByExpr, FunctionSet.DATE_TRUNC)) {
+            return partitionByExpr;
         }
-        if (mvPartitionColumn == null) {
-            throw new SemanticException("Materialized view partition exp column:"
-                    + slotRef.getColumnName() + " is not found in query statement");
+        // why resolve slot ref to mv columns?
+        // generated column should refer mv's defined column, but partitionByExpr is ref to base table's column,
+        // so resolve slot ref to mv columns.
+        resolveRefToMVColumns(mvColumns, slotRef, mvTableName);
+        int zoneHourOffset = getIcebergPartitionColumnTimeZoneOffset(icebergTable, slotRef);
+        return getIcebergAdjustPartitionExpr(partitionByExpr, slotRef, zoneHourOffset);
+    }
+
+    /**
+     * For MV with olap tables that contain common partition expressions which uses a generated column inner,
+     * we need to adjust the partition expression to the associated generated column.
+     */
+    public static Expr getAdjustedOlapTablePartitionExpr(Map<Integer, Expr> changedPartitionByExprs,
+                                                         Integer i,
+                                                         List<Column> mvColumns, TableName mvTableName,
+                                                         SlotRef slotRef,
+                                                         Expr partitionByExpr) {
+        if (changedPartitionByExprs.containsKey(i)) {
+            // why resolve slot ref to mv columns?
+            // generated column should refer mv's defined column, but partitionByExpr is ref to base table's column,
+            // so resolve slot ref to mv columns.
+            resolveRefToMVColumns(mvColumns, slotRef, mvTableName);
+            return partitionByExpr;
         }
-        SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(columnId), slotRef.getColumnName(),
-                mvPartitionColumn.getType(), mvPartitionColumn.isAllowNull());
-        slotRef.setDesc(slotDescriptor);
-        slotRef.setType(mvPartitionColumn.getType());
-        slotRef.setNullable(mvPartitionColumn.isAllowNull());
-        slotRef.setType(mvPartitionColumn.getType());
-        slotRef.setColumnName(mvPartitionColumn.getName());
-        slotRef.setTblName(mvTableName);
+        return partitionByExpr;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -53,7 +53,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private RefreshSchemeClause refreshSchemeDesc;
 
     // partition by clause which may be list or range partition expr.
-    private final List<Expr> partitionByExprs;
+    private List<Expr> partitionByExprs;
     // partition type of the mv which is deduced by its referred base table.
     private PartitionType partitionType;
 
@@ -92,6 +92,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private List<Integer> queryOutputIndices = Lists.newArrayList();
     // Generated partition columns for mv's partition by expressions, partition expression index to generated column.
     private Map<Integer, Column> generatedPartitionCols = Maps.newHashMap();
+    private Map<Expr, Expr> partitionByExprToAdjustExprMap = Maps.newHashMap();
 
     public CreateMaterializedViewStatement(TableName tableName, boolean ifNotExists,
                                            List<ColWithComment> colWithComments,
@@ -164,6 +165,10 @@ public class CreateMaterializedViewStatement extends DdlStmt {
      */
     public List<Expr> getPartitionByExprs() {
         return partitionByExprs;
+    }
+
+    public void setPartitionByExprs(List<Expr> partitionByExprs) {
+        this.partitionByExprs = partitionByExprs;
     }
 
     /**
@@ -305,6 +310,10 @@ public class CreateMaterializedViewStatement extends DdlStmt {
 
     public Map<Integer, Column> getGeneratedPartitionCols() {
         return generatedPartitionCols;
+    }
+
+    public Map<Expr, Expr> getPartitionByExprToAdjustExprMap() {
+        return partitionByExprToAdjustExprMap;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -927,9 +927,9 @@ public class MvRewritePreprocessor {
      */
     public static List<Column> getMvOutputColumns(MaterializedView mv) {
         if (mv.getQueryOutputIndices() == null || mv.getQueryOutputIndices().isEmpty()) {
-            return mv.getBaseSchema();
+            return mv.getBaseSchemaWithoutGeneratedColumn();
         } else {
-            List<Column> schema = mv.getBaseSchema();
+            List<Column> schema = mv.getBaseSchemaWithoutGeneratedColumn();
             List<Column> outputColumns = Lists.newArrayList();
             for (Integer index : mv.getQueryOutputIndices()) {
                 outputColumns.add(schema.get(index));
@@ -955,7 +955,7 @@ public class MvRewritePreprocessor {
 
         // first add base schema to avoid replaced in full schema.
         Set<String> columnNames = Sets.newHashSet();
-        for (Column column : mv.getBaseSchema()) {
+        for (Column column : mv.getBaseSchemaWithoutGeneratedColumn()) {
             ColumnRefOperator columnRef = columnRefFactory.create(column.getName(),
                     column.getType(),
                     column.isAllowNull());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -160,7 +160,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
                 mv, mvPlanContext, ConstantOperator.TRUE, mvUpdateInfo, queryTables);
 
         Map<Column, ColumnRefOperator> columnToColumnRefMap = olapScanOperator.getColumnMetaToColRefMap();
-        List<Column> mvColumns = mv.getBaseSchema();
+        List<Column> mvColumns = mv.getBaseSchemaWithoutGeneratedColumn();
         List<ColumnRefOperator> expectOutputColumns = mvColumns.stream()
                 .map(c -> columnToColumnRefMap.get(c))
                 .collect(Collectors.toList());
@@ -207,7 +207,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
                 mv, mvPlanContext, ConstantOperator.TRUE, mvUpdateInfo, queryTables);
         logMVRewrite(mvContext, "Get mv transparent plan failed, and redirect to mv's defined query");
         Map<Column, ColumnRefOperator> columnToColumnRefMap = olapScanOperator.getColumnMetaToColRefMap();
-        List<Column> mvColumns = mv.getBaseSchema();
+        List<Column> mvColumns = mv.getBaseSchemaWithoutGeneratedColumn();
         List<ColumnRefOperator> expectOutputColumns = mvColumns.stream()
                 .map(c -> columnToColumnRefMap.get(c))
                 .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/OptCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/OptCompensator.java
@@ -210,10 +210,10 @@ public class OptCompensator extends OptExpressionVisitor<OptExpression, Void> {
                                     optimizerContext.getColumnRefFactory());
                             predicates.add(predicate);
                         }
-                        externalPredicates.add(Utils.compoundAnd(predicates));
                     }
-                    externalExtraPredicate = Utils.compoundOr(externalPredicates);
+                    externalPredicates.add(Utils.compoundAnd(predicates));
                 }
+                externalExtraPredicate = Utils.compoundOr(externalPredicates);
             }
         }
         if (externalExtraPredicate == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -4876,7 +4876,8 @@ public class CreateMaterializedViewTest {
                         "as select dt, province, sum(age) from t3 group by dt, province;");
                 Assert.fail();
             } catch (Exception e) {
-                Assert.assertTrue(e.getMessage().contains("Partition expression with function is not supported yet"));
+                Assert.assertTrue(e.getMessage().contains("List partition expression can only be ref-base-table's partition " +
+                        "expression but contains"));
             }
         }
         starRocksAssert.dropTable("t3");
@@ -5313,5 +5314,49 @@ public class CreateMaterializedViewTest {
         Assert.assertEquals("dt > current_date() - interval 1 month", retentionCondition);
         starRocksAssert.dropMaterializedView("mv1");
         starRocksAssert.dropTable("r1");
+    }
+
+    @Test
+    public void testCreateMVWithMultiCommonPartitionExpressions1() throws Exception {
+        starRocksAssert.withTable("create table tt1(k1 datetime, k2 datetime, v int) " +
+                "partition by date_trunc('day', k1), date_trunc('month', k2);\n");
+        starRocksAssert.withMaterializedView("\n" +
+                "CREATE MATERIALIZED VIEW mv1\n" +
+                "PARTITION BY (date_trunc('day', k1), date_trunc('month', k2))\n" +
+                "REFRESH ASYNC\n" +
+                "PROPERTIES(\n" +
+                "    \"auto_refresh_partitions_limit\"=\"30\"\n" +
+                ")\n" +
+                "as select * from tt1;");
+        MaterializedView mv = starRocksAssert.getMv("test", "mv1");
+        Assert.assertTrue(mv != null);
+        String alterTableSql = "ALTER MATERIALIZED VIEW mv1 SET ('partition_retention_condition' = " +
+                "'date_trunc(\\'day\\', k1) > current_date() - interval 2 month')";
+        starRocksAssert.alterMvProperties(alterTableSql);
+        String retentionCondition = mv.getTableProperty().getPartitionRetentionCondition();
+        Assert.assertEquals("date_trunc('day', k1) > current_date() - interval 2 month", retentionCondition);
+        starRocksAssert.dropMaterializedView("mv1");
+        starRocksAssert.dropTable("tt1");
+    }
+
+    @Test
+    public void testCreateMVWithMultiCommonPartitionExpressions2() throws Exception {
+        starRocksAssert.withTable("create table tt1(k1 datetime, k2 datetime, v int) " +
+                "partition by date_trunc('day', k1), date_trunc('month', k2);\n");
+        starRocksAssert.withMaterializedView("\n" +
+                "CREATE MATERIALIZED VIEW mv1\n" +
+                "PARTITION BY (date_trunc('day', k1), date_trunc('month', k2))\n" +
+                "REFRESH ASYNC\n" +
+                "PROPERTIES(\n" +
+                "    \"auto_refresh_partitions_limit\"=\"30\",\n" +
+                "   'partition_retention_condition' = 'date_trunc(\\'day\\', k1) > current_date() - interval 2 month'" +
+                ")\n" +
+                "as select * from tt1;");
+        MaterializedView mv = starRocksAssert.getMv("test", "mv1");
+        Assert.assertTrue(mv != null);
+        String retentionCondition = mv.getTableProperty().getPartitionRetentionCondition();
+        Assert.assertEquals("date_trunc('day', k1) > current_date() - interval 2 month", retentionCondition);
+        starRocksAssert.dropMaterializedView("mv1");
+        starRocksAssert.dropTable("tt1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MIcebergTableMeta.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MIcebergTableMeta.java
@@ -164,11 +164,39 @@ public class MIcebergTableMeta {
         }
     };
 
+    // multi partition columns: id, data, day(ts)
+    public static final MIcebergTable T0_MULTI_DAY_TZ = new MIcebergTable() {
+        @Override
+        public String getTableName() {
+            return "t0_multi_day_tz";
+        }
+
+        @Override
+        public TestTables.TestTable getTestTable(Schema schema) throws IOException {
+            PartitionSpec spec =
+                    PartitionSpec.builderFor(schema)
+                            .identity("id")
+                            .identity("data")
+                            .day("ts")
+                            .build();
+            String tableName = getTableName();
+            return TestTables.create(
+                    new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_TRANSFORMS_DB_NAME + "/"
+                            + tableName), tableName, schema, spec, 1);
+        }
+
+        @Override
+        public List<String> getTransformTablePartitionNames(String tblName) {
+            return Lists.newArrayList("id=1/data=a/ts_day=2022-01-01", "id=2/data=a/ts_day=2022-01-02");
+        }
+    };
+
     public static Map<String, MIcebergTable> MOCKED_ICEBERG_TABLES = ImmutableMap.<String, MIcebergTable>builder()
             .put(T0_MULTI_HOUR.getTableName(), T0_MULTI_HOUR)
             .put(T0_MULTI_DAY.getTableName(), T0_MULTI_DAY)
             .put(T0_MULTI_MONTH.getTableName(), T0_MULTI_MONTH)
             .put(T0_MULTI_YEAR.getTableName(), T0_MULTI_YEAR)
             .put(T0_MULTI_BUCKET.getTableName(), T0_MULTI_BUCKET)
+            .put(T0_MULTI_DAY_TZ.getTableName(), T0_MULTI_DAY_TZ)
             .build();
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
+import com.starrocks.clone.DynamicPartitionScheduler;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.server.GlobalStateMgr;
@@ -481,5 +482,124 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVRefreshTestBa
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Unsupported expr 'date_trunc('bucket', ts)' in PARTITION BY clause"));
         }
+    }
+
+    @Test
+    public void testCreateMVForIcebergWithRetentionCondition1() throws Exception {
+        // test partition by day(ts)
+        String mvName = "iceberg_day_mv1";
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_day_mv1`\n" +
+                "PARTITION BY date_trunc('day', ts)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"partition_retention_condition\" = \"date_trunc('day', ts) >= current_date() - interval 1 year\"" +
+                ")\n" +
+                "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day` as a;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "iceberg_day_mv1"));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
+
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(0, partitions.size());
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreateMVForIcebergWithRetentionCondition2() throws Exception {
+        // test partition by day(ts)
+        String mvName = "iceberg_day_mv1";
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_day_mv1`\n" +
+                "PARTITION BY (id, data, date_trunc('day', ts))\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"partition_retention_condition\" = \"date_trunc('day', ts) >= current_date() - interval 1 year\"" +
+                ")\n" +
+                "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_multi_day` as a;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "iceberg_day_mv1"));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
+
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(0, partitions.size());
+        starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day`")
+                .explainWithout(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreateMVForIcebergWithRetentionCondition3() throws Exception {
+        // test partition by day(ts)
+        String mvName = "iceberg_day_tz_mv1";
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_day_tz_mv1`\n" +
+                "PARTITION BY (id, data, date_trunc('day', ts))\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"partition_retention_condition\" = \"date_trunc('day', ts) >= current_date() - interval 1 year\"" +
+                ")\n" +
+                "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_multi_day_tz` as a;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "iceberg_day_tz_mv1"));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
+
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(0, partitions.size());
+        starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_multi_day_tz`")
+                .explainContains(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreateMVForIcebergWithRetentionCondition4() throws Exception {
+        // test partition by day(ts)
+        String mvName = "iceberg_day_tz_mv1";
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_day_tz_mv1`\n" +
+                "PARTITION BY (id, data, date_trunc('day', ts))\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_multi_day_tz` as a;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView partitionedMaterializedView =
+                ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(testDb.getFullName(), "iceberg_day_tz_mv1"));
+        triggerRefreshMv(testDb, partitionedMaterializedView);
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(2, partitions.size());
+        starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_multi_day_tz`")
+                .explainContains(mvName);
+        String alterTableSql = String.format("alter materialized view %s set (" +
+                "\"partition_retention_condition\" = \"date_trunc('day', ts) >= current_date() - interval 1 year\")",
+                mvName);
+        starRocksAssert.alterMvProperties(alterTableSql);
+        triggerRefreshMv(testDb, partitionedMaterializedView);
+
+        // trigger ttl
+        DynamicPartitionScheduler scheduler = GlobalStateMgr.getCurrentState()
+                .getDynamicPartitionScheduler();
+        scheduler.runOnceForTest();
+
+        partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(0, partitions.size());
+        starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_multi_day_tz`")
+                .explainWithout(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
     }
 }

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_common_partition_expressions
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_list_partitions_with_common_partition_expressions
@@ -1,0 +1,511 @@
+-- name: test_mv_refresh_list_partitions_with_common_partition_expressions
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t1(
+    dt1 datetime, 
+    dt2 datetime, 
+    v int) 
+partition by date_trunc('day', dt1), date_trunc('month', dt2);
+-- result:
+-- !result
+insert into t1 values
+    ('2024-01-01','2024-01-02', 1),
+    ('2024-02-01','2024-02-02', 2),
+    ('2024-03-01','2024-03-02', 3)
+;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY (__generated_partition_column_0, __generated_partition_column_1)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+    SELECT dt1, dt2, v, __generated_partition_column_0, __generated_partition_column_1 FROM t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+-- result:
+2024-01-01 00:00:00	2024-01-02 00:00:00	1
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+True
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+-- !result
+INSERT INTO t1 VALUES 
+    ('2024-04-01','2024-04-02', 4),
+    ('2024-05-01','2024-05-02', 2),
+    ('2024-06-01','2024-06-02', 3);
+-- result:
+-- !result
+select * from mv1 order by 1, 2;
+-- result:
+2024-01-01 00:00:00	2024-01-02 00:00:00	1
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+True
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	1
+2024-05-01 00:00:00	1
+2024-06-01 00:00:00	1
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+-- result:
+2024-01-01 00:00:00	2024-01-02 00:00:00	1
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+True
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	1
+2024-05-01 00:00:00	1
+2024-06-01 00:00:00	1
+-- !result
+drop materialized view mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY (date_trunc('day', dt1), date_trunc('month', dt2))
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+    SELECT * FROM t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+-- result:
+2024-01-01 00:00:00	2024-01-02 00:00:00	1
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+False
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	1
+2024-05-01 00:00:00	1
+2024-06-01 00:00:00	1
+-- !result
+INSERT INTO t1 VALUES 
+    ('2024-04-01','2024-04-02', 4),
+    ('2024-05-01','2024-05-02', 2),
+    ('2024-06-01','2024-06-02', 3);
+-- result:
+-- !result
+select * from mv1 order by 1, 2;
+-- result:
+2024-01-01 00:00:00	2024-01-02 00:00:00	1
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+False
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	2
+2024-05-01 00:00:00	2
+2024-06-01 00:00:00	2
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+-- result:
+2024-01-01 00:00:00	2024-01-02 00:00:00	1
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+False
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	2
+2024-05-01 00:00:00	2
+2024-06-01 00:00:00	2
+-- !result
+drop materialized view mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY (date_trunc('month', dt2))
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+    SELECT * FROM t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+-- result:
+2024-01-01 00:00:00	2024-01-02 00:00:00	1
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+False
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	2
+2024-05-01 00:00:00	2
+2024-06-01 00:00:00	2
+-- !result
+INSERT INTO t1 VALUES 
+    ('2024-04-01','2024-04-02', 4),
+    ('2024-05-01','2024-05-02', 2),
+    ('2024-06-01','2024-06-02', 3);
+-- result:
+-- !result
+select * from mv1 order by 1, 2;
+-- result:
+2024-01-01 00:00:00	2024-01-02 00:00:00	1
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+False
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	3
+2024-05-01 00:00:00	3
+2024-06-01 00:00:00	3
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+-- result:
+2024-01-01 00:00:00	2024-01-02 00:00:00	1
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+False
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	3
+2024-05-01 00:00:00	3
+2024-06-01 00:00:00	3
+-- !result
+drop materialized view mv1;
+-- result:
+-- !result
+SET disable_generated_column_rewrite=TRUE;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY  (date_trunc('day', dt1), date_trunc('month', dt2))
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "partition_retention_condition" = "date_trunc('day', dt1) >= '2024-02-01'"
+)
+AS 
+    SELECT * FROM t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+-- result:
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+True
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	3
+2024-05-01 00:00:00	3
+2024-06-01 00:00:00	3
+-- !result
+INSERT INTO t1 VALUES 
+    ('2024-04-01','2024-04-02', 4),
+    ('2024-05-01','2024-05-02', 2),
+    ('2024-06-01','2024-06-02', 3);
+-- result:
+-- !result
+select * from mv1 order by 1, 2;
+-- result:
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+True
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	4
+2024-05-01 00:00:00	4
+2024-06-01 00:00:00	4
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+-- result:
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	4
+2024-05-01 00:00:00	4
+2024-06-01 00:00:00	4
+-- !result
+drop materialized view mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY  (date_trunc('month', dt2))
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "partition_retention_condition" = "date_trunc('month', dt2) >= '2024-02-01'"
+)
+AS 
+    SELECT * FROM t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+-- result:
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+True
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	4
+2024-05-01 00:00:00	4
+2024-06-01 00:00:00	4
+-- !result
+INSERT INTO t1 VALUES 
+    ('2024-04-01','2024-04-02', 4),
+    ('2024-05-01','2024-05-02', 2),
+    ('2024-06-01','2024-06-02', 3);
+-- result:
+-- !result
+select * from mv1 order by 1, 2;
+-- result:
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+True
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	5
+2024-05-01 00:00:00	5
+2024-06-01 00:00:00	5
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+-- result:
+2024-02-01 00:00:00	2024-02-02 00:00:00	2
+2024-03-01 00:00:00	2024-03-02 00:00:00	3
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-04-01 00:00:00	2024-04-02 00:00:00	4
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-05-01 00:00:00	2024-05-02 00:00:00	2
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+2024-06-01 00:00:00	2024-06-02 00:00:00	3
+-- !result
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+-- result:
+True
+-- !result
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+-- result:
+2024-01-01 00:00:00	1
+2024-02-01 00:00:00	1
+2024-03-01 00:00:00	1
+2024-04-01 00:00:00	5
+2024-05-01 00:00:00	5
+2024-06-01 00:00:00	5
+-- !result
+drop table t1;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_common_partition_expressions
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_list_partitions_with_common_partition_expressions
@@ -1,0 +1,168 @@
+-- name: test_mv_refresh_list_partitions_with_common_partition_expressions
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1(
+    dt1 datetime, 
+    dt2 datetime, 
+    v int) 
+partition by date_trunc('day', dt1), date_trunc('month', dt2);
+
+insert into t1 values
+    ('2024-01-01','2024-01-02', 1),
+    ('2024-02-01','2024-02-02', 2),
+    ('2024-03-01','2024-03-02', 3)
+;
+-------- TEST ONE TO ONE BY GENERATED_COLUMN REMAPPING-----
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY (__generated_partition_column_0, __generated_partition_column_1)
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+    SELECT dt1, dt2, v, __generated_partition_column_0, __generated_partition_column_1 FROM t1;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+INSERT INTO t1 VALUES 
+    ('2024-04-01','2024-04-02', 4),
+    ('2024-05-01','2024-05-02', 2),
+    ('2024-06-01','2024-06-02', 3);
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+drop materialized view mv1;
+-------- TEST ONE TO ONE REMAPPING-----
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY (date_trunc('day', dt1), date_trunc('month', dt2))
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+    SELECT * FROM t1;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+INSERT INTO t1 VALUES 
+    ('2024-04-01','2024-04-02', 4),
+    ('2024-05-01','2024-05-02', 2),
+    ('2024-06-01','2024-06-02', 3);
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+drop materialized view mv1;
+
+-------- TEST MANY TO ONE REMAPPING-----
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY (date_trunc('month', dt2))
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1"
+)
+AS 
+    SELECT * FROM t1;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+INSERT INTO t1 VALUES 
+    ('2024-04-01','2024-04-02', 4),
+    ('2024-05-01','2024-05-02', 2),
+    ('2024-06-01','2024-06-02', 3);
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+drop materialized view mv1;
+
+-- DISABLE GENERATED COLUMN REWRITE FOR MV REWRITE
+
+SET disable_generated_column_rewrite=TRUE;
+-------- TEST ONE TO ONE REMAPPING WITH PARTITION TTL -----
+
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY  (date_trunc('day', dt1), date_trunc('month', dt2))
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "partition_retention_condition" = "date_trunc('day', dt1) >= '2024-02-01'"
+)
+AS 
+    SELECT * FROM t1;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+INSERT INTO t1 VALUES 
+    ('2024-04-01','2024-04-02', 4),
+    ('2024-05-01','2024-05-02', 2),
+    ('2024-06-01','2024-06-02', 3);
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+drop materialized view mv1;
+
+-------- TEST MANY TO ONE REMAPPING WITH PARTITINO TTL -----
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY  (date_trunc('month', dt2))
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+    "replication_num" = "1",
+    "partition_retention_condition" = "date_trunc('month', dt2) >= '2024-02-01'"
+)
+AS 
+    SELECT * FROM t1;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+INSERT INTO t1 VALUES 
+    ('2024-04-01','2024-04-02', 4),
+    ('2024-05-01','2024-05-02', 2),
+    ('2024-06-01','2024-06-02', 3);
+select * from mv1 order by 1, 2;
+
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select * from mv1 order by 1, 2;
+function: print_hit_materialized_view("select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2)", "mv1")
+select date_trunc('month', dt2), count(1) from t1 group by date_trunc('month', dt2) order by 1;
+
+drop table t1;
+drop database db_${uuid0} force;

--- a/test/sql/test_transparent_mv/R/test_mv_with_iceberg_transform_and_force_mv
+++ b/test/sql/test_transparent_mv/R/test_mv_with_iceberg_transform_and_force_mv
@@ -1,0 +1,113 @@
+-- name: test_mv_with_iceberg_transform_and_force_mv
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_days
+PARTITION BY (l_returnflag, l_linestatus, date_trunc('day', l_shipdate))
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "replication_num" = "1",
+  "partition_retention_condition" = "date_trunc('day', l_shipdate) >= '2024-11-13'",
+  "query_rewrite_consistency" = "force_mv"
+)
+AS
+  SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_days PARTITION (('R', 'F', '2024-11-12 08:00:00')) WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT * FROM test_days order by l_orderkey;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+test_days
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+test_days
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;")
+-- result:
+test_days
+-- !result
+SELECT * FROM test_days order by l_orderkey;
+-- result:
+-- !result
+SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_days WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT * FROM test_days order by l_orderkey;")
+-- result:
+test_days
+-- !result
+function: print_hit_materialized_views("SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+test_days
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+test_days
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+test_days
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;")
+-- result:
+test_days
+-- !result
+SELECT * FROM test_days order by l_orderkey;
+-- result:
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;
+-- result:
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+DROP MATERIALIZED VIEW test_days;
+-- result:
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/R/test_mv_with_iceberg_transform_and_force_mv
+++ b/test/sql/test_transparent_mv/R/test_mv_with_iceberg_transform_and_force_mv
@@ -37,15 +37,15 @@ function: print_hit_materialized_views("SELECT * FROM test_days where l_shipdate
 -- !result
 function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
 -- result:
-test_days
+
 -- !result
 function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
 -- result:
-test_days
+
 -- !result
 function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;")
 -- result:
-test_days
+
 -- !result
 SELECT * FROM test_days order by l_orderkey;
 -- result:
@@ -55,12 +55,16 @@ SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_ord
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
 -- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
 -- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;
 -- result:
+1	1001	5001	1	10.00	1000.00	0.05	0.08	N	O	2024-11-12 00:00:00	2024-11-15 00:00:00	2024-11-20 00:00:00	DELIVER IN PERSON	AIR	Quick delivery required
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
 -- !result
 REFRESH MATERIALIZED VIEW test_days WITH SYNC MODE;
 function: print_hit_materialized_views("SELECT * FROM test_days order by l_orderkey;")
@@ -73,7 +77,7 @@ test_days
 -- !result
 function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
 -- result:
-test_days
+
 -- !result
 function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
 -- result:
@@ -93,13 +97,17 @@ SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_ord
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
 -- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
 -- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
 3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
 -- !result
 SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;
 -- result:
+1	1001	5001	1	10.00	1000.00	0.05	0.08	N	O	2024-11-12 00:00:00	2024-11-15 00:00:00	2024-11-20 00:00:00	DELIVER IN PERSON	AIR	Quick delivery required
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
 3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
 -- !result
 DROP MATERIALIZED VIEW test_days;

--- a/test/sql/test_transparent_mv/R/test_mv_with_multi_partition_columns_iceberg2
+++ b/test/sql/test_transparent_mv/R/test_mv_with_multi_partition_columns_iceberg2
@@ -235,6 +235,110 @@ SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_ord
 DROP MATERIALIZED VIEW test_days;
 -- result:
 -- !result
+CREATE MATERIALIZED VIEW test_days
+PARTITION BY (l_returnflag, l_linestatus, date_trunc('day', l_shipdate))
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "replication_num" = "1",
+  "partition_retention_condition" = "date_trunc('day', l_shipdate) >= '2024-11-13'"
+)
+AS
+  SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_days PARTITION (('R', 'F', '2024-11-12 08:00:00')) WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT * FROM test_days order by l_orderkey;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;")
+-- result:
+
+-- !result
+SELECT * FROM test_days order by l_orderkey;
+-- result:
+-- !result
+SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;
+-- result:
+1	1001	5001	1	10.00	1000.00	0.05	0.08	N	O	2024-11-12 00:00:00	2024-11-15 00:00:00	2024-11-20 00:00:00	DELIVER IN PERSON	AIR	Quick delivery required
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+REFRESH MATERIALIZED VIEW test_days WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT * FROM test_days order by l_orderkey;")
+-- result:
+test_days
+-- !result
+function: print_hit_materialized_views("SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+test_days
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+-- result:
+test_days
+-- !result
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;")
+-- result:
+test_days
+-- !result
+SELECT * FROM test_days order by l_orderkey;
+-- result:
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+-- result:
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;
+-- result:
+1	1001	5001	1	10.00	1000.00	0.05	0.08	N	O	2024-11-12 00:00:00	2024-11-15 00:00:00	2024-11-20 00:00:00	DELIVER IN PERSON	AIR	Quick delivery required
+2	1002	5002	2	20.00	2000.00	0.10	0.15	R	F	2024-11-13 00:00:00	2024-11-16 00:00:00	2024-11-21 00:00:00	TAKE BACK RETURN	RAIL	Handle with care
+3	1003	5003	3	30.00	3000.00	0.15	0.20	A	P	2024-11-14 00:00:00	2024-11-17 00:00:00	2024-11-22 00:00:00	NONE	SHIP	Fragile item
+-- !result
+DROP MATERIALIZED VIEW test_days;
+-- result:
+-- !result
+DROP MATERIALIZED VIEW test_days;
+-- result:
+E: (1064, 'Materialized view test_days is not found')
+-- !result
 CREATE MATERIALIZED VIEW test_months
 PARTITION BY (l_returnflag, l_linestatus, date_trunc('month', l_shipdate))
 REFRESH DEFERRED MANUAL

--- a/test/sql/test_transparent_mv/T/test_mv_with_iceberg_transform_and_force_mv
+++ b/test/sql/test_transparent_mv/T/test_mv_with_iceberg_transform_and_force_mv
@@ -1,0 +1,53 @@
+-- name: test_mv_with_iceberg_transform_and_force_mv
+
+-- create mv
+create database db_${uuid0};
+use db_${uuid0};
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+-------------------------------- DAYS WITH PARTITION TTL --------------------------------
+CREATE MATERIALIZED VIEW test_days
+PARTITION BY (l_returnflag, l_linestatus, date_trunc('day', l_shipdate))
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "replication_num" = "1",
+  "partition_retention_condition" = "date_trunc('day', l_shipdate) >= '2024-11-13'",
+  "query_rewrite_consistency" = "force_mv"
+)
+AS
+  SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days;
+REFRESH MATERIALIZED VIEW test_days PARTITION (('R', 'F', '2024-11-12 08:00:00')) WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT * FROM test_days order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;")
+SELECT * FROM test_days order by l_orderkey;
+SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;
+
+REFRESH MATERIALIZED VIEW test_days WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT * FROM test_days order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;")
+SELECT * FROM test_days order by l_orderkey;
+SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;
+DROP MATERIALIZED VIEW test_days;
+
+
+drop database db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};

--- a/test/sql/test_transparent_mv/T/test_mv_with_multi_partition_columns_iceberg2
+++ b/test/sql/test_transparent_mv/T/test_mv_with_multi_partition_columns_iceberg2
@@ -81,6 +81,42 @@ SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_ord
 
 DROP MATERIALIZED VIEW test_days;
 
+-------------------------------- DAYS WITH PARTITION TTL --------------------------------
+CREATE MATERIALIZED VIEW test_days
+PARTITION BY (l_returnflag, l_linestatus, date_trunc('day', l_shipdate))
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "replication_num" = "1",
+  "partition_retention_condition" = "date_trunc('day', l_shipdate) >= '2024-11-13'"
+)
+AS
+  SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days;
+REFRESH MATERIALIZED VIEW test_days PARTITION (('R', 'F', '2024-11-12 08:00:00')) WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT * FROM test_days order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;")
+SELECT * FROM test_days order by l_orderkey;
+SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;
+
+REFRESH MATERIALIZED VIEW test_days WITH SYNC MODE;
+function: print_hit_materialized_views("SELECT * FROM test_days order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;")
+function: print_hit_materialized_views("SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;")
+SELECT * FROM test_days order by l_orderkey;
+SELECT * FROM test_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_returnflag = 'R' and l_linestatus = 'F' and l_shipdate = '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days where l_shipdate >= '2024-11-13 00:00:00' order by l_orderkey;
+SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.lineitem_days order by l_orderkey;
+DROP MATERIALIZED VIEW test_days;
+
+DROP MATERIALIZED VIEW test_days;
 -------------------------------- MONTHS --------------------------------
 CREATE MATERIALIZED VIEW test_months
 PARTITION BY (l_returnflag, l_linestatus, date_trunc('month', l_shipdate))


### PR DESCRIPTION
## Why I'm doing:
Fix bugs for mv with iceberg transforms and `query_rewrite_consistency=force_mv`;

## What I'm doing:
1. Fix bugs for  mv with iceberg transforms and `query_rewrite_consistency=force_mv`:
- MV with `partition_retention_condition` should also take care icerberg transform in creating mv since the partition expression has been adjusted with time-zone: https://github.com/StarRocks/starrocks/pull/52966
- Fix partition compenstion bugs for iceberg with transformations.
- Add more tests for mv with iceberg transforms and `query_rewrite_consistency=force_mv`;

2. Support creating mv for list partition tables with common partition expression
- Like mv with iceberg transforms, mv for list partition tables with common partition expression will create generated columns for each partition expression.
- TODO: by default mv for  list partition tables with common partition expression can not be used for rewrite as expected because user's query will be rewritten by generated columns. but you can `SET disable_generated_column_rewrite=TRUE;`  to walk around to skip generated column rewrite and enable mv rewrite.

Fixes https://github.com/StarRocks/starrocks/issues/53117
Fixes https://github.com/StarRocks/starrocks/issues/52576

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0