### PR TITLE
[Enhancement] Support aws.glue.catalog_id parameters

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtils.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.hive.glue.util;
 
 import com.google.common.collect.Maps;
 import com.starrocks.connector.hive.glue.metastore.GlueMetastoreClientDelegate;
+import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -122,8 +123,13 @@ public final class MetastoreClientUtils {
     }
 
     public static String getCatalogId(Configuration conf) {
-        if (StringUtils.isNotEmpty(conf.get(GlueMetastoreClientDelegate.CATALOG_ID_CONF))) {
-            return conf.get(GlueMetastoreClientDelegate.CATALOG_ID_CONF);
+        String catalogId = conf.get(GlueMetastoreClientDelegate.CATALOG_ID_CONF);
+        if (StringUtils.isNotEmpty(catalogId)) {
+            return catalogId;
+        }
+        catalogId = conf.get(CloudConfigurationConstants.AWS_GLUE_CATALOG_ID);
+        if (StringUtils.isNotEmpty(catalogId)) {
+            return catalogId;
         }
         // This case defaults to using the caller's account Id as Catalog Id.
         return null;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtilsTest.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.util;
+
+import com.starrocks.connector.hive.glue.metastore.GlueMetastoreClientDelegate;
+import com.starrocks.connector.share.credential.CloudConfigurationConstants;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetastoreClientUtilsTest {
+
+    @Test
+    public void testGetGlueCatalogId() {
+        Configuration conf = new Configuration();
+        Assert.assertNull(MetastoreClientUtils.getCatalogId(conf));
+        conf.set(GlueMetastoreClientDelegate.CATALOG_ID_CONF, "123");
+        Assert.assertEquals("123", MetastoreClientUtils.getCatalogId(conf));
+        conf = new Configuration();
+        conf.set(CloudConfigurationConstants.AWS_GLUE_CATALOG_ID, "1234");
+        Assert.assertEquals("1234", MetastoreClientUtils.getCatalogId(conf));
+    }
+}

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
@@ -72,6 +72,8 @@ public class CloudConfigurationConstants {
     public static final String AWS_GLUE_EXTERNAL_ID = "aws.glue.external_id";
     public static final String AWS_GLUE_REGION = "aws.glue.region";
     public static final String AWS_GLUE_ENDPOINT = "aws.glue.endpoint";
+    // https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-databases.html
+    public static final String AWS_GLUE_CATALOG_ID = "aws.glue.catalog_id";
 
     // Credential for Azure storage
     // For Azure Blob Storage

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/IcebergAwsClientFactory.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/IcebergAwsClientFactory.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.share.iceberg;
 
+import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import org.apache.iceberg.aws.AwsClientFactory;
 import org.apache.iceberg.aws.AwsProperties;
 import org.slf4j.Logger;
@@ -68,6 +69,7 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.DEFAULT_AWS_REGION;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_GLUE_CATALOG_ID;
 
 public class IcebergAwsClientFactory implements AwsClientFactory {
     private static final Logger LOG = LoggerFactory.getLogger(IcebergAwsClientFactory.class);
@@ -129,6 +131,10 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
         glueExternalId = properties.getOrDefault(AWS_GLUE_EXTERNAL_ID, "");
         glueRegion = properties.getOrDefault(AWS_GLUE_REGION, "");
         glueEndpoint = properties.getOrDefault(AWS_GLUE_ENDPOINT, "");
+        String glueCatalogId = properties.get(AWS_GLUE_CATALOG_ID);
+        if (glueCatalogId != null) {
+            this.awsProperties.setGlueCatalogId(glueCatalogId);
+        }
     }
 
     private StsAssumeRoleCredentialsProvider getAssumeRoleCredentialsProvider(AwsCredentialsProvider baseCredentials,

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/IcebergAwsClientFactory.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/IcebergAwsClientFactory.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.connector.share.iceberg;
 
-import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import org.apache.iceberg.aws.AwsClientFactory;
 import org.apache.iceberg.aws.AwsProperties;
 import org.slf4j.Logger;
@@ -46,6 +45,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_GLUE_ACCESS_KEY;
+import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_GLUE_CATALOG_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_GLUE_ENDPOINT;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_GLUE_EXTERNAL_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_GLUE_IAM_ROLE_ARN;
@@ -69,7 +69,6 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.DEFAULT_AWS_REGION;
-import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_GLUE_CATALOG_ID;
 
 public class IcebergAwsClientFactory implements AwsClientFactory {
     private static final Logger LOG = LoggerFactory.getLogger(IcebergAwsClientFactory.class);


### PR DESCRIPTION
## Why I'm doing:
Support `aws.glue.catalog_id` for aws glue

## What I'm doing:

Support it

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0