### PR TITLE
[BugFix] Fix possble task run state incosistent in leader/follwer FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
@@ -95,6 +95,9 @@ public class LoadJobMVListener implements LoadJobListener {
      * @throws MetaNotFoundException
      */
     private void triggerToRefreshRelatedMVs(TransactionState transactionState, boolean isTriggerIfBaseTableIsMV) {
+        if (!GlobalStateMgr.getCurrentState().isLeader()) {
+            return;
+        }
         // Refresh materialized view when base table update transaction has been visible
         long dbId = transactionState.getDbId();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
@@ -133,6 +136,9 @@ public class LoadJobMVListener implements LoadJobListener {
      * @throws MetaNotFoundException
      */
     private void doTriggerToRefreshRelatedMVs(Database db, Table table) throws DdlException, MetaNotFoundException {
+        if (!GlobalStateMgr.getCurrentState().isLeader()) {
+            return;
+        }
         if (table == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -702,11 +702,10 @@ public class TaskManager implements MemoryTrackable {
                         .newBuilder(task)
                         .setExecuteOption(executeOption)
                         .build();
-
                 // TODO: To avoid the same query id collision, use a new query id instead of an old query id
                 taskRun.initStatus(status.getQueryId(), status.getCreateTime());
-                if (!taskRunManager.arrangeTaskRun(taskRun, true)) {
-                    LOG.warn("Submit task run to pending queue failed, reject the submit:{}", taskRun);
+                if (!taskRunScheduler.addPendingTaskRun(taskRun)) {
+                    LOG.warn("Submit task run to pending queue failed in follower, reject the submit:{}", taskRun);
                 }
                 break;
             // this will happen in build image
@@ -717,6 +716,7 @@ public class TaskManager implements MemoryTrackable {
             case FAILED:
                 taskRunManager.getTaskRunHistory().addHistory(status);
                 break;
+            case MERGED:
             case SUCCESS:
                 status.setProgress(100);
                 taskRunManager.getTaskRunHistory().addHistory(status);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Fix possble task run state incosistent in leader/follwer FE:
1. LoadJobMVListener should not be triggered in Follower which is ensured not to schedule but it may generated some duplicated task runs.
2. use taskRunScheduler.addPendingTaskRun directly instead of taskRunScheduler.addPendingTaskRun in replay policy.

Backport from: https://github.com/StarRocks/starrocks/pull/54236


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0