### PR TITLE
[Enhancement] Remove csv scanner error report when use flexible column mapping

### DIFF
--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -382,7 +382,6 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
 
         SCOPED_RAW_TIMER(&_counter->fill_ns);
         bool has_error = false;
-        bool error_reported = false;
         for (int j = 0, k = 0; j < _num_fields_in_csv; j++) {
             auto slot = _src_slot_descriptors[j];
             if (slot == nullptr) {
@@ -391,24 +390,8 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
 
             if (j >= row.columns.size()) {
                 // table columns are more than file fields
-
                 // append null.
                 _column_raw_ptrs[k]->append_default(1);
-
-                // report error.
-                if (_strict_mode && !error_reported) {
-                    if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
-                        std::string error_msg = make_column_count_not_matched_error_message(
-                                _num_fields_in_csv, row.columns.size(), _parse_options);
-                        _report_error(record, error_msg);
-                    }
-                    if (_state->enable_log_rejected_record()) {
-                        std::string error_msg = make_column_count_not_matched_error_message(
-                                _num_fields_in_csv, row.columns.size(), _parse_options);
-                        _report_rejected_record(record, error_msg);
-                    }
-                    error_reported = true;
-                }
                 k++;
                 continue;
             }
@@ -500,7 +483,6 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
 
         SCOPED_RAW_TIMER(&_counter->fill_ns);
         bool has_error = false;
-        bool error_reported = false;
         for (int j = 0, k = 0; j < _num_fields_in_csv; j++) {
             auto slot = _src_slot_descriptors[j];
             if (slot == nullptr) {
@@ -509,24 +491,8 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
 
             if (j >= fields.size()) {
                 // table columns are more than file fields
-
                 // append null.
                 _column_raw_ptrs[k]->append_default(1);
-
-                // report error.
-                if (_strict_mode && !error_reported) {
-                    if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
-                        std::string error_msg = make_column_count_not_matched_error_message(
-                                _num_fields_in_csv, fields.size(), _parse_options);
-                        _report_error(record, error_msg);
-                    }
-                    if (_state->enable_log_rejected_record()) {
-                        std::string error_msg = make_column_count_not_matched_error_message(
-                                _num_fields_in_csv, fields.size(), _parse_options);
-                        _report_rejected_record(record, error_msg);
-                    }
-                    error_reported = true;
-                }
                 k++;
                 continue;
             }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

error report is not necessary, so remove it.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0