### PR TITLE
[BugFix] Fix UAF in shared UDF

### DIFF
--- a/be/src/exprs/java_function_call_expr.h
+++ b/be/src/exprs/java_function_call_expr.h
@@ -36,8 +36,7 @@ public:
     bool is_constant() const override;
 
 private:
-    StatusOr<std::shared_ptr<JavaUDFContext>> _build_udf_func_desc(ExprContext* context,
-                                                                   FunctionContext::FunctionStateScope scope,
+    StatusOr<std::shared_ptr<JavaUDFContext>> _build_udf_func_desc(FunctionContext::FunctionStateScope scope,
                                                                    const std::string& libpath);
     void _call_udf_close();
     RuntimeState* _runtime_state = nullptr;

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -329,7 +329,7 @@ void JVMFunctionHelper::batch_update_if_not_null(FunctionContext* ctx, jobject u
     CHECK_UDF_CALL_EXCEPTION(_env, ctx);
 }
 
-jobject JVMFunctionHelper::batch_call(BatchEvaluateStub* stub, jobject* input, int cols, int rows) {
+StatusOr<jobject> JVMFunctionHelper::batch_call(BatchEvaluateStub* stub, jobject* input, int cols, int rows) {
     return stub->batch_evaluate(rows, input, cols);
 }
 
@@ -853,7 +853,7 @@ void AggBatchCallStub::batch_update_single(int num_rows, jobject state, jobject*
     CHECK_UDF_CALL_EXCEPTION(env, this->_ctx);
 }
 
-jobject BatchEvaluateStub::batch_evaluate(int num_rows, jobject* input, int cols) {
+StatusOr<jobject> BatchEvaluateStub::batch_evaluate(int num_rows, jobject* input, int cols) {
     jvalue jni_inputs[2 + cols];
     jni_inputs[0].i = num_rows;
     jni_inputs[1].l = _caller;
@@ -863,7 +863,7 @@ jobject BatchEvaluateStub::batch_evaluate(int num_rows, jobject* input, int cols
     auto* env = JVMFunctionHelper::getInstance().getEnv();
     auto res = env->CallStaticObjectMethodA(_stub_clazz.clazz(), env->FromReflectedMethod(_stub_method.handle()),
                                             jni_inputs);
-    CHECK_UDF_CALL_EXCEPTION(env, this->_ctx);
+    RETURN_ERROR_IF_JNI_EXCEPTION(env);
     return res;
 }
 

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -91,7 +91,7 @@ public:
     void batch_update_state(FunctionContext* ctx, jobject udaf, jobject update, jobject* input, int cols);
 
     // batch call evalute by callstub
-    jobject batch_call(BatchEvaluateStub* stub, jobject* input, int cols, int rows);
+    StatusOr<jobject> batch_call(BatchEvaluateStub* stub, jobject* input, int cols, int rows);
     // batch call method by reflect
     jobject batch_call(FunctionContext* ctx, jobject caller, jobject method, jobject* input, int cols, int rows);
     // batch call no-args function by reflect
@@ -347,14 +347,12 @@ public:
     static inline const char* stub_clazz_name = "com.starrocks.udf.gen.CallStub";
     static inline const char* batch_evaluate_method_name = "batchCallV";
 
-    BatchEvaluateStub(FunctionContext* ctx, jobject caller, JVMClass&& clazz, JavaGlobalRef&& method)
-            : _ctx(ctx), _caller(caller), _stub_clazz(std::move(clazz)), _stub_method(std::move(method)) {}
+    BatchEvaluateStub(jobject caller, JVMClass&& clazz, JavaGlobalRef&& method)
+            : _caller(caller), _stub_clazz(std::move(clazz)), _stub_method(std::move(method)) {}
 
-    FunctionContext* ctx() { return _ctx; }
-    jobject batch_evaluate(int num_rows, jobject* input, int cols);
+    StatusOr<jobject> batch_evaluate(int num_rows, jobject* input, int cols);
 
 private:
-    FunctionContext* _ctx;
     jobject _caller;
     JVMClass _stub_clazz;
     JavaGlobalRef _stub_method;

--- a/test/sql/test_udf/R/test_jvm_udf
+++ b/test/sql/test_udf/R/test_jvm_udf
@@ -61,6 +61,17 @@ PROPERTIES
 );
 -- result:
 -- !result
+CREATE FUNCTION shared_exception_test(string)
+RETURNS string
+PROPERTIES
+(
+"symbol" = "ExceptionUDF2", 
+"isolation"="shared",
+"type" = "StarrocksJar", 
+"file" = "${udf_url}/starrocks-jdbc/ExceptionUDF2.jar"
+);
+-- result:
+-- !result
 CREATE TABLE `t0` (
   `c0` int(11) NULL COMMENT "",
   `c1` varchar(20) NULL COMMENT "",
@@ -83,7 +94,7 @@ select count(udtfstring) from t0, udtfstring(c1);
 -- !result
 select count(udtfstring_wrong_match) from t0, udtfstring_wrong_match(c1);
 -- result:
-[REGEX].*Type not matched, expect class java.lang.Integer, but got class java.lang.String.*
+E: (1064, 'Type not matched, expect class java.lang.Integer, but got class java.lang.String: BE:10004')
 -- !result
 select count(udtfint) from t0, udtfint(c1);
 -- result:
@@ -150,6 +161,14 @@ select sum(delta), count(*), count(delta) from (select (sum(c3) - sumbigint(c3))
 0	40960	40960
 -- !result
 select count(*) from t0 where exception_test(c1) is null;
+-- result:
+[REGEX].*java.lang.NullPointerException.*
+-- !result
+select count(*) from t0 where shared_exception_test(c1) is null;
+-- result:
+[REGEX].*java.lang.NullPointerException.*
+-- !result
+select count(*) from t0 where shared_exception_test(c1) is null;
 -- result:
 [REGEX].*java.lang.NullPointerException.*
 -- !result

--- a/test/sql/test_udf/R/test_jvm_udf
+++ b/test/sql/test_udf/R/test_jvm_udf
@@ -94,7 +94,7 @@ select count(udtfstring) from t0, udtfstring(c1);
 -- !result
 select count(udtfstring_wrong_match) from t0, udtfstring_wrong_match(c1);
 -- result:
-E: (1064, 'Type not matched, expect class java.lang.Integer, but got class java.lang.String: BE:10004')
+[REGEX].*Type not matched, expect class java.lang.Integer, but got class java.lang.String.*
 -- !result
 select count(udtfint) from t0, udtfint(c1);
 -- result:

--- a/test/sql/test_udf/T/test_jvm_udf
+++ b/test/sql/test_udf/T/test_jvm_udf
@@ -53,6 +53,16 @@ PROPERTIES
 "file" = "${udf_url}/starrocks-jdbc/ExceptionUDF2.jar"
 );
 
+CREATE FUNCTION shared_exception_test(string)
+RETURNS string
+PROPERTIES
+(
+"symbol" = "ExceptionUDF2", 
+"isolation"="shared",
+"type" = "StarrocksJar", 
+"file" = "${udf_url}/starrocks-jdbc/ExceptionUDF2.jar"
+);
+
 CREATE TABLE `t0` (
   `c0` int(11) NULL COMMENT "",
   `c1` varchar(20) NULL COMMENT "",
@@ -95,3 +105,6 @@ set spill_mode="force";
 select sum(delta), count(*), count(delta) from (select (sum(c3) - sumbigint(c3)) as delta from t0 group by c0,c1) tb;
 -- test udf exception case
 select count(*) from t0 where exception_test(c1) is null;
+-- run two times
+select count(*) from t0 where shared_exception_test(c1) is null;
+select count(*) from t0 where shared_exception_test(c1) is null;


### PR DESCRIPTION
## Why I'm doing:

In shared UDF the function context object is cached in memory, this can lead to a UAF when accessing the function context, resulting in undefined behavior.



## What I'm doing:
In this commit, we remove the Function Context object of BatchCallStub. Use the StatusOr interface instead of the control flow.

```
==1404951==ERROR: AddressSanitizer: heap-use-after-free on address 0x614001250e80 at pc 0x00000c6298a1 bp 0x7f7f81b806f0 sp 0x7f7f81b806e0
READ of size 8 at 0x614001250e80 thread T590
    #0 0xc6298a0 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::size() const /usr/include/c++/11/bits/basic_string.h:921
    #1 0xc685eed in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::empty() const /usr/include/c++/11/bits/basic_string.h:1024
    #2 0x14934659 in starrocks::FunctionContext::has_error() const be/src/exprs/function_context.cpp:160
    #3 0x162357c1 in starrocks::UDFFunctionCallHelper::call(starrocks::FunctionContext*, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > >&, unsigned long) be/src/exprs/java_function_call_expr.cpp:81
    #4 0x1622959e in operator() be/src/exprs/java_function_call_expr.cpp:114
    #5 0x16231d53 in __invoke_impl<starrocks::Status, starrocks::JavaFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)::<lambda()>&> /usr/include/c++/11/bits/invoke.h:61
    #6 0x16231093 in __invoke_r<starrocks::Status, starrocks::JavaFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)::<lambda()>&> /usr/include/c++/11/bits/invoke.h:116
    #7 0x16230746 in _M_invoke /usr/include/c++/11/bits/std_function.h:291
    #8 0xe2ada11 in std::function<starrocks::Status ()>::operator()() const /usr/include/c++/11/bits/std_function.h:590
    #9 0x19a18955 in starrocks::call_function_in_pthread(starrocks::RuntimeState*, std::function<starrocks::Status ()> const&) be/src/udf/java/utils.cpp:45
    #10 0x16229da8 in starrocks::JavaFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*) be/src/exprs/java_function_call_expr.cpp:117
    #11 0x1491137f in starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*) be/src/exprs/expr_context.cpp:188
    #12 0x14910a53 in starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*) be/src/exprs/expr_context.cpp:164
    #13 0xfd85334 in starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&) be/src/exec/pipeline/project_operator.cpp:60
    #14 0x10156289 in starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int) be/src/exec/pipeline/pipeline_driver.cpp:352
```

close https://github.com/StarRocks/StarRocksTest/issues/9031

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0