### PR TITLE
[Enhancement] use cloud native persistent index by default in all scenarios (backport #52209)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3000,7 +3000,7 @@ public class Config extends ConfigBase {
      * Using cloud native persistent index in primary key table by default when creating table.
      */
     @ConfField(mutable = true)
-    public static boolean enable_cloud_native_persistent_index_by_default = false;
+    public static boolean enable_cloud_native_persistent_index_by_default = true;
 
     /**
      * timeout for external table commit

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1310,15 +1310,6 @@ public class GlobalStateMgr {
                                         LiteralExpr.create("true", Type.BOOLEAN)),
                             false);
             }
-            if (nodeMgr.isFirstTimeStartUp()) {
-                // When the cluster is initially deployed, we use cloud native persistent index by default
-                variableMgr.setSystemVariable(variableMgr.getDefaultSessionVariable(), new SystemVariable(SetType.GLOBAL,
-                                        SessionVariable.ENABLE_CLOUD_NATIVE_PERSISTENT_INDEX_BY_DEFAULT,
-                                        LiteralExpr.create("true", Type.BOOLEAN)),
-                        false);
-            }
-            Config.enable_cloud_native_persistent_index_by_default = variableMgr.getDefaultSessionVariable()
-                    .getEnableCloudNativePersistentIndexByDefault();
         } catch (UserException e) {
             LOG.warn("Failed to set ENABLE_ADAPTIVE_SINK_DOP", e);
         } catch (Throwable t) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -292,7 +292,7 @@ public class PropertyAnalyzerTest {
     public void testPersistentIndexType() throws AnalysisException {
         // empty property
         Map<String, String> property = new HashMap<>();
-        Assert.assertEquals(TPersistentIndexType.LOCAL, PropertyAnalyzer.analyzePersistentIndexType(property));
+        Assert.assertEquals(TPersistentIndexType.CLOUD_NATIVE, PropertyAnalyzer.analyzePersistentIndexType(property));
 
         Map<String, String> property2 = new HashMap<>();
         property2.put(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, "LOCAL");


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
When create PK table in shared-data mode, and user doesn't use specific persistent_index_type, then use CLOUD_NATIVE persistent index as default index type.

Backport #52209

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
