### PR TITLE
[BugFix] fix lock release issue in cloud native pk table

### DIFF
--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -901,6 +901,55 @@ TEST_P(LakePrimaryKeyPublishTest, test_recover_with_dels2) {
     config::enable_primary_key_recover = false;
 }
 
+TEST_P(LakePrimaryKeyPublishTest, test_index_load_failure) {
+    auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    bool ingest_failure = true;
+    std::string sync_point = "lake_index_load.1";
+    SyncPoint::GetInstance()->SetCallBack(sync_point, [&](void* arg) {
+        if (ingest_failure) {
+            *(Status*)arg = Status::AlreadyExist("ut_test");
+            ingest_failure = false;
+        } else {
+            ingest_failure = true;
+        }
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    for (int i = 0; i < 6; i++) {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        // upsert
+        ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        // Publish version
+        ASSERT_FALSE(publish_single_version(tablet_id, version + 1, txn_id).ok());
+        ASSERT_TRUE(publish_single_version(tablet_id, version + 1, txn_id).ok());
+        EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_absent(tablet_id, txn_id));
+        EXPECT_TRUE(_update_mgr->TEST_check_primary_index_cache_ref(tablet_id, 1));
+        EXPECT_TRUE(_update_mgr->try_remove_primary_index_cache(tablet_id));
+        version++;
+    }
+    SyncPoint::GetInstance()->ClearCallBack(sync_point);
+    SyncPoint::GetInstance()->DisableProcessing();
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+    if (GetParam().enable_persistent_index && GetParam().persistent_index_type == PersistentIndexTypePB::LOCAL) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
+}
+
 TEST_P(LakePrimaryKeyPublishTest, test_write_rebuild_persistent_index) {
     if (!GetParam().enable_persistent_index) {
         // only test persistent index


### PR DESCRIPTION
## Why I'm doing:
When `prepare_primary_index`, PK index load will fail and remove this index from cache:
```
StatusOr<IndexEntry*> UpdateManager::prepare_primary_index(
        const TabletMetadataPtr& metadata, MetaFileBuilder* builder, int64_t base_version, int64_t new_version,
        std::unique_ptr<std::lock_guard<std::shared_timed_mutex>>& guard) {
    ......
    // Fetch lock guard before `lake_load`
    guard = index.fetch_guard(); <---- get lock guard
    Status st = index.lake_load(_tablet_mgr, metadata, base_version, builder);
    ...
    if (!st.ok()) {
        .....
        _index_cache.remove(index_entry); <---- remove index
        ....
        return Status::InternalError(msg);
    }
```
But `PrimaryKeyTxnLogApplier` still hold the lock guard. After `PrimaryKeyTxnLogApplier` been destroyed, lock guard will release the lock which address is invalid because PK index already been remove.

This will cause invalid address access, it lead to unexpected behavior like stucking at here:
<img width="1249" alt="img_v3_02hg_05c4b134-a793-412d-8fec-67c4dc70577g" src="https://github.com/user-attachments/assets/693e145b-4111-472e-b007-d70d126ab5f4" />


## What I'm doing:
If PK index load fail, we need to release the lock before PK index been removed.

This pull request includes changes to improve error handling in the `UpdateManager` class and adds a new test case to cover index load failures. The most important changes include releasing the lock guard before removing the index entry when load or prepare operations fail, and adding a new test case in `LakePrimaryKeyPublishTest`.

Improvements to error handling:

* [`be/src/storage/lake/update_manager.cpp`](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66R147-R149): Added code to release the lock guard before removing the index entry if the load operation fails in `prepare_primary_index`.
* [`be/src/storage/lake/update_manager.cpp`](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66R158-R159): Added code to release the lock guard before removing the index entry if the prepare operation fails in `prepare_primary_index`.

New test case:

* [`be/test/storage/lake/primary_key_publish_test.cpp`](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0R904-R952): Added a new test case `test_index_load_failure` to `LakePrimaryKeyPublishTest` to verify the behavior when index load fails.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0