### PR TITLE
[BugFix] Fix retry upload failure when backup files using HDFS filesystem interface (backport #53679)

### DIFF
--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -565,11 +565,8 @@ StatusOr<std::unique_ptr<WritableFile>> HdfsFileSystem::new_writable_file(const 
     std::shared_ptr<HdfsFsClient> hdfs_client;
     RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, hdfs_client, _options));
     int flags = O_WRONLY;
-    if (opts.mode == FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE) {
-        if (auto st = _path_exists(hdfs_client->hdfs_fs, path); st.ok()) {
-            return Status::NotSupported(fmt::format("Cannot truncate a file by hdfs writer, path={}", path));
-        }
-    } else if (opts.mode == MUST_CREATE) {
+    // O_WRONLY means create or overwrite for hdfsOpenFile, which is exactly CREATE_OR_OPEN_WITH_TRUNCATE
+    if (opts.mode == MUST_CREATE) {
         if (auto st = _path_exists(hdfs_client->hdfs_fs, path); st.ok()) {
             return Status::AlreadyExist(path);
         }
@@ -577,12 +574,10 @@ StatusOr<std::unique_ptr<WritableFile>> HdfsFileSystem::new_writable_file(const 
         return Status::NotSupported("Open with MUST_EXIST not supported by hdfs writer");
     } else if (opts.mode == CREATE_OR_OPEN) {
         return Status::NotSupported("Open with CREATE_OR_OPEN not supported by hdfs writer");
-    } else {
+    } else if (opts.mode != CREATE_OR_OPEN_WITH_TRUNCATE) {
         auto msg = strings::Substitute("Unsupported open mode $0", opts.mode);
         return Status::NotSupported(msg);
     }
-
-    flags |= O_CREAT;
 
     int hdfs_write_buffer_size = 0;
     // pass zero to hdfsOpenFile will use the default hdfs_write_buffer_size

--- a/be/test/fs/fs_hdfs_test.cpp
+++ b/be/test/fs/fs_hdfs_test.cpp
@@ -73,4 +73,54 @@ TEST_F(HdfsFileSystemTest, create_file_and_destroy) {
     thread.join();
 }
 
+TEST_F(HdfsFileSystemTest, create_file_with_open_truncate) {
+    auto fs = new_fs_hdfs(FSOptions());
+    const std::string filepath = "file://" + _root_path + "/create_file_with_open_truncate";
+    auto st = fs->path_exists(filepath);
+    EXPECT_TRUE(st.is_not_found());
+    std::string str1 = "123";
+    std::string str2 = "456";
+    Slice data1(str1);
+    Slice data2(str2);
+
+    WritableFileOptions opts{.sync_on_close = false, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+
+    auto wfile_1 = fs->new_writable_file(opts, filepath);
+    EXPECT_TRUE(wfile_1.ok());
+    EXPECT_TRUE((*wfile_1)->append(data1).ok());
+    EXPECT_TRUE((*wfile_1)->flush(WritableFile::FlushMode::FLUSH_SYNC).ok());
+    EXPECT_TRUE((*wfile_1)->sync().ok());
+    (*wfile_1)->close();
+
+    st = fs->path_exists(filepath);
+    EXPECT_TRUE(st.ok());
+
+    auto open_res1 = fs->new_random_access_file(filepath);
+    EXPECT_TRUE(open_res1.ok());
+    auto rfile1 = std::move(open_res1.value());
+    auto read_res_1 = rfile1->read_all();
+    EXPECT_TRUE(read_res_1.ok());
+    EXPECT_TRUE(read_res_1.value() == str1);
+
+    auto wfile_2 = fs->new_writable_file(opts, filepath);
+    EXPECT_TRUE(wfile_2.ok());
+    EXPECT_TRUE((*wfile_2)->append(data2).ok());
+    EXPECT_TRUE((*wfile_2)->flush(WritableFile::FlushMode::FLUSH_SYNC).ok());
+    EXPECT_TRUE((*wfile_2)->sync().ok());
+    (*wfile_2)->close();
+
+    st = fs->path_exists(filepath);
+    EXPECT_TRUE(st.ok());
+
+    auto open_res2 = fs->new_random_access_file(filepath);
+    EXPECT_TRUE(open_res2.ok());
+    auto rfile2 = std::move(open_res2.value());
+    auto read_res_2 = rfile2->read_all();
+    EXPECT_TRUE(read_res_2.ok());
+    EXPECT_TRUE(read_res_2.value() == str2);
+
+    (*wfile_1).reset();
+    (*wfile_2).reset();
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
