### PR TITLE
[Enhancement] skip PK table apply state preload when memory usage high

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1445,7 +1445,7 @@ CONF_Bool(report_python_worker_error, "true");
 CONF_Bool(python_worker_reuse, "true");
 CONF_Int32(python_worker_expire_time_sec, "300");
 CONF_mBool(enable_pk_strict_memcheck, "true");
-CONF_mBool(skip_lake_pk_preload, "false");
+CONF_mBool(skip_pk_preload, "false");
 // Reduce core file size by not dumping jemalloc retain pages
 CONF_mBool(enable_core_file_size_optimization, "true");
 // Current supported modules:

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -739,7 +739,7 @@ Status DeltaWriter::commit() {
     auto rowset_build_ts = watch.elapsed_time();
 
     if (_tablet->keys_type() == KeysType::PRIMARY_KEYS &&
-        !_storage_engine->update_manager()->mem_tracker()->limit_exceeded_by_ratio(70)) {
+        !_storage_engine->update_manager()->mem_tracker()->limit_exceeded_by_ratio(config::memory_high_level)) {
         auto st = _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get());
         if (!st.ok()) {
             _set_state(kAborted, st);

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -738,7 +738,8 @@ Status DeltaWriter::commit() {
     }
     auto rowset_build_ts = watch.elapsed_time();
 
-    if (_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
+    if (_tablet->keys_type() == KeysType::PRIMARY_KEYS &&
+        !_storage_engine->update_manager()->mem_tracker()->limit_exceeded_by_ratio(70)) {
         auto st = _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get());
         if (!st.ok()) {
             _set_state(kAborted, st);

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -738,7 +738,7 @@ Status DeltaWriter::commit() {
     }
     auto rowset_build_ts = watch.elapsed_time();
 
-    if (_tablet->keys_type() == KeysType::PRIMARY_KEYS &&
+    if (_tablet->keys_type() == KeysType::PRIMARY_KEYS && !config::skip_pk_preload &&
         !_storage_engine->update_manager()->mem_tracker()->limit_exceeded_by_ratio(config::memory_high_level)) {
         auto st = _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get());
         if (!st.ok()) {

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -485,7 +485,7 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
     }
 
     // handle partial update
-    bool skip_pk_preload = config::skip_lake_pk_preload;
+    bool skip_pk_preload = config::skip_pk_preload;
     RowsetTxnMetaPB* rowset_txn_meta = _tablet_writer->rowset_txn_meta();
     if (rowset_txn_meta != nullptr) {
         if (is_partial_update()) {

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -451,7 +451,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_publish_with_oom) {
-    config::skip_lake_pk_preload = true;
+    config::skip_pk_preload = true;
     auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
     auto txns = std::vector<int64_t>();
     auto version = 1;
@@ -478,7 +478,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_with_oom) {
         EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_absent(tablet_id, txn_id));
     }
     _update_mgr->mem_tracker()->set_limit(old_limit);
-    config::skip_lake_pk_preload = false;
+    config::skip_pk_preload = false;
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_publish_concurrent) {

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -41,12 +41,18 @@
 
 namespace starrocks {
 
-class RowsetColumnPartialUpdateTest : public ::testing::Test, testing::WithParamInterface<int64_t> {
+struct Param {
+    int64_t primary_key_batch_get_index_memory_limit;
+    bool skip_pk_preload;
+};
+
+class RowsetColumnPartialUpdateTest : public ::testing::Test, testing::WithParamInterface<Param> {
 public:
     void SetUp() override {
         _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
         _update_mem_tracker = std::make_unique<MemTracker>();
-        config::primary_key_batch_get_index_memory_limit = GetParam();
+        config::primary_key_batch_get_index_memory_limit = GetParam().primary_key_batch_get_index_memory_limit;
+        config::skip_pk_preload = GetParam().skip_pk_preload;
         config::enable_pk_size_tiered_compaction_strategy = false;
     }
 
@@ -58,6 +64,7 @@ public:
             }
         }
         config::enable_pk_size_tiered_compaction_strategy = true;
+        config::skip_pk_preload = false;
     }
 
     RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys, bool add_v3 = false) {
@@ -1229,6 +1236,6 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_source_chunk_limit) {
 }
 
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,
-                         ::testing::Values(1, 1024, 104857600));
+                         ::testing::Values(Param{1, false}, Param{1024, true}, Param{104857600, false}));
 
 } // namespace starrocks

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -758,7 +758,7 @@ TEST_P(RowsetColumnPartialUpdateTest, TEST_Pull_clone2) {
 
 TEST_P(RowsetColumnPartialUpdateTest, test_dcg_gc) {
     // Only run one parameter here
-    if (GetParam() != 104857600) return;
+    if (GetParam().primary_key_batch_get_index_memory_limit != 104857600) return;
     fs::remove_all(get_stores()->path());
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -41,12 +41,13 @@
 
 namespace starrocks {
 
-struct Param {
+struct RowsetColumnPartialUpdateParam {
     int64_t primary_key_batch_get_index_memory_limit;
     bool skip_pk_preload;
 };
 
-class RowsetColumnPartialUpdateTest : public ::testing::Test, testing::WithParamInterface<Param> {
+class RowsetColumnPartialUpdateTest : public ::testing::Test,
+                                      testing::WithParamInterface<RowsetColumnPartialUpdateParam> {
 public:
     void SetUp() override {
         _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
@@ -1236,6 +1237,8 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_source_chunk_limit) {
 }
 
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,
-                         ::testing::Values(Param{1, false}, Param{1024, true}, Param{104857600, false}));
+                         ::testing::Values(RowsetColumnPartialUpdateParam{1, false},
+                                           RowsetColumnPartialUpdateParam{1024, true},
+                                           RowsetColumnPartialUpdateParam{104857600, false}));
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
`on_rowset_finished` is used for apply state preload which can optimize subsequent apply executions, but it will also hold memory on cache, and won't release them until apply finish. It will cause memory issue.

## What I'm doing:
1. So during PK ingestion, if `update` memory usage is higher than 75% (by `config::memory_high_level`), we will skip the `on_rowset_finished`.
2. Reuse config `skip_pk_preload` with shared-data PK table, if `skip_pk_preload` is true, skip `on_rowset_finished` totally.

Configuration flag renaming:

* [`be/src/common/config.h`](diffhunk://#diff-46e8c1ada0d43acf8c2965e46e90909089aada1f46531976c10605b837f8da3dL1448-R1448): Renamed the configuration flag from `skip_lake_pk_preload` to `skip_pk_preload`.

Conditional logic updates:

* [`be/src/storage/delta_writer.cpp`](diffhunk://#diff-ad18ff1e238eaacdf4512ff093d2939505e48c8f6d1b9d3b7037e490fd52619dL741-R742): Updated the conditional logic in the `DeltaWriter::commit()` method to use the new `skip_pk_preload` flag and added a check for memory limit exceeded ratio.
* [`be/src/storage/lake/delta_writer.cpp`](diffhunk://#diff-24e44403f5e4c75144f9645f2fcff77dcdd9269836bafd5b79d5b2d6589e49fdL488-R488): Modified the `DeltaWriterImpl::finish_with_txnlog` method to use the new `skip_pk_preload` flag.

Test case modifications:

* [`be/test/storage/lake/primary_key_publish_test.cpp`](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0L454-R454): Updated the `test_publish_with_oom` test case to use the new `skip_pk_preload` flag. [[1]](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0L454-R454) [[2]](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0L481-R481)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0