### PR TITLE
[Feature] bulk load optimization(Part 3 Block merger)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1527,6 +1527,8 @@ CONF_mBool(batch_write_trace_log_enable, "false");
 CONF_mBool(enable_load_spill, "false");
 // Max chunk bytes which allow to spill per flush. Default is 10MB.
 CONF_mInt64(load_spill_max_chunk_bytes, "10485760");
+// Max merge input bytes during spill merge. Default is 1024MB.
+CONF_mInt64(load_spill_max_merge_bytes, "1073741824");
 
 // ignore union type tag in avro kafka routine load
 CONF_mBool(avro_ignore_union_type_tag, "false");

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -699,6 +699,7 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
                                               .set_partial_update_mode(params.partial_update_mode())
                                               .set_column_to_expr_value(&_column_to_expr_value)
                                               .set_load_id(params.id())
+                                              .set_profile(_profile)
                                               .build());
         _delta_writers.emplace(tablet.tablet_id(), std::move(writer));
         tablet_ids.emplace_back(tablet.tablet_id());

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -364,6 +364,7 @@ StatusOr<AsyncDeltaWriterBuilder::AsyncDeltaWriterPtr> AsyncDeltaWriterBuilder::
                                           .set_partial_update_mode(_partial_update_mode)
                                           .set_column_to_expr_value(_column_to_expr_value)
                                           .set_load_id(_load_id)
+                                          .set_profile(_profile)
                                           .build());
     auto impl = new AsyncDeltaWriterImpl(std::move(writer));
     return std::make_unique<AsyncDeltaWriter>(impl);

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -23,6 +23,7 @@
 #include "gen_cpp/olap_file.pb.h"
 #include "gutil/macros.h"
 #include "storage/lake/delta_writer_finish_mode.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 class MemTracker;
@@ -198,6 +199,11 @@ public:
         return *this;
     }
 
+    AsyncDeltaWriterBuilder& set_profile(RuntimeProfile* profile) {
+        _profile = profile;
+        return *this;
+    }
+
     StatusOr<AsyncDeltaWriterPtr> build();
 
 private:
@@ -215,6 +221,7 @@ private:
     PartialUpdateMode _partial_update_mode{PartialUpdateMode::ROW_MODE};
     const std::map<std::string, std::string>* _column_to_expr_value{nullptr};
     PUniqueId _load_id;
+    RuntimeProfile* _profile{nullptr};
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -23,6 +23,7 @@
 #include "gutil/macros.h"
 #include "storage/lake/delta_writer_finish_mode.h"
 #include "storage/memtable_flush_executor.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 class MemTracker;
@@ -243,6 +244,11 @@ public:
         return *this;
     }
 
+    DeltaWriterBuilder& set_profile(RuntimeProfile* profile) {
+        _profile = profile;
+        return *this;
+    }
+
     StatusOr<DeltaWriterPtr> build();
 
 private:
@@ -261,6 +267,7 @@ private:
     PartialUpdateMode _partial_update_mode{PartialUpdateMode::ROW_MODE};
     const std::map<std::string, std::string>* _column_to_expr_value{nullptr};
     PUniqueId _load_id;
+    RuntimeProfile* _profile{nullptr};
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -44,8 +44,9 @@ Status HorizontalGeneralTabletWriter::open() {
 }
 
 Status HorizontalGeneralTabletWriter::write(const starrocks::Chunk& data, SegmentPB* segment) {
-    if (_seg_writer == nullptr || _seg_writer->estimate_segment_size() >= config::max_segment_file_size ||
-        _seg_writer->num_rows_written() + data.num_rows() >= INT32_MAX /*TODO: configurable*/) {
+    if (_seg_writer == nullptr ||
+        (_auto_flush && (_seg_writer->estimate_segment_size() >= config::max_segment_file_size ||
+                         _seg_writer->num_rows_written() + data.num_rows() >= INT32_MAX /*TODO: configurable*/))) {
         RETURN_IF_ERROR(flush_segment_writer(segment));
         RETURN_IF_ERROR(reset_segment_writer());
     }

--- a/be/src/storage/lake/load_spill_block_manager.h
+++ b/be/src/storage/lake/load_spill_block_manager.h
@@ -29,6 +29,7 @@ public:
     bool empty();
     // No thread safe, UT only
     spill::BlockPtr get_block(size_t gid, size_t bid);
+    std::vector<spill::BlockGroup>& block_groups() { return _block_groups; }
 
 private:
     // Mutex for the container.
@@ -48,6 +49,9 @@ public:
 
     // Default destructor.
     ~LoadSpillBlockManager();
+
+    int64_t tablet_id() const { return _tablet_id; }
+    int64_t txn_id() const { return _txn_id; }
 
     // Initializes the LoadSpillBlockManager.
     Status init();

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -18,6 +18,7 @@
 #include "exec/spill/data_stream.h"
 #include "exec/spill/spiller_factory.h"
 #include "storage/memtable_sink.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 
@@ -52,7 +53,7 @@ private:
 
 class SpillMemTableSink : public MemTableSink {
 public:
-    SpillMemTableSink(LoadSpillBlockManager* block_manager, TabletWriter* w);
+    SpillMemTableSink(LoadSpillBlockManager* block_manager, TabletWriter* writer, RuntimeProfile* profile);
     ~SpillMemTableSink() override = default;
 
     Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment = nullptr, bool eos = false) override;
@@ -73,8 +74,10 @@ private:
     TabletWriter* _writer;
     // destroy spiller before runtime_state
     std::shared_ptr<RuntimeState> _runtime_state;
+    RuntimeProfile* _profile = nullptr;
     spill::SpillerFactoryPtr _spiller_factory;
     std::shared_ptr<spill::Spiller> _spiller;
+    SchemaPtr _schema;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -129,6 +129,10 @@ public:
     // allow to set custom tablet schema for writer, used in partial update
     void set_tablet_schema(TabletSchemaCSPtr schema) { _schema = std::move(schema); }
 
+    const starrocks::TabletSchemaCSPtr& tablet_schema() const { return _schema; }
+
+    void set_auto_flush(bool auto_flush) { _auto_flush = auto_flush; }
+
     void set_fs(const std::shared_ptr<FileSystem> fs) { _fs = std::move(fs); }
     void set_location_provider(const std::shared_ptr<LocationProvider> location_provider) {
         _location_provider = std::move(location_provider);
@@ -147,6 +151,7 @@ protected:
     int64_t _data_size = 0;
     uint32_t _seg_id = 0;
     bool _finished = false;
+    bool _auto_flush = true;
     std::shared_ptr<FileSystem> _fs;
     std::shared_ptr<LocationProvider> _location_provider;
     OlapWriterStatistics _stats;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Implement block group merge in SpillMemTableSink

Fixes #53954

```
Note: Google Test filter = SpillMemTableSinkTest.test_merge
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SpillMemTableSinkTest
[ RUN      ] SpillMemTableSinkTest.test_merge
I20241225 11:26:56.020481 137329194452928 spill_mem_table_sink.cpp:181] LogBlock[container=/tmp/.org.chromium.Chromium.kLhTrC/spill/00000000-0000-0000-0000-000000000000/00000000-0000-0001-0000-000000000001-load_spill-0-0]
I20241225 11:26:56.020657 137329194452928 spill_mem_table_sink.cpp:181] LogBlock[container=/tmp/.org.chromium.Chromium.kLhTrC/spill/00000000-0000-0000-0000-000000000000/00000000-0000-0001-0000-000000000001-load_spill-0-0]
I20241225 11:26:56.023854 137329194452928 spill_mem_table_sink.cpp:242] SpillMemTableSink merge finished, txn:2 tablet:1 blockgroups:1 blocks:2 input_bytes:8192 merges:1 rows:24 chunks:1 duration:3ms
[       OK ] SpillMemTableSinkTest.test_merge (1001 ms)
[----------] 1 test from SpillMemTableSinkTest (1001 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1002 ms total)
[  PASSED  ] 1 test.
I20241225 11:26:57.021432 137326344799936 runtime_filter_worker.cpp:1004] RuntimeFilterWorker going to exit.
I20241225 11:26:57.097586 137326298662592 profile_report_worker.cpp:124] ProfileReportWorker going to exit.
I20241225 11:26:57.103712 137329194452928 pipeline_executor_set.cpp:152] [WORKGROUP] close executors ([name=com] [num_driver_threads=2] [num_scan_threads=2] [num_connector_scan_threads=24] [cpuids=(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23)] [conf=([num_total_cores=24] [num_total_driver_threads=2] [num_total_scan_threads=2] [num_total_connector_scan_threads=24] [enable_bind_cpus=true] [enable_cpu_borrowing=true])])
I20241225 11:26:57.197936 137326275593920 result_buffer_mgr.cpp:194] result buffer manager cancel thread finish.
I20241225 11:26:57.488567 137328121087680 fragment_mgr.cpp:552] FragmentMgr cancel worker is going to exit.

```
## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0