### PR TITLE
[Doc] Added missing _ and clarifications

### DIFF
--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
@@ -937,7 +937,7 @@ select * from small_table where tiny_column in (1,2);
 
 #### Like Operator
 
-This operator is used to compare to a string. ''matches a single character,'%' matches multiple characters. The parameter must match the complete string. Typically, placing'%'at the end of a string is more practical.
+This operator is used to compare to a string. '_' (underscore) matches a single character, '%' matches multiple characters. The parameter must match the complete string. Typically, placing'%'at the end of a string is more practical.
 
 Examples:
 


### PR DESCRIPTION
A simple fix to the documentation.
LIKE operator takes an _ or %. The _ was missing in the documentation. The documentation accidentally showed '' instead of '_'. 

## What I'm doing:
I'm adding the _ and a clarifying word (underscore).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0