### PR TITLE
[Feature] bulk load optimization (Part 2 - SpillMemTableSink)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1514,6 +1514,8 @@ CONF_mInt32(batch_write_rpc_reqeust_timeout_ms, "10000");
 CONF_mInt32(batch_write_poll_load_status_interval_ms, "200");
 CONF_mBool(batch_write_trace_log_enable, "false");
 
+CONF_mBool(enable_load_spill, "false");
+
 // ignore union type tag in avro kafka routine load
 CONF_mBool(avro_ignore_union_type_tag, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1515,6 +1515,8 @@ CONF_mInt32(batch_write_poll_load_status_interval_ms, "200");
 CONF_mBool(batch_write_trace_log_enable, "false");
 
 CONF_mBool(enable_load_spill, "false");
+// Max chunk bytes which allow to spill per flush. Default is 10MB.
+CONF_mInt64(load_spill_max_chunk_bytes, "10485760");
 
 // ignore union type tag in avro kafka routine load
 CONF_mBool(avro_ignore_union_type_tag, "false");

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -31,6 +31,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/pk_tablet_writer.h"
+#include "storage/lake/spill_mem_table_sink.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
@@ -53,13 +54,13 @@ public:
 
     DISALLOW_COPY_AND_MOVE(TabletWriterSink);
 
-    Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment = nullptr) override {
+    Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment = nullptr, bool eos = false) override {
         RETURN_IF_ERROR(_writer->write(chunk, segment));
         return _writer->flush(segment);
     }
 
     Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes,
-                                    starrocks::SegmentPB* segment = nullptr) override {
+                                    starrocks::SegmentPB* segment = nullptr, bool eos = false) override {
         RETURN_IF_ERROR(_writer->flush_del_file(deletes));
         RETURN_IF_ERROR(_writer->write(upserts, segment));
         return _writer->flush(segment);
@@ -152,6 +153,8 @@ private:
 
     bool is_partial_update();
 
+    Status merge_blocks_to_segments();
+
     TabletManager* _tablet_manager;
     const int64_t _tablet_id;
     const int64_t _txn_id;
@@ -208,6 +211,8 @@ private:
     PUniqueId _load_id;
     // Used for maintain spill block for bulk load.
     std::unique_ptr<LoadSpillBlockManager> _load_spill_block_mgr;
+    // End of data ingestion
+    bool _eos = false;
 };
 
 bool DeltaWriterImpl::is_immutable() const {
@@ -245,7 +250,19 @@ Status DeltaWriterImpl::build_schema_and_writer() {
                                                                              _txn_id, false);
         }
         RETURN_IF_ERROR(_tablet_writer->open());
-        _mem_table_sink = std::make_unique<TabletWriterSink>(_tablet_writer.get());
+        if (config::enable_load_spill) {
+            if (_load_spill_block_mgr == nullptr) {
+                _load_spill_block_mgr =
+                        std::make_unique<LoadSpillBlockManager>(UniqueId(_load_id).to_thrift(), _tablet_id, _txn_id,
+                                                                _tablet_manager->tablet_root_location(_tablet_id));
+                RETURN_IF_ERROR(_load_spill_block_mgr->init());
+            }
+            // Init SpillMemTableSink
+            _mem_table_sink = std::make_unique<SpillMemTableSink>(_load_spill_block_mgr.get(), _tablet_writer.get());
+        } else {
+            // Init normal TabletWriterSink
+            _mem_table_sink = std::make_unique<TabletWriterSink>(_tablet_writer.get());
+        }
         _write_schema_for_mem_table = MemTable::convert_schema(_write_schema, _slots);
 
         DCHECK_LE(_write_schema->num_columns(), _tablet_schema->num_columns());
@@ -276,7 +293,7 @@ inline Status DeltaWriterImpl::flush_async() {
         if (_miss_auto_increment_column && _mem_table->get_result_chunk() != nullptr) {
             RETURN_IF_ERROR(fill_auto_increment_id(*_mem_table->get_result_chunk()));
         }
-        st = _flush_token->submit(std::move(_mem_table), false, [this](std::unique_ptr<SegmentPB> seg, bool eos) {
+        st = _flush_token->submit(std::move(_mem_table), _eos, [this](std::unique_ptr<SegmentPB> seg, bool eos) {
             if (_immutable_tablet_size > 0 && !_is_immutable.load(std::memory_order_relaxed)) {
                 if (seg) {
                     _tablet_manager->add_in_writing_data_size(_tablet_id, seg->data_size());
@@ -285,7 +302,8 @@ inline Status DeltaWriterImpl::flush_async() {
                     _is_immutable.store(true, std::memory_order_relaxed);
                 }
                 VLOG(2) << "flush memtable, tablet=" << _tablet_id << ", txn=" << _txn_id
-                        << " _immutable_tablet_size=" << _immutable_tablet_size << ", segment_size=" << seg->data_size()
+                        << " _immutable_tablet_size=" << _immutable_tablet_size
+                        << ", segment_size=" << (seg ? seg->data_size() : 0)
                         << ", in_writing_data_size=" << _tablet_manager->in_writing_data_size(_tablet_id)
                         << ", is_immutable=" << _is_immutable.load(std::memory_order_relaxed);
             }
@@ -364,11 +382,6 @@ Status DeltaWriterImpl::check_partial_update_with_sort_key(const Chunk& chunk) {
 Status DeltaWriterImpl::write(const Chunk& chunk, const uint32_t* indexes, uint32_t indexes_size) {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
 
-    if (_load_spill_block_mgr == nullptr) {
-        _load_spill_block_mgr = std::make_unique<LoadSpillBlockManager>(
-                UniqueId(_load_id).to_thrift(), _tablet_manager->tablet_root_location(_tablet_id));
-        //RETURN_IF_ERROR(_load_spill_block_mgr->init());
-    }
     if (_mem_table == nullptr) {
         // When loading memory usage is larger than hard limit, we will reject new loading task.
         if (!config::enable_new_load_on_memory_limit_exceeded &&
@@ -452,10 +465,20 @@ bool DeltaWriterImpl::is_partial_update() {
     return _write_schema->num_columns() < _tablet_schema->num_columns();
 }
 
+Status DeltaWriterImpl::merge_blocks_to_segments() {
+    if (auto spillSink = dynamic_cast<SpillMemTableSink*>(_mem_table_sink.get())) {
+        // merge spill blocks to segments
+        RETURN_IF_ERROR(spillSink->merge_blocks_to_segments());
+    }
+    return Status::OK();
+}
+
 Status DeltaWriterImpl::finish() {
+    _eos = true;
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
     RETURN_IF_ERROR(build_schema_and_writer());
     RETURN_IF_ERROR(flush());
+    RETURN_IF_ERROR(merge_blocks_to_segments());
     RETURN_IF_ERROR(_tablet_writer->finish());
     return Status::OK();
 }

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -466,9 +466,9 @@ bool DeltaWriterImpl::is_partial_update() {
 }
 
 Status DeltaWriterImpl::merge_blocks_to_segments() {
-    if (auto spillSink = dynamic_cast<SpillMemTableSink*>(_mem_table_sink.get())) {
+    if (auto spill_sink = dynamic_cast<SpillMemTableSink*>(_mem_table_sink.get())) {
         // merge spill blocks to segments
-        RETURN_IF_ERROR(spillSink->merge_blocks_to_segments());
+        RETURN_IF_ERROR(spill_sink->merge_blocks_to_segments());
     }
     return Status::OK();
 }

--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -79,11 +79,7 @@ StatusOr<spill::BlockPtr> LoadSpillBlockManager::acquire_block(size_t block_size
     opts.plan_node_id = 0;
     opts.name = "load_spill";
     opts.block_size = block_size;
-    auto block = _block_manager->acquire_block(opts);
-    if (!block.ok()) {
-        return block.status();
-    }
-    return block.value();
+    return _block_manager->acquire_block(opts);
 }
 
 // return Block to BlockManager

--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -32,7 +32,7 @@ void LoadSpillBlockContainer::append_block(const spill::BlockPtr& block) {
 
 void LoadSpillBlockContainer::create_block_group() {
     std::lock_guard guard(_mutex);
-    _block_groups.push_back(spill::BlockGroup());
+    _block_groups.emplace_back(spill::BlockGroup());
 }
 
 bool LoadSpillBlockContainer::empty() {

--- a/be/src/storage/lake/load_spill_block_manager.h
+++ b/be/src/storage/lake/load_spill_block_manager.h
@@ -16,6 +16,7 @@
 
 #include "exec/spill/block_manager.h"
 #include "exec/spill/dir_manager.h"
+#include "exec/spill/input_stream.h"
 
 namespace starrocks {
 
@@ -23,17 +24,17 @@ namespace lake {
 
 class LoadSpillBlockContainer {
 public:
-    LoadSpillBlockContainer() {}
-    ~LoadSpillBlockContainer() = default;
-
     void append_block(const spill::BlockPtr& block);
-    size_t block_count();
+    void create_block_group();
+    bool empty();
     // No thread safe, UT only
-    spill::BlockPtr get_block(size_t idx) { return _blocks[idx]; }
+    spill::BlockPtr get_block(size_t gid, size_t bid);
 
 private:
-    std::mutex _mutex;                    // Mutex for the container.
-    std::vector<spill::BlockPtr> _blocks; // Blocks generated when loading.
+    // Mutex for the container.
+    std::mutex _mutex;
+    // Blocks generated when loading. Each block group contains multiple blocks which are ordered.
+    std::vector<spill::BlockGroup> _block_groups;
 };
 
 class LoadSpillBlockManager {

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -14,16 +14,99 @@
 
 #include "storage/lake/spill_mem_table_sink.h"
 
+#include "exec/spill/options.h"
+#include "exec/spill/serde.h"
+#include "exec/spill/spiller.h"
+#include "exec/spill/spiller_factory.h"
+#include "runtime/runtime_state.h"
+#include "storage/lake/load_spill_block_manager.h"
+#include "storage/lake/tablet_writer.h"
+
 namespace starrocks::lake {
 
-Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment) {
-    // TODO
+Status LoadSpillOutputDataStream::append(RuntimeState* state, const std::vector<Slice>& data, size_t total_write_size,
+                                         size_t write_num_rows) {
+    _append_rows += write_num_rows;
+    size_t total_size = 0;
+    // calculate total size
+    std::for_each(data.begin(), data.end(), [&](const Slice& slice) { total_size += slice.size; });
+    // acquire block
+    ASSIGN_OR_RETURN(_block, _block_manager->acquire_block(total_size));
+    // append data
+    return _block->append(data);
+}
+
+Status LoadSpillOutputDataStream::flush() {
+    RETURN_IF_ERROR(_block->flush());
+    RETURN_IF_ERROR(_block_manager->release_block(_block));
+    return Status::OK();
+}
+
+bool LoadSpillOutputDataStream::is_remote() const {
+    return _block->is_remote();
+}
+
+SpillMemTableSink::SpillMemTableSink(LoadSpillBlockManager* block_manager, TabletWriter* w) {
+    _block_manager = block_manager;
+    _writer = w;
+    _runtime_state = std::make_shared<RuntimeState>();
+    _spiller_factory = spill::make_spilled_factory();
+}
+
+Status SpillMemTableSink::_prepare(const ChunkPtr& chunk_ptr) {
+    if (_spiller == nullptr) {
+        // 1. alloc & prepare spiller
+        spill::SpilledOptions options;
+        options.encode_level = 7;
+        _spiller = _spiller_factory->create(options);
+        RETURN_IF_ERROR(_spiller->prepare(_runtime_state.get()));
+        // 2. prepare serde
+        if (const_cast<spill::ChunkBuilder*>(&_spiller->chunk_builder())->chunk_schema()->empty()) {
+            const_cast<spill::ChunkBuilder*>(&_spiller->chunk_builder())->chunk_schema()->set_schema(chunk_ptr);
+            RETURN_IF_ERROR(_spiller->serde()->prepare());
+        }
+    }
+    return Status::OK();
+}
+
+Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment, bool eos) {
+    if (eos && _block_manager->block_container()->block_count() == 0) {
+        // If there is only one flush, flush it to segment directly
+        RETURN_IF_ERROR(_writer->write(chunk, segment));
+        return _writer->flush(segment);
+    }
+    ChunkPtr chunk_ptr(const_cast<Chunk*>(&chunk), [](Chunk*) { /* do nothing */ });
+    // 1. prepare
+    RETURN_IF_ERROR(_prepare(chunk_ptr));
+    // 3. serialize chunk
+    auto output = std::make_shared<LoadSpillOutputDataStream>(_block_manager);
+    spill::SerdeContext ctx;
+    RETURN_IF_ERROR(_spiller->serde()->serialize(_runtime_state.get(), ctx, chunk_ptr, output, true));
+    // 4. flush
+    RETURN_IF_ERROR(output->flush());
     return Status::OK();
 }
 
 Status SpillMemTableSink::flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes,
-                                                   starrocks::SegmentPB* segment) {
+                                                   starrocks::SegmentPB* segment, bool eos) {
+    if (eos && _block_manager->block_container()->block_count() == 0) {
+        // If there is only one flush, flush it to segment directly
+        RETURN_IF_ERROR(_writer->flush_del_file(deletes));
+        RETURN_IF_ERROR(_writer->write(upserts, segment));
+        return _writer->flush(segment);
+    }
+    // 1. flush upsert
+    RETURN_IF_ERROR(flush_chunk(upserts, segment, eos));
+    // 2. flush deletes
+    RETURN_IF_ERROR(_writer->flush_del_file(deletes));
+    return Status::OK();
+}
+
+Status SpillMemTableSink::merge_blocks_to_segments() {
     // TODO
+    // 1. get blocks from `_block_manager`(LoadSpillBlockManager)
+    // 2. merge blocks to segments
+    // 3. add these segments to `_writer`(TabletWriter)
     return Status::OK();
 }
 

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -98,7 +98,7 @@ Status SpillMemTableSink::_do_spill(const Chunk& chunk, const spill::SpillOutput
     // 2. serialize chunk
     for (int64_t rowid = 0; rowid < chunk.num_rows(); rowid += spill_rows) {
         int64_t rows = std::min(spill_rows, (int64_t)chunk.num_rows() - rowid);
-        ChunkPtr each_chunk = std::move(chunk.clone_empty());
+        ChunkPtr each_chunk = chunk.clone_empty();
         each_chunk->append(chunk, rowid, rows);
         RETURN_IF_ERROR(_prepare(each_chunk));
         spill::SerdeContext ctx;

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -14,24 +14,61 @@
 
 #pragma once
 
+#include "exec/spill/block_manager.h"
+#include "exec/spill/data_stream.h"
+#include "exec/spill/spiller_factory.h"
 #include "storage/memtable_sink.h"
 
-namespace starrocks::lake {
+namespace starrocks {
+
+class RuntimeState;
+
+namespace lake {
 
 class LoadSpillBlockManager;
+class TabletWriter;
+
+class LoadSpillOutputDataStream : public spill::SpillOutputDataStream {
+public:
+    LoadSpillOutputDataStream(LoadSpillBlockManager* block_manager) : _block_manager(block_manager) {}
+
+    Status append(RuntimeState* state, const std::vector<Slice>& data, size_t total_write_size,
+                  size_t write_num_rows) override;
+
+    Status flush() override;
+
+    bool is_remote() const override;
+
+private:
+    LoadSpillBlockManager* _block_manager = nullptr;
+    spill::BlockPtr _block;
+};
 
 class SpillMemTableSink : public MemTableSink {
 public:
-    SpillMemTableSink() {}
+    SpillMemTableSink(LoadSpillBlockManager* block_manager, TabletWriter* w);
     ~SpillMemTableSink() override = default;
 
-    Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment = nullptr) override;
+    Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment = nullptr, bool eos = false) override;
 
     Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes,
-                                    starrocks::SegmentPB* segment = nullptr) override;
+                                    starrocks::SegmentPB* segment = nullptr, bool eos = false) override;
+
+    Status merge_blocks_to_segments();
+
+    spill::Spiller* get_spiller() { return _spiller.get(); }
 
 private:
-    //LoadSpillBlockManager* _block_manager = nullptr;
+    Status _prepare(const ChunkPtr& chunk_ptr);
+
+private:
+    LoadSpillBlockManager* _block_manager = nullptr;
+    TabletWriter* _writer;
+    // destroy spiller before runtime_state
+    std::shared_ptr<RuntimeState> _runtime_state;
+    spill::SpillerFactoryPtr _spiller_factory;
+    std::shared_ptr<spill::Spiller> _spiller;
 };
 
-} // namespace starrocks::lake
+} // namespace lake
+} // namespace starrocks

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -40,6 +40,12 @@ public:
     bool is_remote() const override;
 
 private:
+    Status _preallocate(size_t block_size);
+
+    // Freeze current block and append it to block container
+    Status _freeze_current_block();
+
+private:
     LoadSpillBlockManager* _block_manager = nullptr;
     spill::BlockPtr _block;
 };
@@ -60,6 +66,7 @@ public:
 
 private:
     Status _prepare(const ChunkPtr& chunk_ptr);
+    Status _do_spill(const Chunk& chunk, const spill::SpillOutputDataStreamPtr& output);
 
 private:
     LoadSpillBlockManager* _block_manager = nullptr;

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -323,7 +323,7 @@ Status MemTable::finalize() {
     return Status::OK();
 }
 
-Status MemTable::flush(SegmentPB* seg_info) {
+Status MemTable::flush(SegmentPB* seg_info, bool eos) {
     if (UNLIKELY(_result_chunk == nullptr)) {
         return Status::OK();
     }
@@ -336,9 +336,9 @@ Status MemTable::flush(SegmentPB* seg_info) {
     {
         SCOPED_RAW_TIMER(&duration_ns);
         if (_deletes) {
-            RETURN_IF_ERROR(_sink->flush_chunk_with_deletes(*_result_chunk, *_deletes, seg_info));
+            RETURN_IF_ERROR(_sink->flush_chunk_with_deletes(*_result_chunk, *_deletes, seg_info, eos));
         } else {
-            RETURN_IF_ERROR(_sink->flush_chunk(*_result_chunk, seg_info));
+            RETURN_IF_ERROR(_sink->flush_chunk(*_result_chunk, seg_info, eos));
         }
     }
     auto io_stat = scope.current_scoped_tls_io();

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -96,7 +96,7 @@ public:
     // return true suggests caller should flush this memory table
     StatusOr<bool> insert(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size);
 
-    Status flush(SegmentPB* seg_info = nullptr);
+    Status flush(SegmentPB* seg_info = nullptr, bool eos = false);
 
     Status finalize();
 

--- a/be/src/storage/memtable_flush_executor.cpp
+++ b/be/src/storage/memtable_flush_executor.cpp
@@ -62,7 +62,7 @@ public:
             segment = std::make_unique<SegmentPB>();
 
             _flush_token->_stats.cur_flush_count++;
-            _flush_token->_flush_memtable(_memtable.get(), segment.get());
+            _flush_token->_flush_memtable(_memtable.get(), segment.get(), _eos);
             _flush_token->_stats.cur_flush_count--;
             _memtable.reset();
 
@@ -130,13 +130,13 @@ Status FlushToken::wait() {
     return _status;
 }
 
-void FlushToken::_flush_memtable(MemTable* memtable, SegmentPB* segment) {
+void FlushToken::_flush_memtable(MemTable* memtable, SegmentPB* segment, bool eos) {
     // If previous flush has failed, return directly
     if (!status().ok()) {
         return;
     }
 
-    set_status(memtable->flush(segment));
+    set_status(memtable->flush(segment, eos));
     _stats.flush_count++;
     _stats.memtable_stats += memtable->get_stat();
 }

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -109,7 +109,7 @@ public:
 private:
     friend class MemtableFlushTask;
 
-    void _flush_memtable(MemTable* memtable, SegmentPB* segment);
+    void _flush_memtable(MemTable* memtable, SegmentPB* segment, bool eos);
 
     std::unique_ptr<ThreadPoolToken> _flush_token;
 

--- a/be/src/storage/memtable_rowset_writer_sink.h
+++ b/be/src/storage/memtable_rowset_writer_sink.h
@@ -28,12 +28,12 @@ public:
 
     DISALLOW_COPY(MemTableRowsetWriterSink);
 
-    Status flush_chunk(const Chunk& chunk, SegmentPB* seg_info = nullptr) override {
+    Status flush_chunk(const Chunk& chunk, SegmentPB* seg_info = nullptr, bool eos = false) override {
         return _rowset_writer->flush_chunk(chunk, seg_info);
     }
 
-    Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes,
-                                    SegmentPB* seg_info = nullptr) override {
+    Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes, SegmentPB* seg_info = nullptr,
+                                    bool eos = false) override {
         return _rowset_writer->flush_chunk_with_deletes(upserts, deletes, seg_info);
     }
 

--- a/be/src/storage/memtable_sink.h
+++ b/be/src/storage/memtable_sink.h
@@ -29,9 +29,9 @@ class MemTableSink {
 public:
     virtual ~MemTableSink() = default;
 
-    virtual Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* seg_info = nullptr) = 0;
-    virtual Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes,
-                                            SegmentPB* seg_info = nullptr) = 0;
+    virtual Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* seg_info = nullptr, bool eos = false) = 0;
+    virtual Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes, SegmentPB* seg_info = nullptr,
+                                            bool eos = false) = 0;
 };
 
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -271,6 +271,7 @@ set(EXEC_FILES
         ./storage/lake/compaction_task_context_test.cpp
         ./storage/lake/lake_primary_key_consistency_test.cpp
         ./storage/lake/load_spill_block_manager_test.cpp
+        ./storage/lake/spill_mem_table_sink_test.cpp
         ./storage/rowset_update_state_test.cpp
         ./storage/rowset_column_update_state_test.cpp
         ./storage/rowset_column_partial_update_test.cpp

--- a/be/test/storage/lake/load_spill_block_manager_test.cpp
+++ b/be/test/storage/lake/load_spill_block_manager_test.cpp
@@ -35,17 +35,17 @@ protected:
 
 TEST_F(LoadSpillBlockManagerTest, test_basic) {
     std::unique_ptr<LoadSpillBlockManager> block_manager =
-            std::make_unique<LoadSpillBlockManager>(TUniqueId(), kTestDir);
+            std::make_unique<LoadSpillBlockManager>(TUniqueId(), 1, 1, kTestDir);
     ASSERT_OK(block_manager->init());
-    ASSIGN_OR_ABORT(auto block, block_manager->acquire_block(1, 1, 1024));
+    ASSIGN_OR_ABORT(auto block, block_manager->acquire_block(1024));
     ASSERT_OK(block_manager->release_block(block));
 }
 
 TEST_F(LoadSpillBlockManagerTest, test_write_read) {
     std::unique_ptr<LoadSpillBlockManager> block_manager =
-            std::make_unique<LoadSpillBlockManager>(TUniqueId(), kTestDir);
+            std::make_unique<LoadSpillBlockManager>(TUniqueId(), 1, 1, kTestDir);
     ASSERT_OK(block_manager->init());
-    ASSIGN_OR_ABORT(auto block, block_manager->acquire_block(1, 1, 1024));
+    ASSIGN_OR_ABORT(auto block, block_manager->acquire_block(1024));
     ASSERT_OK(block->append({Slice("hello"), Slice("world")}));
     ASSERT_OK(block->flush());
     ASSIGN_OR_ABORT(auto input_stream, block->get_readable());

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -1,0 +1,195 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/spill_mem_table_sink.h"
+
+#include <gtest/gtest.h>
+
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "common/logging.h"
+#include "exec/spill/options.h"
+#include "exec/spill/serde.h"
+#include "exec/spill/spiller.h"
+#include "fs/fs.h"
+#include "storage/lake/general_tablet_writer.h"
+#include "storage/lake/load_spill_block_manager.h"
+#include "storage/lake/pk_tablet_writer.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/lake/test_util.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+#include "util/raw_container.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks::lake {
+
+class SpillMemTableSinkTest : public TestBase {
+public:
+    SpillMemTableSinkTest() : TestBase(kTestDir) {
+        _tablet_metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        (void)FileSystem::Default()->create_dir_recursive(kTestDir);
+        CHECK_OK(fs::create_directories(lake::join_path(kTestDir, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestDir, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestDir, lake::kTxnLogDirectoryName)));
+    }
+
+    void TearDown() override { (void)FileSystem::Default()->delete_dir_recursive(kTestDir); }
+
+    ChunkPtr gen_data(int64_t chunk_size, int shift) {
+        std::vector<int> v0(chunk_size);
+        std::vector<int> v1(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            v0[i] = i + shift * chunk_size;
+        }
+        for (int i = 0; i < chunk_size; i++) {
+            v1[i] = v0[i] * 3;
+        }
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        return std::make_shared<Chunk>(Columns{c0, c1}, _schema);
+    }
+
+protected:
+    constexpr static const char* const kTestDir = "./spill_mem_table_sink_test";
+
+    constexpr static const int kChunkSize = 12;
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+    RuntimeProfile _dummy_runtime_profile{"dummy"};
+};
+
+TEST_F(SpillMemTableSinkTest, test_flush_chunk) {
+    int64_t tablet_id = 1;
+    int64_t txn_id = 1;
+    std::unique_ptr<LoadSpillBlockManager> block_manager =
+            std::make_unique<LoadSpillBlockManager>(TUniqueId(), tablet_id, txn_id, kTestDir);
+    ASSERT_OK(block_manager->init());
+    std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get());
+    for (int i = 0; i < 3; i++) {
+        // 3 times
+        auto chunk = gen_data(kChunkSize, i);
+        starrocks::SegmentPB segment;
+        // write chunk to spill
+        ASSERT_OK(sink.flush_chunk(*chunk, &segment, false));
+        // read block
+        auto block = block_manager->block_container()->get_block(i);
+        ASSERT_TRUE(block != nullptr);
+        ASSERT_TRUE(block_manager->block_container()->block_count() == i + 1);
+        spill::SerdeContext ctx;
+        spill::BlockReaderOptions options2;
+        RuntimeProfile::Counter* read_io_timer = ADD_TIMER(&_dummy_runtime_profile, "ReadIOTime");
+        RuntimeProfile::Counter* read_io_count = ADD_COUNTER(&_dummy_runtime_profile, "ReadIOCount", TUnit::UNIT);
+        RuntimeProfile::Counter* read_io_bytes = ADD_COUNTER(&_dummy_runtime_profile, "ReadIOBytes", TUnit::BYTES);
+        options2.read_io_timer = read_io_timer;
+        options2.read_io_count = read_io_count;
+        options2.read_io_bytes = read_io_bytes;
+        // 3. read block data
+        auto reader = block->get_reader(options2);
+        ASSIGN_OR_ABORT(auto result_chunk, sink.get_spiller()->serde()->deserialize(ctx, reader.get()));
+        // 4. check result
+        for (int j = 0; j < kChunkSize; j++) {
+            EXPECT_EQ(j + i * kChunkSize, result_chunk->get(j)[0].get_int32());
+            EXPECT_EQ((j + i * kChunkSize) * 3, result_chunk->get(j)[1].get_int32());
+        }
+    }
+    ASSERT_OK(sink.merge_blocks_to_segments());
+    ASSERT_TRUE(tablet_writer->files().size() == 0);
+}
+
+TEST_F(SpillMemTableSinkTest, test_flush_chunk_with_deletes) {
+    int64_t tablet_id = 1;
+    int64_t txn_id = 1;
+    std::unique_ptr<LoadSpillBlockManager> block_manager =
+            std::make_unique<LoadSpillBlockManager>(TUniqueId(), tablet_id, txn_id, kTestDir);
+    ASSERT_OK(block_manager->init());
+    std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalPkTabletWriter>(
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, nullptr, false);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get());
+    for (int i = 0; i < 3; i++) {
+        // 3 times
+        auto chunk = gen_data(kChunkSize, i);
+        starrocks::SegmentPB segment;
+        // write chunk to spill
+        ASSERT_OK(sink.flush_chunk_with_deletes(*chunk, *(chunk->columns()[0]), &segment, false));
+        // read block
+        auto block = block_manager->block_container()->get_block(i);
+        ASSERT_TRUE(block != nullptr);
+        spill::SerdeContext ctx;
+        spill::BlockReaderOptions options2;
+        RuntimeProfile::Counter* read_io_timer = ADD_TIMER(&_dummy_runtime_profile, "ReadIOTime");
+        RuntimeProfile::Counter* read_io_count = ADD_COUNTER(&_dummy_runtime_profile, "ReadIOCount", TUnit::UNIT);
+        RuntimeProfile::Counter* read_io_bytes = ADD_COUNTER(&_dummy_runtime_profile, "ReadIOBytes", TUnit::BYTES);
+        options2.read_io_timer = read_io_timer;
+        options2.read_io_count = read_io_count;
+        options2.read_io_bytes = read_io_bytes;
+        // 3. read block data
+        auto reader = block->get_reader(options2);
+        ASSIGN_OR_ABORT(auto result_chunk, sink.get_spiller()->serde()->deserialize(ctx, reader.get()));
+        // 4. check result
+        for (int j = 0; j < kChunkSize; j++) {
+            EXPECT_EQ(j + i * kChunkSize, result_chunk->get(j)[0].get_int32());
+            EXPECT_EQ((j + i * kChunkSize) * 3, result_chunk->get(j)[1].get_int32());
+        }
+    }
+    ASSERT_TRUE(tablet_writer->files().size() == 3);
+}
+
+TEST_F(SpillMemTableSinkTest, test_flush_chunk2) {
+    int64_t tablet_id = 1;
+    int64_t txn_id = 1;
+    std::unique_ptr<LoadSpillBlockManager> block_manager =
+            std::make_unique<LoadSpillBlockManager>(TUniqueId(), tablet_id, txn_id, kTestDir);
+    ASSERT_OK(block_manager->init());
+    std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, false);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get());
+    auto chunk = gen_data(kChunkSize, 0);
+    starrocks::SegmentPB segment;
+    ASSERT_OK(sink.flush_chunk(*chunk, &segment, true));
+    ASSERT_TRUE(tablet_writer->files().size() == 1);
+}
+
+TEST_F(SpillMemTableSinkTest, test_flush_chunk_with_delete2) {
+    int64_t tablet_id = 1;
+    int64_t txn_id = 1;
+    std::unique_ptr<LoadSpillBlockManager> block_manager =
+            std::make_unique<LoadSpillBlockManager>(TUniqueId(), tablet_id, txn_id, kTestDir);
+    ASSERT_OK(block_manager->init());
+    std::unique_ptr<TabletWriter> tablet_writer = std::make_unique<HorizontalPkTabletWriter>(
+            _tablet_mgr.get(), tablet_id, _tablet_schema, txn_id, nullptr, false);
+    SpillMemTableSink sink(block_manager.get(), tablet_writer.get());
+    auto chunk = gen_data(kChunkSize, 0);
+    starrocks::SegmentPB segment;
+    ASSERT_OK(sink.flush_chunk_with_deletes(*chunk, *(chunk->columns()[0]), &segment, true));
+    ASSERT_TRUE(tablet_writer->files().size() == 2);
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/memtable_flush_executor_test.cpp
+++ b/be/test/storage/memtable_flush_executor_test.cpp
@@ -394,7 +394,7 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlushStatusNotOk) {
     flush_token->set_status(Status::NotSupported("Not Suppoted"));
     ASSERT_FALSE(flush_token->status().ok());
 
-    flush_token->_flush_memtable(nullptr, nullptr);
+    flush_token->_flush_memtable(nullptr, nullptr, false);
 
     ASSERT_TRUE(MemTableFlushExecutor::calc_max_threads_for_lake_table(data_dirs) > 0);
 }


### PR DESCRIPTION
## Why I'm doing:
Fixes #53954

## What I'm doing:
1. Support `SpillMemTableSink` which can flush memtable to blocks. if `enable_load_spill` is true, create `SpillMemTableSink`, otherwise create `TabletWriterSink`.
2. When do memtable flush, if we only have one memtable then generate segment directly, otherwise generate blocks.
3. At last, call `merge_blocks_to_segments` to merge blocks into segment files. This part will be done in Part3.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0