### PR TITLE
[Enhancement] Limit memory used by ParallelIterable in Iceberg

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -41,7 +41,7 @@ under the License.
         <starrocks.home>${basedir}/../../</starrocks.home>
         <fe_ut_parallel>${env.FE_UT_PARALLEL}</fe_ut_parallel>
         <jacoco.version>0.8.8</jacoco.version>
-        <iceberg.version>1.6.0</iceberg.version>
+        <iceberg.version>1.6.1</iceberg.version>
         <paimon.version>0.8.2</paimon.version>
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>
         <staros.version>3.4-rc2</staros.version>


### PR DESCRIPTION
## Why I'm doing:
The ConcurrentLinkedQueue doesn't have a size limitation in Iceberg 1.6.0.  When the iceberg table is large, the queue will also become really large, which will cause OOM in the FE. 

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/f558d10c-51e9-4019-8599-566c93490aff" />

As per the above screenshot, the ConcurrentLinkedQueue is consuming 91%+ of the heap memory and causing the Frontend (FE) to go down, this indicates a significant memory management issue due to unbounded growth of the queue.

This issue was resolved with Iceberg 1.6.1([#10691](https://github.com/apache/iceberg/pull/10691))
## What I'm doing:
as title

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0