### PR TITLE
[BugFix] Disable stats collection for generated columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -368,7 +368,6 @@ public class StatisticUtils {
             isPrimaryEngine = KeysType.PRIMARY_KEYS.equals(((OlapTable) table).getKeysType());
         }
         List<String> columns = new ArrayList<>();
-        Set<String> partitionColumns = Sets.newHashSet(table.getPartitionColumnNames());
         for (Column column : table.getBaseSchema()) {
             // disable stats collection for auto generated columns, see SelectAnalyzer#analyzeSelect
             if (column.isGeneratedColumn() && column.getName().startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -369,6 +369,10 @@ public class StatisticUtils {
         }
         List<String> columns = new ArrayList<>();
         for (Column column : table.getBaseSchema()) {
+            // disable stats collection for generated columns
+            if (column.isGeneratedColumn()) {
+                continue;
+            }
             if (!column.isAggregated()) {
                 columns.add(column.getName());
             } else if (isPrimaryEngine && column.getAggregationType().equals(AggregateType.REPLACE)) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -368,9 +368,10 @@ public class StatisticUtils {
             isPrimaryEngine = KeysType.PRIMARY_KEYS.equals(((OlapTable) table).getKeysType());
         }
         List<String> columns = new ArrayList<>();
+        Set<String> partitionColumns = Sets.newHashSet(table.getPartitionColumnNames());
         for (Column column : table.getBaseSchema()) {
-            // disable stats collection for generated columns
-            if (column.isGeneratedColumn()) {
+            // disable stats collection for auto generated columns, see SelectAnalyzer#analyzeSelect
+            if (column.isGeneratedColumn() && column.getName().startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
                 continue;
             }
             if (!column.isAggregated()) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -1535,4 +1535,20 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         }
     }
 
+    @Test
+    public void testGetCollectibleColumns() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE test.t_gen_col (" +
+                " c1 datetime NOT NULL," +
+                " c2 bigint," +
+                " c3 DATETIME NULL AS date_trunc('month', c1) " +
+                " ) " +
+                " DUPLICATE KEY(c1) " +
+                " PARTITION BY (c2, c3) " +
+                " PROPERTIES('replication_num'='1')");
+        Table table = starRocksAssert.getTable("test", "t_gen_col");
+        List<String> cols =  StatisticUtils.getCollectibleColumns(table);
+        Assert.assertTrue(cols.size() == 2);
+        Assert.assertTrue(!cols.contains("c3"));
+        starRocksAssert.dropTable("test.t_gen_col");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -1536,7 +1536,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     }
 
     @Test
-    public void testGetCollectibleColumns() throws Exception {
+    public void testGetCollectibleColumns1() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test.t_gen_col (" +
                 " c1 datetime NOT NULL," +
                 " c2 bigint," +
@@ -1547,8 +1547,23 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 " PROPERTIES('replication_num'='1')");
         Table table = starRocksAssert.getTable("test", "t_gen_col");
         List<String> cols =  StatisticUtils.getCollectibleColumns(table);
+        Assert.assertTrue(cols.size() == 3);
+        Assert.assertTrue(cols.contains("c3"));
+        starRocksAssert.dropTable("test.t_gen_col");
+    }
+
+    @Test
+    public void testGetCollectibleColumns2() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE test.t_gen_col (" +
+                " c1 datetime NOT NULL," +
+                " c2 bigint" +
+                " ) " +
+                " DUPLICATE KEY(c1) " +
+                " PARTITION BY c2, date_trunc('month', c1) " +
+                " PROPERTIES('replication_num'='1')");
+        Table table = starRocksAssert.getTable("test", "t_gen_col");
+        List<String> cols =  StatisticUtils.getCollectibleColumns(table);
         Assert.assertTrue(cols.size() == 2);
-        Assert.assertTrue(!cols.contains("c3"));
         starRocksAssert.dropTable("test.t_gen_col");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

```
2024-12-30 14:11:22.694+08:00 ERROR (analyze-task-concurrency-pool-1|271) [HyperQueryJob.executeStatisticsQuery():134] execute statistics query failed, sql: with base_cte_table as ( SELECT * FROM (SELECT *  FROM `db1`.`iceberg_lineitem_days_utc_1000_mv` tablet(30132)  WHERE rand() <= 0.300000  LIMIT 200000) t_low) SELECT cast(9 as INT), cast(30126 as B
IGINT), '__generated_partition_column_0', cast(0 as BIGINT), cast(8 * 1 as BIGINT), hex(hll_serialize(IFNULL(hll_raw(`__generated_partition_column_0`), hll_empty()))), cast((COUNT(*) - COUNT(`__generated_partition_column_0`)) * 1 / COUNT(*) as BIGINT), '', '', cast(-1.0 as BIGINT) FROM base_cte_table
 com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Column '`__generated_partition_column_0`' cannot be resolved.
        at com.starrocks.sql.analyzer.Scope.resolveField(Scope.java:96)
        at com.starrocks.sql.analyzer.Scope.resolveField(Scope.java:90)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer$Visitor.visitSlot(ExpressionAnalyzer.java:434)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer$Visitor.visitSlot(ExpressionAnalyzer.java:376)
        at com.starrocks.analysis.SlotRef.accept(SlotRef.java:535)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:88)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.bottomUpAnalyze(ExpressionAnalyzer.java:372)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.bottomUpAnalyze(ExpressionAnalyzer.java:370)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.bottomUpAnalyze(ExpressionAnalyzer.java:370)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.bottomUpAnalyze(ExpressionAnalyzer.java:370)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.bottomUpAnalyze(ExpressionAnalyzer.java:370)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.analyze(ExpressionAnalyzer.java:136)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.analyzeExpression(ExpressionAnalyzer.java:1822)
        at com.starrocks.sql.analyzer.SelectAnalyzer.analyzeExpression(SelectAnalyzer.java:746)
        at com.starrocks.sql.analyzer.SelectAnalyzer.analyzeSelect(SelectAnalyzer.java:251)
        at com.starrocks.sql.analyzer.SelectAnalyzer.analyze(SelectAnalyzer.java:78)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitSelect(QueryAnalyzer.java:378)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitSelect(QueryAnalyzer.java:286)
        at com.starrocks.sql.ast.SelectRelation.accept(SelectRelation.java:232)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.process(QueryAnalyzer.java:291)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitQueryRelation(QueryAnalyzer.java:306)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitQueryStatement(QueryAnalyzer.java:296)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitQueryStatement(QueryAnalyzer.java:286)
        at com.starrocks.sql.ast.QueryStatement.accept(QueryStatement.java:72)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.process(QueryAnalyzer.java:291)
        at com.starrocks.sql.analyzer.QueryAnalyzer.analyze(QueryAnalyzer.java:124)
        at com.starrocks.sql.analyzer.Analyzer$AnalyzerVisitor.visitQueryStatement(Analyzer.java:443)
        at com.starrocks.sql.analyzer.Analyzer$AnalyzerVisitor.visitQueryStatement(Analyzer.java:179)
        at com.starrocks.sql.ast.QueryStatement.accept(QueryStatement.java:72)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:88)
        at com.starrocks.sql.analyzer.Analyzer.analyze(Analyzer.java:176)
        at com.starrocks.sql.StatementPlanner.analyzeStatement(StatementPlanner.java:204)
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:125)
        at com.starrocks.statistic.StatisticExecutor.executeDQL(StatisticExecutor.java:527)
        at com.starrocks.statistic.StatisticExecutor.executeStatisticDQL(StatisticExecutor.java:481)
        at com.starrocks.statistic.hyper.HyperQueryJob.executeStatisticsQuery(HyperQueryJob.java:130)
        at com.starrocks.statistic.hyper.MetaQueryJob.queryDataMetric(MetaQueryJob.java:107)
        at com.starrocks.statistic.hyper.MetaQueryJob.queryStatistics(MetaQueryJob.java:55)
        at com.starrocks.statistic.HyperStatisticsCollectJob.collect(HyperStatisticsCollectJob.java:93)
        at com.starrocks.statistic.StatisticExecutor.collectStatistics(StatisticExecutor.java:369)
        at com.starrocks.qe.StmtExecutor.executeAnalyze(StmtExecutor.java:1575)
        at com.starrocks.qe.StmtExecutor.executeAnalyze(StmtExecutor.java:1530)
        at com.starrocks.qe.StmtExecutor.lambda$handleAnalyzeStmt$2(StmtExecutor.java:1466)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
```
## What I'm doing:
- Disable stats collection for generated columns

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0