### PR TITLE
[BugFix] Add more checks for pk table apply retry

### DIFF
--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1601,7 +1601,6 @@ void StorageEngine::decommission_disks(const std::vector<string>& decommission_d
 }
 
 void StorageEngine::add_schedule_apply_task(int64_t tablet_id, std::chrono::steady_clock::time_point time_point) {
-    VLOG(1) << "add tablet:" << tablet_id << ", next apply time:" << time_point;
     {
         std::unique_lock<std::mutex> wl(_schedule_apply_mutex);
         _schedule_apply_tasks.emplace(time_point, tablet_id);

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1601,7 +1601,7 @@ void StorageEngine::decommission_disks(const std::vector<string>& decommission_d
 }
 
 void StorageEngine::add_schedule_apply_task(int64_t tablet_id, std::chrono::steady_clock::time_point time_point) {
-    LOG(INFO) << "add tablet:" << tablet_id << ", next apply time:";
+    VLOG(1) << "add tablet:" << tablet_id << ", next apply time:" << time_point;
     {
         std::unique_lock<std::mutex> wl(_schedule_apply_mutex);
         _schedule_apply_tasks.emplace(time_point, tablet_id);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -861,16 +861,36 @@ void TabletUpdates::_ignore_rowset_commit(int64_t version, const RowsetSharedPtr
                               << " txn_id: " << rowset->txn_id() << " rowset: " << rowset->rowset_id().to_string();
 }
 
+// check error message to avoid error code conversion during execution
+bool TabletUpdates::_check_status_msg(std::string_view msg) {
+    std::string lower_msg;
+    lower_msg.reserve(msg.size());
+    for (char ch : msg) {
+        lower_msg.push_back(std::tolower(static_cast<unsigned char>(ch)));
+    }
+    bool has_memory = lower_msg.find("memory") != std::string::npos;
+    bool has_exceed_limit = lower_msg.find("exceed limit") != std::string::npos;
+    bool has_alloc_failed = lower_msg.find("alloc failed") != std::string::npos;
+    return has_memory && (has_exceed_limit || has_alloc_failed);
+}
+
 bool TabletUpdates::_is_tolerable(Status& status) {
+    bool res = true;
     switch (status.code()) {
     case TStatusCode::OK:
     case TStatusCode::MEM_LIMIT_EXCEEDED:
     case TStatusCode::MEM_ALLOC_FAILED:
-        return true;
+    case TStatusCode::TIMEOUT:
+        res = true;
+        break;
     default:
-        return false;
+        res = false;
     }
-    return false;
+    if (!res) {
+        res = _check_status_msg(status.message());
+    }
+
+    return res;
 }
 
 class ApplyCommitTask : public Runnable {
@@ -1629,8 +1649,8 @@ Status TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version
                         _tablet.tablet_id(), rssid, cur_old, cur_add, cur_new, old_del_vec->version(),
                         version.major_number());
                 LOG(ERROR) << msg;
-                _set_error(msg);
-                return Status::InternalError(msg);
+                failure_handler(msg, TStatusCode::INTERNAL_ERROR, false);
+                return apply_st;
             }
             if (VLOG_IS_ON(1)) {
                 StringAppendF(&delvec_change_info, " %u:%zu(%ld)+%zu=%zu", rssid, cur_old, old_del_vec->version(),
@@ -1943,7 +1963,6 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo) {
                 string msg = strings::Substitute("_do_compaction rowset $0 should exists $1", info->inputs[i],
                                                  _debug_string(false));
                 LOG(ERROR) << msg;
-                _set_error(msg);
                 return Status::InternalError(msg);
             } else {
                 input_rowsets[i] = itr->second;
@@ -2509,7 +2528,7 @@ Status TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_in
                 max_rowset_id, max_src_rssid, _debug_compaction_stats(info->inputs, rowset_id),
                 st.ok() ? "" : st.message());
         LOG(ERROR) << msg << debug_string();
-        _set_error(msg + _debug_version_info(true));
+        failure_handler(msg + _debug_version_info(true), st.code());
         DCHECK(st.ok()) << msg;
     }
     return apply_st;
@@ -5264,7 +5283,6 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
                                                   rowset->rowset_meta()->get_rowset_seg_id(),
                                                   rowset->rowset_meta()->get_rowset_seg_id() + rowset->num_segments());
             LOG(ERROR) << msg;
-            _set_error(msg);
             return Status::InternalError(msg);
         }
         // REQUIRE: all rowsets in this tablet have the same path prefix, i.e, can share the same fs
@@ -5403,8 +5421,7 @@ Status TabletUpdates::get_rss_rowids_by_pk_unlock(Tablet* tablet, const Column& 
         std::string msg = strings::Substitute("get_rss_rowids_by_pk error: load primary index failed: $0 $1",
                                               st.message(), debug_string());
         LOG(ERROR) << msg;
-        _set_error(msg);
-        return Status::InternalError(msg);
+        return Status(st.code(), msg);
     }
 
     RETURN_IF_ERROR(index.get(keys, rss_rowids));

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -521,6 +521,7 @@ private:
                                           size_t* total_deletes, size_t* total_rows,
                                           vector<std::pair<uint32_t, DelVectorPtr>>* delvecs);
 
+    bool _check_status_msg(std::string_view msg);
     bool _is_tolerable(Status& status);
 
     void _reset_apply_status(const EditVersionInfo& version_info_apply);


### PR DESCRIPTION
## Why I'm doing:
We add more strict memory limit check for primary key table during apply(https://github.com/StarRocks/starrocks/pull/47889) to avoid BE OOM and we enable retry if apply failed because of memory limit. However, there maybe error code conversion during execution and we will get an error code which is not tolerable even if the root cause is memory limit. After that, we will get error state tablet and can not recover until restart BE.

## What I'm doing:
1. Remove the unnecessary error state in `TabletUpdates`
2. Add error message check for memory limit

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0