### PR TITLE
[Enhancement] Improve query queue pending timeout error message

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -40,8 +40,7 @@ public class QueryQueueManager {
     private static final Logger LOG = LogManager.getLogger(QueryQueueManager.class);
 
     private static final String PENDING_TIMEOUT_ERROR_MSG_FORMAT =
-            "Failed to allocate resource to query: pending timeout [%d], " +
-                    "you could modify the session variable [%s] to pending more time";
+            "Failed to allocate resource to query: pending timeout [%ds], you could modify %s to pending more time";
 
     private static class SingletonHolder {
         private static final QueryQueueManager INSTANCE = new QueryQueueManager();
@@ -73,9 +72,14 @@ public class QueryQueueManager {
                 if (currentMs >= timeoutMs) {
                     MetricRepo.COUNTER_QUERY_QUEUE_TIMEOUT.increase(1L);
                     slotProvider.cancelSlotRequirement(slotRequirement);
+                    int queryQueuePendingTimeout = GlobalVariable.getQueryQueuePendingTimeoutSecond();
+                    int queryTimeout = coord.getJobSpec().getQueryOptions().query_timeout;
+                    String timeoutVar = queryQueuePendingTimeout < queryTimeout ?
+                            String.format("the session variable [%s]", GlobalVariable.QUERY_QUEUE_PENDING_TIMEOUT_SECOND) :
+                            "query/insert timeout";
                     String errMsg = String.format(PENDING_TIMEOUT_ERROR_MSG_FORMAT,
-                            GlobalVariable.getQueryQueuePendingTimeoutSecond(),
-                            GlobalVariable.QUERY_QUEUE_PENDING_TIMEOUT_SECOND);
+                            Math.min(queryQueuePendingTimeout, queryTimeout),
+                            timeoutVar);
                     ResourceGroupMetricMgr.increaseTimeoutQueuedQuery(context, 1L);
                     throw new StarRocksException(errMsg);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.ResourceGroupClassifier;
 import com.starrocks.catalog.ResourceGroupMgr;
 import com.starrocks.common.Config;
+import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.ha.FrontendNodeType;
@@ -599,6 +600,9 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
             DefaultCoordinator coord = getSchedulerWithQueryId("select count(1) from lineitem");
             Assert.assertThrows("pending timeout", StarRocksException.class,
                     () -> manager.maybeWait(connectContext, coord));
+            ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
+                    "the session variable [query_queue_pending_timeout_second]",
+                    () -> manager.maybeWait(connectContext, coord));
         }
 
         {
@@ -607,6 +611,9 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
             DefaultCoordinator coord =
                     getSchedulerWithQueryId("select /*+SET_VAR(query_timeout=2)*/ count(1) from lineitem");
             Assert.assertThrows("pending timeout", StarRocksException.class,
+                    () -> manager.maybeWait(connectContext, coord));
+            ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
+                    "query/insert timeout",
                     () -> manager.maybeWait(connectContext, coord));
         }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
mysql> insert into t properties("timeout"="1") select $1 from files("path"="xxx", "format" = "csv", "csv.column_separator" = "|");
ERROR 1064 (HY000): Failed to allocate resource to query: pending timeout [1s], you could modify query/insert timeout to pending more time
```

if `insert/query timeout` is smaller than `query_queue_pending_timeout_second`, use `insert/query timeout` in the error message.

Fixes https://github.com/StarRocks/StarRocksTest/issues/8908

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0