### PR TITLE
[Doc] fix wrong link for 'ANALYZE PROFILE' in EXPLAIN_ANALYZE.md

### DIFF
--- a/docs/en/sql-reference/sql-statements/cluster-management/plan_profile/EXPLAIN_ANALYZE.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/plan_profile/EXPLAIN_ANALYZE.md
@@ -41,4 +41,4 @@ Example 2: Simulate and analyze an INSERT INTO statement. The loading transactio
 ## Relevant SQLs
 
 - [SHOW PROFILELIST](./SHOW_PROFILELIST.md)
-- [ANALYZE PROFILE](./EXPLAIN_ANALYZE.md)
+- [ANALYZE PROFILE](./ANALYZE_PROFILE.md)


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix wrong link for 'ANALYZE PROFILE' in EXPLAIN_ANALYZE.md

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0