### PR TITLE
[Enhancement] Support fe starting with only image no bdb log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -134,10 +134,12 @@ public class BDBEnvironment {
 
         // constructor
         String selfNodeHostPort = NetUtils.getHostPortInAccessibleFormat(selfNode.first, selfNode.second);
-
+        boolean isFirstTimeStartUp = false;
+    
         File dbEnv = new File(getBdbDir());
         if (!dbEnv.exists()) {
             dbEnv.mkdirs();
+            isFirstTimeStartUp = true;
         }
 
         Pair<String, Integer> helperNode = GlobalStateMgr.getCurrentState().getNodeMgr().getHelperNode();
@@ -147,7 +149,7 @@ public class BDBEnvironment {
                 helperHostPort, GlobalStateMgr.getCurrentState().isElectable());
 
         // setup
-        bdbEnvironment.setup();
+        bdbEnvironment.setup(isFirstTimeStartUp);
         return bdbEnvironment;
     }
 
@@ -165,14 +167,14 @@ public class BDBEnvironment {
     }
 
     // The setup() method opens the environment and database
-    protected void setup() throws JournalException, InterruptedException {
+    protected void setup(boolean isFirstTimeStartUp) throws JournalException, InterruptedException {
         this.closing = false;
         ensureHelperInLocal();
-        initConfigs(isElectable);
+        initConfigs(isFirstTimeStartUp);
         setupEnvironment();
     }
 
-    protected void initConfigs(boolean isElectable) throws JournalException {
+    protected void initConfigs(boolean isFirstTimeStartUp) throws JournalException {
         // Almost never used, just in case the master can not restart
         if (Config.bdbje_reset_election_group) {
             if (!isElectable) {
@@ -180,10 +182,12 @@ public class BDBEnvironment {
                 LOG.error(errMsg);
                 throw new JournalException(errMsg);
             }
-            DbResetRepGroup resetUtility = new DbResetRepGroup(envHome, STARROCKS_JOURNAL_GROUP, selfNodeName,
-                    selfNodeHostPort);
-            resetUtility.reset();
-            LOG.info("group has been reset.");
+            if (!isFirstTimeStartUp) {
+                DbResetRepGroup resetUtility = new DbResetRepGroup(envHome, STARROCKS_JOURNAL_GROUP, selfNodeName,
+                        selfNodeHostPort);
+                resetUtility.reset();
+                LOG.info("group has been reset.");
+            }
         }
 
         // set replication config

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1265,16 +1265,7 @@ public class GlobalStateMgr {
         dominationStartTimeMs = System.currentTimeMillis();
 
         try {
-            // Log the first frontend
-            if (nodeMgr.isFirstTimeStartUp()) {
-                // if isFirstTimeStartUp is true, frontends must contain this Node.
-                Frontend self = nodeMgr.getMySelf();
-                Preconditions.checkNotNull(self);
-                // OP_ADD_FIRST_FRONTEND is emitted, so it can write to BDBJE even if canWrite is false
-                editLog.logAddFirstFrontend(self);
-            }
-
-            if (Config.bdbje_reset_election_group) {
+            if (Config.bdbje_reset_election_group || nodeMgr.isFirstTimeStartUp()) {
                 nodeMgr.resetFrontends();
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -1208,6 +1208,9 @@ public class NodeMgr {
         frontends.clear();
         Frontend self = new Frontend(role, nodeName, selfNode.first, selfNode.second);
         frontends.put(self.getNodeName(), self);
+        // reset helper nodes
+        helperNodes.clear();
+        helperNodes.add(selfNode);
 
         GlobalStateMgr.getCurrentState().getEditLog().logResetFrontends(self);
     }
@@ -1215,6 +1218,9 @@ public class NodeMgr {
     public void replayResetFrontends(Frontend frontend) {
         frontends.clear();
         frontends.put(frontend.getNodeName(), frontend);
+        // reset helper nodes
+        helperNodes.clear();
+        helperNodes.add(Pair.create(frontend.getHost(), frontend.getEditLogPort()));
     }
 
     public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {

--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBEnvironmentTest.java
@@ -88,7 +88,7 @@ public class BDBEnvironmentTest {
                 selfNodeHostPort,
                 selfNodeHostPort,
                 true);
-        environment.setup();
+        environment.setup(true);
 
         CloseSafeDatabase db = environment.openDatabase("testdb");
         DatabaseEntry key = randomEntry();
@@ -117,7 +117,7 @@ public class BDBEnvironmentTest {
                         selfNodeHostPort,
                         selfNodeHostPort,
                         true);
-                environment.setup();
+                environment.setup(true);
             }
             Assert.fail();
         } finally {
@@ -173,7 +173,7 @@ public class BDBEnvironmentTest {
                 leaderNodeHostPort,
                 leaderNodeHostPort,
                 true);
-        leaderEnvironment.setup();
+        leaderEnvironment.setup(true);
         Assert.assertEquals(0, leaderEnvironment.getDatabaseNames().size());
 
         // set up 2 followers
@@ -188,7 +188,7 @@ public class BDBEnvironmentTest {
                     leaderNodeHostPort,
                     true);
             followerEnvironments[i] = followerEnvironment;
-            followerEnvironment.setup();
+            followerEnvironment.setup(true);
             Assert.assertEquals(0, followerEnvironment.getDatabaseNames().size());
         }
         BDBEnvironment.RETRY_TIME = 3;
@@ -243,7 +243,7 @@ public class BDBEnvironmentTest {
                 true);
         Assert.assertTrue(true);
         try {
-            maserEnvironment.setup();
+            maserEnvironment.setup(true);
         } catch (JournalException e) {
             LOG.warn("got Rollback Exception, as expect, ", e);
         }
@@ -268,7 +268,7 @@ public class BDBEnvironmentTest {
                 if (followerEnvironments[i].getReplicatedEnvironment().getState() == ReplicatedEnvironment.State.MASTER) {
                     newMasterEnvironment = followerEnvironments[i];
                     LOG.warn("=========> new leader is {}", newMasterEnvironment.getReplicatedEnvironment().getNodeName());
-                    newMasterEnvironment.setup();
+                    newMasterEnvironment.setup(true);
                     newMasterFollowerIndex = i;
                     break;
                 }
@@ -282,7 +282,7 @@ public class BDBEnvironmentTest {
                 leaderNodeHostPort,
                 leaderNodeHostPort,
                 true);
-        oldMasterEnvironment.setup();
+        oldMasterEnvironment.setup(true);
         LOG.warn("============> old leader is setup as follower");
         Thread.sleep(1000);
 
@@ -335,7 +335,7 @@ public class BDBEnvironmentTest {
                 true);
         LOG.warn("=========> start new follower for the first time");
         // should set up successfully as a standalone leader
-        newfollowerEnvironment.setup();
+        newfollowerEnvironment.setup(true);
         newfollowerEnvironment.close();
 
         // 2. bad new follower start for the second time
@@ -348,7 +348,7 @@ public class BDBEnvironmentTest {
                 true);
         LOG.warn("==========> start new follower for the second time");
         try {
-            newfollowerEnvironment.setup();
+            newfollowerEnvironment.setup(true);
         } catch (Exception e) {
             LOG.warn("===========> failed for the second time, as expect, ", e);
         }
@@ -370,7 +370,7 @@ public class BDBEnvironmentTest {
                 selfNodeHostPort,
                 selfNodeHostPort,
                 true);
-        environment.setup();
+        environment.setup(true);
 
         new MockUp<ReplicatedEnvironment>() {
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJEJournalTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJEJournalTest.java
@@ -88,7 +88,7 @@ public class BDBJEJournalTest {
                 selfNodeHostPort,
                 selfNodeHostPort,
                 true);
-        environment.setup();
+        environment.setup(true);
         return environment;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJournalCursorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJournalCursorTest.java
@@ -85,7 +85,7 @@ public class BDBJournalCursorTest {
                 selfNodeHostPort,
                 selfNodeHostPort,
                 true);
-        environment.setup();
+        environment.setup(true);
         return environment;
     }
 


### PR DESCRIPTION
## Why I'm doing:
When there is only image no bdb log, fe will start failed.

## What I'm doing:
Support fe starting with only image no bdb log.

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0