### PR TITLE
[Enhancement] Support auto refresh for HMS external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -222,6 +222,11 @@ public class HiveTable extends Table {
     }
 
     @Override
+    public boolean isHMSExternalTable() {
+        return hiveTableType.equals(HiveTableType.EXTERNAL_TABLE);
+    }
+
+    @Override
     public String getTableLocation() {
         return this.tableLocation;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -329,6 +329,7 @@ public class HudiTable extends Table {
     public boolean isHMSExternalTable() {
         return hudiProperties.get(HUDI_HMS_TABLE_TYPE).equals("EXTERNAL_TABLE");
     }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("HudiTable{");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -68,6 +68,7 @@ public class HudiTable extends Table {
     private static final String JSON_KEY_HUDI_PROPERTIES = "hudiProperties";
 
     public static final String HUDI_TABLE_TYPE = "hudi.table.type";
+    public static final String HUDI_HMS_TABLE_TYPE = "hudi.hms.table.type";
     public static final String HUDI_BASE_PATH = "hudi.table.base.path";
     public static final String HUDI_TABLE_SERDE_LIB = "hudi.table.serde.lib";
     public static final String HUDI_TABLE_INPUT_FOAMT = "hudi.table.input.format";
@@ -324,6 +325,10 @@ public class HudiTable extends Table {
         return true;
     }
 
+    @Override
+    public boolean isHMSExternalTable() {
+        return hudiProperties.get(HUDI_HMS_TABLE_TYPE).equals("EXTERNAL_TABLE");
+    }
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("HudiTable{");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -454,6 +454,10 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         return idToColumn;
     }
 
+    public boolean isHMSExternalTable() {
+        return false;
+    }
+
     public void setNewFullSchema(List<Column> newSchema) {
         this.fullSchema = newSchema;
         updateSchemaIndex();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.hive;
 
 import com.google.common.base.Preconditions;
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
@@ -22,6 +23,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
@@ -75,10 +78,12 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     protected LoadingCache<HivePartitionName, Partition> partitionCache;
     protected LoadingCache<DatabaseTableName, HivePartitionStats> tableStatsCache;
     protected LoadingCache<HivePartitionName, HivePartitionStats> partitionStatsCache;
+    protected Cache<DatabaseTableName, String> hmsExternalTableCache;
 
     public static CachingHiveMetastore createQueryLevelInstance(IHiveMetastore metastore, long perQueryCacheMaxSize) {
         return new CachingHiveMetastore(
                 metastore,
+                newDirectExecutorService(),
                 newDirectExecutorService(),
                 NEVER_EVICT,
                 NEVER_REFRESH,
@@ -87,13 +92,16 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     }
 
     public static CachingHiveMetastore createCatalogLevelInstance(IHiveMetastore metastore, Executor executor,
-                                                                  long expireAfterWrite, long refreshInterval,
-                                                                  long maxSize, boolean enableListNamesCache) {
-        return new CachingHiveMetastore(metastore, executor, expireAfterWrite, refreshInterval, maxSize, enableListNamesCache);
+                                                                  Executor partitionExecutor, long expireAfterWrite,
+                                                                  long refreshInterval, long maxSize,
+                                                                  boolean enableListNamesCache) {
+        return new CachingHiveMetastore(metastore, executor, partitionExecutor,
+          expireAfterWrite, refreshInterval, maxSize, enableListNamesCache);
     }
 
-    protected CachingHiveMetastore(IHiveMetastore metastore, Executor executor, long expireAfterWriteSec,
-                                   long refreshIntervalSec, long maxSize, boolean enableListNamesCache) {
+    protected CachingHiveMetastore(IHiveMetastore metastore, Executor executor, Executor partitionExecutor,
+                                   long expireAfterWriteSec, long refreshIntervalSec, long maxSize,
+                                   boolean enableListNamesCache) {
         super(executor, expireAfterWriteSec, refreshIntervalSec, maxSize);
         this.metastore = metastore;
         this.enableListNameCache = enableListNamesCache;
@@ -108,7 +116,8 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
                     .build(asyncReloading(CacheLoader.from(this::loadPartitionKeys), executor));
         }
 
-        partitionCache = newCacheBuilder(expireAfterWriteSec, NEVER_REFRESH, maxSize)
+        hmsExternalTableCache = newCacheBuilder(expireAfterWriteSec, NEVER_REFRESH, maxSize).build();
+        partitionCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
                 .build(asyncReloading(new CacheLoader<HivePartitionName, Partition>() {
                     @Override
                     public Partition load(@NotNull HivePartitionName key) {
@@ -116,11 +125,20 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
                     }
 
                     @Override
+                    public ListenableFuture<Partition> reload(
+                            @NotNull HivePartitionName key, @NotNull Partition oldValue) {
+                        if (hmsExternalTableCache.asMap().containsKey(key.getDatabaseTableName())) {
+                            return Futures.immediateFuture(loadPartition(key));
+                        }
+                        return Futures.immediateFuture(oldValue);
+                    }
+
+                    @Override
                     public Map<HivePartitionName, Partition> loadAll(
                             @NotNull Iterable<? extends HivePartitionName> partitionKeys) {
                         return loadPartitionsByNames(partitionKeys);
                     }
-                }, executor));
+                }, partitionExecutor));
 
         tableStatsCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadTableStatistics), executor));
@@ -266,7 +284,11 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     }
 
     public Table loadTable(DatabaseTableName databaseTableName) {
-        return metastore.getTable(databaseTableName.getDatabaseName(), databaseTableName.getTableName());
+        Table table = metastore.getTable(databaseTableName.getDatabaseName(), databaseTableName.getTableName());
+        if (table.isHMSExternalTable()) {
+            hmsExternalTableCache.put(databaseTableName, databaseTableName.toString());
+        }
+        return table;
     }
 
     public Partition getPartition(String dbName, String tblName, List<String> partitionValues) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -118,8 +118,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         }
 
         hmsExternalTableCache = newCacheBuilder(expireAfterWriteSec, NEVER_REFRESH, maxSize).build();
-        // The refresh internal second can be double because partition not need to fresh so frequently
-        partitionCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec * 2, maxSize)
+        partitionCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
                 .build(asyncReloading(new CacheLoader<HivePartitionName, Partition>() {
                     @Override
                     public Partition load(@NotNull HivePartitionName key) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -127,7 +127,8 @@ public class HiveConnectorInternalMgr {
             baseHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
                     hiveMetastore,
                     new ReentrantExecutor(refreshHiveMetastoreExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
-                    new ReentrantExecutor(refreshHiveExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
+                    // As there are many managed table the max threads for the external table refresher can be double
+                    new ReentrantExecutor(refreshHiveExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum() * 2),
                     hmsConf.getCacheTtlSec(),
                     enableHmsEventsIncrementalSync ? NEVER_REFRESH : hmsConf.getCacheRefreshIntervalSec(),
                     hmsConf.getCacheMaxNum(),

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -49,6 +49,7 @@ public class HiveConnectorInternalMgr {
     private final CachingRemoteFileConf remoteFileConf;
 
     private ExecutorService refreshHiveMetastoreExecutor;
+    private ExecutorService refreshHiveExternalTableExecutor;
     private ExecutorService refreshRemoteFileExecutor;
     private ExecutorService pullRemoteFileExecutor;
     private ExecutorService updateRemoteFilesExecutor;
@@ -100,6 +101,9 @@ public class HiveConnectorInternalMgr {
         if (enableMetastoreCache && refreshHiveMetastoreExecutor != null) {
             refreshHiveMetastoreExecutor.shutdown();
         }
+        if (enableMetastoreCache && refreshHiveExternalTableExecutor != null) {
+            refreshHiveExternalTableExecutor.shutdown();
+        }
         if (enableRemoteFileCache && refreshRemoteFileExecutor != null) {
             refreshRemoteFileExecutor.shutdown();
         }
@@ -118,9 +122,12 @@ public class HiveConnectorInternalMgr {
         } else {
             refreshHiveMetastoreExecutor = Executors.newCachedThreadPool(
                     new ThreadFactoryBuilder().setNameFormat("hive-metastore-refresh-%d").build());
+            refreshHiveExternalTableExecutor = Executors.newCachedThreadPool(
+                    new ThreadFactoryBuilder().setNameFormat("hive-external-table-refresh-%d").build());
             baseHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
                     hiveMetastore,
                     new ReentrantExecutor(refreshHiveMetastoreExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
+                    new ReentrantExecutor(refreshHiveExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
                     hmsConf.getCacheTtlSec(),
                     enableHmsEventsIncrementalSync ? NEVER_REFRESH : hmsConf.getCacheRefreshIntervalSec(),
                     hmsConf.getCacheMaxNum(),

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnectorInternalMgr.java
@@ -127,8 +127,7 @@ public class HiveConnectorInternalMgr {
             baseHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
                     hiveMetastore,
                     new ReentrantExecutor(refreshHiveMetastoreExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
-                    // As there are many managed table the max threads for the external table refresher can be double
-                    new ReentrantExecutor(refreshHiveExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum() * 2),
+                    new ReentrantExecutor(refreshHiveExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
                     hmsConf.getCacheTtlSec(),
                     enableHmsEventsIncrementalSync ? NEVER_REFRESH : hmsConf.getCacheRefreshIntervalSec(),
                     hmsConf.getCacheMaxNum(),

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -91,6 +91,7 @@ import static com.starrocks.catalog.HiveTable.HIVE_TABLE_COLUMN_TYPES;
 import static com.starrocks.catalog.HiveTable.HIVE_TABLE_INPUT_FORMAT;
 import static com.starrocks.catalog.HiveTable.HIVE_TABLE_SERDE_LIB;
 import static com.starrocks.catalog.HudiTable.HUDI_BASE_PATH;
+import static com.starrocks.catalog.HudiTable.HUDI_HMS_TABLE_TYPE;
 import static com.starrocks.catalog.HudiTable.HUDI_TABLE_COLUMN_NAMES;
 import static com.starrocks.catalog.HudiTable.HUDI_TABLE_COLUMN_TYPES;
 import static com.starrocks.catalog.HudiTable.HUDI_TABLE_INPUT_FOAMT;
@@ -538,6 +539,7 @@ public class HiveMetastoreApiConverter {
         }
 
         hudiProperties.put(HUDI_TABLE_TYPE, metaClient.getTableType().name());
+        hudiProperties.put(HUDI_HMS_TABLE_TYPE, metastoreTable.getTableType());
 
         StringBuilder columnNamesBuilder = new StringBuilder();
         StringBuilder columnTypesBuilder = new StringBuilder();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartitionName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartitionName.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.connector.hive;
 
+import com.starrocks.connector.DatabaseTableName;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -58,6 +60,10 @@ public class HivePartitionName {
 
     public String getDatabaseName() {
         return databaseName;
+    }
+
+    public DatabaseTableName getDatabaseTableName() {
+        return DatabaseTableName.of(databaseName, tableName);
     }
 
     public List<String> getPartitionValues() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
@@ -121,8 +121,7 @@ public class HudiConnectorInternalMgr {
             baseHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
                     hiveMetastore,
                     new ReentrantExecutor(refreshHiveMetastoreExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
-                    // As there are many managed table the max threads for the external table refresher can be double
-                    new ReentrantExecutor(refreshHudiExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum() * 2),
+                    new ReentrantExecutor(refreshHudiExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
                     hmsConf.getCacheTtlSec(),
                     hmsConf.getCacheRefreshIntervalSec(),
                     hmsConf.getCacheMaxNum(),

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
@@ -50,6 +50,7 @@ public class HudiConnectorInternalMgr {
     private CachingRemoteFileConf remoteFileConf;
 
     private ExecutorService refreshHiveMetastoreExecutor;
+    private ExecutorService refreshHudiExternalTableExecutor;
     private ExecutorService refreshRemoteFileExecutor;
     private ExecutorService pullRemoteFileExecutor;
 
@@ -94,6 +95,9 @@ public class HudiConnectorInternalMgr {
         if (enableMetastoreCache && refreshHiveMetastoreExecutor != null) {
             refreshHiveMetastoreExecutor.shutdown();
         }
+        if (enableMetastoreCache && refreshHudiExternalTableExecutor != null) {
+            refreshHudiExternalTableExecutor.shutdown();
+        }
         if (enableRemoteFileCache && refreshRemoteFileExecutor != null) {
             refreshRemoteFileExecutor.shutdown();
         }
@@ -112,9 +116,12 @@ public class HudiConnectorInternalMgr {
         } else {
             refreshHiveMetastoreExecutor = Executors.newCachedThreadPool(
                     new ThreadFactoryBuilder().setNameFormat("hive-metastore-refresh-%d").build());
+            refreshHudiExternalTableExecutor = Executors.newCachedThreadPool(
+                    new ThreadFactoryBuilder().setNameFormat("hudi-external-table-refresh-%d").build());
             baseHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
                     hiveMetastore,
                     new ReentrantExecutor(refreshHiveMetastoreExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
+                    new ReentrantExecutor(refreshHudiExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
                     hmsConf.getCacheTtlSec(),
                     hmsConf.getCacheRefreshIntervalSec(),
                     hmsConf.getCacheMaxNum(),

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnectorInternalMgr.java
@@ -121,7 +121,8 @@ public class HudiConnectorInternalMgr {
             baseHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
                     hiveMetastore,
                     new ReentrantExecutor(refreshHiveMetastoreExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
-                    new ReentrantExecutor(refreshHudiExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum()),
+                    // As there are many managed table the max threads for the external table refresher can be double
+                    new ReentrantExecutor(refreshHudiExternalTableExecutor, hmsConf.getCacheRefreshThreadMaxNum() * 2),
                     hmsConf.getCacheTtlSec(),
                     hmsConf.getCacheRefreshIntervalSec(),
                     hmsConf.getCacheMaxNum(),

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -67,7 +67,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetAllDatabaseNames() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         List<String> databaseNames = cachingHiveMetastore.getAllDatabaseNames();
         Assert.assertEquals(Lists.newArrayList("db1", "db2"), databaseNames);
         CachingHiveMetastore queryLevelCache = CachingHiveMetastore.createQueryLevelInstance(cachingHiveMetastore, 100);
@@ -77,7 +78,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetAllTableNames() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         List<String> databaseNames = cachingHiveMetastore.getAllTableNames("xxx");
         Assert.assertEquals(Lists.newArrayList("table1", "table2"), databaseNames);
     }
@@ -85,7 +87,7 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetDb() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Database database = cachingHiveMetastore.getDb("db1");
         Assert.assertEquals("db1", database.getFullName());
 
@@ -100,7 +102,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetTable() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         com.starrocks.catalog.Table table = cachingHiveMetastore.getTable("db1", "tbl1");
         HiveTable hiveTable = (HiveTable) table;
         Assert.assertEquals("db1", hiveTable.getCatalogDBName());
@@ -116,7 +119,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetTransactionalTable() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         // get insert only table
         com.starrocks.catalog.Table table = cachingHiveMetastore.getTable("transactional_db", "insert_only");
         Assert.assertNotNull(table);
@@ -129,7 +133,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testTableExists() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Assert.assertTrue(cachingHiveMetastore.tableExists("db1", "tbl1"));
     }
 
@@ -145,7 +150,8 @@ public class CachingHiveMetastoreTest {
             }
         };
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         try {
             cachingHiveMetastore.refreshTable("db1", "notExistTbl", true);
             Assert.fail();
@@ -164,7 +170,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testRefreshTableSync() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Assert.assertFalse(cachingHiveMetastore.tableNameLockMap.containsKey(
                 DatabaseTableName.of("db1", "tbl1")));
         try {
@@ -187,7 +194,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testRefreshTableBackground() throws InterruptedException {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Assert.assertFalse(cachingHiveMetastore.tableNameLockMap.containsKey(
                 DatabaseTableName.of("db1", "tbl1")));
         try {
@@ -230,7 +238,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testRefreshHiveView() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Assert.assertFalse(cachingHiveMetastore.tableNameLockMap.containsKey(
                 DatabaseTableName.of("db1", "tbl1")));
         try {
@@ -262,7 +271,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetPartitionKeys() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Assert.assertEquals(Lists.newArrayList("col1"), cachingHiveMetastore.getPartitionKeysByValue("db1", "tbl1",
                 HivePartitionValue.ALL_PARTITION_VALUES));
     }
@@ -270,7 +280,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetPartition() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Partition partition = cachingHiveMetastore.getPartition(
                 "db1", "tbl1", Lists.newArrayList("par1"));
         Assert.assertEquals(ORC, partition.getFileFormat());
@@ -283,7 +294,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetPartitionByNames() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         List<String> partitionNames = Lists.newArrayList("part1=1/part2=2", "part1=3/part2=4");
         Map<String, Partition> partitions =
                 cachingHiveMetastore.getPartitionsByNames("db1", "table1", partitionNames);
@@ -302,7 +314,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetTableStatistics() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         HivePartitionStats statistics = cachingHiveMetastore.getTableStatistics("db1", "table1");
         HiveCommonStats commonStats = statistics.getCommonStats();
         Assert.assertEquals(50, commonStats.getRowNums());
@@ -316,7 +329,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetPartitionStatistics() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         com.starrocks.catalog.Table hiveTable = cachingHiveMetastore.getTable("db1", "table1");
         Map<String, HivePartitionStats> statistics = cachingHiveMetastore.getPartitionStatistics(
                 hiveTable, Lists.newArrayList("col1=1", "col1=2"));
@@ -357,21 +371,24 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testPartitionExist() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         Assert.assertTrue(cachingHiveMetastore.partitionExists(metastore.getTable("db", "table"), Lists.newArrayList()));
     }
 
     @Test
     public void testDropPartition() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         cachingHiveMetastore.dropPartition("db", "table", Lists.newArrayList("1"), false);
     }
 
     @Test
     public void testUpdateTableStats() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         HivePartitionStats partitionStats = HivePartitionStats.empty();
         cachingHiveMetastore.updateTableStatistics("db", "table", ignore -> partitionStats);
     }
@@ -379,7 +396,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testUpdatePartitionStats() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         HivePartitionStats partitionStats = HivePartitionStats.empty();
         cachingHiveMetastore.updatePartitionStatistics("db", "table", "p1=1", ignore -> partitionStats);
     }
@@ -387,7 +405,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testRefreshTableByEvent() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
 
         HiveCommonStats stats = new HiveCommonStats(10, 100);
 
@@ -411,7 +430,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testRefreshPartitionByEvent() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
 
         HiveCommonStats stats = new HiveCommonStats(10, 100);
         HivePartitionName hivePartitionName = HivePartitionName.of("db1", "unpartitioned_table", "col1=1");
@@ -423,7 +443,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testRefreshPartition() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, true);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, true);
 
         List<HivePartitionName> partitionNames = Lists.newArrayList(
                 HivePartitionName.of("db1", "table1", "col1=1"),
@@ -434,7 +455,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testAddPartitionFailed() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         HivePartition hivePartition = HivePartition.builder()
                 // Unsupported type
                 .setColumns(Lists.newArrayList(new Column("c1", Type.BITMAP)))
@@ -455,7 +477,8 @@ public class CachingHiveMetastoreTest {
     @Test
     public void testGetCachedName() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         HiveCacheUpdateProcessor processor = new HiveCacheUpdateProcessor(
                 "hive_catalog", cachingHiveMetastore, null, null, false, false);
         Assert.assertTrue(processor.getCachedTableNames().isEmpty());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
@@ -59,7 +59,8 @@ public class HiveConnectorTest {
         client = new HiveMetastoreTest.MockedHiveMetaClient();
         metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
         cachingHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
-                metastore, executorForHmsRefresh, 100, 10, 1000, false);
+                metastore, executorForHmsRefresh, executorForHmsRefresh,
+                100, 10, 1000, false);
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
         FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -116,7 +116,8 @@ public class HiveMetadataTest {
         client = new HiveMetastoreTest.MockedHiveMetaClient();
         metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
         cachingHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
-                metastore, executorForHmsRefresh, 100, 10, 1000, false);
+                metastore, executorForHmsRefresh, executorForHmsRefresh,
+                100, 10, 1000, false);
         hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration(), MetastoreType.HMS, "hive_catalog");
 
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreOperationsTest.java
@@ -72,7 +72,8 @@ public class HiveMetastoreOperationsTest {
         metastore = new HiveMetastore(client, "hive_catalog", null);
         executor = Executors.newFixedThreadPool(5);
         cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration(), MetastoreType.HMS, "hive_catalog");
     }
 
@@ -221,7 +222,8 @@ public class HiveMetastoreOperationsTest {
         HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", null);
         ExecutorService executor = Executors.newFixedThreadPool(5);
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         HiveMetastoreOperations hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true,
                 new Configuration(), MetastoreType.HMS, "hive_catalog");
 
@@ -250,7 +252,8 @@ public class HiveMetastoreOperationsTest {
         metastore = new HiveMetastore(new MockedTestMetaClient1(), "hive_catalog", MetastoreType.HMS);
         executor = Executors.newFixedThreadPool(5);
         cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration(), MetastoreType.HMS, "hive_catalog");
 
         hmsOps.dropDb("db1", false);
@@ -269,7 +272,8 @@ public class HiveMetastoreOperationsTest {
         HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
         ExecutorService executor = Executors.newFixedThreadPool(5);
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         HiveMetastoreOperations hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true,
                 new Configuration(), MetastoreType.HMS, "hive_catalog");
 
@@ -294,7 +298,8 @@ public class HiveMetastoreOperationsTest {
         HiveMetaClient client2 = new MockedTestMetaClient2();
         HiveMetastore metastore2 = new HiveMetastore(client2, "hive_catalog", MetastoreType.HMS);
         CachingHiveMetastore cachingHiveMetastore2 = new CachingHiveMetastore(
-                metastore2, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+                metastore2, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
         HiveMetastoreOperations hmsOps2 = new HiveMetastoreOperations(cachingHiveMetastore2, true,
                 new Configuration(), MetastoreType.HMS, "hive_catalog");
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +49,7 @@ import java.util.Map;
 import static com.starrocks.connector.hive.RemoteFileInputFormat.ORC;
 import static org.apache.hadoop.hive.common.StatsSetupConst.NUM_FILES;
 import static org.apache.hadoop.hive.common.StatsSetupConst.ROW_COUNT;
+import static org.apache.hadoop.hive.common.StatsSetupConst.TASK;
 import static org.apache.hadoop.hive.common.StatsSetupConst.TOTAL_SIZE;
 
 public class HiveMetastoreTest {
@@ -349,7 +351,9 @@ public class HiveMetastoreTest {
             } else {
                 msTable1.setPartitionKeys(new ArrayList<>());
             }
-
+            if (tblName.equals("external_table")) {
+                msTable1.setTableType("EXTERNAL_TABLE");
+            }
             return msTable1;
         }
 
@@ -487,7 +491,8 @@ public class HiveMetastoreTest {
 
             Partition partition = new Partition();
             partition.setSd(sd);
-            partition.setParameters(ImmutableMap.of(TOTAL_SIZE, "100", ROW_COUNT, "50"));
+            partition.setParameters(ImmutableMap.of(TOTAL_SIZE, "100",
+                                                    ROW_COUNT, "50", TASK, String.valueOf(Instant.now().getEpochSecond())));
             partition.setValues(partitionValues);
             return partition;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -81,7 +81,8 @@ public class HiveStatisticsProviderTest {
         client = new HiveMetastoreTest.MockedHiveMetaClient();
         metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
         cachingHiveMetastore = new CachingHiveMetastore(
-                metastore, executorForHmsRefresh, 100, 10, 1000, false);
+                metastore, executorForHmsRefresh, executorForHmsRefresh,
+                100, 10, 1000, false);
         hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration(), MetastoreType.HMS, "hive_catalog");
 
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -1722,7 +1722,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         HiveMetaClient metaClient = new HiveMetaClient(new HiveConf());
         HiveMetastore metastore = new HiveMetastore(metaClient, MOCKED_HIVE_CATALOG_NAME, MetastoreType.HMS);
         CachingHiveMetastore cachingHiveMetastore =
-                createCatalogLevelInstance(metastore, Executors.newSingleThreadExecutor(), 0, 0, 0, false);
+                createCatalogLevelInstance(metastore, Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(),
+                    0, 0, 0, false);
         HiveMetastoreOperations hmsOps =
                 new HiveMetastoreOperations(cachingHiveMetastore, false, new Configuration(), MetastoreType.HMS,
                         "hive_catalog");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -73,7 +73,8 @@ public class HudiMetadataTest {
         client = new HiveMetastoreTest.MockedHiveMetaClient();
         metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
         cachingHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
-                metastore, executorForHmsRefresh, 100, 10, 1000, false);
+                metastore, executorForHmsRefresh,  executorForHmsRefresh,
+                100, 10, 1000, false);
         hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration(), MetastoreType.HMS, "hive_catalog");
 
         hudiRemoteFileIO = new HudiRemoteFileIO(new Configuration());


### PR DESCRIPTION
## Why I'm doing:
As we all know for users can change the partition path for the HMS external tables.
And for SR we will not auto refresh HMS external table that will make users need to refresh external table manually.
It is not user friendly.
## What I'm doing:
Implement a method that will check the HMS external table and add one executor to refresh it.
After that the partition for HMS external table will be auto refreshed.
## Note that:
No config or properties need to be changed for the new auto refresh for external table mechanism.
And the new mechanism will not influence existing resources, no need to add switch for it.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0