### PR TITLE
[BugFix] Only enable query context cache when there are more than one related mvs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -108,6 +108,9 @@ public abstract class ConnectorPartitionTraits {
         if (Config.enable_mv_query_context_cache && ctx != null && ctx.getQueryMVContext() != null) {
             QueryMaterializationContext queryMVContext = ctx.getQueryMVContext();
             Cache<Object, Object> cache = queryMVContext.getMvQueryContextCache();
+            if (cache == null || queryMVContext.getQueryCacheStats() == null) {
+                return delegate;
+            }
             return new CachedPartitionTraits(cache, delegate, queryMVContext.getQueryCacheStats(), mv);
         } else {
             return delegate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
@@ -20,6 +20,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.api.client.util.Lists;
 import com.google.api.client.util.Sets;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.MaterializedView;
@@ -107,8 +108,13 @@ public class QueryMaterializationContext {
         isEnableQueryContextCache = enableQueryContextCache;
     }
 
+    @VisibleForTesting
+    public boolean isEnableQueryContextCache() {
+        return isEnableQueryContextCache;
+    }
+
     public Cache<Object, Object> getMvQueryContextCache() {
-        if (isEnableQueryContextCache && mvQueryContextCache == null) {
+        if (isEnableQueryContextCache() && mvQueryContextCache == null) {
             mvQueryContextCache = Caffeine.newBuilder()
                     .maximumSize(Config.mv_query_context_cache_max_size)
                     .recordStats()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Lists;
@@ -1422,8 +1421,6 @@ public class MvUtils {
         }
 
         QueryMaterializationContext queryMaterializationContext = optimizerContext.getQueryMaterializationContext();
-        Cache<Object, Object> predicateSplitCache = queryMaterializationContext.getMvQueryContextCache();
-        Preconditions.checkArgument(predicateSplitCache != null);
         // Cache predicate split for predicates because it's time costing if there are too many materialized views.
         return queryMaterializationContext.getPredicateSplit(queryConjuncts, queryColumnRefRewriter);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -335,6 +335,7 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
                                 "REFRESH DEFERRED MANUAL\n" +
                                 "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;",
                     () -> {
+                        UtFrameUtils.mockEnableQueryContextCache();
                         MaterializedView mv = getMv("test", "test_mv1");
                         PartitionBasedMvRefreshProcessor processor = refreshMV("test", mv);
                         RuntimeProfile runtimeProfile = processor.getRuntimeProfile();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBas
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TGetTasksParams;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.logging.log4j.LogManager;
@@ -274,6 +275,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVTestBase {
                         "refresh deferred manual\n" +
                         "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;",
                 () -> {
+                    UtFrameUtils.mockEnableQueryContextCache();
                     executeInsertSql(connectContext, "insert into tbl1 values(\"2022-02-20\", 1, 10)");
                     OlapTable table = (OlapTable) getTable("test", "tbl1");
                     MaterializedView mv = getMv("test", "test_mv1");

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -118,6 +118,7 @@ import com.starrocks.sql.optimizer.LogicalPlanPrinter;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
 import com.starrocks.sql.optimizer.OptimizerConfig;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
@@ -1336,6 +1337,15 @@ public class UtFrameUtils {
             @Mock
             public void execute() throws Exception {
                 runnable.run();
+            }
+        };
+    }
+
+    public static void mockEnableQueryContextCache() {
+        new MockUp<QueryMaterializationContext>() {
+            @Mock
+            public boolean isEnableQueryContextCache() {
+                return true;
             }
         };
     }


### PR DESCRIPTION
## Why I'm doing:

- mvQueryContextCache is enabled when related mv is more than 1 since the cache is used to  cache query predicates rewrite for different mvs.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0