### PR TITLE
[Feature] Support restoring from a cluster snapshot for shared-data mode (part 4, use gtid to handle dirty tablet metadata)

### DIFF
--- a/be/src/storage/lake/lake_delvec_loader.cpp
+++ b/be/src/storage/lake/lake_delvec_loader.cpp
@@ -37,8 +37,8 @@ Status LakeDelvecLoader::load(const TabletSegmentId& tsid, int64_t version, DelV
 Status LakeDelvecLoader::load_from_file(const TabletSegmentId& tsid, int64_t version, DelVectorPtr* pdelvec) {
     (*pdelvec).reset(new DelVector());
     // 2. find in delvec file
-    std::string filepath = _tablet_manager->tablet_metadata_location(tsid.tablet_id, version);
-    ASSIGN_OR_RETURN(auto metadata, _tablet_manager->get_tablet_metadata(_lake_io_opts.fs, filepath, _fill_cache));
+    ASSIGN_OR_RETURN(auto metadata,
+                     _tablet_manager->get_tablet_metadata(tsid.tablet_id, version, _fill_cache, 0, _lake_io_opts.fs));
     RETURN_IF_ERROR(
             lake::get_del_vec(_tablet_manager, *metadata, tsid.segment_id, _fill_cache, _lake_io_opts, pdelvec->get()));
     return Status::OK();

--- a/be/src/storage/lake/metadata_iterator.h
+++ b/be/src/storage/lake/metadata_iterator.h
@@ -16,7 +16,7 @@
 
 #include <fmt/format.h>
 
-#include <vector>
+#include <set>
 
 #include "common/status.h"
 #include "storage/lake/tablet_manager.h"
@@ -28,7 +28,7 @@ class TabletManager;
 template <typename T>
 class MetadataIterator {
 public:
-    explicit MetadataIterator(TabletManager* manager, int64_t tablet_id, std::vector<std::string> files)
+    explicit MetadataIterator(TabletManager* manager, int64_t tablet_id, std::set<std::string> files)
             : _manager(manager), _tablet_id(tablet_id), _files(std::move(files)), _iter(_files.begin()){};
 
     bool has_next() const { return _iter != _files.end(); }
@@ -46,8 +46,10 @@ private:
 
     TabletManager* _manager;
     int64_t _tablet_id;
-    std::vector<std::string> _files;
-    std::vector<std::string>::iterator _iter;
+    // Use sorted set
+    std::set<std::string> _files;
+    std::set<std::string>::iterator _iter;
+    int64_t _max_gtid = 0;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -47,10 +47,6 @@ Status Tablet::delete_metadata(int64_t version) {
     return _mgr->delete_tablet_metadata(_id, version);
 }
 
-Status Tablet::metadata_exists(int64_t version) {
-    return _mgr->tablet_metadata_exists(_id, version);
-}
-
 Status Tablet::put_txn_log(const TxnLog& log) {
     return _mgr->put_txn_log(log);
 }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -137,6 +137,11 @@ std::string TabletManager::tablet_latest_metadata_cache_key(int64_t tablet_id) {
     return fmt::format("TL{}", tablet_id);
 }
 
+Status TabletManager::drop_local_cache(const std::string& path) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
+    return fs->drop_local_cache(path);
+}
+
 // current lru cache does not support updating value size, so use refill to update.
 void TabletManager::update_segment_cache_size(std::string_view key, intptr_t segment_addr_hint) {
     // use write lock to protect parallel segment size update
@@ -239,70 +244,75 @@ Status TabletManager::put_tablet_metadata(const TabletMetadata& metadata) {
     return put_tablet_metadata(std::move(metadata_ptr));
 }
 
-StatusOr<TabletMetadataPtr> TabletManager::load_tablet_metadata(std::shared_ptr<FileSystem> fs,
-                                                                const string& metadata_location, bool fill_cache) {
+StatusOr<TabletMetadataPtr> TabletManager::load_tablet_metadata(const string& metadata_location, bool fill_cache,
+                                                                int64_t expected_gtid,
+                                                                const std::shared_ptr<FileSystem>& fs) {
     TEST_ERROR_POINT("TabletManager::load_tablet_metadata");
     auto t0 = butil::gettimeofday_us();
     auto metadata = std::make_shared<TabletMetadataPB>();
-    ProtobufFile file(metadata_location, std::move(fs));
+    ProtobufFile file(metadata_location, fs);
     auto s = file.load(metadata.get(), fill_cache);
     if (!s.ok()) {
         if (s.is_corruption() && config::lake_clear_corrupted_cache) {
-            auto tmp_fs = FileSystem::CreateSharedFromString(metadata_location);
-            if (!tmp_fs.ok()) {
-                LOG(WARNING) << "fail to get file system to clear corrupted cache for " << metadata_location
-                             << ", error: " << tmp_fs.status();
-                return s;
-            }
-            auto drop_status = (*tmp_fs)->drop_local_cache(metadata_location);
-            if (drop_status.ok()) {
-                LOG(INFO) << "clear corrupted cache for " << metadata_location;
-                // reset metadata
-                metadata = std::make_shared<TabletMetadataPB>();
-                // read again
-                RETURN_IF_ERROR(file.load(metadata.get(), fill_cache));
-            } else {
+            auto drop_status = drop_local_cache(metadata_location);
+            if (!drop_status.ok()) {
                 LOG(WARNING) << "clear corrupted cache for " << metadata_location << " failed, "
                              << "error: " << drop_status;
                 return s; // return error so load tablet meta can be retried
             }
+            LOG(INFO) << "clear corrupted cache for " << metadata_location;
+            // reset metadata
+            metadata = std::make_shared<TabletMetadataPB>();
+            // read again
+            RETURN_IF_ERROR(file.load(metadata.get(), fill_cache));
         } else {
             return s;
         }
     }
+
+    if (expected_gtid > 0 && metadata->gtid() > 0 && expected_gtid != metadata->gtid()) {
+        auto drop_status = drop_local_cache(metadata_location);
+        if (!drop_status.ok()) {
+            LOG(WARNING) << "clear dirty cache for " << metadata_location << " failed, "
+                         << "error: " << drop_status;
+            return drop_status;
+        }
+        LOG(INFO) << "clear dirty cache for " << metadata_location;
+        return Status::NotFound("Not found expected tablet metadata");
+    }
+
     g_get_tablet_metadata_latency << (butil::gettimeofday_us() - t0);
-    return std::move(metadata);
+    return metadata;
 }
 
 TabletMetadataPtr TabletManager::get_latest_cached_tablet_metadata(int64_t tablet_id) {
     return _metacache->lookup_tablet_metadata(tablet_latest_metadata_cache_key(tablet_id));
 }
 
-StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id, int64_t version, bool fill_cache) {
+StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id, int64_t version, bool fill_cache,
+                                                               int64_t expected_gtid,
+                                                               const std::shared_ptr<FileSystem>& fs) {
     if (version <= kInitialVersion) {
         // Handle tablet initial metadata
-        auto initial_metadata = get_tablet_metadata(tablet_initial_metadata_location(tablet_id), fill_cache);
+        auto initial_metadata =
+                get_tablet_metadata(tablet_initial_metadata_location(tablet_id), fill_cache, expected_gtid, fs);
         if (initial_metadata.ok()) {
             auto tablet_metadata = std::make_shared<TabletMetadata>(*initial_metadata.value());
             tablet_metadata->set_id(tablet_id);
             return tablet_metadata;
         }
     }
-    return get_tablet_metadata(tablet_metadata_location(tablet_id, version), fill_cache);
+    return get_tablet_metadata(tablet_metadata_location(tablet_id, version), fill_cache, expected_gtid, fs);
 }
 
-StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& path, bool fill_cache) {
-    std::shared_ptr<FileSystem> fs;
-    return get_tablet_metadata(fs, path, fill_cache);
-}
-
-StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(std::shared_ptr<FileSystem> fs, const string& path,
-                                                               bool fill_cache) {
+StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& path, bool fill_cache,
+                                                               int64_t expected_gtid,
+                                                               const std::shared_ptr<FileSystem>& fs) {
     if (auto ptr = _metacache->lookup_tablet_metadata(path); ptr != nullptr) {
         TRACE("got cached tablet metadata");
         return ptr;
     }
-    ASSIGN_OR_RETURN(auto ptr, load_tablet_metadata(std::move(fs), path, fill_cache));
+    ASSIGN_OR_RETURN(auto ptr, load_tablet_metadata(path, fill_cache, expected_gtid, fs));
     if (fill_cache) {
         _metacache->cache_tablet_metadata(path, ptr);
     }
@@ -319,28 +329,8 @@ Status TabletManager::delete_tablet_metadata(int64_t tablet_id, int64_t version)
     return fs::delete_file(location);
 }
 
-Status TabletManager::tablet_metadata_exists(int64_t tablet_id, int64_t version) {
-    if (version <= kInitialVersion) {
-        // Handle tablet initial metadata
-        auto status = tablet_metadata_exists(tablet_initial_metadata_location(tablet_id));
-        if (status.ok()) {
-            return status;
-        }
-    }
-    return tablet_metadata_exists(tablet_metadata_location(tablet_id, version));
-}
-
-Status TabletManager::tablet_metadata_exists(const std::string& path) {
-    if (auto ptr = _metacache->lookup_tablet_metadata(path); ptr != nullptr) {
-        TRACE("got cached tablet metadata");
-        return Status::OK();
-    }
-    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
-    return fs->path_exists(path);
-}
-
 StatusOr<TabletMetadataIter> TabletManager::list_tablet_metadata(int64_t tablet_id) {
-    std::vector<std::string> objects{};
+    std::set<std::string> objects;
     // TODO: construct prefix in LocationProvider
     std::string prefix = fmt::format("{:016X}_", tablet_id);
 
@@ -348,7 +338,7 @@ StatusOr<TabletMetadataIter> TabletManager::list_tablet_metadata(int64_t tablet_
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root));
     auto scan_cb = [&](std::string_view name) {
         if (HasPrefixString(name, prefix)) {
-            objects.emplace_back(join_path(root, name));
+            objects.insert(join_path(root, name));
         }
         return true;
     };
@@ -357,7 +347,7 @@ StatusOr<TabletMetadataIter> TabletManager::list_tablet_metadata(int64_t tablet_
 
     if (objects.empty()) {
         // Put tablet initial metadata
-        objects.emplace_back(join_path(root, tablet_initial_metadata_filename()));
+        objects.insert(join_path(root, tablet_initial_metadata_filename()));
     }
 
     return TabletMetadataIter{this, tablet_id, std::move(objects)};

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -77,7 +77,8 @@ static void clear_remote_snapshot_async(TabletManager* tablet_mgr, int64_t table
     files_to_delete->emplace_back(std::move(slog_path));
 }
 
-int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64_t base_version, int64_t new_version) {
+int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64_t base_version, int64_t new_version,
+                             const std::span<const TxnInfoPB>& txns) {
     int64_t version = base_version;
     auto metadata = tablet_mgr->get_latest_cached_tablet_metadata(tablet_id);
     if (metadata != nullptr && metadata->version() <= new_version) {
@@ -92,7 +93,8 @@ int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64
     if (index_version > version) {
         // There is a possibility that the index version is newer than the version in remote storage.
         // Check whether the index version exists in remote storage. If not, clear and rebuild the index.
-        auto res = tablet_mgr->tablet_metadata_exists(tablet_id, index_version);
+        auto res = tablet_mgr->get_tablet_metadata(tablet_id, index_version, true,
+                                                   txns[index_version - base_version - 1].gtid());
         if (res.ok()) {
             version = index_version;
         } else {
@@ -182,14 +184,14 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
         return std::move(cached_new_metadata);
     }
 
-    auto new_version_metadata_or_error = [=](Status error) -> StatusOr<TabletMetadataPtr> {
-        auto res = tablet_mgr->get_tablet_metadata(tablet_id, new_version);
+    auto new_version_metadata_or_error = [=](const Status& error) -> StatusOr<TabletMetadataPtr> {
+        auto res = tablet_mgr->get_tablet_metadata(tablet_id, new_version, txns.back().gtid());
         if (res.ok()) return res;
         return error;
     };
 
     int64_t ori_base_version = base_version;
-    int64_t new_base_version = cal_new_base_version(tablet_id, tablet_mgr, base_version, new_version);
+    int64_t new_base_version = cal_new_base_version(tablet_id, tablet_mgr, base_version, new_version, txns);
     if (new_base_version > base_version) {
         LOG(INFO) << "Base version has been adjusted. tablet_id=" << tablet_id << " base_version=" << base_version
                   << " new_base_version=" << new_base_version << " new_version=" << new_version << " txns=" << txns;
@@ -203,7 +205,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
     }
 
     if (base_version == new_version) {
-        return tablet_mgr->get_tablet_metadata(tablet_id, base_version);
+        return tablet_mgr->get_tablet_metadata(tablet_id, new_version, true, txns.back().gtid());
     }
 
     // Read base version metadata
@@ -249,7 +251,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
                 // needs take compaction(force_publish=true) into consideration
                 // 1. duplicate publish in mode single
                 if (txns.size() == 1) {
-                    auto res = tablet_mgr->get_tablet_metadata(tablet_id, new_version);
+                    auto res = tablet_mgr->get_tablet_metadata(tablet_id, new_version, true, txns.back().gtid());
                     if (!res.ok() && res.status().is_not_found()) {
                         if (!txns[i].force_publish()) {
                             return txn_log_st.status();
@@ -270,7 +272,8 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
                 // then txn3 is published successfully in BE and the txn_log of txn3 has been deleted, but FE do not get the response for some reason,
                 // turn the mode of publish to batch,
                 // txn3 ,txn4, txn5 will be published in one publish batch task, so txn3 should be skipped just apply txn_log of txn4 and txn5.
-                auto missig_txn_log_meta = tablet_mgr->get_tablet_metadata(tablet_id, base_version + 1);
+                auto missig_txn_log_meta =
+                        tablet_mgr->get_tablet_metadata(tablet_id, base_version + 1, true, txns[0].gtid());
                 if (missig_txn_log_meta.status().is_not_found()) {
                     if (txns[i].force_publish()) {
                         // can not change `base_metadata` below, just use old one

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -644,10 +644,9 @@ Status UpdateManager::get_del_vec(const TabletSegmentId& tsid, int64_t version, 
 // get delvec in meta file
 Status UpdateManager::get_del_vec_in_meta(const TabletSegmentId& tsid, int64_t meta_ver, bool fill_cache,
                                           DelVector* delvec) {
-    std::string filepath = _tablet_mgr->tablet_metadata_location(tsid.tablet_id, meta_ver);
     LakeIOOptions lake_io_opts;
     lake_io_opts.fill_data_cache = fill_cache;
-    ASSIGN_OR_RETURN(auto metadata, _tablet_mgr->get_tablet_metadata(filepath, fill_cache));
+    ASSIGN_OR_RETURN(auto metadata, _tablet_mgr->get_tablet_metadata(tsid.tablet_id, meta_ver, fill_cache));
     RETURN_IF_ERROR(lake::get_del_vec(_tablet_mgr, *metadata, tsid.segment_id, fill_cache, lake_io_opts, delvec));
     return Status::OK();
 }

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -87,7 +87,6 @@ TEST_F(LakeTabletManagerTest, tablet_meta_write_and_read) {
     rowset_meta_pb->set_data_size(1024);
     rowset_meta_pb->set_num_rows(5);
     EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
-    EXPECT_OK(_tablet_manager->tablet_metadata_exists(12345, 2));
     string result;
     ASSERT_TRUE(execute_script("System.print(StorageEngine.get_lake_tablet_metadata_json(12345,2))", result).ok());
     auto res = _tablet_manager->get_tablet_metadata(12345, 2);
@@ -95,7 +94,6 @@ TEST_F(LakeTabletManagerTest, tablet_meta_write_and_read) {
     EXPECT_EQ(res.value()->id(), 12345);
     EXPECT_EQ(res.value()->version(), 2);
     EXPECT_OK(_tablet_manager->delete_tablet_metadata(12345, 2));
-    EXPECT_STATUS(Status::NotFound(""), _tablet_manager->tablet_metadata_exists(12345, 2));
     res = _tablet_manager->get_tablet_metadata(12345, 2);
     EXPECT_TRUE(res.status().is_not_found());
 }

--- a/format-sdk/src/main/cpp/format/starrocks_format_writer.cpp
+++ b/format-sdk/src/main/cpp/format/starrocks_format_writer.cpp
@@ -172,7 +172,7 @@ private:
         }
         std::sort(objects.begin(), objects.end());
         auto metadata_location = objects.back();
-        return _lake_tablet_manager->get_tablet_metadata(fs, metadata_location, true);
+        return _lake_tablet_manager->get_tablet_metadata(metadata_location, true, 0, fs);
     }
 
 private:


### PR DESCRIPTION
## Why I'm doing:
The dirty data must be handled after restoring from a cluster snapshot.

## What I'm doing:
Use gtid to handle dirty tablet metadata in publish version.

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0