### PR TITLE
[Enhancement] optimize buffer strategy of merge-sort

### DIFF
--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -117,7 +117,8 @@ Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
     if (!_staging_unsorted_rows) {
         return Status::OK();
     }
-    bool reach_limit = _staging_unsorted_rows >= max_buffered_rows || _staging_unsorted_bytes >= max_buffered_bytes;
+    bool reach_limit = _staging_unsorted_rows >= kDefaultMinBufferRows &&
+                       (_staging_unsorted_rows >= max_buffered_rows || _staging_unsorted_bytes >= max_buffered_bytes);
     if (done || reach_limit) {
         _max_num_rows = std::max<int>(_max_num_rows, _staging_unsorted_rows);
         _profiler->input_required_memory->update(_staging_unsorted_bytes);
@@ -147,6 +148,7 @@ Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
 Status ChunksSorterFullSort::_merge_sorted(RuntimeState* state) {
     SCOPED_TIMER(_merge_timer);
     _profiler->num_sorted_runs->set((int64_t)_sorted_chunks.size());
+    // TODO: introduce an extra merge before cascading merge to handle the case that has a lot of sortruns
     // In cascading merging phase, the height of merging tree is ceiling(log2(num_sorted_runs)) + 1,
     // so when num_sorted_runs is 1 or 2, the height merging tree is less than 2, the sorted runs just be processed
     // in at most one pass. there is no need to enable lazy materialization which eliminates non-order-by output

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -17,7 +17,6 @@
 #include "column/vectorized_fwd.h"
 #include "exec/chunks_sorter.h"
 #include "exec/sorting/merge.h"
-#include "gtest/gtest_prod.h"
 
 namespace starrocks {
 class ExprContext;
@@ -90,9 +89,11 @@ protected:
     std::unique_ptr<ObjectPool> _object_pool = nullptr;
     ChunksSorterFullSortProfiler* _profiler = nullptr;
 
+    // Parameters to control the buffering behavior: buffering some chunks before partial-sort to reduce memory random access
     // TODO: further tunning the buffer parameter
     const size_t max_buffered_rows;  // Max buffer 1024000 rows
     const size_t max_buffered_bytes; // Max buffer 16MB bytes
+    std::set<SlotId> _sort_slots;    // Slots participating in the sorting procedure
 
     // only when order-by columns(_sort_exprs) are all ColumnRefs and the cost of eager-materialization of
     // other columns is large than ordinal column, then we materialize order-by columns and ordinal columns eagerly,

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -33,6 +33,10 @@ struct ChunksSorterFullSortProfiler {
 };
 class ChunksSorterFullSort : public ChunksSorter {
 public:
+    static constexpr size_t kDefaultMaxBufferRows = 2 << 20;   // 2097152 rows
+    static constexpr size_t kDefaultMinBufferRows = 1 << 20;   // 1048576 rows
+    static constexpr size_t kDefaultMaxBufferBytes = 16 << 20; // 16MB
+
     /**
      * Constructor.
      * @param sort_exprs     The order-by columns or columns with expression. This sorter will use but not own the object.
@@ -91,8 +95,8 @@ protected:
 
     // Parameters to control the buffering behavior: buffering some chunks before partial-sort to reduce memory random access
     // TODO: further tunning the buffer parameter
-    const size_t max_buffered_rows;  // Max buffer 1024000 rows
-    const size_t max_buffered_bytes; // Max buffer 16MB bytes
+    const size_t max_buffered_rows;  // Max buffer 2097152 rows
+    const size_t max_buffered_bytes; // Max buffer 16MB
     std::set<SlotId> _sort_slots;    // Slots participating in the sorting procedure
 
     // only when order-by columns(_sort_exprs) are all ColumnRefs and the cost of eager-materialization of

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -33,9 +33,10 @@ struct ChunksSorterFullSortProfiler {
 };
 class ChunksSorterFullSort : public ChunksSorter {
 public:
-    static constexpr size_t kDefaultMaxBufferRows = 2 << 20;   // 2097152 rows
-    static constexpr size_t kDefaultMinBufferRows = 1 << 20;   // 1048576 rows
-    static constexpr size_t kDefaultMaxBufferBytes = 16 << 20; // 16MB
+    static constexpr size_t kDefaultMaxBufferRows =
+            1 << 30; // 1 billion rows, the number of rows has little impact on performance
+    static constexpr size_t kDefaultMaxBufferBytes =
+            256 << 20; // 256MB, a larger limit may improve performance but is not memory allocator friendly
 
     /**
      * Constructor.
@@ -93,11 +94,9 @@ protected:
     std::unique_ptr<ObjectPool> _object_pool = nullptr;
     ChunksSorterFullSortProfiler* _profiler = nullptr;
 
-    // Parameters to control the buffering behavior: buffering some chunks before partial-sort to reduce memory random access
-    // TODO: further tunning the buffer parameter
-    const size_t max_buffered_rows;  // Max buffer 2097152 rows
-    const size_t max_buffered_bytes; // Max buffer 16MB
-    std::set<SlotId> _sort_slots;    // Slots participating in the sorting procedure
+    // Parameters to control the Merge-Sort behavior
+    const size_t max_buffered_rows;
+    const size_t max_buffered_bytes;
 
     // only when order-by columns(_sort_exprs) are all ColumnRefs and the cost of eager-materialization of
     // other columns is large than ordinal column, then we materialize order-by columns and ordinal columns eagerly,

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -325,10 +325,11 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> TopNNode::_decompose_to_
     int64_t max_buffered_rows = ChunksSorterFullSort::kDefaultMaxBufferRows;
     int64_t max_buffered_bytes =
             std::max<int64_t>(ChunksSorterFullSort::kDefaultMaxBufferBytes, CpuInfo::get_l3_cache_size());
-
     if (_tnode.sort_node.__isset.max_buffered_bytes) {
-        max_buffered_rows = _tnode.sort_node.max_buffered_rows;
         max_buffered_bytes = _tnode.sort_node.max_buffered_bytes;
+    }
+    if (_tnode.sort_node.__isset.max_buffered_rows) {
+        max_buffered_rows = _tnode.sort_node.max_buffered_rows;
     }
 
     sink_operator = std::make_shared<SinkFactory>(

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -322,8 +322,10 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> TopNNode::_decompose_to_
 
     OperatorFactoryPtr sink_operator;
 
-    int64_t max_buffered_rows = 1024000;
-    int64_t max_buffered_bytes = 16 * 1024 * 1024;
+    int64_t max_buffered_rows = ChunksSorterFullSort::kDefaultMaxBufferRows;
+    int64_t max_buffered_bytes =
+            std::max<int64_t>(ChunksSorterFullSort::kDefaultMaxBufferBytes, CpuInfo::get_l3_cache_size());
+
     if (_tnode.sort_node.__isset.max_buffered_bytes) {
         max_buffered_rows = _tnode.sort_node.max_buffered_rows;
         max_buffered_bytes = _tnode.sort_node.max_buffered_bytes;

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -14,7 +14,6 @@
 
 #include "exec/topn_node.h"
 
-#include <any>
 #include <memory>
 
 #include "exec/chunks_sorter.h"
@@ -22,7 +21,6 @@
 #include "exec/chunks_sorter_heap_sort.h"
 #include "exec/chunks_sorter_topn.h"
 #include "exec/pipeline/limit_operator.h"
-#include "exec/pipeline/noop_sink_operator.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "exec/pipeline/sort/local_merge_sort_source_operator.h"
 #include "exec/pipeline/sort/local_parallel_merge_sort_source_operator.h"
@@ -34,7 +32,6 @@
 #include "exec/pipeline/sort/spillable_partition_sort_sink_operator.h"
 #include "exec/pipeline/source_operator.h"
 #include "exec/pipeline/spill_process_channel.h"
-#include "exec/pipeline/spill_process_operator.h"
 #include "gutil/casts.h"
 #include "runtime/current_thread.h"
 
@@ -323,8 +320,7 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> TopNNode::_decompose_to_
     OperatorFactoryPtr sink_operator;
 
     int64_t max_buffered_rows = ChunksSorterFullSort::kDefaultMaxBufferRows;
-    int64_t max_buffered_bytes =
-            std::max<int64_t>(ChunksSorterFullSort::kDefaultMaxBufferBytes, CpuInfo::get_l3_cache_size());
+    int64_t max_buffered_bytes = ChunksSorterFullSort::kDefaultMaxBufferBytes;
     if (_tnode.sort_node.__isset.max_buffered_bytes) {
         max_buffered_bytes = _tnode.sort_node.max_buffered_bytes;
     }

--- a/be/src/util/cpu_info.h
+++ b/be/src/util/cpu_info.h
@@ -97,6 +97,12 @@ public:
         return cache_sizes;
     }
 
+    static long get_l3_cache_size() {
+        auto& cache_sizes = get_cache_sizes();
+        return cache_sizes[CacheLevel::L3_CACHE] ? cache_sizes[CacheLevel::L3_CACHE]
+                                                 : cache_sizes[CacheLevel::L2_CACHE];
+    }
+
     static std::vector<size_t> get_core_ids();
 
     static bool is_cgroup_with_cpuset() { return is_cgroup_with_cpuset_; }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -50,6 +50,7 @@ import com.starrocks.common.IdGenerator;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.operator.TopNType;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TNormalPlanNode;
@@ -220,8 +221,14 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
         msg.sort_node = new TSortNode(sortInfo, useTopN);
         msg.sort_node.setOffset(offset);
         SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
-        msg.sort_node.setMax_buffered_rows(sessionVariable.getFullSortMaxBufferedRows());
-        msg.sort_node.setMax_buffered_bytes(sessionVariable.getFullSortMaxBufferedBytes());
+        SessionVariable defaultVariable = GlobalStateMgr.getCurrentState().getVariableMgr().getDefaultSessionVariable();
+        if (sessionVariable.getFullSortMaxBufferedBytes() != defaultVariable.getFullSortMaxBufferedBytes()) {
+            msg.sort_node.setMax_buffered_bytes(sessionVariable.getFullSortMaxBufferedBytes());
+        }
+        if (sessionVariable.getFullSortMaxBufferedRows() != defaultVariable.getFullSortMaxBufferedRows()) {
+            msg.sort_node.setMax_buffered_rows(sessionVariable.getFullSortMaxBufferedRows());
+        }
+
         msg.sort_node.setLate_materialization(sessionVariable.isFullSortLateMaterialization());
         msg.sort_node.setEnable_parallel_merge(sessionVariable.isEnableParallelMerge());
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2040,10 +2040,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private long groupConcatMaxLen = 1024;
 
     @VariableMgr.VarAttr(name = FULL_SORT_MAX_BUFFERED_ROWS, flag = VariableMgr.INVISIBLE)
-    private long fullSortMaxBufferedRows = 1024000;
+    private long fullSortMaxBufferedRows = 1 * 1024 * 1024 * 1024;
 
     @VariableMgr.VarAttr(name = FULL_SORT_MAX_BUFFERED_BYTES, flag = VariableMgr.INVISIBLE)
-    private long fullSortMaxBufferedBytes = 16L * 1024 * 1024;
+    private long fullSortMaxBufferedBytes = 256L * 1024 * 1024;
 
     @VariableMgr.VarAttr(name = FULL_SORT_LATE_MATERIALIZATION_V2, alias = FULL_SORT_LATE_MATERIALIZATION,
             show = FULL_SORT_LATE_MATERIALIZATION)


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The current MergeSort process consists of two main steps:
1. Partial Sort: Input chunks are accumulated into larger chunks and then sorted. These sorted chunks are referred to as `SortedRuns`.
2. Merge Sort: A cascading multi-way merge is performed on the `SortedRuns` to produce the final sorted result.

The size of a SortedRun is a critical parameter:
- Previous Misconception: It was assumed that smaller chunks would improve sorting performance because they fit into the CPU cache.
- Reality: While having too many SortedRuns does degrade merge performance due to increased memory copying and randomness, the assumption about small chunks being more efficient for sorting is incorrect. The FastSort algorithm is highly cache-friendly and accesses memory mostly sequentially. Therefore, limiting SortedRuns to a small size, such as 16MB, is unnecessary.

Changes Introduced:
- Adjusted the SortedRun size limits to: max_buffered_bytes = 256MB, max_buffered_rows = 1B


**Experiments**
```
select
  count(*)
from
  (
    select
      *
    from
      (
        select
          row_number() over (
            PARTITION BY 
            L_SHIPDATE,
            L_LINENUMBER,
            L_SHIPMODE
            ORDER BY
              L_QUANTITY,
              L_ORDERKEY
          ) c2
        from
          tpch_100g.lineitem
      ) r
    where
      c2 = 1
  ) cnt;  

```


| Version       | MaxRows  | MaxBytes    | Elapsed   | NumSortedRuns | RowsPerRun | MergeTime | SortTime  |
|---------------|----------|-------------|-----------|---------------|------------|-----------|-----------|
| opt           | 16097152 | 8777215000  | 25s252ms  | 48            | 12500449   | 6s3ms     | 7s837ms   |
| opt           | 8097152  | 8777215000  | 28s234ms  | 84            | 7143114    | 8s754ms   | 7s485ms   |
| opt           | 8097152  | 128486592   | 27s828ms  | 120           | 5000179    | 9s765ms   | 7s351ms   |
| opt           | 4097152  | 8777215000  | 27.452s   | 156           | 3846292    | 10s741ms  | 7s504ms   |
| opt           | 8097152  | 64486592    | 30s280ms  | 228           | 2631673    | 12s167ms  | 7s507ms   |
| opt           | 2097152  | 8777215000  | 29s633ms  | 291           | 2061929    | 13s291ms  | 7s650ms   |
| opt-default   | 2097152  | 37486592    | 32s989ms  | 390           | 1538516    | 14s555ms  | 7s595ms   |
| opt           | 1024001  | 16777215    | 34s884ms  | 861           | 696889     | 18s227ms  | 7s410ms   |
| opt           | 1024001  | 8777215     | 36s65ms   | 1639          | 366090     | 20s424ms  | 7s138ms   |


![image](https://github.com/user-attachments/assets/bd7346cd-169a-4ac1-84ef-5c55d57c38b8)



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0