### PR TITLE
[Enhancement] Support struct subfield zonemap filter in parquet reader

### DIFF
--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -500,7 +500,7 @@ StatusOr<ColumnPredicate*> StructColumnReader::_try_to_rewrite_subfield_expr(
 Status StructColumnReader::_rewrite_column_expr_predicate(ObjectPool* pool,
                                                           const std::vector<const ColumnPredicate*>& src_preds,
                                                           std::vector<const ColumnPredicate*>& dst_preds) const {
-    DCHECK_NOTNULL(pool);
+    DCHECK(pool != nullptr);
 
     for (const ColumnPredicate* src_pred : src_preds) {
         // it's not ColumnExprPredicate, don't need to rewrite it

--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -18,8 +18,10 @@
 #include "column/map_column.h"
 #include "column/struct_column.h"
 #include "formats/parquet/schema.h"
+#include "formats/parquet/zone_map_filter_evaluator.h"
 #include "gutil/casts.h"
 #include "gutil/strings/substitute.h"
+#include "storage/column_expr_predicate.h"
 
 namespace starrocks::parquet {
 
@@ -299,6 +301,223 @@ Status StructColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
             }
         } else {
             return Status::InternalError(strings::Substitute("there is no match subfield reader for $1", field_name));
+        }
+    }
+    return Status::OK();
+}
+
+StatusOr<bool> StructColumnReader::row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                                             CompoundNodeType pred_relation,
+                                                             const uint64_t rg_first_row,
+                                                             const uint64_t rg_num_rows) const {
+    ObjectPool pool;
+
+    auto is_satisfied = [&](const ColumnPredicate* predicate) -> bool {
+        std::vector<std::string> subfield{};
+        auto res = _try_to_rewrite_subfield_expr(&pool, predicate, &subfield);
+        // rewrite failed, always return true, select all
+        RETURN_IF(!res.ok(), true);
+
+        ColumnPredicate* rewritten_subfield_predicate = res.value();
+        pool.add(rewritten_subfield_predicate);
+
+        const ColumnReader* column_reader = get_child_column_reader(subfield);
+
+        RETURN_IF(column_reader == nullptr, true);
+        // make sure ColumnReader is scalar column
+        RETURN_IF(column_reader->get_column_parquet_field()->type != ColumnType::SCALAR, true);
+
+        auto ret = column_reader->row_group_zone_map_filter({rewritten_subfield_predicate}, pred_relation, rg_first_row,
+                                                            rg_num_rows);
+        // row_group_zone_map_filter failed, always return true, select all
+        RETURN_IF(!res.ok(), true);
+
+        return ret.value();
+    };
+
+    std::vector<const ColumnPredicate*> rewritten_predicates;
+    RETURN_IF_ERROR(_rewrite_column_expr_predicate(&pool, predicates, rewritten_predicates));
+
+    if (pred_relation == CompoundNodeType::AND) {
+        return std::ranges::all_of(rewritten_predicates, [&](const auto* pred) { return is_satisfied(pred); });
+    } else {
+        return rewritten_predicates.empty() ||
+               std::ranges::any_of(rewritten_predicates, [&](const auto* pred) { return is_satisfied(pred); });
+    }
+}
+
+StatusOr<bool> StructColumnReader::page_index_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                                              SparseRange<uint64_t>* row_ranges,
+                                                              CompoundNodeType pred_relation,
+                                                              const uint64_t rg_first_row, const uint64_t rg_num_rows) {
+    DCHECK(row_ranges->empty());
+    ObjectPool pool;
+
+    auto handle_page_index = [&](const ColumnPredicate* predicate, SparseRange<uint64_t>* cur_row_ranges) -> bool {
+        DCHECK(cur_row_ranges->empty());
+        std::vector<std::string> subfield{};
+        auto res = _try_to_rewrite_subfield_expr(&pool, predicate, &subfield);
+        // rewrite failed, always return false, means no page index happened
+        RETURN_IF(!res.ok(), false);
+
+        ColumnPredicate* rewrite_subfield_predicate = res.value();
+        pool.add(rewrite_subfield_predicate);
+
+        ColumnReader* column_reader = get_child_column_reader(subfield);
+
+        RETURN_IF(column_reader == nullptr, false);
+        // make sure ColumnReader is scalar column
+        RETURN_IF(column_reader->get_column_parquet_field()->type != ColumnType::SCALAR, false);
+
+        auto ret = column_reader->page_index_zone_map_filter({rewrite_subfield_predicate}, cur_row_ranges,
+                                                             pred_relation, rg_first_row, rg_num_rows);
+        // page_index_zone_map_filter failed, always return false, no page index filter happened
+        RETURN_IF(!res.ok(), false);
+
+        return ret.value();
+    };
+
+    std::vector<const ColumnPredicate*> rewritten_predicates;
+    RETURN_IF_ERROR(_rewrite_column_expr_predicate(&pool, predicates, rewritten_predicates));
+
+    std::optional<SparseRange<uint64_t>> result_sparse_range = std::nullopt;
+
+    for (const ColumnPredicate* predicate : rewritten_predicates) {
+        SparseRange<uint64_t> tmp_row_ranges;
+
+        if (!handle_page_index(predicate, &tmp_row_ranges)) {
+            // no page index filter happened, means select all
+            tmp_row_ranges.add({rg_first_row, rg_first_row + rg_num_rows});
+        }
+
+        if (pred_relation == CompoundNodeType::AND) {
+            ZoneMapEvaluatorUtils::merge_row_ranges<CompoundNodeType::AND>(result_sparse_range, tmp_row_ranges);
+        } else {
+            ZoneMapEvaluatorUtils::merge_row_ranges<CompoundNodeType::OR>(result_sparse_range, tmp_row_ranges);
+        }
+    }
+
+    if (!result_sparse_range.has_value()) {
+        return false;
+    }
+    *row_ranges = std::move(result_sparse_range.value());
+    return row_ranges->span_size() < rg_num_rows;
+}
+
+ColumnReader* StructColumnReader::get_child_column_reader(const std::string& subfield) const {
+    auto it = _child_readers.find(subfield);
+    if (it == _child_readers.end()) {
+        return nullptr;
+    } else {
+        return it->second.get();
+    }
+}
+
+ColumnReader* StructColumnReader::get_child_column_reader(const std::vector<std::string>& subfields) const {
+    ColumnReader* column_reader = nullptr;
+    for (const std::string& subfield : subfields) {
+        if (column_reader == nullptr) {
+            column_reader = get_child_column_reader(subfield);
+        } else {
+            const auto* struct_column_reader = down_cast<StructColumnReader*>(column_reader);
+            column_reader = struct_column_reader->get_child_column_reader(subfield);
+        }
+
+        RETURN_IF(column_reader == nullptr, nullptr);
+    }
+    return column_reader;
+}
+
+// Rewrite ColumnExprPredicate which contains subfield expr and put subfield path into subfield_output
+// For example, WHERE col.a.b.c > 5, a.b.c is subfields, we will rewrite it to c > 5
+StatusOr<ColumnPredicate*> StructColumnReader::_try_to_rewrite_subfield_expr(
+        ObjectPool* pool, const ColumnPredicate* predicate, std::vector<std::string>* subfield_output) const {
+    // make sure it's expr predicate
+    if (!predicate->is_expr_predicate()) {
+        return Status::InternalError("Predicate is not an expression predicate");
+    }
+
+    const ColumnExprPredicate* expr_predicate = down_cast<const ColumnExprPredicate*>(predicate);
+    const std::vector<ExprContext*>& expr_contexts = expr_predicate->get_expr_ctxs();
+    if (expr_contexts.size() != 1) {
+        // just defense code, make sure each ColumnExprPredicate has only one ExprContext
+        return Status::InternalError("ColumnExprPredicate should has one ExprContext");
+    }
+
+    ExprContext* expr_context = expr_contexts[0];
+    // Get root_expr like:
+    //       OP_CODE(=, <, >, ...)
+    //       /                  \
+    //   subfield            right expr
+    const Expr* root_expr = expr_context->root();
+    const std::vector<Expr*>& expr_children = root_expr->children();
+    // check there must have two children, and the left one is SubfieldExpr
+    if (expr_children.size() != 2 || expr_children[0]->node_type() != TExprNodeType::type::SUBFIELD_EXPR) {
+        return Status::InternalError("Invalid pattern for predicate");
+    }
+
+    Expr* subfield_expr = expr_children[0];
+    Expr* right_expr = expr_children[1];
+
+    // check exprs are monotonic
+    if (!root_expr->is_monotonic() || !subfield_expr->is_monotonic() || !right_expr->is_monotonic()) {
+        return Status::InternalError("Predicate's expr is not monotonic");
+    }
+
+    std::vector<std::vector<std::string>> subfields{};
+    int num_subfield = subfield_expr->get_subfields(&subfields);
+    if (num_subfield != 1) {
+        // must only exist one subfield
+        return Status::InternalError("Should have only one subfield path");
+    }
+    subfield_output->insert(subfield_output->end(), subfields[0].begin(), subfields[0].end());
+
+    // check subfield expr has only one child, and it's a SlotRef
+    if (subfield_expr->children().size() != 1 && !subfield_expr->get_child(0)->is_slotref()) {
+        return Status::InternalError("Invalid pattern for predicate");
+    }
+
+    // extract subfield expr's SlotRef, and copy it
+    Expr* new_slot_expr = Expr::copy(pool, subfield_expr->get_child(0));
+    Expr* new_right_expr = Expr::copy(pool, right_expr);
+    Expr* new_root_expr = root_expr->clone(pool);
+    new_root_expr->set_monotonic(true);
+    new_root_expr->add_child(new_slot_expr);
+    new_root_expr->add_child(new_right_expr);
+
+    const auto rewritten_expr = std::make_unique<ExprContext>(new_root_expr);
+    RETURN_IF_ERROR(rewritten_expr->prepare(expr_predicate->runtime_state()));
+    RETURN_IF_ERROR(rewritten_expr->open(expr_predicate->runtime_state()));
+    return ColumnExprPredicate::make_column_expr_predicate(
+            get_type_info(subfield_expr->type().type, subfield_expr->type().precision, subfield_expr->type().scale),
+            expr_predicate->column_id(), expr_predicate->runtime_state(), rewritten_expr.get(),
+            expr_predicate->slot_desc());
+}
+
+// rewrite std::vector<const ColumnPredicate*> src_preds
+// If we face EQ ColumnExprPredicates, we have to rewrite it to ColumnExprPredicates <= val AND ColumnExprPredicates >= val
+// So we can apply ZoneMap to evaluate.
+Status StructColumnReader::_rewrite_column_expr_predicate(ObjectPool* pool,
+                                                          const std::vector<const ColumnPredicate*>& src_preds,
+                                                          std::vector<const ColumnPredicate*>& dst_preds) const {
+    DCHECK_NOTNULL(pool);
+
+    for (const ColumnPredicate* src_pred : src_preds) {
+        // it's not ColumnExprPredicate, don't need to rewrite it
+        if (!src_pred->is_expr_predicate()) {
+            dst_preds.emplace_back(src_pred);
+            continue;
+        }
+
+        const ColumnExprPredicate* expr_predicate = down_cast<const ColumnExprPredicate*>(src_pred);
+        std::vector<const ColumnExprPredicate*> output;
+        RETURN_IF_ERROR(expr_predicate->try_to_rewrite_for_zone_map_filter(pool, &output));
+        if (output.empty()) {
+            // no rewrite happened, insert the original predicate
+            dst_preds.emplace_back(src_pred);
+        } else {
+            // insert rewritten predicates
+            dst_preds.insert(dst_preds.end(), output.begin(), output.end());
         }
     }
     return Status::OK();

--- a/be/src/formats/parquet/complex_column_reader.h
+++ b/be/src/formats/parquet/complex_column_reader.h
@@ -210,7 +210,26 @@ public:
         }
     }
 
+    StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                             CompoundNodeType pred_relation, const uint64_t rg_first_row,
+                                             const uint64_t rg_num_rows) const override;
+
+    StatusOr<bool> page_index_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                              SparseRange<uint64_t>* row_ranges, CompoundNodeType pred_relation,
+                                              const uint64_t rg_first_row, const uint64_t rg_num_rows) override;
+
+    ColumnReader* get_child_column_reader(const std::string& subfield) const;
+
+    // retrieve multi level subfield's ColumnReader
+    ColumnReader* get_child_column_reader(const std::vector<std::string>& subfields) const;
+
 private:
+    Status _rewrite_column_expr_predicate(ObjectPool* pool, const std::vector<const ColumnPredicate*>& src_preds,
+                                          std::vector<const ColumnPredicate*>& dst_preds) const;
+
+    StatusOr<ColumnPredicate*> _try_to_rewrite_subfield_expr(ObjectPool* pool, const ColumnPredicate* predicate,
+                                                             std::vector<std::string>* subfield_output) const;
+
     void _handle_null_rows(uint8_t* is_nulls, bool* has_null, size_t num_rows);
 
     // _children_readers order is the same as TypeDescriptor children order.

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -264,8 +264,8 @@ protected:
             "./be/test/formats/parquet/test_data/file_read_test_filter_row_group_2.parquet";
 
     std::shared_ptr<RowDescriptor> _row_desc = nullptr;
-    ObjectPool _pool;
     RuntimeState* _runtime_state = nullptr;
+    ObjectPool _pool;
     const size_t _chunk_size = 4096;
     TypeDescriptor _type_int;
 };

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -264,8 +264,8 @@ protected:
             "./be/test/formats/parquet/test_data/file_read_test_filter_row_group_2.parquet";
 
     std::shared_ptr<RowDescriptor> _row_desc = nullptr;
-    RuntimeState* _runtime_state = nullptr;
     ObjectPool _pool;
+    RuntimeState* _runtime_state = nullptr;
     const size_t _chunk_size = 4096;
     TypeDescriptor _type_int;
 };
@@ -861,6 +861,7 @@ void FileReaderTest::_create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode
     node0.__isset.opcode = true;
     node0.__isset.child_type = true;
     node0.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+    node0.__set_is_monotonic(true);
     nodes.emplace_back(node0);
 
     TExprNode node1;
@@ -870,6 +871,7 @@ void FileReaderTest::_create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode
     node1.num_children = 1;
     node1.used_subfield_names = subfiled_path;
     node1.__isset.used_subfield_names = true;
+    node1.__set_is_monotonic(true);
     nodes.emplace_back(node1);
 
     TExprNode node2;
@@ -881,6 +883,7 @@ void FileReaderTest::_create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode
     t_slot_ref.tuple_id = 0;
     node2.__set_slot_ref(t_slot_ref);
     node2.is_nullable = true;
+    node2.__set_is_monotonic(true);
     nodes.emplace_back(node2);
 
     TExprNode node3;
@@ -891,6 +894,7 @@ void FileReaderTest::_create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode
     string_literal.value = value;
     node3.__set_string_literal(string_literal);
     node3.is_nullable = false;
+    node3.__set_is_monotonic(true);
     nodes.emplace_back(node3);
 
     TExpr t_expr;
@@ -3113,6 +3117,87 @@ TEST_F(FileReaderTest, TestStructSubfieldDictFilter) {
         }
     }
     EXPECT_EQ(100, total_row_nums);
+}
+
+TEST_F(FileReaderTest, TestStructSubfieldZonemap) {
+    const std::string struct_in_struct_file_path =
+            "./be/test/formats/parquet/test_data/test_parquet_struct_in_struct.parquet";
+    auto ctx = _create_file_struct_in_struct_read_context(struct_in_struct_file_path);
+
+    auto file = _create_file(struct_in_struct_file_path);
+
+    TypeDescriptor type_struct = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+    type_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
+    type_struct.field_names.emplace_back("c0");
+
+    type_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
+    type_struct.field_names.emplace_back("c1");
+
+    TypeDescriptor type_struct_in_struct = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+    type_struct_in_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
+    type_struct_in_struct.field_names.emplace_back("c0");
+
+    type_struct_in_struct.children.emplace_back(type_struct);
+    type_struct_in_struct.field_names.emplace_back("c_struct");
+
+    std::vector<std::string> subfield_path({"c_struct", "c0"});
+
+    _create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode::EQ, 3, type_struct_in_struct, subfield_path, "0",
+                                                    &ctx->conjunct_ctxs_by_slot[3]);
+
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                                    std::filesystem::file_size(struct_in_struct_file_path));
+
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), true),
+                         chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), true),
+                         chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_struct, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_struct_in_struct, true), chunk->num_columns());
+
+    // setup OlapScanConjunctsManager
+    // TypeDescriptor type_struct = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+    // type_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
+    // type_struct.field_names.emplace_back("c0");
+    //
+    // type_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
+    // type_struct.field_names.emplace_back("c1");
+    //
+    // TypeDescriptor type_struct_in_struct = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+    // type_struct_in_struct.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
+    // type_struct_in_struct.field_names.emplace_back("c0");
+    //
+    // type_struct_in_struct.children.emplace_back(type_struct);
+    // type_struct_in_struct.field_names.emplace_back("c_struct");
+
+    // tuple desc
+    Utils::SlotDesc slot_descs[] = {
+            {"c0", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)},
+            {"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)},
+            {"c_struct", type_struct},
+            {"c_struct_struct", type_struct_in_struct},
+            {""},
+    };
+    TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+    // RETURN_IF_ERROR(Expr::clone_if_not_exists(state, &_pool, _min_max_conjunct_ctxs, &cloned_conjunct_ctxs));
+    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[3], tuple_desc, _runtime_state, ctx);
+
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ(1, file_reader->_group_reader_param.stats->parquet_filtered_row_groups);
+    EXPECT_EQ(0, file_reader->_row_group_readers.size());
+    size_t total_row_nums = 0;
+    while (!status.is_end_of_file()) {
+        chunk->reset();
+        status = file_reader->get_next(&chunk);
+        chunk->check_or_die();
+        total_row_nums += chunk->num_rows();
+    }
+    EXPECT_EQ(0, total_row_nums);
+
+    ctx->predicate_free_pool.clear();
+    ctx->conjuncts_manager = nullptr;
 }
 
 TEST_F(FileReaderTest, TestReadRoundByRound) {


### PR DESCRIPTION
## Why I'm doing:
Support struct subfield zone map filter(include row group/page index level)

## What I'm doing:
We can only support subfield like `select * from tbl where col.subfield1.subfield2 > 4`

We need to make sure ColumnPredicateExpr like:
```bash

                                  Expr(=, <, ...)
                                  /             \
     subfield("subfield1", "subfield2")          OtherMonotonicExpr
                              |
                            SlotRef
```




## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0