### PR TITLE
[BugFix] fix local pk index backgroud compaction not trigger (backport #41737)

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -149,6 +149,7 @@ Status UpdateManager::commit_primary_index(IndexEntry* index_entry, Tablet* tabl
             // Call `on_commited` here, which will remove old files is safe.
             // Because if publish version fail after `on_commited`, index will be rebuild.
             RETURN_IF_ERROR(index.on_commited());
+            index.set_local_pk_index_write_amp_score(PersistentIndex::major_compaction_score(index_meta));
             _index_cache.update_object_size(index_entry, index.memory_usage());
             TRACE("commit primary index");
         }


### PR DESCRIPTION
## Why I'm doing:
local pk index backgroud compaction not trigger

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
