### PR TITLE
[BugFix] Fix concurrent issue in olap table listener

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionWithoutChannelHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionWithoutChannelHandler.java
@@ -97,7 +97,7 @@ public class TransactionWithoutChannelHandler implements TransactionOperationHan
         switch (txnStatus) {
             case PREPARED:
                 GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                        .commitPreparedTransaction(db, txnId, timeoutMillis);
+                        .commitPreparedTransaction(db.getId(), txnId, timeoutMillis);
                 result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
                 result.addResultEntry(TransactionResult.LABEL_KEY, label);
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -36,6 +36,7 @@ import com.starrocks.common.util.LogKey;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.http.rest.TransactionResult;
@@ -940,7 +941,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                 timeoutMs / 1000, warehouseId);
     }
 
-    public void unprotectedPrepareTxn() throws StarRocksException {
+    public void unprotectedPrepareTxn() throws StarRocksException, LockTimeoutException {
         List<TabletCommitInfo> commitInfos = TabletCommitInfo.fromThrift(coord.getCommitInfos());
         List<TabletFailInfo> failInfos = TabletFailInfo.fromThrift(coord.getFailInfos());
         finishPreparingTimeMs = System.currentTimeMillis();
@@ -948,8 +949,8 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                 beforeLoadTimeMs, startLoadingTimeMs, startPreparingTimeMs, finishPreparingTimeMs,
                 endTimeMs, numRowsNormal, numRowsAbnormal, numRowsUnselected, numLoadBytesTotal,
                 trackingUrl);
-        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().prepareTransaction(dbId,
-                txnId, commitInfos, failInfos, txnCommitAttachment);
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().prepareTransaction(
+                dbId, txnId, commitInfos, failInfos, txnCommitAttachment, timeoutMs);
     }
 
     public boolean checkNeedRemove(long currentMs, boolean isForce) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -274,13 +274,32 @@ public class GlobalTransactionMgr implements MemoryTrackable {
                                    List<TabletFailInfo> tabletFailInfos,
                                    TxnCommitAttachment txnCommitAttachment)
             throws StarRocksException {
-        if (Config.disable_load_job) {
-            throw new TransactionCommitFailedException("disable_load_job is set to true, all load jobs are prevented");
-        }
+        // timeout is 0, means no timeout
+        prepareTransaction(dbId, transactionId, tabletCommitInfos, tabletFailInfos, txnCommitAttachment, 0);
+    }
 
+    public void prepareTransaction(
+            @NotNull long dbId, long transactionId, @NotNull List<TabletCommitInfo> tabletCommitInfos,
+            @NotNull List<TabletFailInfo> tabletFailInfos,
+            @Nullable TxnCommitAttachment attachment, long timeoutMs) throws StarRocksException {
+        TransactionState transactionState = getTransactionState(dbId, transactionId);
+        List<Long> tableId = transactionState.getTableIdList();
         LOG.debug("try to pre commit transaction: {}", transactionId);
-        DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-        dbTransactionMgr.prepareTransaction(transactionId, tabletCommitInfos, tabletFailInfos, txnCommitAttachment, true);
+        Locker locker = new Locker();
+        if (!locker.tryLockTablesWithIntensiveDbLock(dbId, tableId, LockType.WRITE, timeoutMs, TimeUnit.MILLISECONDS)) {
+            throw new StarRocksException("get database write lock timeout, database=" + dbId + ", timeout=" + timeoutMs + "ms");
+        }
+        try {
+            if (Config.disable_load_job) {
+                throw new TransactionCommitFailedException("disable_load_job is set to true, all load jobs are prevented");
+            }
+
+            DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
+            dbTransactionMgr.prepareTransaction(transactionId, tabletCommitInfos, tabletFailInfos, attachment, true);
+            LOG.debug("prepare transaction: {} success", transactionId);
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(dbId, tableId, LockType.WRITE);
+        }
     }
 
     public void commitPreparedTransaction(long dbId, long transactionId, long timeoutMillis)

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -16,7 +16,6 @@ package com.starrocks.http;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
-import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
@@ -590,7 +589,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                             anyLong, anyLong,
                             (List<TabletCommitInfo>) any,
                             (List<TabletFailInfo>) any,
-                            (TxnCommitAttachment) any);
+                            (TxnCommitAttachment) any, anyLong);
                     times = 1;
                     result = new StarRocksException("prepare transaction error");
 
@@ -624,7 +623,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                             anyLong, anyLong,
                             (List<TabletCommitInfo>) any,
                             (List<TabletFailInfo>) any,
-                            (TxnCommitAttachment) any);
+                            (TxnCommitAttachment) any, anyLong);
                     times = 1;
                 }
             };
@@ -831,7 +830,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                     times = 1;
                     result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.PREPARED);
 
-                    globalTransactionMgr.commitPreparedTransaction((Database) any, anyLong, anyLong);
+                    globalTransactionMgr.commitPreparedTransaction(anyLong, anyLong, anyLong);
                     times = 1;
                     result = new StarRocksException("commit prepared transaction error");
                 }
@@ -866,7 +865,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                     times = 1;
                     result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.PREPARED);
 
-                    globalTransactionMgr.commitPreparedTransaction((Database) any, anyLong, anyLong);
+                    globalTransactionMgr.commitPreparedTransaction(anyLong, anyLong, anyLong);
                     times = 1;
                 }
             };
@@ -981,7 +980,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                             newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED)
                     );
 
-                    globalTransactionMgr.commitPreparedTransaction((Database) any, anyLong, anyLong);
+                    globalTransactionMgr.commitPreparedTransaction(anyLong, anyLong, anyLong);
                     times = 1;
                     result = new StarRocksException("commit prepared transaction error");
                 }
@@ -1011,7 +1010,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                             newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED)
                     );
 
-                    globalTransactionMgr.commitPreparedTransaction((Database) any, anyLong, anyLong);
+                    globalTransactionMgr.commitPreparedTransaction(anyLong, anyLong, anyLong);
                     times = 1;
                 }
             };
@@ -1058,10 +1057,10 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                         anyLong, anyLong,
                         (List<TabletCommitInfo>) any,
                         (List<TabletFailInfo>) any,
-                        (TxnCommitAttachment) any);
+                        (TxnCommitAttachment) any, anyLong);
                 times = 1;
 
-                globalTransactionMgr.commitPreparedTransaction((Database) any, anyLong, anyLong);
+                globalTransactionMgr.commitPreparedTransaction(anyLong, anyLong, anyLong);
                 times = 1;
             }
         };


### PR DESCRIPTION
## Why I'm doing:
prepareTransaction in http interface isn't protect by db/table lock make it concurrent issue.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0