### PR TITLE
[Enhancement] Optimize the Chunk destructor

### DIFF
--- a/be/src/util/phmap/phmap.h
+++ b/be/src/util/phmap/phmap.h
@@ -1157,9 +1157,12 @@ public:
         if (capacity_ > 127) {
             destroy_slots();
         } else if (capacity_) {
-            for (size_t i = 0; i != capacity_; ++i) {
-                if (IsFull(ctrl_[i])) {
-                    PolicyTraits::destroy(&alloc_ref(), slots_ + i);
+            PHMAP_IF_CONSTEXPR((!std::is_trivially_destructible<typename PolicyTraits::value_type>::value ||
+                                std::is_same<typename Policy::is_flat, std::false_type>::value)) {
+                for (size_t i = 0; i != capacity_; ++i) {
+                    if (IsFull(ctrl_[i])) {
+                        PolicyTraits::destroy(&alloc_ref(), slots_ + i);
+                    }
                 }
             }
             size_ = 0;
@@ -1837,9 +1840,12 @@ private:
 
     void destroy_slots() {
         if (!capacity_) return;
-        for (size_t i = 0; i != capacity_; ++i) {
-            if (IsFull(ctrl_[i])) {
-                PolicyTraits::destroy(&alloc_ref(), slots_ + i);
+        PHMAP_IF_CONSTEXPR((!std::is_trivially_destructible<typename PolicyTraits::value_type>::value ||
+                            std::is_same<typename Policy::is_flat, std::false_type>::value)) {
+            for (size_t i = 0; i != capacity_; ++i) {
+                if (IsFull(ctrl_[i])) {
+                    PolicyTraits::destroy(&alloc_ref(), slots_ + i);
+                }
             }
         }
         auto layout = MakeLayout(capacity_);
@@ -3745,6 +3751,7 @@ struct FlatHashSetPolicy {
     using key_type = T;
     using init_type = T;
     using constant_iterators = std::true_type;
+    using is_flat = std::true_type;
 
     template <class Allocator, class... Args>
     static void construct(Allocator* alloc, slot_type* slot, Args&&... args) {
@@ -3782,6 +3789,7 @@ struct FlatHashMapPolicy {
     using key_type = K;
     using mapped_type = V;
     using init_type = std::pair</*non const*/ key_type, mapped_type>;
+    using is_flat = std::true_type;
 
     template <class Allocator, class... Args>
     static void construct(Allocator* alloc, slot_type* slot, Args&&... args) {
@@ -3858,6 +3866,7 @@ struct NodeHashSetPolicy : phmap::priv::node_hash_policy<T&, NodeHashSetPolicy<T
     using key_type = T;
     using init_type = T;
     using constant_iterators = std::true_type;
+    using is_flat = std::false_type;
 
     template <class Allocator, class... Args>
     static T* new_element(Allocator* alloc, Args&&... args) {
@@ -3896,6 +3905,7 @@ public:
     using key_type = Key;
     using mapped_type = Value;
     using init_type = std::pair</*non const*/ key_type, mapped_type>;
+    using is_flat = std::false_type;
 
     template <class Allocator, class... Args>
     static value_type* new_element(Allocator* alloc, Args&&... args) {


### PR DESCRIPTION
## Why I'm doing:

When phmap performs destructuring, it needs to iterate over the key/value to execute the destructor function of the slot type. But in fact, the Map storage in the Chunk is of type POD, so we don't need to traverse the hash table.

```
       │                                                                                                                                             ▒
       │     ~__shared_count() noexcept                                                                                                              ▒
       │     {                                                                                                                                       ▒
       │     if (_M_pi != nullptr)                                                                                                                   ▒
  0.13 │       mov     0xa0(%rdi),%rdi                                                                                                               ▒
       │       test    %rdi,%rdi                                                                                                                     ▒
  0.28 │     ↓ je      23                                                                                                                            ▒
       │     _M_pi->_M_release();                                                                                                                    ▒
       │     → call    std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release                                                                 ▒
       │     phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<int, unsigned long>, starrocks::StdHash<int>, phmap::EqualTo<int>, std::allocat▒
       │     be/build_Release/src/runtime/be/src/util/phmap/phmap.h:1839                                                                             ▒
 69.11 │ 23:   cmpq    $0x0,0x70(%rbx)                                                                                                               ▒
  0.67 │     ↓ je      3f                                                                                                                            ▒
       │     be/build_Release/src/runtime/be/src/util/phmap/phmap.h:1848                                                                             ▒
  0.34 │       mov     0x58(%rbx),%rdi                                                                                                               ▒
  0.02 │       lea     phmap::priv::EmptyGroup()::empty_group,%rax                                                                                   ▒
  0.12 │       cmp     %rax,%rdi                                                                                                                     ▒
       │     ↓ je      3f
```

I found that upstream already supports this optimization, so I introduced it to our repository.

```
commit 38ded9bba8d8962261848570583cc6f94a41ba98
Author: greg7mdp <greg7mdp@gmail.com>
Date:   Sat Sep 2 14:47:18 2023 -0400

    Simplify `clear()` and avoid iterating when values have trivial destructor.
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0