### PR TITLE
[BugFix] Fix a bug that will lead no writable spill storage directories issue

### DIFF
--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -137,7 +137,6 @@ Status LogBlockContainer::close() {
 }
 
 Status LogBlockContainer::append_data(const std::vector<Slice>& data, size_t total_size) {
-    RETURN_IF_ERROR(_writable_file->pre_allocate(total_size));
     RETURN_IF_ERROR(_writable_file->appendv(data.data(), data.size()));
     _data_size += total_size;
     return Status::OK();


### PR DESCRIPTION
## Why I'm doing:
Fix a bug for be that will lead no writable spill storage directories issue
From the stack and code we can see that
W20241212 15:34:15.303994 139676325242624 pipeline_driver_executor.cpp:168] [Driver] Process error, query_id=7a9a93e1-b85b-11ef-99e1-d61caef69f96, instance_id=7a9a93e1-b85b-11ef-99e1-d61caef69f9a, status=Capaticy limit exceeded: no writable spill storage directories
be/src/exec/spill/log_block_manager.cpp:251 value_or_err_L251
be/src/exec/spill/data_stream.cpp:67 value_or_err_L67
be/src/exec/spill/data_stream.cpp:82 _prepare_block(state, total_write_size)
be/src/exec/spill/serde.cpp:159 output->append(state, {Slice(serialize_buffer.data(), written_bytes)}, written_bytes, chunk->num_rows())
be/src/exec/spill/mem_table.cpp:91 serde->serialize(_runtime_state, serde_ctx, chunk, output, need_aligned)
be/src/exec/spill/spill_components.cpp:478 mem_table->finalize(yield_ctx, output)
be/src/exec/spill/spill_components.cpp:503 spill_partition(yield_ctx, context, partition)
be/src/exec/spill/spill_components.cpp:686 _spill_input_partitions(ctx, spill_ctx, spilling_partitions)
be/src/exec/spill/spiller.hpp:40 task_status()
be/src/exec/hash_joiner.cpp:185 spiller()->spill(state, chunk, spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this(), spiller()->weak_from_this()))
be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp:210 _join_builder->append_chunk_to_spill_buffer(state, spill_chunk)
in the acquire_writable_dir in dir_manager.cpp we will increase the size first
![image](https://github.com/user-attachments/assets/ca975ae3-3049-4e4e-80a5-6af070dc13b5)
and in the log_block_manager.cpp we will decrease the size when LogBlockContainer is closed
![image](https://github.com/user-attachments/assets/17869587-b6da-495a-aa51-f631d30b64e8)
And also in the log_block_manager.cpp  when we append data we will also increase the size
![image](https://github.com/user-attachments/assets/ba1a117c-bc65-469d-bc79-2ca02fbbed2d)
![image](https://github.com/user-attachments/assets/333a10b2-7863-4842-af3d-f5198cc24fa4)
So the bug comes.
And I added some log to provide the bug
in log_block_manger.cpp
![image](https://github.com/user-attachments/assets/fe348e3d-ed16-40b3-875a-ef50b02033e9)
in dir_manager.cpp
![image](https://github.com/user-attachments/assets/c307ed2e-039d-4db5-b714-70a8eeb55e0e)
here is the log
![image](https://github.com/user-attachments/assets/72b750dc-1dd6-4bbe-a6c2-6923a033e06d)
![image](https://github.com/user-attachments/assets/daf48353-ff53-4458-b796-8e067fe7e0a5)
The bug produce

## What I'm doing:
Remove the `RETURN_IF_ERROR(_writable_file->pre_allocate(total_size));` in the `append_data` method
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0