### PR TITLE
[BugFix] Fix HistogramMetric output in json format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/HistogramMetric.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/HistogramMetric.java
@@ -52,6 +52,10 @@ public final class HistogramMetric extends Histogram {
         return Joiner.on(", ").join(labelStrings);
     }
 
+    public List<MetricLabel> getLabels() {
+        return labels;
+    }
+
     /**
      * Get the histogram name with tags in the format of "name_tag1=value1, tag2=value2"
      */

--- a/fe/fe-core/src/main/java/com/starrocks/metric/JsonMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/JsonMetricVisitor.java
@@ -41,6 +41,7 @@ import com.starrocks.monitor.jvm.JvmStats;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.system.SystemInfoService;
+import org.apache.commons.collections.ListUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -151,11 +152,33 @@ public class JsonMetricVisitor extends MetricVisitor {
 
     @Override
     public void visitHistogram(HistogramMetric histogram) {
+        final String fullName = prefix + "_" + histogram.getName().replace("\\.", "_");
+        Snapshot snapshot = histogram.getSnapshot();
+        List<MetricLabel> labels = histogram.getLabels();
+        buildMetric(fullName, MILLISECONDS, String.valueOf(snapshot.get75thPercentile()),
+                ListUtils.union(labels, Collections.singletonList(new MetricLabel(QUANTILE, "0.75"))));
+        buildMetric(fullName, MILLISECONDS, String.valueOf(snapshot.get95thPercentile()),
+                ListUtils.union(labels, Collections.singletonList(new MetricLabel(QUANTILE, "0.95"))));
+        buildMetric(fullName, MILLISECONDS, String.valueOf(snapshot.get98thPercentile()),
+                ListUtils.union(labels, Collections.singletonList(new MetricLabel(QUANTILE, "0.98"))));
+        buildMetric(fullName, MILLISECONDS, String.valueOf(snapshot.get99thPercentile()),
+                ListUtils.union(labels, Collections.singletonList(new MetricLabel(QUANTILE, "0.99"))));
+        buildMetric(fullName, MILLISECONDS, String.valueOf(snapshot.get999thPercentile()),
+                ListUtils.union(labels, Collections.singletonList(new MetricLabel(QUANTILE, "0.999"))));
 
+        buildMetric(fullName + "_sum", MILLISECONDS,
+                String.valueOf(histogram.getCount() * snapshot.getMean()), labels);
+        buildMetric(fullName + "_count", NOUNIT,
+                String.valueOf(histogram.getCount()), labels);
     }
 
     @Override
     public void visitHistogram(String name, Histogram histogram) {
+        // skip HistogramMetric since it needs extra processing
+        if (histogram instanceof HistogramMetric) {
+            visitHistogram((HistogramMetric) histogram);
+            return;
+        }
         final String fullName = prefix + "_" + name.replace("\\.", "_");
         Snapshot snapshot = histogram.getSnapshot();
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/SimpleCoreMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/SimpleCoreMetricVisitor.java
@@ -136,6 +136,11 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
 
     @Override
     public void visitHistogram(String name, Histogram histogram) {
+        // skip HistogramMetric since it needs extra processing
+        if (histogram instanceof HistogramMetric) {
+            visitHistogram((HistogramMetric) histogram);
+            return;
+        }
         if (!CORE_METRICS.containsKey(name)) {
             return;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
@@ -162,4 +162,60 @@ public class MetricsTest {
             Assert.assertTrue(output.contains(metricName));
         }
     }
+
+    @Test
+    public void testJsonHistogramMetrics1() {
+        JsonMetricVisitor visitor = new JsonMetricVisitor("sr");
+        HistogramMetric histogramMetric = new HistogramMetric("duration");
+        histogramMetric.addLabel(new MetricLabel("k1", "v1"));
+        histogramMetric.addLabel(new MetricLabel("k2", "v2"));
+        visitor.visitHistogram(histogramMetric);
+        String output = visitor.build();
+        List<String> metricNames = Arrays.asList(
+                "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.75\"}," +
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.95\"}," +
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.98\"}," +
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.99\"}," +
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.999\"}," +
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration_sum\",\"k1\":\"v1\",\"k2\":\"v2\"},\"unit\":\"milliseconds\",\"value\":0" +
+                        ".0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration_count\",\"k1\":\"v1\",\"k2\":\"v2\"},\"unit\":\"nounit\",\"value\":0}"
+        );
+        for (String metricName : metricNames) {
+            Assert.assertTrue(output.contains(metricName));
+        }
+    }
+
+    @Test
+    public void testJsonHistogramMetrics2() {
+        JsonMetricVisitor visitor = new JsonMetricVisitor("sr");
+        HistogramMetric histogramMetric = new HistogramMetric("duration");
+        histogramMetric.addLabel(new MetricLabel("k1", "v1"));
+        histogramMetric.addLabel(new MetricLabel("k2", "v2"));
+        visitor.visitHistogram("", histogramMetric);
+        String output = visitor.build();
+        List<String> metricNames = Arrays.asList(
+                "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.75\"}," +
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.95\"}," +
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.98\"}," +
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.99\"}," +
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.999\"}," +
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration_sum\",\"k1\":\"v1\",\"k2\":\"v2\"},\"unit\":\"milliseconds\",\"value\":0" +
+                        ".0},\n" ,
+                "{\"tags\":{\"metric\":\"sr_duration_count\",\"k1\":\"v1\",\"k2\":\"v2\"},\"unit\":\"nounit\",\"value\":0}"
+        );
+        for (String metricName : metricNames) {
+            Assert.assertTrue(output.contains(metricName));
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
@@ -173,17 +173,17 @@ public class MetricsTest {
         String output = visitor.build();
         List<String> metricNames = Arrays.asList(
                 "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.75\"}," +
-                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.95\"}," +
-                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.98\"}," +
-                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.99\"}," +
-                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.999\"}," +
-                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration_sum\",\"k1\":\"v1\",\"k2\":\"v2\"},\"unit\":\"milliseconds\",\"value\":0" +
-                        ".0},\n" ,
+                        ".0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration_count\",\"k1\":\"v1\",\"k2\":\"v2\"},\"unit\":\"nounit\",\"value\":0}"
         );
         for (String metricName : metricNames) {
@@ -201,17 +201,17 @@ public class MetricsTest {
         String output = visitor.build();
         List<String> metricNames = Arrays.asList(
                 "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.75\"}," +
-                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.95\"}," +
-                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.98\"}," +
-                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.99\"}," +
-                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration\",\"k1\":\"v1\",\"k2\":\"v2\",\"quantile\":\"0.999\"}," +
-                        "\"unit\":\"milliseconds\",\"value\":0.0},\n" ,
+                        "\"unit\":\"milliseconds\",\"value\":0.0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration_sum\",\"k1\":\"v1\",\"k2\":\"v2\"},\"unit\":\"milliseconds\",\"value\":0" +
-                        ".0},\n" ,
+                        ".0},\n",
                 "{\"tags\":{\"metric\":\"sr_duration_count\",\"k1\":\"v1\",\"k2\":\"v2\"},\"unit\":\"nounit\",\"value\":0}"
         );
         for (String metricName : metricNames) {


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/53735 will output histogram metrics in json format, but doesn't handle HistogramMetric.


## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/8971

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0