### PR TITLE
[BugFix] use relative path to get file instead of filename for delta lake

### DIFF
--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -282,6 +282,7 @@ public:
     DeltaLakeTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool);
     ~DeltaLakeTableDescriptor() override = default;
     bool has_partition() const override { return true; }
+    bool has_base_path() const override { return true; }
 };
 
 class HudiTableDescriptor : public HiveTableDescriptor {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
@@ -95,8 +95,8 @@ public class DeltaConnectorScanRangeSource implements ConnectorScanRangeSource {
         DescriptorTable.ReferencedPartitionInfo referencedPartitionInfo = referencedPartitions.get(partitionId);
         TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
         THdfsScanRange hdfsScanRange = new THdfsScanRange();
-        hdfsScanRange.setRelative_path("/" + Paths.get(table.getTableLocation()).
-                relativize(Paths.get(fileStatus.getPath())));
+        hdfsScanRange.setRelative_path(URLDecoder.decode("/" + Paths.get(table.getTableLocation()).
+                relativize(Paths.get(fileStatus.getPath())), StandardCharsets.UTF_8));
         hdfsScanRange.setOffset(0);
         hdfsScanRange.setLength(fileStatus.getSize());
         hdfsScanRange.setPartition_id(partitionId);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -94,7 +95,8 @@ public class DeltaConnectorScanRangeSource implements ConnectorScanRangeSource {
         DescriptorTable.ReferencedPartitionInfo referencedPartitionInfo = referencedPartitions.get(partitionId);
         TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
         THdfsScanRange hdfsScanRange = new THdfsScanRange();
-        hdfsScanRange.setRelative_path(new Path(fileStatus.getPath()).getName());
+        hdfsScanRange.setRelative_path("/" + Paths.get(table.getTableLocation()).
+                relativize(Paths.get(fileStatus.getPath())));
         hdfsScanRange.setOffset(0);
         hdfsScanRange.setLength(fileStatus.getSize());
         hdfsScanRange.setPartition_id(partitionId);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
refer to https://kb.databricks.com/delta/hive-style-partitions-not-found-on-delta-table-after-enabling-column-mapping-mode

like this, it's unpartitioned table
![image](https://github.com/user-attachments/assets/c0c6ebc2-5dd0-4dbe-b323-997256f52a58)

When Delta Lake column mapping is enabled on a table, it uses random file prefixes, can not use hive style partition path

Fixes #53948 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0