### PR TITLE
[BugFix] fix char padding missing after partial update

### DIFF
--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -317,49 +317,51 @@ std::vector<size_t> ChunkHelper::get_char_field_indexes(const Schema& schema) {
     return char_field_indexes;
 }
 
+void ChunkHelper::padding_char_column(const starrocks::TabletSchemaCSPtr& tschema, const Field& field, Column* column) {
+    size_t num_rows = column->size();
+    Column* data_column = ColumnHelper::get_data_column(column);
+    auto* binary = down_cast<BinaryColumn*>(data_column);
+
+    Offsets& offset = binary->get_offset();
+    Bytes& bytes = binary->get_bytes();
+
+    // Padding 0 to CHAR field, the storage bitmap index and zone map need it.
+    // TODO(kks): we could improve this if there are many null valus
+    auto new_binary = BinaryColumn::create();
+    Offsets& new_offset = new_binary->get_offset();
+    Bytes& new_bytes = new_binary->get_bytes();
+
+    // |schema| maybe partial columns in vertical compaction, so get char column length by name.
+    uint32_t len = tschema->column(tschema->field_index(field.name())).length();
+
+    new_offset.resize(num_rows + 1);
+    new_bytes.assign(num_rows * len, 0); // padding 0
+
+    uint32_t from = 0;
+    for (size_t j = 0; j < num_rows; ++j) {
+        uint32_t copy_data_len = std::min(len, offset[j + 1] - offset[j]);
+        strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset[j], copy_data_len);
+        from += len; // no copy data will be 0
+    }
+
+    for (size_t j = 1; j <= num_rows; ++j) {
+        new_offset[j] = static_cast<uint32_t>(len * j);
+    }
+
+    if (field.is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(column);
+        auto new_column = NullableColumn::create(new_binary, nullable_column->null_column());
+        new_column->swap_column(*column);
+    } else {
+        new_binary->swap_column(*column);
+    }
+}
+
 void ChunkHelper::padding_char_columns(const std::vector<size_t>& char_column_indexes, const Schema& schema,
                                        const starrocks::TabletSchemaCSPtr& tschema, Chunk* chunk) {
-    size_t num_rows = chunk->num_rows();
     for (auto field_index : char_column_indexes) {
         Column* column = chunk->get_column_by_index(field_index).get();
-        Column* data_column = ColumnHelper::get_data_column(column);
-        auto* binary = down_cast<BinaryColumn*>(data_column);
-
-        Offsets& offset = binary->get_offset();
-        Bytes& bytes = binary->get_bytes();
-
-        // Padding 0 to CHAR field, the storage bitmap index and zone map need it.
-        // TODO(kks): we could improve this if there are many null valus
-        auto new_binary = BinaryColumn::create();
-        Offsets& new_offset = new_binary->get_offset();
-        Bytes& new_bytes = new_binary->get_bytes();
-
-        // |schema| maybe partial columns in vertical compaction, so get char column length by name.
-        uint32_t len = tschema->column(tschema->field_index(schema.field(field_index)->name())).length();
-
-        new_offset.resize(num_rows + 1);
-        new_bytes.assign(num_rows * len, 0); // padding 0
-
-        uint32_t from = 0;
-        for (size_t j = 0; j < num_rows; ++j) {
-            uint32_t copy_data_len = std::min(len, offset[j + 1] - offset[j]);
-            strings::memcpy_inlined(new_bytes.data() + from, bytes.data() + offset[j], copy_data_len);
-            from += len; // no copy data will be 0
-        }
-
-        for (size_t j = 1; j <= num_rows; ++j) {
-            new_offset[j] = static_cast<uint32_t>(len * j);
-        }
-
-        const auto& field = schema.field(field_index);
-
-        if (field->is_nullable()) {
-            auto* nullable_column = down_cast<NullableColumn*>(column);
-            auto new_column = NullableColumn::create(new_binary, nullable_column->null_column());
-            new_column->swap_column(*column);
-        } else {
-            new_binary->swap_column(*column);
-        }
+        padding_char_column(tschema, *schema.field(field_index), column);
     }
 }
 
@@ -764,9 +766,13 @@ public:
         return {};
     }
 
-    Status do_visit(const ConstColumn& column) { return Status::NotSupported("SegmentedColumnVisitor"); }
+    Status do_visit(const ConstColumn& column) {
+        return Status::NotSupported("SegmentedColumnVisitor");
+    }
 
-    ColumnPtr result() { return _result; }
+    ColumnPtr result() {
+        return _result;
+    }
 
 private:
     __attribute__((always_inline)) std::pair<size_t, size_t> _segment_address(size_t idx, size_t segment_size) {

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -766,13 +766,9 @@ public:
         return {};
     }
 
-    Status do_visit(const ConstColumn& column) {
-        return Status::NotSupported("SegmentedColumnVisitor");
-    }
+    Status do_visit(const ConstColumn& column) { return Status::NotSupported("SegmentedColumnVisitor"); }
 
-    ColumnPtr result() {
-        return _result;
-    }
+    ColumnPtr result() { return _result; }
 
 private:
     __attribute__((always_inline)) std::pair<size_t, size_t> _segment_address(size_t idx, size_t segment_size) {

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -90,6 +90,9 @@ public:
     static void padding_char_columns(const std::vector<size_t>& char_column_indexes, const Schema& schema,
                                      const TabletSchemaCSPtr& tschema, Chunk* chunk);
 
+    // Padding one char column
+    static void padding_char_column(const starrocks::TabletSchemaCSPtr& tschema, const Field& field, Column* column);
+
     // Reorder columns of `chunk` according to the order of |tuple_desc|.
     static void reorder_chunk(const TupleDescriptor& tuple_desc, Chunk* chunk);
     // Reorder columns of `chunk` according to the order of |slots|.

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -570,6 +570,11 @@ Status UpdateManager::get_column_values(const RowsetUpdateStateParams& params, s
             ASSIGN_OR_RETURN(auto col_iter, (*segment)->new_column_iterator_or_default(col, nullptr));
             RETURN_IF_ERROR(col_iter->init(iter_opts));
             RETURN_IF_ERROR(col_iter->fetch_values_by_rowid(rowids.data(), rowids.size(), (*columns)[i].get()));
+            // padding char columns
+            const auto& field = tablet_schema->schema()->field(read_column_ids[i]);
+            if (field->type()->type() == TYPE_CHAR) {
+                ChunkHelper::padding_char_column(tablet_schema, *field, (*columns)[i].get());
+            }
         }
         return Status::OK();
     };

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5319,6 +5319,11 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
                 }
                 RETURN_IF_ERROR(col_iter->init(iter_opts));
                 RETURN_IF_ERROR(col_iter->fetch_values_by_rowid(rowids.data(), rowids.size(), (*columns)[i].get()));
+                // padding char columns
+                const auto& field = read_tablet_schema->schema()->field(column_ids[i]);
+                if (field->type()->type() == TYPE_CHAR) {
+                    ChunkHelper::padding_char_column(read_tablet_schema, *field, (*columns)[i].get());
+                }
             }
         }
     }
@@ -5360,6 +5365,11 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
             }
             RETURN_IF_ERROR(col_iter->init(iter_opts));
             RETURN_IF_ERROR(col_iter->fetch_values_by_rowid(rowids.data(), rowids.size(), (*columns)[i].get()));
+            // padding char columns
+            const auto& field = read_tablet_schema->schema()->field(column_ids[i]);
+            if (field->type()->type() == TYPE_CHAR) {
+                ChunkHelper::padding_char_column(read_tablet_schema, *field, (*columns)[i].get());
+            }
         }
     }
     return Status::OK();

--- a/test/sql/test_stream_load/R/test_partial_update_with_char
+++ b/test/sql/test_stream_load/R/test_partial_update_with_char
@@ -1,0 +1,50 @@
+-- name: test_partial_update_with_char
+create database test_partial_update_with_char_db;
+-- result:
+-- !result
+use test_partial_update_with_char_db;
+-- result:
+-- !result
+CREATE TABLE test1 (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `name` char(16) NULL DEFAULT "" COMMENT "",
+  `city` char(16) NULL DEFAULT "" COMMENT "",
+  `age` char(24) NULL DEFAULT "" COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "true",
+"compression" = "LZ4"
+); 
+
+insert into test_partial_update_with_char_db.test1 values(1,'name1','SD',5),(2,'name2','SH',25),(3,'name3','BJ',50);
+-- result:
+-- !result
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format: json" -H "partial_update: true" -H "columns: id, city" -d '{"id":1, "city": "xx"}' ${url}/api/test_partial_update_with_char_db/test1/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from test_partial_update_with_char_db.test1;
+-- result:
+2	name2	SH	25
+1	name1	xx	5
+3	name3	BJ	50
+-- !result
+select * from test_partial_update_with_char_db.test1 where name = "name1";
+-- result:
+1	name1	xx	5
+-- !result
+drop database test_partial_update_with_char_db force;
+-- result:
+-- !result

--- a/test/sql/test_stream_load/T/test_partial_update_with_char
+++ b/test/sql/test_stream_load/T/test_partial_update_with_char
@@ -1,0 +1,27 @@
+-- name: test_partial_update_with_char
+create database test_partial_update_with_char_db;
+use test_partial_update_with_char_db;
+CREATE TABLE test1 (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `name` char(16) NULL DEFAULT "" COMMENT "",
+  `city` char(16) NULL DEFAULT "" COMMENT "",
+  `age` char(24) NULL DEFAULT "" COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "true",
+"compression" = "LZ4"
+); 
+
+insert into test_partial_update_with_char_db.test1 values(1,'name1','SD',5),(2,'name2','SH',25),(3,'name3','BJ',50);
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "format: json" -H "partial_update: true" -H "columns: id, city" -d '{"id":1, "city": "xx"}' ${url}/api/test_partial_update_with_char_db/test1/_stream_load
+sync;
+
+select * from test_partial_update_with_char_db.test1;
+select * from test_partial_update_with_char_db.test1 where name = "name1";
+
+drop database test_partial_update_with_char_db force;


### PR DESCRIPTION
## Why I'm doing:
Fix this BUG #54181

## What I'm doing:
The char column write by partial update task, which miss the char column padding and it will lead to select result error:
```
select * from where col = "xxx";
```
If `col` is a char column, and this sql will return empty.

This pull request includes several changes to improve the handling and padding of char columns in the `ChunkHelper` class and related test cases. The most important changes include refactoring the `padding_char_columns` method, updating the `get_column_values` method to include char column padding, and adding new test cases for partial updates with char columns.

Refactoring and improvements:

* [`be/src/storage/chunk_helper.cpp`](diffhunk://#diff-b1a9111732dbe59d1759017979eb2777f7903db91d3fa9ae3f3bcdc8476b7f33L320-R321): Refactored the `padding_char_columns` method to delegate padding of individual columns to a new `padding_char_column` method, simplifying the code and improving readability. [[1]](diffhunk://#diff-b1a9111732dbe59d1759017979eb2777f7903db91d3fa9ae3f3bcdc8476b7f33L320-R321) [[2]](diffhunk://#diff-b1a9111732dbe59d1759017979eb2777f7903db91d3fa9ae3f3bcdc8476b7f33L338-R335) [[3]](diffhunk://#diff-b1a9111732dbe59d1759017979eb2777f7903db91d3fa9ae3f3bcdc8476b7f33L354-R365)
* [`be/src/storage/chunk_helper.h`](diffhunk://#diff-e0780e369942067dececa5e0cf2a038e877f6f986722a392ad7b695593055776R93-R95): Added the declaration for the new `padding_char_column` method.

Column value updates:

* [`be/src/storage/lake/update_manager.cpp`](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66R573-R577): Updated the `get_column_values` method to include padding for char columns after fetching values by row ID.
* [`be/src/storage/tablet_updates.cpp`](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR5322-R5326): Updated the `get_column_values` method to include padding for char columns after fetching values by row ID. [[1]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR5322-R5326) [[2]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR5368-R5372)

New test cases:

* [`test/sql/test_stream_load/R/test_partial_update_with_char`](diffhunk://#diff-e787b716677da8db90a08714244d5405f380556c5518b73bcb812673e908a774R1-R50): Added a new test case for partial updates with char columns to ensure proper handling and padding.
* [`test/sql/test_stream_load/T/test_partial_update_with_char`](diffhunk://#diff-79595c2008b246f79303b6159715d7b27c68f78244b4b5fea0b77d71a692fdfdR1-R27): Added a corresponding test case for partial updates with char columns.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0