### PR TITLE
[BugFix] Fix Create automic partitions with case insensitive bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -123,6 +123,8 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.statistic.StatsConstants;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -147,6 +149,7 @@ import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
 import static com.starrocks.statistic.StatsConstants.STATISTICS_DB_NAME;
 
 public class AnalyzerUtils {
+    private static final Logger LOG = LogManager.getLogger(AnalyzerUtils.class);
 
     // The partition format supported by date_trunc
     public static final Set<String> DATE_TRUNC_SUPPORTED_PARTITION_FORMAT =
@@ -1426,7 +1429,7 @@ public class AnalyzerUtils {
                         // change partition name, how to generate a unique partition name
                         partitionName = calculateUniquePartitionName(partitionName, tablePartitions);
                         if (tablePartitions.containsKey(partitionName)) {
-                            throw new AnalysisException("partition name " + partitionName + " already exists.");
+                            LOG.warn("partition name " + partitionName + " already exists.");
                         }
                     }
                     MultiItemListPartitionDesc multiItemListPartitionDesc = new MultiItemListPartitionDesc(true,
@@ -1461,10 +1464,7 @@ public class AnalyzerUtils {
             int i = 0;
             do {
                 newPartitionName = partitionName + "_" + Integer.toHexString(diff + (i++));
-                if (i > 100) {
-                    break;
-                }
-            } while (tablePartitions.containsKey(newPartitionName));
+            } while (tablePartitions.containsKey(newPartitionName) && i < 100);
         }
         return newPartitionName;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -28,9 +28,9 @@ import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 
 public class AnalyzeTestUtil {
-    private static ConnectContext connectContext;
-    private static StarRocksAssert starRocksAssert;
-    private static String DB_NAME = "test";
+    protected static ConnectContext connectContext;
+    protected static StarRocksAssert starRocksAssert;
+    protected static String DB_NAME = "test";
 
     public static void init() throws Exception {
         Config.enable_experimental_rowstore = true;
@@ -314,6 +314,17 @@ public class AnalyzeTestUtil {
                 "PROPERTIES (\n" +
                 "\"replication_num\" = \"1\",\n" +
                 "\"storage_type\" = \"column_with_row\"" +
+                ");");
+        starRocksAssert.withTable("CREATE TABLE test.auto_tbl1 (\n" +
+                "  col1 varchar(100),\n" +
+                "  col2 varchar(100),\n" +
+                "  col3 bigint\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY (col1)\n" +
+                "PARTITION BY (col1)\n" +
+                "DISTRIBUTED BY HASH(col1) BUCKETS 5\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
                 ");");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUtilTest.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.UtFrameUtils;
+import org.apache.hadoop.util.Sets;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -420,7 +421,7 @@ public class AnalyzeUtilTest {
     @Test
     public void testCalculateStringDiff() throws Exception {
         OlapTable t1 = (OlapTable) starRocksAssert.getTable(DB_NAME, "auto_tbl1");
-        List<String> combinations = generateCaseCombinations("abc_def?ghi|g.com");
+        List<String> combinations = generateCaseCombinations("aac_def?gHi|Gx.com");
         List<List<String>> partitionValues = combinations.stream()
                 .map(s -> Lists.newArrayList(s))
                 .collect(Collectors.toList());
@@ -457,6 +458,18 @@ public class AnalyzeUtilTest {
             for (PartitionDesc desc : descs) {
                 Assert.assertTrue(partitionNames.get(desc.getPartitionName()) != null);
             }
+        }
+    }
+
+    @Test
+    public void testIntToHexString() {
+        int j = Integer.MAX_VALUE - 50;
+        Set<String> values = Sets.newTreeSet();
+        for (int i = 0; i < 100; i++) {
+            j += 1;
+            String v = Integer.toHexString(j);
+            Assert.assertTrue(!values.contains(v));
+            values.add(v);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeUtilTest.java
@@ -16,13 +16,19 @@
 package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.CreateViewStmt;
+import com.starrocks.sql.ast.ListPartitionDesc;
+import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.UtFrameUtils;
@@ -33,8 +39,11 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.DB_NAME;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.starRocksAssert;
 
 public class AnalyzeUtilTest {
     @BeforeClass
@@ -406,6 +415,76 @@ public class AnalyzeUtilTest {
             Pair<Boolean, String> result = AnalyzerUtils.containsNonDeterministicFunction(statementBase);
             Assert.assertEquals(true, result.first);
             Assert.assertTrue(!Strings.isNullOrEmpty(result.second));
+        }
+    }
+    @Test
+    public void testCalculateStringDiff() throws Exception {
+        OlapTable t1 = (OlapTable) starRocksAssert.getTable(DB_NAME, "auto_tbl1");
+        List<String> combinations = generateCaseCombinations("abc_def?ghi|g.com");
+        List<List<String>> partitionValues = combinations.stream()
+                .map(s -> Lists.newArrayList(s))
+                .collect(Collectors.toList());
+        Map<String, PartitionDesc> partitionNames = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        {
+            AddPartitionClause addPartitionClauses =
+                    AnalyzerUtils.getAddPartitionClauseFromPartitionValues(t1, partitionValues, false, "");
+            ListPartitionDesc listPartitionDesc = (ListPartitionDesc) addPartitionClauses.getPartitionDesc();
+            List<PartitionDesc> descs = listPartitionDesc.getPartitionDescs();
+            Assert.assertEquals(combinations.size(), descs.size());
+            for (PartitionDesc desc : descs) {
+                Assert.assertTrue(partitionNames.get(desc.getPartitionName()) == null);
+                partitionNames.put(desc.getPartitionName(), desc);
+            }
+        }
+
+        {
+            AddPartitionClause addPartitionClauses =
+                    AnalyzerUtils.getAddPartitionClauseFromPartitionValues(t1, partitionValues, false, "");
+            ListPartitionDesc listPartitionDesc = (ListPartitionDesc) addPartitionClauses.getPartitionDesc();
+            List<PartitionDesc> descs = listPartitionDesc.getPartitionDescs();
+            Assert.assertEquals(combinations.size(), descs.size());
+            for (PartitionDesc desc : descs) {
+                Assert.assertTrue(partitionNames.get(desc.getPartitionName()) != null);
+            }
+        }
+
+        {
+            AddPartitionClause addPartitionClauses =
+                    AnalyzerUtils.getAddPartitionClauseFromPartitionValues(t1, partitionValues, false, "");
+            ListPartitionDesc listPartitionDesc = (ListPartitionDesc) addPartitionClauses.getPartitionDesc();
+            List<PartitionDesc> descs = listPartitionDesc.getPartitionDescs();
+            Assert.assertEquals(combinations.size(), descs.size());
+            for (PartitionDesc desc : descs) {
+                Assert.assertTrue(partitionNames.get(desc.getPartitionName()) != null);
+            }
+        }
+    }
+
+    public static List<String> generateCaseCombinations(String input) {
+        List<String> results = Lists.newArrayList();
+        generateHelper(input.toCharArray(), 0, results);
+        return results;
+    }
+
+    private static void generateHelper(char[] chars, int index, List<String> results) {
+        if (index == chars.length) {
+            // Add the current combination to the results
+            results.add(new String(chars));
+            return;
+        }
+
+        // If the current character is alphabetic, generate both lowercase and uppercase
+        if (Character.isLetter(chars[index])) {
+            // Recurse with the lowercase version
+            chars[index] = Character.toLowerCase(chars[index]);
+            generateHelper(chars, index + 1, results);
+
+            // Recurse with the uppercase version
+            chars[index] = Character.toUpperCase(chars[index]);
+            generateHelper(chars, index + 1, results);
+        } else {
+            // If not alphabetic, just continue to the next character
+            generateHelper(chars, index + 1, results);
         }
     }
 }

--- a/test/sql/test_automatic_bucket/R/test_automatic_partition_with_case_names
+++ b/test/sql/test_automatic_bucket/R/test_automatic_partition_with_case_names
@@ -19,15 +19,40 @@ ORDER BY (col2);
 insert into t1 values ('a.com', 'val1', 100), ('A.com', 'val1', 200), ('A.Com', 'val1', 300);
 -- result:
 -- !result
+insert into t1 values ('a.com', 'val1', 100), ('A.com', 'val1', 200), ('A.Com', 'val1', 300);
+-- result:
+-- !result
+insert into t1 values ('a.cOm', 'val1', 100), ('A.coM', 'val1', 200), ('A.COm', 'val1', 300);
+-- result:
+-- !result
+insert into t1 values ('a.cOM', 'val1', 100), ('A.COM', 'val1', 200), ('a.COM', 'val1', 300);
+-- result:
+-- !result
+insert into t1 values ('a.com', 'val1', 100), ('A.com', 'val1', 200), ('A.Com', 'val1', 300);
+-- result:
+-- !result
+insert into t1 values ('a.cOm', 'val1', 100), ('A.coM', 'val1', 200), ('A.COm', 'val1', 300);
+-- result:
+-- !result
+insert into t1 values ('b.cOm', 'val1', 100), ('A.coM', 'val1', 200), ('A.COm', 'val1', 300);
+-- result:
+-- !result
 SELECT count(1) FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't1' ;
 -- result:
-4
+11
 -- !result
 select * from t1 order by col1, col2, col3;
 -- result:
+A.COM	val1	200
+A.COm	val1	300
 A.Com	val1	300
+A.coM	val1	200
 A.com	val1	200
+a.COM	val1	300
+a.cOM	val1	100
+a.cOm	val1	100
 a.com	val1	100
+b.cOm	val1	100
 -- !result
 select * from t1 where col1 = 'a.com' order by col1, col2, col3;
 -- result:
@@ -55,9 +80,16 @@ AS SELECT col1, sum(col3) from t1 group by col1;
 refresh materialized view test_async_mv with sync mode;
 select * from test_async_mv order by col1;
 -- result:
+A.COM	200
+A.COm	300
 A.Com	300
+A.coM	200
 A.com	200
+a.COM	300
+a.cOM	100
+a.cOm	100
 a.com	100
+b.cOm	100
 -- !result
 select * from test_async_mv where col1 = 'a.com' order by col1;
 -- result:

--- a/test/sql/test_automatic_bucket/R/test_automatic_partition_with_case_names
+++ b/test/sql/test_automatic_bucket/R/test_automatic_partition_with_case_names
@@ -1,0 +1,72 @@
+-- name: test_automatic_partition_with_case_names
+create database test_db_${uuid0};
+-- result:
+-- !result
+use test_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  col1 varchar(100),
+  col2 varchar(100),
+  col3 bigint
+) ENGINE=OLAP
+PRIMARY KEY (col1)
+PARTITION BY (col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 5
+ORDER BY (col2);
+-- result:
+-- !result
+insert into t1 values ('a.com', 'val1', 100), ('A.com', 'val1', 200), ('A.Com', 'val1', 300);
+-- result:
+-- !result
+SELECT count(1) FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't1' ;
+-- result:
+4
+-- !result
+select * from t1 order by col1, col2, col3;
+-- result:
+A.Com	val1	300
+A.com	val1	200
+a.com	val1	100
+-- !result
+select * from t1 where col1 = 'a.com' order by col1, col2, col3;
+-- result:
+a.com	val1	100
+-- !result
+select * from t1 where col1 = 'A.com' order by col1, col2, col3;
+-- result:
+A.com	val1	200
+-- !result
+select * from t1 where col1 in ('A.com', 'a.com') order by col1, col2, col3;
+-- result:
+A.com	val1	200
+a.com	val1	100
+-- !result
+CREATE MATERIALIZED VIEW `test_async_mv`
+PARTITION BY (col1)
+DISTRIBUTED BY HASH(col1)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "query_rewrite_consistency" = "LOOSE"
+)
+AS SELECT col1, sum(col3) from t1 group by col1;
+-- result:
+-- !result
+refresh materialized view test_async_mv with sync mode;
+select * from test_async_mv order by col1;
+-- result:
+A.Com	300
+A.com	200
+a.com	100
+-- !result
+select * from test_async_mv where col1 = 'a.com' order by col1;
+-- result:
+a.com	100
+-- !result
+select * from test_async_mv where col1 = 'A.com' order by col1;
+-- result:
+A.com	200
+-- !result
+drop database test_db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_automatic_bucket/T/test_automatic_partition_with_case_names
+++ b/test/sql/test_automatic_bucket/T/test_automatic_partition_with_case_names
@@ -14,6 +14,12 @@ ORDER BY (col2);
 
 -- insert partition name with different case
 insert into t1 values ('a.com', 'val1', 100), ('A.com', 'val1', 200), ('A.Com', 'val1', 300);
+insert into t1 values ('a.com', 'val1', 100), ('A.com', 'val1', 200), ('A.Com', 'val1', 300);
+insert into t1 values ('a.cOm', 'val1', 100), ('A.coM', 'val1', 200), ('A.COm', 'val1', 300);
+insert into t1 values ('a.cOM', 'val1', 100), ('A.COM', 'val1', 200), ('a.COM', 'val1', 300);
+insert into t1 values ('a.com', 'val1', 100), ('A.com', 'val1', 200), ('A.Com', 'val1', 300);
+insert into t1 values ('a.cOm', 'val1', 100), ('A.coM', 'val1', 200), ('A.COm', 'val1', 300);
+insert into t1 values ('b.cOm', 'val1', 100), ('A.coM', 'val1', 200), ('A.COm', 'val1', 300);
 
 SELECT count(1) FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't1' ;
 

--- a/test/sql/test_automatic_bucket/T/test_automatic_partition_with_case_names
+++ b/test/sql/test_automatic_bucket/T/test_automatic_partition_with_case_names
@@ -1,0 +1,39 @@
+-- name: test_automatic_partition_with_case_names
+create database test_db_${uuid0};
+use test_db_${uuid0};
+
+CREATE TABLE `t1` (
+  col1 varchar(100),
+  col2 varchar(100),
+  col3 bigint
+) ENGINE=OLAP
+PRIMARY KEY (col1)
+PARTITION BY (col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 5
+ORDER BY (col2);
+
+-- insert partition name with different case
+insert into t1 values ('a.com', 'val1', 100), ('A.com', 'val1', 200), ('A.Com', 'val1', 300);
+
+SELECT count(1) FROM information_schema.partitions_meta WHERE DB_NAME='test_db_${uuid0}' AND table_name = 't1' ;
+
+select * from t1 order by col1, col2, col3;
+select * from t1 where col1 = 'a.com' order by col1, col2, col3;
+select * from t1 where col1 = 'A.com' order by col1, col2, col3;
+select * from t1 where col1 in ('A.com', 'a.com') order by col1, col2, col3;
+
+CREATE MATERIALIZED VIEW `test_async_mv`
+PARTITION BY (col1)
+DISTRIBUTED BY HASH(col1)
+REFRESH DEFERRED MANUAL
+PROPERTIES (
+  "query_rewrite_consistency" = "LOOSE"
+)
+AS SELECT col1, sum(col3) from t1 group by col1;
+refresh materialized view test_async_mv with sync mode;
+
+select * from test_async_mv order by col1;
+select * from test_async_mv where col1 = 'a.com' order by col1;
+select * from test_async_mv where col1 = 'A.com' order by col1;
+
+drop database test_db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

```
CREATE TABLE `test_base_tbl` (
  col1 varchar(100),
  col2 varchar(100),
  col3 bigint
) ENGINE=OLAP
PRIMARY KEY (col1)
PARTITION BY (col1)
DISTRIBUTED BY HASH(col1) BUCKETS 5
ORDER BY (col2)
PROPERTIES (
  "persistent_index_type" = "CLOUD_NATIVE"
);

mysql> insert into test_base_tbl values
    -> ('a.com', 'val1', 100),
    -> ('A.com', 'val1', 200),
    -> ('A.Com', 'val1', 300);
ERROR 1064 (HY000): Insert has filtered data, txn_id = 19015, tracking sql = select tracking_log from information_schema.load_tracking_logs where job_id=30034
mysql> select tracking_log from information_schema.load_tracking_logs where job_id=30034
    -> ;
+------------------------------------------------------------------------------------------------------+
| tracking_log                                                                                         |
+------------------------------------------------------------------------------------------------------+
| Error: The row is out of partition ranges. Please add a new partition.. Row: ['A.com', 'val1', 200]
 |
+------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)

mysql> show partitions from test_base_tbl;
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+-------------+-----------------+---------+----------------+---------------+---------------------+--------------------------+----------+------------+----------+-------------+--------------------+----------------+
| PartitionId | PartitionName | VisibleVersion | VisibleVersionTime  | VisibleVersionHash | State  | PartitionKey | List        | DistributionKey | Buckets | ReplicationNum | StorageMedium | CooldownTime        | LastConsistencyCheckTime | DataSize | IsInMemory | RowCount | DataVersion | VersionEpoch       | VersionTxnType |
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+-------------+-----------------+---------+----------------+---------------+---------------------+--------------------------+----------+------------+----------+-------------+--------------------+----------------+
| 30036       | pa2ecom       | 1              | 2024-12-24 13:38:57 | 0                  | NORMAL | col1         | [["a.com"]] | col1            | 5       | 1              | HDD           | 9999-12-31 23:59:59 | NULL                     | 0B       | false      | 0        | 1           | 329634415550398464 | TXN_NORMAL     |
| 30060       | pA2eCom       | 1              | 2024-12-24 13:38:57 | 0                  | NORMAL | col1         | [["A.Com"]] | col1            | 5       | 1              | HDD           | 9999-12-31 23:59:59 | NULL                     | 0B       | false      | 0        | 1           | 329634415550398466 | TXN_NORMAL     |
| 30048       | pA2ecom       | 1              | 2024-12-24 13:38:57 | 0                  | NORMAL | col1         | [["A.com"]] | col1            | 5       | 1              | HDD           | 9999-12-31 23:59:59 | NULL                     | 0B       | false      | 0        | 1           | 329634415550398465 | TXN_NORMAL     |
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+-------------+-----------------+---------+----------------+---------------+---------------------+--------------------------+----------+------------+----------+-------------+--------------------+----------------+
3 rows in set (0.01 sec)
```
## What I'm doing:
- our partition names in FE's metadata are always case-insensitive, but automatic partitions in be will create case-sensitive partitions.


Fixes https://github.com/StarRocks/starrocks/issues/54202

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0