### PR TITLE
[Enhancement] Revert Support persistent configuration

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -107,9 +107,7 @@ public class StarRocksFE {
             }
 
             // init config
-            Config config = new Config();
-            config.init(starRocksDir + "/conf/fe.conf");
-            config.initMutable(starRocksDir + "/conf/fe_mutable.conf");
+            new Config().init(starRocksDir + "/conf/fe.conf");
 
             // check command line options
             // NOTE: do it before init log4jConfig to avoid unnecessary stdout messages

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -1144,56 +1144,41 @@ public class NodeMgr {
     }
 
     public void setConfig(AdminSetConfigStmt stmt) throws DdlException {
-        if (GlobalStateMgr.getCurrentState().isLeader()) {
-            setFrontendConfig(stmt.getConfig().getMap());
-            List<Frontend> allFrontends = getFrontends(null);
-            int timeout = ConnectContext.get().getExecTimeout() * 1000 + Config.thrift_rpc_timeout_ms;
-            StringBuilder errMsg = new StringBuilder();
-            for (Frontend fe : allFrontends) {
-                if (fe.getHost().equals(getSelfNode().first)) {
-                    continue;
+        setFrontendConfig(stmt.getConfig().getMap());
+
+        List<Frontend> allFrontends = getFrontends(null);
+        int timeout = ConnectContext.get().getExecTimeout() * 1000 + Config.thrift_rpc_timeout_ms;
+        StringBuilder errMsg = new StringBuilder();
+        for (Frontend fe : allFrontends) {
+            if (fe.getHost().equals(getSelfNode().first)) {
+                continue;
+            }
+
+            TSetConfigRequest request = new TSetConfigRequest();
+            request.setKeys(Lists.newArrayList(stmt.getConfig().getKey()));
+            request.setValues(Lists.newArrayList(stmt.getConfig().getValue()));
+            try {
+                TSetConfigResponse response = ThriftRPCRequestExecutor.call(
+                        ThriftConnectionPool.frontendPool,
+                        new TNetworkAddress(fe.getHost(), fe.getRpcPort()),
+                        timeout,
+                        client -> client.setConfig(request));
+                TStatus status = response.getStatus();
+                if (status.getStatus_code() != TStatusCode.OK) {
+                    errMsg.append("set config for fe[").append(fe.getHost()).append("] failed: ");
+                    if (status.getError_msgs() != null && status.getError_msgs().size() > 0) {
+                        errMsg.append(String.join(",", status.getError_msgs()));
+                    }
+                    errMsg.append(";");
                 }
-                errMsg.append(callFrontNodeSetConfig(stmt, fe, timeout, errMsg));
-            }
-            if (errMsg.length() > 0) {
-                ErrorReport.reportDdlException(ErrorCode.ERROR_SET_CONFIG_FAILED, errMsg.toString());
-            }
-        } else {
-            Pair<String, Integer> leaderIpAndRpcPort = getLeaderIpAndRpcPort();
-            Frontend fe = new Frontend(FrontendNodeType.LEADER, "leader", leaderIpAndRpcPort.first,
-                    leaderIpAndRpcPort.second);
-            StringBuilder errMsg =
-                    callFrontNodeSetConfig(stmt, fe, Config.thrift_rpc_timeout_ms, new StringBuilder());
-            if (errMsg.length() > 0) {
-                ErrorReport.reportDdlException(ErrorCode.ERROR_SET_CONFIG_FAILED, errMsg.toString());
+            } catch (Exception e) {
+                LOG.warn("set remote fe: {} config failed", fe.getHost(), e);
+                errMsg.append("set config for fe[").append(fe.getHost()).append("] failed: ").append(e.getMessage());
             }
         }
-
-    }
-
-    private StringBuilder callFrontNodeSetConfig(AdminSetConfigStmt stmt, Frontend fe, int timeout, StringBuilder errMsg) {
-        TSetConfigRequest request = new TSetConfigRequest();
-        request.setKeys(Lists.newArrayList(stmt.getConfig().getKey()));
-        request.setValues(Lists.newArrayList(stmt.getConfig().getValue()));
-        try {
-            TSetConfigResponse response = ThriftRPCRequestExecutor.call(
-                    ThriftConnectionPool.frontendPool,
-                    new TNetworkAddress(fe.getHost(), fe.getRpcPort()),
-                    timeout,
-                    client -> client.setConfig(request));
-            TStatus status = response.getStatus();
-            if (status.getStatus_code() != TStatusCode.OK) {
-                errMsg.append("set config for fe[").append(fe.getHost()).append("] failed: ");
-                if (status.getError_msgs() != null && status.getError_msgs().size() > 0) {
-                    errMsg.append(String.join(",", status.getError_msgs()));
-                }
-                errMsg.append(";");
-            }
-        } catch (Exception e) {
-            LOG.warn("set remote fe: {} config failed", fe.getHost(), e);
-            errMsg.append("set config for fe[").append(fe.getHost()).append("] failed: ").append(e.getMessage());
+        if (errMsg.length() > 0) {
+            ErrorReport.reportDdlException(ErrorCode.ERROR_SET_CONFIG_FAILED, errMsg.toString());
         }
-        return errMsg;
     }
 
     public void setFrontendConfig(Map<String, String> configs) throws DdlException {

--- a/fe/fe-core/src/test/java/com/starrocks/common/ConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/ConfigTest.java
@@ -38,10 +38,6 @@ public class ConfigTest {
         URL resource = getClass().getClassLoader().getResource("conf/config_test.properties");
         assert resource != null;
         config.init(Paths.get(resource.toURI()).toFile().getAbsolutePath());
-
-        resource = getClass().getClassLoader().getResource("conf/config_mutable.properties");
-        assert resource != null;
-        config.initMutable(Paths.get(resource.toURI()).toFile().getAbsolutePath());
     }
 
     @Test
@@ -49,43 +45,6 @@ public class ConfigTest {
         PatternMatcher matcher = PatternMatcher.createMysqlPattern("tablet_sched_slot_num_per_path", false);
         List<List<String>> configs = Config.getConfigInfo(matcher);
         Assert.assertEquals("3", configs.get(0).get(2));
-    }
-
-    @Test
-    public void testMutableConfig() throws Exception {
-        PatternMatcher matcher = PatternMatcher.createMysqlPattern("adaptive_choose_instances_threshold", false);
-        List<List<String>> configs = Config.getConfigInfo(matcher);
-        Assert.assertEquals("99", configs.get(0).get(2));
-
-        Config.setMutableConfig("adaptive_choose_instances_threshold", "98");
-        configs = Config.getConfigInfo(matcher);
-        Assert.assertEquals("98", configs.get(0).get(2));
-        Assert.assertEquals(98, Config.adaptive_choose_instances_threshold);
-
-        // Reload from file
-        URL resource = getClass().getClassLoader().getResource("conf/config_mutable.properties");
-        config.initMutable(Paths.get(resource.toURI()).toFile().getAbsolutePath());
-        configs = Config.getConfigInfo(matcher);
-        Assert.assertEquals("98", configs.get(0).get(2));
-        Assert.assertEquals(98, Config.adaptive_choose_instances_threshold);
-    }
-
-    @Test
-    public void testDisableStoreConfig() throws Exception {
-        Config.setIsPersisted(false);
-        Config.setMutableConfig("adaptive_choose_instances_threshold", "98");
-        PatternMatcher matcher = PatternMatcher.createMysqlPattern("adaptive_choose_instances_threshold", false);
-        List<List<String>>  configs = Config.getConfigInfo(matcher);
-        Assert.assertEquals("98", configs.get(0).get(2));
-        Assert.assertEquals(98, Config.adaptive_choose_instances_threshold);
-
-        // Reload from file
-        URL resource = getClass().getClassLoader().getResource("conf/config_mutable.properties");
-        assert resource != null;
-        config.initMutable(Paths.get(resource.toURI()).toFile().getAbsolutePath());
-        configs = Config.getConfigInfo(matcher);
-        Assert.assertEquals("99", configs.get(0).get(2));
-        Assert.assertEquals(99, Config.adaptive_choose_instances_threshold);
     }
 
     @Test
@@ -108,11 +67,6 @@ public class ConfigTest {
         URL resource = getClass().getClassLoader().getResource("conf/config_test3.properties");
         assert resource != null;
         configForTest.init(Paths.get(resource.toURI()).toFile().getAbsolutePath());
-
-        resource = getClass().getClassLoader().getResource("conf/config_mutable.properties");
-        assert resource != null;
-        configForTest.initMutable(Paths.get(resource.toURI()).toFile().getAbsolutePath());
-
         PatternMatcher matcher = PatternMatcher.createMysqlPattern("schedule_slot_num_per_path_only_for_test", false);
         List<List<String>> configs = ConfigForTest.getConfigInfo(matcher);
         Assert.assertEquals(1, configs.size());
@@ -123,11 +77,11 @@ public class ConfigTest {
 
     @Test
     public void testConfigSetCompatibleWithOldName() throws Exception {
-        Config.setMutableConfig("max_scheduling_tablets", "4");
-        PatternMatcher matcher = PatternMatcher.createMysqlPattern("max_scheduling_tablets", false);
+        Config.setMutableConfig("schedule_slot_num_per_path", "4");
+        PatternMatcher matcher = PatternMatcher.createMysqlPattern("schedule_slot_num_per_path", false);
         List<List<String>> configs = Config.getConfigInfo(matcher);
         Assert.assertEquals("4", configs.get(0).get(2));
-        Assert.assertEquals(4, Config.tablet_sched_max_scheduling_tablets);
+        Assert.assertEquals(4, Config.tablet_sched_slot_num_per_path);
     }
 
     private static class ConfigForArray extends ConfigBase {
@@ -150,11 +104,6 @@ public class ConfigTest {
         URL resource = getClass().getClassLoader().getResource("conf/config_test3.properties");
         assert resource != null;
         configForArray.init(Paths.get(resource.toURI()).toFile().getAbsolutePath());
-
-        resource = getClass().getClassLoader().getResource("conf/config_mutable.properties");
-        assert resource != null;
-        configForArray.initMutable(Paths.get(resource.toURI()).toFile().getAbsolutePath());
-
         List<List<String>> configs = ConfigForArray.getConfigInfo(null);
         Assert.assertEquals("[1, 1]", configs.get(0).get(2));
         Assert.assertEquals("short[]", configs.get(0).get(3));

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontend.java
@@ -175,9 +175,7 @@ public class PseudoFrontend {
 
             try {
                 // init config
-                Config config = new Config();
-                config.init(frontend.getRunningDir() + "/conf/fe.conf");
-                config.initMutable(frontend.getRunningDir() + "/conf/fe_mutable.conf");
+                new Config().init(frontend.getRunningDir() + "/conf/fe.conf");
                 Config.statistic_collect_query_timeout = 60;
 
                 Log4jConfig.initLogging();

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -27,7 +27,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.PatternMatcher;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.ha.FrontendNodeType;
@@ -1141,7 +1140,7 @@ public class FrontendServiceImplTest {
     }
 
     @Test
-    public void testSetFrontendConfig() throws Exception {
+    public void testSetFrontendConfig() throws TException {
         FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
         TSetConfigRequest request = new TSetConfigRequest();
         request.keys = Lists.newArrayList("mysql_server_version");
@@ -1149,15 +1148,6 @@ public class FrontendServiceImplTest {
 
         TSetConfigResponse result = impl.setConfig(request);
         Assert.assertEquals("5.1.1", GlobalVariable.version);
-
-        request.keys = Lists.newArrayList("adaptive_choose_instances_threshold");
-        request.values = Lists.newArrayList("98");
-        impl.setConfig(request);
-
-        PatternMatcher matcher = PatternMatcher.createMysqlPattern("adaptive_choose_instances_threshold", false);
-        List<List<String>> configs = Config.getConfigInfo(matcher);
-        Assert.assertEquals("98", configs.get(0).get(2));
-        Assert.assertEquals(98, Config.adaptive_choose_instances_threshold);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedFrontend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedFrontend.java
@@ -230,9 +230,7 @@ public class MockedFrontend {
 
             try {
                 // init config
-                Config config = new Config();
-                config.init(frontend.getRunningDir() + "/conf/fe.conf");
-                config.initMutable(frontend.getRunningDir() + "/conf/fe_mutable.conf");
+                new Config().init(frontend.getRunningDir() + "/conf/fe.conf");
 
                 // set dns cache ttl
                 java.security.Security.setProperty("networkaddress.cache.ttl", "60");

--- a/fe/fe-core/src/test/resources/conf/config_mutable.properties
+++ b/fe/fe-core/src/test/resources/conf/config_mutable.properties
@@ -1,1 +1,0 @@
-adaptive_choose_instances_threshold = 99


### PR DESCRIPTION
This reverts commit 7e7a7250cf964336811a62ba4c95eb585bad418b.

## Why I'm doing:
Using new files to store changed configurations can be confusing if users don't know about this feature, so we should introduce a more compatible solution. And some external management components of StarRocks also need to be compatible with this, which is not very friendly to them.

@crossoverJie Thank you for your contribution, we will work together to find a better solution.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0