### PR TITLE
[Enhancement] Convert the constant value to target type while making kudu predicate.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/kudu/KuduPredicateConverter.java
@@ -16,6 +16,8 @@ package com.starrocks.connector.kudu;
 
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.BinaryType;
+import com.starrocks.catalog.Type;
+import com.starrocks.connector.ColumnTypeConverter;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -103,7 +105,9 @@ public class KuduPredicateConverter extends ScalarOperatorVisitor<List<KuduPredi
         if (columnName == null) {
             return Lists.newArrayList();
         }
-        Object literal = getLiteral(operator.getChild(1));
+        ColumnSchema column = schema.getColumn(columnName);
+        Type targetType = ColumnTypeConverter.fromKuduType(column);
+        Object literal = getLiteral(operator.getChild(1), targetType);
         if (literal == null) {
             return Lists.newArrayList();
         }
@@ -137,10 +141,12 @@ public class KuduPredicateConverter extends ScalarOperatorVisitor<List<KuduPredi
         if (columnName == null) {
             return Lists.newArrayList();
         }
+        ColumnSchema column = schema.getColumn(columnName);
+        Type targetType = ColumnTypeConverter.fromKuduType(column);
         List<ScalarOperator> valuesOperatorList = operator.getListChildren();
         List<Object> literalValues = new ArrayList<>(valuesOperatorList.size());
         for (ScalarOperator valueOperator : valuesOperatorList) {
-            Object literal = getLiteral(valueOperator);
+            Object literal = getLiteral(valueOperator, targetType);
             if (literal == null) {
                 return Lists.newArrayList();
             }
@@ -154,11 +160,18 @@ public class KuduPredicateConverter extends ScalarOperatorVisitor<List<KuduPredi
         return Lists.newArrayList();
     }
 
-    private Object getLiteral(ScalarOperator operator) {
+    private Object getLiteral(ScalarOperator operator, Type targetType) {
         if (!(operator instanceof ConstantOperator)) {
             return null;
         }
+
         ConstantOperator constValue = (ConstantOperator) operator;
+        Optional<ConstantOperator> casted = constValue.castTo(targetType);
+        if (!casted.isPresent()) {
+            // Illegal cast. Do not push down the predicate.
+            return null;
+        }
+        constValue = casted.get();
         switch (constValue.getType().getPrimitiveType()) {
             case BOOLEAN:
                 return constValue.getBoolean();
@@ -202,7 +215,7 @@ public class KuduPredicateConverter extends ScalarOperatorVisitor<List<KuduPredi
     }
 
     private String getColumnName(ScalarOperator operator) {
-        if (operator == null || operator instanceof CastOperator) {
+        if (operator == null) {
             return null;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduPredicateConverterTest.java
@@ -78,10 +78,10 @@ public class KuduPredicateConverterTest {
 
     @Test
     public void testEqCast() {
-        ConstantOperator value = ConstantOperator.createInt(5);
+        ConstantOperator value = ConstantOperator.createVarchar("5");
         ScalarOperator op = new BinaryPredicateOperator(BinaryType.EQ, F0_CAST, value);
         List<KuduPredicate> result = CONVERTER.convert(op);
-        Assert.assertEquals(result.size(), 0);
+        Assert.assertEquals(result.get(0).toString(), "`f0` = 5");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
For now, the following fails.
`select * from (select cast(coin_num as varchar) tmp from kudu.user_3) where tmp = '145';`
The error showed below:
`coin_num's type isn't [Type: string, Type: varchar], it's double`
The error is raised by Kudu client, it builds the predicate according to the type of the literal value we passed in. For this sql, we passed a string '145' but the column type is actually a double, so the error occurred.

## What I'm doing:
Cast the constant operator to the target type to get the correct literal value while building the kudu predicate.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0