### PR TITLE
[BugFix] fix cloud native index memtable memory calculation

### DIFF
--- a/be/src/storage/lake/persistent_index_memtable.cpp
+++ b/be/src/storage/lake/persistent_index_memtable.cpp
@@ -176,7 +176,7 @@ Status PersistentIndexMemtable::get(const Slice* keys, IndexValue* values, const
 }
 
 size_t PersistentIndexMemtable::memory_usage() const {
-    return _map.bytes_used();
+    return _keys_size + _map.size() * sizeof(IndexValueWithVer);
 }
 
 Status PersistentIndexMemtable::flush(WritableFile* wf, uint64_t* filesize) {


### PR DESCRIPTION
## Why I'm doing:
In previous PR #54358 , I change the memtable's `memory_usage()` function to:
```
size_t PersistentIndexMemtable::memory_usage() const {
-    return _keys_size + _map.size() * sizeof(IndexValueWithVer);
 +   return _map.bytes_used();
}
```
But I found that `bytes_used()` provide by btree map can't get the real memory usage. 

## What I'm doing:
Rollback to previous strategy first, will find out a better way later.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0