### PR TITLE
[BugFix] Fix mv union rewrite and partition prune bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -462,8 +462,8 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         List<ColumnRefOperator> originalOutputColumns = new ArrayList<>(queryColumnRefMap.keySet());
         // rewrite query
         OptExpressionDuplicator duplicator = new OptExpressionDuplicator(materializationContext);
-        // reset original partition predicates to prune partitions/tablets again
-        OptExpression newQueryInput = duplicator.duplicate(queryInput, true);
+        // don't reset selected partition ids for query input, because query's partition ranges should not be extended.
+        OptExpression newQueryInput = duplicator.duplicate(queryInput, false);
         List<ColumnRefOperator> newQueryOutputColumns = duplicator.getMappedColumns(originalOutputColumns);
 
         Projection projection = getMvOptExprProjection(viewInput);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -2230,11 +2230,10 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         // keys of queryColumnRefMap and mvColumnRefMap are the same
         List<ColumnRefOperator> originalOutputColumns =
                 queryColumnRefMap.keySet().stream().collect(Collectors.toList());
-
         // rewrite query
         OptExpressionDuplicator duplicator = new OptExpressionDuplicator(materializationContext);
-        // NOTE: selected partitions and tablets should be deduced again.
-        OptExpression newQueryInput = duplicator.duplicate(queryInput, true);
+        // don't reset selected partition ids for query input, because query's partition ranges should not be extended.
+        OptExpression newQueryInput = duplicator.duplicate(queryInput, false);
         List<ColumnRefOperator> newQueryOutputColumns = duplicator.getMappedColumns(originalOutputColumns);
 
         // rewrite viewInput

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -88,6 +88,7 @@ public class MvRewriteTestBase {
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+        connectContext.setDatabase(DB_NAME);
 
         // set default config for async mvs
         UtFrameUtils.setDefaultConfigForAsyncMVTest(connectContext);
@@ -243,6 +244,10 @@ public class MvRewriteTestBase {
         connectContext.setQueryId(UUIDUtil.genUUID());
         StatementBase statement = SqlParser.parseSingleStatement(sql, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor.newInternalExecutor(connectContext, statement).execute();
+    }
+
+    public static void sql(String sql) throws Exception {
+        cluster.runSql(DB_NAME, sql);
     }
 
     /**

--- a/test/sql/test_transparent_mv/R/test_transparent_mv_union_olap
+++ b/test/sql/test_transparent_mv/R/test_transparent_mv_union_olap
@@ -117,9 +117,9 @@ SELECT * FROM t1 where dt > '2020-07-01' and num > 4 order by 1, 2 limit 3;
 -- !result
 SELECT * FROM t1 where dt > '2020-06-20'  order by 1, 2 limit 3;
 -- result:
-1	2020-06-15
 1	2020-07-02
 1	2020-07-16
+2	2020-07-02
 -- !result
 SELECT * FROM t1 where dt > '2020-06-20' and num > 4 order by 1, 2 limit 3;
 -- result:
@@ -187,9 +187,9 @@ SELECT * FROM t1 where dt > '2020-07-01' and num > 4 order by 1, 2 limit 3;
 -- !result
 SELECT * FROM t1 where dt > '2020-06-20'  order by 1, 2 limit 3;
 -- result:
-1	2020-06-15
-1	2020-06-15
 1	2020-07-02
+1	2020-07-16
+2	2020-07-02
 -- !result
 SELECT * FROM t1 where dt > '2020-06-20' and num > 4 order by 1, 2 limit 3;
 -- result:
@@ -263,9 +263,9 @@ SELECT dt, sum(num) as num FROM t1 where dt >'2020-07-01' GROUP BY dt having sum
 -- !result
 SELECT dt, sum(num) as num FROM t1 where dt > '2020-06-20'  GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	4
-2020-06-18	5
 2020-06-21	7
+2020-06-24	9
+2020-07-02	3
 -- !result
 SELECT dt, sum(num) as num FROM t1 where dt >'2020-06-20' GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;
 -- result:
@@ -328,9 +328,9 @@ SELECT dt, sum(num) as num FROM t1 where dt >'2020-07-01' GROUP BY dt having sum
 -- !result
 SELECT dt, sum(num) as num FROM t1 where dt > '2020-06-20'  GROUP BY dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	5
-2020-06-18	5
 2020-06-21	7
+2020-06-24	9
+2020-07-02	3
 -- !result
 SELECT dt, sum(num) as num FROM t1 where dt >'2020-06-20' GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;
 -- result:
@@ -400,15 +400,15 @@ SELECT t2.dt, sum(t2.num) as num FROM t1 join t2 on t1.dt = t2.dt where t2.dt > 
 -- !result
 SELECT t2.dt, sum(t2.num) as num FROM t1 join t2 on t1.dt = t2.dt where t2.dt > '2020-06-20' GROUP BY t2.dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	12
-2020-06-18	10
 2020-06-21	14
+2020-06-24	18
+2020-07-02	6
 -- !result
 SELECT t2.dt, sum(t2.num) as num FROM t1 join t2 on t1.dt = t2.dt where t2.dt > '2020-06-20' GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;
 -- result:
-2020-06-15	12
 2020-06-21	14
 2020-06-24	18
+2020-07-08	14
 -- !result
 SELECT t2.dt, sum(t2.num) as num FROM t1 join t2 on t1.dt = t2.dt GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;
 -- result:
@@ -460,15 +460,15 @@ SELECT t2.dt, sum(t2.num) as num FROM t1 join t2 on t1.dt = t2.dt where t2.dt > 
 -- !result
 SELECT t2.dt, sum(t2.num) as num FROM t1 join t2 on t1.dt = t2.dt where t2.dt > '2020-06-20' GROUP BY t2.dt order by 1, 2 limit 3;
 -- result:
-2020-06-15	12
-2020-06-18	10
 2020-06-21	14
+2020-06-24	18
+2020-07-02	6
 -- !result
 SELECT t2.dt, sum(t2.num) as num FROM t1 join t2 on t1.dt = t2.dt where t2.dt > '2020-06-20' GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;
 -- result:
-2020-06-15	12
 2020-06-21	14
 2020-06-24	18
+2020-07-08	14
 -- !result
 SELECT t2.dt, sum(t2.num) as num FROM t1 join t2 on t1.dt = t2.dt GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;
 -- result:


### PR DESCRIPTION
## Why I'm doing:
- don't reset selected partition ids for query input, because query's partition ranges should not be extended.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0