### PR TITLE
[Enhancement] Return aborted reason when getting label/transaction state

### DIFF
--- a/be/src/runtime/batch_write/isomorphic_batch_write.cpp
+++ b/be/src/runtime/batch_write/isomorphic_batch_write.cpp
@@ -486,7 +486,7 @@ Status IsomorphicBatchWrite::_wait_for_load_status(StreamLoadContext* data_ctx, 
     case TTransactionStatus::VISIBLE:
         return Status::OK();
     case TTransactionStatus::ABORTED:
-        return Status::InternalError("Load is aborted because of failure");
+        return Status::InternalError("Load is aborted, reason: " + response.reason);
     default:
         return Status::InternalError("Load status is unknown: " + to_string(response.status));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/GetStreamLoadState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/GetStreamLoadState.java
@@ -42,6 +42,7 @@ import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.transaction.TransactionStateSnapshot;
 import io.netty.handler.codec.http.HttpMethod;
 
 public class GetStreamLoadState extends RestBaseAction {
@@ -81,16 +82,19 @@ public class GetStreamLoadState extends RestBaseAction {
             throw new DdlException("unknown database, database=" + dbName);
         }
 
-        String status = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getLabelStatus(db.getId(), label).toString();
-
-        sendResult(request, response, new Result(status));
+        TransactionStateSnapshot transactionStateSnapshot =
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getLabelStatus(db.getId(), label);
+        sendResult(request, response,
+                new Result(transactionStateSnapshot.getStatus().name(), transactionStateSnapshot.getReason()));
     }
 
     private static class Result extends RestBaseResult {
         private String state;
+        private String reason;
 
-        public Result(String state) {
+        public Result(String state, String reason) {
             this.state = state;
+            this.reason = reason;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
@@ -248,7 +248,7 @@ public class Pipe implements GsonPostProcessable {
             if (StringUtils.isEmpty(file.insertLabel)) {
                 file.loadState = FileListRepo.PipeFileState.ERROR;
             } else {
-                TransactionStatus txnStatus = txnMgr.getLabelStatus(dbId, file.insertLabel);
+                TransactionStatus txnStatus = txnMgr.getLabelStatus(dbId, file.insertLabel).getStatus();
                 if (txnStatus == null || txnStatus.isFailed()) {
                     file.loadState = FileListRepo.PipeFileState.ERROR;
                 } else {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -345,6 +345,7 @@ import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionNotFoundException;
 import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStateSnapshot;
 import com.starrocks.transaction.TxnCommitAttachment;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.WarehouseInfo;
@@ -1494,10 +1495,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
 
         try {
-            TTransactionStatus status =
-                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTxnStatus(db, request.getTxnId());
-            LOG.debug("txn {} status is {}", request.getTxnId(), status);
-            result.setStatus(status);
+            TransactionStateSnapshot transactionStateSnapshot =
+                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTxnState(db, request.getTxnId());
+            LOG.debug("txn {} status is {}", request.getTxnId(), transactionStateSnapshot);
+            result.setStatus(transactionStateSnapshot.getStatus().toThrift());
+            result.setReason(transactionStateSnapshot.getReason());
         } catch (Throwable e) {
             result.setStatus(TTransactionStatus.UNKNOWN);
             LOG.warn("catch unknown result.", e);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -71,7 +71,6 @@ import com.starrocks.replication.ReplicationTxnCommitAttachment;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.FeNameFormat;
-import com.starrocks.thrift.TTransactionStatus;
 import com.starrocks.thrift.TUniqueId;
 import io.opentelemetry.api.trace.Span;
 import org.apache.commons.collections4.CollectionUtils;
@@ -713,16 +712,17 @@ public class DatabaseTransactionMgr {
         info.add(txnState.getErrMsg());
     }
 
-    public TransactionStatus getLabelState(String label) {
+    public TransactionStateSnapshot getLabelState(String label) {
         readLock();
         try {
             Set<Long> existingTxnIds = unprotectedGetTxnIdsByLabel(label);
             if (existingTxnIds == null || existingTxnIds.isEmpty()) {
-                return TransactionStatus.UNKNOWN;
+                return new TransactionStateSnapshot(TransactionStatus.UNKNOWN, null);
             }
             // find the latest txn (which id is largest)
             long maxTxnId = existingTxnIds.stream().max(Comparator.comparingLong(Long::valueOf)).orElse(Long.MIN_VALUE);
-            return unprotectedGetTransactionState(maxTxnId).getTransactionStatus();
+            TransactionState transactionState = unprotectedGetTransactionState(maxTxnId);
+            return new TransactionStateSnapshot(transactionState.getTransactionStatus(), transactionState.getReason());
         } finally {
             readUnlock();
         }
@@ -2006,18 +2006,15 @@ public class DatabaseTransactionMgr {
         return stateListeners;
     }
 
-    public TTransactionStatus getTxnStatus(long txnId) {
-        TransactionState transactionState;
+    public TransactionStateSnapshot getTxnState(long txnId) {
         readLock();
         try {
-            transactionState = unprotectedGetTransactionState(txnId);
+            TransactionState transactionState = unprotectedGetTransactionState(txnId);
+            return transactionState == null ? new TransactionStateSnapshot(TransactionStatus.UNKNOWN, null)
+                    : new TransactionStateSnapshot(transactionState.getTransactionStatus(), transactionState.getReason());
         } finally {
             readUnlock();
         }
-        return Optional.ofNullable(transactionState)
-                .map(TransactionState::getTransactionStatus)
-                .map(TransactionStatus::toThrift)
-                .orElse(TTransactionStatus.UNKNOWN);
     }
 
     private void checkDatabaseDataQuota() throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -60,7 +60,6 @@ import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
-import com.starrocks.thrift.TTransactionStatus;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
@@ -216,13 +215,13 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         }
     }
 
-    public TransactionStatus getLabelStatus(long dbId, String label) {
+    public TransactionStateSnapshot getLabelStatus(long dbId, String label) {
         try {
             DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
             return dbTransactionMgr.getLabelState(label);
         } catch (AnalysisException e) {
             LOG.warn("Get transaction status by label " + label + " failed", e);
-            return TransactionStatus.UNKNOWN;
+            return new TransactionStateSnapshot(TransactionStatus.UNKNOWN, null);
         }
     }
 
@@ -494,9 +493,9 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         dbTransactionMgr.abortTransaction(label, reason);
     }
 
-    public TTransactionStatus getTxnStatus(Database db, long transactionId) throws StarRocksException {
+    public TransactionStateSnapshot getTxnState(Database db, long transactionId) throws StarRocksException {
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(db.getId());
-        return dbTransactionMgr.getTxnStatus(transactionId);
+        return dbTransactionMgr.getTxnState(transactionId);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateSnapshot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateSnapshot.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+/** A snapshot of {@link TransactionState}. */
+public class TransactionStateSnapshot {
+
+    private final TransactionStatus status;
+    private final String reason;
+
+    public TransactionStateSnapshot(TransactionStatus status, String reason) {
+        this.status = status;
+        this.reason = reason;
+    }
+
+    public TransactionStatus getStatus() {
+        return status;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionStateSnapshot{" +
+                "status=" + status +
+                ", reason='" + reason + '\'' +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateSnapshot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateSnapshot.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.transaction;
 
-/** A snapshot of {@link TransactionState}. */
+/** A snapshot of {@link TransactionState}. The snapshot can include more members in the future. */
 public class TransactionStateSnapshot {
 
     private final TransactionStatus status;

--- a/fe/fe-core/src/test/java/com/starrocks/http/GetStreamLoadStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/GetStreamLoadStateTest.java
@@ -1,0 +1,130 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionStateSnapshot;
+import com.starrocks.transaction.TransactionStatus;
+import mockit.Expectations;
+import mockit.Mocked;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class GetStreamLoadStateTest  extends StarRocksHttpTestCase {
+
+    private final OkHttpClient client = new OkHttpClient.Builder()
+            .readTimeout(100, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .build();
+
+    @Mocked
+    private GlobalTransactionMgr globalTransactionMgr;
+
+    @Test
+    public void testSuccessLoad() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        String label = UUID.randomUUID().toString();
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelStatus(db.getId(), label);
+                times = 1;
+                result = new TransactionStateSnapshot(TransactionStatus.PREPARE, "");
+            }
+        };
+        verifyResult(label, TransactionStatus.PREPARE, "");
+
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelStatus(db.getId(), label);
+                times = 1;
+                result = new TransactionStateSnapshot(TransactionStatus.PREPARED, "");
+            }
+        };
+        verifyResult(label, TransactionStatus.PREPARED, "");
+
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelStatus(db.getId(), label);
+                times = 1;
+                result = new TransactionStateSnapshot(TransactionStatus.COMMITTED, "");
+            }
+        };
+        verifyResult(label, TransactionStatus.COMMITTED, "");
+
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelStatus(db.getId(), label);
+                times = 1;
+                result = new TransactionStateSnapshot(TransactionStatus.VISIBLE, "");
+            }
+        };
+        verifyResult(label, TransactionStatus.VISIBLE, "");
+    }
+
+    @Test
+    public void testAbortedState() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        String label = UUID.randomUUID().toString();
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelStatus(db.getId(), label);
+                times = 1;
+                result = new TransactionStateSnapshot(TransactionStatus.ABORTED, "artificial failure");
+            }
+        };
+        verifyResult(label, TransactionStatus.ABORTED, "artificial failure");
+    }
+
+    @Test
+    public void testUnknownState() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        String label = UUID.randomUUID().toString();
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelStatus(db.getId(), label);
+                times = 1;
+                result = new TransactionStateSnapshot(TransactionStatus.UNKNOWN, null);
+            }
+        };
+        verifyResult(label, TransactionStatus.UNKNOWN, null);
+    }
+
+    private void verifyResult(String label, TransactionStatus expectedStatus, String expectedReason) throws Exception {
+        Request request = new Request.Builder()
+                .addHeader("Authorization", rootAuth)
+                .url(String.format("%s/api/%s/get_load_state?label=%s", BASE_URL, DB_NAME, label))
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            Map<String, Object> result = parseResponseBody(response);
+            assertEquals("0", result.get("code"));
+            assertEquals("OK", result.get("status"));
+            assertEquals("OK", result.get("message"));
+            assertEquals("Success", result.get("msg"));
+            assertEquals(expectedStatus.name(), result.get("state"));
+            assertEquals(expectedReason, result.get("reason"));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteTestBase.java
@@ -103,6 +103,7 @@ public abstract class BatchWriteTestBase {
     }
 
     protected TransactionStatus getTxnStatus(String label) {
-        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getLabelStatus(DATABASE_1.getId(), label);
+        return GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .getLabelStatus(DATABASE_1.getId(), label).getStatus();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/LoadExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/LoadExecutorTest.java
@@ -133,7 +133,8 @@ public class LoadExecutorTest extends BatchWriteTestBase {
         assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
         assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
         TransactionStatus txnStatus =
-                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getLabelStatus(DATABASE_1.getId(), label);
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                        .getLabelStatus(DATABASE_1.getId(), label).getStatus();
         assertEquals(TransactionStatus.VISIBLE, txnStatus);
     }
 
@@ -261,7 +262,8 @@ public class LoadExecutorTest extends BatchWriteTestBase {
         assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
         assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
         TransactionStatus txnStatus =
-                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getLabelStatus(DATABASE_1.getId(), label);
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                        .getLabelStatus(DATABASE_1.getId(), label).getStatus();
         assertEquals(expectedTxnStatus, txnStatus);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
@@ -62,6 +62,7 @@ import com.starrocks.thrift.TListPipesParams;
 import com.starrocks.thrift.TResultBatch;
 import com.starrocks.thrift.TUserIdentity;
 import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionStateSnapshot;
 import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -1073,8 +1074,8 @@ public class PipeManagerTest {
                     FileListRepo.PipeFileState.LOADING, "insert-label");
             new MockUp<GlobalTransactionMgr>() {
                 @Mock
-                public TransactionStatus getLabelStatus(long dbId, String label) {
-                    return TransactionStatus.COMMITTED;
+                public TransactionStateSnapshot getLabelStatus(long dbId, String label) {
+                    return new TransactionStateSnapshot(TransactionStatus.COMMITTED, "");
                 }
             };
 

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -1106,16 +1106,25 @@ public class FrontendServiceImplTest {
         request.setTxnId(100);
         TGetLoadTxnStatusResult result1 = impl.getLoadTxnStatus(request);
         Assert.assertEquals(TTransactionStatus.UNKNOWN, result1.getStatus());
+        Assert.assertNull(result1.getReason());
         request.setDb("test");
         TGetLoadTxnStatusResult result2 = impl.getLoadTxnStatus(request);
         Assert.assertEquals(TTransactionStatus.UNKNOWN, result2.getStatus());
+        Assert.assertNull(result2.getReason());
         request.setTxnId(transactionId);
         GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.FOLLOWER);
         TGetLoadTxnStatusResult result3 = impl.getLoadTxnStatus(request);
         Assert.assertEquals(TTransactionStatus.UNKNOWN, result3.getStatus());
+        Assert.assertNull(result3.getReason());
         GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.LEADER);
         TGetLoadTxnStatusResult result4 = impl.getLoadTxnStatus(request);
         Assert.assertEquals(TTransactionStatus.PREPARE, result4.getStatus());
+        Assert.assertEquals("", result4.getReason());
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
+                db.getId(), transactionId, "artificial failure");
+        TGetLoadTxnStatusResult result5 = impl.getLoadTxnStatus(request);
+        Assert.assertEquals(TTransactionStatus.ABORTED, result5.getStatus());
+        Assert.assertEquals("artificial failure", result5.getReason());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -52,7 +52,6 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.thrift.TTransactionStatus;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.Assert;
@@ -129,7 +128,7 @@ public class DatabaseTransactionMgrTest {
                 Lists.newArrayList(), null);
         DatabaseTransactionMgr masterDbTransMgr =
                 masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
-        assertEquals(TTransactionStatus.COMMITTED, masterDbTransMgr.getTxnStatus(transactionId1));
+        assertEquals(TransactionStatus.COMMITTED, masterDbTransMgr.getTxnState(transactionId1).getStatus());
         lableToTxnId.put(GlobalStateMgrTestUtil.testTxnLable10, transactionId1);
 
     }
@@ -166,7 +165,7 @@ public class DatabaseTransactionMgrTest {
                 Lists.newArrayList(), null);
         DatabaseTransactionMgr masterDbTransMgr =
                 masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
-        assertEquals(TTransactionStatus.COMMITTED, masterDbTransMgr.getTxnStatus(transactionId1));
+        assertEquals(TransactionStatus.COMMITTED, masterDbTransMgr.getTxnState(transactionId1).getStatus());
 
         Assert.assertEquals(transactionId1, masterTransMgr.getMinActiveTxnId());
         Assert.assertEquals(idGenerator.peekNextTransactionId(), masterTransMgr.getMinActiveCompactionTxnId());
@@ -232,13 +231,13 @@ public class DatabaseTransactionMgrTest {
 
         masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId6, transTablets,
                 Lists.newArrayList(), null);
-        assertEquals(TTransactionStatus.COMMITTED, masterDbTransMgr.getTxnStatus(transactionId6));
+        assertEquals(TransactionStatus.COMMITTED, masterDbTransMgr.getTxnState(transactionId6).getStatus());
         masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId7, transTablets,
                 Lists.newArrayList(), null);
-        assertEquals(TTransactionStatus.COMMITTED, masterDbTransMgr.getTxnStatus(transactionId7));
+        assertEquals(TransactionStatus.COMMITTED, masterDbTransMgr.getTxnState(transactionId7).getStatus());
         masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId8, transTablets,
                 Lists.newArrayList(), null);
-        assertEquals(TTransactionStatus.COMMITTED, masterDbTransMgr.getTxnStatus(transactionId8));
+        assertEquals(TransactionStatus.COMMITTED, masterDbTransMgr.getTxnState(transactionId8).getStatus());
 
         lableToTxnId.put(GlobalStateMgrTestUtil.testTxnLable2, transactionId2);
         lableToTxnId.put(GlobalStateMgrTestUtil.testTxnLable3, transactionId3);
@@ -290,7 +289,7 @@ public class DatabaseTransactionMgrTest {
                 masterDbTransMgr.getTransactionState(lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable1));
         assertEquals(txnId1.longValue(), transactionState1.getTransactionId());
         assertEquals(TransactionStatus.VISIBLE, transactionState1.getTransactionStatus());
-        assertEquals(TTransactionStatus.VISIBLE, masterDbTransMgr.getTxnStatus(txnId1.longValue()));
+        assertEquals(TransactionStatus.VISIBLE, masterDbTransMgr.getTxnState(txnId1.longValue()).getStatus());
 
         Long txnId2 =
                 masterDbTransMgr.unprotectedGetTxnIdsByLabel(GlobalStateMgrTestUtil.testTxnLable2).iterator().next();
@@ -298,9 +297,9 @@ public class DatabaseTransactionMgrTest {
         TransactionState transactionState2 = masterDbTransMgr.getTransactionState(txnId2);
         assertEquals(txnId2.longValue(), transactionState2.getTransactionId());
         assertEquals(TransactionStatus.PREPARE, transactionState2.getTransactionStatus());
-        assertEquals(TTransactionStatus.PREPARE, masterDbTransMgr.getTxnStatus(txnId2.longValue()));
+        assertEquals(TransactionStatus.PREPARE, masterDbTransMgr.getTxnState(txnId2.longValue()).getStatus());
 
-        assertEquals(TTransactionStatus.UNKNOWN, masterDbTransMgr.getTxnStatus(12134));
+        assertEquals(TransactionStatus.UNKNOWN, masterDbTransMgr.getTxnState(12134).getStatus());
     }
 
     @Test
@@ -325,7 +324,7 @@ public class DatabaseTransactionMgrTest {
         assertEquals(0, masterDbTransMgr.getRunningRoutineLoadTxnNums());
         assertEquals(2, masterDbTransMgr.getFinishedTxnNums());
         assertEquals(8, masterDbTransMgr.getTransactionNum());
-        assertEquals(TTransactionStatus.ABORTED, masterDbTransMgr.getTxnStatus(txnId2));
+        assertEquals(TransactionStatus.ABORTED, masterDbTransMgr.getTxnState(txnId2).getStatus());
 
         long txnId3 = lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable3);
         masterDbTransMgr.abortTransaction(txnId3, "test abort transaction", null);
@@ -333,7 +332,7 @@ public class DatabaseTransactionMgrTest {
         assertEquals(0, masterDbTransMgr.getRunningRoutineLoadTxnNums());
         assertEquals(3, masterDbTransMgr.getFinishedTxnNums());
         assertEquals(8, masterDbTransMgr.getTransactionNum());
-        assertEquals(TTransactionStatus.ABORTED, masterDbTransMgr.getTxnStatus(txnId3));
+        assertEquals(TransactionStatus.ABORTED, masterDbTransMgr.getTxnState(txnId3).getStatus());
     }
 
     @Test
@@ -351,7 +350,7 @@ public class DatabaseTransactionMgrTest {
 
         long txnId = lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable10);
         masterDbTransMgr.finishTransaction(txnId, null);
-        assertEquals(TTransactionStatus.VISIBLE, masterDbTransMgr.getTxnStatus(txnId));
+        assertEquals(TransactionStatus.VISIBLE, masterDbTransMgr.getTxnState(txnId).getStatus());
     }
 
 
@@ -370,7 +369,7 @@ public class DatabaseTransactionMgrTest {
 
         long txnId = lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable10);
         masterDbTransMgr.finishTransaction(txnId, null);
-        assertEquals(TTransactionStatus.VISIBLE, masterDbTransMgr.getTxnStatus(txnId));
+        assertEquals(TransactionStatus.VISIBLE, masterDbTransMgr.getTxnState(txnId).getStatus());
     }
     @Test
     public void testAbortTransactionWithNotFoundException() throws StarRocksException {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1069,6 +1069,7 @@ struct TLoadTxnRollbackRequest {
 
 struct TGetLoadTxnStatusResult {
     1: required Status.TTransactionStatus status
+    2: optional string reason;
 }
 
 struct TGetLoadTxnStatusRequest {


### PR DESCRIPTION
## Why I'm doing:
There are two interfaces to get the label/transaction state
* HTTP get_label_state (http client -> FE)
* Thrift getLoadTxnStatus (BE -> FE)

Currently the interfaces only return the `TransactionStatus`. But If the status is `ABORTED`, the caller also wants to know the reason. So also need to return the reason 

## What I'm doing:
* for HTTP get_label_state, add `reason` field in the response json
* for Thrift getLoadTxnStatus, add `reason` field in the response `TGetLoadTxnStatusResult`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0