### PR TITLE
[Enhancement] auto analyze predicate columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
@@ -102,6 +102,7 @@ public class AnalyzeStatusSystemTable extends SystemTable {
                     continue;
                 }
             } catch (MetaNotFoundException ignored) {
+                continue;
             }
 
             String columnStr = "ALL";

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2084,13 +2084,19 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long statistic_auto_collect_small_table_rows = 10000000; // 10M
 
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "If the number of columns of table exceeds it, use predicate-columns strategy")
+    public static int statistic_auto_collect_predicate_columns_threshold = 32;
+
+    @ConfField(mutable = true, comment = "The interval of auto stats for small tables")
     public static long statistic_auto_collect_small_table_interval = 0; // unit: second, default 0
 
-    @ConfField(mutable = true, comment = "The interval of auto collecting histogram statistics")
+    @ConfField(mutable = true, comment = "The interval of auto stats for predicate-columns strategy")
+    public static long statistic_auto_collect_predicate_columns_interval = 60L * 10; // unit: second, default 10 minutes
+
+    @ConfField(mutable = true, comment = "The interval of auto stats for histogram")
     public static long statistic_auto_collect_histogram_interval = 3600L * 1; // 1h
 
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "The interval of auto stats for large tables")
     public static long statistic_auto_collect_large_table_interval = 3600L * 12; // unit: second, default 12h
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ColumnUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ColumnUsage.java
@@ -21,6 +21,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.TimeUtils;
@@ -80,6 +81,11 @@ public class ColumnUsage implements GsonPostProcessable {
 
     public ColumnFullId getColumnFullId() {
         return columnId;
+    }
+
+    public String getOlapColumnName(OlapTable olap) {
+        return Preconditions.checkNotNull(olap.getColumnByUniqueId(columnId.getColumnUniqueId()),
+                this + " not exists").getName();
     }
 
     public void setTableName(TableName tableName) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -78,6 +78,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         PlanTestNoneDBBase.beforeClass();
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         ConnectorPlanTestBase.mockAllCatalogs(connectContext, temp.newFolder().toURI().toString());
+        Config.statistic_auto_collect_predicate_columns_threshold = 0;
 
         String dbName = "test";
         starRocksAssert.withDatabase(dbName).useDatabase(dbName);
@@ -210,6 +211,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         OlapTable structTable = (OlapTable) globalStateMgr.getLocalMetastore().getDb("stats").getTable("struct_a");
         new ArrayList<>(structTable.getPartitions()).get(0).getDefaultPhysicalPartition().updateVisibleVersion(2);
         setTableStatistics(structTable, 20000000);
+
     }
 
     @Before
@@ -1362,7 +1364,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         new Expectations(execMeta2) {
             {
                 execMeta2.getHealthy();
-                times = 0;
+                times = 1;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
@@ -15,12 +15,24 @@
 package com.starrocks.statistic.columns;
 
 import com.google.common.base.Splitter;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.scheduler.history.TableKeeper;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.AnalyzeStmt;
 import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.statistic.AnalyzeJob;
+import com.starrocks.statistic.AnalyzeMgr;
+import com.starrocks.statistic.BasicStatsMeta;
+import com.starrocks.statistic.NativeAnalyzeJob;
+import com.starrocks.statistic.StatisticsCollectJob;
+import com.starrocks.statistic.StatisticsCollectJobFactory;
 import com.starrocks.statistic.StatisticsMetaManager;
+import com.starrocks.statistic.StatsConstants;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,7 +40,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -149,5 +163,74 @@ class ColumnUsageTest extends PlanTestBase {
                 StringUtils.isNotEmpty(expectedColumns) ? Splitter.on(",").splitToList(expectedColumns) : List.of();
         Assertions.assertEquals(expect.stream().sorted().collect(Collectors.toList()),
                 stmt.getColumnNames().stream().sorted().collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testAutoAnalyzePredicateColumns() throws Exception {
+        AnalyzeTestUtil.init();
+        Table table = starRocksAssert.getTable(connectContext.getDatabase(), "t0");
+        setTableStatistics((OlapTable) table, Config.statistic_auto_collect_small_table_rows + 1);
+        setPartitionStatistics((OlapTable) table, "t0", Config.statistic_auto_collect_small_table_rows + 1);
+
+        starRocksAssert.query("select * from t0 where v1 > 1").explainQuery();
+        starRocksAssert.getCtx().executeSql("analyze table t0 predicate columns with sync mode");
+
+        String analyzeSql = "create analyze table t0";
+        starRocksAssert.ddl(analyzeSql);
+
+        List<AnalyzeJob> allAnalyzeJobList =
+                starRocksAssert.getCtx().getGlobalStateMgr().getAnalyzeMgr().getAllAnalyzeJobList()
+                        .stream().filter(x -> {
+                            try {
+                                return x.getTableName().equalsIgnoreCase("t0");
+                            } catch (MetaNotFoundException e) {
+                                return false;
+                            }
+                        })
+                        .collect(Collectors.toList());
+        NativeAnalyzeJob analyzeJob = (NativeAnalyzeJob) allAnalyzeJobList.get(0);
+        AnalyzeMgr analyzeMgr = GlobalStateMgr.getCurrentState().getAnalyzeMgr();
+
+        // mock a small table, with staled stats
+        LocalDateTime mockUpdate = LocalDateTime.now().minusDays(1);
+        BasicStatsMeta statsMeta = analyzeMgr.getTableBasicStatsMeta(table.getId());
+        statsMeta = Mockito.mock(BasicStatsMeta.class);
+        Mockito.when(statsMeta.getTableId()).thenReturn(table.getId());
+        analyzeMgr.addBasicStatsMeta(statsMeta);
+
+        Mockito.when(statsMeta.getUpdateTime()).thenReturn(mockUpdate);
+        Mockito.when(statsMeta.isUpdatedAfterLoad(Mockito.any())).thenReturn(false);
+        Mockito.when(statsMeta.getHealthy()).thenReturn(0.1);
+
+        // enable the predicate-columns strategy
+        {
+            List<StatisticsCollectJob> collectJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(analyzeJob);
+            Assertions.assertEquals(1, collectJobs.size());
+            StatisticsCollectJob job0 = collectJobs.get(0);
+            Assertions.assertEquals(StatsConstants.AnalyzeType.FULL, job0.getType());
+            Assertions.assertEquals(List.of("v1"), job0.getColumnNames());
+        }
+
+        // disable the strategy
+        {
+            int defaultValue =
+                    Config.statistic_auto_collect_predicate_columns_threshold;
+            Config.statistic_auto_collect_predicate_columns_threshold = 0;
+            List<StatisticsCollectJob> collectJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(analyzeJob);
+            Assertions.assertEquals(1, collectJobs.size());
+            StatisticsCollectJob job0 = collectJobs.get(0);
+            Assertions.assertEquals(StatsConstants.AnalyzeType.FULL, job0.getType());
+            Assertions.assertEquals(List.of("v1", "v2", "v3"), job0.getColumnNames());
+            Config.statistic_auto_collect_predicate_columns_threshold = defaultValue;
+        }
+
+        // Enlarge the statistics interval, which will stop the job
+        {
+            long defaultValue = Config.statistic_auto_collect_small_table_interval;
+            Config.statistic_auto_collect_small_table_interval = 3600 * 24 * 7;
+            List<StatisticsCollectJob> collectJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(analyzeJob);
+            Assertions.assertEquals(0, collectJobs.size());
+            Config.statistic_auto_collect_small_table_interval = defaultValue;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
@@ -204,17 +204,21 @@ class ColumnUsageTest extends PlanTestBase {
 
         // enable the predicate-columns strategy
         {
+            int defaultValue = Config.statistic_auto_collect_predicate_columns_threshold;
+            Config.statistic_auto_collect_predicate_columns_threshold = 32;
+
             List<StatisticsCollectJob> collectJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(analyzeJob);
             Assertions.assertEquals(1, collectJobs.size());
             StatisticsCollectJob job0 = collectJobs.get(0);
             Assertions.assertEquals(StatsConstants.AnalyzeType.FULL, job0.getType());
             Assertions.assertEquals(List.of("v1"), job0.getColumnNames());
+
+            Config.statistic_auto_collect_predicate_columns_threshold = defaultValue;
         }
 
         // disable the strategy
         {
-            int defaultValue =
-                    Config.statistic_auto_collect_predicate_columns_threshold;
+            int defaultValue = Config.statistic_auto_collect_predicate_columns_threshold;
             Config.statistic_auto_collect_predicate_columns_threshold = 0;
             List<StatisticsCollectJob> collectJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(analyzeJob);
             Assertions.assertEquals(1, collectJobs.size());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Change the default auto-analyze strategy:
1. Before: every 12h auto analyze for large table, realtime analyze small table
2. Now: analyze only predicate columns if the statistics is not healthy, every 10min

Benefit:
1. Reduce the overhead of analyzing tables with massive columns
2. Reduce the analyze interval for big table, which is limited to 12h before, but 10min now

Changed configs:
1. `statistic_auto_collect_predicate_columns_interval = 60L * 10`: interval limitation of analyze interval
3. `statistic_auto_collect_predicate_columns_threshold = 32`
    1. Threshold of applying the predicate columns strategy
    2. If set to 0, disable the strategy

Fixes #53204

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0