### PR TITLE
[Enhancement] skip replica which in error state

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -291,7 +291,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
                                      long visibleVersion, long localBeId, int schemaHash) {
         try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
             for (Replica replica : replicas) {
-                if (replica.isBad()) {
+                if (replica.isBad() || replica.isErrorState()) {
                     continue;
                 }
 
@@ -326,7 +326,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         int size = 0;
         try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
             for (Replica replica : replicas) {
-                if (replica.isBad()) {
+                if (replica.isBad() || replica.isErrorState()) {
                     continue;
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
@@ -266,4 +266,17 @@ public class LocalTabletTest {
         Assert.assertEquals(-1L, tablet.getQuorumVersion(2));
         replica.setState(ReplicaState.NORMAL);
     }
+
+    @Test
+    public void testGetQueryableReplicaWithErrorState() {
+        List<Replica> replicas = Lists.newArrayList(new Replica(10001, 20001, ReplicaState.NORMAL, 10, -1),
+                new Replica(10002, 20002, ReplicaState.NORMAL, 10, -1),
+                new Replica(10003, 20003, ReplicaState.NORMAL, 10, -1));
+        LocalTablet tablet = new LocalTablet(10004, replicas);
+        Assert.assertTrue(tablet.getQueryableReplicasSize(10, -1) == 3);
+        replicas.get(0).setIsErrorState(true);
+        Assert.assertTrue(tablet.getQueryableReplicasSize(10, -1) == 2);
+        replicas.get(1).setIsErrorState(true);
+        Assert.assertTrue(tablet.getQueryableReplicasSize(10, -1) == 1);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
 If a PK tablet encounters a critical error during the apply execution, `ErrorState` will be set and then reject query and ingestion.

## What I'm doing:
Skip replica which in `ErrorState` when generate query plan.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0