### PR TITLE
[Enhancement] Remove unnecessary frequent memory alloc and release requests

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -229,20 +229,22 @@ Status ImmutableIndexShard::compress_and_write(const CompressionTypePB& compress
         return write(wb);
     }
 
+    
     if (npage() > 0) {
         const BlockCompressionCodec* codec = nullptr;
         RETURN_IF_ERROR(get_block_compression_codec(compression_type, &codec));
         int32_t offset = 0;
+        faststring compressed_body;
+        compressed_body.resize(codec->max_compressed_len(_page_size));
         for (int32_t i = 0; i < npage(); i++) {
             Slice input((uint8_t*)_pages.data() + i * _page_size, _page_size);
             *uncompressed_size += input.get_size();
-            faststring compressed_body;
-            compressed_body.resize(codec->max_compressed_len(_page_size));
             Slice compressed_slice(compressed_body);
             RETURN_IF_ERROR(codec->compress(input, &compressed_slice));
             RETURN_IF_ERROR(wb.append(compressed_slice));
             compressed_pages_off[i] = offset;
             offset += compressed_slice.get_size();
+            compressed_body.clear();
         }
         compressed_pages_off[npage()] = offset;
         return Status::OK();

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -234,8 +234,8 @@ Status ImmutableIndexShard::compress_and_write(const CompressionTypePB& compress
         RETURN_IF_ERROR(get_block_compression_codec(compression_type, &codec));
         int32_t offset = 0;
         faststring compressed_body;
-        compressed_body.resize(codec->max_compressed_len(_page_size));
         for (int32_t i = 0; i < npage(); i++) {
+            compressed_body.resize(codec->max_compressed_len(_page_size));
             Slice input((uint8_t*)_pages.data() + i * _page_size, _page_size);
             *uncompressed_size += input.get_size();
             Slice compressed_slice(compressed_body);

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -243,7 +243,6 @@ Status ImmutableIndexShard::compress_and_write(const CompressionTypePB& compress
             RETURN_IF_ERROR(wb.append(compressed_slice));
             compressed_pages_off[i] = offset;
             offset += compressed_slice.get_size();
-            compressed_body.clear();
         }
         compressed_pages_off[npage()] = offset;
         return Status::OK();

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -229,7 +229,6 @@ Status ImmutableIndexShard::compress_and_write(const CompressionTypePB& compress
         return write(wb);
     }
 
-    
     if (npage() > 0) {
         const BlockCompressionCodec* codec = nullptr;
         RETURN_IF_ERROR(get_block_compression_codec(compression_type, &codec));


### PR DESCRIPTION
## Why I'm doing:
There are frequent memory alloc and release request during compress a shard of pindex file which is not necessary. And it may cause more cpu cost.
![image](https://github.com/user-attachments/assets/ac9474b5-0139-4af9-b4b8-34fc069f45f0)


## What I'm doing:
Remove unnecessary and frequent memory alloc and release requests
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0