### PR TITLE
[BugFix] Fix query error for delta lake with is null filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScalarOperationToDeltaLakeExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/ScalarOperationToDeltaLakeExpr.java
@@ -138,6 +138,10 @@ public class ScalarOperationToDeltaLakeExpr {
                 return null;
             }
             Column column = context.getColumn(columnName);
+            // For struct subfield, cannot get the column for now, just return null
+            if (column == null) {
+                return null;
+            }
 
             if (operator.isNotNull()) {
                 return new Predicate("IS_NOT_NULL", column);

--- a/test/sql/test_deltalake/R/test_deltalake_catalog
+++ b/test/sql/test_deltalake/R/test_deltalake_catalog
@@ -289,6 +289,21 @@ select col_tinyint,col_array,col_map,col_struct from delta_test_${uuid0}.delta_o
 4	[10,11,12]	{"key7":"value7","key8":"value8"}	{"name":"Diana","sex":"female","age":28}
 5	[13,14,15]	{"key9":"value9","key10":"value10"}	{"name":"Edward","sex":"male","age":40}
 -- !result
+select c_int,c_date from delta_test_${uuid0}.delta_oss_db.column_mapping_test where c_nest.c_struct_new.c_int is not null order by c_int nulls last, c_date nulls first;
+-- result:
+1	None
+1	2001-01-01
+2	2002-01-01
+3	2003-01-01
+5	2005-01-01
+None	2006-01-01
+-- !result
+select a.c_int, b.c_map, b.c_nest.c_struct, a.c_nest.c_array[6] from delta_test_${uuid0}.delta_oss_db.column_mapping_test a join delta_test_${uuid0}.delta_oss_db.column_mapping_test b on a.c_int = b.c_nest.c_struct_new.c_int order by 1;
+-- result:
+1	{1:{"c_date":"2001-01-03"}}	None	None
+1	{1:{"c_date":"2001-01-03"}}	None	None
+3	{33:{"c_date":"2003-01-02"}}	None	None
+-- !result
 drop catalog delta_test_${uuid0}
 -- result:
 -- !result

--- a/test/sql/test_deltalake/T/test_deltalake_catalog
+++ b/test/sql/test_deltalake/T/test_deltalake_catalog
@@ -84,4 +84,8 @@ select task_id, request_id, parent_request_id from delta_test_${uuid0}.delta_oss
 -- test shallow clone table
 select col_tinyint,col_array,col_map,col_struct from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type_shallow_clone where col_tinyint < 6 order by col_tinyint;
 
+-- test struct subfield is null
+select c_int,c_date from delta_test_${uuid0}.delta_oss_db.column_mapping_test where c_nest.c_struct_new.c_int is not null order by c_int nulls last, c_date nulls first;
+select a.c_int, b.c_map, b.c_nest.c_struct, a.c_nest.c_array[6] from delta_test_${uuid0}.delta_oss_db.column_mapping_test a join delta_test_${uuid0}.delta_oss_db.column_mapping_test b on a.c_int = b.c_nest.c_struct_new.c_int order by 1;
+
 drop catalog delta_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:
when query delta lake with struct subfileld is null filter, will throw unknown error
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0