### PR TITLE
[BugFix] Fix arrow flight sql start blcoked

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlService.java
@@ -78,11 +78,6 @@ public class ArrowFlightSqlService {
             running = true;
             LOG.info("[ARROW] Arrow Flight SQL server starts on {}:{}.",
                     location.getUri().getHost(), location.getUri().getPort());
-            flightServer.awaitTermination();
-        } catch (InterruptedException e) {
-            LOG.error("[ARROW] Arrow Flight SQL server was interrupted", e);
-            Thread.currentThread().interrupt();
-            System.exit(-1);
         } catch (Exception e) {
             LOG.error("[ARROW] Failed to start Arrow Flight SQL server on {}:{}. Its port might be occupied. You can " +
                             "modify `arrow_flight_port` in `fe.conf` to an unused port or set it to -1 to disable it.",

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceTest.java
@@ -57,6 +57,11 @@ public class ArrowFlightSqlServiceTest {
             }
 
             {
+                server.awaitTermination();
+                times = 0;
+            }
+
+            {
                 server.awaitTermination(anyLong, TimeUnit.SECONDS);
                 result = true;
                 times = 1;


### PR DESCRIPTION
## Why I'm doing:

`ArrowFlightSqlService::start` calls `awaitTermination`, which will block subsequent start processes and this thread.

## What I'm doing:

Related to #50285.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0