### PR TITLE
[Enhancement] Support empty cluster_snapshot.yaml config file

### DIFF
--- a/conf/cluster_snapshot.yaml
+++ b/conf/cluster_snapshot.yaml
@@ -1,3 +1,5 @@
+--- # cluster_snapshot.yaml
+
 # do not include leader fe
 #frontends:
 #  - host: 172.26.92.1

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -180,9 +180,9 @@ public class StarRocksFE {
 
             addShutdownHook();
 
-            LOG.info("FE started successfully");
-
             RestoreClusterSnapshotMgr.finishRestoring();
+
+            LOG.info("FE started successfully");
 
             while (!stopped) {
                 Thread.sleep(2000);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotConfig.java
@@ -241,6 +241,10 @@ public class ClusterSnapshotConfig {
             ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
             ClusterSnapshotConfig config = objectMapper.readValue(new File(clusterSnapshotYamlFile),
                     ClusterSnapshotConfig.class);
+            if (config == null) {
+                // Empty config file
+                config = new ClusterSnapshotConfig();
+            }
             return config;
         } catch (Exception e) {
             LOG.warn("Failed to load cluster snapshot config {} ", clusterSnapshotYamlFile, e);

--- a/fe/fe-core/src/test/resources/conf/cluster_snapshot.yaml
+++ b/fe/fe-core/src/test/resources/conf/cluster_snapshot.yaml
@@ -1,3 +1,5 @@
+--- # cluster_snapshot.yaml
+
 # do not include leader fe
 frontends:
   - host: 172.26.92.1


### PR DESCRIPTION
## Why I'm doing:
Empty cluster_snapshot.yaml config file is not handled, if users give an empty cluster_snapshot.yaml to restore then fe will start failed.

## What I'm doing:
Support empty cluster_snapshot.yaml config file.

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0