### PR TITLE
[Enhancement] Equivalent conversions for in null and not in null

### DIFF
--- a/be/src/exprs/in_const_predicate.hpp
+++ b/be/src/exprs/in_const_predicate.hpp
@@ -158,8 +158,19 @@ public:
 
                 ColumnViewer<Type> viewer(value);
                 if (viewer.is_null(0)) {
-                    _null_in_set = true;
-                    continue;
+                    if (_is_join_runtime_filter || _eq_null) {
+                        _null_in_set = true;
+                        continue;
+                    } else {
+                        if (_is_not_in) {
+                            _null_in_set = true;
+                            _hash_set.clear();
+                            _init_array_buffer();
+                            break;
+                        } else {
+                            continue;
+                        }
+                    }
                 }
 
                 // insert into set

--- a/be/src/testutil/CMakeLists.txt
+++ b/be/src/testutil/CMakeLists.txt
@@ -25,5 +25,6 @@ add_library(TestUtil
     sync_point_impl.cc
     schema_test_helper.cpp
     tablet_test_helper.cpp
+    exprs_test_helper.cpp
 )
 

--- a/be/src/testutil/exprs_test_helper.cpp
+++ b/be/src/testutil/exprs_test_helper.cpp
@@ -1,0 +1,19 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testutil/exprs_test_helper.h"
+
+namespace starrocks {
+const TTypeDesc ExprsTestHelper::IntTTypeDesc = ExprsTestHelper::create_scalar_type_desc(TPrimitiveType::INT);
+}

--- a/be/test/exprs/in_const_predicate_test.cpp
+++ b/be/test/exprs/in_const_predicate_test.cpp
@@ -19,6 +19,7 @@
 #include "exprs/column_ref.h"
 #include "runtime/runtime_state.h"
 #include "testutil/column_test_helper.h"
+#include "testutil/exprs_test_helper.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
@@ -28,9 +29,70 @@ public:
     void SetUp() override {}
 
 protected:
+    TExpr _create_not_in_null_mid(SlotId slot_id, const std::vector<int32_t>& values, bool has_null);
+
     ObjectPool _pool;
     RuntimeState _runtime_state;
 };
+
+TExpr InConstPredicateTest::_create_not_in_null_mid(SlotId slot_id, const std::vector<int32_t>& values, bool has_null) {
+    std::vector<TExprNode> nodes;
+
+    nodes.emplace_back(ExprsTestHelper::create_not_in_pred_node(values.size() + 1 + has_null));
+    nodes.emplace_back(ExprsTestHelper::create_slot_expr_node(0, slot_id, ExprsTestHelper::IntTTypeDesc, true));
+    for (size_t i = 0; i < values.size()/2; i++) {
+        nodes.emplace_back(ExprsTestHelper::create_int_literal(values[i], ExprsTestHelper::IntTTypeDesc, false));
+    }
+    if (has_null) {
+        nodes.emplace_back(ExprsTestHelper::create_null_literal(ExprsTestHelper::IntTTypeDesc));
+    }
+    for (size_t i = values.size()/2; i < values.size(); i++) {
+        nodes.emplace_back(ExprsTestHelper::create_int_literal(values[i], ExprsTestHelper::IntTTypeDesc, false));
+    }
+
+    TExpr t_expr;
+    t_expr.nodes = nodes;
+    return t_expr;
+}
+
+TEST_F(InConstPredicateTest, in_open_with_null) {
+    std::vector<int32_t> values{1, 3, 5, 7, 9};
+    TExpr in_texpr = ExprsTestHelper::create_in_pred_texpr(0, values, true);
+    std::vector<TExpr> exprs{in_texpr};
+    std::vector<ExprContext*> expr_ctxs;
+    ASSERT_OK(ExprsTestHelper::create_and_open_conjunct_ctxs(&_pool, &_runtime_state, &exprs, &expr_ctxs));
+    ASSERT_EQ(expr_ctxs.size(), 1);
+
+    const auto* in_const_pred = reinterpret_cast<const VectorizedInConstPredicate<TYPE_INT>*>(expr_ctxs[0]->root());
+    ColumnPtr col = in_const_pred->get_all_values();
+    ASSERT_EQ(col->debug_string(), "[9, 5, 1, 7, 3]");
+}
+
+TEST_F(InConstPredicateTest, not_in_open_with_null) {
+    std::vector<int32_t> values{1, 3, 5, 7, 9};
+    TExpr in_texpr = ExprsTestHelper::create_not_in_pred_texpr(0, values, true);
+    std::vector<TExpr> exprs{in_texpr};
+    std::vector<ExprContext*> expr_ctxs;
+    ASSERT_OK(ExprsTestHelper::create_and_open_conjunct_ctxs(&_pool, &_runtime_state, &exprs, &expr_ctxs));
+    ASSERT_EQ(expr_ctxs.size(), 1);
+
+    const auto* in_const_pred = reinterpret_cast<const VectorizedInConstPredicate<TYPE_INT>*>(expr_ctxs[0]->root());
+    ColumnPtr col = in_const_pred->get_all_values();
+    ASSERT_EQ(col->debug_string(), "[NULL]");
+}
+
+TEST_F(InConstPredicateTest, not_in_open_with_null_break) {
+    std::vector<int32_t> values{1, 3, 5, 7, 9};
+    TExpr in_texpr = _create_not_in_null_mid(0, values, true);
+    std::vector<TExpr> exprs{in_texpr};
+    std::vector<ExprContext*> expr_ctxs;
+    ASSERT_OK(ExprsTestHelper::create_and_open_conjunct_ctxs(&_pool, &_runtime_state, &exprs, &expr_ctxs));
+    ASSERT_EQ(expr_ctxs.size(), 1);
+
+    const auto* in_const_pred = reinterpret_cast<const VectorizedInConstPredicate<TYPE_INT>*>(expr_ctxs[0]->root());
+    ColumnPtr col = in_const_pred->get_all_values();
+    ASSERT_EQ(col->debug_string(), "[NULL]");
+}
 
 TEST_F(InConstPredicateTest, clone) {
     ColumnRef* col_ref = _pool.add(new ColumnRef(TYPE_INT_DESC, 1));

--- a/be/test/exprs/in_const_predicate_test.cpp
+++ b/be/test/exprs/in_const_predicate_test.cpp
@@ -40,13 +40,13 @@ TExpr InConstPredicateTest::_create_not_in_null_mid(SlotId slot_id, const std::v
 
     nodes.emplace_back(ExprsTestHelper::create_not_in_pred_node(values.size() + 1 + has_null));
     nodes.emplace_back(ExprsTestHelper::create_slot_expr_node(0, slot_id, ExprsTestHelper::IntTTypeDesc, true));
-    for (size_t i = 0; i < values.size()/2; i++) {
+    for (size_t i = 0; i < values.size() / 2; i++) {
         nodes.emplace_back(ExprsTestHelper::create_int_literal(values[i], ExprsTestHelper::IntTTypeDesc, false));
     }
     if (has_null) {
         nodes.emplace_back(ExprsTestHelper::create_null_literal(ExprsTestHelper::IntTTypeDesc));
     }
-    for (size_t i = values.size()/2; i < values.size(); i++) {
+    for (size_t i = values.size() / 2; i < values.size(); i++) {
         nodes.emplace_back(ExprsTestHelper::create_int_literal(values[i], ExprsTestHelper::IntTTypeDesc, false));
     }
 

--- a/be/test/formats/parquet/parquet_ut_base.cpp
+++ b/be/test/formats/parquet/parquet_ut_base.cpp
@@ -160,37 +160,11 @@ void ParquetUTBase::create_in_predicate_int_conjunct_ctxs(TExprOpcode::type opco
                                                           std::set<int32_t>& values, std::vector<TExpr>* tExprs) {
     std::vector<TExprNode> nodes;
 
-    TExprNode node0;
-    node0.node_type = TExprNodeType::IN_PRED;
-    node0.opcode = opcode;
-    node0.child_type = TPrimitiveType::INT;
-    node0.num_children = values.size() + 1;
-    node0.__isset.opcode = true;
-    node0.__isset.child_type = true;
-    node0.type = gen_type_desc(TPrimitiveType::BOOLEAN);
-    nodes.emplace_back(node0);
-
-    TExprNode node1;
-    node1.node_type = TExprNodeType::SLOT_REF;
-    node1.type = gen_type_desc(TPrimitiveType::INT);
-    node1.num_children = 0;
-    TSlotRef t_slot_ref = TSlotRef();
-    t_slot_ref.slot_id = slot_id;
-    t_slot_ref.tuple_id = 0;
-    node1.__set_slot_ref(t_slot_ref);
-    node1.is_nullable = true;
-    nodes.emplace_back(node1);
+    nodes.emplace_back(ExprsTestHelper::create_in_pred_node(values.size() + 1));
+    nodes.emplace_back(ExprsTestHelper::create_slot_expr_node(0, slot_id, ExprsTestHelper::IntTTypeDesc, true));
 
     for (int32_t value : values) {
-        TExprNode node;
-        node.node_type = TExprNodeType::INT_LITERAL;
-        node.type = gen_type_desc(TPrimitiveType::INT);
-        node.num_children = 0;
-        TIntLiteral int_literal;
-        int_literal.value = value;
-        node.__set_int_literal(int_literal);
-        node.is_nullable = false;
-        nodes.emplace_back(node);
+        nodes.emplace_back(ExprsTestHelper::create_int_literal(value, ExprsTestHelper::IntTTypeDesc, false));
     }
 
     TExpr t_expr;


### PR DESCRIPTION
## Why I'm doing:

int (1, 2, 3, 4, null) equivalent to in (1 2, 3, 4)
not int (1, 2, 3, 4, null) equivalent to not in (1, 2, 3, 4)

## What I'm doing:

After equivalent conversion, it can be pushed to the storage layer

```
select * from lineorder_nullable_1_tablet_large where lo_orderkey in (1, 2, null);
```

Without the opt: 0.67s
With the opt: 0.01s


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0