### PR TITLE
[BugFix] Add insert_max_filter_ratio value check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -44,6 +44,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.ToNumberPolicy;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.common.VectorSearchOptions;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -2905,6 +2907,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public void setInsertMaxFilterRatio(double insertMaxFilterRatio) {
+        if (insertMaxFilterRatio < 0 || insertMaxFilterRatio > 1) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_VALUE, SessionVariable.INSERT_MAX_FILTER_RATIO,
+                    insertMaxFilterRatio, "between 0.0 and 1.0");
+        }
         this.insertMaxFilterRatio = insertMaxFilterRatio;
     }
 

--- a/test/sql/test_files/R/test_insert_properties
+++ b/test/sql/test_files/R/test_insert_properties
@@ -148,3 +148,18 @@ truncate table t2;
 -- !result
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/csv_format/${uuid0}/ > /dev/null
+
+set insert_max_filter_ratio = xxx;
+-- result:
+[REGEX].*Invalid insert_max_filter_ratio: 'xxx'\. Expected values should be between 0\.0 and 1\.0
+-- !result
+
+set insert_max_filter_ratio = -1;
+-- result:
+[REGEX].*Invalid insert_max_filter_ratio: '-1'\. Expected values should be between 0\.0 and 1\.0
+-- !result
+
+set insert_max_filter_ratio = 1.2;
+-- result:
+[REGEX].*Invalid insert_max_filter_ratio: '1\.2'\. Expected values should be between 0\.0 and 1\.0
+-- !result

--- a/test/sql/test_files/T/test_insert_properties
+++ b/test/sql/test_files/T/test_insert_properties
@@ -95,3 +95,8 @@ select * from t2;
 truncate table t2;
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/csv_format/${uuid0}/ > /dev/null
+
+-- check insert_max_filter_ratio
+set insert_max_filter_ratio = xxx;
+set insert_max_filter_ratio = -1;
+set insert_max_filter_ratio = 1.2;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
mysql> set insert_max_filter_ratio = -1;
ERROR 5018 (HY000): Invalid insert_max_filter_ratio: '-1'. Expected values should be between 0.0 and 1.0
mysql> set insert_max_filter_ratio = xx;
ERROR 5018 (HY000): Invalid insert_max_filter_ratio: 'xx'. Expected values should be between 0.0 and 1.0
```

Fixes https://github.com/StarRocks/StarRocksTest/issues/8909

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0