### PR TITLE
[Enhancement] Support column mismatch fill property in files()

### DIFF
--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -370,7 +370,7 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
         if (((_file_scan_type == TFileScanType::LOAD && row.columns.size() != _num_fields_in_csv) ||
              (_file_scan_type == TFileScanType::FILES_INSERT && row.columns.size() < _num_fields_in_csv)) &&
             !_scan_range.params.flexible_column_mapping) {
-            // broker load / stream load will filter rows when file column count is consistent with column list.
+            // broker load / stream load will filter rows when file column count is inconsistent with column list.
             //
             // insert from files() will filter rows when file column count is less than files() schema.
             // file column count more than schema is normal, extra columns will be ignored.
@@ -388,11 +388,11 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
             continue;
         } else if (_file_scan_type == TFileScanType::FILES_QUERY && row.columns.size() < _num_fields_in_csv &&
                    !_scan_range.params.flexible_column_mapping) {
+            // query files() will return error when file column count is less than files() schema.
+            // file column count more than schema is normal, extra columns will be ignored.
             if (status.is_end_of_file()) {
                 break;
             }
-            // query files() will return error when file column count is less than files() schema.
-            // file column count more than schema is normal, extra columns will be ignored.
             std::string error_msg = make_column_count_not_matched_error_message_for_query(
                     _num_fields_in_csv, row.columns.size(), _parse_options, record.to_string(),
                     _curr_reader->filename());
@@ -490,7 +490,7 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
         if (((_file_scan_type == TFileScanType::LOAD && fields.size() != _num_fields_in_csv) ||
              (_file_scan_type == TFileScanType::FILES_INSERT && fields.size() < _num_fields_in_csv)) &&
             !_scan_range.params.flexible_column_mapping) {
-            // broker load / stream load will filter rows when file column count is consistent with column list.
+            // broker load / stream load will filter rows when file column count is inconsistent with column list.
             //
             // insert from files() will filter rows when file column count is less than files() schema.
             // file column count more than schema is normal, extra columns will be ignored.

--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -370,9 +370,9 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
         if (((_file_scan_type == TFileScanType::LOAD && row.columns.size() != _num_fields_in_csv) ||
              (_file_scan_type == TFileScanType::FILES_INSERT && row.columns.size() < _num_fields_in_csv)) &&
             !_scan_range.params.flexible_column_mapping) {
-            // broker load / stream load will filter rows when file column count is consistent with schema.
+            // broker load / stream load will filter rows when file column count is consistent with column list.
             //
-            // insert from files() will filter rows when file column count is less than schema.
+            // insert from files() will filter rows when file column count is less than files() schema.
             // file column count more than schema is normal, extra columns will be ignored.
             if (status.is_end_of_file()) {
                 break;
@@ -391,7 +391,7 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
             if (status.is_end_of_file()) {
                 break;
             }
-            // query files() will return error when file column count is less than schema.
+            // query files() will return error when file column count is less than files() schema.
             // file column count more than schema is normal, extra columns will be ignored.
             std::string error_msg = make_column_count_not_matched_error_message_for_query(
                     _num_fields_in_csv, row.columns.size(), _parse_options, record.to_string(),
@@ -487,19 +487,13 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
         fields.clear();
         _curr_reader->split_record(record, &fields);
 
-        if (_file_scan_type == TFileScanType::LOAD && fields.size() != _num_fields_in_csv &&
+        if (((_file_scan_type == TFileScanType::LOAD && fields.size() != _num_fields_in_csv) ||
+             (_file_scan_type == TFileScanType::FILES_INSERT && fields.size() < _num_fields_in_csv)) &&
             !_scan_range.params.flexible_column_mapping) {
-            std::string error_msg = make_column_count_not_matched_error_message_for_load(_num_fields_in_csv,
-                                                                                         fields.size(), _parse_options);
-            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
-                _report_error(record, error_msg);
-            }
-            if (_state->enable_log_rejected_record()) {
-                _report_rejected_record(record, error_msg);
-            }
-            continue;
-        } else if (_file_scan_type == TFileScanType::FILES_INSERT && fields.size() < _num_fields_in_csv &&
-                   !_scan_range.params.flexible_column_mapping) {
+            // broker load / stream load will filter rows when file column count is consistent with column list.
+            //
+            // insert from files() will filter rows when file column count is less than files() schema.
+            // file column count more than schema is normal, extra columns will be ignored.
             std::string error_msg = make_column_count_not_matched_error_message_for_load(_num_fields_in_csv,
                                                                                          fields.size(), _parse_options);
             if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
@@ -511,7 +505,8 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
             continue;
         } else if (_file_scan_type == TFileScanType::FILES_QUERY && fields.size() < _num_fields_in_csv &&
                    !_scan_range.params.flexible_column_mapping) {
-            // files() query return error
+            // query files() will return error when file column count is less than files() schema.
+            // file column count more than schema is normal, extra columns will be ignored.
             std::string error_msg = make_column_count_not_matched_error_message_for_query(
                     _num_fields_in_csv, fields.size(), _parse_options, record.to_string(), _curr_reader->filename());
             return Status::DataQualityError(error_msg);

--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -45,13 +45,27 @@ static std::string string_2_asc(const std::string& input) {
     return oss.str();
 }
 
-static std::string make_column_count_not_matched_error_message(int expected_count, int actual_count,
-                                                               CSVParseOptions& parse_options) {
+static std::string make_column_count_not_matched_error_message_for_load(int expected_count, int actual_count,
+                                                                        CSVParseOptions& parse_options) {
     std::stringstream error_msg;
     error_msg << "Target column count: " << expected_count
               << " doesn't match source value column count: " << actual_count << ". "
               << "Column separator: " << string_2_asc(parse_options.column_delimiter) << ", "
               << "Row delimiter: " << string_2_asc(parse_options.row_delimiter);
+    return error_msg.str();
+}
+
+static std::string make_column_count_not_matched_error_message_for_query(int expected_count, int actual_count,
+                                                                         CSVParseOptions& parse_options,
+                                                                         const std::string& row,
+                                                                         const std::string& filename) {
+    std::stringstream error_msg;
+    error_msg << "Schema column count: " << expected_count
+              << " doesn't match source value column count: " << actual_count << ". "
+              << "Column separator: " << string_2_asc(parse_options.column_delimiter) << ", "
+              << "Row delimiter: " << string_2_asc(parse_options.row_delimiter) << ", "
+              << "Row: '" << row << "', File: " << filename << ". "
+              << "Consider setting 'fill_mismatch_column_with' = 'null'";
     return error_msg.str();
 }
 
@@ -357,17 +371,23 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
             if (status.is_end_of_file()) {
                 break;
             }
-            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
-                std::string error_msg = make_column_count_not_matched_error_message(_num_fields_in_csv,
-                                                                                    row.columns.size(), _parse_options);
-                _report_error(record, error_msg);
+            if (_is_load) {
+                std::string error_msg = make_column_count_not_matched_error_message_for_load(
+                        _num_fields_in_csv, row.columns.size(), _parse_options);
+                if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                    _report_error(record, error_msg);
+                }
+                if (_state->enable_log_rejected_record()) {
+                    _report_rejected_record(record, error_msg);
+                }
+                continue;
+            } else {
+                // files() query return error
+                std::string error_msg = make_column_count_not_matched_error_message_for_query(
+                        _num_fields_in_csv, row.columns.size(), _parse_options, record.to_string(),
+                        _curr_reader->filename());
+                return Status::DataQualityError(error_msg);
             }
-            if (_state->enable_log_rejected_record()) {
-                std::string error_msg = make_column_count_not_matched_error_message(_num_fields_in_csv,
-                                                                                    row.columns.size(), _parse_options);
-                _report_rejected_record(record, error_msg);
-            }
-            continue;
         }
         if (!validate_utf8(record.data, record.size)) {
             if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
@@ -459,17 +479,23 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
         _curr_reader->split_record(record, &fields);
 
         if (fields.size() != _num_fields_in_csv && !_scan_range.params.flexible_column_mapping) {
-            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
-                std::string error_msg =
-                        make_column_count_not_matched_error_message(_num_fields_in_csv, fields.size(), _parse_options);
-                _report_error(record, error_msg);
+            if (_is_load) {
+                std::string error_msg = make_column_count_not_matched_error_message_for_load(
+                        _num_fields_in_csv, fields.size(), _parse_options);
+                if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                    _report_error(record, error_msg);
+                }
+                if (_state->enable_log_rejected_record()) {
+                    _report_rejected_record(record, error_msg);
+                }
+                continue;
+            } else {
+                // files() query return error
+                std::string error_msg = make_column_count_not_matched_error_message_for_query(
+                        _num_fields_in_csv, fields.size(), _parse_options, record.to_string(),
+                        _curr_reader->filename());
+                return Status::DataQualityError(error_msg);
             }
-            if (_state->enable_log_rejected_record()) {
-                std::string error_msg =
-                        make_column_count_not_matched_error_message(_num_fields_in_csv, fields.size(), _parse_options);
-                _report_rejected_record(record, error_msg);
-            }
-            continue;
         }
         if (!validate_utf8(record.data, record.size)) {
             if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {

--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -367,27 +367,44 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
 
         const char* data = _curr_reader->buffBasePtr() + row.parsed_start;
         CSVReader::Record record(data, row.parsed_end - row.parsed_start);
-        if (row.columns.size() != _num_fields_in_csv && !_scan_range.params.flexible_column_mapping) {
+        if (_file_scan_type == TFileScanType::LOAD && row.columns.size() != _num_fields_in_csv &&
+            !_scan_range.params.flexible_column_mapping) {
             if (status.is_end_of_file()) {
                 break;
             }
-            if (_is_load) {
-                std::string error_msg = make_column_count_not_matched_error_message_for_load(
-                        _num_fields_in_csv, row.columns.size(), _parse_options);
-                if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
-                    _report_error(record, error_msg);
-                }
-                if (_state->enable_log_rejected_record()) {
-                    _report_rejected_record(record, error_msg);
-                }
-                continue;
-            } else {
-                // files() query return error
-                std::string error_msg = make_column_count_not_matched_error_message_for_query(
-                        _num_fields_in_csv, row.columns.size(), _parse_options, record.to_string(),
-                        _curr_reader->filename());
-                return Status::DataQualityError(error_msg);
+            std::string error_msg = make_column_count_not_matched_error_message_for_load(
+                    _num_fields_in_csv, row.columns.size(), _parse_options);
+            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                _report_error(record, error_msg);
             }
+            if (_state->enable_log_rejected_record()) {
+                _report_rejected_record(record, error_msg);
+            }
+            continue;
+        } else if (_file_scan_type == TFileScanType::FILES_INSERT && row.columns.size() < _num_fields_in_csv &&
+                   !_scan_range.params.flexible_column_mapping) {
+            if (status.is_end_of_file()) {
+                break;
+            }
+            std::string error_msg = make_column_count_not_matched_error_message_for_load(
+                    _num_fields_in_csv, row.columns.size(), _parse_options);
+            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                _report_error(record, error_msg);
+            }
+            if (_state->enable_log_rejected_record()) {
+                _report_rejected_record(record, error_msg);
+            }
+            continue;
+        } else if (_file_scan_type == TFileScanType::FILES_QUERY && row.columns.size() < _num_fields_in_csv &&
+                   !_scan_range.params.flexible_column_mapping) {
+            if (status.is_end_of_file()) {
+                break;
+            }
+            // files() query return error
+            std::string error_msg = make_column_count_not_matched_error_message_for_query(
+                    _num_fields_in_csv, row.columns.size(), _parse_options, record.to_string(),
+                    _curr_reader->filename());
+            return Status::DataQualityError(error_msg);
         }
         if (!validate_utf8(record.data, record.size)) {
             if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
@@ -478,24 +495,34 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
         fields.clear();
         _curr_reader->split_record(record, &fields);
 
-        if (fields.size() != _num_fields_in_csv && !_scan_range.params.flexible_column_mapping) {
-            if (_is_load) {
-                std::string error_msg = make_column_count_not_matched_error_message_for_load(
-                        _num_fields_in_csv, fields.size(), _parse_options);
-                if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
-                    _report_error(record, error_msg);
-                }
-                if (_state->enable_log_rejected_record()) {
-                    _report_rejected_record(record, error_msg);
-                }
-                continue;
-            } else {
-                // files() query return error
-                std::string error_msg = make_column_count_not_matched_error_message_for_query(
-                        _num_fields_in_csv, fields.size(), _parse_options, record.to_string(),
-                        _curr_reader->filename());
-                return Status::DataQualityError(error_msg);
+        if (_file_scan_type == TFileScanType::LOAD && fields.size() != _num_fields_in_csv &&
+            !_scan_range.params.flexible_column_mapping) {
+            std::string error_msg = make_column_count_not_matched_error_message_for_load(_num_fields_in_csv,
+                                                                                         fields.size(), _parse_options);
+            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                _report_error(record, error_msg);
             }
+            if (_state->enable_log_rejected_record()) {
+                _report_rejected_record(record, error_msg);
+            }
+            continue;
+        } else if (_file_scan_type == TFileScanType::FILES_INSERT && fields.size() < _num_fields_in_csv &&
+                   !_scan_range.params.flexible_column_mapping) {
+            std::string error_msg = make_column_count_not_matched_error_message_for_load(_num_fields_in_csv,
+                                                                                         fields.size(), _parse_options);
+            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                _report_error(record, error_msg);
+            }
+            if (_state->enable_log_rejected_record()) {
+                _report_rejected_record(record, error_msg);
+            }
+            continue;
+        } else if (_file_scan_type == TFileScanType::FILES_QUERY && fields.size() < _num_fields_in_csv &&
+                   !_scan_range.params.flexible_column_mapping) {
+            // files() query return error
+            std::string error_msg = make_column_count_not_matched_error_message_for_query(
+                    _num_fields_in_csv, fields.size(), _parse_options, record.to_string(), _curr_reader->filename());
+            return Status::DataQualityError(error_msg);
         }
         if (!validate_utf8(record.data, record.size)) {
             if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {

--- a/be/src/exec/file_scanner.cpp
+++ b/be/src/exec/file_scanner.cpp
@@ -46,7 +46,7 @@ FileScanner::FileScanner(starrocks::RuntimeState* state, starrocks::RuntimeProfi
           _row_desc(nullptr),
           _strict_mode(false),
           _error_counter(0),
-          _is_load(true),
+          _file_scan_type(TFileScanType::LOAD),
           _schema_only(schema_only) {}
 
 FileScanner::~FileScanner() = default;
@@ -136,8 +136,8 @@ Status FileScanner::open() {
         _strict_mode = _params.strict_mode;
     }
 
-    if (_params.__isset.is_load) {
-        _is_load = _params.is_load;
+    if (_params.__isset.file_scan_type) {
+        _file_scan_type = _params.file_scan_type;
     }
 
     if (_strict_mode && !_params.__isset.dest_sid_to_src_sid_without_trans) {

--- a/be/src/exec/file_scanner.cpp
+++ b/be/src/exec/file_scanner.cpp
@@ -46,6 +46,7 @@ FileScanner::FileScanner(starrocks::RuntimeState* state, starrocks::RuntimeProfi
           _row_desc(nullptr),
           _strict_mode(false),
           _error_counter(0),
+          _is_load(true),
           _schema_only(schema_only) {}
 
 FileScanner::~FileScanner() = default;
@@ -133,6 +134,10 @@ Status FileScanner::open() {
 
     if (_params.__isset.strict_mode) {
         _strict_mode = _params.strict_mode;
+    }
+
+    if (_params.__isset.is_load) {
+        _is_load = _params.is_load;
     }
 
     if (_strict_mode && !_params.__isset.dest_sid_to_src_sid_without_trans) {

--- a/be/src/exec/file_scanner.h
+++ b/be/src/exec/file_scanner.h
@@ -100,11 +100,12 @@ protected:
 
     bool _strict_mode;
     int64_t _error_counter;
-    // When column mismatch, query and load have different behaviors.
+    // When column mismatch, files query/load and other type load have different behaviors.
     // Query returns error, while load counts the filtered rows, and return error or not is based on max filter ratio,
-    // so need to check query or load in scanner.
+    // files load will not filter rows if file column count is larger that the schema,
+    // so need to check files query/load or other type load in scanner.
     // Currently only used in csv scanner.
-    bool _is_load;
+    TFileScanType::type _file_scan_type;
 
     // sources
     std::vector<SlotDescriptor*> _src_slot_descriptors;

--- a/be/src/exec/file_scanner.h
+++ b/be/src/exec/file_scanner.h
@@ -100,6 +100,11 @@ protected:
 
     bool _strict_mode;
     int64_t _error_counter;
+    // When column mismatch, query and load have different behaviors.
+    // Query returns error, while load counts the filtered rows, and return error or not is based on max filter ratio,
+    // so need to check query or load in scanner.
+    // Currently only used in csv scanner.
+    bool _is_load;
 
     // sources
     std::vector<SlotDescriptor*> _src_slot_descriptors;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -81,6 +81,7 @@ import com.starrocks.thrift.TBrokerScanRangeParams;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.TFileScanNode;
+import com.starrocks.thrift.TFileScanType;
 import com.starrocks.thrift.TFileType;
 import com.starrocks.thrift.THdfsProperties;
 import com.starrocks.thrift.TNetworkAddress;
@@ -163,11 +164,12 @@ public class FileScanNode extends LoadScanNode {
     private LoadJob.JSONOptions jsonOptions = new LoadJob.JSONOptions();
     
     private boolean flexibleColumnMapping = false;
-    // When column mismatch, query and load have different behaviors.
+    // When column mismatch, files query/load and other type load have different behaviors.
     // Query returns error, while load counts the filtered rows, and return error or not is based on max filter ratio,
-    // so need to check query or load in scanner.
+    // files load will not filter rows if file column count is larger that the schema,
+    // so need to check files query/load or other type load in scanner.
     // Currently only used in csv scanner.
-    private boolean isLoad = true;
+    private TFileScanType fileScanType = TFileScanType.LOAD;
 
     private boolean nullExprInAutoIncrement;
 
@@ -265,8 +267,8 @@ public class FileScanNode extends LoadScanNode {
         this.flexibleColumnMapping = enable;
     }
 
-    public void setIsLoad(boolean isLoad) {
-        this.isLoad = isLoad;
+    public void setFileScanType(TFileScanType fileScanType) {
+        this.fileScanType = fileScanType;
     }
 
     public void setUseVectorizedLoad(boolean useVectorizedLoad) {
@@ -326,7 +328,7 @@ public class FileScanNode extends LoadScanNode {
         params.setEscape(fileGroup.getEscape());
         params.setJson_file_size_limit(Config.json_file_size_limit);
         params.setFlexible_column_mapping(flexibleColumnMapping);
-        params.setIs_load(isLoad);
+        params.setFile_scan_type(fileScanType);
         initColumns(context);
         initWhereExpr(fileGroup.getWhereExpr(), analyzer);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3865,8 +3865,8 @@ public class PlanFragmentBuilder {
             int dop = ConnectContext.get().getSessionVariable().getSinkDegreeOfParallelism();
             scanNode.setLoadInfo(-1, -1, table, new BrokerDesc(table.getProperties()), fileGroups, table.isStrictMode(), dop);
             scanNode.setUseVectorizedLoad(true);
-            // table function enable flexible column mapping by default.
-            scanNode.setFlexibleColumnMapping(true);
+            scanNode.setFlexibleColumnMapping(table.isFlexibleColumnMapping());
+            scanNode.setIsLoad(table.isLoadType());
 
             Analyzer analyzer = new Analyzer(GlobalStateMgr.getCurrentState(), context.getConnectContext());
             analyzer.setDescTbl(context.getDescTbl());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -201,6 +201,7 @@ import com.starrocks.sql.optimizer.rule.tree.prunesubfield.SubfieldExpressionCol
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.thrift.TBrokerFileStatus;
+import com.starrocks.thrift.TFileScanType;
 import com.starrocks.thrift.TPartitionType;
 import com.starrocks.thrift.TResultSinkType;
 import org.apache.commons.collections4.CollectionUtils;
@@ -3866,7 +3867,7 @@ public class PlanFragmentBuilder {
             scanNode.setLoadInfo(-1, -1, table, new BrokerDesc(table.getProperties()), fileGroups, table.isStrictMode(), dop);
             scanNode.setUseVectorizedLoad(true);
             scanNode.setFlexibleColumnMapping(table.isFlexibleColumnMapping());
-            scanNode.setIsLoad(table.isLoadType());
+            scanNode.setFileScanType(table.isLoadType() ? TFileScanType.FILES_INSERT : TFileScanType.FILES_QUERY);
 
             Analyzer analyzer = new Analyzer(GlobalStateMgr.getCurrentState(), context.getConnectContext());
             analyzer.setDescTbl(context.getDescTbl());

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -271,6 +271,7 @@ struct TBrokerScanRangeParams {
     30: optional i64 schema_sample_file_count
     31: optional i64 schema_sample_file_row_count
     32: optional bool flexible_column_mapping
+    33: optional bool is_load
 }
 
 // Broker scan range

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -210,6 +210,7 @@ struct THdfsProperties {
 }
 
 enum TFileScanType {
+    // broker load, stream load, except insert from files
     LOAD,
     FILES_INSERT,
     FILES_QUERY

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -209,6 +209,12 @@ struct THdfsProperties {
   12: optional CloudConfiguration.TCloudConfiguration cloud_configuration
 }
 
+enum TFileScanType {
+    LOAD,
+    FILES_INSERT,
+    FILES_QUERY
+}
+
 struct TBrokerScanRangeParams {
     1: required i8 column_separator;
     2: required i8 row_delimiter;
@@ -271,7 +277,7 @@ struct TBrokerScanRangeParams {
     30: optional i64 schema_sample_file_count
     31: optional i64 schema_sample_file_row_count
     32: optional bool flexible_column_mapping
-    33: optional bool is_load
+    33: optional TFileScanType file_scan_type
 }
 
 // Broker scan range

--- a/test/sql/test_files/R/test_csv_files_merge
+++ b/test/sql/test_files/R/test_csv_files_merge
@@ -92,6 +92,7 @@ select * from t1;
 1	Julia	20.2	1
 2	Andy	21.3	0
 3	Joke	22.4	1
+5	Jerry	40.8	0
 -- !result
 
 truncate table t1;

--- a/test/sql/test_files/R/test_csv_files_merge
+++ b/test/sql/test_files/R/test_csv_files_merge
@@ -1,0 +1,134 @@
+-- name: test_csv_files_merge
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/csv_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic0_column_mismatch.csv oss://${oss_bucket}/test_files/csv_format/${uuid0}/ | grep -Pv "(average|elapsed)"
+-- result:
+0
+
+Succeed: Total num: 1, size: 34. OK num: 1(upload 1 files).
+-- !result
+
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic1.csv oss://${oss_bucket}/test_files/csv_format/${uuid0}/ | grep -Pv "(average|elapsed)"
+-- result:
+0
+
+Succeed: Total num: 1, size: 52. OK num: 1(upload 1 files).
+-- !result
+
+
+desc files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1");
+-- result:
+$1	bigint	YES
+$2	varchar(1048576)	YES
+$3	double	YES
+$4	boolean	YES
+-- !result
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "null");
+-- result:
+4	Tom	30.4	None
+5	Jerry	40.8	0
+1	Julia	20.2	1
+2	Andy	21.3	0
+3	Joke	22.4	1
+-- !result
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "none");
+-- result:
+[REGEX].*Schema column count: 4 doesn't match source value column count: 3. Column separator: ',', Row delimiter: .*, Row: '4,Tom,30.4', File: .*basic0_column_mismatch.csv. Consider setting 'fill_mismatch_column_with' = 'null'.*
+-- !result
+
+
+create table t1 (k1 bigint, k2 varchar(256), k3 double, k4 boolean);
+-- result:
+-- !result
+
+insert into t1 
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "none");
+-- result:
+[REGEX].*Insert has filtered data.*
+-- !result
+
+insert into t1 properties ("max_filter_ratio" = "0.5") 
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "none");
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+1	Julia	20.2	1
+2	Andy	21.3	0
+3	Joke	22.4	1
+-- !result
+
+truncate table t1;
+-- result:
+-- !result
+
+insert into t1 
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "null");
+-- result:
+-- !result
+
+select * from t1;
+-- result:
+1	Julia	20.2	1
+2	Andy	21.3	0
+3	Joke	22.4	1
+4	Tom	30.4	None
+5	Jerry	40.8	0
+-- !result
+
+
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "xxx");
+-- result:
+[REGEX].*Invalid fill_mismatch_column_with: 'xxx'. Expected values should be none, null \(case insensitive\).
+-- !result
+
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/csv_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/R/test_orc_files_merge
+++ b/test/sql/test_files/R/test_orc_files_merge
@@ -75,6 +75,7 @@ select * from files(
 select * from files(
     "path" = "oss://${oss_bucket}/test_files/orc_format/${uuid0}/*",
     "format" = "orc",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -88,6 +89,7 @@ None	21	None	None	2024-10-03	None	c	None
 select k2, k5, k7 from files(
     "path" = "oss://${oss_bucket}/test_files/orc_format/${uuid0}/*",
     "format" = "orc",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -101,6 +103,7 @@ select k2, k5, k7 from files(
 select k1, k3, k8 from files(
     "path" = "oss://${oss_bucket}/test_files/orc_format/${uuid0}/*",
     "format" = "orc",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",

--- a/test/sql/test_files/R/test_parquet_files_merge
+++ b/test/sql/test_files/R/test_parquet_files_merge
@@ -75,6 +75,7 @@ select * from files(
 select * from files(
     "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -88,6 +89,7 @@ None	21	None	None	2024-10-03	None	c	None
 select k2, k5, k7 from files(
     "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -101,6 +103,7 @@ select k2, k5, k7 from files(
 select k1, k3, k8 from files(
     "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",

--- a/test/sql/test_files/T/test_csv_files_merge
+++ b/test/sql/test_files/T/test_csv_files_merge
@@ -1,0 +1,75 @@
+-- name: test_csv_files_merge
+
+create database db_${uuid0};
+use db_${uuid0};
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/csv_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic0_column_mismatch.csv oss://${oss_bucket}/test_files/csv_format/${uuid0}/ | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic1.csv oss://${oss_bucket}/test_files/csv_format/${uuid0}/ | grep -Pv "(average|elapsed)"
+
+-- query
+desc files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1");
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "null");
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "none");
+
+
+-- load
+create table t1 (k1 bigint, k2 varchar(256), k3 double, k4 boolean);
+
+insert into t1 
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "none");
+
+insert into t1 properties ("max_filter_ratio" = "0.5") 
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "none");
+select * from t1;
+truncate table t1;
+
+insert into t1 
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "null");
+select * from t1;
+
+-- error property
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/csv_format/${uuid0}/*",
+    "format" = "csv",
+    "csv.column_separator" = ",",
+    "csv.row_delimiter" = "\n",
+    "auto_detect_sample_files" = "1",
+    "fill_mismatch_column_with" = "xxx");
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/csv_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/T/test_orc_files_merge
+++ b/test/sql/test_files/T/test_orc_files_merge
@@ -37,6 +37,7 @@ select * from files(
 select * from files(
     "path" = "oss://${oss_bucket}/test_files/orc_format/${uuid0}/*",
     "format" = "orc",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -44,6 +45,7 @@ select * from files(
 select k2, k5, k7 from files(
     "path" = "oss://${oss_bucket}/test_files/orc_format/${uuid0}/*",
     "format" = "orc",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -51,6 +53,7 @@ select k2, k5, k7 from files(
 select k1, k3, k8 from files(
     "path" = "oss://${oss_bucket}/test_files/orc_format/${uuid0}/*",
     "format" = "orc",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",

--- a/test/sql/test_files/T/test_parquet_files_merge
+++ b/test/sql/test_files/T/test_parquet_files_merge
@@ -37,6 +37,7 @@ select * from files(
 select * from files(
     "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -44,6 +45,7 @@ select * from files(
 select k2, k5, k7 from files(
     "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -51,6 +53,7 @@ select k2, k5, k7 from files(
 select k1, k3, k8 from files(
     "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
+    "fill_mismatch_column_with" = "null",
     "auto_detect_sample_files" = "2",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",

--- a/test/sql/test_files/csv_format/basic0_column_mismatch.csv
+++ b/test/sql/test_files/csv_format/basic0_column_mismatch.csv
@@ -1,0 +1,2 @@
+4,Tom,30.4
+5,Jerry,40.8,false,xxx


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`select * from files("path" = "xxx", "format" = "csv", "fill_mismatch_column_with" = "null");
`

add `fill_mismatch_column_with` property in files() to process column mismatch(file column count is less than schema), default value is `none`.

query files()
`none`: return error 
`null`: fill null 

insert from files()
`none`: filter rows, return error or not, based on max filter ratio
`null`: fill null

behavior change:
after this pr, query `csv` files() `return error` when file column count is less than schema, but previous behavior is `fill null`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0