### PR TITLE
[Refactor] make in-memory PK index deprecated when create table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3043,12 +3043,6 @@ public class Config extends ConfigBase {
     public static int max_download_task_per_be = 0;
 
     /*
-     * Using persistent index in primary key table by default when creating table.
-     */
-    @ConfField(mutable = true)
-    public static boolean enable_persistent_index_by_default = true;
-
-    /*
      * Using cloud native persistent index in primary key table by default when creating table.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -928,10 +928,7 @@ public class PropertyAnalyzer {
             properties.remove(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX);
             return Pair.create(Boolean.parseBoolean(val), true);
         } else {
-            if (isPrimaryKey) {
-                return Pair.create(Config.enable_persistent_index_by_default, false);
-            }
-            return Pair.create(false, false);
+            return Pair.create(true, false);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -341,11 +341,11 @@ public class OlapTableFactory implements AbstractTableFactory {
             Pair<Boolean, Boolean> analyzeRet = PropertyAnalyzer.analyzeEnablePersistentIndex(properties,
                     table.getKeysType() == KeysType.PRIMARY_KEYS);
             boolean enablePersistentIndex = analyzeRet.first;
-            if (!enablePersistentIndex) {
+            if (!enablePersistentIndex && table.getKeysType() == KeysType.PRIMARY_KEYS) {
                 throw new DdlException("The in-memory PK index has been deprecated. "
                         + "Please set property enable_persistent_index to true.");
             }
-            if (table.isCloudNativeTable()) {
+            if (table.isCloudNativeTable() && table.getKeysType() == KeysType.PRIMARY_KEYS) {
                 TPersistentIndexType persistentIndexType;
                 try {
                     persistentIndexType = PropertyAnalyzer.analyzePersistentIndexType(properties);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -82,7 +82,7 @@ public class LakeTableAlterMetaJobTest {
 
         table = createTable(connectContext,
                     "CREATE TABLE t0(c0 INT) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
-                                "PROPERTIES('enable_persistent_index'='false')");
+                                "PROPERTIES('enable_persistent_index'='true')");
         Assert.assertFalse(table.enablePersistentIndex());
         job = new LakeTableAlterMetaJob(GlobalStateMgr.getCurrentState().getNextId(), db.getId(), table.getId(),
                     table.getName(), 60 * 1000, TTabletMetaType.ENABLE_PERSISTENT_INDEX, true, "CLOUD_NATIVE");

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -239,14 +239,11 @@ public class PropertyAnalyzerTest {
         Assert.assertEquals(false, ret.first);
         Assert.assertEquals(true, ret.second);
 
-        // change config
-        Config.enable_persistent_index_by_default = false;
-
         // empty property
         Map<String, String> property4 = new HashMap<>();
         ret = PropertyAnalyzer.analyzeEnablePersistentIndex(property4, true);
-        Assert.assertEquals(false, ret.first);
-        Assert.assertEquals(false, ret.second);
+        Assert.assertEquals(true, ret.first);
+        Assert.assertEquals(true, ret.second);
         // with property
         Map<String, String> property5 = new HashMap<>();
         property5.put(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, "true");
@@ -259,13 +256,12 @@ public class PropertyAnalyzerTest {
         ret = PropertyAnalyzer.analyzeEnablePersistentIndex(property6, true);
         Assert.assertEquals(false, ret.first);
         Assert.assertEquals(true, ret.second);
-        Config.enable_persistent_index_by_default = true;
 
         // non primary key
         Map<String, String> property7 = new HashMap<>();
         ret = PropertyAnalyzer.analyzeEnablePersistentIndex(property7, false);
-        Assert.assertEquals(false, ret.first);
-        Assert.assertEquals(false, ret.second);
+        Assert.assertEquals(true, ret.first);
+        Assert.assertEquals(true, ret.second);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
After 3.3, we already support cloud native PK index, there is no reason to maintain in-memory PK index any more. And in-memory index will cause OOM issue which is uncontrollable.

## What I'm doing:
Make in-memory PK index deprecated when create new table

Changes to persistent index handling:

* [`fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java`](diffhunk://#diff-b0209c12a04a4b700190e7d3048526b6c15a75a7fc7fdd3ecf3ef9422fe259c9L344-R348): Modified the `createTable` method to throw a `DdlException` if the `enable_persistent_index` property is not set to true, as the in-memory PK index has been deprecated.
* [`fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java`](diffhunk://#diff-b0209c12a04a4b700190e7d3048526b6c15a75a7fc7fdd3ecf3ef9422fe259c9L361-L372): Updated the error message to instruct users to use the CloudNative persistent index when a ComputeNode lacks a storage path.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0