### PR TITLE
[Enhancement] release the query queue slots asap (backport #54032)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -502,9 +502,16 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     @Override
+    public void onReleaseSlots() {
+        if (slot != null) {
+            jobSpec.getSlotProvider().cancelSlotRequirement(slot);
+            jobSpec.getSlotProvider().releaseSlot(slot);
+        }
+    }
+
+    @Override
     public void onFinished() {
-        jobSpec.getSlotProvider().cancelSlotRequirement(slot);
-        jobSpec.getSlotProvider().releaseSlot(slot);
+        onReleaseSlots();
         // for async profile, if Be doesn't report profile in time, we upload the most complete profile
         // into profile Manager here. IN other case, queryProfile.finishAllInstances just do nothing here
         queryProfile.finishAllInstances(Status.OK);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -687,24 +687,29 @@ public class StmtExecutor {
                             // to this failed execution.
                             String queryId = DebugUtil.printId(context.getExecutionId());
                             ProfileManager.getInstance().removeProfile(queryId);
-                        }
-
-                        if (context instanceof ArrowFlightSqlConnectContext) {
-                            isAsync = true;
-                            tryProcessProfileAsync(execPlan, i);
-                        } else if (context.isProfileEnabled()) {
-                            isAsync = tryProcessProfileAsync(execPlan, i);
-                        }
-
-                        if (parsedStmt.isExplain() &&
-                                StatementBase.ExplainLevel.ANALYZE.equals(parsedStmt.getExplainLevel())) {
-                            if (coord != null && coord.isShortCircuit()) {
-                                throw new UserException(
-                                        "short circuit point query doesn't suppot explain analyze stmt, " +
-                                                "you can set it off by using  set enable_short_circuit=false");
+                        } else {
+                            // Release all resources after the query finish as soon as possible, as query profile is
+                            // asynchronous which can be delayed a long time.
+                            if (coord != null) {
+                                coord.onReleaseSlots();
                             }
-                            handleExplainStmt(ExplainAnalyzer.analyze(
-                                    ProfilingExecPlan.buildFrom(execPlan), profile, null));
+
+                            if (context instanceof ArrowFlightSqlConnectContext) {
+                                isAsync = true;
+                                tryProcessProfileAsync(execPlan, i);
+                            } else if (context.isProfileEnabled()) {
+                                isAsync = tryProcessProfileAsync(execPlan, i);
+                                if (parsedStmt.isExplain() &&
+                                        StatementBase.ExplainLevel.ANALYZE.equals(parsedStmt.getExplainLevel())) {
+                                    if (coord != null && coord.isShortCircuit()) {
+                                        throw new UserException(
+                                                "short circuit point query doesn't suppot explain analyze stmt, " +
+                                                        "you can set it off by using  set enable_short_circuit=false");
+                                    }
+                                    handleExplainStmt(ExplainAnalyzer.analyze(
+                                            ProfilingExecPlan.buildFrom(execPlan), profile, null));
+                                }
+                            }
                         }
 
                         if (context.getState().isError()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -143,6 +143,10 @@ public abstract class Coordinator {
         return List.of();
     }
 
+    // Release query queue resources
+    public void onReleaseSlots() {
+    }
+
     public abstract void onFinished();
 
     public abstract LogicalSlot getSlot();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The query queue slots should be released once the queue finished, otherwise it can be delayed by profile processing.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

