### PR TITLE
[Feature] Support restoring from a cluster snapshot for shared-data mode (part 2, update metadata during restoring)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotConfig.java
@@ -133,22 +133,6 @@ public class ClusterSnapshotConfig {
     }
 
     public static class StorageVolume {
-        public static enum StorageVolumeType {
-            S3,
-            HDFS,
-            AZBLOB;
-
-            @JsonCreator
-            public static StorageVolumeType forValue(String value) {
-                return StorageVolumeType.valueOf(value.toUpperCase());
-            }
-
-            @JsonValue
-            public String toValue() {
-                return name().toLowerCase();
-            }
-        }
-
         private static class PropertiesDeserializer extends JsonDeserializer<Map<String, String>> {
 
             @Override
@@ -178,7 +162,7 @@ public class ClusterSnapshotConfig {
         private String name;
 
         @JsonProperty("type")
-        private StorageVolumeType type;
+        private String type;
 
         @JsonProperty("location")
         private String location;
@@ -198,11 +182,11 @@ public class ClusterSnapshotConfig {
             this.name = name;
         }
 
-        public StorageVolumeType getType() {
+        public String getType() {
             return type;
         }
 
-        public void setType(StorageVolumeType type) {
+        public void setType(String type) {
             this.type = type;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -15,6 +15,7 @@
 package com.starrocks.server;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.staros.util.LockCloseable;
@@ -152,27 +153,31 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
     }
 
     public void updateStorageVolume(AlterStorageVolumeStmt stmt) throws DdlException {
-        Map<String, String> params = new HashMap<>();
-        Optional<Boolean> enabled = parseProperties(stmt.getProperties(), params);
-        updateStorageVolume(stmt.getName(), params, enabled, stmt.getComment());
+        updateStorageVolume(stmt.getName(), null, null, stmt.getProperties(), stmt.getComment());
     }
 
-    public void updateStorageVolume(String name, Map<String, String> params, Optional<Boolean> enabled, String comment)
-            throws DdlException {
+    public void updateStorageVolume(String name, String svType, List<String> locations,
+            Map<String, String> properties, String comment) throws DdlException {
+        Map<String, String> params = new HashMap<>();
+        Optional<Boolean> enabled = parseProperties(properties, params);
+        updateStorageVolume(name, svType, locations, params, enabled, comment);
+    }
+
+    public void updateStorageVolume(String name, String svType, List<String> locations,
+            Map<String, String> params, Optional<Boolean> enabled, String comment) throws DdlException {
+        List<String> immutableProperties = Lists.newArrayList(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX,
+                CloudConfigurationConstants.AWS_S3_ENABLE_PARTITIONED_PREFIX);
+        for (String param : immutableProperties) {
+            if (params.containsKey(param)) {
+                throw new DdlException(String.format("Storage volume property '%s' is immutable!", param));
+            }
+        }
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
             StorageVolume sv = getStorageVolumeByName(name);
             Preconditions.checkState(sv != null, "Storage volume '%s' does not exist", name);
             StorageVolume copied = new StorageVolume(sv);
             validateParams(copied.getType(), params);
 
-            List<String> immutableProperties =
-                    Lists.newArrayList(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX,
-                            CloudConfigurationConstants.AWS_S3_ENABLE_PARTITIONED_PREFIX);
-            for (String param : immutableProperties) {
-                if (params.containsKey(param)) {
-                    throw new DdlException(String.format("Storage volume property '%s' is immutable!", param));
-                }
-            }
             if (enabled.isPresent()) {
                 boolean enabledValue = enabled.get();
                 if (!enabledValue) {
@@ -182,7 +187,15 @@ public abstract class StorageVolumeMgr implements Writable, GsonPostProcessable 
                 copied.setEnabled(enabledValue);
             }
 
-            if (!comment.isEmpty()) {
+            if (!Strings.isNullOrEmpty(svType)) {
+                copied.setType(svType);
+            }
+
+            if (locations != null) {
+                copied.setLocations(locations);
+            }
+
+            if (!Strings.isNullOrEmpty(comment)) {
                 copied.setComment(comment);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
+++ b/fe/fe-core/src/main/java/com/starrocks/storagevolume/StorageVolume.java
@@ -174,8 +174,17 @@ public class StorageVolume implements Writable, GsonPostProcessable {
     public String getComment() {
         return comment;
     }
+
+    public void setLocations(List<String> locations) {
+        this.locations = locations;
+    }
+
     public List<String> getLocations() {
         return locations;
+    }
+
+    public void setType(String type) {
+        this.svt = toStorageVolumeType(type);
     }
 
     public String getType() {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotConfigTest.java
@@ -62,7 +62,7 @@ public class ClusterSnapshotConfigTest {
 
         ClusterSnapshotConfig.StorageVolume storageVolume1 = config.getStorageVolumes().get(0);
         Assert.assertEquals("my_s3_volume", storageVolume1.getName());
-        Assert.assertEquals(ClusterSnapshotConfig.StorageVolume.StorageVolumeType.S3, storageVolume1.getType());
+        Assert.assertEquals("S3", storageVolume1.getType());
         Assert.assertEquals("s3://defaultbucket/test/", storageVolume1.getLocation());
         Assert.assertEquals("my s3 volume", storageVolume1.getComment());
         Assert.assertEquals(4, storageVolume1.getProperties().size());
@@ -74,7 +74,7 @@ public class ClusterSnapshotConfigTest {
 
         ClusterSnapshotConfig.StorageVolume storageVolume2 = config.getStorageVolumes().get(1);
         Assert.assertEquals("my_hdfs_volume", storageVolume2.getName());
-        Assert.assertEquals(ClusterSnapshotConfig.StorageVolume.StorageVolumeType.HDFS, storageVolume2.getType());
+        Assert.assertEquals("HDFS", storageVolume2.getType());
         Assert.assertEquals("hdfs://127.0.0.1:9000/sr/test/", storageVolume2.getLocation());
         Assert.assertEquals("my hdfs volume", storageVolume2.getComment());
         Assert.assertEquals(2, storageVolume2.getProperties().size());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgrTest.java
@@ -14,10 +14,14 @@
 
 package com.starrocks.lake.snapshot;
 
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Optional;
 
 public class RestoreClusterSnapshotMgrTest {
     @BeforeClass
@@ -30,6 +34,12 @@ public class RestoreClusterSnapshotMgrTest {
         RestoreClusterSnapshotMgr.init("src/test/resources/conf/cluster_snapshot.yaml",
                 new String[] { "-cluster_snapshot" });
         Assert.assertTrue(RestoreClusterSnapshotMgr.isRestoring());
+
+        for (ClusterSnapshotConfig.StorageVolume sv : RestoreClusterSnapshotMgr.getConfig().getStorageVolumes()) {
+            GlobalStateMgr.getCurrentState().getStorageVolumeMgr().createStorageVolume(sv.getName(), sv.getType(),
+                    Collections.singletonList(sv.getLocation()), sv.getProperties(), Optional.of(true),
+                    sv.getComment());
+        }
 
         RestoreClusterSnapshotMgr.finishRestoring();
         Assert.assertFalse(RestoreClusterSnapshotMgr.isRestoring());

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -216,16 +216,16 @@ public class SharedDataStorageVolumeMgrTest {
         storageParams.put(AWS_S3_ACCESS_KEY, "ak");
         storageParams.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
         try {
-            svm.updateStorageVolume(svName1, storageParams, Optional.of(false), "test update");
+            svm.updateStorageVolume(svName1, null, null, storageParams, Optional.of(false), "test update");
             Assert.fail();
         } catch (IllegalStateException e) {
             Assert.assertTrue(e.getMessage().contains("Storage volume 'test1' does not exist"));
         }
         storageParams.put("aaa", "bbb");
         Assert.assertThrows(DdlException.class, () ->
-                svm.updateStorageVolume(svName, storageParams, Optional.of(true), "test update"));
+                svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(true), "test update"));
         storageParams.remove("aaa");
-        svm.updateStorageVolume(svName, storageParams, Optional.of(true), "test update");
+        svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(true), "test update");
         sv = svm.getStorageVolumeByName(svName);
         cloudConfiguration = sv.getCloudConfiguration();
         Assert.assertEquals("region1", ((AwsCloudConfiguration) cloudConfiguration).getAwsCloudCredential()
@@ -246,7 +246,7 @@ public class SharedDataStorageVolumeMgrTest {
         Assert.assertEquals(sv.getId(), svm.getDefaultStorageVolumeId());
 
         Throwable ex = Assert.assertThrows(IllegalStateException.class,
-                () -> svm.updateStorageVolume(svName, storageParams, Optional.of(false), ""));
+                () -> svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(false), ""));
         Assert.assertEquals("Default volume can not be disabled", ex.getMessage());
 
         // remove
@@ -261,7 +261,7 @@ public class SharedDataStorageVolumeMgrTest {
         Assert.assertEquals("Storage volume 'test1' does not exist", ex.getMessage());
 
         svm.createStorageVolume(svName1, "S3", locations, storageParams, Optional.of(false), "");
-        svm.updateStorageVolume(svName1, storageParams, Optional.of(true), "test update");
+        svm.updateStorageVolume(svName1, null, null, storageParams, Optional.of(true), "test update");
         svm.setDefaultStorageVolume(svName1);
 
         sv = svm.getStorageVolumeByName(svName);
@@ -285,14 +285,14 @@ public class SharedDataStorageVolumeMgrTest {
             Map<String, String> modifyParams = new HashMap<>();
             modifyParams.put(CloudConfigurationConstants.AWS_S3_ENABLE_PARTITIONED_PREFIX, "true");
             Assert.assertThrows(DdlException.class, () ->
-                    svm.updateStorageVolume(svName, modifyParams, Optional.of(false), ""));
+                    svm.updateStorageVolume(svName, null, null, modifyParams, Optional.of(false), ""));
         }
 
         {
             Map<String, String> modifyParams = new HashMap<>();
             modifyParams.put(CloudConfigurationConstants.AWS_S3_NUM_PARTITIONED_PREFIX, "12");
             Assert.assertThrows(DdlException.class, () ->
-                    svm.updateStorageVolume(svName, modifyParams, Optional.of(false), ""));
+                    svm.updateStorageVolume(svName, null, null, modifyParams, Optional.of(false), ""));
         }
     }
 
@@ -313,7 +313,7 @@ public class SharedDataStorageVolumeMgrTest {
         Assert.assertTrue(svm.bindDbToStorageVolume(svName, 1L));
         Assert.assertTrue(svm.bindTableToStorageVolume(svName, 1L, 1L));
 
-        svm.updateStorageVolume(svName, storageParams, Optional.of(false), "test update");
+        svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(false), "test update");
         // disabled storage volume can not be bound.
         Throwable ex = Assert.assertThrows(DdlException.class, () -> svm.bindDbToStorageVolume(svName, 1L));
         Assert.assertEquals(String.format("Storage volume %s is disabled", svName), ex.getMessage());
@@ -891,7 +891,7 @@ public class SharedDataStorageVolumeMgrTest {
 
         storageParams.put("dfs.client.failover.proxy.provider",
                 "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
-        svm.updateStorageVolume("test", storageParams, Optional.of(false), "");
+        svm.updateStorageVolume("test", null, null, storageParams, Optional.of(false), "");
         Assert.assertEquals(false, svm.getStorageVolumeByName(svName).getEnabled());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedNothingStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedNothingStorageVolumeMgrTest.java
@@ -98,16 +98,16 @@ public class SharedNothingStorageVolumeMgrTest {
         storageParams.put(AWS_S3_ACCESS_KEY, "ak");
         storageParams.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
         try {
-            svm.updateStorageVolume(svName1, storageParams, Optional.of(false), "test update");
+            svm.updateStorageVolume(svName1, null, null, storageParams, Optional.of(false), "test update");
             Assert.fail();
         } catch (IllegalStateException e) {
             Assert.assertTrue(e.getMessage().contains("Storage volume 'test1' does not exist"));
         }
         storageParams.put("aaa", "bbb");
         Assert.assertThrows(DdlException.class, () ->
-                svm.updateStorageVolume(svName, storageParams, Optional.of(true), "test update"));
+                svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(true), "test update"));
         storageParams.remove("aaa");
-        svm.updateStorageVolume(svName, storageParams, Optional.of(true), "test update");
+        svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(true), "test update");
         sv = svm.getStorageVolumeByName(svName);
         cloudConfiguration = sv.getCloudConfiguration();
         Assert.assertEquals("region1", ((AwsCloudConfiguration) cloudConfiguration).getAwsCloudCredential()
@@ -127,7 +127,7 @@ public class SharedNothingStorageVolumeMgrTest {
         svm.setDefaultStorageVolume(svName);
         Assert.assertEquals(sv.getId(), svm.getDefaultStorageVolumeId());
         try {
-            svm.updateStorageVolume(svName, storageParams, Optional.of(false), "");
+            svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(false), "");
             Assert.fail();
         } catch (IllegalStateException e) {
             Assert.assertTrue(e.getMessage().contains("Default volume can not be disabled"));
@@ -148,7 +148,7 @@ public class SharedNothingStorageVolumeMgrTest {
         Assert.assertEquals("Storage volume 'test1' does not exist", ex.getMessage());
 
         svm.createStorageVolume(svName1, "S3", locations, storageParams, Optional.empty(), "");
-        svm.updateStorageVolume(svName1, storageParams, Optional.empty(), "test update");
+        svm.updateStorageVolume(svName1, null, null, storageParams, Optional.empty(), "test update");
         svm.setDefaultStorageVolume(svName1);
 
         sv = svm.getStorageVolumeByName(svName);


### PR DESCRIPTION
## Why I'm doing:
To support disaster recovery for shared-data mode.

## What I'm doing:
Update metadata during restoring from a cluster snapshot according to the `cluster_snapshot.yaml`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0