### PR TITLE
[BugFix] cache delta lake snapshot instead of table object

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeSnapshot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeSnapshot.java
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import io.delta.kernel.internal.SnapshotImpl;
+
+public class DeltaLakeSnapshot {
+    private final String dbName;
+    private final String tableName;
+    private final DeltaLakeEngine deltaLakeEngine;
+    private final SnapshotImpl snapshot;
+    private final long createTime;
+    private final String path;
+
+    public DeltaLakeSnapshot(String dbName, String tableName, DeltaLakeEngine engine, SnapshotImpl snapshot,
+                             long createTime, String path) {
+        this.dbName = dbName;
+        this.tableName = tableName;
+        this.deltaLakeEngine = engine;
+        this.snapshot = snapshot;
+        this.createTime = createTime;
+        this.path = path;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public DeltaLakeEngine getDeltaLakeEngine() {
+        return deltaLakeEngine;
+    }
+
+    public SnapshotImpl getSnapshot() {
+        return snapshot;
+    }
+
+    public long getCreateTime() {
+        return createTime;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
@@ -87,7 +87,7 @@ public class DeltaUtils {
                 loadPartitionColumnNames(snapshotImpl), snapshotImpl, path, deltaLakeEngine, snapshot.getCreateTime());
     }
 
-    private static List<String> loadPartitionColumnNames(SnapshotImpl snapshot) {
+    public static List<String> loadPartitionColumnNames(SnapshotImpl snapshot) {
         ArrayValue partitionColumns = snapshot.getMetadata().getPartitionColumns();
         ColumnVector partitionColNameVector = partitionColumns.getElements();
         List<String> partitionColumnNames = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaUtils.java
@@ -21,18 +21,12 @@ import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
-import com.starrocks.common.profile.Timer;
-import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ColumnTypeConverter;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.ErrorType;
-import io.delta.kernel.Table;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
-import io.delta.kernel.engine.Engine;
-import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
@@ -48,7 +42,6 @@ import java.util.List;
 import java.util.Locale;
 
 import static com.starrocks.catalog.Column.COLUMN_UNIQUE_ID_INIT_VALUE;
-import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
 
 public class DeltaUtils {
@@ -62,28 +55,20 @@ public class DeltaUtils {
         }
     }
 
-    public static DeltaLakeTable convertDeltaToSRTable(String catalog, String dbName, String tblName, String path,
-                                                       Engine deltaEngine, long createTime) {
-        SnapshotImpl snapshot;
+    public static DeltaLakeTable convertDeltaSnapshotToSRTable(String catalog, DeltaLakeSnapshot snapshot) {
+        String dbName = snapshot.getDbName();
+        String tblName = snapshot.getTableName();
+        DeltaLakeEngine deltaLakeEngine = snapshot.getDeltaLakeEngine();
+        SnapshotImpl snapshotImpl = snapshot.getSnapshot();
+        String path = snapshot.getPath();
 
-        try (Timer ignored = Tracers.watchScope(EXTERNAL, "DeltaLake.getSnapshot")) {
-            Table deltaTable = Table.forPath(deltaEngine, path);
-            snapshot = (SnapshotImpl) deltaTable.getLatestSnapshot(deltaEngine);
-        } catch (TableNotFoundException e) {
-            LOG.error("Failed to find Delta table for {}.{}.{}, {}", catalog, dbName, tblName, e.getMessage());
-            throw new SemanticException("Failed to find Delta table for " + catalog + "." + dbName + "." + tblName);
-        } catch (Exception e) {
-            LOG.error("Failed to get latest snapshot for {}.{}.{}, {}", catalog, dbName, tblName, e.getMessage());
-            throw new SemanticException("Failed to get latest snapshot for " + catalog + "." + dbName + "." + tblName);
-        }
-
-        StructType deltaSchema = snapshot.getSchema(deltaEngine);
+        StructType deltaSchema = snapshotImpl.getSchema(deltaLakeEngine);
         if (deltaSchema == null) {
             throw new IllegalArgumentException(String.format("Unable to find Schema information in Delta log for " +
                     "%s.%s.%s", catalog, dbName, tblName));
         }
 
-        String columnMappingMode = ColumnMapping.getColumnMappingMode(snapshot.getMetadata().getConfiguration());
+        String columnMappingMode = ColumnMapping.getColumnMappingMode(snapshotImpl.getMetadata().getConfiguration());
         List<Column> fullSchema = Lists.newArrayList();
         for (StructField field : deltaSchema.fields()) {
             DataType dataType = field.getDataType();
@@ -99,8 +84,7 @@ public class DeltaUtils {
         }
 
         return new DeltaLakeTable(CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalog, dbName, tblName, fullSchema,
-                loadPartitionColumnNames(snapshot), snapshot, path,
-                deltaEngine, createTime);
+                loadPartitionColumnNames(snapshotImpl), snapshotImpl, path, deltaLakeEngine, snapshot.getCreateTime());
     }
 
     private static List<String> loadPartitionColumnNames(SnapshotImpl snapshot) {
@@ -125,7 +109,7 @@ public class DeltaUtils {
 
         if (columnMappingMode.equalsIgnoreCase(ColumnMapping.COLUMN_MAPPING_MODE_ID) &&
                 field.getMetadata().contains(ColumnMapping.COLUMN_MAPPING_ID_KEY)) {
-            columnUniqueId = ((Long)  field.getMetadata().get(ColumnMapping.COLUMN_MAPPING_ID_KEY)).intValue();
+            columnUniqueId = ((Long) field.getMetadata().get(ColumnMapping.COLUMN_MAPPING_ID_KEY)).intValue();
         }
         if (columnMappingMode.equalsIgnoreCase(ColumnMapping.COLUMN_MAPPING_MODE_NAME) &&
                 field.getMetadata().contains(ColumnMapping.COLUMN_MAPPING_PHYSICAL_NAME_KEY)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/IDeltaLakeMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/IDeltaLakeMetastore.java
@@ -21,7 +21,11 @@ import com.starrocks.memory.MemoryTrackable;
 import java.util.List;
 
 public interface IDeltaLakeMetastore extends IMetastore, MemoryTrackable {
+    String getCatalogName();
+
     Table getTable(String dbName, String tableName);
 
     List<String> getPartitionKeys(String dbName, String tableName);
+
+    DeltaLakeSnapshot getLatestSnapshot(String dbName, String tableName);
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCacheUpdateProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCacheUpdateProcessorTest.java
@@ -27,7 +27,6 @@ import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.IHiveMetastore;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
-import io.delta.kernel.engine.Engine;
 import mockit.Expectations;
 import mockit.MockUp;
 import mockit.Mocked;
@@ -73,10 +72,17 @@ public class DeltaLakeCacheUpdateProcessorTest {
             }
         };
 
+        new MockUp<CachingDeltaLakeMetastore>() {
+            @mockit.Mock
+            public DeltaLakeSnapshot getCachedSnapshot(DatabaseTableName databaseTableName) {
+                return new DeltaLakeSnapshot("db1", "table1", null, null,
+                        123, "s3://bucket/path/to/table");
+            }
+        };
+
         new MockUp<DeltaUtils>() {
             @mockit.Mock
-            public DeltaLakeTable convertDeltaToSRTable(String catalog, String dbName, String tblName, String path,
-                                                        Engine deltaEngine, long createTime) {
+            public DeltaLakeTable convertDeltaSnapshotToSRTable(String catalog, DeltaLakeSnapshot snapshot) {
                 return new DeltaLakeTable(1, "delta0", "db1", "table1",
                         Lists.newArrayList(), Lists.newArrayList("ts"), null,
                         "s3://bucket/path/to/table", null, 0);
@@ -107,10 +113,25 @@ public class DeltaLakeCacheUpdateProcessorTest {
             }
         };
 
+        new MockUp<CachingDeltaLakeMetastore>() {
+            @mockit.Mock
+            public DeltaLakeSnapshot getCachedSnapshot(DatabaseTableName databaseTableName) {
+                return new DeltaLakeSnapshot("db1", "table1", null, null,
+                        123, "s3://bucket/path/to/table");
+            }
+        };
+
+        new MockUp<DeltaLakeMetastore>() {
+            @mockit.Mock
+            public DeltaLakeSnapshot getLatestSnapshot(String dbName, String tableName) {
+                return new DeltaLakeSnapshot("db1", "table1", null, null,
+                        123, "s3://bucket/path/to/table");
+            }
+        };
+
         new MockUp<DeltaUtils>() {
             @mockit.Mock
-            public DeltaLakeTable convertDeltaToSRTable(String catalog, String dbName, String tblName, String path,
-                                                        Engine deltaEngine, long createTime) {
+            public DeltaLakeTable convertDeltaSnapshotToSRTable(String catalog, DeltaLakeSnapshot snapshot) {
                 return new DeltaLakeTable(1, "delta0", "db1", "table1",
                         Lists.newArrayList(), Lists.newArrayList("ts"), null,
                         "s3://bucket/path/to/table", null, 0);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorType;
+import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.hive.HiveMetaClient;
@@ -97,10 +98,17 @@ public class DeltaLakeMetadataTest {
     @Test
     public void testListPartitionNames(@Mocked SnapshotImpl snapshot, @Mocked ScanBuilder scanBuilder,
                                        @Mocked Scan scan) {
+        new MockUp<DeltaLakeMetastore>() {
+            @mockit.Mock
+            public DeltaLakeSnapshot getLatestSnapshot(String dbName, String tableName) {
+                return new DeltaLakeSnapshot("db1", "table1", null, null,
+                        123, "s3://bucket/path/to/table");
+            }
+        };
+
         new MockUp<DeltaUtils>() {
             @Mock
-            public DeltaLakeTable convertDeltaToSRTable(String catalog, String dbName, String tblName, String path,
-                                                        Engine deltaEngine, long createTime) {
+            public DeltaLakeTable convertDeltaSnapshotToSRTable(String catalog, DeltaLakeSnapshot deltaLakeSnapshot) {
                 return new DeltaLakeTable(1, "delta0", "db1", "table1",
                         Lists.newArrayList(), Lists.newArrayList("ts"), snapshot,
                         "s3://bucket/path/to/table", null, 0);
@@ -185,10 +193,17 @@ public class DeltaLakeMetadataTest {
 
     @Test
     public void testGetTable() {
+        new MockUp<CachingDeltaLakeMetastore>() {
+            @mockit.Mock
+            public DeltaLakeSnapshot getCachedSnapshot(DatabaseTableName databaseTableName) {
+                return new DeltaLakeSnapshot("db1", "table1", null, null,
+                        123, "s3://bucket/path/to/table");
+            }
+        };
+
         new MockUp<DeltaUtils>() {
             @mockit.Mock
-            public DeltaLakeTable convertDeltaToSRTable(String catalog, String dbName, String tblName, String path,
-                                                        Engine deltaEngine, long createTime) {
+            public DeltaLakeTable convertDeltaSnapshotToSRTable(String catalog, DeltaLakeSnapshot snapshot) {
                 return new DeltaLakeTable(1, "delta0", "db1", "table1", Lists.newArrayList(),
                         Lists.newArrayList("col1"), null, "path/to/table", null, 0);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
@@ -16,7 +16,6 @@ package com.starrocks.connector.delta;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.validate.ValidateException;
 import io.delta.kernel.Operation;
 import io.delta.kernel.Snapshot;
@@ -69,25 +68,9 @@ public class DeltaUtilsTest {
     }
 
     @Test
-    public void testConvertDeltaToSRTableWithException1() {
-        expectedEx.expect(SemanticException.class);
-        expectedEx.expectMessage("Failed to find Delta table for catalog.db.tbl");
-
-        new MockUp<Table>() {
-            @mockit.Mock
-            public Table forPath(Engine deltaEngine, String path) throws TableNotFoundException {
-                throw new TableNotFoundException("Table not found");
-            }
-        };
-
-        DeltaUtils.convertDeltaToSRTable("catalog", "db", "tbl", "path",
-                DeltaLakeEngine.create(new Configuration()), 0);
-    }
-
-    @Test
     public void testConvertDeltaToSRTableWithException2() {
-        expectedEx.expect(SemanticException.class);
-        expectedEx.expectMessage("Failed to get latest snapshot for catalog.db.tbl");
+        expectedEx.expect(RuntimeException.class);
+        expectedEx.expectMessage("Failed to get latest snapshot");
         Table table = new Table() {
             public Table forPath(Engine engine, String path) {
                 return this;
@@ -132,7 +115,8 @@ public class DeltaUtilsTest {
             }
         };
 
-        DeltaUtils.convertDeltaToSRTable("catalog", "db", "tbl", "path",
-                DeltaLakeEngine.create(new Configuration()), 0);
+        Engine engine = DeltaLakeEngine.create(new Configuration());
+        Table deltaTable = Table.forPath(engine, "path");
+        deltaTable.getLatestSnapshot(engine);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
@@ -77,59 +77,6 @@ public class DeltaUtilsTest {
     }
 
     @Test
-    public void testConvertDeltaToSRTableWithException2() {
-        expectedEx.expect(RuntimeException.class);
-        expectedEx.expectMessage("Failed to get latest snapshot");
-        Table table = new Table() {
-            public Table forPath(Engine engine, String path) {
-                return this;
-            }
-
-            @Override
-            public String getPath(Engine engine) {
-                return null;
-            }
-
-            @Override
-            public SnapshotImpl getLatestSnapshot(Engine engine) {
-                throw new RuntimeException("Failed to get latest snapshot");
-            }
-
-            @Override
-            public Snapshot getSnapshotAsOfVersion(Engine engine, long versionId) throws TableNotFoundException {
-                return null;
-            }
-
-            @Override
-            public Snapshot getSnapshotAsOfTimestamp(Engine engine, long millisSinceEpochUTC)
-                    throws TableNotFoundException {
-                return null;
-            }
-
-            @Override
-            public TransactionBuilder createTransactionBuilder(Engine engine, String engineInfo, Operation operation) {
-                return null;
-            }
-
-            @Override
-            public void checkpoint(Engine engine, long version)
-                    throws TableNotFoundException, CheckpointAlreadyExistsException, IOException {
-            }
-        };
-
-        new MockUp<TableImpl>() {
-            @Mock
-            public Table forPath(Engine engine, String path) {
-                return table;
-            }
-        };
-
-        Engine engine = DeltaLakeEngine.create(new Configuration());
-        Table deltaTable = Table.forPath(engine, "path");
-        deltaTable.getLatestSnapshot(engine);
-    }
-
-    @Test
     public void testConvertDeltaSnapshotToSRTable(@Mocked SnapshotImpl snapshot) {
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaUtilsTest.java
@@ -18,15 +18,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.sql.optimizer.validate.ValidateException;
-import io.delta.kernel.Operation;
-import io.delta.kernel.Snapshot;
-import io.delta.kernel.Table;
-import io.delta.kernel.TransactionBuilder;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
-import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.SnapshotImpl;
-import io.delta.kernel.internal.TableImpl;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.util.ColumnMapping;
@@ -44,7 +37,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
 import java.util.List;
 
 import static io.delta.kernel.internal.util.ColumnMapping.COLUMN_MAPPING_MODE_KEY;

--- a/test/sql/test_deltalake/R/test_deltalake_catalog
+++ b/test/sql/test_deltalake/R/test_deltalake_catalog
@@ -304,6 +304,12 @@ select a.c_int, b.c_map, b.c_nest.c_struct, a.c_nest.c_array[6] from delta_test_
 1	{1:{"c_date":"2001-01-03"}}	None	None
 3	{33:{"c_date":"2003-01-02"}}	None	None
 -- !result
+select a.c_int, b.c_map, b.c_nest.c_struct_new, a.c_nest.c_array[6] from delta_test_${uuid0}.delta_oss_db.delta_nested_type_par a join delta_test_${uuid0}.delta_oss_db.delta_nested_type_par b on a.c_int = b.c_nest.c_struct_new.c_int order by 1;
+-- result:
+1	{1:{"c_date":"2001-01-03"}}	{"c_int":1}	None
+1	{1:{"c_date":"2001-01-03"}}	{"c_int":1}	None
+3	{33:{"c_date":"2003-01-02"}}	{"c_int":3}	None
+-- !result
 drop catalog delta_test_${uuid0}
 -- result:
 -- !result

--- a/test/sql/test_deltalake/T/test_deltalake_catalog
+++ b/test/sql/test_deltalake/T/test_deltalake_catalog
@@ -88,4 +88,7 @@ select col_tinyint,col_array,col_map,col_struct from delta_test_${uuid0}.delta_o
 select c_int,c_date from delta_test_${uuid0}.delta_oss_db.column_mapping_test where c_nest.c_struct_new.c_int is not null order by c_int nulls last, c_date nulls first;
 select a.c_int, b.c_map, b.c_nest.c_struct, a.c_nest.c_array[6] from delta_test_${uuid0}.delta_oss_db.column_mapping_test a join delta_test_${uuid0}.delta_oss_db.column_mapping_test b on a.c_int = b.c_nest.c_struct_new.c_int order by 1;
 
+-- test table join self
+select a.c_int, b.c_map, b.c_nest.c_struct_new, a.c_nest.c_array[6] from delta_test_${uuid0}.delta_oss_db.delta_nested_type_par a join delta_test_${uuid0}.delta_oss_db.delta_nested_type_par b on a.c_int = b.c_nest.c_struct_new.c_int order by 1;
+
 drop catalog delta_test_${uuid0}


### PR DESCRIPTION
## Why I'm doing:
For query table join self, like` select *  from delta_table a join delta_table b on a.id = b.id;`， the query result would be unstable, because delta lake delivery partition values and add partition according to the table id
<img width="977" alt="image" src="https://github.com/user-attachments/assets/4b64827a-915d-4ea4-84ab-6c5c9220fbfe" />
but join selft query has same table, so has same table id, the partiton values would be error-prone and chaotic 
## What I'm doing:
1. generate different table object for same table in different scan node
2. cache delta lake snapshot instead of table object

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0