### PR TITLE
[Enhancement] improve performance of show materialized views statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -656,7 +656,7 @@ public class TaskManager implements MemoryTrackable {
                 .forEach(addResult);
 
         // history
-        taskRunManager.getTaskRunHistory().lookupHistoryByTaskNames(dbName, taskNames)
+        taskRunManager.getTaskRunHistory().lookupLastJobOfTasks(dbName, taskNames)
                 .stream()
                 .filter(taskRunFilter)
                 .forEach(addResult);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -104,6 +104,20 @@ public class TaskRunHistory {
         return result;
     }
 
+    /**
+     * Return the list of task runs belong to the LAST JOB:
+     * Each task run has a `startTaskRunId` as JobId, a job may have multiple task runs.
+     */
+    public List<TaskRunStatus> lookupLastJobOfTasks(String dbName, Set<String> taskNames) {
+        List<TaskRunStatus> result = getInMemoryHistory().stream()
+                .filter(x -> x.matchByTaskName(dbName, taskNames))
+                .collect(Collectors.toList());
+        if (isEnableArchiveHistory()) {
+            result.addAll(historyTable.lookupLastJobOfTasks(dbName, taskNames));
+        }
+        return result;
+    }
+
     public List<TaskRunStatus> lookupHistory(TGetTasksParams params) {
         List<TaskRunStatus> result = getInMemoryHistory().stream()
                 .filter(x -> x.match(params))

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -32,7 +32,10 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
 
+import java.io.StringWriter;
 import java.text.MessageFormat;
 import java.time.ZoneId;
 import java.util.Collections;
@@ -91,6 +94,13 @@ public class TaskRunHistoryTable {
     private static final String INSERT_SQL_VALUE = "({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})";
     private static final String LOOKUP =
             "SELECT history_content_json " + "FROM " + TABLE_FULL_NAME + " WHERE ";
+
+    private static final VelocityEngine DEFAULT_VELOCITY_ENGINE;
+
+    static {
+        DEFAULT_VELOCITY_ENGINE = new VelocityEngine();
+        DEFAULT_VELOCITY_ENGINE.setProperty(VelocityEngine.RUNTIME_LOG_REFERENCE_LOG_INVALID, false);
+    }
 
     private static final TableKeeper KEEPER =
             new TableKeeper(DATABASE_NAME, TABLE_NAME, CREATE_TABLE,
@@ -225,5 +235,49 @@ public class TaskRunHistoryTable {
         // sort results by create time desc to make the result more stable.
         Collections.sort(result, TaskRunStatus.COMPARATOR_BY_CREATE_TIME_DESC);
         return result;
+    }
+
+    public List<TaskRunStatus> lookupLastJobOfTasks(String dbName, Set<String> taskNames) {
+        final String template =
+                "WITH MaxStartRunID AS (" +
+                        "    SELECT " +
+                        "       task_name, " +
+                        "       cast(history_content_json->'startTaskRunId' as string) start_run_id" +
+                        "    FROM $tableName " +
+                        "    WHERE (task_name, create_time) IN (" +
+                        "            SELECT task_name, MAX(create_time)" +
+                        "            FROM $tableName" +
+                        "            WHERE $taskFilter" +
+                        "            GROUP BY task_name" +
+                        "    )" +
+                        " )" +
+                        " SELECT t.history_content_json" +
+                        " FROM $tableName t" +
+                        " JOIN MaxStartRunID msr" +
+                        "   ON t.task_name = msr.task_name" +
+                        "   AND cast(t.history_content_json->'startTaskRunId' as string) = msr.start_run_id" +
+                        " ORDER BY t.create_time DESC";
+
+        List<String> predicates = Lists.newArrayList("TRUE");
+        if (StringUtils.isNotEmpty(dbName)) {
+            predicates.add(" get_json_string(" + CONTENT_COLUMN + ", 'dbName') = "
+                    + Strings.quote(ClusterNamespace.getFullName(dbName)));
+        }
+        if (CollectionUtils.isNotEmpty(taskNames)) {
+            String values = taskNames.stream().sorted().map(Strings::quote).collect(Collectors.joining(","));
+            predicates.add(" task_name IN (" + values + ")");
+        }
+        String where = Joiner.on(" AND ").join(predicates);
+
+        VelocityContext context = new VelocityContext();
+        context.put("tableName", TABLE_FULL_NAME);
+        context.put("taskFilter", where);
+
+        StringWriter sw = new StringWriter();
+        DEFAULT_VELOCITY_ENGINE.evaluate(context, sw, "", template);
+        String sql = sw.toString();
+
+        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        return TaskRunStatus.fromResultBatch(batch);
     }
 }

--- a/test/sql/test_materialized_view/R/test_show_materialized_view
+++ b/test/sql/test_materialized_view/R/test_show_materialized_view
@@ -80,6 +80,45 @@ AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) A
 FROM `test_show_materialized_view`.`user_tags`
 GROUP BY `user_tags`.`user_id`;
 -- !result
+refresh materialized view user_tags_mv1 with sync mode;
+select 
+    TABLE_NAME,
+    LAST_REFRESH_STATE,
+    LAST_REFRESH_ERROR_CODE,
+    IS_ACTIVE,
+    INACTIVE_REASON
+from information_schema.materialized_views where table_name = 'user_tags_mv1';
+-- result:
+user_tags_mv1	SUCCESS	0	true	
+-- !result
+set @last_refresh_time = (
+    select max(last_refresh_start_time)
+    from information_schema.materialized_views where table_name = 'user_tags_mv1'
+);
+-- result:
+-- !result
+refresh materialized view user_tags_mv1 force with sync mode;
+select 
+    TABLE_NAME,
+    LAST_REFRESH_STATE,
+    LAST_REFRESH_ERROR_CODE,
+    IS_ACTIVE,
+    INACTIVE_REASON
+from information_schema.materialized_views where table_name = 'user_tags_mv1';
+-- result:
+user_tags_mv1	SUCCESS	0	true	
+-- !result
+set @this_refresh_time = (
+    select max(last_refresh_start_time)
+    from information_schema.materialized_views where table_name = 'user_tags_mv1'
+);
+-- result:
+-- !result
+select if(@last_refresh_time != @this_refresh_time, 
+    'refreshed', concat('no refresh after ', @last_refresh_time));
+-- result:
+refreshed
+-- !result
 drop database test_show_materialized_view;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_show_materialized_view
+++ b/test/sql/test_materialized_view/T/test_show_materialized_view
@@ -5,10 +5,43 @@ use test_show_materialized_view;
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
 
+
 show create materialized view user_tags_mv1;
 show create table user_tags_mv1;
 alter materialized view user_tags_mv1 set ("session.insert_timeout" = "3600");
 alter materialized view user_tags_mv1 set ("mv_rewrite_staleness_second" = "3600");
 show create materialized view user_tags_mv1;
 show create table user_tags_mv1;
+
+-- information_schema.materialized_views
+refresh materialized view user_tags_mv1 with sync mode;
+select 
+    TABLE_NAME,
+    LAST_REFRESH_STATE,
+    LAST_REFRESH_ERROR_CODE,
+    IS_ACTIVE,
+    INACTIVE_REASON
+from information_schema.materialized_views where table_name = 'user_tags_mv1';
+set @last_refresh_time = (
+    select max(last_refresh_start_time)
+    from information_schema.materialized_views where table_name = 'user_tags_mv1'
+);
+
+-- multiple refresh tasks
+refresh materialized view user_tags_mv1 force with sync mode;
+select 
+    TABLE_NAME,
+    LAST_REFRESH_STATE,
+    LAST_REFRESH_ERROR_CODE,
+    IS_ACTIVE,
+    INACTIVE_REASON
+from information_schema.materialized_views where table_name = 'user_tags_mv1';
+set @this_refresh_time = (
+    select max(last_refresh_start_time)
+    from information_schema.materialized_views where table_name = 'user_tags_mv1'
+);
+select if(@last_refresh_time != @this_refresh_time, 
+    'refreshed', concat('no refresh after ', @last_refresh_time));
+
+
 drop database test_show_materialized_view;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

When executing `SHOW MATERIALIZED VIEWS`, it is necessary to check the status of the last job.

Currently, we retrieve all historical records for a materialized view (MV), which can be slow when there are many entries. To improve performance, we now only query the records for the most recent job.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0