### PR TITLE
[Enhancement] Improve files() parquet orc column mismatch error message

### DIFF
--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -65,7 +65,7 @@ static std::string make_column_count_not_matched_error_message_for_query(int exp
               << "Column separator: " << string_2_asc(parse_options.column_delimiter) << ", "
               << "Row delimiter: " << string_2_asc(parse_options.row_delimiter) << ", "
               << "Row: '" << row << "', File: " << filename << ". "
-              << "Consider setting 'fill_mismatch_column_with' = 'null'";
+              << "Consider setting 'fill_mismatch_column_with' = 'null' property";
     return error_msg.str();
 }
 

--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -229,6 +229,9 @@ Status ORCScanner::_open_next_orc_reader() {
         if (st.is_end_of_file()) {
             LOG(WARNING) << "Failed to init orc reader. filename: " << file_name << ", status: " << st.to_string();
             continue;
+        } else if (st.is_not_found() &&
+                   (_file_scan_type == TFileScanType::FILES_INSERT || _file_scan_type == TFileScanType::FILES_QUERY)) {
+            st = st.clone_and_append("Consider setting 'fill_mismatch_column_with' = 'null' property");
         }
         return st;
     }

--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -252,7 +252,7 @@ Status ParquetReaderWrap::column_indices(const std::vector<SlotDescriptor*>& tup
             std::stringstream str_error;
             str_error << "Column: " << slot_desc->col_name() << " is not found in file: " << _filename;
             LOG(WARNING) << str_error.str();
-            return Status::InvalidArgument(str_error.str());
+            return Status::NotFound(str_error.str());
         }
     }
     return Status::OK();

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -441,6 +441,9 @@ Status ParquetScanner::next_batch() {
                     _last_file_scan_bytes += incr_bytes;
                     _state->update_num_bytes_scan_from_source(incr_bytes);
                 }
+            } else if (status.is_not_found() && (_file_scan_type == TFileScanType::FILES_INSERT ||
+                                                 _file_scan_type == TFileScanType::FILES_QUERY)) {
+                status = status.clone_and_append("Consider setting 'fill_mismatch_column_with' = 'null' property");
             }
             return status;
         }

--- a/test/sql/test_files/R/test_csv_files_merge
+++ b/test/sql/test_files/R/test_csv_files_merge
@@ -56,7 +56,7 @@ select * from files(
     "auto_detect_sample_files" = "1",
     "fill_mismatch_column_with" = "none");
 -- result:
-[REGEX].*Schema column count: 4 doesn't match source value column count: 3. Column separator: ',', Row delimiter: .*, Row: '4,Tom,30.4', File: .*basic0_column_mismatch.csv. Consider setting 'fill_mismatch_column_with' = 'null'.*
+[REGEX].*Schema column count: 4 doesn't match source value column count: 3. Column separator: ',', Row delimiter: .*, Row: '4,Tom,30.4', File: .*basic0_column_mismatch.csv. Consider setting 'fill_mismatch_column_with' = 'null' property.*
 -- !result
 
 

--- a/test/sql/test_files/R/test_orc_files_merge
+++ b/test/sql/test_files/R/test_orc_files_merge
@@ -115,4 +115,17 @@ None	None	None
 -- !result
 
 
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/orc_format/${uuid0}/*",
+    "format" = "orc",
+    "fill_mismatch_column_with" = "none",
+    "auto_detect_sample_files" = "2",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+[REGEX].*Column: k1 is not found in file: .*basic_type_k2k5k7.orc.* Consider setting 'fill_mismatch_column_with' = 'null' property.*
+-- !result
+
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/orc_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/R/test_parquet_files_merge
+++ b/test/sql/test_files/R/test_parquet_files_merge
@@ -115,4 +115,17 @@ None	None	None
 -- !result
 
 
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "fill_mismatch_column_with" = "none",
+    "auto_detect_sample_files" = "2",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+[REGEX].*Column: k1 is not found in file: .*basic_type_k2k5k7.parquet.* Consider setting 'fill_mismatch_column_with' = 'null' property.*
+-- !result
+
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/T/test_orc_files_merge
+++ b/test/sql/test_files/T/test_orc_files_merge
@@ -59,4 +59,14 @@ select k1, k3, k8 from files(
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}");
 
+-- column mismatch
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/orc_format/${uuid0}/*",
+    "format" = "orc",
+    "fill_mismatch_column_with" = "none",
+    "auto_detect_sample_files" = "2",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/orc_format/${uuid0}/ > /dev/null

--- a/test/sql/test_files/T/test_parquet_files_merge
+++ b/test/sql/test_files/T/test_parquet_files_merge
@@ -59,4 +59,14 @@ select k1, k3, k8 from files(
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}");
 
+-- column mismatch
+select * from files(
+    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "format" = "parquet",
+    "fill_mismatch_column_with" = "none",
+    "auto_detect_sample_files" = "2",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}");
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null


### PR DESCRIPTION
## Why I'm doing:

`ERROR 1064 (HY000): Column: k1 is not found in file: hdfs://xxx/basic_type_k2k5k7.parquet: BE:10004`

## What I'm doing:

`ERROR 1064 (HY000): Column: k1 is not found in file: hdfs://xxx/basic_type_k2k5k7.parquet: Consider setting 'fill_mismatch_column_with' = 'null': BE:10004`

only for files()

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0