### PR TITLE
[BugFix] fix resolve predicate columns of union operator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalSetOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalSetOperator.java
@@ -55,6 +55,24 @@ public abstract class LogicalSetOperator extends LogicalOperator {
         return childOutputColumns;
     }
 
+    /**
+     * Return the children refs correspond to the output ref
+     *
+     * @param ref output ref
+     * @return children
+     */
+    public List<ColumnRefOperator> resolveColumnRef(ColumnRefOperator ref) {
+        int index = outputColumnRefOp.indexOf(ref);
+        if (index == -1) {
+            return null;
+        }
+        List<ColumnRefOperator> result = Lists.newArrayList();
+        for (var child : childOutputColumns) {
+            result.add(child.get(index));
+        }
+        return result;
+    }
+
     @Override
     public ColumnRefSet getOutputColumns(ExpressionContext expressionContext) {
         if (projection != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
@@ -138,6 +138,20 @@ class ColumnUsageTest extends PlanTestBase {
             // window
             "select max(v1) over (partition by v2 order by v3) from t0" +
                     "|analyze table t0 predicate columns|v2",
+
+            // union
+            "select max(v1) from (select v1,v2 from t0 union all select v4,v5 from t1) r group by v2" +
+                    "| analyze table t0 predicate columns | v2",
+            "select max(v1) from (select v1,v2 from t0 union all select v4,v5 from t1) r group by v2" +
+                    "| analyze table t1 predicate columns | v5",
+
+            // cte
+            "with cte1 as (select max(v1) v1 from t0 group by v2), cte2 as (select max(v4) v4 from t1 group by v5) " +
+                    "select * from cte1 join cte2 on cte1.v1 = cte2.v4 " +
+                    "| analyze table t0 predicate columns | v2",
+            "with cte1 as (select max(v1) v1 from t0 group by v2), cte2 as (select max(v4) v4 from t1 group by v5) " +
+                    "select * from cte1 join cte2 on cte1.v1 = cte2.v4 " +
+                    "| analyze table t1 predicate columns | v5",
     })
     public void testAnalyzePredicateColumns(String query, String analyzeStmt, String expectedColumns) throws Exception {
         AnalyzeTestUtil.init();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

For Union Operator, it needs to resolve corresponding children columnref.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0