### PR TITLE
[Enhancement] Improve file sample in files() schema detection

### DIFF
--- a/be/src/exec/file_scanner.h
+++ b/be/src/exec/file_scanner.h
@@ -87,6 +87,9 @@ protected:
     // chunk depicted by dest_slot_descriptors
     StatusOr<ChunkPtr> materialize(const starrocks::ChunkPtr& src, starrocks::ChunkPtr& cast);
 
+    static void sample_files(size_t total_file_count, int64_t sample_file_count,
+                             std::vector<size_t>* sample_file_indexes);
+
 protected:
     RuntimeState* _state;
     RuntimeProfile* _profile;

--- a/be/test/exec/file_scanner_test.cpp
+++ b/be/test/exec/file_scanner_test.cpp
@@ -61,9 +61,9 @@ TEST_F(FileScannerTest, sample_schema) {
                 {"col1", TypeDescriptor::from_logical_type(TYPE_BIGINT)}};
 
         RuntimeState state(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr);
-        auto scan_range = create_scan_range({test_exec_dir + "/test_data/parquet_data/schema1.parquet",
+        auto scan_range = create_scan_range({test_exec_dir + "/test_data/parquet_data/schema3.parquet",
                                              test_exec_dir + "/test_data/parquet_data/schema2.parquet",
-                                             test_exec_dir + "/test_data/parquet_data/schema3.parquet"});
+                                             test_exec_dir + "/test_data/parquet_data/schema1.parquet"});
 
         scan_range.params.__set_schema_sample_file_count(1);
 
@@ -159,7 +159,7 @@ TEST_F(FileScannerTest, sample_schema) {
     }
 
     {
-        // sample 1 file.
+        // sample 2 file.
         // file1: col1,int64
         // file4: col1,int64; COL1,int64
         // result: duplicated column name
@@ -173,6 +173,72 @@ TEST_F(FileScannerTest, sample_schema) {
         auto st = FileScanner::sample_schema(&state, scan_range, &schema);
         //Identical names in upper/lower cases, files: [/work/starrocks-main/be/test/exec/test_data/parquet_data/schema4.parquet] [/work/starrocks-main/be/test/exec/test_data/parquet_data/schema1.parquet], names: [COL1] [col1]"
         EXPECT_TRUE(st.is_not_supported());
+    }
+}
+
+TEST_F(FileScannerTest, select_sample_files) {
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(1, 0, &sample_file_indexes);
+        ASSERT_TRUE(sample_file_indexes.empty());
+        FileScanner::sample_files(0, 1, &sample_file_indexes);
+        ASSERT_TRUE(sample_file_indexes.empty());
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(10, 1, &sample_file_indexes);
+        std::vector<size_t> expect = {9};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(1, 10, &sample_file_indexes);
+        std::vector<size_t> expect = {0};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(10, 2, &sample_file_indexes);
+        std::vector<size_t> expect = {0, 9};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(10, 3, &sample_file_indexes);
+        std::vector<size_t> expect = {0, 5, 9};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(10, 4, &sample_file_indexes);
+        std::vector<size_t> expect = {0, 3, 6, 9};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(10, 5, &sample_file_indexes);
+        std::vector<size_t> expect = {0, 2, 5, 7, 9};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(10, 6, &sample_file_indexes);
+        std::vector<size_t> expect = {0, 2, 4, 5, 7, 9};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(10, 10, &sample_file_indexes);
+        std::vector<size_t> expect = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        ASSERT_EQ(expect, sample_file_indexes);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -98,7 +98,7 @@ public class TableFunctionTable extends Table {
             .column("MODIFICATION_TIME", Type.DATETIME)
             .build();
 
-    private static final int DEFAULT_AUTO_DETECT_SAMPLE_FILES = 1;
+    private static final int DEFAULT_AUTO_DETECT_SAMPLE_FILES = 2;
     private static final int DEFAULT_AUTO_DETECT_SAMPLE_ROWS = 500;
 
     private static final Logger LOG = LogManager.getLogger(TableFunctionTable.class);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. change `auto_detect_sample_files` default value to 2
2. improve file sample
select the last file if sample only 1 file or total only 1 file, because the last file may be the newest file.
select the first file, the last file, and some middle files with fixed step.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0