### PR TITLE
[BugFix]If the OP_DROP_TABLE_V2 event is lost, it will cause a null pointer error to be reported when processing the OP_ADD_PARTITION_V2 event.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -303,11 +303,12 @@ public class Database extends MetaObject implements Writable {
             idToTable.put(tableId, table);
         } else {
             String tableName = table.getName();
-            if (nameToTable.containsKey(tableName)) {
+            long tableId = table.getId();
+            if (idToTable.containsKey(tableId)) {
                 return false;
             }
-            idToTable.put(table.getId(), table);
-            nameToTable.put(table.getName(), table);
+            idToTable.put(tableId, table);
+            nameToTable.put(tableName, table);
         }
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -303,12 +303,11 @@ public class Database extends MetaObject implements Writable {
             idToTable.put(tableId, table);
         } else {
             String tableName = table.getName();
-            long tableId = table.getId();
-            if (idToTable.containsKey(tableId)) {
+            if (nameToTable.containsKey(tableName)) {
                 return false;
             }
-            idToTable.put(tableId, table);
-            nameToTable.put(tableName, table);
+            idToTable.put(table.getId(), table);
+            nameToTable.put(table.getName(), table);
         }
         return true;
     }


### PR DESCRIPTION
## Why I'm doing:
1. https://github.com/StarRocks/starrocks/pull/53951 result OP_DROP_TABLE_V2 lost, but nameToTable/idToTable is clear,so can create a materialized view with the same name. For examplt, old mv tableId is 100001, new tableId is 100002,mv name is test.dws_ofo_mv4.
2. OP_CREATE_TABLE_V2 event will not take effect because OP_DROP_TABLE_V2 is lost, so checkpoint thread/follwer fe remains test.dws_ofo_mv4-100001.
3. The object of refresh is test.dws_ofo_mv4-100002, so the null pointer is encountered in the OP_ADD_PARTITION_V2 event.
## What I'm doing:

Fixes #53955

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0