### PR TITLE
[Enhancement] add skip rows into split context to avoid re-build deletion vector

### DIFF
--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -40,6 +40,11 @@ struct HdfsSplitContext : public pipeline::ScanSplitContext {
 };
 using HdfsSplitContextPtr = std::unique_ptr<HdfsSplitContext>;
 
+struct SkipRowsContext {
+    std::set<int64_t> need_skip_rowids;
+};
+using SkipRowsContextPtr = std::shared_ptr<SkipRowsContext>;
+
 struct HdfsScanStats {
     int64_t raw_rows_read = 0;
     int64_t rows_read = 0;

--- a/be/src/exec/hdfs_scanner_parquet.h
+++ b/be/src/exec/hdfs_scanner_parquet.h
@@ -23,7 +23,7 @@ class FileReader;
 
 class HdfsParquetScanner final : public HdfsScanner {
 public:
-    HdfsParquetScanner() = default;
+    HdfsParquetScanner() : _skip_rows_ctx(std::make_shared<SkipRowsContext>()){};
     ~HdfsParquetScanner() override = default;
 
     Status do_open(RuntimeState* runtime_state) override;
@@ -34,7 +34,7 @@ public:
 
 private:
     std::shared_ptr<parquet::FileReader> _reader = nullptr;
-    std::set<int64_t> _need_skip_rowids;
+    SkipRowsContextPtr _skip_rows_ctx;
 };
 
 } // namespace starrocks

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -65,13 +65,13 @@ namespace starrocks::parquet {
 
 FileReader::FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
                        const DataCacheOptions& datacache_options, io::SharedBufferedInputStream* sb_stream,
-                       const std::set<int64_t>* _need_skip_rowids)
+                       const SkipRowsContextPtr skip_rows_context)
         : _chunk_size(chunk_size),
           _file(file),
           _file_size(file_size),
           _datacache_options(datacache_options),
           _sb_stream(sb_stream),
-          _need_skip_rowids(_need_skip_rowids) {}
+          _skip_rows_ctx(skip_rows_context) {}
 
 FileReader::~FileReader() = default;
 
@@ -166,6 +166,7 @@ Status FileReader::_build_split_tasks() {
         split_ctx->split_start = start_offset;
         split_ctx->split_end = end_offset;
         split_ctx->file_metadata = _file_metadata;
+        split_ctx->skip_rows_ctx = _skip_rows_ctx;
         _scanner_ctx->split_tasks.emplace_back(std::move(split_ctx));
     }
     _scanner_ctx->merge_split_tasks();
@@ -544,8 +545,8 @@ Status FileReader::_init_group_readers() {
             continue;
         }
 
-        auto row_group_reader =
-                std::make_shared<GroupReader>(_group_reader_param, i, _need_skip_rowids, row_group_first_row);
+        auto row_group_reader = std::make_shared<GroupReader>(_group_reader_param, i, &_skip_rows_ctx->need_skip_rowids,
+                                                              row_group_first_row);
         RETURN_IF_ERROR(row_group_reader->init());
 
         _group_reader_param.stats->parquet_total_row_groups += 1;
@@ -560,9 +561,9 @@ Status FileReader::_init_group_readers() {
         _row_group_readers.emplace_back(row_group_reader);
         int64_t num_rows = _file_metadata->t_metadata().row_groups[i].num_rows;
         // for iceberg v2 pos delete
-        if (_need_skip_rowids != nullptr && !_need_skip_rowids->empty()) {
-            auto start_iter = _need_skip_rowids->lower_bound(row_group_first_row);
-            auto end_iter = _need_skip_rowids->upper_bound(row_group_first_row + num_rows - 1);
+        if (_skip_rows_ctx != nullptr && !_skip_rows_ctx->need_skip_rowids.empty()) {
+            auto start_iter = _skip_rows_ctx->need_skip_rowids.lower_bound(row_group_first_row);
+            auto end_iter = _skip_rows_ctx->need_skip_rowids.upper_bound(row_group_first_row + num_rows - 1);
             num_rows -= std::distance(start_iter, end_iter);
         }
         _total_row_count += num_rows;

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -65,7 +65,7 @@ namespace starrocks::parquet {
 
 FileReader::FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
                        const DataCacheOptions& datacache_options, io::SharedBufferedInputStream* sb_stream,
-                       const SkipRowsContextPtr skip_rows_context)
+                       const SkipRowsContextPtr& skip_rows_context)
         : _chunk_size(chunk_size),
           _file(file),
           _file_size(file_size),

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -65,7 +65,7 @@ namespace starrocks::parquet {
 
 FileReader::FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
                        const DataCacheOptions& datacache_options, io::SharedBufferedInputStream* sb_stream,
-                       const SkipRowsContextPtr& skip_rows_context)
+                       SkipRowsContextPtr skip_rows_context)
         : _chunk_size(chunk_size),
           _file(file),
           _file_size(file_size),

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -71,7 +71,7 @@ FileReader::FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
           _file_size(file_size),
           _datacache_options(datacache_options),
           _sb_stream(sb_stream),
-          _skip_rows_ctx(skip_rows_context) {}
+          _skip_rows_ctx(std::move(skip_rows_context)) {}
 
 FileReader::~FileReader() = default;
 

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -71,7 +71,7 @@ class FileReader {
 public:
     FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
                const DataCacheOptions& datacache_options = DataCacheOptions(),
-               io::SharedBufferedInputStream* sb_stream = nullptr, const SkipRowsContextPtr skipRowsContext = nullptr);
+               io::SharedBufferedInputStream* sb_stream = nullptr, const SkipRowsContextPtr& skipRowsContext = nullptr);
     ~FileReader();
 
     Status init(HdfsScannerContext* scanner_ctx);

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -71,7 +71,7 @@ class FileReader {
 public:
     FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
                const DataCacheOptions& datacache_options = DataCacheOptions(),
-               io::SharedBufferedInputStream* sb_stream = nullptr, const SkipRowsContextPtr& skipRowsContext = nullptr);
+               io::SharedBufferedInputStream* sb_stream = nullptr, SkipRowsContextPtr skipRowsContext = nullptr);
     ~FileReader();
 
     Status init(HdfsScannerContext* scanner_ctx);
@@ -145,7 +145,7 @@ private:
     io::SharedBufferedInputStream* _sb_stream = nullptr;
     GroupReaderParam _group_reader_param;
     std::shared_ptr<MetaHelper> _meta_helper = nullptr;
-    const SkipRowsContextPtr _skip_rows_ctx = nullptr;
+    SkipRowsContextPtr _skip_rows_ctx = nullptr;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -57,10 +57,12 @@ namespace starrocks::parquet {
 
 struct SplitContext : public HdfsSplitContext {
     FileMetaDataPtr file_metadata;
+    SkipRowsContextPtr skip_rows_ctx;
 
     HdfsSplitContextPtr clone() override {
         auto ctx = std::make_unique<SplitContext>();
         ctx->file_metadata = file_metadata;
+        ctx->skip_rows_ctx = skip_rows_ctx;
         return ctx;
     }
 };
@@ -69,8 +71,7 @@ class FileReader {
 public:
     FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
                const DataCacheOptions& datacache_options = DataCacheOptions(),
-               io::SharedBufferedInputStream* sb_stream = nullptr,
-               const std::set<int64_t>* _need_skip_rowids = nullptr);
+               io::SharedBufferedInputStream* sb_stream = nullptr, const SkipRowsContextPtr skipRowsContext = nullptr);
     ~FileReader();
 
     Status init(HdfsScannerContext* scanner_ctx);
@@ -144,7 +145,7 @@ private:
     io::SharedBufferedInputStream* _sb_stream = nullptr;
     GroupReaderParam _group_reader_param;
     std::shared_ptr<MetaHelper> _meta_helper = nullptr;
-    const std::set<int64_t>* _need_skip_rowids;
+    const SkipRowsContextPtr _skip_rows_ctx = nullptr;
 };
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -1081,10 +1081,11 @@ TEST_F(FileReaderTest, TestGetNext) {
 TEST_F(FileReaderTest, TestGetNextWithSkipID) {
     int64_t ids[] = {1};
     std::set<int64_t> need_skip_rowids(ids, ids + 1);
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>(need_skip_rowids);
     auto file = _create_file(_file1_path);
     auto file_reader =
             std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(_file1_path),
-                                         _mock_datacache_options(), nullptr, &need_skip_rowids);
+                                         _mock_datacache_options(), nullptr, skip_rows_ctx);
 
     // init
     auto* ctx = _create_file1_base_context();


### PR DESCRIPTION
## Why I'm doing:
BE would split scan range, each scan range need to re-build deletion vector,  it's time-consuming
## What I'm doing:
add SkipRowsContext in split context, use SkipRowsContext in sub task directly, avoid to re-build deletion vector.
example: query ssb table lineorder_flat with deletion vector
### before :
**query tasks 20s+**, build dv 6497 times
![image](https://github.com/user-attachments/assets/c51ad035-91d6-47b5-9474-2142ac646609)

### after:
**query task 6s+**, build dv 743 times
![image](https://github.com/user-attachments/assets/a25bb8cc-1463-41c9-b6bd-a2739fc21db5)


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0