### PR TITLE
[BugFix] Fix query error when delta lake using shallow clone

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
@@ -95,8 +95,12 @@ public class DeltaConnectorScanRangeSource implements ConnectorScanRangeSource {
         DescriptorTable.ReferencedPartitionInfo referencedPartitionInfo = referencedPartitions.get(partitionId);
         TScanRangeLocations scanRangeLocations = new TScanRangeLocations();
         THdfsScanRange hdfsScanRange = new THdfsScanRange();
-        hdfsScanRange.setRelative_path(URLDecoder.decode("/" + Paths.get(table.getTableLocation()).
-                relativize(Paths.get(fileStatus.getPath())), StandardCharsets.UTF_8));
+        if (fileStatus.getPath().contains(table.getTableLocation())) {
+            hdfsScanRange.setRelative_path(URLDecoder.decode("/" + Paths.get(table.getTableLocation()).
+                    relativize(Paths.get(fileStatus.getPath())), StandardCharsets.UTF_8));
+        } else {
+            hdfsScanRange.setFull_path(URLDecoder.decode(fileStatus.getPath(), StandardCharsets.UTF_8));
+        }
         hdfsScanRange.setOffset(0);
         hdfsScanRange.setLength(fileStatus.getSize());
         hdfsScanRange.setPartition_id(partitionId);

--- a/test/sql/test_deltalake/R/test_deltalake_catalog
+++ b/test/sql/test_deltalake/R/test_deltalake_catalog
@@ -281,6 +281,14 @@ select task_id, request_id, parent_request_id from delta_test_${uuid0}.delta_oss
 -- result:
 UW-33393	111A893698524BD68886AD339701DAAA	111259989C2845BAAEF898D81951B6A1
 -- !result
+select col_tinyint,col_array,col_map,col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type_shallow_clone where col_tinyint < 6 order by col_tinyint;
+-- result:
+1	[1,2,3]	{"key1":"value1","key2":"value2"}	{"name":"Alice","sex":"female","age":30}
+2	[4,5,6]	{"key3":"value3","key4":"value4"}	{"name":"Bob","sex":"male","age":25}
+3	[7,8,9]	{"key5":"value5","key6":"value6"}	{"name":"Charlie","sex":"male","age":35}
+4	[10,11,12]	{"key7":"value7","key8":"value8"}	{"name":"Diana","sex":"female","age":28}
+5	[13,14,15]	{"key9":"value9","key10":"value10"}	{"name":"Edward","sex":"male","age":40}
+-- !result
 drop catalog delta_test_${uuid0}
 -- result:
 -- !result

--- a/test/sql/test_deltalake/T/test_deltalake_catalog
+++ b/test/sql/test_deltalake/T/test_deltalake_catalog
@@ -81,4 +81,7 @@ select col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type whe
 -- test multi-partitions
 select task_id, request_id, parent_request_id from delta_test_${uuid0}.delta_oss_db.sample_multi_partitions where task_id = 'UW-33393' limit 1;
 
+-- test shallow clone table
+select col_tinyint,col_array,col_map,col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type_shallow_clone where col_tinyint < 6 order by col_tinyint;
+
 drop catalog delta_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:
because in #53949 we set relative path for delta lake table, but for delta lake shallow clone table, it's data directory is not at table location
## What I'm doing:
use absolute path for shallow clone table

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0