### PR TITLE
[BugFix] Fix list files when no files were found

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -241,6 +241,9 @@ public class TableFunctionTable extends Table {
                     files.add(fileInfo);
                 }
             }
+            if (files.isEmpty()) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_NO_FILES_FOUND, path);
+            }
             return files;
         } catch (StarRocksException e) {
             LOG.warn("failed to parse files", e);

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1203,7 +1203,7 @@ public class HdfsFsManager {
         Path pathPattern = new Path(pathUri.getPath());
         try {
             FileStatus[] files = fileSystem.getDFSFileSystem().globStatus(pathPattern);
-            return Lists.newArrayList(files);
+            return files != null ? Lists.newArrayList(files) : Lists.newArrayList();
         } catch (FileNotFoundException e) {
             LOG.info("file not found: " + path, e);
             throw new StarRocksException("file not found: " + path, e);

--- a/test/sql/test_files/R/csv_format
+++ b/test/sql/test_files/R/csv_format
@@ -73,6 +73,17 @@ select path, size, is_dir from files(
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
+[REGEX].*failed to parse files: No files were found matching the pattern\(s\) or path\(s\).*
+-- !result
+
+select path, size, is_dir from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/xxxxxx",
+    "list_files_only" = "true",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+[REGEX].*failed to parse files: No files were found matching the pattern\(s\) or path\(s\).*
 -- !result
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/csv_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/T/csv_format
+++ b/test/sql/test_files/T/csv_format
@@ -34,5 +34,12 @@ select path, size, is_dir from files(
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}");
 
+select path, size, is_dir from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/xxxxxx",
+    "list_files_only" = "true",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
 -- clean
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/csv_format/${uuid0}/ > /dev/null


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

return no files found error when list invalid path or pattern.

```
mysql> select * from files("path"="hdfs://xxx/yyy/", "list_files_only" = "true");
ERROR 5600 (58030): Getting analyzing error. Detail message: failed to parse files: No files were found matching the pattern(s) or path(s): 'hdfs://xxx/yyy/'. You should check whether there are files under the path, and make sure the process has the permission to access the path.
```
Fixes https://github.com/StarRocks/StarRocksTest/issues/8916

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0