### PR TITLE
[Enhancement] Implement ConnectContext.toString() (#54563)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1256,6 +1256,18 @@ public class ConnectContext {
         }
     }
 
+    @Override
+    public String toString() {
+        return "ConnectContext{remoteIP=" + remoteIP +
+                ", connectionId=" + connectionId +
+                ", closed=" + closed +
+                ", isKilled=" + isKilled +
+                ", queryId=" + queryId +
+                ", stmtId=" + stmtId +
+                ", forwardedStmtId=" + forwardedStmtId +
+                '}';
+    }
+
     /**
      * Set thread-local context for the scope, and remove it after leaving the scope
      */


### PR DESCRIPTION
## Why I'm doing:

ConnectContext didn't implement Object.toString(), causing logger content is meaningless in https://github.com/StarRocks/starrocks/blob/3.3.7/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java#L920 and  https://github.com/StarRocks/starrocks/blob/3.3.7/fe/fe-core/src/main/java/com/starrocks/mysql/nio/ReadListener.java#L81 .

## What I'm doing:

Implement ConnectContext.toString() 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0