### PR TITLE
[BugFix] Fix sequence of selection and input_chunk for streaming_agg_with_selection

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -948,7 +948,7 @@ Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk
 
     DCHECK(!use_selection || !_group_by_columns.empty());
     // If using selection, then `_group_by_columns` has been filtered by `_streaming_selection`, and input_chunk has
-    // not been filtered yet. After input_chunk is filtered by `_streaming_selection` after `evaluate_agg_fn_exprs`.
+    // not been filtered yet. `input_chunk` is filtered by `_streaming_selection` after `evaluate_agg_fn_exprs`.
     const size_t num_input_rows = input_chunk->num_rows();
     const size_t num_rows = use_selection ? _group_by_columns[0]->size() : num_input_rows;
 

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -939,15 +939,20 @@ Status Aggregator::evaluate_groupby_exprs(Chunk* chunk) {
     return _evaluate_group_by_exprs(chunk);
 }
 
-Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk) {
+Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, bool use_selection) {
     // The input chunk is already intermediate-typed, so there is no need to convert it again.
     // Only when the input chunk is input-typed, we should convert it into intermediate-typed chunk.
     // is_passthrough is on indicate that the chunk is input-typed.
     auto use_intermediate_as_input = _use_intermediate_as_input();
     const auto& slots = _intermediate_tuple_desc->slots();
 
+    DCHECK(!use_selection || !_group_by_columns.empty());
+    // If using selection, then `_group_by_columns` has been filtered by `_streaming_selection`, and input_chunk has
+    // not been filtered yet. After input_chunk is filtered by `_streaming_selection` after `evaluate_agg_fn_exprs`.
+    const size_t num_input_rows = input_chunk->num_rows();
+    const size_t num_rows = use_selection ? _group_by_columns[0]->size() : num_input_rows;
+
     // build group by columns
-    size_t num_rows = input_chunk->num_rows();
     ChunkPtr result_chunk = std::make_shared<Chunk>();
     for (size_t i = 0; i < _group_by_columns.size(); i++) {
         DCHECK_EQ(num_rows, _group_by_columns[i]->size());
@@ -966,7 +971,23 @@ Status Aggregator::output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk
         DCHECK(!_group_by_columns.empty());
 
         RETURN_IF_ERROR(evaluate_agg_fn_exprs(input_chunk));
-        const auto num_rows = _group_by_columns[0]->size();
+        if (use_selection) {
+            for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+                for (auto& agg_input_column : _agg_input_columns[i]) {
+                    // AggColumn and GroupColumn may be the same SharedPtr,
+                    // If ColumnSize and ChunkSize are not equal,
+                    // indicating that the Filter has been executed in GroupByColumn
+                    // e.g.: select c1, count(distinct c1) from t1 group by c1;
+
+                    // At present, the type of problem cannot be completely solved,
+                    // and a new solution needs to be designed to solve it completely
+                    if (agg_input_column != nullptr && agg_input_column->size() == num_input_rows) {
+                        agg_input_column->filter(_streaming_selection);
+                    }
+                }
+            }
+        }
+
         Columns agg_result_column = _create_agg_result_columns(num_rows, true);
         for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
             size_t id = _group_by_columns.size() + i;
@@ -1056,22 +1077,8 @@ Status Aggregator::output_chunk_by_streaming_with_selection(Chunk* input_chunk, 
             _group_by_column->filter(_streaming_selection);
         }
     }
-    for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
-        for (auto& agg_input_column : _agg_input_columns[i]) {
-            // AggColumn and GroupColumn may be the same SharedPtr,
-            // If ColumnSize and ChunkSize are not equal,
-            // indicating that the Filter has been executed in GroupByColumn
-            // e.g.: select c1, count(distinct c1) from t1 group by c1;
 
-            // At present, the type of problem cannot be completely solved,
-            // and a new solution needs to be designed to solve it completely
-            if (agg_input_column != nullptr && agg_input_column->size() == chunk_size) {
-                agg_input_column->filter(_streaming_selection);
-            }
-        }
-    }
-
-    RETURN_IF_ERROR(output_chunk_by_streaming(input_chunk, chunk));
+    RETURN_IF_ERROR(output_chunk_by_streaming(input_chunk, chunk, true));
     return Status::OK();
 }
 

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -348,7 +348,8 @@ public:
     Status evaluate_agg_fn_exprs(Chunk* chunk, bool use_intermediate);
     Status evaluate_agg_input_column(Chunk* chunk, std::vector<ExprContext*>& agg_expr_ctxs, int i);
 
-    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, bool use_selection = false);
+    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk);
+    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, size_t num_input_rows, bool use_selection);
 
     // convert input chunk to spill format
     Status convert_to_spill_format(Chunk* input_chunk, ChunkPtr* chunk);

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -348,7 +348,7 @@ public:
     Status evaluate_agg_fn_exprs(Chunk* chunk, bool use_intermediate);
     Status evaluate_agg_input_column(Chunk* chunk, std::vector<ExprContext*>& agg_expr_ctxs, int i);
 
-    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk);
+    Status output_chunk_by_streaming(Chunk* input_chunk, ChunkPtr* chunk, bool use_selection = false);
 
     // convert input chunk to spill format
     Status convert_to_spill_format(Chunk* input_chunk, ChunkPtr* chunk);


### PR DESCRIPTION
## Why I'm doing:

**Previous Logic:**
1. `evaluate_group_by_columns`.
2. `evaluate_input_columns`
3. calculate `_streaming_selection` to indicate which rows hit HT.
4. `output_chunk_by_streaming_with_selection` (filter `group_by_columns` and `input_columns` by `_streaming_selection`)
5. `output_chunk_by_streaming`

**Recent Logic:**
1. `evaluate_group_by_columns`
2.  calculate `_streaming_selection` to indicate which rows hit HT.
3. `output_chunk_by_streaming_with_selection` (**filter `group_by_columns` by `_streaming_selection`**)
4. `output_chunk_by_streaming` (**evaluate `input_columns` here now)**

This cause two issues.
1. In `output_chunk_by_streaming`, before calling `evaluate_input_columns`, the number of rows in `group_by_columns` and `input_chunk` differs. This is because `group_by_columns` is filtered by `_streaming_selection`, whereas `input_chunk` is not.

2. The result of `evaluate_input_columns` is not filtered by `_streaming_selection`.

```
*** Aborted at 1735817590 (unix time) try "date -d @1735817590" if you are using GNU date ***
PC: @     0x7ff6544c3387 __GI_raise
*** SIGABRT (@0x3e80000448c) received by PID 17548 (TID 0x7ff56c586700) from PID 17548; stack trace: ***
    @         0x1c6fcf47 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7ff65695920b __pthread_once_slow
    @         0x1c6fc754 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
F20250102 19:33:10.237299 140692041484032 aggregator.cpp:951] Check failed: num_rows == _group_by_columns[i]->size() (3014 vs. 2357)
    @     0x7ff656962630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @     0x7ff6544c3387 __GI_raise
    @     0x7ff6544c4a78 __GI_abort
    @          0xd76fc0a starrocks::failure_function()
    @         0x1c6f154a google::LogMessage::Fail()
    @         0x1c6f2f84 google::LogMessageFatal::~LogMessageFatal()
    @          0xf5700ac starrocks::Aggregator::output_chunk_by_streaming(starrocks::Chunk*, std::shared_ptr<starrocks::Chunk>*)
    @          0xf5730bc starrocks::Aggregator::output_chunk_by_streaming_with_selection(starrocks::Chunk*, std::shared_ptr<starrocks::Chunk>*)
    @          0xf1612ae starrocks::pipeline::AggregateStreamingSinkOperator::_push_chunk_by_selective_preaggregation(std::shared_ptr<starrocks::Chunk> const&, unsigned long, bool)
    @          0xf163d30 starrocks::pipeline::AggregateStreamingSinkOperator::_push_chunk_by_auto(std::shared_ptr<starrocks::Chunk> const&, unsigned long)
    @          0xf15eba3 starrocks::pipeline::AggregateStreamingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0xf0c306c starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0xfed09a3 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xfecf1c6 starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @          0xfed99ec void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @          0xfed8dca std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @          0xfed877f std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @          0xbdcd888 std::function<void ()>::operator()() const
    @          0xc595650 starrocks::FunctionRunnable::run()
    @          0xc592494 starrocks::ThreadPool::dispatch_thread()
    @          0xc5b1ae0 void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @          0xc5b03f3 std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @          0xc5aee80 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @          0xc5ad442 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @          0xc5ab4f4 void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @          0xc5a8f02 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool:@
    @          0xc5a477f std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
    @          0xbdcd888 std::function<void ()>::operator()() const
    @          0xc5785c9 starrocks::Thread::supervise_thread(void*)
```

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9009

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0