### PR TITLE
[Enhancement] Change insert match by name syntax

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1011,6 +1011,7 @@ public class Config extends ConfigBase {
     /**
      * Default insert load timeout
      */
+    @Deprecated
     @ConfField(mutable = true)
     public static int insert_load_default_timeout_second = 3600; // 1 hour
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -17,7 +17,6 @@ package com.starrocks.sql;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.analysis.DescriptorTable;
@@ -598,31 +597,8 @@ public class InsertPlanner {
 
     private OptExprBuilder fillDefaultValue(LogicalPlan logicalPlan, ColumnRefFactory columnRefFactory,
                                             InsertStmt insertStatement, List<ColumnRefOperator> outputColumns) {
-        // targetColumnNames is for check whether schema column is in target column list or not
-        Set<String> targetColumnNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-        targetColumnNames.addAll(
-                insertStatement.getTargetColumnNames() != null ? insertStatement.getTargetColumnNames() :
-                        outputBaseSchema.stream().map(Column::getName).collect(Collectors.toList()));
-
-        // sourceColumnMappedNames is the mapped name of source columns corresponding to the target columns.
-        // 1. if match by position, source mapped column name can be converted from target column name one by one.
-        // 2. if match by name, source mapped column name is same as the source column name.
-        Map<String, Integer> mappedColumnToSourceIdx = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
-        List<String> sourceColumnMappedNames = null;
-        if (insertStatement.isColumnMatchByPosition()) {
-            sourceColumnMappedNames = insertStatement.getTargetColumnNames() != null ? insertStatement.getTargetColumnNames() :
-                    outputBaseSchema.stream().map(Column::getName).collect(Collectors.toList());
-        } else {
-            Preconditions.checkState(insertStatement.isColumnMatchByName());
-            sourceColumnMappedNames = insertStatement.getQueryStatement().getQueryRelation().getColumnOutputNames();
-        }
-        Preconditions.checkState(sourceColumnMappedNames != null);
-        for (int columnIdx = 0; columnIdx < sourceColumnMappedNames.size(); ++columnIdx) {
-            mappedColumnToSourceIdx.put(sourceColumnMappedNames.get(columnIdx), columnIdx);
-        }
-
-        // generate columnRefMap (fill default value)
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
+
         for (int columnIdx = 0; columnIdx < outputBaseSchema.size(); ++columnIdx) {
             if (needToSkip(insertStatement, columnIdx)) {
                 continue;
@@ -632,35 +608,40 @@ public class InsertPlanner {
             if (targetColumn.isGeneratedColumn()) {
                 continue;
             }
-
-            String targetColumnName = targetColumn.getName();
-            if (mappedColumnToSourceIdx.containsKey(targetColumnName) && targetColumnNames.contains(targetColumnName)) {
-                ColumnRefOperator col = logicalPlan.getOutputColumn().get(mappedColumnToSourceIdx.get(targetColumnName));
-                outputColumns.add(col);
-                columnRefMap.put(col, col);
+            if (insertStatement.getTargetColumnNames() == null) {
+                outputColumns.add(logicalPlan.getOutputColumn().get(columnIdx));
+                columnRefMap.put(logicalPlan.getOutputColumn().get(columnIdx),
+                        logicalPlan.getOutputColumn().get(columnIdx));
             } else {
-                ScalarOperator scalarOperator;
-                Column.DefaultValueType defaultValueType = targetColumn.getDefaultValueType();
-                if (defaultValueType == Column.DefaultValueType.NULL || targetColumn.isAutoIncrement()) {
-                    scalarOperator = ConstantOperator.createNull(targetColumn.getType());
-                } else if (defaultValueType == Column.DefaultValueType.CONST) {
-                    scalarOperator = ConstantOperator.createVarchar(targetColumn.calculatedDefaultValue());
-                } else if (defaultValueType == Column.DefaultValueType.VARY) {
-                    if (SUPPORTED_DEFAULT_FNS.contains(targetColumn.getDefaultExpr().getExpr())) {
-                        scalarOperator = SqlToScalarOperatorTranslator.
-                                translate(targetColumn.getDefaultExpr().obtainExpr());
+                int idx = insertStatement.getTargetColumnNames().indexOf(targetColumn.getName().toLowerCase());
+                if (idx == -1) {
+                    ScalarOperator scalarOperator;
+                    Column.DefaultValueType defaultValueType = targetColumn.getDefaultValueType();
+                    if (defaultValueType == Column.DefaultValueType.NULL || targetColumn.isAutoIncrement()) {
+                        scalarOperator = ConstantOperator.createNull(targetColumn.getType());
+                    } else if (defaultValueType == Column.DefaultValueType.CONST) {
+                        scalarOperator = ConstantOperator.createVarchar(targetColumn.calculatedDefaultValue());
+                    } else if (defaultValueType == Column.DefaultValueType.VARY) {
+                        if (SUPPORTED_DEFAULT_FNS.contains(targetColumn.getDefaultExpr().getExpr())) {
+                            scalarOperator = SqlToScalarOperatorTranslator.
+                                    translate(targetColumn.getDefaultExpr().obtainExpr());
+                        } else {
+                            throw new SemanticException(
+                                    "Column:" + targetColumn.getName() + " has unsupported default value:"
+                                            + targetColumn.getDefaultExpr().getExpr());
+                        }
                     } else {
-                        throw new SemanticException("Column:" + targetColumnName + " has unsupported default value:"
-                                + targetColumn.getDefaultExpr().getExpr());
+                        throw new SemanticException("Unknown default value type:%s", defaultValueType.toString());
                     }
-                } else {
-                    throw new SemanticException("Unknown default value type:%s", defaultValueType.toString());
-                }
-                ColumnRefOperator col = columnRefFactory
-                        .create(scalarOperator, scalarOperator.getType(), scalarOperator.isNullable());
+                    ColumnRefOperator col = columnRefFactory
+                            .create(scalarOperator, scalarOperator.getType(), scalarOperator.isNullable());
 
-                outputColumns.add(col);
-                columnRefMap.put(col, scalarOperator);
+                    outputColumns.add(col);
+                    columnRefMap.put(col, scalarOperator);
+                } else {
+                    outputColumns.add(logicalPlan.getOutputColumn().get(idx));
+                    columnRefMap.put(logicalPlan.getOutputColumn().get(idx), logicalPlan.getOutputColumn().get(idx));
+                }
             }
         }
         return logicalPlan.getRootBuilder().withNewRoot(new LogicalProjectOperator(new HashMap<>(columnRefMap)));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -216,13 +216,34 @@ public class InsertAnalyzer {
             }
         }
 
+        // Set insert stmt target columns using select output columns if match column by name
+        QueryRelation query = insertStmt.getQueryStatement().getQueryRelation();
+        if (insertStmt.isColumnMatchByName()) {
+            if (query instanceof ValuesRelation) {
+                throw new SemanticException("Insert match column by name does not support values()");
+            }
+
+            Set<String> selectColumnNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+            for (String colName : query.getColumnOutputNames()) {
+                if (!selectColumnNames.add(colName)) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_DUP_FIELDNAME, colName);
+                }
+            }
+
+            Preconditions.checkState(insertStmt.getTargetColumnNames() == null);
+            // column name is case insensitive
+            insertStmt.setTargetColumnNames(
+                    query.getColumnOutputNames().stream().map(String::toLowerCase).collect(Collectors.toList()));
+        }
+
         // Build target columns
         List<Column> targetColumns;
         Set<String> mentionedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         if (insertStmt.getTargetColumnNames() == null) {
             if (table instanceof OlapTable) {
-                targetColumns = new ArrayList<>(((OlapTable) table).getBaseSchemaWithoutGeneratedColumn());
-                mentionedColumns.addAll(((OlapTable) table).getBaseSchemaWithoutGeneratedColumn().stream().map(Column::getName)
+                OlapTable olapTable = (OlapTable) table;
+                targetColumns = new ArrayList<>(olapTable.getBaseSchemaWithoutGeneratedColumn());
+                mentionedColumns.addAll(olapTable.getBaseSchemaWithoutGeneratedColumn().stream().map(Column::getName)
                         .collect(Collectors.toSet()));
             } else {
                 targetColumns = new ArrayList<>(table.getBaseSchema());
@@ -264,8 +285,10 @@ public class InsertAnalyzer {
         if (!insertStmt.usePartialUpdate()) {
             for (Column column : table.getBaseSchema()) {
                 Column.DefaultValueType defaultValueType = column.getDefaultValueType();
-                if (defaultValueType == Column.DefaultValueType.NULL && !column.isAllowNull() &&
-                        !column.isAutoIncrement() && !column.isGeneratedColumn() &&
+                if (defaultValueType == Column.DefaultValueType.NULL &&
+                        !column.isAllowNull() &&
+                        !column.isAutoIncrement() &&
+                        !column.isGeneratedColumn() &&
                         !mentionedColumns.contains(column.getName())) {
                     StringBuilder msg = new StringBuilder();
                     for (String s : mentionedColumns) {
@@ -285,34 +308,9 @@ public class InsertAnalyzer {
         }
 
         // check target and source columns match
-        QueryRelation query = insertStmt.getQueryStatement().getQueryRelation();
-        if (insertStmt.isColumnMatchByPosition()) {
-            if (query.getRelationFields().size() != mentionedColumnSize) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_INSERT_COLUMN_COUNT_MISMATCH, mentionedColumnSize,
-                        query.getRelationFields().size());
-            }
-        } else {
-            Preconditions.checkState(insertStmt.isColumnMatchByName());
-            if (query instanceof ValuesRelation) {
-                throw new SemanticException("Insert match column by name does not support values()");
-            }
-
-            Set<String> selectColumnNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-            for (String colName : insertStmt.getQueryStatement().getQueryRelation().getColumnOutputNames()) {
-                if (!selectColumnNames.add(colName)) {
-                    ErrorReport.reportSemanticException(ErrorCode.ERR_DUP_FIELDNAME, colName);
-                }
-            }
-            if (!selectColumnNames.containsAll(mentionedColumns)) {
-                mentionedColumns.removeAll(selectColumnNames);
-                ErrorReport.reportSemanticException(
-                        ErrorCode.ERR_INSERT_COLUMN_NAME_MISMATCH, "Target", String.join(", ", mentionedColumns), "source");
-            }
-            if (!mentionedColumns.containsAll(selectColumnNames)) {
-                selectColumnNames.removeAll(mentionedColumns);
-                ErrorReport.reportSemanticException(
-                        ErrorCode.ERR_INSERT_COLUMN_NAME_MISMATCH, "Source", String.join(", ", selectColumnNames), "target");
-            }
+        if (query.getRelationFields().size() != mentionedColumnSize) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INSERT_COLUMN_COUNT_MISMATCH, mentionedColumnSize,
+                    query.getRelationFields().size());
         }
 
         // check default value expr

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -46,7 +46,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DefaultValueExpr;
 import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.InsertStmt;
-import com.starrocks.sql.ast.InsertStmt.ColumnMatchPolicy;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.QueryRelation;
@@ -343,19 +342,6 @@ public class InsertAnalyzer {
 
     private static void analyzeProperties(InsertStmt insertStmt, ConnectContext session) {
         Map<String, String> properties = insertStmt.getProperties();
-
-        // column match by related properties
-        // parse the property and remove it for 'LoadStmt.checkProperties' validation
-        if (properties.containsKey(InsertStmt.PROPERTY_MATCH_COLUMN_BY)) {
-            String property = properties.remove(InsertStmt.PROPERTY_MATCH_COLUMN_BY);
-            ColumnMatchPolicy columnMatchPolicy = ColumnMatchPolicy.fromString(property);
-            if (columnMatchPolicy == null) {
-                String msg = String.format("%s (case insensitive)", String.join(", ", ColumnMatchPolicy.getCandidates()));
-                ErrorReport.reportSemanticException(
-                        ErrorCode.ERR_INVALID_VALUE, InsertStmt.PROPERTY_MATCH_COLUMN_BY, property, msg);
-            }
-            insertStmt.setColumnMatchPolicy(columnMatchPolicy);
-        }
 
         // check common properties
         // use session variable if not set max_filter_ratio, strict_mode, timeout property

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -97,6 +97,11 @@ public class InsertStmt extends DmlStmt {
     private boolean isVersionOverwrite = false;
 
     // column match by position or name
+    public enum ColumnMatchPolicy {
+        POSITION,
+        NAME
+    }
+
     private ColumnMatchPolicy columnMatchPolicy = ColumnMatchPolicy.POSITION;
 
     // create partition if not exists
@@ -346,15 +351,6 @@ public class InsertStmt extends DmlStmt {
         checkState(tableFunctionAsTargetTable, "tableFunctionAsTargetTable is false");
         List<Column> columns = collectSelectedFieldsFromQueryStatement();
         return new TableFunctionTable(columns, getTableFunctionProperties(), sessionVariable);
-    }
-
-    public enum ColumnMatchPolicy {
-        POSITION,
-        NAME
-    }
-
-    public boolean isColumnMatchByPosition() {
-        return columnMatchPolicy == ColumnMatchPolicy.POSITION;
     }
 
     public boolean isColumnMatchByName() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -29,7 +29,6 @@ import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -54,7 +53,6 @@ import static com.google.common.base.Preconditions.checkState;
  */
 public class InsertStmt extends DmlStmt {
     public static final String STREAMING = "STREAMING";
-    public static final String PROPERTY_MATCH_COLUMN_BY = "match_column_by";
 
     private final TableName tblName;
     private PartitionNames targetPartitionNames;
@@ -352,20 +350,7 @@ public class InsertStmt extends DmlStmt {
 
     public enum ColumnMatchPolicy {
         POSITION,
-        NAME;
-
-        public static ColumnMatchPolicy fromString(String value) {
-            for (ColumnMatchPolicy policy : values()) {
-                if (policy.name().equalsIgnoreCase(value)) {
-                    return policy;
-                }
-            }
-            return null;
-        }
-
-        public static List<String> getCandidates() {
-            return Arrays.stream(values()).map(p -> p.name().toLowerCase()).collect(Collectors.toList());
-        }
+        NAME
     }
 
     public boolean isColumnMatchByPosition() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2213,7 +2213,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             }
 
             String label = null;
+            boolean hasColumnAliases = false;
+            boolean hasByName = false;
             List<String> columnAliases = null;
+            InsertStmt.ColumnMatchPolicy columnMatchPolicy = InsertStmt.ColumnMatchPolicy.POSITION;
             for (StarRocksParser.InsertLabelOrColumnAliasesContext desc : ListUtils.emptyIfNull(
                     context.insertLabelOrColumnAliases())) {
                 NodePosition clausePos = createPos(desc);
@@ -2223,11 +2226,25 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                     }
                     label = ((Identifier) visit(desc.label)).getValue();
                 }
-                if (desc.columnAliases() != null) {
-                    if (columnAliases != null) {
+                if (desc.columnAliasesOrByName() != null) {
+                    StarRocksParser.ColumnAliasesOrByNameContext columnAliasesOrByNameContext = desc.columnAliasesOrByName();
+                    if (hasColumnAliases && columnAliasesOrByNameContext.columnAliases() != null) {
                         throw new ParsingException(PARSER_ERROR_MSG.duplicatedClause("COLUMN LIST", "insert"), clausePos);
+                    } else if (hasByName && columnAliasesOrByNameContext.BY() != null) {
+                        throw new ParsingException(PARSER_ERROR_MSG.duplicatedClause("BY NAME", "insert"), clausePos);
+                    } else if (hasColumnAliases || hasByName) {
+                        throw new ParsingException("Cannot use COLUMN LIST and BY NAME clause together in insert");
                     }
-                    columnAliases = getColumnNames(desc.columnAliases());
+
+                    if (columnAliasesOrByNameContext.columnAliases() != null) {
+                        columnAliases = getColumnNames(columnAliasesOrByNameContext.columnAliases());
+                        hasColumnAliases = true;
+                    } else {
+                        Preconditions.checkState(columnAliasesOrByNameContext.BY() != null &&
+                                columnAliasesOrByNameContext.NAME() != null);
+                        columnMatchPolicy = InsertStmt.ColumnMatchPolicy.NAME;
+                        hasByName = true;
+                    }
                 }
             }
 
@@ -2235,8 +2252,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                     context.OVERWRITE() != null, getProperties(context.properties()), createPos(context));
             stmt.setHintNodes(hintMap.get(context));
             stmt.setTargetBranch(targetBranch);
-            stmt.setColumnMatchPolicy(context.BY() != null && context.NAME() != null ?
-                    InsertStmt.ColumnMatchPolicy.NAME : InsertStmt.ColumnMatchPolicy.POSITION);
+            stmt.setColumnMatchPolicy(columnMatchPolicy);
             return stmt;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2235,6 +2235,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                     context.OVERWRITE() != null, getProperties(context.properties()), createPos(context));
             stmt.setHintNodes(hintMap.get(context));
             stmt.setTargetBranch(targetBranch);
+            stmt.setColumnMatchPolicy(context.BY() != null && context.NAME() != null ?
+                    InsertStmt.ColumnMatchPolicy.NAME : InsertStmt.ColumnMatchPolicy.POSITION);
             return stmt;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1157,14 +1157,19 @@ partitionRenameClause
 
 insertStatement
     : explainDesc? INSERT (INTO | OVERWRITE) (qualifiedName writeBranch? partitionNames? | (FILES propertyList) | (BLACKHOLE '(' ')'))
-        insertLabelOrColumnAliases* (BY NAME)? properties?
+        insertLabelOrColumnAliases* properties?
         (queryStatement | (VALUES expressionsWithDefault (',' expressionsWithDefault)*))
     ;
 
 // for compatibility with the case 'LABEL before columnAliases'
 insertLabelOrColumnAliases
-    : WITH LABEL label=identifier
-    | columnAliases
+    : columnAliasesOrByName
+    | WITH LABEL label=identifier
+    ;
+
+columnAliasesOrByName
+    : columnAliases
+    | BY NAME
     ;
 
 updateStatement

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1157,7 +1157,7 @@ partitionRenameClause
 
 insertStatement
     : explainDesc? INSERT (INTO | OVERWRITE) (qualifiedName writeBranch? partitionNames? | (FILES propertyList) | (BLACKHOLE '(' ')'))
-        insertLabelOrColumnAliases* properties?
+        insertLabelOrColumnAliases* (BY NAME)? properties?
         (queryStatement | (VALUES expressionsWithDefault (',' expressionsWithDefault)*))
     ;
 

--- a/test/sql/test_insert_empty/R/test_insert_by_name
+++ b/test/sql/test_insert_empty/R/test_insert_by_name
@@ -31,7 +31,7 @@ truncate table t1;
 -- result:
 -- !result
 
-insert into t1 (k2, k1) by name select "d" as k1, 4 as k2;
+insert into t1 (k2, k1) select "d" as k1, 4 as k2;
 -- result:
 -- !result
 

--- a/test/sql/test_insert_empty/R/test_insert_by_name
+++ b/test/sql/test_insert_empty/R/test_insert_by_name
@@ -5,7 +5,7 @@ use db_${uuid0};
 
 create table t1 (k1 int, k2 varchar(100));
 
-insert into t1 properties("match_column_by" = "name") select "a" as k2, 1 as k1;
+insert into t1 by name select "a" as k2, 1 as k1;
 -- result:
 -- !result
 
@@ -18,7 +18,7 @@ truncate table t1;
 -- result:
 -- !result
 
-insert into t1 (k2, k1) properties("match_column_by" = "name") select 2 as k1, "b" as k2;
+insert into t1 (k2, k1) by name select 2 as k1, "b" as k2;
 -- result:
 -- !result
 
@@ -31,7 +31,7 @@ truncate table t1;
 -- result:
 -- !result
 
-insert into t1 (k2, k1) properties("match_column_by" = "position") select "d" as k1, 4 as k2;
+insert into t1 (k2, k1) by name select "d" as k1, 4 as k2;
 -- result:
 -- !result
 
@@ -44,24 +44,19 @@ truncate table t1;
 -- result:
 -- !result
 
-insert into t1 properties("match_column_by" = "name") values(1, "a");
+insert into t1 by name values(1, "a");
 -- result:
 [REGEX].*Insert match column by name does not support values\(\).
 -- !result
 
-insert into t1 properties("match_column_by" = "name") select "a" as k2, 1 as k1, 2 as k3;
+insert into t1 by name select "a" as k2, 1 as k1, 2 as k3;
 -- result:
 [REGEX].*Source column: k3 has no matching target column.
 -- !result
 
-insert into t1 properties("match_column_by" = "name") select 1 as k1;
+insert into t1 by name select 1 as k1;
 -- result:
 [REGEX].*Target column: k2 has no matching source column.
--- !result
-
-insert into t1 properties("match_column_by" = "invalid_value") values(1, "a");
--- result:
-[REGEX].*Invalid match_column_by: 'invalid_value'. Expected values should be position, name \(case insensitive\).
 -- !result
 
 
@@ -76,7 +71,7 @@ select * from t1;
 3	c
 -- !result
 
-insert into t2 (k1, k2) properties("match_column_by" = "name") select * from t1;
+insert into t2 (k1, k2) by name select * from t1;
 -- result:
 -- !result
 
@@ -89,7 +84,7 @@ truncate table t2;
 -- result:
 -- !result
 
-insert into t2 properties("match_column_by" = "name") select *, 11 as k3 from t1;
+insert into t2 by name select *, 11 as k3 from t1;
 -- result:
 -- !result
 
@@ -102,7 +97,7 @@ truncate table t2;
 -- result:
 -- !result
 
-insert into t2 properties("match_column_by" = "name") select k1 + 1 as k1, k2, 12 as k3 from t1;
+insert into t2 by name select k1 + 1 as k1, k2, 12 as k3 from t1;
 -- result:
 -- !result
 
@@ -115,12 +110,12 @@ truncate table t2;
 -- result:
 -- !result
 
-insert into t2 properties("match_column_by" = "name") select * from t1;
+insert into t2 by name select * from t1;
 -- result:
 [REGEX].*Target column: k3 has no matching source column.
 -- !result
 
-insert into t2 properties("match_column_by" = "name") select k1 + 1 as k1, k1, 12 as k3 from t1;
+insert into t2 by name select k1 + 1 as k1, k1, 12 as k3 from t1;
 -- result:
 [REGEX].*Duplicate column name 'k1'.
 -- !result

--- a/test/sql/test_insert_empty/R/test_insert_by_name
+++ b/test/sql/test_insert_empty/R/test_insert_by_name
@@ -18,19 +18,6 @@ truncate table t1;
 -- result:
 -- !result
 
-insert into t1 (k2, k1) by name select 2 as k1, "b" as k2;
--- result:
--- !result
-
-select * from t1;
--- result:
-2	b
--- !result
-
-truncate table t1;
--- result:
--- !result
-
 insert into t1 (k2, k1) select "d" as k1, 4 as k2;
 -- result:
 -- !result
@@ -44,6 +31,20 @@ truncate table t1;
 -- result:
 -- !result
 
+insert into t1 by name select 2 as k1;
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+2	None
+-- !result
+
+truncate table t1;
+-- result:
+-- !result
+
+
 insert into t1 by name values(1, "a");
 -- result:
 [REGEX].*Insert match column by name does not support values\(\).
@@ -51,12 +52,12 @@ insert into t1 by name values(1, "a");
 
 insert into t1 by name select "a" as k2, 1 as k1, 2 as k3;
 -- result:
-[REGEX].*Source column: k3 has no matching target column.
+[REGEX].*Unknown column 'k3' in 't1'.
 -- !result
 
-insert into t1 by name select 1 as k1;
+insert into t1 (k1) by name select 2 as k1;
 -- result:
-[REGEX].*Target column: k2 has no matching source column.
+[REGEX].*Cannot use COLUMN LIST and BY NAME clause together in insert.
 -- !result
 
 
@@ -71,7 +72,7 @@ select * from t1;
 3	c
 -- !result
 
-insert into t2 (k1, k2) by name select * from t1;
+insert into t2 by name select * from t1;
 -- result:
 -- !result
 
@@ -110,10 +111,6 @@ truncate table t2;
 -- result:
 -- !result
 
-insert into t2 by name select * from t1;
--- result:
-[REGEX].*Target column: k3 has no matching source column.
--- !result
 
 insert into t2 by name select k1 + 1 as k1, k1, 12 as k3 from t1;
 -- result:

--- a/test/sql/test_insert_empty/R/test_insert_label
+++ b/test/sql/test_insert_empty/R/test_insert_label
@@ -1,0 +1,43 @@
+-- name: test_insert_label
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1 (k1 int, k2 varchar(100));
+
+insert into t1 (k1, k2) with label label0 values (1, "a");
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+1	a
+-- !result
+
+truncate table t1;
+-- result:
+-- !result
+
+insert into t1 (k1, k2) with label label0 values (1, "a");
+-- result:
+[REGEX].*Label \[label0\] has already been used.*
+-- !result
+
+
+insert into t1 with label label1 (k1, k2) values (2, "b");
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+2	b
+-- !result
+
+truncate table t1;
+-- result:
+-- !result
+
+insert into t1 with label label1 (k1, k2) values (2, "b");
+-- result:
+[REGEX].*Label \[label1\] has already been used.*
+-- !result

--- a/test/sql/test_insert_empty/T/test_insert_by_name
+++ b/test/sql/test_insert_empty/T/test_insert_by_name
@@ -9,18 +9,18 @@ insert into t1 by name select "a" as k2, 1 as k1;
 select * from t1;
 truncate table t1;
 
-insert into t1 (k2, k1) by name select 2 as k1, "b" as k2;
+insert into t1 (k2, k1) select "d" as k1, 4 as k2;
 select * from t1;
 truncate table t1;
 
-insert into t1 (k2, k1) select "d" as k1, 4 as k2;
+insert into t1 by name select 2 as k1;
 select * from t1;
 truncate table t1;
 
 -- error case
 insert into t1 by name values(1, "a");
 insert into t1 by name select "a" as k2, 1 as k1, 2 as k3;
-insert into t1 by name select 1 as k1;
+insert into t1 (k1) by name select 2 as k1;
 
 
 create table t2 (k1 int, k2 varchar(100), k3 int default "10");
@@ -28,7 +28,7 @@ create table t2 (k1 int, k2 varchar(100), k3 int default "10");
 insert into t1 values(3, "c");
 select * from t1;
 
-insert into t2 (k1, k2) by name select * from t1;
+insert into t2 by name select * from t1;
 select * from t2;
 truncate table t2;
 
@@ -41,5 +41,4 @@ select * from t2;
 truncate table t2;
 
 -- error case
-insert into t2 by name select * from t1;
 insert into t2 by name select k1 + 1 as k1, k1, 12 as k3 from t1;

--- a/test/sql/test_insert_empty/T/test_insert_by_name
+++ b/test/sql/test_insert_empty/T/test_insert_by_name
@@ -5,23 +5,22 @@ use db_${uuid0};
 
 create table t1 (k1 int, k2 varchar(100));
 
-insert into t1 properties("match_column_by" = "name") select "a" as k2, 1 as k1;
+insert into t1 by name select "a" as k2, 1 as k1;
 select * from t1;
 truncate table t1;
 
-insert into t1 (k2, k1) properties("match_column_by" = "name") select 2 as k1, "b" as k2;
+insert into t1 (k2, k1) by name select 2 as k1, "b" as k2;
 select * from t1;
 truncate table t1;
 
-insert into t1 (k2, k1) properties("match_column_by" = "position") select "d" as k1, 4 as k2;
+insert into t1 (k2, k1) by name select "d" as k1, 4 as k2;
 select * from t1;
 truncate table t1;
 
 -- error case
-insert into t1 properties("match_column_by" = "name") values(1, "a");
-insert into t1 properties("match_column_by" = "name") select "a" as k2, 1 as k1, 2 as k3;
-insert into t1 properties("match_column_by" = "name") select 1 as k1;
-insert into t1 properties("match_column_by" = "invalid_value") values(1, "a");
+insert into t1 by name values(1, "a");
+insert into t1 by name select "a" as k2, 1 as k1, 2 as k3;
+insert into t1 by name select 1 as k1;
 
 
 create table t2 (k1 int, k2 varchar(100), k3 int default "10");
@@ -29,18 +28,18 @@ create table t2 (k1 int, k2 varchar(100), k3 int default "10");
 insert into t1 values(3, "c");
 select * from t1;
 
-insert into t2 (k1, k2) properties("match_column_by" = "name") select * from t1;
+insert into t2 (k1, k2) by name select * from t1;
 select * from t2;
 truncate table t2;
 
-insert into t2 properties("match_column_by" = "name") select *, 11 as k3 from t1;
+insert into t2 by name select *, 11 as k3 from t1;
 select * from t2;
 truncate table t2;
 
-insert into t2 properties("match_column_by" = "name") select k1 + 1 as k1, k2, 12 as k3 from t1;
+insert into t2 by name select k1 + 1 as k1, k2, 12 as k3 from t1;
 select * from t2;
 truncate table t2;
 
 -- error case
-insert into t2 properties("match_column_by" = "name") select * from t1;
-insert into t2 properties("match_column_by" = "name") select k1 + 1 as k1, k1, 12 as k3 from t1;
+insert into t2 by name select * from t1;
+insert into t2 by name select k1 + 1 as k1, k1, 12 as k3 from t1;

--- a/test/sql/test_insert_empty/T/test_insert_by_name
+++ b/test/sql/test_insert_empty/T/test_insert_by_name
@@ -13,7 +13,7 @@ insert into t1 (k2, k1) by name select 2 as k1, "b" as k2;
 select * from t1;
 truncate table t1;
 
-insert into t1 (k2, k1) by name select "d" as k1, 4 as k2;
+insert into t1 (k2, k1) select "d" as k1, 4 as k2;
 select * from t1;
 truncate table t1;
 

--- a/test/sql/test_insert_empty/T/test_insert_label
+++ b/test/sql/test_insert_empty/T/test_insert_label
@@ -1,0 +1,21 @@
+-- name: test_insert_label
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1 (k1 int, k2 varchar(100));
+
+insert into t1 (k1, k2) with label label0 values (1, "a");
+select * from t1;
+truncate table t1;
+
+-- error case
+insert into t1 (k1, k2) with label label0 values (1, "a");
+
+
+insert into t1 with label label1 (k1, k2) values (2, "b");
+select * from t1;
+truncate table t1;
+
+-- error case
+insert into t1 with label label1 (k1, k2) values (2, "b");


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. make insert match by name syntax same as other databases, remove match by name property.
```
insert into t1 by name select "a" as k2, 1 as k1;
```

2. cannot use COLUMN LIST and BY NAME clause together in insert.
when match column by name, use the `query output column names` to produce the `column list` in the order of query, and does not need to write a explicit column list.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0