### PR TITLE
[Enhancement] Disable extract agg columns on complex and json type columns for pruning  columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ExtractAggregateColumn.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ExtractAggregateColumn.java
@@ -69,12 +69,12 @@ public class ExtractAggregateColumn implements TreeRewriteRule {
             return false;
         }
 
-        private boolean hasCollectionTypeColumn(ScalarOperator operator) {
-            if (operator.isColumnRef() && operator.getType().isCollectionType()) {
+        private boolean hasComplexOrJsonTypeColumn(ScalarOperator operator) {
+            if (operator.isColumnRef() && (operator.getType().isComplexType() || operator.getType().isJsonType())) {
                 return true;
             }
             for (ScalarOperator child : operator.getChildren()) {
-                if (hasCollectionTypeColumn(child)) {
+                if (hasComplexOrJsonTypeColumn(child)) {
                     return true;
                 }
             }
@@ -104,8 +104,7 @@ public class ExtractAggregateColumn implements TreeRewriteRule {
                             return;
                         }
                         if (!scalarOperator.isColumnRef() && !hasDictMappingOperator(scalarOperator) &&
-                                !(scalarOperator.getOpType() == OperatorType.SUBFIELD) &&
-                                !hasCollectionTypeColumn(scalarOperator)) {
+                                !hasComplexOrJsonTypeColumn(scalarOperator)) {
                             rewriteMap.put(childRef, scalarOperator);
                             extractedColumns.add(childRef);
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ExtractAggregateColumn.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ExtractAggregateColumn.java
@@ -20,7 +20,6 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
-import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -447,7 +447,7 @@ public class TrinoQueryTest extends TrinoTestBase {
 
         sql = "select avg(c1[1]) from test_map where c1[1] is not null";
         assertPlanContains(sql, "2:AGGREGATE (update finalize)\n" +
-                "  |  output: avg(2: c1[1])");
+                "  |  output: avg(5: expr)");
 
         sql = "select c2[2][1] from test_map";
         assertPlanContains(sql, "<slot 5> : 3: c2[2][1]");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1658,11 +1658,11 @@ public class AggregateTest extends PlanTestBase {
                 "sum(arrays_overlap(v3, [1])) as q2, " +
                 "sum(arrays_overlap(v3, [1])) as q3 FROM tarray;");
         assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
-                "  |  output: sum(arrays_overlap(3: v3, CAST([1] AS ARRAY<BIGINT>)))\n" +
+                "  |  output: sum(4: arrays_overlap)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
                 "  1:Project\n" +
-                "  |  <slot 3> : 3: v3\n" +
+                "  |  <slot 4> : arrays_overlap(3: v3, CAST([1] AS ARRAY<BIGINT>))\n" +
                 "  |  \n" +
                 "  0:OlapScanNode");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -738,7 +738,12 @@ public class ArrayTypeTest extends PlanTestBase {
                 "count(distinct array_length(array_map(x -> x + 1, d_2))) from adec";
         String plan = getFragmentPlan(sql);
         assertCContains(plan, "  2:AGGREGATE (update finalize)\n" +
-                "  |  output: multi_distinct_count(array_length(array_map" +
-                "(<slot 10> -> CAST(<slot 10> AS DECIMAL64(13,3)) + 1, 5: d_2)))");
+                "  |  output: multi_distinct_count(11: array_length)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 11> : array_length(array_map(<slot 10> -> CAST(<slot 10> AS DECIMAL64(13,3)) + 1, 5: d_2))\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -728,9 +728,11 @@ public class ExpressionTest extends PlanTestBase {
         String sql = "select array_agg(array_length(array_map(x->x*2, c2))) from test_array12";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  2:AGGREGATE (update finalize)\n" +
-                "  |  output: array_agg(array_length(array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) * 2, 3: c2)))"));
-        Assert.assertTrue(plan.contains("  1:Project\n" +
-                "  |  <slot 3> : 3: c2"));
+                "  |  output: array_agg(5: array_length)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 5> : array_length(array_map(<slot 4> -> CAST(<slot 4> AS BIGINT) * 2, 3: c2))"));
 
         sql = "select array_map(x->x > count(c1), c2) from test_array12 group by c2";
         plan = getFragmentPlan(sql);


### PR DESCRIPTION
## Why I'm doing:

if we execute query `select avg(array_length(arr_col))`,   array column can't be pruned to offset. also olap scan node doesn't exist `ColumnAccessPath` in the explain query. This is because EliminateOveruseColumnAccessPathRule eliminated ColumnAccessPath. We can filter the collection type column in the extract agg column rule because this optimization has little impact on the collection type.

base:
```
mysql> explain verbose select avg(array_length(k2)) from test_array;
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                                                                                          |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                                                                                                                                                              |
|                                                                                                                                                                                                                         |
| PLAN COST                                                                                                                                                                                                               |
|   CPU: 4.000000004E10                                                                                                                                                                                                   |
|   Memory: 8.0                                                                                                                                                                                                           |
|                                                                                                                                                                                                                         |
| PLAN FRAGMENT 0(F00)                                                                                                                                                                                                    |
|   Fragment Cost: 2.0000000036E10                                                                                                                                                                                        |
|   Output Exprs:4: avg                                                                                                                                                                                                   |
|   Input Partition: RANDOM                                                                                                                                                                                               |
|   RESULT SINK                                                                                                                                                                                                           |
|                                                                                                                                                                                                                         |
|   2:AGGREGATE (update finalize)                                                                                                                                                                                         |
|   |  aggregate: avg[(array_length[([2: k2, ARRAY<BIGINT>, true]); args: INVALID_TYPE; result: INT; args nullable: true; result nullable: true]); args: INT; result: DOUBLE; args nullable: true; result nullable: true] |
|   |  cardinality: 1                                                                                                                                                                                                     |
|   |                                                                                                                                                                                                                     |
|   1:Project                                                                                                                                                                                                             |
|   |  output columns:                                                                                                                                                                                                    |
|   |  2 <-> [2: k2, ARRAY<BIGINT>, true]                                                                                                                                                                                 |
|   |  cardinality: 1000000001                                                                                                                                                                                            |
|   |                                                                                                                                                                                                                     |
|   0:OlapScanNode                                                                                                                                                                                                        |
|      table: test_array, rollup: test_array                                                                                                                                                                              |
|      preAggregation: on                                                                                                                                                                                                 |
|      partitionsRatio=1/1, tabletsRatio=1/1                                                                                                                                                                              |
|      tabletList=203130                                                                                                                                                                                                  |
|      actualRows=1000000001, avgRowSize=17.0                                                                                                                                                                             |
|      Pruned type: 2 <-> [ARRAY<BIGINT>]                                                                                                                                                                                 |
|      cardinality: 1000000001                                                                                                                                                                                            |
+------------------------------------
```

update:
```
mysql>  explain costs select avg(array_length(k2)) from test_array;
+--------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                       |
+--------------------------------------------------------------------------------------------------------------------------------------+
| PLAN COST                                                                                                                            |
|   CPU: 4.000000004E10                                                                                                                |
|   Memory: 8.0                                                                                                                        |
|                                                                                                                                      |
| PLAN FRAGMENT 0(F00)                                                                                                                 |
|   Output Exprs:4: avg                                                                                                                |
|   Input Partition: RANDOM                                                                                                            |
|   RESULT SINK                                                                                                                        |
|                                                                                                                                      |
|   2:AGGREGATE (update finalize)                                                                                                      |
|   |  aggregate: avg[([3: array_length, INT, true]); args: INT; result: DOUBLE; args nullable: true; result nullable: true]           |
|   |  cardinality: 1                                                                                                                  |
|   |  column statistics:                                                                                                              |
|   |  * avg-->[-Infinity, Infinity, 0.0, 1.0, 1.0, -1.0] UNKNOWN                                                                      |
|   |                                                                                                                                  |
|   1:Project                                                                                                                          |
|   |  output columns:                                                                                                                 |
|   |  3 <-> array_length[([2: k2, ARRAY<BIGINT>, true]); args: INVALID_TYPE; result: INT; args nullable: true; result nullable: true] |
|   |  cardinality: 1000000001                                                                                                         |
|   |  column statistics:                                                                                                              |
|   |  * array_length-->[-Infinity, Infinity, 0.0, 1.0, 1.0, -1.0] UNKNOWN                                                             |
|   |                                                                                                                                  |
|   0:OlapScanNode                                                                                                                     |
|      table: test_array, rollup: test_array                                                                                           |
|      preAggregation: on                                                                                                              |
|      partitionsRatio=1/1, tabletsRatio=1/1                                                                                           |
|      tabletList=203239                                                                                                               |
|      actualRows=1000000001, avgRowSize=2.0                                                                                           |
|      Pruned type: 2 <-> [ARRAY<BIGINT>]                                                                                              |
|      ColumnAccessPath: [/k2/OFFSET]                                                                                                  |
|      cardinality: 1000000001                                                                                                         |
|      column statistics:                                                                                                              |
|      * k2-->[-Infinity, Infinity, 0.0, 1.0, 1.0, -1.0] UNKNOWN                                                                       |
|      * array_length-->[-Infinity, Infinity, 0.0, 1.0, 1.0, -1.0] UNKNOWN                                                             |
+--------------------------------------------------------------------------------------------------------------------------------------+
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0