### PR TITLE
[Feature] Support restoring from a cluster snapshot for shared-data mode (part 3, introduce gtid for tablet metadata)

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -167,6 +167,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
     tablet_metadata_pb->set_version(kInitialVersion);
     tablet_metadata_pb->set_next_rowset_id(1);
     tablet_metadata_pb->set_cumulative_point(0);
+    tablet_metadata_pb->set_gtid(req.gtid);
 
     if (req.__isset.enable_persistent_index) {
         tablet_metadata_pb->set_enable_persistent_index(req.enable_persistent_index);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -64,6 +64,8 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
     private static final Logger LOG = LogManager.getLogger(LakeTableAlterMetaJobBase.class);
     @SerializedName(value = "watershedTxnId")
     private long watershedTxnId = -1;
+    @SerializedName(value = "watershedGtid")
+    private long watershedGtid = -1;
     // PhysicalPartitionId -> indexId -> MaterializedIndex
     @SerializedName(value = "partitionIndexMap")
     private Table<Long, Long, MaterializedIndex> physicalPartitionIndexMap = HashBasedTable.create();
@@ -107,6 +109,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         if (this.watershedTxnId == -1) {
             this.watershedTxnId = globalStateMgr.getGlobalTransactionMgr().getTransactionIDGenerator()
                     .getNextTransactionId();
+            this.watershedGtid = globalStateMgr.getGtidGenerator().nextGtid();
             GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
         }
 
@@ -259,6 +262,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             txnInfo.combinedTxnLog = false;
             txnInfo.commitTime = finishedTimeMs / 1000;
             txnInfo.txnType = TxnTypePB.TXN_NORMAL;
+            txnInfo.gtid = watershedGtid;
             for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
                 long commitVersion = commitVersionMap.get(partitionId);
                 Map<Long, MaterializedIndex> dirtyIndexMap = physicalPartitionIndexMap.row(partitionId);
@@ -475,6 +479,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
 
             this.physicalPartitionIndexMap = other.physicalPartitionIndexMap;
             this.watershedTxnId = other.watershedTxnId;
+            this.watershedGtid = other.watershedGtid;
             this.commitVersionMap = other.commitVersionMap;
 
             restoreState(other);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
@@ -45,6 +45,8 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
     // The job will wait all transactions before this txn id finished, then send the rollup tasks.
     @SerializedName(value = "watershedTxnId")
     protected long watershedTxnId = -1;
+    @SerializedName(value = "watershedGtid")
+    protected long watershedGtid = -1;
 
     public LakeTableSchemaChangeJobBase(long jobId, JobType jobType, long dbId, long tableId,
                                         String tableName, long timeoutMs) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TxnInfoHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TxnInfoHelper.java
@@ -33,6 +33,7 @@ public class TxnInfoHelper {
         } else {
             infoPB.forcePublish = false;
         }
+        infoPB.setGtid(state.getGlobalTransactionId());
         return infoPB;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1791,18 +1791,23 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             numReplicas += partition.storageReplicaCount();
         }
 
+        TabletTaskExecutor.CreateTabletOption option = new TabletTaskExecutor.CreateTabletOption();
+        option.setEnableTabletCreationOptimization(table.isCloudNativeTableOrMaterializedView()
+                && Config.lake_enable_tablet_creation_optimization);
+        option.setGtid(GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid());
+
         try {
             GlobalStateMgr.getCurrentState().getConsistencyChecker().addCreatingTableId(table.getId());
             if (numReplicas > Config.create_table_max_serial_replicas) {
                 LOG.info("start to build {} partitions concurrently for table {}.{} with {} replicas",
                         partitions.size(), db.getFullName(), table.getName(), numReplicas);
                 TabletTaskExecutor.buildPartitionsConcurrently(
-                        db.getId(), table, partitions, numReplicas, numAliveNodes, warehouseId);
+                        db.getId(), table, partitions, numReplicas, numAliveNodes, warehouseId, option);
             } else {
                 LOG.info("start to build {} partitions sequentially for table {}.{} with {} replicas",
                         partitions.size(), db.getFullName(), table.getName(), numReplicas);
                 TabletTaskExecutor.buildPartitionsSequentially(
-                        db.getId(), table, partitions, numReplicas, numAliveNodes, warehouseId);
+                        db.getId(), table, partitions, numReplicas, numAliveNodes, warehouseId, option);
             }
         } finally {
             GlobalStateMgr.getCurrentState().getConsistencyChecker().deleteCreatingTableId(table.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -84,6 +84,7 @@ public class CreateReplicaTask extends AgentTask {
     private boolean createSchemaFile = true;
     private boolean enableTabletCreationOptimization = false;
     private final TTabletSchema tabletSchema;
+    private long gtid = 0;
     private long timeoutMs = -1;
 
     private CreateReplicaTask(Builder builder) {
@@ -105,6 +106,7 @@ public class CreateReplicaTask extends AgentTask {
         this.baseTabletId = builder.getBaseTabletId();
         this.recoverySource = builder.getRecoverySource();
         this.inRestoreMode = builder.isInRestoreMode();
+        this.gtid = builder.getGtid();
     }
 
     public static Builder newBuilder() {
@@ -182,6 +184,7 @@ public class CreateReplicaTask extends AgentTask {
         createTabletReq.setTablet_type(tabletType);
         createTabletReq.setCreate_schema_file(createSchemaFile);
         createTabletReq.setEnable_tablet_creation_optimization(enableTabletCreationOptimization);
+        createTabletReq.setGtid(gtid);
         return createTabletReq;
     }
 
@@ -210,6 +213,7 @@ public class CreateReplicaTask extends AgentTask {
         private boolean createSchemaFile = true;
         private boolean enableTabletCreationOptimization = false;
         private TTabletSchema tabletSchema;
+        private long gtid = 0;
 
         private Builder() {
         }
@@ -409,6 +413,15 @@ public class CreateReplicaTask extends AgentTask {
 
         public Builder setTabletSchema(TTabletSchema tabletSchema) {
             this.tabletSchema = tabletSchema;
+            return this;
+        }
+
+        public long getGtid() {
+            return gtid;
+        }
+
+        public Builder setGtid(long gtid) {
+            this.gtid = gtid;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -59,21 +59,41 @@ import java.util.stream.Collectors;
 public class TabletTaskExecutor {
     private static final Logger LOG = LogManager.getLogger(TabletTaskExecutor.class);
 
+    public static class CreateTabletOption {
+        private boolean enableTabletCreationOptimization;
+        private long gtid;
+
+        public boolean isEnableTabletCreationOptimization() {
+            return enableTabletCreationOptimization;
+        }
+
+        public void setEnableTabletCreationOptimization(boolean enableTabletCreationOptimization) {
+            this.enableTabletCreationOptimization = enableTabletCreationOptimization;
+        }
+
+        public long getGtid() {
+            return gtid;
+        }
+
+        public void setGtid(long gtid) {
+            this.gtid = gtid;
+        }
+    }
+
     public static void buildPartitionsSequentially(long dbId, OlapTable table, List<PhysicalPartition> partitions,
                                                    int numReplicas,
-                                                   int numBackends, long warehouseId) throws DdlException {
+                                                   int numBackends, long warehouseId,
+                                                   CreateTabletOption option) throws DdlException {
         // Try to bundle at least 200 CreateReplicaTask's in a single AgentBatchTask.
         // The number 200 is just an experiment value that seems to work without obvious problems, feel free to
         // change it if you have a better choice.
         long start = System.currentTimeMillis();
         int avgReplicasPerPartition = numReplicas / partitions.size();
         int partitionGroupSize = Math.max(1, numBackends * 200 / Math.max(1, avgReplicasPerPartition));
-        boolean enableTabletCreationOptimization = table.isCloudNativeTableOrMaterializedView()
-                && Config.lake_enable_tablet_creation_optimization;
         for (int i = 0; i < partitions.size(); i += partitionGroupSize) {
             int endIndex = Math.min(partitions.size(), i + partitionGroupSize);
             List<CreateReplicaTask> tasks = buildCreateReplicaTasks(dbId, table, partitions.subList(i, endIndex),
-                    warehouseId, enableTabletCreationOptimization);
+                    warehouseId, option);
             int partitionCount = endIndex - i;
             int indexCountPerPartition = partitions.get(i).getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE).size();
             int timeout = Config.tablet_create_timeout_second * countMaxTasksPerBackend(tasks);
@@ -99,16 +119,15 @@ public class TabletTaskExecutor {
 
     public static void buildPartitionsConcurrently(long dbId, OlapTable table, List<PhysicalPartition> partitions,
                                                    int numReplicas,
-                                                   int numBackends, long warehouseId) throws DdlException {
+                                                   int numBackends, long warehouseId,
+                                                   CreateTabletOption option) throws DdlException {
         long start = System.currentTimeMillis();
         int timeout = Math.max(1, numReplicas / numBackends) * Config.tablet_create_timeout_second;
         int numIndexes = partitions.stream().mapToInt(
                 partition -> partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE).size()).sum();
         int maxTimeout = numIndexes * Config.max_create_table_timeout_second;
         long maxWaitTimeSeconds = Math.min(timeout, maxTimeout);
-        boolean enableTabletCreationOptimization = table.isCloudNativeTableOrMaterializedView()
-                && Config.lake_enable_tablet_creation_optimization;
-        if (enableTabletCreationOptimization) {
+        if (option.isEnableTabletCreationOptimization()) {
             numReplicas = numIndexes;
         }
         MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<>(numReplicas);
@@ -122,7 +141,7 @@ public class TabletTaskExecutor {
                     break;
                 }
                 List<CreateReplicaTask> tasks = buildCreateReplicaTasks(dbId, table, partition, warehouseId,
-                        enableTabletCreationOptimization);
+                        option);
                 for (CreateReplicaTask task : tasks) {
                     List<Long> signatures =
                             taskSignatures.computeIfAbsent(task.getBackendId(), k -> new ArrayList<>());
@@ -173,24 +192,23 @@ public class TabletTaskExecutor {
     }
 
     private static List<CreateReplicaTask> buildCreateReplicaTasks(long dbId, OlapTable table, List<PhysicalPartition> partitions,
-                                                                   long warehouseId, boolean enableTabletCreationOptimization)
+                                                                   long warehouseId, CreateTabletOption option)
             throws DdlException {
         List<CreateReplicaTask> tasks = new ArrayList<>();
         for (PhysicalPartition partition : partitions) {
             tasks.addAll(
-                    buildCreateReplicaTasks(dbId, table, partition, warehouseId, enableTabletCreationOptimization));
+                    buildCreateReplicaTasks(dbId, table, partition, warehouseId, option));
         }
         return tasks;
     }
 
     private static List<CreateReplicaTask> buildCreateReplicaTasks(long dbId, OlapTable table,
                                                                    PhysicalPartition physicalPartition,
-                                                                   long warehouseId, boolean enableTabletCreationOptimization)
+                                                                   long warehouseId, CreateTabletOption option)
             throws DdlException {
         ArrayList<CreateReplicaTask> tasks = new ArrayList<>((int) physicalPartition.storageReplicaCount());
         for (MaterializedIndex index : physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
-            tasks.addAll(buildCreateReplicaTasks(dbId, table, physicalPartition, index, warehouseId,
-                    enableTabletCreationOptimization));
+            tasks.addAll(buildCreateReplicaTasks(dbId, table, physicalPartition, index, warehouseId, option));
         }
         return tasks;
     }
@@ -200,7 +218,7 @@ public class TabletTaskExecutor {
                                                                    PhysicalPartition physicalPartition,
                                                                    MaterializedIndex index,
                                                                    long warehouseId,
-                                                                   boolean enableTabletCreationOptimization) {
+                                                                   CreateTabletOption option) {
         LOG.info("build create replica tasks for index {} db {} table {} partition {}",
                 index, dbId, table.getId(), physicalPartition);
         boolean isCloudNativeTable = table.isCloudNativeTableOrMaterializedView();
@@ -258,13 +276,14 @@ public class TabletTaskExecutor {
                         .setCompressionLevel(table.getCompressionLevel())
                         .setTabletSchema(tabletSchema)
                         .setCreateSchemaFile(createSchemaFile)
-                        .setEnableTabletCreationOptimization(enableTabletCreationOptimization)
+                        .setEnableTabletCreationOptimization(option.isEnableTabletCreationOptimization())
+                        .setGtid(option.getGtid())
                         .build();
                 tasks.add(task);
                 createSchemaFile = false;
             }
 
-            if (enableTabletCreationOptimization) {
+            if (option.isEnableTabletCreationOptimization()) {
                 break;
             }
         }

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -153,6 +153,8 @@ message TabletMetadataPB {
     map<int64, TabletSchemaPB> historical_schemas = 17;
     // rowset_id -> schema_id
     map<uint32, int64> rowset_to_schema = 18;
+    // global transaction id
+    optional int64 gtid = 19 [default=0];
 }
 
 message MetadataUpdateInfoPB {
@@ -233,5 +235,6 @@ message TxnInfoPB {
     optional TxnTypePB txn_type = 4;
     optional bool force_publish = 5; // only used for compaction
     optional bool rebuild_pindex = 6;
+    optional int64 gtid = 7 [default=0];
 };
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -120,6 +120,8 @@ struct TCreateTabletReq {
     22: optional bool enable_tablet_creation_optimization = false;
     // The timeout FE will wait for the tablet to be created.
     23: optional i64 timeout_ms = -1;
+    // Global transaction id
+    24: optional i64 gtid = 0;
 }
 
 struct TDropTabletReq {


### PR DESCRIPTION
## Why I'm doing:
The dirty data must be detected when restoring from a cluster snapshot.

## What I'm doing:
Introduce gtid for tablet metadata, gtid will be used for the following:
1. Check if a tablet metadata version is dirty using gtid during publish version. If the gtid of a tablet metadata version is not equal to the value saved in fe, it indicates that the tablet metadata version is dirty and need to be deleted.
2. Query versions before a given time for time travel, like `select a from b before t`.

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0