### PR TITLE
[BugFix] Fix restore fail for table with multi level partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -492,7 +492,7 @@ public class CreateTableAnalyzer {
                 partitionColumnList.add(identifier.getValue());
             }
             if (partitionExpr instanceof FunctionCallExpr) {
-                FunctionCallExpr expr = (FunctionCallExpr) partitionExpr;
+                FunctionCallExpr expr = (FunctionCallExpr) (((Expr) partitionExpr).clone());
                 ExpressionAnalyzer.analyzeExpression(expr, new AnalyzeState(), new Scope(RelationId.anonymous(),
                                 new RelationFields(columnDefs.stream().map(col -> new Field(col.getName(),
                                         col.getType(), null, null)).collect(Collectors.toList()))),
@@ -515,11 +515,12 @@ public class CreateTableAnalyzer {
                     throw new SemanticException("Generate partition column " + columnName
                             + " for multi expression partition error: " + e.getMessage(), partitionDesc.getPos());
                 }
+                // generated column expression should be saved in unanalyzed way in meta
                 ColumnDef generatedPartitionColumn = new ColumnDef(
                         columnName, typeDef, null, false, null, null, true,
-                        ColumnDef.DefaultValueDef.NOT_SET, null, expr, "");
+                        ColumnDef.DefaultValueDef.NOT_SET, null, (FunctionCallExpr) partitionExpr, "");
                 columnDefs.add(generatedPartitionColumn);
-                partitionExprs.add(expr);
+                partitionExprs.add((FunctionCallExpr) partitionExpr);
             }
         }
         for (ColumnDef columnDef : columnDefs) {


### PR DESCRIPTION
## Why I'm doing:
In general, generated column expression should be saved in unanalyzed way in meta. If we restore a snapshot
with a table using multi level partition and this table has already existed in current database. The restore
may fail because of the failure of schema check. The problem here is that, the existed table create has the
expression with analyzed but not the one on snapshot. The column comparation will fail.

## What I'm doing:
Save the expression in unanalyzed way when create table with multi level partition.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0