### PR TITLE
[BugFix] Fix show materialized views where name ='xxx' Incorrect result

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -391,6 +391,9 @@ public class ShowMaterializedViewStatus {
             // sort by process start time
             lastJobTaskRunStatus.sort(Comparator.comparing(TaskRunStatus::getProcessStartTime));
             this.lastJobTaskRunStatus = lastJobTaskRunStatus;
+            if (!lastJobTaskRunStatus.isEmpty()) {
+                this.lastJobTaskRunStatus.add(lastJobTaskRunStatus.get(lastJobTaskRunStatus.size() - 1));
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -640,7 +640,7 @@ public class TaskManager implements MemoryTrackable {
                         && (CollectionUtils.isEmpty(taskNames) || taskNames.contains(task.getTaskName()));
         Consumer<TaskRunStatus> addResult = task -> {
             // Keep only the first one of duplicated task runs
-            if (isSameTaskRunJob(task, mvNameRunStatusMap)) {
+            if (!isSameTaskRunJob(task, mvNameRunStatusMap)) {
                 mvNameRunStatusMap.computeIfAbsent(task.getTaskName(), x -> Lists.newArrayList()).add(task);
             }
         };
@@ -672,14 +672,14 @@ public class TaskManager implements MemoryTrackable {
         // 1. if task status has already existed, existed task run status's job id is not null, find the same job id.
         // 2. otherwise, add it to the result.
         if (!mvNameRunStatusMap.containsKey(taskRunStatus.getTaskName())) {
-            return true;
+            return false;
         }
         List<TaskRunStatus> existedTaskRuns = mvNameRunStatusMap.get(taskRunStatus.getTaskName());
         if (existedTaskRuns == null || existedTaskRuns.isEmpty()) {
-            return true;
+            return false;
         }
         if (!Config.enable_show_materialized_views_include_all_task_runs) {
-            return false;
+            return true;
         }
         String jobId = taskRunStatus.getStartTaskRunId();
         return !Strings.isNullOrEmpty(jobId) && jobId.equals(existedTaskRuns.get(0).getStartTaskRunId());


### PR DESCRIPTION
## Why I'm doing:
Getting the task status returned is not the latest
## What I'm doing:
There is a logic problem in determining whether the task is the same
Fixes #issue
[#53887](https://github.com/StarRocks/starrocks/issues/53887)
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
