### PR TITLE
[Enhancement] check partition scan number limit in resource group

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -48,6 +48,7 @@ public class ResourceGroup {
     public static final String BIG_QUERY_SCAN_ROWS_LIMIT = "big_query_scan_rows_limit";
     public static final String BIG_QUERY_CPU_SECOND_LIMIT = "big_query_cpu_second_limit";
     public static final String CONCURRENCY_LIMIT = "concurrency_limit";
+    public static final String PARTITION_SCAN_NUMBER_LIMIT_RULE = "partition_scan_number_limit_rule";
     public static final String DEFAULT_RESOURCE_GROUP_NAME = "default_wg";
     public static final String DISABLE_RESOURCE_GROUP_NAME = "disable_resource_group";
     public static final String DEFAULT_MV_RESOURCE_GROUP_NAME = "default_mv_wg";
@@ -119,6 +120,9 @@ public class ResourceGroup {
                     (rg, classifier) -> new DecimalFormat("#.##").format(
                             Objects.requireNonNullElse(rg.getSpillMemLimitThreshold(), 1.0) * 100) + "%"),
             new ColumnMeta(
+                    new Column(PARTITION_SCAN_NUMBER_LIMIT_RULE, ScalarType.createVarchar(1024)),
+                    (rg, classifier) -> rg.getPartitionScanNumberLimitRule()),
+            new ColumnMeta(
                     new Column(GROUP_TYPE, ScalarType.createVarchar(200)),
                     (rg, classifier) -> rg.getResourceGroupType().name().substring("WG_".length()), false),
             new ColumnMeta(
@@ -172,6 +176,8 @@ public class ResourceGroup {
     private TWorkGroupType resourceGroupType;
     @SerializedName(value = "version")
     private long version;
+    @SerializedName(value = "partitionScanNumberLimitRule")
+    private String partitionScanNumberLimitRule;
 
     public ResourceGroup() {
     }
@@ -196,6 +202,14 @@ public class ResourceGroup {
 
     public void setVersion(long version) {
         this.version = version;
+    }
+
+    public String getPartitionScanNumberLimitRule() {
+        return partitionScanNumberLimitRule;
+    }
+
+    public void setPartitionScanNumberLimitRule(String partitionScanNumberLimitRule) {
+        this.partitionScanNumberLimitRule = partitionScanNumberLimitRule;
     }
 
     public List<List<String>> show(boolean verbose) {
@@ -259,6 +273,10 @@ public class ResourceGroup {
         }
         if (resourceGroupType != null) {
             twg.setWorkgroup_type(resourceGroupType);
+        }
+
+        if (partitionScanNumberLimitRule != null) {
+            twg.setPartition_scan_number_limit_rule(partitionScanNumberLimitRule);
         }
 
         twg.setExclusive_cpu_cores(getNormalizedExclusiveCpuCores());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -418,6 +418,11 @@ public class ResourceGroupMgr implements Writable {
                     wg.setSpillMemLimitThreshold(spillMemLimitThreshold);
                 }
 
+                String partitionScanNumberLimitRule = changedProperties.getPartitionScanNumberLimitRule();
+                if (partitionScanNumberLimitRule != null) {
+                    wg.setPartitionScanNumberLimitRule(partitionScanNumberLimitRule);
+                }
+
                 // Type is guaranteed to be immutable during the analyzer phase.
                 TWorkGroupType workGroupType = changedProperties.getResourceGroupType();
                 Preconditions.checkState(workGroupType == null);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.StringLiteral;
+import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.VariableExpr;
 import com.starrocks.authentication.UserProperty;
 import com.starrocks.authorization.AccessDeniedException;
@@ -237,6 +238,10 @@ public class ConnectContext {
     private ConnectContext parent;
 
     private boolean relationAliasCaseInsensitive = false;
+
+    private boolean isExplain = false;
+
+    protected Map<Long, TableName> resolvedTables = Maps.newHashMap();
 
     private final Map<String, PrepareStmtContext> preparedStmtCtxs = Maps.newHashMap();
 
@@ -919,6 +924,14 @@ public class ConnectContext {
         return relationAliasCaseInsensitive;
     }
 
+    public void setExplain(boolean explain) {
+        isExplain = explain;
+    }
+
+    public boolean isExplain() {
+        return isExplain;
+    }
+
     public void setForwardTimes(int forwardTimes) {
         this.forwardTimes = forwardTimes;
     }
@@ -1207,6 +1220,14 @@ public class ConnectContext {
         } catch (Throwable e) {
             LOG.warn("Failed to clean temporary table on session {}, {}", sessionId, e);
         }
+    }
+
+    public Map<Long, TableName> getResolvedTables() {
+        return resolvedTables;
+    }
+
+    public void addResolvedTable(TableName tableName, long tableId) {
+        resolvedTables.putIfAbsent(tableId, tableName);
     }
 
     // We can not make sure the set variables are all valid. Even if some variables are invalid, we should let user continue

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -38,7 +38,9 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.gson.reflect.TypeToken;
 import com.starrocks.analysis.DescriptorTable;
+import com.starrocks.analysis.TableName;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.catalog.FsBroker;
@@ -59,6 +61,8 @@ import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.exception.RemoteFileNotFoundException;
 import com.starrocks.datacache.DataCacheSelectMetrics;
 import com.starrocks.mysql.MysqlCommand;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.planner.ResultSink;
@@ -101,6 +105,7 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTabletCommitInfo;
 import com.starrocks.thrift.TTabletFailInfo;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWorkGroup;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -533,6 +538,7 @@ public class DefaultCoordinator extends Coordinator {
 
     @Override
     public void startScheduling(ScheduleOption option) throws StarRocksException, InterruptedException, RpcException {
+        checkPartitionScanNumberLimit();
         try (Timer timer = Tracers.watchScope(Tracers.Module.SCHEDULER, "Pending")) {
             QueryQueueManager.getInstance().maybeWait(connectContext, this);
         }
@@ -1337,5 +1343,45 @@ public class DefaultCoordinator extends Coordinator {
 
     public ResultReceiver getReceiver() {
         return receiver;
+    }
+
+    private void checkPartitionScanNumberLimit() throws StarRocksException {
+        if (connectContext.isExplain()
+                && !connectContext.getSessionVariable().isCheckPartitionScanNumberLimitWhenExplain()) {
+            return;
+        }
+        if (!connectContext.getSessionVariable().isCheckPartitionScanNumberLimit()) {
+            return;
+        }
+        TWorkGroup workGroup = jobSpec.getResourceGroup();
+        if (workGroup == null) {
+            return;
+        }
+        if (workGroup.getPartition_scan_number_limit_rule() == null) {
+            return;
+        }
+        Map<String, Integer> rule = GsonUtils.GSON.fromJson(workGroup.getPartition_scan_number_limit_rule(),
+                new TypeToken<Map<String, Integer>>() {
+                }.getType());
+        for (ScanNode scanNode : jobSpec.getScanNodes()) {
+            if (!(scanNode instanceof OlapScanNode)) {
+                continue;
+            }
+            TableName tableName =
+                    connectContext.getResolvedTables().get(((OlapScanNode) scanNode).getOlapTable().getId());
+            if (tableName == null) {
+                continue;
+            }
+            String tblName = tableName.getDb() + "." + tableName.getTbl();
+            Integer limit = rule.get(tblName);
+            if (limit == null) {
+                continue;
+            }
+            if (((OlapScanNode) scanNode).getSelectedPartitionIds().size() > limit) {
+                throw new StarRocksException(tblName + " scans more than " + limit +
+                        " partition(s), which violates the limit defined in partition_scan_number_limit_rule in resource" +
+                        " group " + workGroup.getName());
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -566,6 +566,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_WAIT_DEPENDENT_EVENT = "enable_wait_dependent_event";
 
+    public static final String CHECK_PARTITION_SCAN_NUMBER_LIMIT
+            = "check_partition_scan_number_limit";
+
+    public static final String CHECK_PARTITION_SCAN_NUMBER_LIMIT_WHEN_EXPLAIN
+            = "check_partition_scan_number_limit_when_explain";
+
     public static final String ENABLE_PHASED_SCHEDULER = "enable_phased_scheduler";
     public static final String PHASED_SCHEDULER_MAX_CONCURRENCY = "phased_scheduler_max_concurrency";
 
@@ -2436,6 +2442,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public int getExprChildrenLimit() {
         return exprChildrenLimit;
     }
+
+    @VarAttr(name = CHECK_PARTITION_SCAN_NUMBER_LIMIT)
+    private boolean checkPartitionScanNumberLimit = true;
+
+    @VarAttr(name = CHECK_PARTITION_SCAN_NUMBER_LIMIT_WHEN_EXPLAIN)
+    private boolean checkPartitionScanNumberLimitWhenExplain = false;
 
     public void setExprChildrenLimit(int exprChildrenLimit) {
         this.exprChildrenLimit = exprChildrenLimit;
@@ -4456,6 +4468,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableRewriteUnnestBitmapToArray() {
         return enableRewriteUnnestBitmapToArray;
+    }
+
+    public boolean isCheckPartitionScanNumberLimit() {
+        return checkPartitionScanNumberLimit;
+    }
+
+    public void setCheckPartitionScanNumberLimit(boolean checkPartitionScanNumberLimit) {
+        this.checkPartitionScanNumberLimit = checkPartitionScanNumberLimit;
+    }
+
+    public boolean isCheckPartitionScanNumberLimitWhenExplain() {
+        return checkPartitionScanNumberLimitWhenExplain;
+    }
+
+    public void setCheckPartitionScanNumberLimitWhenExplain(boolean checkPartitionScanNumberLimitWhenExplain) {
+        this.checkPartitionScanNumberLimitWhenExplain = checkPartitionScanNumberLimitWhenExplain;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1211,6 +1211,7 @@ public class StmtExecutor {
         boolean executeInFe = !isExplainAnalyze && !isSchedulerExplain && !isOutfileQuery
                 && canExecuteInFe(context, execPlan.getPhysicalPlan());
 
+        context.setExplain(parsedStmt.isExplain());
         if (isExplainAnalyze) {
             context.getSessionVariable().setEnableProfile(true);
             context.getSessionVariable().setEnableAsyncProfile(false);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1461,6 +1461,7 @@ public class QueryAnalyzer {
                 ((OlapTable) table).maySetDatabaseName(db.getFullName());
             }
 
+            session.addResolvedTable(tableName, table.getId());
             return table;
         } catch (AnalysisException e) {
             throw new SemanticException(e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterResourceGroupStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterResourceGroupStmt.java
@@ -85,10 +85,11 @@ public class AlterResourceGroupStmt extends DdlStmt {
                     changedProperties.getBigQueryCpuSecondLimit() == null &&
                     changedProperties.getBigQueryMemLimit() == null &&
                     changedProperties.getBigQueryScanRowsLimit() == null &&
+                    changedProperties.getPartitionScanNumberLimitRule() == null &&
                     changedProperties.getSpillMemLimitThreshold() == null) {
                 throw new SemanticException("At least one of ('cpu_weight','exclusive_cpu_cores','mem_limit'," +
                         "'max_cpu_cores','concurrency_limit','big_query_mem_limit', 'big_query_scan_rows_limit'," +
-                        "'big_query_cpu_second_limit','spill_mem_limit_threshold') " +
+                        "'big_query_cpu_second_limit','spill_mem_limit_threshold','partition_scan_number_limit_rule') " +
                         "should be specified");
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -236,22 +236,22 @@ public class ResourceGroupStmtTest {
         createResourceGroups();
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String result = rowsToString(rows);
-        String expect = "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|NORMAL|(weight=0.0)\n" +
-                "default_wg|32|0|100.0%|null|0|0|0|null|100%|NORMAL|(weight=0.0)\n" +
-                "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
-                "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
-                "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
-                "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_user4)\n" +
-                "rg2|30|0|50.0%|null|0|0|0|20|100%|NORMAL|(weight=3.475, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
-                "rg2|30|0|50.0%|null|0|0|0|20|100%|NORMAL|(weight=2.375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
-                "rg2|30|0|50.0%|null|0|0|0|20|100%|NORMAL|(weight=1.0, role=rg2_role3)\n" +
-                "rg3|32|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
-                "rg3|32|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=1.1, query_type in (SELECT))\n" +
-                "rg4|25|0|80.0%|null|1024|1024|1024|10|100%|NORMAL|(weight=1.375, source_ip=192.168.7.1/24)\n" +
-                "rg5|25|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
-                "rg6|32|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
-                "rg7|32|0|80.0%|null|0|0|0|10|30%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
-                "rt_rg1|25|25|80.0%|null|0|0|0|10|100%|SHORT_QUERY|(weight=1.0, user=rt_rg_user)";
+        String expect = "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|null|NORMAL|(weight=0.0)\n" +
+                "default_wg|32|0|100.0%|null|0|0|0|null|100%|null|NORMAL|(weight=0.0)\n" +
+                "rg1|10|0|20.0%|8|0|0|0|11|100%|null|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
+                "rg1|10|0|20.0%|8|0|0|0|11|100%|null|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
+                "rg1|10|0|20.0%|8|0|0|0|11|100%|null|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
+                "rg1|10|0|20.0%|8|0|0|0|11|100%|null|NORMAL|(weight=1.0, user=rg1_user4)\n" +
+                "rg2|30|0|50.0%|null|0|0|0|20|100%|null|NORMAL|(weight=3.475, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
+                "rg2|30|0|50.0%|null|0|0|0|20|100%|null|NORMAL|(weight=2.375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
+                "rg2|30|0|50.0%|null|0|0|0|20|100%|null|NORMAL|(weight=1.0, role=rg2_role3)\n" +
+                "rg3|32|0|80.0%|null|0|0|0|10|100%|null|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rg3|32|0|80.0%|null|0|0|0|10|100%|null|NORMAL|(weight=1.1, query_type in (SELECT))\n" +
+                "rg4|25|0|80.0%|null|1024|1024|1024|10|100%|null|NORMAL|(weight=1.375, source_ip=192.168.7.1/24)\n" +
+                "rg5|25|0|80.0%|null|0|0|0|10|100%|null|NORMAL|(weight=10.0, db='db1')\n" +
+                "rg6|32|0|80.0%|null|0|0|0|10|100%|null|NORMAL|(weight=2.475, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
+                "rg7|32|0|80.0%|null|0|0|0|10|30%|null|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rt_rg1|25|25|80.0%|null|0|0|0|10|100%|null|SHORT_QUERY|(weight=1.0, user=rt_rg_user)";
         Assert.assertEquals(expect, result);
         dropResourceGroups();
     }
@@ -486,7 +486,7 @@ public class ResourceGroupStmtTest {
         starRocksAssert.executeResourceGroupDdlSql("ALTER RESOURCE GROUP rg1 DROP ALL;");
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg1");
         String actual = rowsToString(rows);
-        String expect = "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=0.0)";
+        String expect = "rg1|10|0|20.0%|8|0|0|0|11|100%|null|NORMAL|(weight=0.0)";
         Assert.assertEquals(expect, actual);
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
@@ -582,9 +582,9 @@ public class ResourceGroupStmtTest {
                 starRocksAssert.getCtx(), true, false);
         String result = rowsToString(rows);
         String expect = "" +
-                "rg5|25|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
-                "rg1|10|0|20.0%|8|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
-                "rg3|32|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=1.1, query_type in (SELECT))";
+                "rg5|25|0|80.0%|null|0|0|0|10|100%|null|NORMAL|(weight=10.0, db='db1')\n" +
+                "rg1|10|0|20.0%|8|0|0|0|11|100%|null|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
+                "rg3|32|0|80.0%|null|0|0|0|10|100%|null|NORMAL|(weight=1.1, query_type in (SELECT))";
         Assert.assertEquals(expect, result);
         dropResourceGroups();
     }
@@ -639,22 +639,22 @@ public class ResourceGroupStmtTest {
         }
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String result = rowsToString(rows);
-        String expect = "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|NORMAL|(weight=0.0)\n" +
-                "default_wg|32|0|100.0%|null|0|0|0|null|100%|NORMAL|(weight=0.0)\n" +
-                "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
-                "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
-                "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
-                "rg1|21|0|20.0%|4|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_user4)\n" +
-                "rg2|30|0|37.0%|null|0|0|0|20|100%|NORMAL|(weight=3.475, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
-                "rg2|30|0|37.0%|null|0|0|0|20|100%|NORMAL|(weight=2.375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
-                "rg2|30|0|37.0%|null|0|0|0|20|100%|NORMAL|(weight=1.0, role=rg2_role3)\n" +
-                "rg3|32|0|80.0%|3|0|0|0|23|100%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
-                "rg3|32|0|80.0%|3|0|0|0|23|100%|NORMAL|(weight=1.1, query_type in (SELECT))\n" +
-                "rg4|13|0|41.0%|null|1024|1024|1024|23|100%|NORMAL|(weight=1.375, source_ip=192.168.7.1/24)\n" +
-                "rg5|25|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=10.0, db='db1')\n" +
-                "rg6|32|0|80.0%|null|0|0|0|10|100%|NORMAL|(weight=2.475, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
-                "rg7|32|0|80.0%|null|0|0|0|10|30%|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
-                "rt_rg1|25|25|80.0%|null|0|0|0|10|100%|SHORT_QUERY|(weight=1.0, user=rt_rg_user)";
+        String expect = "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|null|NORMAL|(weight=0.0)\n" +
+                "default_wg|32|0|100.0%|null|0|0|0|null|100%|null|NORMAL|(weight=0.0)\n" +
+                "rg1|21|0|20.0%|4|0|0|0|11|100%|null|NORMAL|(weight=4.475, user=rg1_user1, role=rg1_role1, query_type in (SELECT), source_ip=192.168.2.1/24)\n" +
+                "rg1|21|0|20.0%|4|0|0|0|11|100%|null|NORMAL|(weight=3.475, user=rg1_user2, query_type in (SELECT), source_ip=192.168.3.1/24)\n" +
+                "rg1|21|0|20.0%|4|0|0|0|11|100%|null|NORMAL|(weight=2.375, user=rg1_user3, source_ip=192.168.4.1/24)\n" +
+                "rg1|21|0|20.0%|4|0|0|0|11|100%|null|NORMAL|(weight=1.0, user=rg1_user4)\n" +
+                "rg2|30|0|37.0%|null|0|0|0|20|100%|null|NORMAL|(weight=3.475, role=rg2_role1, query_type in (SELECT), source_ip=192.168.5.1/24)\n" +
+                "rg2|30|0|37.0%|null|0|0|0|20|100%|null|NORMAL|(weight=2.375, role=rg2_role2, source_ip=192.168.6.1/24)\n" +
+                "rg2|30|0|37.0%|null|0|0|0|20|100%|null|NORMAL|(weight=1.0, role=rg2_role3)\n" +
+                "rg3|32|0|80.0%|3|0|0|0|23|100%|null|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rg3|32|0|80.0%|3|0|0|0|23|100%|null|NORMAL|(weight=1.1, query_type in (SELECT))\n" +
+                "rg4|13|0|41.0%|null|1024|1024|1024|23|100%|null|NORMAL|(weight=1.375, source_ip=192.168.7.1/24)\n" +
+                "rg5|25|0|80.0%|null|0|0|0|10|100%|null|NORMAL|(weight=10.0, db='db1')\n" +
+                "rg6|32|0|80.0%|null|0|0|0|10|100%|null|NORMAL|(weight=2.475, query_type in (INSERT), source_ip=192.168.6.1/24)\n" +
+                "rg7|32|0|80.0%|null|0|0|0|10|30%|null|NORMAL|(weight=2.475, query_type in (SELECT), source_ip=192.168.6.1/24)\n" +
+                "rt_rg1|25|25|80.0%|null|0|0|0|10|100%|null|SHORT_QUERY|(weight=1.0, user=rt_rg_user)";
         Assert.assertEquals(expect, result);
         dropResourceGroups();
     }
@@ -885,7 +885,7 @@ public class ResourceGroupStmtTest {
             List<List<String>> rows =
                     starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_valid_max_cpu_cores");
             String actual = rowsToString(rows);
-            String expect = "rg_valid_max_cpu_cores|32|0|20.0%|17|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
+            String expect = "rg_valid_max_cpu_cores|32|0|20.0%|17|0|0|0|11|100%|null|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
             Assert.assertEquals(expect, actual);
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg_valid_max_cpu_cores");
         }
@@ -896,7 +896,7 @@ public class ResourceGroupStmtTest {
             List<List<String>> rows =
                     starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_valid_max_cpu_cores");
             String actual = rowsToString(rows);
-            String expect = "rg_valid_max_cpu_cores|31|0|20.0%|17|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
+            String expect = "rg_valid_max_cpu_cores|31|0|20.0%|17|0|0|0|11|100%|null|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
             Assert.assertEquals(expect, actual);
         }
 
@@ -920,7 +920,7 @@ public class ResourceGroupStmtTest {
             List<List<String>> rows =
                     starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_valid_max_cpu_cores");
             String actual = rowsToString(rows);
-            String expect = "rg_valid_max_cpu_cores|31|0|20.0%|32|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
+            String expect = "rg_valid_max_cpu_cores|31|0|20.0%|32|0|0|0|11|100%|null|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
             Assert.assertEquals(expect, actual);
         }
 
@@ -930,11 +930,63 @@ public class ResourceGroupStmtTest {
             List<List<String>> rows =
                     starRocksAssert.executeResourceGroupShowSql("show verbose resource group rg_valid_max_cpu_cores");
             String actual = rowsToString(rows);
-            String expect = "rg_valid_max_cpu_cores|31|0|20.0%|30|0|0|0|11|100%|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
+            String expect = "rg_valid_max_cpu_cores|31|0|20.0%|30|0|0|0|11|100%|null|NORMAL|(weight=1.0, user=rg1_if_not_exists)";
             Assert.assertEquals(expect, actual);
         }
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg_valid_max_cpu_cores");
+    }
+
+    @Test
+    public void testCreateRgWithPartitionScanLimitRule() throws Exception {
+        final int numCores = 32;
+
+        String createSQLTemplate = "create resource group rg_partition_scan_rule\n" +
+                "to\n" +
+                "    (user='rg1_if_not_exists')\n" +
+                "   with (" +
+                "   'cpu_core_limit' = '32'," +
+                "   'mem_limit' = '20%'," +
+                "   'concurrency_limit' = '11'," +
+                "   'partition_scan_number_limit_rule'='{\"test_pt\":1}'," +
+                "   'type' = 'normal'" +
+                "   );";
+
+        String alterSQLTemplate = "ALTER resource group rg_partition_scan_rule \n" +
+                "WITH (\n" +
+                "   'partition_scan_number_limit_rule'='{\"test_pt\":'\n" +
+                ")";
+
+        {
+            String sql = createSQLTemplate;
+            starRocksAssert.executeResourceGroupDdlSql(sql);
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg_partition_scan_rule");
+            String actual = rowsToString(rows);
+            String expect = "rg_partition_scan_rule|32|0|20.0%|0|0|0|11|100%|{\"test_pt\":1}|(weight=1.0, user=rg1_if_not_exists)";
+            Assert.assertEquals(expect, actual);
+
+            sql = String.format(alterSQLTemplate, numCores);
+            String finalSql = sql;
+            Assert.assertThrows("Not valid partition scan number limit rule json",
+                    SemanticException.class, () -> starRocksAssert.executeResourceGroupDdlSql(finalSql));
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg_partition_scan_rule");
+        }
+
+        {
+            String sql = "create resource group rg_partition_scan_rule\n" +
+                    "to\n" +
+                    "    (user='rg1_if_not_exists')\n" +
+                    "   with (" +
+                    "   'cpu_core_limit' = '1'," +
+                    "   'mem_limit' = '20%'," +
+                    "   'max_cpu_cores' = '17'," +
+                    "   'concurrency_limit' = '11'," +
+                    "   'partition_scan_number_limit_rule'='{\"test_pt\":1'," +
+                    "   'type' = 'normal'" +
+                    "   );";
+            Assert.assertThrows("Not valid partition scan number limit rule json",
+                    SemanticException.class, () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
     }
 
     @Test
@@ -1045,16 +1097,16 @@ public class ResourceGroupStmtTest {
 
         List<TestCase> testCases = ImmutableList.of(
                 new TestCase("[1.12345678901234567,10.2)", "[2, 100.2)",
-                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[1.1234567890123457, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[1.1234567890123457, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
                 new TestCase("[1.1,10.2)", "[2, 100.2)",
-                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[1.1, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[1.1, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
 
                 new TestCase("[-1,10)", "[2, 100)",
-                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[-1.0, 10.0), plan_mem_cost_range=[2.0, 100.0))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[-1.0, 10.0), plan_mem_cost_range=[2.0, 100.0))"),
                 new TestCase("[0, 10)", "[0, 100)",
-                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
                 new TestCase(" [ 0,  10) ", "  [ 0,  100  )  ",
-                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))")
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))")
         );
         for (TestCase c : testCases) {
             String createSQL = String.format(createSQLTemplate, c.planCpuCostRange, c.PlanMemCostRange);
@@ -1102,21 +1154,21 @@ public class ResourceGroupStmtTest {
 
         List<TestCase> testCases = ImmutableList.of(
                 new TestCase("[1.12345678901234567,10.2)", "[2, 100.2)",
-                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
-                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.1234567890123457, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.1234567890123457, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
                 new TestCase("[1.1,10.2)", "[2, 100.2)",
-                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
-                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.1, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.1, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
 
                 new TestCase("[-1,10)", "[2, 100)",
-                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
-                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[-1.0, 10.0), plan_mem_cost_range=[2.0, 100.0))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[-1.0, 10.0), plan_mem_cost_range=[2.0, 100.0))"),
                 new TestCase("[0, 10)", "[0, 100)",
-                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
-                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
                 new TestCase(" [ 0,  10) ", "  [ 0,  100  )  ",
-                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
-                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))")
+                        "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))")
         );
         for (TestCase c : testCases) {
             starRocksAssert.executeResourceGroupDdlSql(createSQL);
@@ -1273,10 +1325,10 @@ public class ResourceGroupStmtTest {
                 "   'concurrency_limit' = '31'," +
                 "   'type' = 'normal'" +
                 "   );";
-        String showResult = "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|NORMAL|(weight=0.0)\n" +
-                "default_wg|32|0|100.0%|null|0|0|0|null|100%|NORMAL|(weight=0.0)\n" +
-                "rg1|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.0, 2.0), plan_mem_cost_range=[-100.0, 1000.0))\n" +
-                "rg2|32|0|30.0%|null|0|0|0|31|100%|NORMAL|(weight=2.0, user=rg1_user, plan_mem_cost_range=[0.0, 2000.0))";
+        String showResult = "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|null|NORMAL|(weight=0.0)\n" +
+                "default_wg|32|0|100.0%|null|0|0|0|null|100%|null|NORMAL|(weight=0.0)\n" +
+                "rg1|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.0, 2.0), plan_mem_cost_range=[-100.0, 1000.0))\n" +
+                "rg2|32|0|30.0%|null|0|0|0|31|100%|null|NORMAL|(weight=2.0, user=rg1_user, plan_mem_cost_range=[0.0, 2000.0))";
 
         starRocksAssert.executeResourceGroupDdlSql(createSQL1);
         starRocksAssert.executeResourceGroupDdlSql(createSQL2);
@@ -1372,11 +1424,11 @@ public class ResourceGroupStmtTest {
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
         String actual = rowsToString(rows);
         String expected =
-                "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|NORMAL|(weight=0.0)\n" +
-                        "default_wg|32|0|100.0%|null|0|0|0|null|100%|NORMAL|(weight=0.0)\n" +
-                        "rg1|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=2.0, plan_cpu_cost_range=[11.0, 12.0), plan_mem_cost_range=[-100.0, 11000.0))\n" +
-                        "rg2|16|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_cpu_cost_range=[21.0, 22.0))\n" +
-                        "rg3|17|0|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_mem_cost_range=[-100.0, 31000.0))";
+                "default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|null|NORMAL|(weight=0.0)\n" +
+                        "default_wg|32|0|100.0%|null|0|0|0|null|100%|null|NORMAL|(weight=0.0)\n" +
+                        "rg1|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=2.0, plan_cpu_cost_range=[11.0, 12.0), plan_mem_cost_range=[-100.0, 11000.0))\n" +
+                        "rg2|16|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=1.0, plan_cpu_cost_range=[21.0, 22.0))\n" +
+                        "rg3|17|0|20.0%|null|0|0|0|11|100%|null|NORMAL|(weight=1.0, plan_mem_cost_range=[-100.0, 31000.0))";
         Assert.assertEquals(expected, actual);
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
@@ -1404,9 +1456,9 @@ public class ResourceGroupStmtTest {
                 ");";
         starRocksAssert.executeResourceGroupDdlSql(createSQL);
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show verbose resource groups all");
-        assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|NORMAL|(weight=0.0)\n" +
-                "default_wg|32|0|100.0%|null|0|0|0|null|100%|NORMAL|(weight=0.0)\n" +
-                "rg1|10|0|20.0%|8|0|0|0|null|100%|NORMAL|(weight=1.5, source_ip=192.168.2.1/32)");
+        assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|null|0|0|0|null|80%|null|NORMAL|(weight=0.0)\n" +
+                "default_wg|32|0|100.0%|null|0|0|0|null|100%|null|NORMAL|(weight=0.0)\n" +
+                "rg1|10|0|20.0%|8|0|0|0|null|100%|null|NORMAL|(weight=1.5, source_ip=192.168.2.1/32)");
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
     }
@@ -1434,11 +1486,11 @@ public class ResourceGroupStmtTest {
                 ");");
 
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-        assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                "rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
-                "rg2|0|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)\n" +
-                "rt_rg1|15|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rt_rg1_user)");
+        assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                "rg1|17|0|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)\n" +
+                "rg2|0|16|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg2_user)\n" +
+                "rt_rg1|15|15|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rt_rg1_user)");
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg2");
@@ -1507,9 +1559,9 @@ public class ResourceGroupStmtTest {
                     ");";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|17|0|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
 
@@ -1522,9 +1574,9 @@ public class ResourceGroupStmtTest {
                     ");";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|17|0|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
 
@@ -1538,9 +1590,9 @@ public class ResourceGroupStmtTest {
                     ");";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|0|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|0|17|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
 
@@ -1553,9 +1605,9 @@ public class ResourceGroupStmtTest {
                     ");";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|0|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|0|17|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
     }
@@ -1571,9 +1623,9 @@ public class ResourceGroupStmtTest {
                     ");";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|17|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|17|0|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)");
         }
 
         {
@@ -1640,9 +1692,9 @@ public class ResourceGroupStmtTest {
                     ")";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|0|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|0|16|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)");
         }
 
         {
@@ -1653,9 +1705,9 @@ public class ResourceGroupStmtTest {
                     ")";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|15|0|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|15|0|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)");
         }
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
@@ -1686,9 +1738,9 @@ public class ResourceGroupStmtTest {
                     "   'type' = 'short_query'" +
                     ");");
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|17|17|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|17|17|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)");
 
             String sql = "ALTER resource group rg1 \n" +
                     "WITH (\n" +
@@ -1719,10 +1771,10 @@ public class ResourceGroupStmtTest {
                     "   'exclusive_cpu_cores' = '15'" +
                     ");");
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|0|16|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
-                    "rg2|0|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|0|16|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)\n" +
+                    "rg2|0|15|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg2_user)");
         }
 
         {
@@ -1744,10 +1796,10 @@ public class ResourceGroupStmtTest {
                     ")";
             starRocksAssert.executeResourceGroupDdlSql(sql);
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|0|14|20.0%|0|0|0|null|100%|(weight=1.0, user=rg1_user)\n" +
-                    "rg2|0|15|20.0%|0|0|0|null|100%|(weight=1.0, user=rg2_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|0|14|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg1_user)\n" +
+                    "rg2|0|15|20.0%|0|0|0|null|100%|null|(weight=1.0, user=rg2_user)");
         }
 
         {
@@ -1800,8 +1852,8 @@ public class ResourceGroupStmtTest {
     public void testAlterPropertyBuiltinGroup() throws Exception {
         {
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)");
         }
 
         {
@@ -1813,8 +1865,8 @@ public class ResourceGroupStmtTest {
             starRocksAssert.executeResourceGroupDdlSql(sql2);
 
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|12|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|14|0|100.0%|0|0|0|null|100%|(weight=0.0)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|12|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|14|0|100.0%|0|0|0|null|100%|null|(weight=0.0)");
         }
 
         {
@@ -1826,8 +1878,8 @@ public class ResourceGroupStmtTest {
             starRocksAssert.executeResourceGroupDdlSql(sql2);
 
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)");
         }
     }
 
@@ -1900,9 +1952,9 @@ public class ResourceGroupStmtTest {
             starRocksAssert.executeResourceGroupDdlSql(sql);
 
             List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|(weight=0.0)\n" +
-                    "default_wg|32|0|100.0%|0|0|0|null|100%|(weight=0.0)\n" +
-                    "rg1|0|1|20.0%|9223372036|0|0|null|100%|(weight=1.0, user=rg1_user)");
+            assertThat(rowsToString(rows)).isEqualTo("default_mv_wg|1|0|80.0%|0|0|0|null|80%|null|(weight=0.0)\n" +
+                    "default_wg|32|0|100.0%|0|0|0|null|100%|null|(weight=0.0)\n" +
+                    "rg1|0|1|20.0%|9223372036|0|0|null|100%|null|(weight=1.0, user=rg1_user)");
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg1");
         }
     }

--- a/gensrc/thrift/WorkGroup.thrift
+++ b/gensrc/thrift/WorkGroup.thrift
@@ -42,6 +42,7 @@ struct TWorkGroup {
   15: optional i32 exclusive_cpu_cores
 
   100: optional i32 max_cpu_cores
+  200: optional string partition_scan_number_limit_rule
 }
 
 enum TWorkGroupOpType {


### PR DESCRIPTION
## Why I'm doing:

Want to limit the number of scanned partitions to prevent starrocks from heavy load

## What I'm doing:
Fixes #issue

Add a limit rule in resource group.
eg :
![image](https://github.com/user-attachments/assets/cf73ade6-ac0d-4851-9962-3edd82f44376)

`partition_scan_number_limit_rule: {"db_1.tbl_1":7, "db_1.tbl_2":10}`

If table scan in a  single sub-query exceeds the limit, the query will be rejected.


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0