### PR TITLE
[Enhancement] improve cloud native index memtable memory usage and statistic

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -36,8 +36,6 @@ class PersistentIndexMemtable;
 class PersistentIndexSstable;
 class TabletManager;
 
-using IndexValueWithVer = std::pair<int64_t, IndexValue>;
-
 class KeyValueMerger {
 public:
     explicit KeyValueMerger(const std::string& key, uint64_t max_rss_rowid, sstable::TableBuilder* builder,

--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -19,11 +19,10 @@
 
 namespace starrocks::lake {
 
-void PersistentIndexMemtable::update_index_value(std::list<IndexValueWithVer>* index_value_infos, int64_t version,
+void PersistentIndexMemtable::update_index_value(IndexValueWithVer* index_value_info, int64_t version,
                                                  const IndexValue& value) {
-    std::list<IndexValueWithVer> t;
-    t.emplace_front(version, value);
-    index_value_infos->swap(t);
+    index_value_info->first = version;
+    index_value_info->second = value;
 }
 
 Status PersistentIndexMemtable::upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values,
@@ -33,17 +32,15 @@ Status PersistentIndexMemtable::upsert(size_t n, const Slice* keys, const IndexV
     for (size_t i = 0; i < n; ++i) {
         auto key = keys[i].to_string();
         const auto value = values[i];
-        std::list<IndexValueWithVer> index_value_vers;
-        index_value_vers.emplace_front(version, value);
-        if (auto [it, inserted] = _map.emplace(key, index_value_vers); inserted) {
+        if (auto [it, inserted] = _map.emplace(key, std::make_pair(version, value)); inserted) {
             not_founds->insert(i);
             _keys_size += key.capacity() + sizeof(std::string);
         } else {
-            auto& old_index_value_vers = it->second;
-            auto old_value = old_index_value_vers.front().second;
+            auto& old_index_value_ver = it->second;
+            auto old_value = old_index_value_ver.second;
             old_values[i] = old_value;
             nfound += old_value.get_value() != NullIndexValue;
-            update_index_value(&old_index_value_vers, version, value);
+            update_index_value(&old_index_value_ver, version, value);
         }
         _max_rss_rowid = std::max(_max_rss_rowid, value.get_value());
     }
@@ -57,13 +54,11 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
         auto key = keys[i].to_string();
         auto size = keys[i].get_size();
         const auto value = values[i];
-        std::list<IndexValueWithVer> index_value_vers;
-        index_value_vers.emplace_front(version, value);
-        if (auto [it, inserted] = _map.emplace(key, index_value_vers); inserted) {
+        if (auto [it, inserted] = _map.emplace(key, std::make_pair(version, value)); inserted) {
             _keys_size += key.capacity() + sizeof(std::string);
         } else {
-            auto& old_index_value_vers = it->second;
-            auto old_index_value = old_index_value_vers.front().second;
+            auto& old_index_value_ver = it->second;
+            auto old_index_value = old_index_value_ver.second;
             if (old_index_value.get_value() != NullIndexValue) {
                 // shouldn't happen
                 std::string msg = strings::Substitute("PersistentIndexMemtable<$0> insert found duplicate key $1", size,
@@ -72,11 +67,11 @@ Status PersistentIndexMemtable::insert(size_t n, const Slice* keys, const IndexV
                 if (!config::experimental_lake_ignore_pk_consistency_check) {
                     return Status::AlreadyExist(msg);
                 } else {
-                    update_index_value(&old_index_value_vers, version, value);
+                    update_index_value(&old_index_value_ver, version, value);
                 }
             } else {
                 // cover delete operation.
-                update_index_value(&old_index_value_vers, version, value);
+                update_index_value(&old_index_value_ver, version, value);
             }
         }
         _max_rss_rowid = std::max(_max_rss_rowid, value.get_value());
@@ -90,18 +85,16 @@ Status PersistentIndexMemtable::erase(size_t n, const Slice* keys, IndexValue* o
     size_t nfound = 0;
     for (size_t i = 0; i < n; ++i) {
         auto key = keys[i].to_string();
-        std::list<IndexValueWithVer> index_value_vers;
-        index_value_vers.emplace_front(version, IndexValue(NullIndexValue));
-        if (auto [it, inserted] = _map.emplace(key, index_value_vers); inserted) {
+        if (auto [it, inserted] = _map.emplace(key, std::make_pair(version, IndexValue(NullIndexValue))); inserted) {
             old_values[i] = NullIndexValue;
             not_founds->insert(i);
             _keys_size += key.capacity() + sizeof(std::string);
         } else {
-            auto& old_index_value_vers = it->second;
-            auto old_index_value = old_index_value_vers.front().second;
+            auto& old_index_value_ver = it->second;
+            auto old_index_value = old_index_value_ver.second;
             old_values[i] = old_index_value;
             nfound += old_index_value.get_value() != NullIndexValue;
-            update_index_value(&old_index_value_vers, version, IndexValue(NullIndexValue));
+            update_index_value(&old_index_value_ver, version, IndexValue(NullIndexValue));
         }
     }
     // Delete is after upsert, so using UINT32_MAX as it's rowid
@@ -118,13 +111,11 @@ Status PersistentIndexMemtable::erase_with_filter(size_t n, const Slice* keys, c
             continue;
         }
         auto key = keys[i].to_string();
-        std::list<IndexValueWithVer> index_value_vers;
-        index_value_vers.emplace_front(version, IndexValue(NullIndexValue));
-        if (auto [it, inserted] = _map.emplace(key, index_value_vers); inserted) {
+        if (auto [it, inserted] = _map.emplace(key, std::make_pair(version, IndexValue(NullIndexValue))); inserted) {
             _keys_size += key.capacity() + sizeof(std::string);
         } else {
-            auto& old_index_value_vers = it->second;
-            update_index_value(&old_index_value_vers, version, IndexValue(NullIndexValue));
+            auto& old_index_value_ver = it->second;
+            update_index_value(&old_index_value_ver, version, IndexValue(NullIndexValue));
         }
     }
     // Delete is after upsert, so using UINT32_MAX as it's rowid
@@ -138,9 +129,7 @@ Status PersistentIndexMemtable::replace(const Slice* keys, const IndexValue* val
     for (unsigned long idx : replace_idxes) {
         auto key = keys[idx].to_string();
         const auto value = values[idx];
-        std::list<IndexValueWithVer> index_value_vers;
-        index_value_vers.emplace_front(version, value);
-        if (auto [it, inserted] = _map.emplace(key, index_value_vers); !inserted) {
+        if (auto [it, inserted] = _map.emplace(key, std::make_pair(version, value)); !inserted) {
             update_index_value(&it->second, version, value);
         } else {
             _keys_size += key.capacity() + sizeof(std::string);
@@ -161,8 +150,8 @@ Status PersistentIndexMemtable::get(size_t n, const Slice* keys, IndexValue* val
             not_founds->insert(i);
         } else {
             // Assuming we want the latest (first) value due to emplace_front in updates/inserts
-            auto& index_value_vers = it->second;
-            auto index_value = index_value_vers.front().second;
+            auto& index_value_ver = it->second;
+            auto index_value = index_value_ver.second;
             values[i] = index_value;
         }
     }
@@ -177,8 +166,8 @@ Status PersistentIndexMemtable::get(const Slice* keys, IndexValue* values, const
         auto it = _map.find(key);
         if (it != _map.end()) {
             // Assuming we want the latest (first) value due to emplace_front in updates/inserts
-            auto& index_value_vers = it->second;
-            auto& index_value = index_value_vers.front().second;
+            auto& index_value_ver = it->second;
+            auto& index_value = index_value_ver.second;
             values[key_index] = index_value.get_value();
             found_key_indexes->insert(key_index);
         }
@@ -187,7 +176,7 @@ Status PersistentIndexMemtable::get(const Slice* keys, IndexValue* values, const
 }
 
 size_t PersistentIndexMemtable::memory_usage() const {
-    return _keys_size + _map.size() * sizeof(IndexValueWithVer);
+    return _map.bytes_used();
 }
 
 Status PersistentIndexMemtable::flush(WritableFile* wf, uint64_t* filesize) {

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -21,7 +21,6 @@ namespace starrocks::lake {
 
 using KeyIndex = size_t;
 using KeyIndexSet = std::set<KeyIndex>;
-using IndexValueWithVer = std::pair<int64_t, IndexValue>;
 
 class PersistentIndexMemtable {
 public:
@@ -72,12 +71,11 @@ public:
     const uint64_t max_rss_rowid() const { return _max_rss_rowid; }
 
 private:
-    static void update_index_value(std::list<IndexValueWithVer>* index_value_info, int64_t version,
-                                   const IndexValue& value);
+    static void update_index_value(IndexValueWithVer* index_value_info, int64_t version, const IndexValue& value);
 
 private:
     // The size can be up to 230K. The performance of std::map may be poor.
-    phmap::btree_map<std::string, std::list<IndexValueWithVer>, std::less<>> _map;
+    phmap::btree_map<std::string, IndexValueWithVer, std::less<>> _map;
     int64_t _keys_size{0};
     uint64_t _max_rss_rowid{0};
 };

--- a/be/src/storage/lake/persistent_index_sstable.h
+++ b/be/src/storage/lake/persistent_index_sstable.h
@@ -42,7 +42,7 @@ public:
     Status init(std::unique_ptr<RandomAccessFile> rf, const PersistentIndexSstablePB& sstable_pb, Cache* cache,
                 bool need_filter = true);
 
-    static Status build_sstable(const phmap::btree_map<std::string, std::list<IndexValueWithVer>, std::less<>>& map,
+    static Status build_sstable(const phmap::btree_map<std::string, IndexValueWithVer, std::less<>>& map,
                                 WritableFile* wf, uint64_t* filesz);
 
     // multi_get can get multi keys at onces

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -123,6 +123,8 @@ struct IndexValue {
     void operator=(uint64_t rhs) { return UNALIGNED_STORE64(v, rhs); }
 };
 
+using IndexValueWithVer = std::pair<int64_t, IndexValue>;
+
 static constexpr size_t kIndexValueSize = 8;
 static_assert(sizeof(IndexValue) == kIndexValueSize);
 constexpr static size_t kSliceMaxFixLength = 64;

--- a/be/src/util/phmap/btree.h
+++ b/be/src/util/phmap/btree.h
@@ -3114,6 +3114,7 @@ public:
     size_type size() const { return tree_.size(); }
     size_type max_size() const { return tree_.max_size(); }
     bool empty() const { return tree_.empty(); }
+    size_type bytes_used() const { return tree_.bytes_used(); }
 
     friend bool operator==(const btree_container& x, const btree_container& y) {
         if (x.size() != y.size()) return false;

--- a/be/test/storage/lake/persistent_index_memtable_test.cpp
+++ b/be/test/storage/lake/persistent_index_memtable_test.cpp
@@ -145,4 +145,25 @@ TEST(PersistentIndexMemtableTest, test_replace) {
     }
 }
 
+TEST(PersistentIndexMemtableTest, test_memory_usage) {
+    auto memtable = std::make_unique<PersistentIndexMemtable>();
+    {
+        using Key = uint64_t;
+        const int N = 1000;
+        vector<Key> keys;
+        vector<Slice> key_slices;
+        vector<IndexValue> values;
+        vector<size_t> idxes;
+        keys.reserve(N);
+        key_slices.reserve(N);
+        for (int i = 0; i < N; i++) {
+            keys.emplace_back(i);
+            values.emplace_back(i * 2);
+            key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
+        }
+        ASSERT_OK(memtable->insert(N, key_slices.data(), values.data(), -1));
+    }
+    ASSERT_TRUE(memtable->memory_usage() < 100000 && memtable->memory_usage() > 0);
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -212,11 +212,9 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
     // 1. build sstable
     const std::string filename = "test_persistent_index_sstable_1.sst";
     ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
-    phmap::btree_map<std::string, std::list<IndexValueWithVer>, std::less<>> map;
+    phmap::btree_map<std::string, IndexValueWithVer, std::less<>> map;
     for (int i = 0; i < N; i++) {
-        std::list<IndexValueWithVer> index_value_vers;
-        index_value_vers.emplace_front(100, i);
-        map.insert({fmt::format("test_key_{:016X}", i), index_value_vers});
+        map.insert({fmt::format("test_key_{:016X}", i), std::make_pair(100, i)});
     }
     uint64_t filesize = 0;
     ASSERT_OK(PersistentIndexSstable::build_sstable(map, file.get(), &filesize));

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -214,7 +214,7 @@ TEST_F(PersistentIndexSstableTest, test_persistent_index_sstable) {
     ASSIGN_OR_ABORT(auto file, fs::new_writable_file(lake::join_path(kTestDir, filename)));
     phmap::btree_map<std::string, IndexValueWithVer, std::less<>> map;
     for (int i = 0; i < N; i++) {
-        map.insert({fmt::format("test_key_{:016X}", i), std::make_pair(100, i)});
+        map.emplace(fmt::format("test_key_{:016X}", i), std::make_pair(100, IndexValue(i)));
     }
     uint64_t filesize = 0;
     ASSERT_OK(PersistentIndexSstable::build_sstable(map, file.get(), &filesize));


### PR DESCRIPTION
## Why I'm doing:
There are two issue in current implementation:
1. Use `std::list<IndexValueWithVer>` as value will cause too much memory overhead here, because there will be 3 useless address pointers.
2. Use `_keys_size + _map.size() * sizeof(IndexValueWithVer)` can't get the real memory usage because `_map` is a btree and there will have overhead memory usage on internal nodes and leaf nodes.

## What I'm doing:
1. Use `IndexValueWithVer` instead of `std::list<IndexValueWithVer>` as value, it can reduce 45% memory usage.
2. Use `bytes_used ` from btree class to get the memory usage info.

This pull request focuses on simplifying the data structure used in `PersistentIndexMemtable` by replacing `std::list` with `std::pair` for storing index values and their versions. Additionally, it includes a new method to calculate memory usage and updates the relevant tests.

Key changes:

### Data Structure Simplification:
* Replaced `std::list<IndexValueWithVer>` with `std::pair<int64_t, IndexValue>` in `PersistentIndexMemtable` to simplify the data structure and improve performance. (`be/src/storage/lake/lake_persistent_index.h` - [[1]](diffhunk://#diff-d7ad440fb6d98ac0f9a31747c9c6a1a112e18fb29d4ef0857ca483687eb7e349L39-L40) `be/src/storage/lake/persistent_index_memtable.cpp` - [[2]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L22-R25) [[3]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L36-R43) [[4]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L60-R61) [[5]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L75-R74) [[6]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L93-R97) [[7]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L121-R118) [[8]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L141-R132) [[9]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L164-R154) [[10]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L180-R170) [[11]](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L190-R179) `be/src/storage/lake/persistent_index_memtable.h` - [[12]](diffhunk://#diff-0fa7a9fa792819b27a25ea176c8c8154af0ed664f12dfd466c8ed781e304b2aeL24) [[13]](diffhunk://#diff-0fa7a9fa792819b27a25ea176c8c8154af0ed664f12dfd466c8ed781e304b2aeL75-R78)

### Memory Usage Calculation:
* Added a new method `bytes_used` to `btree_container` to calculate the memory usage of the btree map. (`be/src/util/phmap/btree.h` - [be/src/util/phmap/btree.hR3117](diffhunk://#diff-046f97a143d6a9077078ca0eb6617170530ddb65aabeb0d5e5cce76388ae2992R3117))
* Updated `PersistentIndexMemtable::memory_usage` to use the new `bytes_used` method for more accurate memory usage reporting. (`be/src/storage/lake/persistent_index_memtable.cpp` - [be/src/storage/lake/persistent_index_memtable.cppL190-R179](diffhunk://#diff-2a0d7738bf81a53d3c0561225e77a7ddfb6f5aec5f831a03c4b0371715c04728L190-R179))

### Test Updates:
* Added a new test case `test_memory_usage` to verify the memory usage calculation of `PersistentIndexMemtable`. (`be/test/storage/lake/persistent_index_memtable_test.cpp` - [be/test/storage/lake/persistent_index_memtable_test.cppR148-R168](diffhunk://#diff-7d1f9790afeeb78e0094558d42bd03f02678b901331c017c433d71eea3ec03a2R148-R168))

### Other Updates:
* Updated `PersistentIndexSstable::build_sstable` to reflect the change in data structure from `std::list<IndexValueWithVer>` to `std::pair<int64_t, IndexValue>`. (`be/src/storage/lake/persistent_index_sstable.cpp` - [[1]](diffhunk://#diff-944f1a344f7f65e05aa9a179b3c047563225c2658b39f4c4129abfb919a2f402L42-R54) `be/src/storage/lake/persistent_index_sstable.h` - [[2]](diffhunk://#diff-730a4bbffe684fca8ff8657698ba70e972f7cfb2001abb5f5393ccfc95709baeL45-R45)
* Moved the `IndexValueWithVer` type definition to `persistent_index.h` for better organization. (`be/src/storage/persistent_index.h` - [be/src/storage/persistent_index.hR126-R127](diffhunk://#diff-da797af69ced87554b37fff696a558293c3ecda50ecca66a2c7ff4f6140d2d3eR126-R127))

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0