### PR TITLE
[BugFix] Fix query cache crash when enable group execution

### DIFF
--- a/be/src/exec/pipeline/bucket_process_operator.cpp
+++ b/be/src/exec/pipeline/bucket_process_operator.cpp
@@ -43,6 +43,7 @@ Status BucketProcessContext::finish_current_sink(RuntimeState* state) {
 Status BucketProcessSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     RETURN_IF_ERROR(_ctx->sink->prepare(state));
+    _ctx->sink->set_runtime_filter_probe_sequence(_runtime_filter_probe_sequence);
     return Status::OK();
 }
 
@@ -105,7 +106,9 @@ Status BucketProcessSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr
 
 Status BucketProcessSourceOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    return _ctx->source->prepare(state);
+    RETURN_IF_ERROR(_ctx->source->prepare(state));
+    _ctx->source->set_runtime_filter_probe_sequence(_runtime_filter_probe_sequence);
+    return Status::OK();
 }
 // case 1: has_output() is true then call pull_chunk to pull chunk
 // case 2: has_output() is false (empty bucket) then to reset state

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -41,7 +41,8 @@ Operator::Operator(OperatorFactory* factory, int32_t id, std::string name, int32
           _name(std::move(name)),
           _plan_node_id(plan_node_id),
           _is_subordinate(is_subordinate),
-          _driver_sequence(driver_sequence) {
+          _driver_sequence(driver_sequence),
+          _runtime_filter_probe_sequence(driver_sequence) {
     std::string upper_name(_name);
     std::transform(upper_name.begin(), upper_name.end(), upper_name.begin(), ::toupper);
     std::string profile_name = strings::Substitute("$0 (plan_node_id=$1)", upper_name, _plan_node_id);
@@ -263,7 +264,7 @@ void Operator::_init_rf_counters(bool init_bloom) {
                 ADD_COUNTER(_common_metrics, "JoinRuntimeFilterOutputRows", TUnit::UNIT);
         _bloom_filter_eval_context.join_runtime_filter_eval_counter =
                 ADD_COUNTER(_common_metrics, "JoinRuntimeFilterEvaluate", TUnit::UNIT);
-        _bloom_filter_eval_context.driver_sequence = _driver_sequence;
+        _bloom_filter_eval_context.driver_sequence = _runtime_filter_probe_sequence;
     }
 }
 

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -250,6 +250,9 @@ public:
         }
     }
     int32_t get_driver_sequence() const { return _driver_sequence; }
+    void set_runtime_filter_probe_sequence(int32_t probe_sequence) {
+        this->_runtime_filter_probe_sequence = probe_sequence;
+    }
     OperatorFactory* get_factory() const { return _factory; }
 
     // memory to be reserved before executing push_chunk
@@ -281,6 +284,7 @@ protected:
     const int32_t _plan_node_id;
     const bool _is_subordinate;
     const int32_t _driver_sequence;
+    int32_t _runtime_filter_probe_sequence;
     // _common_metrics and _unique_metrics are the only children of _runtime_profile
     // _common_metrics contains the common metrics of Operator, including counters and sub profiles,
     // e.g. OperatorTotalTime/PushChunkNum/PullChunkNum etc.

--- a/be/src/exec/query_cache/conjugate_operator.cpp
+++ b/be/src/exec/query_cache/conjugate_operator.cpp
@@ -43,6 +43,8 @@ Status ConjugateOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     RETURN_IF_ERROR(_source_op->prepare(state));
     RETURN_IF_ERROR(_sink_op->prepare(state));
+    _source_op->set_runtime_filter_probe_sequence(_runtime_filter_probe_sequence);
+    _sink_op->set_runtime_filter_probe_sequence(_runtime_filter_probe_sequence);
     return Status::OK();
 }
 

--- a/be/src/exec/query_cache/multilane_operator.cpp
+++ b/be/src/exec/query_cache/multilane_operator.cpp
@@ -332,6 +332,9 @@ pipeline::OperatorPtr MultilaneOperatorFactory::create(int32_t degree_of_paralle
         processors.push_back(
                 _factory->create(degree_of_parallelism * _num_lanes, i * degree_of_parallelism + driver_sequence));
     }
+    for (auto& operators : processors) {
+        operators->set_runtime_filter_probe_sequence(driver_sequence);
+    }
     auto op = std::make_shared<MultilaneOperator>(this, driver_sequence, _num_lanes, std::move(processors),
                                                   _can_passthrough);
     return op;

--- a/test/sql/test_one_stage_aggr_having_preds_should_apply_to_pre_cache_aggr/R/test_pre_cache_agg_with_runtime_filter
+++ b/test/sql/test_one_stage_aggr_having_preds_should_apply_to_pre_cache_aggr/R/test_pre_cache_agg_with_runtime_filter
@@ -45,6 +45,9 @@ insert into t0 SELECT generate_series, generate_series, generate_series, generat
 insert into t1 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
 -- result:
 -- !result
+set enable_query_cache=true;
+-- result:
+-- !result
 select count(*),sum(v) from (select c0,c1,c2,count(distinct c3) v from t0 group by c0,c1,c2)l join [broadcast] t1 r on l.c0 = r.c1 where r.c2 < 5000;
 -- result:
 4999	4999
@@ -52,4 +55,8 @@ select count(*),sum(v) from (select c0,c1,c2,count(distinct c3) v from t0 group 
 select count(*),sum(v) from (select c0,c1,c2,count(distinct c3) v from t0 group by c0,c1,c2)l join [broadcast] t1 r on l.v = r.c1 where r.c2 < 5000;
 -- result:
 40960	40960
+-- !result
+select count(*) from (select c0,c1 from t0 group by c0,c1)l join t1 r on l.c1 = r.c1 and l.c0=r.c0 where r.c2 < 5000;
+-- result:
+4999
 -- !result

--- a/test/sql/test_one_stage_aggr_having_preds_should_apply_to_pre_cache_aggr/T/test_pre_cache_agg_with_runtime_filter
+++ b/test/sql/test_one_stage_aggr_having_preds_should_apply_to_pre_cache_aggr/T/test_pre_cache_agg_with_runtime_filter
@@ -40,5 +40,10 @@ PROPERTIES (
 insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
 insert into t1 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
 
+set enable_query_cache=true;
+
 select count(*),sum(v) from (select c0,c1,c2,count(distinct c3) v from t0 group by c0,c1,c2)l join [broadcast] t1 r on l.c0 = r.c1 where r.c2 < 5000;
 select count(*),sum(v) from (select c0,c1,c2,count(distinct c3) v from t0 group by c0,c1,c2)l join [broadcast] t1 r on l.v = r.c1 where r.c2 < 5000;
+
+-- TODO avoid runtime filter push down to scan
+select count(*) from (select c0,c1 from t0 group by c0,c1)l join t1 r on l.c1 = r.c1 and l.c0=r.c0 where r.c2 < 5000;


### PR DESCRIPTION
## Why I'm doing:

When group execution and query cache are turned on, if a runtime filter is pushed down to AGG instead of SCAN, it will cause the colocate runtime filter to use the wrong runtime filter, resulting in a crash.

I apply this patch to make runtime filter evaluate on aggregate node:
```patch
diff --git a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
index 282f355ad5..352a52cdfd 100644
--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -189,6 +189,9 @@ public class RuntimeFilterDescription {
 
     // return true if Node could accept the Filter
     public boolean canAcceptFilter(PlanNode node, RuntimeFilterPushDownContext rfPushCtx) {
+        if (node instanceof ScanNode) {
+            return false;
+        }
         if (RuntimeFilterType.TOPN_FILTER.equals(runtimeFilterType())) {
             if (node instanceof ScanNode) {
                 ScanNode scanNode = (ScanNode) node;
```
then execution the test case:
```
select count(*) from (select c0,c1 from t0 group by c0,c1)l join t1 r on l.c1 = r.c1 and l.c0=r.c0 where r.c2 < 5000;
```

```
    @         0x11ee3b9c starrocks::failure_function()
    @         0x2119856e google::LogMessage::Fail()
    @         0x211997e9 google::LogMessageFatal::~LogMessageFatal()
    @         0x12447378 starrocks::RuntimeFilterProbeDescriptor::runtime_filter(int) const
    @         0x1a3ff6a3 starrocks::RuntimeFilterProbeCollector::update_selectivity(starrocks::Chunk*, starrocks::RuntimeBloomFilterEvalContext&)
    @         0x1a3fb165 starrocks::RuntimeFilterProbeCollector::do_evaluate(starrocks::Chunk*, starrocks::RuntimeBloomFilterEvalContext&)
    @         0x1a3fdaab starrocks::RuntimeFilterProbeCollector::evaluate(starrocks::Chunk*, starrocks::RuntimeBloomFilterEvalContext&)
    @         0x14975c81 starrocks::pipeline::Operator::eval_runtime_bloom_filters(starrocks::Chunk*)
    @         0x14ee48a9 starrocks::pipeline::AggregateDistinctBlockingSourceOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x15225c30 starrocks::query_cache::ConjugateOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x151ee2b7 starrocks::query_cache::MultilaneOperator::_pull_chunk_from_lane(starrocks::RuntimeState*, starrocks::query_cache::MultilaneOperator::Lane&, bool)
    @         0x151eea54 starrocks::query_cache::MultilaneOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x14dfd1c5 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x14daff82 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x14dae2fa starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x14dba4a2 void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x14db987b std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver_^A
    @         0x14db91fd std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x11eb18d6 std::function<void ()>::operator()() const
    @         0x1ee8ec8c starrocks::FunctionRunnable::run()
    @         0x1ee8aba4 starrocks::ThreadPool::dispatch_thread()
    @         0x1eeac1fe void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x1eeabc9f std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x1eeaab5c void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0