### PR TITLE
[BugFix] Fix primary key table add an visible rowset

### DIFF
--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -415,6 +415,11 @@ Status DataDir::load() {
 
         } else if (rowset_meta->rowset_state() == RowsetStatePB::VISIBLE &&
                    rowset_meta->tablet_uid() == tablet->tablet_uid()) {
+            if (tablet->keys_type() == KeysType::PRIMARY_KEYS) {
+                VLOG(1) << "skip a visible rowset meta, tablet: " << tablet->tablet_id()
+                        << ", rowset: " << rowset_meta->rowset_id();
+                continue;
+            }
             Status publish_status = tablet->load_rowset(rowset);
             if (!rowset_meta->tablet_schema()) {
                 rowset_meta->set_tablet_schema(tablet->tablet_schema());

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -418,19 +418,19 @@ Status DataDir::load() {
             if (tablet->keys_type() == KeysType::PRIMARY_KEYS) {
                 VLOG(1) << "skip a visible rowset meta, tablet: " << tablet->tablet_id()
                         << ", rowset: " << rowset_meta->rowset_id();
-                continue;
-            }
-            Status publish_status = tablet->load_rowset(rowset);
-            if (!rowset_meta->tablet_schema()) {
-                rowset_meta->set_tablet_schema(tablet->tablet_schema());
-                rowset_meta->set_skip_tablet_schema(true);
-            }
-            if (!publish_status.ok() && !publish_status.is_already_exist()) {
-                LOG(WARNING) << "Fail to add visible rowset=" << rowset->rowset_id()
-                             << " to tablet=" << rowset_meta->tablet_id() << " txn id=" << rowset_meta->txn_id()
-                             << " start version=" << rowset_meta->version().first
-                             << " end version=" << rowset_meta->version().second;
-                error_rowset_count++;
+            } else {
+                Status publish_status = tablet->load_rowset(rowset);
+                if (!rowset_meta->tablet_schema()) {
+                    rowset_meta->set_tablet_schema(tablet->tablet_schema());
+                    rowset_meta->set_skip_tablet_schema(true);
+                }
+                if (!publish_status.ok() && !publish_status.is_already_exist()) {
+                    LOG(WARNING) << "Fail to add visible rowset=" << rowset->rowset_id()
+                                 << " to tablet=" << rowset_meta->tablet_id() << " txn id=" << rowset_meta->txn_id()
+                                 << " start version=" << rowset_meta->version().first
+                                 << " end version=" << rowset_meta->version().second;
+                    error_rowset_count++;
+                }
             }
         } else {
             LOG(WARNING) << "Found invalid rowset=" << rowset_meta->rowset_id()

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1827,6 +1827,7 @@ const TabletSchemaCSPtr Tablet::thread_safe_get_tablet_schema() const {
     return _max_version_schema;
 }
 
+DEFINE_FAIL_POINT(tablet_get_visible_rowset);
 // for non-pk tablet, all published rowset will be rewrite when save `tablet_meta`
 // for pk tablet, we need to get the rowset which without `tablet_schema` and rewrite
 // the rowsets in `_committed_rs_map` is committed success but not publish yet, so if we update the
@@ -1841,6 +1842,14 @@ void Tablet::_get_rewrite_meta_rs(std::vector<RowsetSharedPtr>& rewrite_meta_rs)
     if (_updates) {
         _updates->rewrite_rs_meta(true);
     }
+    FAIL_POINT_TRIGGER_EXECUTE(tablet_get_visible_rowset, {
+        if (_updates) {
+            auto rowset_map = _updates->get_rowset_map();
+            for (const auto& [_, rs] : (*rowset_map)) {
+                rewrite_meta_rs.emplace_back(rs);
+            }
+        }
+    });
 }
 
 void Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
@@ -1858,7 +1867,7 @@ void Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
         std::vector<RowsetSharedPtr> rewrite_meta_rs;
         _get_rewrite_meta_rs(rewrite_meta_rs);
         _tablet_meta->save_tablet_schema(_max_version_schema, rewrite_meta_rs, _data_dir,
-                                         keys_type == KeysType::PRIMARY_KEYS);
+                                         _max_version_schema->keys_type() == KeysType::PRIMARY_KEYS);
         _committed_rs_map.clear();
     }
 }

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1857,7 +1857,8 @@ void Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
         }
         std::vector<RowsetSharedPtr> rewrite_meta_rs;
         _get_rewrite_meta_rs(rewrite_meta_rs);
-        _tablet_meta->save_tablet_schema(_max_version_schema, rewrite_meta_rs, _data_dir);
+        _tablet_meta->save_tablet_schema(_max_version_schema, rewrite_meta_rs, _data_dir,
+                                         keys_type == KeysType::PRIMARY_KEYS);
         _committed_rs_map.clear();
     }
 }

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -203,12 +203,16 @@ Status TabletMeta::save_meta(DataDir* data_dir, bool skip_tablet_schema) {
 }
 
 void TabletMeta::save_tablet_schema(const TabletSchemaCSPtr& tablet_schema, std::vector<RowsetSharedPtr>& committed_rs,
-                                    DataDir* data_dir) {
+                                    DataDir* data_dir, bool is_primary_key) {
     std::unique_lock wrlock(_meta_lock);
     _schema = tablet_schema;
     for (auto& rs : committed_rs) {
         RowsetMetaPB meta_pb;
         rs->rowset_meta()->get_full_meta_pb(&meta_pb);
+        if (is_primary_key && rs->rowset_meta()->rowset_state() == RowsetStatePB::VISIBLE) {
+            LOG(INFO) << "skip visible rowset: " << rs->rowset_meta()->rowset_id() << " of tablet: " << tablet_id();
+            continue;
+        }
         Status res = RowsetMetaManager::save(data_dir->get_meta(), tablet_uid(), meta_pb);
         LOG_IF(FATAL, !res.ok()) << "failed to save rowset " << rs->rowset_id() << " to local meta store: " << res;
         rs->rowset_meta()->set_skip_tablet_schema(false);

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -165,7 +165,7 @@ public:
 
     void set_tablet_schema(const TabletSchemaCSPtr& tablet_schema) { _schema = tablet_schema; }
     void save_tablet_schema(const TabletSchemaCSPtr& tablet_schema, std::vector<RowsetSharedPtr>& committed_rs,
-                            DataDir* data_dir);
+                            DataDir* data_dir, bool is_primary_key);
 
     TabletSchemaCSPtr& tablet_schema_ptr() { return _schema; }
     const TabletSchemaCSPtr& tablet_schema_ptr() const { return _schema; }

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3920,6 +3920,20 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
         ASSERT_EQ(rs2->tablet_schema()->id(), old_schema_id);
         ASSERT_EQ(rs1->tablet_schema()->id(), old_schema_id);
     }
+
+    {
+        PFailPointTriggerMode trigger_mode;
+        trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+        std::string fp_name = "tablet_get_visible_rowset";
+        auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(fp_name);
+        fp->setMode(trigger_mode);
+
+        auto tmp_tablet1 = create_tablet(rand(), rand(), false, _tablet->tablet_schema()->id() + 1,
+                                         _tablet->tablet_schema()->schema_version() + 1);
+        _tablet->update_max_version_schema(tmp_tablet1->tablet_schema());
+        trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+        fp->setMode(trigger_mode);
+    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Primary key table keep its own visible rowsets in `TabletUpdatesPB`, so primary key table should not call `Tablet::add_rowset` function [[1]](https://github.com/StarRocks/starrocks/pull/54491/files#diff-078479f1100cc9ccb1a3731be8fda75daf9b5a3ae8833a01e7bf45ef6e999ae7L324-L325). 
However, when we update schema version, we will first get all `COMMITTED` rowsets and rewrite these rowsets meta[[2]](https://github.com/StarRocks/starrocks/pull/54491/files#diff-078479f1100cc9ccb1a3731be8fda75daf9b5a3ae8833a01e7bf45ef6e999ae7L1859-L1860).  But this could run concurrency with publish version task and these rowsets will be update to `VISIBLE`[[3]](https://github.com/StarRocks/starrocks/blob/main/be/src/storage/txn_manager.cpp#L376-L385). So we will write a visible rowset into RocksDB for primary key table.

## What I'm doing:
1. Check rowset state before rewrite rowset meta into RocksDB.
2. Skip visible RowsetMetaPB in RocksDB if table is a primary key table and the RowsetMetaPB will be deleted when the rowset is expired.

Fixes https://github.com/StarRocks/StarRocksTest/issues/9002

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0