### PR TITLE
[Enhancement] relax the restriction of  topn runtime filter

### DIFF
--- a/be/src/exec/chunks_sorter.h
+++ b/be/src/exec/chunks_sorter.h
@@ -186,16 +186,20 @@ struct SortRuntimeFilterBuilder {
             need_null = true;
             if (column->is_null(rid)) {
                 if (is_close_interval) {
+                    // Null first and all values is null, only need to read null value later.
                     return RuntimeBloomFilter<ltype>::create_with_only_null_range(pool);
                 } else {
-                    return RuntimeBloomFilter<ltype>::create_with_empty_range(pool);
+                    // Null first and all values is null, no need to read any value.
+                    return RuntimeBloomFilter<ltype>::create_with_empty_range_without_null(pool);
                 }
             }
         } else {
             if (column->is_null(rid)) {
                 if (is_close_interval) {
+                    // Null last and all values is null, need to read all values, so will not build runtime filter.
                     return nullptr;
                 } else {
+                    // Null last and all values is null, need to read all values without null.
                     return RuntimeBloomFilter<ltype>::create_with_full_range_without_null(pool);
                 }
             }
@@ -221,14 +225,18 @@ struct SortRuntimeFilterUpdater {
         if (null_first) {
             if (column->is_null(rid)) {
                 if (is_close_interval) {
+                    // all values is null, only need to read null.
                     down_cast<RuntimeBloomFilter<ltype>*>(filter)->update_to_all_null();
                 } else {
+                    // all values is null, no need to read any value.
                     down_cast<RuntimeBloomFilter<ltype>*>(filter)->update_to_empty_and_not_null();
                 }
                 return nullptr;
             }
         } else {
             if (column->is_null(rid)) {
+                // For nulls last, if all values is null, the rf builded is also all null, it's not changed,
+                // so no need to update here.
                 return nullptr;
             }
         }

--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -130,7 +130,9 @@ std::vector<JoinRuntimeFilter*>* ChunksSorterTopn::runtime_filters(ObjectPool* p
         auto* rf = type_dispatch_predicate<JoinRuntimeFilter*>(
                 (*_sort_exprs)[0]->root()->type().type, false, detail::SortRuntimeFilterBuilder(), pool,
                 order_by_column, current_max_value_row_id, asc, null_first, is_close_interval);
-        if (rf != nullptr) {
+        if (rf == nullptr) {
+            return nullptr;
+        } else {
             _runtime_filter.emplace_back(rf);
         }
     } else {

--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -126,8 +126,6 @@ std::vector<JoinRuntimeFilter*>* ChunksSorterTopn::runtime_filters(ObjectPool* p
     bool asc = _sort_desc.descs[0].asc_order();
     bool null_first = _sort_desc.descs[0].is_null_first();
 
-    LOG(ERROR) << "TOPN: " << max_value_row_id << ":" << current_max_value_row_id;
-
     if (_runtime_filter.empty()) {
         auto* rf = type_dispatch_predicate<JoinRuntimeFilter*>(
                 (*_sort_exprs)[0]->root()->type().type, false, detail::SortRuntimeFilterBuilder(), pool,

--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -123,20 +123,22 @@ std::vector<JoinRuntimeFilter*>* ChunksSorterTopn::runtime_filters(ObjectPool* p
     size_t current_max_value_row_id = _topn_type == TTopNType::RANK ? order_by_column->size() - 1 : max_value_row_id;
     // _topn_type != TTopNType::RANK means we need reserve the max_value
     bool is_close_interval = _topn_type == TTopNType::RANK || _sort_desc.num_columns() != 1;
+    bool asc = _sort_desc.descs[0].asc_order();
+    bool null_first = _sort_desc.descs[0].is_null_first();
 
-    if (order_by_column->is_null(current_max_value_row_id)) {
-        return nullptr;
-    }
+    LOG(ERROR) << "TOPN: " << max_value_row_id << ":" << current_max_value_row_id;
 
     if (_runtime_filter.empty()) {
-        auto rf = type_dispatch_predicate<JoinRuntimeFilter*>(
+        auto* rf = type_dispatch_predicate<JoinRuntimeFilter*>(
                 (*_sort_exprs)[0]->root()->type().type, false, detail::SortRuntimeFilterBuilder(), pool,
-                order_by_column, current_max_value_row_id, _sort_desc.descs[0].asc_order(), is_close_interval);
-        _runtime_filter.emplace_back(rf);
+                order_by_column, current_max_value_row_id, asc, null_first, is_close_interval);
+        if (rf != nullptr) {
+            _runtime_filter.emplace_back(rf);
+        }
     } else {
         type_dispatch_predicate<std::nullptr_t>(
                 (*_sort_exprs)[0]->root()->type().type, false, detail::SortRuntimeFilterUpdater(),
-                _runtime_filter.back(), order_by_column, current_max_value_row_id, _sort_desc.descs[0].asc_order());
+                _runtime_filter.back(), order_by_column, current_max_value_row_id, asc, null_first, is_close_interval);
     }
 
     return &_runtime_filter;

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -477,7 +477,7 @@ public:
         return p;
     }
 
-    static RuntimeBloomFilter* create_with_empty_range(ObjectPool* pool) {
+    static RuntimeBloomFilter* create_with_empty_range_without_null(ObjectPool* pool) {
         auto* rf = pool->add(new RuntimeBloomFilter());
         rf->_always_true = true;
         return rf;

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -468,7 +468,6 @@ public:
     using CppType = RunTimeCppType<Type>;
     using ColumnType = RunTimeColumnType<Type>;
     using ContainerType = RunTimeProxyContainerType<Type>;
-    using SelfType = RuntimeBloomFilter<Type>;
 
     RuntimeBloomFilter() { _init_min_max(); }
     ~RuntimeBloomFilter() override = default;
@@ -476,7 +475,27 @@ public:
     RuntimeBloomFilter* create_empty(ObjectPool* pool) override {
         auto* p = pool->add(new RuntimeBloomFilter());
         return p;
-    };
+    }
+
+    static RuntimeBloomFilter* create_with_empty_range(ObjectPool* pool) {
+        auto* rf = pool->add(new RuntimeBloomFilter());
+        rf->_always_true = true;
+        return rf;
+    }
+
+    static RuntimeBloomFilter* create_with_only_null_range(ObjectPool* pool) {
+        auto* rf = pool->add(new RuntimeBloomFilter());
+        rf->insert_null();
+        rf->_always_true = true;
+        return rf;
+    }
+
+    static RuntimeBloomFilter* create_with_full_range_without_null(ObjectPool* pool) {
+        auto* rf = pool->add(new RuntimeBloomFilter());
+        rf->_init_full_range();
+        rf->_always_true = true;
+        return rf;
+    }
 
     // create a min/max LT/GT RuntimeFilter with val
     template <bool is_min>
@@ -503,6 +522,16 @@ public:
     }
 
     template <bool is_min>
+    static RuntimeBloomFilter* create_with_range(ObjectPool* pool, CppType val, bool is_close_internal,
+                                                 bool need_null) {
+        auto* rf = create_with_range<is_min>(pool, val, is_close_internal);
+        if (need_null) {
+            rf->insert_null();
+        }
+        return rf;
+    }
+
+    template <bool is_min>
     void update_min_max(CppType val) {
         // now slice have not support update min/max
         if constexpr (IsSlice<CppType>) {
@@ -519,6 +548,24 @@ public:
                 _max = val;
                 _update_version();
             }
+        }
+    }
+
+    void update_to_all_null() {
+        DCHECK(_has_null);
+
+        if (is_empty_range()) {
+            return;
+        }
+        _init_min_max();
+        _update_version();
+    }
+
+    void update_to_empty_and_not_null() {
+        if (!is_empty_range() || _has_null) {
+            _init_min_max();
+            _has_null = false;
+            _update_version();
         }
     }
 
@@ -749,6 +796,27 @@ public:
         } else {
             dispatch_layout<WithModuloArg<ModuloOp>::HashValueCompute>(_global, layout, columns, num_rows,
                                                                        _hash_partition_bf.size(), _hash_values);
+        }
+    }
+
+    bool test_data(CppType value) const { return _test_data(value); }
+
+    bool is_empty_range() const { return _min > _max; }
+    bool is_full_range() const {
+        if constexpr (IsSlice<CppType>) {
+            return _min == Slice::min_value() && _max == Slice::max_value();
+        } else if constexpr (std::is_integral_v<CppType> || std::is_floating_point_v<CppType>) {
+            return _min == std::numeric_limits<CppType>::lowest() && _max == std::numeric_limits<CppType>::max();
+        } else if constexpr (IsDate<CppType>) {
+            return _min == DateValue::MIN_DATE_VALUE && _max == DateValue::MAX_DATE_VALUE;
+        } else if constexpr (IsTimestamp<CppType>) {
+            return _min = TimestampValue::MIN_TIMESTAMP_VALUE && _max == TimestampValue::MAX_TIMESTAMP_VALUE;
+        } else if constexpr (IsDecimal<CppType>) {
+            return _min == DecimalV2Value::get_min_decimal() && _max == DecimalV2Value::get_max_decimal();
+        } else if constexpr (Type != TYPE_JSON) {
+            return _min == RunTimeTypeLimits<Type>::min_value() && _max == RunTimeTypeLimits<Type>::max_value();
+        } else {
+            return false;
         }
     }
 

--- a/be/src/storage/olap_runtime_range_pruner.hpp
+++ b/be/src/storage/olap_runtime_range_pruner.hpp
@@ -238,8 +238,6 @@ inline Status OlapRuntimeScanRangePruner::_update(const ColumnIdToGlobalDictMap*
                 ObjectPool pool;
 
                 ASSIGN_OR_RETURN(auto predicates, _get_predicates(global_dictmaps, i, &pool));
-
-                //ASSIGN_OR_RETURN(auto predicates, _get_predicates(global_dictmaps, i, &pool));
                 if (!predicates.empty()) {
                     RETURN_IF_ERROR(updater(predicates.front()->column_id(), predicates));
                 }

--- a/be/src/storage/olap_runtime_range_pruner.hpp
+++ b/be/src/storage/olap_runtime_range_pruner.hpp
@@ -237,9 +237,7 @@ inline Status OlapRuntimeScanRangePruner::_update(const ColumnIdToGlobalDictMap*
                 (rf_version > _rf_versions[i] && raw_read_rows - _raw_read_rows > rf_update_threshold)) {
                 ObjectPool pool;
 
-                auto tmp_ret = _get_predicates(global_dictmaps, i, &pool);
-                RETURN_IF_ERROR(tmp_ret);
-                auto predicates = tmp_ret.value();
+                ASSIGN_OR_RETURN(auto predicates, _get_predicates(global_dictmaps, i, &pool));
 
                 //ASSIGN_OR_RETURN(auto predicates, _get_predicates(global_dictmaps, i, &pool));
                 if (!predicates.empty()) {

--- a/be/src/testutil/column_test_helper.h
+++ b/be/src/testutil/column_test_helper.h
@@ -49,6 +49,13 @@ public:
     }
 
     template <class T>
+    static ColumnPtr build_nullable_column(const std::vector<T>& values) {
+        auto null_column = NullColumn::create(values.size(), 0);
+        auto data_column = build_column<T>(values);
+        return  NullableColumn::create(std::move(data_column), std::move(null_column));
+    }
+
+    template <class T>
     static ColumnPtr build_nullable_column(const std::vector<T>& values, const std::vector<uint8_t>& nullflags) {
         DCHECK_EQ(values.size(), nullflags.size());
         auto null = NullColumn::create();

--- a/be/src/testutil/column_test_helper.h
+++ b/be/src/testutil/column_test_helper.h
@@ -52,7 +52,7 @@ public:
     static ColumnPtr build_nullable_column(const std::vector<T>& values) {
         auto null_column = NullColumn::create(values.size(), 0);
         auto data_column = build_column<T>(values);
-        return  NullableColumn::create(std::move(data_column), std::move(null_column));
+        return NullableColumn::create(std::move(data_column), std::move(null_column));
     }
 
     template <class T>

--- a/be/test/exprs/runtime_filter_test.cpp
+++ b/be/test/exprs/runtime_filter_test.cpp
@@ -43,7 +43,7 @@ protected:
 };
 
 TEST_F(RuntimeBloomFilterTest, create_with_empty_range) {
-    auto* rf = Int32RF::create_with_empty_range(&_pool);
+    auto* rf = Int32RF::create_with_empty_range_without_null(&_pool);
     ASSERT_TRUE(rf->is_empty_range());
     ASSERT_FALSE(rf->has_null());
 }
@@ -854,7 +854,7 @@ TEST_F(RuntimeFilterTest, TestGlobalRuntimeFilterMinMax) {
 
 void test_pipeline_level_helper(TRuntimeFilterBuildJoinMode::type join_mode, const RuntimeFilterLayout& layout,
                                 size_t num_rows, size_t num_partitions) {
-    auto part_by_func_gen = [=](bool is_reduce) -> auto{
+    auto part_by_func_gen = [=](bool is_reduce) -> auto {
         return [is_reduce, layout, num_rows, num_partitions](BinaryColumn* column, std::vector<uint32_t>& hash_values,
                                                              std::vector<size_t>& num_rows_per_partitions) {
             if (is_reduce) {

--- a/be/test/exprs/runtime_filter_test.cpp
+++ b/be/test/exprs/runtime_filter_test.cpp
@@ -30,9 +30,56 @@ class RuntimeFilterTest : public ::testing::Test {
 public:
     void SetUp() override {}
     void TearDown() override {}
-
-public:
 };
+
+class RuntimeBloomFilterTest : public ::testing::Test {
+public:
+    void SetUp() override {}
+    void TearDown() override {}
+
+protected:
+    using Int32RF = RuntimeBloomFilter<TYPE_INT>;
+    ObjectPool _pool;
+};
+
+TEST_F(RuntimeBloomFilterTest, create_with_empty_range) {
+    auto* rf = Int32RF::create_with_empty_range(&_pool);
+    ASSERT_TRUE(rf->is_empty_range());
+    ASSERT_FALSE(rf->has_null());
+}
+
+TEST_F(RuntimeBloomFilterTest, create_with_only_null_range) {
+    auto* rf = Int32RF::create_with_only_null_range(&_pool);
+    ASSERT_TRUE(rf->is_empty_range());
+    ASSERT_TRUE(rf->has_null());
+}
+
+TEST_F(RuntimeBloomFilterTest, create_with_full_range_without_null) {
+    auto* rf = Int32RF::create_with_full_range_without_null(&_pool);
+    ASSERT_TRUE(rf->is_full_range());
+    ASSERT_FALSE(rf->has_null());
+}
+
+TEST_F(RuntimeBloomFilterTest, create_with_range) {
+    auto* rf = Int32RF::create_with_range<true>(&_pool, 10, true, true);
+    ASSERT_EQ(rf->min_value(), 10);
+    ASSERT_EQ(rf->max_value(), std::numeric_limits<int32_t>::max());
+    ASSERT_TRUE(rf->has_null());
+}
+
+TEST_F(RuntimeBloomFilterTest, update_to_all_null) {
+    auto* rf = Int32RF::create_with_range<true>(&_pool, 10, true, true);
+
+    rf->update_to_all_null();
+    ASSERT_EQ(rf->rf_version(), 1);
+    ASSERT_TRUE(rf->is_empty_range());
+    ASSERT_TRUE(rf->has_null());
+
+    rf->update_to_all_null();
+    ASSERT_EQ(rf->rf_version(), 1);
+    ASSERT_TRUE(rf->is_empty_range());
+    ASSERT_TRUE(rf->has_null());
+}
 
 TEST_F(RuntimeFilterTest, TestSimdBlockFilter) {
     SimdBlockFilter bf0;
@@ -113,7 +160,7 @@ static std::shared_ptr<BinaryColumn> gen_random_binary_column(const std::string&
         size_t length = length_g(rd);
         std::string s;
         s.reserve(length);
-        for (auto i = 0; i < length; ++i) {
+        for (auto j = 0; j < length; ++j) {
             s.push_back(alphabet[g(rd)]);
         }
         col->append(Slice(s));
@@ -131,8 +178,8 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilter) {
     EXPECT_EQ(bf.min_value(), 0);
     EXPECT_EQ(bf.max_value(), 187);
     for (int i = 0; i <= 200; i += 17) {
-        EXPECT_TRUE(bf._test_data(i));
-        EXPECT_FALSE(bf._test_data(i + 1));
+        EXPECT_TRUE(bf.test_data(i));
+        EXPECT_FALSE(bf.test_data(i + 1));
     }
     EXPECT_FALSE(rf->has_null());
     bf.insert_null();
@@ -164,24 +211,19 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilter) {
 
 TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterSlice) {
     RuntimeBloomFilter<TYPE_VARCHAR> bf;
-    // JoinRuntimeFilter* rf = &bf;
-    std::vector<std::string> data = {"aa", "bb", "cc", "dd"};
-    std::vector<Slice> values;
-    for (const auto& s : data) {
-        values.emplace_back(Slice(s));
-    }
     bf.init(100);
+    std::vector<Slice> values{"aa", "bb", "cc", "d"};
     for (auto& s : values) {
         bf.insert(s);
     }
     EXPECT_EQ(bf.min_value(), values[0]);
     EXPECT_EQ(bf.max_value(), values[values.size() - 1]);
     for (auto& s : values) {
-        EXPECT_TRUE(bf._test_data(s));
+        EXPECT_TRUE(bf.test_data(s));
     }
     std::vector<std::string> ex_data = {"ee", "ff", "gg"};
     for (const auto& s : ex_data) {
-        EXPECT_FALSE(bf._test_data(Slice(s)));
+        EXPECT_FALSE(bf.test_data(Slice(s)));
     }
 }
 
@@ -274,9 +316,9 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterMerge) {
     bf2.merge(rf0);
     bf2.merge(rf1);
     for (int i = 0; i <= 200; i += 17) {
-        EXPECT_TRUE(bf2._test_data(i));
-        EXPECT_TRUE(bf2._test_data(i + 1));
-        EXPECT_FALSE(bf2._test_data(i + 2));
+        EXPECT_TRUE(bf2.test_data(i));
+        EXPECT_TRUE(bf2.test_data(i + 1));
+        EXPECT_FALSE(bf2.test_data(i + 2));
     }
     EXPECT_EQ(bf2.min_value(), 0);
     EXPECT_EQ(bf2.max_value(), 188);
@@ -772,32 +814,6 @@ TEST_F(RuntimeFilterTest, TestShuffleHashBucketRuntimeFilter3) {
     test_shuffle_hash_bucket_grf_helper(100, 5);
 }
 
-void test_local_hash_bucket_grf_helper(size_t num_rows, const std::vector<int32_t>& bucketseq_to_partition) {
-    DCHECK(!bucketseq_to_partition.empty());
-    auto num_buckets = bucketseq_to_partition.size();
-    std::unordered_set<int32_t> partitions(bucketseq_to_partition.begin(), bucketseq_to_partition.end());
-    partitions.erase(BUCKET_ABSENT);
-    auto num_partitions = partitions.size();
-    DCHECK(std::all_of(partitions.begin(), partitions.end(),
-                       [num_partitions](auto part_idx) { return part_idx < num_partitions; }));
-
-    auto part_by_func = [num_rows, num_buckets](BinaryColumn* column, std::vector<uint32_t>& hash_values,
-                                                std::vector<size_t>& num_rows_per_partitions) {
-        hash_values.assign(num_rows, 0);
-        column->crc32_hash(hash_values.data(), 0, num_rows);
-        for (auto i = 0; i < num_rows; ++i) {
-            hash_values[i] %= num_buckets;
-            ++num_rows_per_partitions[hash_values[i]];
-        }
-    };
-    auto grf_config_func = [](JoinRuntimeFilter* grf, JoinRuntimeFilter::RunningContext* ctx) {
-        grf->set_join_mode(TRuntimeFilterBuildJoinMode::LOCAL_HASH_BUCKET);
-    };
-    RuntimeFilterLayout layout;
-    layout.init(1, bucketseq_to_partition);
-    test_grf_helper(num_rows, num_partitions, part_by_func, grf_config_func, layout);
-}
-
 TEST_F(RuntimeFilterTest, TestLocalHashBucketRuntimeFilter1) {
     test_bucket_shuffle_grf_helper(100, 3, 6, {1, 1, 0, 0, 2, 2});
 }
@@ -838,7 +854,7 @@ TEST_F(RuntimeFilterTest, TestGlobalRuntimeFilterMinMax) {
 
 void test_pipeline_level_helper(TRuntimeFilterBuildJoinMode::type join_mode, const RuntimeFilterLayout& layout,
                                 size_t num_rows, size_t num_partitions) {
-    auto part_by_func_gen = [=](bool is_reduce) -> auto {
+    auto part_by_func_gen = [=](bool is_reduce) -> auto{
         return [is_reduce, layout, num_rows, num_partitions](BinaryColumn* column, std::vector<uint32_t>& hash_values,
                                                              std::vector<size_t>& num_rows_per_partitions) {
             if (is_reduce) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -860,12 +860,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
                     if (!slot.getId().equals(slotRef.getSlotId())) {
                         continue;
                     }
-                    if (!slotRef.isNullable() || rfDesc.isNullLast()) {
-                        return true;
-                    }
-                    if (slotRef.isNullable() && canEliminateNull(slot)) {
-                        return true;
-                    }
+                    return true;
                 }
             }
             return false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -20,6 +20,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.SemanticException;
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,7 +47,7 @@ class OrderByTest extends PlanTestBase {
                 "               ORDER  BY state) \n" +
                 "ORDER  BY hiredate";
         String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("LEFT SEMI JOIN"));
+        Assertions.assertTrue(planFragment.contains("LEFT SEMI JOIN"));
     }
 
     @Test
@@ -54,14 +55,14 @@ class OrderByTest extends PlanTestBase {
         String sql = "select count(*) from (select L_QUANTITY, L_PARTKEY, L_ORDERKEY from lineitem " +
                 "order by L_QUANTITY, L_PARTKEY, L_ORDERKEY limit 5000, 10000) as a;";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("2:MERGING-EXCHANGE"));
+        Assertions.assertTrue(plan.contains("2:MERGING-EXCHANGE"));
     }
 
     @Test
     void testPruneSortColumns() throws Exception {
         String sql = "select count(v1) from (select v1 from t0 order by v2 limit 10) t";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  3:Project\n" +
+        Assertions.assertTrue(plan.contains("  3:Project\n" +
                 "  |  <slot 1> : 1: v1"));
     }
 
@@ -70,7 +71,7 @@ class OrderByTest extends PlanTestBase {
         String sql = "select avg(null) over (order by ref_0.v1) as c2 "
                 + "from t0 as ref_0 left join t1 as ref_1 on (ref_0.v1 = ref_1.v4 );";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains(
+        Assertions.assertTrue(plan.contains(
                 "sort_tuple_slot_exprs:[TExpr(nodes:[TExprNode(node_type:SLOT_REF, type:TTypeDesc(types:[TTypeNode"
                         + "(type:SCALAR, scalar_type:TScalarType(type:BIGINT))]), num_children:0, slot_ref:TSlotRef"
                         + "(slot_id:1, tuple_id:2), output_scale:-1, output_column:-1, "
@@ -83,7 +84,7 @@ class OrderByTest extends PlanTestBase {
         connectContext.getSessionVariable().setSqlSelectLimit(200);
         String sql = "select * from (select * from t0 order by v1 limit 5) as a left join t1 on a.v1 = t1.v4";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("  1:TOP-N\n" +
+        Assertions.assertTrue(plan.contains("  1:TOP-N\n" +
                 "  |  order by: <slot 1> 1: v1 ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  limit: 5"));
@@ -94,7 +95,7 @@ class OrderByTest extends PlanTestBase {
     void testOrderBySameColumnDiffOrder() throws Exception {
         String sql = "select v1 from t0 order by v1 desc, v1 asc";
         String plan = getFragmentPlan(sql);
-        Assert.assertTrue(plan.contains("1:SORT\n" +
+        Assertions.assertTrue(plan.contains("1:SORT\n" +
                 "  |  order by: <slot 1> 1: v1 DESC"));
     }
 
@@ -557,7 +558,7 @@ class OrderByTest extends PlanTestBase {
         // order by null case
         sql = "select * from test_all_type_not_null order by null + 1 limit 1";
         plan = getVerboseExplain(sql);
-        assertNotContains(plan, "runtime filters");
+        assertContains(plan, "runtime filters");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -637,7 +637,7 @@ class OrderByTest extends PlanTestBase {
 
         String sql2 = "select * from t0 where v1 is null order by v1 limit 10";
         String plan2 = getVerboseExplain(sql2);
-        assertNotContains(plan2, " runtime filters");
+        assertContains(plan2, " runtime filters");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -528,7 +528,7 @@ class OrderByTest extends PlanTestBase {
         // TopN filter only works in no-nullable column
         sql = "select * from test_all_type order by t1a limit 10";
         plan = getVerboseExplain(sql);
-        assertNotContains(plan, "runtime filters");
+        assertContains(plan, "runtime filters");
 
         // only first order by column can use top n filter
         sql = "select * from test_all_type_not_null order by t1a, t1b limit 10";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -698,6 +698,8 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
 
         assertContains(plan, "  1:TOP-N\n" +
                 "  |  order by: [1, BIGINT, true] ASC\n" +
+                "  |  build runtime filters:\n" +
+                "  |  - filter_id = 0, build_expr = (<slot 1> 1: v4), remote = false\n" +
                 "  |  offset: 0\n" +
                 "  |  limit: 1000000000\n" +
                 "  |  cardinality: 1000000000\n" +


### PR DESCRIPTION
## Why I'm doing:

Currently, if `null first` or has null in the runtime filter, `topn runtime filter` can not be pushed down, the storage layer already supports it, so this restriction can be relaxed.

## What I'm doing:

relax the restriction of topn runtime filter

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0