### PR TITLE
[BugFix] Fix BFD initialization error on aarch64

### DIFF
--- a/be/src/util/bfd_parser.cpp
+++ b/be/src/util/bfd_parser.cpp
@@ -103,9 +103,17 @@ void BfdParser::init_bfd() {
     }
     std::lock_guard<std::mutex> lock(_bfd_mutex);
     bfd_init();
+#if defined(__x86_64__)
     if (!bfd_set_default_target("elf64-x86-64")) {
         LOG(ERROR) << "set default target to elf64-x86-64 failed.";
     }
+#elif defined(__aarch64__)
+    if (!bfd_set_default_target("elf64-littleaarch64")) {
+        LOG(ERROR) << "set default target to elf64-littleaarch64 failed.";
+    }
+#else
+#error "Not supported architecture"
+#endif
     _is_bfd_inited = true;
 }
 


### PR DESCRIPTION
## Why I'm doing:
BFD initialization error on aarch64:
```
[root@starrocks be]# uname -a
Linux starrocks 4.19.90-2107.6.0.0192.8.oe1.bclinux.aarch64 #1 SMP Tue Mar 21 09:23:05 CST 2023 aarch64 aarch64 aarch64 GNU/Linux
[root@starrocks be]# ./bin/start_be.sh --daemon
[root@starrocks be]# tail log/be.WARNING
E20241217 09:49:19.948438 70369568784448 bfd_parser.cpp:107] set default target to elf64-x86-64 failed.
[root@starrocks be]#
```
## What I'm doing:

Fix BFD initialization error on aarch64.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0