### PR TITLE
[BugFix] Fix decimal type merge in files() schema detection

### DIFF
--- a/be/src/exec/parquet_schema_builder.cpp
+++ b/be/src/exec/parquet_schema_builder.cpp
@@ -58,8 +58,8 @@ static Status get_parquet_type_from_primitive(const ::parquet::schema::NodePtr& 
             *type_desc = TypeDescriptor(TYPE_TIME);
         } else if (logical_type->is_decimal()) {
             auto decimal_logical_type = std::dynamic_pointer_cast<const parquet::DecimalLogicalType>(logical_type);
-            *type_desc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, decimal_logical_type->precision(),
-                                                               decimal_logical_type->scale());
+            *type_desc = TypeDescriptor::promote_decimal_type(decimal_logical_type->precision(),
+                                                              decimal_logical_type->scale());
         } else {
             *type_desc = TypeDescriptor(TYPE_INT);
         }
@@ -73,8 +73,8 @@ static Status get_parquet_type_from_primitive(const ::parquet::schema::NodePtr& 
             *type_desc = TypeDescriptor(TYPE_DATETIME);
         } else if (logical_type->is_decimal()) {
             auto decimal_logical_type = std::dynamic_pointer_cast<const parquet::DecimalLogicalType>(logical_type);
-            *type_desc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, decimal_logical_type->precision(),
-                                                               decimal_logical_type->scale());
+            *type_desc = TypeDescriptor::promote_decimal_type(decimal_logical_type->precision(),
+                                                              decimal_logical_type->scale());
         } else {
             *type_desc = TypeDescriptor(TYPE_BIGINT);
         }
@@ -87,8 +87,8 @@ static Status get_parquet_type_from_primitive(const ::parquet::schema::NodePtr& 
             *type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
         } else if (logical_type->is_decimal()) {
             auto decimal_logical_type = std::dynamic_pointer_cast<const parquet::DecimalLogicalType>(logical_type);
-            *type_desc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, decimal_logical_type->precision(),
-                                                               decimal_logical_type->scale());
+            *type_desc = TypeDescriptor::promote_decimal_type(decimal_logical_type->precision(),
+                                                              decimal_logical_type->scale());
         } else if (logical_type->is_JSON()) {
             *type_desc = TypeDescriptor::create_json_type();
         } else {
@@ -98,8 +98,8 @@ static Status get_parquet_type_from_primitive(const ::parquet::schema::NodePtr& 
     case parquet::Type::FIXED_LEN_BYTE_ARRAY: {
         if (logical_type->is_decimal()) {
             auto decimal_logical_type = std::dynamic_pointer_cast<const parquet::DecimalLogicalType>(logical_type);
-            *type_desc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, decimal_logical_type->precision(),
-                                                               decimal_logical_type->scale());
+            *type_desc = TypeDescriptor::promote_decimal_type(decimal_logical_type->precision(),
+                                                              decimal_logical_type->scale());
         } else {
             *type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
         }

--- a/be/src/formats/orc/column_reader.h
+++ b/be/src/formats/orc/column_reader.h
@@ -46,7 +46,7 @@ const std::unordered_map<orc::TypeKind, LogicalType> g_orc_starrocks_logical_typ
         {orc::LONG, starrocks::TYPE_BIGINT},
         {orc::FLOAT, starrocks::TYPE_FLOAT},
         {orc::DOUBLE, starrocks::TYPE_DOUBLE},
-        {orc::DECIMAL, starrocks::TYPE_DECIMALV2},
+        {orc::DECIMAL, starrocks::TYPE_DECIMAL128},
         {orc::DATE, starrocks::TYPE_DATE},
         {orc::TIMESTAMP, starrocks::TYPE_DATETIME},
         {orc::STRING, starrocks::TYPE_VARCHAR},

--- a/be/src/formats/orc/orc_schema_builder.cpp
+++ b/be/src/formats/orc/orc_schema_builder.cpp
@@ -92,7 +92,7 @@ static Status get_orc_type_from_scalar_type(const orc::Type* typ, TypeDescriptor
         return Status::NotSupported(fmt::format("Unkown supported orc type: {}", typ->getKind()));
 
     case orc::TypeKind::DECIMAL:
-        *desc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, typ->getPrecision(), typ->getScale());
+        *desc = TypeDescriptor::promote_decimal_type(typ->getPrecision(), typ->getScale());
         break;
 
     case orc::TypeKind::DATE:

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -351,6 +351,7 @@ struct TypeDescriptor {
     size_t get_array_depth_limit() const;
 
     static TypeDescriptor promote_types(const TypeDescriptor& type1, const TypeDescriptor& type2);
+    static TypeDescriptor promote_decimal_type(int precision, int scale);
 
 private:
     /// Used to create a possibly nested type from the flattened Thrift representation.

--- a/be/test/runtime/type_descriptor_test.cpp
+++ b/be/test/runtime/type_descriptor_test.cpp
@@ -712,8 +712,24 @@ TEST_F(TypeDescriptorTest, test_promote_types) {
              TypeDescriptor::from_logical_type(TYPE_DOUBLE)},
 
             {TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2),
-             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 4, 3),
-             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 5, 3)},
+             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 4, 3),
+             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 6, 3)},
+
+            {TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2),
+             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 4, 1),
+             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2)},
+
+            {TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2),
+             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 17, 1),
+             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 18, 2)},
+
+            {TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2),
+             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 17, 0),
+             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 19, 2)},
+
+            {TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 38, 38),
+             TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 38, 0),
+             TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH)},
 
             {TypeDescriptor::create_varchar_type(10), TypeDescriptor::create_varchar_type(20),
              TypeDescriptor::create_varchar_type(20)},


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. fix decimal type merge
2. when precision is bigger than 38, use varchar type
3. change default decimal type from `decimalv2` to `decimal128` in orc column reader type mapping for reading big precision and scale decimal value

Fixes https://github.com/StarRocks/StarRocksTest/issues/9016

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0