### PR TITLE
[BugFix] Fix wrong use of ErrorCode.ERR_WRONG_OBJECT (#54234)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -70,7 +70,7 @@ public class CreateFunctionAnalyzer {
         } else if (CreateFunctionStmt.TYPE_STARROCKS_PYTHON.equalsIgnoreCase(langType)) {
             analyzePython(stmt);
         } else {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_OBJECT, "unknown lang type");
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "unknown lang type");
         }
         // build function
     }
@@ -155,14 +155,14 @@ public class CreateFunctionAnalyzer {
                 }
 
             } catch (IOException e) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_OBJECT,
-                        "Failed to load object_file: " + objectFile, e);
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Failed to load object_file: " + objectFile);
             } catch (ClassNotFoundException e) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_OBJECT,
-                        "Class '" + className + "' not found in object_file :" + objectFile, e);
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Class '" + className + "' not found in object_file :" + objectFile);
             } catch (Exception e) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_OBJECT,
-                        "other exception when load class. exception:", e);
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "other exception when load class. exception:" + e.getClass().getCanonicalName());
             }
         } finally {
             System.setSecurityManager(null);
@@ -524,11 +524,11 @@ public class CreateFunctionAnalyzer {
         String objectFile = stmt.getProperties().get(CreateFunctionStmt.FILE_KEY);
 
         if (isInline && !StringUtils.equals(objectFile, "inline")) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_OBJECT, "inline function file should be 'inline'");
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "inline function file should be 'inline'");
         }
 
         if (!inputType.equalsIgnoreCase("arrow") && !inputType.equalsIgnoreCase("scalar")) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_WRONG_OBJECT, "unknown input type:", inputType);
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "unknown input type:" + inputType);
         }
 
         FunctionName functionName = stmt.getFunctionName();


### PR DESCRIPTION
## Why I'm doing:

Fix wrong use of ErrorCode.ERR_WRONG_OBJECT, when I create function with wrong class name, I got an error message:
```
ERROR 1347 (HY000): Getting analyzing error. Detail message: '%s'.'%s' is not '%s'.
```
I expected to get a message:
```
ERROR 1347 (HY000): Getting analyzing error. Detail message: Class 'Identity' not found in object_file :file:///root/starrocks/udf.jar.
```

## What I'm doing:

Fix wrong use of ErrorCode.ERR_WRONG_OBJECT

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0