### PR TITLE
[Enhancement] Use bthread lock in merge commit rpc

### DIFF
--- a/be/src/runtime/batch_write/batch_write_mgr.h
+++ b/be/src/runtime/batch_write/batch_write_mgr.h
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <shared_mutex>
 #include <unordered_map>
 
 #include "common/statusor.h"
 #include "runtime/batch_write/isomorphic_batch_write.h"
 #include "runtime/stream_load/stream_load_context.h"
+#include "util/bthreads/bthread_shared_mutex.h"
 #include "util/bthreads/executor.h"
 
 namespace brpc {
@@ -58,7 +58,7 @@ private:
                                                              bool create_if_missing);
 
     std::unique_ptr<bthreads::ThreadPoolExecutor> _executor;
-    std::shared_mutex _mutex;
+    bthreads::BThreadSharedMutex _rw_mutex;
     std::unordered_map<BatchWriteId, IsomorphicBatchWriteSharedPtr, BatchWriteIdHash, BatchWriteIdEqual>
             _batch_write_map;
     bool _stopped{false};

--- a/be/src/runtime/batch_write/isomorphic_batch_write.h
+++ b/be/src/runtime/batch_write/isomorphic_batch_write.h
@@ -20,8 +20,6 @@
 
 #include <atomic>
 #include <map>
-#include <mutex>
-#include <shared_mutex>
 #include <string>
 #include <unordered_set>
 
@@ -73,8 +71,8 @@ private:
     bthreads::ThreadPoolExecutor* _executor;
     bool _batch_write_async{false};
 
-    std::mutex _mutex;
-    std::condition_variable _cv;
+    bthread::Mutex _mutex;
+    bthread::ConditionVariable _cv;
     std::unordered_set<StreamLoadContext*> _alive_stream_load_pipe_ctxs;
     std::unordered_set<StreamLoadContext*> _dead_stream_load_pipe_ctxs;
 


### PR DESCRIPTION
## Why I'm doing:
using std lock in brpc request can block brpc threads 

## What I'm doing:
use bthread lock instead

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0