### PR TITLE
[BugFix] Fix NPE workgroup executor

### DIFF
--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -569,8 +569,6 @@ void WorkGroupManager::create_workgroup_unlocked(const WorkGroupPtr& wg, UniqueL
     std::unique_ptr<PipelineExecutorSet> exclusive_executors = nullptr;
     {
         const auto& cpuids = _executors_manager.get_cpuids_of_workgroup(wg.get());
-        unique_lock.unlock();
-        DeferOp unlock_guard([&unique_lock] { unique_lock.lock(); });
         exclusive_executors = _executors_manager.maybe_create_exclusive_executors_unlocked(wg.get(), cpuids);
     }
     if (exclusive_executors != nullptr) {


### PR DESCRIPTION

## Why I'm doing:

Early unlock causes the other thread to return an uninitialized workgroup object. Then causes the NPE.

the rax is 0x00 (workgroup->executors) is nullptr
```
   0x00000000043203d6 <+486>:   mov    0x58(%r12),%rax
   0x00000000043203db <+491>:   mov    0x48(%r12),%rsi
   0x00000000043203e0 <+496>:   lea    -0x60(%rbp),%rdi
   0x00000000043203e4 <+500>:   mov    0x1b0(%rax),%rax
=> 0x00000000043203eb <+507>:   mov    0x58(%rax),%rdx

(gdb) info registers 
rax            0x0                 0
rbx            0x7f7a793f07c0      140163996911552
rcx            0x17                23
rdx            0x0                 0
rsi            0x7f7a7942a290      140163997147792
rdi            0x7f7955dcb2c0      140159108297408
rbp            0x7f7955dcb320      0x7f7955dcb320
rsp            0x7f7955dcb260      0x7f7955dcb260
r8             0x3                 3
r9             0xc2a               3114
r10            0x18                24

(gdb) p this
$34 = (starrocks::pipeline::FragmentExecutor * const) 0x7f7955dcb340
(gdb) p &this->_query_ctx
$37 = (starrocks::pipeline::QueryContext **) 0x7f7955dcb380
(gdb) p &this->_fragment_ctx
$38 = (starrocks::pipeline::FragmentContextPtr *) 0x7f7955dcb388
(gdb) p this
(gdb) p &this->_wg
$45 = (starrocks::workgroup::WorkGroupPtr *) 0x7f7955dcb398
(gdb) p (0x7f7955dcb340 - 0x7f7955dcb398)
$46 = -88
(gdb) p &this->_wg
$47 = (starrocks::workgroup::WorkGroupPtr *) 0x7f7955dcb398
(gdb) p 0x1b0
$54 = 432
(gdb) p &this->_wg._M_ptr[0]
$55 = (std::__shared_ptr<starrocks::workgroup::WorkGroup, (__gnu_cxx::_Lock_policy)2>::element_type *) 0x7f7a79329810
(gdb) p &this->_wg._M_ptr->_executors
$56 = (starrocks::workgroup::PipelineExecutorSet **) 0x7f7a793299c0
(gdb) p (0x7f7a79329810 - 0x7f7a793299c0)
$57 = -432
```


## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9004

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0