### PR TITLE
[BugFix] Fix log block not record disks requested from the DirManager

### DIFF
--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -28,13 +28,14 @@ namespace starrocks::spill {
 class FileBlockContainer {
 public:
     FileBlockContainer(DirPtr dir, const TUniqueId& query_id, const TUniqueId& fragment_instance_id,
-                       int32_t plan_node_id, std::string plan_node_name, uint64_t id)
+                       int32_t plan_node_id, std::string plan_node_name, uint64_t id, size_t acquired_size)
             : _dir(std::move(dir)),
               _query_id(query_id),
               _fragment_instance_id(fragment_instance_id),
               _plan_node_id(plan_node_id),
               _plan_node_name(std::move(plan_node_name)),
-              _id(id) {}
+              _id(id),
+              _acquired_data_size(acquired_size) {}
 
     ~FileBlockContainer() {
         // @TODO we need add a gc thread to delete file
@@ -81,7 +82,7 @@ public:
 
     static StatusOr<FileBlockContainerPtr> create(const DirPtr& dir, const TUniqueId& query_id,
                                                   const TUniqueId& fragment_instance_id, int32_t plan_node_id,
-                                                  const std::string& plan_node_name, uint64_t id);
+                                                  const std::string& plan_node_name, uint64_t id, size_t block_size);
 
 private:
     DirPtr _dir;
@@ -134,9 +135,10 @@ StatusOr<std::unique_ptr<io::InputStreamWrapper>> FileBlockContainer::get_readab
 
 StatusOr<FileBlockContainerPtr> FileBlockContainer::create(const DirPtr& dir, const TUniqueId& query_id,
                                                            const TUniqueId& fragment_instance_id, int32_t plan_node_id,
-                                                           const std::string& plan_node_name, uint64_t id) {
-    auto container =
-            std::make_shared<FileBlockContainer>(dir, query_id, fragment_instance_id, plan_node_id, plan_node_name, id);
+                                                           const std::string& plan_node_name, uint64_t id,
+                                                           size_t block_size) {
+    auto container = std::make_shared<FileBlockContainer>(dir, query_id, fragment_instance_id, plan_node_id,
+                                                          plan_node_name, id, block_size);
     RETURN_IF_ERROR(container->open());
     return container;
 }
@@ -205,8 +207,8 @@ StatusOr<BlockPtr> FileBlockManager::acquire_block(const AcquireBlockOptions& op
     AcquireDirOptions acquire_dir_opts;
     acquire_dir_opts.data_size = opts.block_size;
     ASSIGN_OR_RETURN(auto dir, _dir_mgr->acquire_writable_dir(acquire_dir_opts));
-    ASSIGN_OR_RETURN(auto block_container,
-                     get_or_create_container(dir, opts.fragment_instance_id, opts.plan_node_id, opts.name));
+    ASSIGN_OR_RETURN(auto block_container, get_or_create_container(dir, opts.fragment_instance_id, opts.plan_node_id,
+                                                                   opts.name, opts.block_size));
     auto res = std::make_shared<FileBlock>(block_container);
     res->set_is_remote(dir->is_remote());
     return res;
@@ -223,14 +225,15 @@ Status FileBlockManager::release_block(BlockPtr block) {
 StatusOr<FileBlockContainerPtr> FileBlockManager::get_or_create_container(const DirPtr& dir,
                                                                           const TUniqueId& fragment_instance_id,
                                                                           int32_t plan_node_id,
-                                                                          const std::string& plan_node_name) {
+                                                                          const std::string& plan_node_name,
+                                                                          size_t block_size) {
     TRACE_SPILL_LOG << "get_or_create_container at dir: " << dir->dir() << ", plan node:" << plan_node_id << ", "
                     << plan_node_name;
     uint64_t id = _next_container_id++;
     std::string container_dir = dir->dir() + "/" + print_id(_query_id);
     RETURN_IF_ERROR(dir->fs()->create_dir_if_missing(container_dir));
     ASSIGN_OR_RETURN(auto block_container, FileBlockContainer::create(dir, _query_id, fragment_instance_id,
-                                                                      plan_node_id, plan_node_name, id));
+                                                                      plan_node_id, plan_node_name, id, block_size));
     RETURN_IF_ERROR(block_container->open());
     return block_container;
 }

--- a/be/src/exec/spill/file_block_manager.h
+++ b/be/src/exec/spill/file_block_manager.h
@@ -43,7 +43,8 @@ public:
 
 private:
     StatusOr<FileBlockContainerPtr> get_or_create_container(const DirPtr& dir, const TUniqueId& fragment_instance_id,
-                                                            int32_t plan_node_id, const std::string& plan_node_name);
+                                                            int32_t plan_node_id, const std::string& plan_node_name,
+                                                            size_t block_size);
 
     TUniqueId _query_id;
     std::atomic<uint64_t> _next_container_id = 0;

--- a/be/src/exec/spill/log_block_manager.h
+++ b/be/src/exec/spill/log_block_manager.h
@@ -64,7 +64,8 @@ public:
 private:
     StatusOr<LogBlockContainerPtr> get_or_create_container(const DirPtr& dir, const TUniqueId& fragment_instance_id,
                                                            int32_t plan_node_id, const std::string& plan_node_name,
-                                                           bool direct_io, BlockAffinityGroup affinity_group);
+                                                           bool direct_io, size_t block_size,
+                                                           BlockAffinityGroup affinity_group);
 
 private:
     typedef phmap::flat_hash_map<uint64_t, LogBlockContainerPtr> ContainerMap;

--- a/be/test/io/spill_block_manager_test.cpp
+++ b/be/test/io/spill_block_manager_test.cpp
@@ -323,4 +323,21 @@ TEST_F(SpillBlockManagerTest, hybird_block_allocation_test) {
         ASSERT_EQ(block->debug_string(), expected);
     }
 }
+
+TEST_F(SpillBlockManagerTest, dir_allocate_test) {
+    auto log_block_mgr = std::make_shared<spill::LogBlockManager>(dummy_query_id, local_dir_mgr.get());
+    ASSERT_OK(log_block_mgr->open());
+    {
+        // 1. allocate the first block but not release it
+        spill::AcquireBlockOptions opts{.query_id = dummy_query_id,
+                                        .fragment_instance_id = dummy_query_id,
+                                        .plan_node_id = 1,
+                                        .name = "node1",
+                                        .block_size = 10};
+        auto res = log_block_mgr->acquire_block(opts);
+        ASSERT_TRUE(res.ok());
+    }
+    ASSERT_EQ(local_dir_mgr->_dirs[0]->get_current_size(), 0);
+}
+
 } // namespace starrocks::vectorized


### PR DESCRIPTION
## Why I'm doing:

the request bytes allocate from dir manager will never release. it will cause always no writeable spill dirs.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0