### PR TITLE
[BugFix] Replace `sqlalchemy.util.raise` with Python 3 `raise`

### DIFF
--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -188,13 +188,10 @@ class StarRocksDDLCompiler(MySQLDDLCompiler):
                 if column.primary_key:
                     first_pk = True
             except exc.CompileError as ce:
-                util.raise_(
-                    exc.CompileError(
-                        util.u("(in table '%s', column '%s'): %s")
-                        % (table.description, column.name, ce.args[0])
-                    ),
-                    from_=ce,
-                )
+                raise exc.CompileError(
+                    "(in table '%s', column '%s'): %s"
+                    % (table.description, column.name, ce.args[0])
+                ) from ce
 
         # N.B. Primary Key is specified in post_create_table
         #  Indexes are created by SQLA after the creation of the table using CREATE INDEX
@@ -429,7 +426,7 @@ class StarRocksDialect(MySQLDialect_pymysql):
             ).exec_driver_sql(st)
         except exc.DBAPIError as e:
             if self._extract_error_code(e.orig) == 1146:
-                util.raise_(exc.NoSuchTableError(full_name), replace_context=e)
+                raise exc.NoSuchTableError(full_name) from e
             else:
                 raise
         index_results = self._compat_fetchall(rp, charset=charset)


### PR DESCRIPTION
This changed upstream in SQLAlchemy 2.0: https://github.com/sqlalchemy/sqlalchemy/commit/13e6e5608898a2c85751372ba88d357e5b80fe3f

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0