### PR TITLE
[BugFix] Fix the bug of parquet::StatisticsHelper processing in runtime filter with null

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -313,6 +313,7 @@ bool FileReader::_filter_group_with_more_filter(const GroupReaderPtr& group_read
                 } else if (filter_type == StatisticsHelper::StatSupportedFilter::FILTER_IN) {
                     std::vector<string> min_values;
                     std::vector<string> max_values;
+                    std::vector<int64_t> null_counts;
 
                     const ParquetField* field = group_reader->get_column_parquet_field(slot->id());
                     if (field == nullptr) {
@@ -322,8 +323,10 @@ bool FileReader::_filter_group_with_more_filter(const GroupReaderPtr& group_read
                     auto st = StatisticsHelper::get_min_max_value(_file_metadata.get(), slot->type(), column_meta,
                                                                   field, min_values, max_values);
                     if (!st.ok()) continue;
+                    st = StatisticsHelper::get_null_counts(column_meta, null_counts);
+                    if (!st.ok()) continue;
                     Filter selected(min_values.size(), 1);
-                    st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, ctx, field,
+                    st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, null_counts, ctx, field,
                                                                      _scanner_ctx->timezone, selected);
                     if (!st.ok()) continue;
                     if (!selected[0]) {

--- a/be/src/formats/parquet/page_index_reader.cpp
+++ b/be/src/formats/parquet/page_index_reader.cpp
@@ -183,7 +183,8 @@ Status PageIndexReader::_deal_with_more_conjunct(const std::vector<ExprContext*>
                 }
             } else if (filter_type == StatisticsHelper::StatSupportedFilter::FILTER_IN) {
                 RETURN_IF_ERROR(StatisticsHelper::in_filter_on_min_max_stat(
-                        column_index.min_values, column_index.max_values, ctx, field, timezone, page_filter));
+                        column_index.min_values, column_index.max_values, column_index.null_counts, ctx, field,
+                        timezone, page_filter));
             }
         }
     }

--- a/be/src/formats/parquet/statistics_helper.cpp
+++ b/be/src/formats/parquet/statistics_helper.cpp
@@ -192,7 +192,8 @@ void translate_to_string_value(const ColumnPtr& col, size_t i, std::string& valu
 }
 
 Status StatisticsHelper::in_filter_on_min_max_stat(const std::vector<std::string>& min_values,
-                                                   const std::vector<std::string>& max_values, ExprContext* ctx,
+                                                   const std::vector<std::string>& max_values,
+                                                   const std::vector<int64_t>& null_counts, ExprContext* ctx,
                                                    const ParquetField* field, const std::string& timezone,
                                                    Filter& selected) {
     const Expr* root_expr = ctx->root();
@@ -200,12 +201,16 @@ Status StatisticsHelper::in_filter_on_min_max_stat(const std::vector<std::string
     const Expr* c = root_expr->get_child(0);
     LogicalType ltype = c->type().type;
     ColumnPtr values;
+    bool is_runtime_filter = false;
+    bool has_null = false;
     switch (ltype) {
 #define M(NAME)                                                                                                \
     case LogicalType::NAME: {                                                                                  \
         const auto* in_filter = dynamic_cast<const VectorizedInConstPredicate<LogicalType::NAME>*>(root_expr); \
         if (in_filter != nullptr) {                                                                            \
             values = in_filter->get_all_values();                                                              \
+            has_null = in_filter->null_in_set();                                                               \
+            is_runtime_filter = in_filter->is_join_runtime_filter();                                           \
             break;                                                                                             \
         } else {                                                                                               \
             return Status::OK();                                                                               \
@@ -247,6 +252,10 @@ Status StatisticsHelper::in_filter_on_min_max_stat(const std::vector<std::string
     for (size_t i = 0; i < min_values.size(); i++) {
         // just skip the area that filtered
         if (!selected[i]) {
+            continue;
+        }
+        if (is_runtime_filter && has_null && null_counts[i] > 0) {
+            selected[i] = 1;
             continue;
         }
 
@@ -307,6 +316,15 @@ Status StatisticsHelper::get_has_nulls(const tparquet::ColumnMetaData* column_me
         return Status::Aborted("No null_count in column statistics");
     }
     has_nulls.emplace_back(column_meta->statistics.null_count > 0);
+    return Status::OK();
+}
+
+Status StatisticsHelper::get_null_counts(const tparquet::ColumnMetaData* column_meta,
+                                         std::vector<int64_t>& null_counts) {
+    if (!column_meta->statistics.__isset.null_count) {
+        return Status::Aborted("No null_count in column statistics");
+    }
+    null_counts.emplace_back(column_meta->statistics.null_count);
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/statistics_helper.h
+++ b/be/src/formats/parquet/statistics_helper.h
@@ -34,7 +34,9 @@ public:
     static bool can_be_used_for_statistics_filter(ExprContext* ctx, StatSupportedFilter& filter_type);
 
     static Status in_filter_on_min_max_stat(const std::vector<std::string>& min_values,
-                                            const std::vector<std::string>& max_values, ExprContext* ctx,
+                                            const std::vector<std::string>& max_values,
+                                            const std::vector<int64_t>& null_counts,
+                                            ExprContext* ctx,
                                             const ParquetField* field, const std::string& timezone, Filter& selected);
 
     // get min/max value from row group stats
@@ -43,6 +45,7 @@ public:
                                     std::vector<std::string>& min_values, std::vector<std::string>& max_values);
 
     static Status get_has_nulls(const tparquet::ColumnMetaData* column_meta, std::vector<bool>& has_nulls);
+    static Status get_null_counts(const tparquet::ColumnMetaData* column_meta, std::vector<int64_t>& null_counts);
 
     static bool has_correct_min_max_stats(const FileMetaData* file_metadata,
                                           const tparquet::ColumnMetaData& column_meta, const SortOrder& sort_order);

--- a/be/src/formats/parquet/statistics_helper.h
+++ b/be/src/formats/parquet/statistics_helper.h
@@ -35,8 +35,7 @@ public:
 
     static Status in_filter_on_min_max_stat(const std::vector<std::string>& min_values,
                                             const std::vector<std::string>& max_values,
-                                            const std::vector<int64_t>& null_counts,
-                                            ExprContext* ctx,
+                                            const std::vector<int64_t>& null_counts, ExprContext* ctx,
                                             const ParquetField* field, const std::string& timezone, Filter& selected);
 
     // get min/max value from row group stats

--- a/be/test/formats/parquet/statistics_helper_test.cpp
+++ b/be/test/formats/parquet/statistics_helper_test.cpp
@@ -59,8 +59,10 @@ TEST_F(StatisticsHelperTest, TestInFilterInt) {
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctxs);
     EXPECT_EQ(ctxs.size(), 1);
 
+    std::vector<int64_t> null_counts{0, 0};
     Filter selected(min_values.size(), true);
-    auto st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, ctxs[0], &field, timezone, selected);
+    auto st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, null_counts, ctxs[0], &field,
+                                                          timezone, selected);
     ASSERT_OK(st);
     ASSERT_TRUE(selected[0]);
     ASSERT_FALSE(selected[1]);
@@ -82,9 +84,10 @@ TEST_F(StatisticsHelperTest, TestInFilterString) {
         ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctxs);
         EXPECT_EQ(ctxs.size(), 1);
 
+        std::vector<int64_t> null_counts{0};
         Filter selected(min_values.size(), true);
-        auto st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, ctxs[0], &field, timezone,
-                                                              selected);
+        auto st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, null_counts, ctxs[0], &field,
+                                                              timezone, selected);
         ASSERT_OK(st);
         ASSERT_FALSE(selected[0]);
     }
@@ -98,9 +101,10 @@ TEST_F(StatisticsHelperTest, TestInFilterString) {
         ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctxs);
         EXPECT_EQ(ctxs.size(), 1);
 
+        std::vector<int64_t> null_counts{0};
         Filter selected(min_values.size(), true);
-        auto st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, ctxs[0], &field, timezone,
-                                                              selected);
+        auto st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, null_counts, ctxs[0], &field,
+                                                              timezone, selected);
         ASSERT_OK(st);
         ASSERT_TRUE(selected[0]);
     }
@@ -128,8 +132,10 @@ TEST_F(StatisticsHelperTest, TestInFilterDate) {
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctxs);
     EXPECT_EQ(ctxs.size(), 1);
 
+    std::vector<int64_t> null_counts{0, 0};
     Filter selected(min_values.size(), true);
-    auto st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, ctxs[0], &field, timezone, selected);
+    auto st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, null_counts, ctxs[0], &field,
+                                                          timezone, selected);
     ASSERT_OK(st);
     ASSERT_TRUE(selected[0]);
     ASSERT_FALSE(selected[1]);
@@ -163,8 +169,10 @@ TEST_F(StatisticsHelperTest, TestInFilterDatetime) {
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctxs);
     EXPECT_EQ(ctxs.size(), 1);
 
+    std::vector<int64_t> null_counts{0, 0};
     Filter selected(min_values.size(), true);
-    auto st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, ctxs[0], &field, timezone, selected);
+    auto st = StatisticsHelper::in_filter_on_min_max_stat(min_values, max_values, null_counts, ctxs[0], &field,
+                                                          timezone, selected);
     ASSERT_OK(st);
     ASSERT_TRUE(selected[0]);
     ASSERT_FALSE(selected[1]);

--- a/test/sql/test_iceberg/R/test_runtime_filter_in_null
+++ b/test/sql/test_iceberg/R/test_runtime_filter_in_null
@@ -1,0 +1,17 @@
+-- name: test_runtime_filter_in_null @slow
+update information_schema.be_configs set value = "false" where name= "parquet_advance_zonemap_filter";
+-- result:
+-- !result
+create external catalog test_runtime_filter_in_null_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+select count(*) from test_runtime_filter_in_null_${uuid0}.iceberg_oss_db.in_runtime_filter_t1 as t1 join test_runtime_filter_in_null_${uuid0}.iceberg_oss_db.in_runtime_filter_t2 as t2 on t1.c1<=>t2.c1;
+-- result:
+6
+-- !result
+drop catalog test_runtime_filter_in_null_${uuid0};
+-- result:
+-- !result
+update information_schema.be_configs set value = "true" where name= "parquet_advance_zonemap_filter";
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_runtime_filter_in_null
+++ b/test/sql/test_iceberg/T/test_runtime_filter_in_null
@@ -1,0 +1,10 @@
+-- name: test_runtime_filter_in_null @slow
+update information_schema.be_configs set value = "false" where name= "parquet_advance_zonemap_filter";
+
+create external catalog test_runtime_filter_in_null_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+select count(*) from test_runtime_filter_in_null_${uuid0}.iceberg_oss_db.in_runtime_filter_t1 as t1 join test_runtime_filter_in_null_${uuid0}.iceberg_oss_db.in_runtime_filter_t2 as t2 on t1.c1<=>t2.c1;
+
+drop catalog test_runtime_filter_in_null_${uuid0};
+
+update information_schema.be_configs set value = "true" where name= "parquet_advance_zonemap_filter";


### PR DESCRIPTION
## Why I'm doing:

`VectorizedInConstPredicate` has two meanings. 

If in_const_pred (1, 2, 3, null) is generated by runtime filter, it is equivalent to xxx in (1, 2, 3) or xxx is null, 
if not,  in_const_pred (1, 2, 3, null)  is equivalent to xxx in (1, 2, 3).

But the `in_filter_on_min_max_stat` don't check the in_const_pred is runtime_filter or not, so it will unexpectedly filtering out some `RowGroups` or `Pages` when using null-safe equal join.

```
mysql> select * from in_runtime_filter_t1;
+------+------+
| c1   | c2   |
+------+------+
| NULL |   11 |
| NULL |   22 |
| NULL |   33 |
|    4 |   44 |
|    5 |   55 |
|    6 |   66 |
+------+------+
6 rows in set (0.04 sec)

mysql> select * from in_runtime_filter_t2;
+------+------+
| c1   | c2   |
+------+------+
| NULL |   11 |
| NULL |   22 |
+------+------+

```

Before the fix pr:
```
mysql> select count(*) from in_runtime_filter_t1 t1 join in_runtime_filter_t2 t2 on t1.c1<=>t2.c1;
+----------+
| count(*) |
+----------+
|        0 |
+----------+
```

After the fix pr:
```
mysql> select count(*) from in_runtime_filter_t1 t1 join in_runtime_filter_t2 t2 on t1.c1<=>t2.c1;
+----------+
| count(*) |
+----------+
|        6 |
+----------+
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0