### PR TITLE
[BugFix] Fix avro bytes type to json

### DIFF
--- a/be/src/formats/avro/binary_column.cpp
+++ b/be/src/formats/avro/binary_column.cpp
@@ -218,8 +218,8 @@ static Status avro_value_to_rapidjson(const avro_value_t& value, rapidjson::Docu
     case AVRO_BYTES: {
         const char* in;
         size_t size;
-        if (avro_value_get_fixed(&value, (const void**)&in, &size) != 0) {
-            return Status::InvalidArgument(strings::Substitute("Get string value error $0", avro_strerror()));
+        if (avro_value_get_bytes(&value, (const void**)&in, &size) != 0) {
+            return Status::InvalidArgument(strings::Substitute("Get bytes value error $0", avro_strerror()));
         }
         out.SetString(in, allocator);
         return Status::OK();
@@ -420,6 +420,7 @@ static Status add_column_with_array_object_value(BinaryColumn* column, const Typ
         std::string json_str;
         auto st = avro_value_to_json_str(value, &json_str);
         if (!st.ok()) {
+            LOG(WARNING) << "avro to json failed. column=" << name << ", err=" << st;
             return Status::InternalError(
                     strings::Substitute("avro to json failed. column=$0, err=$1", name, st.message()));
         }
@@ -428,7 +429,7 @@ static Status add_column_with_array_object_value(BinaryColumn* column, const Typ
     } else {
         char* as_json;
         if (avro_value_to_json(&value, 1, &as_json)) {
-            LOG(WARNING) << "avro to json failed: %s" << avro_strerror();
+            LOG(WARNING) << "avro to json failed. column=" << name << ", err=" << avro_strerror();
             return Status::InternalError(
                     strings::Substitute("avro to json failed. column=$0, err=$1", name, avro_strerror()));
         }
@@ -484,6 +485,7 @@ Status add_native_json_column(Column* column, const TypeDescriptor& type_desc, c
         std::string json_str;
         st = avro_value_to_json_str(value, &json_str);
         if (!st.ok()) {
+            LOG(WARNING) << "avro to json failed. column=" << name << ", err=" << st;
             return Status::InternalError(
                     strings::Substitute("avro to json failed. column=$0, err=$1", name, st.message()));
         }
@@ -492,7 +494,7 @@ Status add_native_json_column(Column* column, const TypeDescriptor& type_desc, c
     } else {
         char* as_json;
         if (avro_value_to_json(&value, 1, &as_json)) {
-            LOG(WARNING) << "avro to json failed: %s" << avro_strerror();
+            LOG(WARNING) << "avro to json failed. column=" << name << ", err=" << avro_strerror();
             return Status::InternalError(
                     strings::Substitute("avro to json failed. column=$0, err=$1", name, avro_strerror()));
         }

--- a/be/test/exec/test_data/avro_scanner/avro_basic_schema.json
+++ b/be/test/exec/test_data/avro_scanner/avro_basic_schema.json
@@ -7,6 +7,7 @@
         {"name": "longtype", "type": "long"},
         {"name": "doubletype", "type": "double"},
         {"name": "stringtype", "type": "string"},
+        {"name": "bytestype", "type": "bytes"},
         {"name": "enumtype", "type": {"type": "enum", "name": "ThirdEnum", "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]}}  
     ]
 }


### PR DESCRIPTION
## Why I'm doing:

use wrong `avro_value_get_fixed` method to get `bytes` type value.

## What I'm doing:

use `avro_value_get_bytes`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0