### PR TITLE
[BugFix] Reject table create request with time type in complex type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -43,7 +43,6 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.StructField;
 import com.starrocks.catalog.StructType;
-import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.TimeoutException;
@@ -267,7 +266,7 @@ public class Util {
                     return TYPE_STRING_MAP.get(primitiveType);
             }
         } else {
-            return type.prettyPrint(); 
+            return type.prettyPrint();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -588,6 +588,7 @@ public class OlapTableFactory implements AbstractTableFactory {
             } catch (AnalysisException e) {
                 throw new DdlException(e.getMessage());
             }
+            Util.checkColumnSupported(baseSchema);
             int schemaHash = Util.schemaHash(schemaVersion, baseSchema, bfColumns, bfFpp);
 
             if (stmt.getSortKeys() != null) {

--- a/test/sql/test_create_table/R/test_create_table_with_time
+++ b/test/sql/test_create_table/R/test_create_table_with_time
@@ -1,0 +1,57 @@
+-- name: test_create_table_with_time
+CREATE TABLE dup_test (
+    id bigint,
+    city varchar(100) not null,
+    time TIME not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (city)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Type:TIME of column:time does not support.')
+-- !result
+CREATE TABLE dup_test (
+    id bigint,
+    city varchar(100) not null,
+    time array<TIME> not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (city)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Type:ARRAY<TIME> of column:time does not support.')
+-- !result
+CREATE TABLE dup_test (
+    id bigint,
+    city varchar(100) not null,
+    time map<bigint, TIME> not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (city)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Type:MAP<BIGINT,TIME> of column:time does not support.')
+-- !result
+CREATE TABLE dup_test (
+    id bigint,
+    city varchar(100) not null,
+    time struct<c1 bigint, c2 TIME> not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (city)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Type:struct<c1 bigint(20), c2 TIME> of column:time does not support.')
+-- !result

--- a/test/sql/test_create_table/T/test_create_table_with_time
+++ b/test/sql/test_create_table/T/test_create_table_with_time
@@ -1,0 +1,49 @@
+-- name: test_create_table_with_time
+
+CREATE TABLE dup_test (
+    id bigint,
+    city varchar(100) not null,
+    time TIME not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (city)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE dup_test (
+    id bigint,
+    city varchar(100) not null,
+    time array<TIME> not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (city)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE dup_test (
+    id bigint,
+    city varchar(100) not null,
+    time map<bigint, TIME> not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (city)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE dup_test (
+    id bigint,
+    city varchar(100) not null,
+    time struct<c1 bigint, c2 TIME> not null
+)
+DUPLICATE KEY(id)
+PARTITION BY (city)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);


### PR DESCRIPTION
## Why I'm doing:
Starrocks does not support `TIME` type column and we should reject these table create request. However, if we create a new column like `array<time>`, the table will be created. But when we try to ingestion data into the table, the BE will crash.

## What I'm doing:
Reject table create request with time type in complex type

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0