### PR TITLE
[Enhancement] support exec debug options

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -289,6 +289,7 @@ set(EXEC_FILES
     pipeline/schedule/event_scheduler.cpp
     pipeline/schedule/observer.cpp
     pipeline/schedule/pipeline_timer.cpp
+    pipeline/wait_operator.cpp
     workgroup/pipeline_executor_set.cpp
     workgroup/pipeline_executor_set_manager.cpp
     workgroup/work_group.cpp

--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -316,6 +316,8 @@ pipeline::OpFactories AggregateBlockingNode::decompose_to_pipeline(pipeline::Pip
         may_add_chunk_accumulate_operator(ops_with_source, context, id());
     }
 
+    ops_with_source = context->maybe_interpolate_debug_ops(runtime_state(), _id, ops_with_source);
+
     return ops_with_source;
 }
 

--- a/be/src/exec/aggregate/aggregate_streaming_node.cpp
+++ b/be/src/exec/aggregate/aggregate_streaming_node.cpp
@@ -256,6 +256,7 @@ pipeline::OpFactories AggregateStreamingNode::decompose_to_pipeline(pipeline::Pi
         ops_with_source.emplace_back(
                 std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
+    ops_with_source = context->maybe_interpolate_debug_ops(runtime_state(), _id, ops_with_source);
     return ops_with_source;
 }
 

--- a/be/src/exec/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/aggregate/distinct_blocking_node.cpp
@@ -251,6 +251,7 @@ pipeline::OpFactories DistinctBlockingNode::decompose_to_pipeline(pipeline::Pipe
     if (!_tnode.conjuncts.empty() || ops_with_source.back()->has_runtime_filters()) {
         may_add_chunk_accumulate_operator(ops_with_source, context, id());
     }
+    ops_with_source = context->maybe_interpolate_debug_ops(runtime_state(), _id, ops_with_source);
 
     return ops_with_source;
 }

--- a/be/src/exec/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/aggregate/distinct_streaming_node.cpp
@@ -214,6 +214,7 @@ pipeline::OpFactories DistinctStreamingNode::decompose_to_pipeline(pipeline::Pip
         ops_with_source.emplace_back(
                 std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
+    ops_with_source = context->maybe_interpolate_debug_ops(runtime_state(), _id, ops_with_source);
     return ops_with_source;
 }
 

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -286,6 +286,7 @@ pipeline::OpFactories ExchangeNode::decompose_to_pipeline(pipeline::PipelineBuil
         may_add_chunk_accumulate_operator(operators, context, id());
     }
 
+    operators = context->maybe_interpolate_debug_ops(runtime_state(), _id, operators);
     operators = context->maybe_interpolate_collect_stats(runtime_state(), id(), operators);
 
     return operators;

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -910,7 +910,8 @@ pipeline::OpFactories OlapScanNode::decompose_to_pipeline(pipeline::PipelineBuil
                                                                        std::move(scan_ctx_factory));
     this->init_runtime_filter_for_operator(scan_op.get(), context, rc_rf_probe_collector);
 
-    return pipeline::decompose_scan_node_to_pipeline(scan_op, this, context);
+    auto ops = pipeline::decompose_scan_node_to_pipeline(scan_op, this, context);
+    return context->maybe_interpolate_debug_ops(runtime_state(), _id, ops);
 }
 
 } // namespace starrocks

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -294,6 +294,11 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const Unified
     if (query_options.__isset.enable_spill && query_options.enable_spill) {
         RETURN_IF_ERROR(_query_ctx->init_spill_manager(query_options));
     }
+
+    for (const auto& action : request.debug_actions()) {
+        runtime_state->debug_action_mgr().add_action(action);
+    }
+
     _fragment_ctx->init_jit_profile();
     return Status::OK();
 }

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -77,6 +77,8 @@ public:
         return _unique_request.params.__isset.pipeline_sink_dop ? _unique_request.params.pipeline_sink_dop : 1;
     }
 
+    const std::vector<TExecDebugOption>& debug_actions() const { return _unique_request.params.exec_debug_options; }
+
     const TUniqueId& fragment_instance_id() const { return _unique_request.params.fragment_instance_id; }
     int32_t sender_id() const { return _unique_request.params.sender_id; }
 

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -125,6 +125,8 @@ public:
 
     OpFactories maybe_interpolate_collect_stats(RuntimeState* state, int32_t plan_node_id, OpFactories& pred_operators);
 
+    OpFactories maybe_interpolate_debug_ops(RuntimeState* state, int32_t plan_node_id, OpFactories& pred_operators);
+
     uint32_t next_pipe_id() { return _next_pipeline_id++; }
 
     uint32_t next_operator_id() { return _next_operator_id++; }

--- a/be/src/exec/pipeline/wait_operator.cpp
+++ b/be/src/exec/pipeline/wait_operator.cpp
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/wait_operator.h"
+
+#include <memory>
+
+#include "util/stopwatch.hpp"
+
+namespace starrocks::pipeline {
+Status WaitSourceOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(SourceOperator::prepare(state));
+    _mono_timer = state->obj_pool()->add(new MonotonicStopWatch());
+    _mono_timer->start();
+    return Status::OK();
+}
+bool WaitSourceOperator::has_output() const {
+    if (!_reached_timeout) {
+        if (_mono_timer->elapsed_time() > _wait_time_ns) {
+            _reached_timeout = true;
+        } else {
+            return false;
+        }
+    }
+    return !_wait_context->is_finished && !_wait_context->chunk_buffer->is_empty();
+}
+
+Status WaitSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    _metrics = std::make_unique<BufferMetrics>(_unique_metrics.get());
+    _wait_context->chunk_buffer = std::make_unique<LimitedPipelineChunkBuffer<BufferMetrics>>(
+            _metrics.get(), 1, config::local_exchange_buffer_mem_limit_per_driver, state->chunk_size() * 16);
+    return Status::OK();
+}
+
+bool WaitSinkOperator::need_input() const {
+    return !_wait_context->chunk_buffer->is_full();
+}
+
+bool WaitSinkOperator::is_finished() const {
+    return _wait_context->is_finished || (_wait_context->is_finishing && _wait_context->chunk_buffer->is_empty());
+}
+
+Status WaitSinkOperator::set_finishing(RuntimeState* state) {
+    _wait_context->is_finishing = true;
+    return Status::OK();
+}
+
+Status WaitSinkOperator::set_finished(RuntimeState* state) {
+    _wait_context->chunk_buffer->clear();
+    _wait_context->is_finished = true;
+    return Status::OK();
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/wait_operator.h
+++ b/be/src/exec/pipeline/wait_operator.h
@@ -1,0 +1,162 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "column/vectorized_fwd.h"
+#include "exec/limited_pipeline_chunk_buffer.h"
+#include "exec/pipeline/operator.h"
+#include "exec/pipeline/source_operator.h"
+
+namespace starrocks {
+
+class RuntimeState;
+
+namespace pipeline {
+struct BufferMetrics {
+    BufferMetrics(RuntimeProfile* runtime_profile) {
+        chunk_buffer_peak_memory = ADD_PEAK_COUNTER(runtime_profile, "ChunkBufferPeakMem", TUnit::BYTES);
+        chunk_buffer_peak_size = ADD_PEAK_COUNTER(runtime_profile, "ChunkBufferPeakSize", TUnit::UNIT);
+    }
+
+    RuntimeProfile::HighWaterMarkCounter* chunk_buffer_peak_memory{};
+    RuntimeProfile::HighWaterMarkCounter* chunk_buffer_peak_size{};
+};
+
+struct WaitContext {
+    bool is_finished = false;
+    bool is_finishing = false;
+    std::unique_ptr<LimitedPipelineChunkBuffer<BufferMetrics>> chunk_buffer;
+};
+
+class WaitSourceOperator final : public SourceOperator {
+public:
+    WaitSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
+                       WaitContext* wait_context, int32_t wait_times_ms)
+            : SourceOperator(factory, id, "wait_source", plan_node_id, true, driver_sequence),
+              _wait_context(wait_context),
+              _wait_time_ns(wait_times_ms * 1000L * 1000L) {}
+
+    ~WaitSourceOperator() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override { return _wait_context->chunk_buffer->pull(); }
+
+    bool has_output() const override;
+    bool is_finished() const override {
+        return _wait_context->is_finished || (_wait_context->is_finishing && _wait_context->chunk_buffer->is_empty());
+    }
+
+    bool ignore_empty_eos() const override { return false; }
+
+    Status set_finished(RuntimeState* state) override {
+        _wait_context->is_finished = true;
+        return Status::OK();
+    }
+
+private:
+    mutable bool _reached_timeout = false;
+    MonotonicStopWatch* _mono_timer = nullptr;
+    WaitContext* _wait_context = nullptr;
+    int64_t _wait_time_ns = 0;
+};
+
+class WaitSinkOperator final : public Operator {
+public:
+    WaitSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
+                     WaitContext* wait_context)
+            : Operator(factory, id, "wait_sink", plan_node_id, true, driver_sequence), _wait_context(wait_context) {}
+
+    ~WaitSinkOperator() override = default;
+
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override {
+        _wait_context->chunk_buffer->push(chunk);
+        return Status::OK();
+    }
+
+    Status prepare(RuntimeState* state) override;
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override {
+        return Status::NotSupported("unsupported push chunk in wait_source_operator");
+    }
+
+    bool has_output() const override { return false; }
+    bool need_input() const override;
+    bool is_finished() const override;
+
+    bool ignore_empty_eos() const override { return false; }
+
+    Status set_finishing(RuntimeState* state) override;
+    Status set_finished(RuntimeState* state) override;
+
+private:
+    std::unique_ptr<BufferMetrics> _metrics;
+    WaitContext* _wait_context = nullptr;
+};
+
+class WaitContextFactory {
+public:
+    size_t wait_times_ms() const { return _wait_time_ms; }
+    void resize(int dop) { buffer.resize(dop); }
+    WaitContext* get(int driver_sequence) { return &buffer[driver_sequence]; }
+
+    WaitContextFactory(size_t wait_time_ms) : _wait_time_ms(wait_time_ms) {}
+
+private:
+    size_t _wait_time_ms = 0;
+    std::vector<WaitContext> buffer;
+};
+
+using WaitContextFactoryPtr = std::shared_ptr<WaitContextFactory>;
+
+class WaitOperatorSourceFactory final : public SourceOperatorFactory {
+public:
+    WaitOperatorSourceFactory(int32_t id, int32_t plan_node_id, WaitContextFactoryPtr single_chunk_buffer)
+            : SourceOperatorFactory(id, "wait_source", plan_node_id), _buffer_factory(std::move(single_chunk_buffer)) {}
+
+    ~WaitOperatorSourceFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        _buffer_factory->resize(degree_of_parallelism);
+        auto single_chunk_buffer = _buffer_factory->get(driver_sequence);
+        return std::make_shared<WaitSourceOperator>(this, _id, _plan_node_id, driver_sequence, single_chunk_buffer,
+                                                    _buffer_factory->wait_times_ms());
+    }
+
+private:
+    WaitContextFactoryPtr _buffer_factory;
+};
+
+class WaitOperatorSinkFactory final : public OperatorFactory {
+public:
+    WaitOperatorSinkFactory(int32_t id, int32_t plan_node_id, WaitContextFactoryPtr wait_context_factory)
+            : OperatorFactory(id, "wait_sink", plan_node_id), _wait_context_factory(std::move(wait_context_factory)) {}
+
+    ~WaitOperatorSinkFactory() override = default;
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        _wait_context_factory->resize(degree_of_parallelism);
+        auto wait_context = _wait_context_factory->get(driver_sequence);
+        return std::make_shared<WaitSinkOperator>(this, _id, _plan_node_id, driver_sequence, wait_context);
+    }
+
+private:
+    std::shared_ptr<WaitContextFactory> _wait_context_factory;
+};
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -57,6 +57,7 @@
 #include "runtime/global_dict/types.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
+#include "util/debug_action.h"
 #include "util/logging.h"
 #include "util/phmap/phmap.h"
 #include "util/runtime_profile.h"
@@ -508,6 +509,8 @@ public:
     bool enable_event_scheduler() const { return _enable_event_scheduler; }
     void set_enable_event_scheduler(bool enable) { _enable_event_scheduler = enable; }
 
+    DebugActionMgr& debug_action_mgr() { return _debug_action_mgr; }
+
 private:
     // Set per-query state.
     void _init(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,
@@ -649,6 +652,8 @@ private:
     BroadcastJoinRightOffsprings _broadcast_join_right_offsprings;
 
     std::optional<TSpillOptions> _spill_options;
+
+    DebugActionMgr _debug_action_mgr;
 
     bool _enable_event_scheduler = false;
 };

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -105,6 +105,7 @@ set(UTIL_FILES
   bthreads/future.h
   bthreads/future_impl.cpp
   hash_util.cpp
+  debug_action.cpp
   internal_service_recoverable_stub.cpp
 )
 

--- a/be/src/util/debug_action.cpp
+++ b/be/src/util/debug_action.cpp
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/debug_action.h"
+
+#include <optional>
+
+#include "gen_cpp/InternalService_types.h"
+
+namespace starrocks {
+void DebugActionMgr::add_action(const TExecDebugOption& debug_action) {
+    if (debug_action.debug_action == TDebugAction::WAIT) {
+        DebugAction action;
+        action.node_id = debug_action.debug_node_id;
+        action.action = EnumDebugAction::WAIT;
+        action.value = debug_action.value;
+        _debug_actions.emplace(action.node_id, action);
+    }
+}
+
+} // namespace starrocks

--- a/be/src/util/debug_action.h
+++ b/be/src/util/debug_action.h
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+
+#include "util/hash.h"
+#include "util/phmap/phmap.h"
+
+namespace starrocks {
+class TExecDebugOption;
+enum class EnumDebugAction { WAIT };
+
+struct DebugAction {
+    int node_id;
+    EnumDebugAction action;
+    int value;
+    bool is_wait_action() const { return action == EnumDebugAction::WAIT; }
+};
+
+class DebugActionMgr {
+public:
+    void add_action(const TExecDebugOption&);
+
+    std::optional<DebugAction> get_debug_action(int plan_node_id) const {
+        if (auto iter = _debug_actions.find(plan_node_id); iter != _debug_actions.end()) {
+            return iter->second;
+        }
+        return {};
+    }
+
+private:
+    phmap::flat_hash_map<int32_t, DebugAction, StdHash<int32_t>> _debug_actions;
+};
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -25,6 +25,7 @@ import com.starrocks.qe.scheduler.dag.ExecutionDAG;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
 import com.starrocks.qe.scheduler.dag.FragmentInstance;
 import com.starrocks.qe.scheduler.dag.JobSpec;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.thrift.InternalServiceVersion;
 import com.starrocks.thrift.TAdaptiveDopParam;
 import com.starrocks.thrift.TDescriptorTable;
@@ -147,6 +148,8 @@ public class TFragmentInstanceFactory {
         // For broker load, the ConnectContext.get() is null
         if (context != null) {
             SessionVariable sessionVariable = context.getSessionVariable();
+            final List<QueryDebugOptions.ExecDebugOption> execDebugOptions =
+                    sessionVariable.getQueryDebugOptions().getExecDebugOptions();
 
             if (isEnablePipeline) {
                 result.setIs_pipeline(true);
@@ -154,6 +157,9 @@ public class TFragmentInstanceFactory {
                 result.setEnable_shared_scan(sessionVariable.isEnableSharedScan());
                 result.params.setEnable_exchange_pass_through(sessionVariable.isEnableExchangePassThrough());
                 result.params.setEnable_exchange_perf(sessionVariable.isEnableExchangePerf());
+                for (QueryDebugOptions.ExecDebugOption option : execDebugOptions) {
+                    result.params.addToExec_debug_options(option.toThirft());
+                }
 
                 result.setEnable_resource_group(true);
                 if (jobSpec.getResourceGroup() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/QueryDebugOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/QueryDebugOptions.java
@@ -14,11 +14,16 @@
 
 package com.starrocks.sql.common;
 
+import com.google.api.client.util.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.thrift.TDebugAction;
+import com.starrocks.thrift.TExecDebugOption;
 import org.apache.logging.log4j.util.Strings;
+
+import java.util.List;
 
 public class QueryDebugOptions {
     private static QueryDebugOptions INSTANCE = new QueryDebugOptions();
@@ -38,6 +43,24 @@ public class QueryDebugOptions {
 
     @SerializedName(value = "mvRefreshTraceModule")
     private String mvRefreshTraceModule;
+
+    public static class ExecDebugOption {
+        @SerializedName(value = "plan_node_id")
+        private int planNodeId;
+        @SerializedName(value = "debug_action")
+        private String debugAction;
+        @SerializedName(value = "value")
+        private int value = 0;
+        public TExecDebugOption toThirft() {
+            final TExecDebugOption option = new TExecDebugOption();
+            option.setDebug_node_id(planNodeId);
+            option.setDebug_action(TDebugAction.valueOf(debugAction));
+            option.setValue(value);
+            return option;
+        }
+    }
+    @SerializedName(value = "execDebugOptions")
+    private List<ExecDebugOption> execDebugOptions = Lists.newArrayList();
 
     public QueryDebugOptions() {
         // To make unit test more stable, add retry times for refreshing materialized views.
@@ -76,6 +99,10 @@ public class QueryDebugOptions {
 
     public Tracers.Module getMvRefreshTraceModule() {
         return Strings.isEmpty(mvRefreshTraceModule) ? Tracers.Module.BASE : Tracers.Module.valueOf(mvRefreshTraceModule);
+    }
+
+    public List<ExecDebugOption> getExecDebugOptions() {
+        return execDebugOptions;
     }
 
     public static QueryDebugOptions getInstance() {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -338,6 +338,12 @@ struct TScanRangeParams {
   4: optional bool has_more = false;
 }
 
+struct TExecDebugOption {
+  1: optional Types.TPlanNodeId debug_node_id
+  2: optional PlanNodes.TDebugAction debug_action
+  3: optional i32 value
+}
+
 // Parameters for a single execution instance of a particular TPlanFragment
 // TODO: for range partitioning, we also need to specify the range boundaries
 struct TPlanFragmentExecParams {
@@ -361,11 +367,6 @@ struct TPlanFragmentExecParams {
   // The number of output partitions is destinations.size().
   5: list<DataSinks.TPlanFragmentDestination> destinations
 
-  // Debug options: perform some action in a particular phase of a particular node
-  6: optional Types.TPlanNodeId debug_node_id
-  7: optional PlanNodes.TExecNodePhase debug_phase
-  8: optional PlanNodes.TDebugAction debug_action
-
   // Id of this fragment in its role as a sender.
   9: optional i32 sender_id
   10: optional i32 num_senders
@@ -384,7 +385,10 @@ struct TPlanFragmentExecParams {
 
   70: optional i32 pipeline_sink_dop
 
-  73: optional bool report_when_finish;
+  73: optional bool report_when_finish
+
+  // Debug options: perform some action in a particular phase of a particular node
+  74: optional list<TExecDebugOption> exec_debug_options
 }
 
 // Global query parameters assigned by the coordinator.

--- a/test/sql/test_pipeline/R/test_debug_wait
+++ b/test/sql/test_pipeline/R/test_debug_wait
@@ -1,0 +1,38 @@
+-- name: test_debug_wait
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+-- result:
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"WAIT", "value":500}]}';
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+409600
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"WAIT", "value":500}]}';
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+409600
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"WAIT", "value":500}]}';
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+409600
+-- !result

--- a/test/sql/test_pipeline/T/test_debug_wait
+++ b/test/sql/test_pipeline/T/test_debug_wait
@@ -1,0 +1,21 @@
+-- name: test_debug_wait
+
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"WAIT", "value":500}]}';
+select count(*) from t0;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":2, "debug_action":"WAIT", "value":500}]}';
+select count(*) from t0;
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"WAIT", "value":500}]}';
+select count(*) from t0;


### PR DESCRIPTION
## Why I'm doing:

Currently it is very difficult to add cases to cover the pipeline state with OUTPUT_FULL, this patch implements a debug option to help us add OUTPUT FULL type test cases.

usage:
```
mysql> set query_debug_options = '{"execDebugOptions":[{"plan_node_id":3, "debug_action":"WAIT", "value":500}]}';
Query OK, 0 rows affected (0.00 sec)

mysql> select count(*) from t0;
+----------+
| count(*) |
+----------+
|    40960 |
+----------+
1 row in set (0.51 sec)
```


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0