### PR TITLE
[Enhancement] dump LWP when BE crash

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -254,6 +254,7 @@ fi
 if [ ! -f $PATCHED_MARK ] && [ $GLOG_SOURCE == "glog-0.7.1" ]; then
     patch -p1 < $TP_PATCH_DIR/glog-0.7.1.patch
     patch -p1 < $TP_PATCH_DIR/glog-0.7.1-add-handler-after-output-log.patch
+    patch -p1 < $TP_PATCH_DIR/glog-0.7.1-lwp.patch
     touch $PATCHED_MARK
 fi
 cd -

--- a/thirdparty/patches/glog-0.7.1-lwp.patch
+++ b/thirdparty/patches/glog-0.7.1-lwp.patch
@@ -1,0 +1,28 @@
+diff --git a/src/signalhandler.cc b/src/signalhandler.cc
+index c5bae59..b46b41c 100644
+--- a/src/signalhandler.cc
++++ b/src/signalhandler.cc
+@@ -53,6 +53,8 @@
+ #  include <sys/ucontext.h>
+ #endif
+ #ifdef HAVE_UNISTD_H
++#include <sys/syscall.h>
++#include <sys/types.h>
+ #  include <unistd.h>
+ #endif
+ 
+@@ -218,6 +220,14 @@ void DumpSignalInfo(int signal_number, siginfo_t* siginfo) {
+   formatter.AppendString(oss.str().c_str());
+ 
+   formatter.AppendString(") ");
++
++#ifdef HAVE_UNISTD_H
++  pid_t tid = syscall(SYS_gettid);
++  formatter.AppendString("LWP(");
++  formatter.AppendUint64(tid, 10);
++  formatter.AppendString(") ");
++#endif
++
+   // Only linux has the PID of the signal sender in si_pid.
+ #  ifdef GLOG_OS_LINUX
+   formatter.AppendString("from PID ");


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
dump result:
```
*** SIGSEGV (@0x0) received by PID 1685392 (TID 0x7efb65eb0640) (LWP 1685991) from PID 0; stack trace: ***
    @     0x7efc952f8ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
```

usage:
```
# usage
# > python get_thread_by_lwp(1778991) 
import gdb
def get_thread_inferior_by_pred(pred):
    inferiors = gdb.inferiors()
    res = []
    for inferior in inferiors:
        for thread in inferior.threads():
            if pred(thread):
                res.append(thread)
    return res

def thread_lwp(thread_inferior):
    return thread_inferior.ptid[1]

def get_thread_by_lwp(tid):
    tid = tid
    match_tid = lambda thread_inferior: thread_lwp(thread_inferior) == tid
    res = get_thread_inferior_by_pred(match_tid)
    print("\n\n".join([thread_meta(thread_inferior) for thread_inferior in res]))
    return "OK"

python get_thread_by_lwp(1685991) 
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0