### PR TITLE
[BugFix] Fix wrong physical partition id in colocate table balancer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -48,6 +48,7 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.clone.ColocateMatchResult.Status;
 import com.starrocks.clone.TabletSchedCtx.Priority;
@@ -789,11 +790,11 @@ public class ColocateTableBalancer extends FrontendDaemon {
                         continue;
                     }
 
-                    long visibleVersion = partition.getDefaultPhysicalPartition().getVisibleVersion();
+                    PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+                    long visibleVersion = physicalPartition.getVisibleVersion();
                     // Here we only get VISIBLE indexes. All other indexes are not queryable.
                     // So it does not matter if tablets of other indexes are not matched.
-                    for (MaterializedIndex index :
-                            partition.getDefaultPhysicalPartition().getMaterializedIndices(IndexExtState.VISIBLE)) {
+                    for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
                         Preconditions.checkState(backendBucketsSeq.size() == index.getTablets().size(),
                                 backendBucketsSeq.size() + " v.s. " + index.getTablets().size());
                         int idx = 0;
@@ -823,9 +824,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
                                                 tablet.getId(), st);
                                         TabletSchedCtx tabletCtx = new TabletSchedCtx(
                                                 TabletSchedCtx.Type.REPAIR,
-                                                // physical partition id is same as partition id
-                                                // since colocate table should have only one physical partition
-                                                db.getId(), tableId, partition.getId(),
+                                                db.getId(), tableId, physicalPartition.getId(),
                                                 index.getId(), tablet.getId(),
                                                 System.currentTimeMillis());
                                         // the tablet status will be checked and set again when being scheduled


### PR DESCRIPTION
## Why I'm doing:

decommission backend failed
```
| 10336    | REPAIR | NULL   | COLOCATE_REDUNDANT | CANCELLED | HIGH     | HIGH     | -1    | -1      | -1     | -1       | 0       | 2024-12-19 15:49:55 | 2024-12-19 15:49:55 | 2024-12-19 15:49:55 | 2024-12-19 15:49:55 | NULL | 1           | 0             | NULL       | -1         | 0              | -1     | 0          | physical partition 10327does not exist |
```

## What I'm doing:

should use physical partition, not parent partition id.

Fixes https://github.com/StarRocks/StarRocksTest/issues/8954

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0