### PR TITLE
[Enhancement] in null/not having null supports normalized to value range

### DIFF
--- a/be/src/exec/olap_common.cpp
+++ b/be/src/exec/olap_common.cpp
@@ -177,6 +177,17 @@ void ColumnValueRange<T>::clear() {
     _empty_range = false;
 }
 
+template <class T>
+void ColumnValueRange<T>::clear_to_empty() {
+    _fixed_values.clear();
+    _low_value = _type_max;
+    _high_value = _type_min;
+    _low_op = FILTER_LARGER_OR_EQUAL;
+    _high_op = FILTER_LESS_OR_EQUAL;
+    _fixed_op = FILTER_IN;
+    _empty_range = true;
+}
+
 Status OlapScanKeys::get_key_range(std::vector<std::unique_ptr<OlapScanRange>>* key_range) {
     key_range->clear();
 

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -130,6 +130,7 @@ public:
     TCondition to_olap_not_null_filter() const;
 
     void clear();
+    void clear_to_empty();
 
 private:
     std::string _column_name;

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -385,15 +385,29 @@ requires(!lt_is_date<SlotType>) Status ChunkPredicateBuilder<E, Type>::normalize
                     continue;
                 }
 
-                if (is_not_in<Negative>(pred) || pred->null_in_set() ||
-                    pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
+                if (is_not_in<Negative>(pred) || pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
                     continue;
                 }
 
                 std::set<RangeValueType> values;
+                if (pred->null_in_set()) {
+                    if (pred->is_eq_null()) {
+                        // TODO: equal null is also can be normalized, will be optimized later
+                        continue;
+                    }
+                    if constexpr (Negative) {
+                        // or col not in (v1, v2, v3, null)
+                        _normalized_exprs[i] = true;
+                        continue;
+                    } else {
+                        // and col in (v1, v2, v3, null), null can be eliminated
+                    }
+                }
+
                 for (const auto& value : pred->hash_set()) {
                     values.insert(value);
                 }
+
                 if (range->add_fixed_values(FILTER_IN, values).ok()) {
                     _normalized_exprs[i] = true;
                 }
@@ -462,9 +476,18 @@ requires lt_is_date<SlotType> Status ChunkPredicateBuilder<E, Type>::normalize_i
                         continue;
                     }
 
-                    if (is_not_in<Negative>(pred) || pred->null_in_set() ||
+                    if (is_not_in<Negative>(pred) ||
                         pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
                         continue;
+                    }
+                    if (pred->null_in_set()) {
+                        if (pred->is_eq_null()) {
+                            continue;
+                        }
+                        if constexpr (Negative) {
+                            _normalized_exprs[i] = true;
+                            continue;
+                        }
                     }
 
                     for (const TimestampValue& ts : pred->hash_set()) {
@@ -476,9 +499,18 @@ requires lt_is_date<SlotType> Status ChunkPredicateBuilder<E, Type>::normalize_i
                 } else if (pred_type == starrocks::TYPE_DATE) {
                     const auto* pred = down_cast<const VectorizedInConstPredicate<starrocks::TYPE_DATE>*>(root_expr);
 
-                    if (is_not_in<Negative>(pred) || pred->null_in_set() ||
+                    if (is_not_in<Negative>(pred) ||
                         pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
                         continue;
+                    }
+                    if (pred->null_in_set()) {
+                        if (pred->is_eq_null()) {
+                            continue;
+                        }
+                        if constexpr (Negative) {
+                            _normalized_exprs[i] = true;
+                            continue;
+                        }
                     }
                     for (const DateValue& date : pred->hash_set()) {
                         values.insert(date);
@@ -759,12 +791,27 @@ Status ChunkPredicateBuilder<E, Type>::normalize_not_in_or_not_equal_predicate(
                     continue;
                 }
 
-                if (!is_not_in<Negative>(pred) || pred->null_in_set() ||
+                if (!is_not_in<Negative>(pred) ||
                     pred->hash_set().size() > config::max_pushdown_conditions_per_column) {
                     continue;
                 }
 
                 std::set<RangeValueType> values;
+                if (pred->null_in_set()) {
+                    if (pred->is_eq_null()) {
+                        continue;
+                    }
+                    if constexpr (!Negative) {
+                        // and col not in (v1, v2, v3, null)
+                        if (range->add_fixed_values(FILTER_IN, values).ok()) {
+                            _normalized_exprs[i] = true;
+                        }
+                        continue;
+                    } else {
+                        // or col in (v1, v2, v3, null)
+                    }
+                }
+
                 for (const auto& value : pred->hash_set()) {
                     values.insert(value);
                 }
@@ -1185,4 +1232,5 @@ const UnarrivedRuntimeFilterList& ScanConjunctsManager::unarrived_runtime_filter
 }
 
 template class ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND>;
+template class ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::OR>;
 } // namespace starrocks

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -803,9 +803,8 @@ Status ChunkPredicateBuilder<E, Type>::normalize_not_in_or_not_equal_predicate(
                     }
                     if constexpr (!Negative) {
                         // and col not in (v1, v2, v3, null)
-                        if (range->add_fixed_values(FILTER_IN, values).ok()) {
-                            _normalized_exprs[i] = true;
-                        }
+                        range->clear_to_empty();
+                        _normalized_exprs[i] = true;
                         continue;
                     } else {
                         // or col in (v1, v2, v3, null)

--- a/be/src/exprs/in_const_predicate.hpp
+++ b/be/src/exprs/in_const_predicate.hpp
@@ -385,6 +385,8 @@ public:
 
     bool null_in_set() const { return _null_in_set; }
 
+    bool is_eq_null() const { return _eq_null; }
+
     void set_null_in_set(bool v) { _null_in_set = v; }
 
     bool is_join_runtime_filter() const { return _is_join_runtime_filter; }

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -369,6 +369,7 @@ static const TypeDescriptor TYPE_SMALLINT_DESC = TypeDescriptor{LogicalType::TYP
 static const TypeDescriptor TYPE_INT_DESC = TypeDescriptor(LogicalType::TYPE_INT);
 static const TypeDescriptor TYPE_BIGINT_DESC = TypeDescriptor(LogicalType::TYPE_BIGINT);
 static const TypeDescriptor TYPE_TIME_DESC = TypeDescriptor(LogicalType::TYPE_TIME);
+static const TypeDescriptor TYPE_DATE_DESC = TypeDescriptor(LogicalType::TYPE_DATE);
 static const TypeDescriptor TYPE_DATETIME_DESC = TypeDescriptor(LogicalType::TYPE_DATETIME);
 static const TypeDescriptor TYPE_CHAR_DESC = TypeDescriptor::create_char_type(TypeDescriptor::MAX_CHAR_LENGTH);
 static const TypeDescriptor TYPE_VARCHAR_DESC = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);

--- a/be/src/testutil/CMakeLists.txt
+++ b/be/src/testutil/CMakeLists.txt
@@ -25,5 +25,6 @@ add_library(TestUtil
     sync_point_impl.cc
     schema_test_helper.cpp
     tablet_test_helper.cpp
+    exprs_test_helper.cpp
 )
 

--- a/be/src/testutil/exprs_test_helper.cpp
+++ b/be/src/testutil/exprs_test_helper.cpp
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testutil/exprs_test_helper.h"
+
+namespace starrocks {
+const TTypeDesc ExprsTestHelper::SmallIntTTypeDesc = ExprsTestHelper::create_scalar_type_desc(TPrimitiveType::SMALLINT);
+const TTypeDesc ExprsTestHelper::IntTTypeDesc = ExprsTestHelper::create_scalar_type_desc(TPrimitiveType::INT);
+const TTypeDesc ExprsTestHelper::BigIntTTypeDesc = ExprsTestHelper::create_scalar_type_desc(TPrimitiveType::BIGINT);
+const TTypeDesc ExprsTestHelper::DateTTypeDesc = ExprsTestHelper::create_scalar_type_desc(TPrimitiveType::DATE);
+const TTypeDesc ExprsTestHelper::DateTimeTTypeDesc = ExprsTestHelper::create_scalar_type_desc(TPrimitiveType::DATETIME);
+const TTypeDesc ExprsTestHelper::Decimal128TTypeDesc =
+        ExprsTestHelper::create_decimal_type_desc(TPrimitiveType::DECIMAL128, 27, 9);
+const TTypeDesc ExprsTestHelper::VarcharTTypeDesc =
+        ExprsTestHelper::create_varchar_type_desc(TypeDescriptor::MAX_VARCHAR_LENGTH);
+} // namespace starrocks

--- a/be/src/testutil/exprs_test_helper.h
+++ b/be/src/testutil/exprs_test_helper.h
@@ -91,6 +91,15 @@ public:
         return type_desc;
     }
 
+    static const TTypeDesc SmallIntTTypeDesc;
+    static const TTypeDesc IntTTypeDesc;
+    static const TTypeDesc BigIntTTypeDesc;
+    static const TTypeDesc DateTTypeDesc;
+    static const TTypeDesc DateTimeTTypeDesc;
+    // precision=27, scale=9
+    static const TTypeDesc Decimal128TTypeDesc;
+    static const TTypeDesc VarcharTTypeDesc;
+
     static TSlotDescriptor create_slot_desc(const TTypeDesc& type, TupleId tuple_id, SlotId slot_id,
                                             const std::string& col_name) {
         //k1_int
@@ -168,10 +177,120 @@ public:
         return node;
     }
 
-    static TExprNode create_slot_expr_node(TupleId tuple_id, SlotId slot_id, TTypeDesc t_type, bool is_nullable) {
+    template <LogicalType LType>
+    static TTypeDesc get_ttype_desc() {
+        if constexpr (LType == TYPE_SMALLINT) {
+            return SmallIntTTypeDesc;
+        } else if constexpr (LType == TYPE_INT) {
+            return IntTTypeDesc;
+        } else if constexpr (LType == TYPE_BIGINT) {
+            return BigIntTTypeDesc;
+        } else if constexpr (LType == TYPE_DATE) {
+            return DateTTypeDesc;
+        } else if constexpr (LType == TYPE_DATETIME) {
+            return DateTimeTTypeDesc;
+        } else if constexpr (LType == TYPE_VARCHAR) {
+            return VarcharTTypeDesc;
+        } else if constexpr (LType == TYPE_DECIMAL128) {
+            return Decimal128TTypeDesc;
+        } else {
+            // not implement
+            CHECK(false);
+        }
+    }
+
+    template <LogicalType LType>
+    static TExprNode create_in_pred_node(size_t size) {
+        TExprNode node;
+
+        node.node_type = TExprNodeType::IN_PRED;
+        node.num_children = size;
+        node.type = get_ttype_desc<LType>();
+
+        node.__set_opcode(TExprOpcode::FILTER_IN);
+        node.__set_child_type(to_thrift(LType));
+
+        return node;
+    }
+
+    template <LogicalType LType>
+    static TExprNode create_not_in_pred_node(size_t size) {
+        TExprNode node;
+        TInPredicate in_pred;
+        in_pred.__set_is_not_in(true);
+
+        node.node_type = TExprNodeType::IN_PRED;
+        node.num_children = size;
+        node.type = get_ttype_desc<LType>();
+
+        node.__set_in_predicate(in_pred);
+        node.__set_opcode(TExprOpcode::FILTER_NOT_IN);
+        node.__set_child_type(to_thrift(LType));
+
+        return node;
+    }
+
+    template <LogicalType LType, typename ValueType>
+    static TExpr create_in_pred_texpr(SlotId slot_id, const std::vector<ValueType>& values, bool has_null) {
+        std::vector<TExprNode> nodes;
+
+        nodes.emplace_back(create_in_pred_node<LType>(values.size() + 1 + has_null));
+        nodes.emplace_back(create_slot_expr_node_t<LType>(0, slot_id, true));
+        for (auto value : values) {
+            nodes.emplace_back(create_literal<LType, ValueType>(value, false));
+        }
+        if (has_null) {
+            nodes.emplace_back(create_null_literal<LType>());
+        }
+
+        TExpr t_expr;
+        t_expr.nodes = nodes;
+        return t_expr;
+    }
+
+    template <LogicalType LType, typename ValueType>
+    static TExpr create_not_in_pred_texpr(SlotId slot_id, const std::vector<ValueType>& values, bool has_null) {
+        std::vector<TExprNode> nodes;
+
+        nodes.emplace_back(create_not_in_pred_node<LType>(values.size() + 1 + has_null));
+        nodes.emplace_back(create_slot_expr_node_t<LType>(0, slot_id, true));
+        for (auto value : values) {
+            nodes.emplace_back(create_literal<LType, ValueType>(value, false));
+        }
+        if (has_null) {
+            nodes.emplace_back(create_null_literal<LType>());
+        }
+
+        TExpr t_expr;
+        t_expr.nodes = nodes;
+        return t_expr;
+    }
+
+    template <LogicalType LType, typename ValueType>
+    static TExpr create_binary_pred_texpr(SlotId slot_id, ValueType value) {
+        TExprNode pred_node = create_binary_pred_node(to_thrift(LType), TExprOpcode::GT);
+        TExprNode col_ref = create_slot_expr_node_t<LType>(0, slot_id, true);
+        TExprNode literal = create_literal<LType, ValueType>(value, false);
+
+        TExpr texpr;
+        texpr.nodes.emplace_back(pred_node);
+        texpr.nodes.emplace_back(col_ref);
+        texpr.nodes.emplace_back(literal);
+
+        return texpr;
+    }
+
+    static Status create_and_open_conjunct_ctxs(ObjectPool* pool, RuntimeState* runtime_state,
+                                                std::vector<TExpr>* tExprs, std::vector<ExprContext*>* conjunct_ctxs) {
+        RETURN_IF_ERROR(Expr::create_expr_trees(pool, *tExprs, conjunct_ctxs, nullptr));
+        RETURN_IF_ERROR(Expr::prepare(*conjunct_ctxs, runtime_state));
+        return Expr::open(*conjunct_ctxs, runtime_state);
+    }
+
+    static TExprNode create_slot_expr_node(TupleId tuple_id, SlotId slot_id, TTypeDesc ttype, bool is_nullable) {
         TExprNode slot_ref;
         slot_ref.node_type = TExprNodeType::SLOT_REF;
-        slot_ref.type = t_type;
+        slot_ref.type = ttype;
         slot_ref.num_children = 0;
         slot_ref.__isset.slot_ref = true;
         slot_ref.slot_ref.slot_id = slot_id;
@@ -180,46 +299,66 @@ public:
         return slot_ref;
     }
 
-    template <typename CppType>
-    static TExprNode create_int_literal(CppType value, TTypeDesc t_type, bool is_nullable) {
-        TIntLiteral int_literal;
-        int_literal.value = value;
+    template <LogicalType LType>
+    static TExprNode create_slot_expr_node_t(TupleId tuple_id, SlotId slot_id, bool is_nullable) {
+        return create_slot_expr_node(tuple_id, slot_id, get_ttype_desc<LType>(), is_nullable);
+    }
 
+    template <LogicalType LType, typename ValueType>
+    static TExprNode create_literal(ValueType value, bool is_nullable) {
         TExprNode node;
-        node.node_type = TExprNodeType::INT_LITERAL;
-        node.type = t_type;
         node.num_children = 0;
-        node.__set_int_literal(int_literal);
         node.is_nullable = is_nullable;
+
+        if constexpr (LType == TYPE_SMALLINT) {
+            node.type = SmallIntTTypeDesc;
+            TIntLiteral int_literal;
+            int_literal.value = value;
+            node.__set_int_literal(int_literal);
+            node.node_type = TExprNodeType::INT_LITERAL;
+        } else if constexpr (LType == TYPE_INT) {
+            node.type = IntTTypeDesc;
+            TIntLiteral int_literal;
+            int_literal.value = value;
+            node.__set_int_literal(int_literal);
+            node.node_type = TExprNodeType::INT_LITERAL;
+        } else if constexpr (LType == TYPE_BIGINT) {
+            node.type = BigIntTTypeDesc;
+            TIntLiteral int_literal;
+            int_literal.value = value;
+            node.__set_int_literal(int_literal);
+            node.node_type = TExprNodeType::INT_LITERAL;
+        } else if constexpr (LType == TYPE_DATE) {
+            node.type = DateTTypeDesc;
+            TDateLiteral date_literal;
+            date_literal.value = value;
+            node.__set_date_literal(date_literal);
+            node.node_type = TExprNodeType::DATE_LITERAL;
+        } else if constexpr (LType == TYPE_DATETIME) {
+            node.type = DateTimeTTypeDesc;
+            TDateLiteral date_literal;
+            date_literal.value = value;
+            node.__set_date_literal(date_literal);
+            node.node_type = TExprNodeType::DATE_LITERAL;
+        } else if constexpr (LType == TYPE_VARCHAR) {
+            node.type = VarcharTTypeDesc;
+            TStringLiteral string_literal;
+            string_literal.value = value;
+            node.__set_string_literal(string_literal);
+            node.node_type = TExprNodeType::STRING_LITERAL;
+        } else {
+            // not implement
+            CHECK(false);
+        }
 
         return node;
     }
 
-    static TExprNode create_date_literal(const std::string& value, TTypeDesc t_type, bool is_nullable) {
-        TDateLiteral date_literal;
-        date_literal.value = value;
-
+    template <LogicalType LType>
+    static TExprNode create_null_literal() {
         TExprNode node;
-        node.node_type = TExprNodeType::DATE_LITERAL;
-        node.type = t_type;
-        node.num_children = 0;
-        node.__set_date_literal(date_literal);
-        node.is_nullable = is_nullable;
-
-        return node;
-    }
-
-    static TExprNode create_varchar_literal(const std::string& value, TTypeDesc t_type, bool is_nullable) {
-        TStringLiteral string_literal;
-        string_literal.value = value;
-
-        TExprNode node;
-        node.node_type = TExprNodeType::STRING_LITERAL;
-        node.type = t_type;
-        node.num_children = 0;
-        node.__set_string_literal(string_literal);
-        node.is_nullable = is_nullable;
-
+        node.node_type = TExprNodeType::NULL_LITERAL;
+        node.type = get_ttype_desc<LType>();
         return node;
     }
 
@@ -280,6 +419,7 @@ public:
         return expr;
     }
 };
+
 class TExprBuilder {
 public:
     TExprBuilder& operator<<(const LogicalType& slot_type) {

--- a/be/src/testutil/schema_test_helper.cpp
+++ b/be/src/testutil/schema_test_helper.cpp
@@ -15,8 +15,8 @@
 #include "testutil/schema_test_helper.h"
 
 namespace starrocks {
-TabletSchemaPB SchemaTestHelper::gen_schema_pb_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
-                                                      size_t num_key_cols) {
+TabletSchemaPB SchemaTestHelper::gen_schema_pb_of_dup(LogicalType type, TabletSchema::SchemaId schema_id,
+                                                      size_t num_cols, size_t num_key_cols) {
     TabletSchemaPB schema_pb;
 
     schema_pb.set_keys_type(DUP_KEYS);
@@ -27,7 +27,7 @@ TabletSchemaPB SchemaTestHelper::gen_schema_pb_of_dup(TabletSchema::SchemaId sch
         auto c0 = schema_pb.add_column();
         c0->set_unique_id(i);
         c0->set_name("c" + std::to_string(i));
-        c0->set_type("INT");
+        c0->set_type(logical_type_to_string(type));
         c0->set_is_nullable(true);
         c0->set_index_length(4);
         if (i < num_key_cols) {
@@ -62,9 +62,9 @@ TabletSchemaPB SchemaTestHelper::gen_varchar_schema_pb_of_dup(TabletSchema::Sche
     return schema_pb;
 }
 
-TabletSchemaSPtr SchemaTestHelper::gen_schema_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
-                                                     size_t num_key_cols) {
-    TabletSchemaPB schema_pb = SchemaTestHelper::gen_schema_pb_of_dup(1, 3, 1);
+TabletSchemaSPtr SchemaTestHelper::gen_schema_of_dup(LogicalType type, TabletSchema::SchemaId schema_id,
+                                                     size_t num_cols, size_t num_key_cols) {
+    TabletSchemaPB schema_pb = SchemaTestHelper::gen_schema_pb_of_dup(type, 1, 3, 1);
     return std::make_shared<TabletSchema>(schema_pb);
 }
 

--- a/be/src/testutil/schema_test_helper.h
+++ b/be/src/testutil/schema_test_helper.h
@@ -20,10 +20,12 @@
 namespace starrocks {
 class SchemaTestHelper {
 public:
-    static TabletSchemaPB gen_schema_pb_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols, size_t num_key_cols);
+    static TabletSchemaPB gen_schema_pb_of_dup(LogicalType type, TabletSchema::SchemaId schema_id, size_t num_cols,
+                                               size_t num_key_cols);
     static TabletSchemaPB gen_varchar_schema_pb_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
                                                        size_t num_key_cols);
-    static TabletSchemaSPtr gen_schema_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols, size_t num_key_cols);
+    static TabletSchemaSPtr gen_schema_of_dup(LogicalType, TabletSchema::SchemaId schema_id, size_t num_cols,
+                                              size_t num_key_cols);
     static TabletSchemaSPtr gen_varchar_schema_of_dup(TabletSchema::SchemaId schema_id, size_t num_cols,
                                                       size_t num_key_cols);
     static TColumn gen_key_column(const std::string& col_name, TPrimitiveType::type type);

--- a/be/test/exec/olap_scan_prepare_test.cpp
+++ b/be/test/exec/olap_scan_prepare_test.cpp
@@ -29,15 +29,17 @@ namespace starrocks {
 class ChunkPredicateBuilderTest : public testing::Test {
 public:
     void SetUp() override {
-        _int_tablet_schema = SchemaTestHelper::gen_schema_of_dup(1, 3, 1);
+        _int_tablet_schema = SchemaTestHelper::gen_schema_of_dup(TYPE_INT, 1, 3, 1);
+        _date_tablet_schema = SchemaTestHelper::gen_schema_of_dup(TYPE_DATE, 1, 3, 1);
+
         _int_pred_parser = _pool.add(new OlapPredicateParser(_int_tablet_schema));
-        _varchar_tablet_schema = SchemaTestHelper::gen_varchar_schema_of_dup(1, 3, 1);
-        _varchar_pred_parser = _pool.add(new OlapPredicateParser(_varchar_tablet_schema));
-        _type_varchar = TypeDescriptor::create_varchar_type(100);
+        _date_pred_parser = _pool.add(new OlapPredicateParser(_date_tablet_schema));
+
         _opts.runtime_state = &_runtime_state;
         _opts.obj_pool = &_pool;
         _opts.pred_tree_params.enable_or = true;
         _opts.key_column_names = &_key_column_names;
+        _opts.conjunct_ctxs_ptr = &_expr_ctxs;
     }
 
 protected:
@@ -54,12 +56,14 @@ protected:
     std::vector<std::string> _key_column_names;
 
     TabletSchemaSPtr _int_tablet_schema;
-    OlapPredicateParser* _int_pred_parser;
-    TabletSchemaSPtr _varchar_tablet_schema;
-    OlapPredicateParser* _varchar_pred_parser;
+    TabletSchemaSPtr _date_tablet_schema;
 
+    OlapPredicateParser* _int_pred_parser;
+    OlapPredicateParser* _date_pred_parser;
+
+    std::vector<TExpr> _texprs;
+    std::vector<ExprContext*> _expr_ctxs;
     ColumnPredicatePtrs _predicate_free_pool;
-    TypeDescriptor _type_varchar;
     std::vector<BoxedExprContext> _expr_containers;
 };
 
@@ -135,6 +139,122 @@ StatusOr<RuntimeFilterProbeCollector*> ChunkPredicateBuilderTest::_gen_range_run
     return rf_collector;
 }
 
+TEST_F(ChunkPredicateBuilderTest, normalized_in_has_null) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    std::vector<int32_t> values{1, 3, 5, 7, 9};
+    _texprs.emplace_back(ExprsTestHelper::create_in_pred_texpr<TYPE_INT, int32_t>(slot_id, values, true));
+    ASSERT_OK(ExprsTestHelper::create_and_open_conjunct_ctxs(&_pool, &_runtime_state, &_texprs, &_expr_ctxs));
+    ASSERT_EQ(_expr_ctxs.size(), 1);
+
+    _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[0]));
+
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, _expr_containers, true);
+    ASSIGN_OR_ASSERT_FAIL(auto normalized, builder.parse_conjuncts());
+    ASSERT_TRUE(normalized);
+
+    ASSIGN_OR_ASSERT_FAIL(auto pred, builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool));
+    ASSERT_EQ(pred.debug_string(), "{\"and\":[{\"pred\":\"((columnId=1)IN(9,5,1,7,3))\"}]}");
+}
+
+TEST_F(ChunkPredicateBuilderTest, normalized_in_has_null_date) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_DATE_DESC, 1}, {"c2", TYPE_DATE_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    _texprs.emplace_back(ExprsTestHelper::create_in_pred_texpr<TYPE_DATE, std::string>(
+            slot_id, {"2014-01-01", "2014-01-02", "2014-01-03"}, true));
+    ASSERT_OK(ExprsTestHelper::create_and_open_conjunct_ctxs(&_pool, &_runtime_state, &_texprs, &_expr_ctxs));
+    ASSERT_EQ(_expr_ctxs.size(), 1);
+
+    _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[0]));
+
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, _expr_containers, true);
+    ASSIGN_OR_ASSERT_FAIL(auto normalized, builder.parse_conjuncts());
+    ASSERT_TRUE(normalized);
+
+    ASSIGN_OR_ASSERT_FAIL(auto pred, builder.get_predicate_tree_root(_date_pred_parser, _predicate_free_pool));
+    ASSERT_EQ(pred.debug_string(), "{\"and\":[{\"pred\":\"((columnId=1)IN(2014-01-01,2014-01-02,2014-01-03))\"}]}");
+}
+
+TEST_F(ChunkPredicateBuilderTest, normalize_or_in_has_null) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    _texprs.emplace_back(ExprsTestHelper::create_binary_pred_texpr<TYPE_INT, int32_t>(slot_id, 10));
+    _texprs.emplace_back(ExprsTestHelper::create_not_in_pred_texpr<TYPE_INT, int32_t>(
+            slot_id, std::vector<int32_t>{1, 3, 5, 7, 9}, true));
+    ASSERT_OK(ExprsTestHelper::create_and_open_conjunct_ctxs(&_pool, &_runtime_state, &_texprs, &_expr_ctxs));
+    ASSERT_EQ(_expr_ctxs.size(), 2);
+    _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[0]));
+    _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[1]));
+
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::OR> builder(_opts, _expr_containers, false);
+    ASSIGN_OR_ASSERT_FAIL(auto normalized, builder.parse_conjuncts());
+    ASSERT_TRUE(normalized);
+
+    ASSIGN_OR_ASSERT_FAIL(auto pred, builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool));
+    ASSERT_EQ(pred.debug_string(), "{\"or\":[{\"pred\":\"(columnId(1)>10)\"}]}");
+}
+
+TEST_F(ChunkPredicateBuilderTest, normalize_or_in_has_null_date) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_DATE_DESC, 1}, {"c2", TYPE_DATE_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    _texprs.emplace_back(ExprsTestHelper::create_binary_pred_texpr<TYPE_DATE, std::string>(slot_id, "2023-01-02"));
+    _texprs.emplace_back(ExprsTestHelper::create_in_pred_texpr<TYPE_DATE, std::string>(
+            slot_id, {"2014-01-01", "2014-01-02", "2014-01-03"}, true));
+    ASSERT_OK(ExprsTestHelper::create_and_open_conjunct_ctxs(&_pool, &_runtime_state, &_texprs, &_expr_ctxs));
+    ASSERT_EQ(_expr_ctxs.size(), 2);
+    _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[0]));
+    _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[1]));
+
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::OR> builder(_opts, _expr_containers, false);
+    ASSIGN_OR_ASSERT_FAIL(auto normalized, builder.parse_conjuncts());
+    ASSERT_FALSE(normalized);
+}
+
+TEST_F(ChunkPredicateBuilderTest, normalized_not_in_has_null) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    _texprs.emplace_back(ExprsTestHelper::create_not_in_pred_texpr<TYPE_INT, int32_t>(slot_id, {1, 3, 5, 7, 9}, true));
+    ASSERT_OK(ExprsTestHelper::create_and_open_conjunct_ctxs(&_pool, &_runtime_state, &_texprs, &_expr_ctxs));
+    ASSERT_EQ(_expr_ctxs.size(), 1);
+
+    _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[0]));
+
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, _expr_containers, true);
+    ASSIGN_OR_ASSERT_FAIL(auto normalized, builder.parse_conjuncts());
+    ASSERT_TRUE(normalized);
+
+    ASSIGN_OR_ASSERT_FAIL(auto pred, builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool));
+    ASSERT_EQ(pred.debug_string(), "{\"and\":[]}");
+}
+
+TEST_F(ChunkPredicateBuilderTest, normalize_or_not_in_has_null) {
+    SlotId slot_id = 1;
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
+    _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
+
+    _texprs.emplace_back(ExprsTestHelper::create_binary_pred_texpr<TYPE_INT, int32_t>(slot_id, 10));
+    _texprs.emplace_back(ExprsTestHelper::create_in_pred_texpr<TYPE_INT, int32_t>(
+            slot_id, std::vector<int32_t>{1, 3, 5, 7, 9}, true));
+    ASSERT_OK(ExprsTestHelper::create_and_open_conjunct_ctxs(&_pool, &_runtime_state, &_texprs, &_expr_ctxs));
+    ASSERT_EQ(_expr_ctxs.size(), 2);
+    _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[0]));
+    _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[1]));
+
+    ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::OR> builder(_opts, _expr_containers, false);
+    ASSIGN_OR_ASSERT_FAIL(auto normalized, builder.parse_conjuncts());
+    ASSERT_FALSE(normalized);
+}
+
 TEST_F(ChunkPredicateBuilderTest, rt_has_no_null) {
     SlotId slot_id = 1;
     parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
@@ -162,16 +282,14 @@ TEST_F(ChunkPredicateBuilderTest, rt_has_null) {
     parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_INT_DESC, 1}, {"c2", TYPE_INT_DESC, 2}, {""}};
     _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
 
-    auto ret1 = _gen_runtime_filter_collector(slot_id, true);
-    ASSERT_TRUE(ret1.ok());
+    ASSIGN_OR_ASSERT_FAIL(auto* rf, _gen_runtime_filter_collector(slot_id, true));
 
-    _opts.runtime_filters = ret1.value();
+    _opts.runtime_filters = rf;
 
     ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, _expr_containers, true);
 
-    auto ret2 = builder.parse_conjuncts();
-    ASSERT_TRUE(ret1.ok());
-    ASSERT_TRUE(ret2.value());
+    ASSIGN_OR_ASSERT_FAIL(auto normalized, builder.parse_conjuncts());
+    ASSERT_TRUE(normalized);
 
     auto ret3 = builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool);
     ASSERT_TRUE(ret3.ok());
@@ -182,7 +300,7 @@ TEST_F(ChunkPredicateBuilderTest, rt_has_null) {
 
 TEST_F(ChunkPredicateBuilderTest, varchar_rt_has_no_null) {
     SlotId slot_id = 1;
-    parquet::Utils::SlotDesc slot_descs[] = {{"c1", _type_varchar, 1}, {"c2", _type_varchar, 2}, {""}};
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_VARCHAR_DESC, 1}, {"c2", TYPE_VARCHAR_DESC, 2}, {""}};
     _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
 
     auto ret1 = _gen_varchar_runtime_filter_collector(slot_id, false);
@@ -204,7 +322,7 @@ TEST_F(ChunkPredicateBuilderTest, varchar_rt_has_no_null) {
 
 TEST_F(ChunkPredicateBuilderTest, varchar_rt_has_null) {
     SlotId slot_id = 1;
-    parquet::Utils::SlotDesc slot_descs[] = {{"c1", _type_varchar, 1}, {"c2", _type_varchar, 2}, {""}};
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_VARCHAR_DESC, 1}, {"c2", TYPE_VARCHAR_DESC, 2}, {""}};
     _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
 
     auto ret1 = _gen_varchar_runtime_filter_collector(slot_id, true);

--- a/be/test/exec/olap_scan_prepare_test.cpp
+++ b/be/test/exec/olap_scan_prepare_test.cpp
@@ -165,7 +165,7 @@ TEST_F(ChunkPredicateBuilderTest, normalized_in_has_null_larger_than_1024) {
     _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
 
     std::vector<int32_t> values;
-    for (int32_t i=0; i < 2048; i++) {
+    for (int32_t i = 0; i < 2048; i++) {
         values.emplace_back(i);
     }
     _texprs.emplace_back(ExprsTestHelper::create_in_pred_texpr<TYPE_INT, int32_t>(slot_id, values, true));
@@ -307,7 +307,7 @@ TEST_F(ChunkPredicateBuilderTest, normalized_not_in_has_null_larger_than_1024) {
     _opts.tuple_desc = parquet::Utils::create_tuple_descriptor(&_runtime_state, &_pool, slot_descs);
 
     std::vector<int32_t> values;
-    for (int32_t i=0; i < 2048; i++) {
+    for (int32_t i = 0; i < 2048; i++) {
         values.emplace_back(i);
     }
 

--- a/be/test/exec/olap_scan_prepare_test.cpp
+++ b/be/test/exec/olap_scan_prepare_test.cpp
@@ -230,11 +230,8 @@ TEST_F(ChunkPredicateBuilderTest, normalized_not_in_has_null) {
     _expr_containers.emplace_back(BoxedExprContext(_expr_ctxs[0]));
 
     ChunkPredicateBuilder<BoxedExprContext, CompoundNodeType::AND> builder(_opts, _expr_containers, true);
-    ASSIGN_OR_ASSERT_FAIL(auto normalized, builder.parse_conjuncts());
-    ASSERT_TRUE(normalized);
-
-    ASSIGN_OR_ASSERT_FAIL(auto pred, builder.get_predicate_tree_root(_int_pred_parser, _predicate_free_pool));
-    ASSERT_EQ(pred.debug_string(), "{\"and\":[]}");
+    auto ret = builder.parse_conjuncts();
+    ASSERT_TRUE(ret.status().is_end_of_file());
 }
 
 TEST_F(ChunkPredicateBuilderTest, normalize_or_not_in_has_null) {

--- a/be/test/formats/parquet/parquet_ut_base.cpp
+++ b/be/test/formats/parquet/parquet_ut_base.cpp
@@ -37,7 +37,7 @@ void ParquetUTBase::append_decimal_conjunct(TExprOpcode::type opcode, SlotId slo
     TTypeDesc decimal_type = ExprsTestHelper::create_decimal_type_desc(TPrimitiveType::DECIMAL128, 27, 9);
 
     TExprNode binary_pred = ExprsTestHelper::create_binary_pred_node(TPrimitiveType::DECIMAL128, opcode);
-    TExprNode decimal_col_ref = ExprsTestHelper::create_slot_expr_node(0, slot_id, decimal_type, true);
+    TExprNode decimal_col_ref = ExprsTestHelper::create_slot_expr_node_t<TYPE_DECIMAL128>(0, slot_id, true);
     TExprNode decimal_literal = ExprsTestHelper::create_decimal_literal(value, decimal_type, false);
 
     TExpr t_expr;
@@ -50,11 +50,9 @@ void ParquetUTBase::append_decimal_conjunct(TExprOpcode::type opcode, SlotId slo
 
 void ParquetUTBase::append_smallint_conjunct(TExprOpcode::type opcode, SlotId slot_id, int value,
                                              std::vector<TExpr>* tExprs) {
-    TTypeDesc smallint_type = ExprsTestHelper::create_scalar_type_desc(TPrimitiveType::SMALLINT);
-
     TExprNode pred_node = ExprsTestHelper::create_binary_pred_node(TPrimitiveType::SMALLINT, opcode);
-    TExprNode smallint_col_ref = ExprsTestHelper::create_slot_expr_node(0, slot_id, smallint_type, true);
-    TExprNode smallint_literal = ExprsTestHelper::create_int_literal<int32_t>(value, smallint_type, false);
+    TExprNode smallint_col_ref = ExprsTestHelper::create_slot_expr_node_t<TYPE_SMALLINT>(0, slot_id, true);
+    TExprNode smallint_literal = ExprsTestHelper::create_literal<TYPE_SMALLINT, int32_t>(value, false);
 
     TExpr t_expr;
     t_expr.nodes.emplace_back(pred_node);
@@ -66,11 +64,9 @@ void ParquetUTBase::append_smallint_conjunct(TExprOpcode::type opcode, SlotId sl
 
 void ParquetUTBase::append_int_conjunct(TExprOpcode::type opcode, SlotId slot_id, int value,
                                         std::vector<TExpr>* tExprs) {
-    TTypeDesc int_type = ExprsTestHelper::create_scalar_type_desc(TPrimitiveType::INT);
-
     TExprNode pred_node = ExprsTestHelper::create_binary_pred_node(TPrimitiveType::INT, opcode);
-    TExprNode int_col_ref = ExprsTestHelper::create_slot_expr_node(0, slot_id, int_type, true);
-    TExprNode int_literal = ExprsTestHelper::create_int_literal<int32_t>(value, int_type, false);
+    TExprNode int_col_ref = ExprsTestHelper::create_slot_expr_node_t<TYPE_INT>(0, slot_id, true);
+    TExprNode int_literal = ExprsTestHelper::create_literal<TYPE_INT, int32_t>(value, false);
 
     TExpr t_expr;
     t_expr.nodes.emplace_back(pred_node);
@@ -82,11 +78,9 @@ void ParquetUTBase::append_int_conjunct(TExprOpcode::type opcode, SlotId slot_id
 
 void ParquetUTBase::append_bigint_conjunct(TExprOpcode::type opcode, SlotId slot_id, int64_t value,
                                            std::vector<TExpr>* tExprs) {
-    TTypeDesc int_type = ExprsTestHelper::create_scalar_type_desc(TPrimitiveType::BIGINT);
-
     TExprNode pred_node = ExprsTestHelper::create_binary_pred_node(TPrimitiveType::BIGINT, opcode);
-    TExprNode int_col_ref = ExprsTestHelper::create_slot_expr_node(0, slot_id, int_type, true);
-    TExprNode int_literal = ExprsTestHelper::create_int_literal<int64_t>(value, int_type, false);
+    TExprNode int_col_ref = ExprsTestHelper::create_slot_expr_node_t<TYPE_BIGINT>(0, slot_id, true);
+    TExprNode int_literal = ExprsTestHelper::create_literal<TYPE_BIGINT, int64_t>(value, false);
 
     TExpr t_expr;
     t_expr.nodes.emplace_back(pred_node);
@@ -98,11 +92,9 @@ void ParquetUTBase::append_bigint_conjunct(TExprOpcode::type opcode, SlotId slot
 
 void ParquetUTBase::append_datetime_conjunct(TExprOpcode::type opcode, SlotId slot_id, const std::string& value,
                                              std::vector<TExpr>* tExprs) {
-    TTypeDesc datetime_type = ExprsTestHelper::create_scalar_type_desc(TPrimitiveType::DATETIME);
-
     TExprNode pred_node = ExprsTestHelper::create_binary_pred_node(TPrimitiveType::DATETIME, opcode);
-    TExprNode datetime_col_ref = ExprsTestHelper::create_slot_expr_node(0, slot_id, datetime_type, true);
-    TExprNode datetime_literal = ExprsTestHelper::create_date_literal(value, datetime_type, false);
+    TExprNode datetime_col_ref = ExprsTestHelper::create_slot_expr_node_t<TYPE_DATETIME>(0, slot_id, true);
+    TExprNode datetime_literal = ExprsTestHelper::create_literal<TYPE_DATETIME>(value, false);
 
     TExpr t_expr;
     t_expr.nodes.emplace_back(pred_node);
@@ -117,8 +109,8 @@ void ParquetUTBase::append_string_conjunct(TExprOpcode::type opcode, starrocks::
     TTypeDesc varchar_type = ExprsTestHelper::create_varchar_type_desc(10);
 
     TExprNode pre_node = ExprsTestHelper::create_binary_pred_node(TPrimitiveType::VARCHAR, opcode);
-    TExprNode varchar_col_ref = ExprsTestHelper::create_slot_expr_node(0, slot_id, varchar_type, true);
-    TExprNode varchar_literal = ExprsTestHelper::create_varchar_literal(value, varchar_type, false);
+    TExprNode varchar_col_ref = ExprsTestHelper::create_slot_expr_node_t<TYPE_VARCHAR>(0, slot_id, true);
+    TExprNode varchar_literal = ExprsTestHelper::create_literal<TYPE_VARCHAR, std::string>(value, false);
 
     TExpr t_expr;
     t_expr.nodes.emplace_back(pre_node);
@@ -160,37 +152,11 @@ void ParquetUTBase::create_in_predicate_int_conjunct_ctxs(TExprOpcode::type opco
                                                           std::set<int32_t>& values, std::vector<TExpr>* tExprs) {
     std::vector<TExprNode> nodes;
 
-    TExprNode node0;
-    node0.node_type = TExprNodeType::IN_PRED;
-    node0.opcode = opcode;
-    node0.child_type = TPrimitiveType::INT;
-    node0.num_children = values.size() + 1;
-    node0.__isset.opcode = true;
-    node0.__isset.child_type = true;
-    node0.type = gen_type_desc(TPrimitiveType::BOOLEAN);
-    nodes.emplace_back(node0);
-
-    TExprNode node1;
-    node1.node_type = TExprNodeType::SLOT_REF;
-    node1.type = gen_type_desc(TPrimitiveType::INT);
-    node1.num_children = 0;
-    TSlotRef t_slot_ref = TSlotRef();
-    t_slot_ref.slot_id = slot_id;
-    t_slot_ref.tuple_id = 0;
-    node1.__set_slot_ref(t_slot_ref);
-    node1.is_nullable = true;
-    nodes.emplace_back(node1);
+    nodes.emplace_back(ExprsTestHelper::create_in_pred_node<TYPE_INT>(values.size() + 1));
+    nodes.emplace_back(ExprsTestHelper::create_slot_expr_node_t<TYPE_INT>(0, slot_id, true));
 
     for (int32_t value : values) {
-        TExprNode node;
-        node.node_type = TExprNodeType::INT_LITERAL;
-        node.type = gen_type_desc(TPrimitiveType::INT);
-        node.num_children = 0;
-        TIntLiteral int_literal;
-        int_literal.value = value;
-        node.__set_int_literal(int_literal);
-        node.is_nullable = false;
-        nodes.emplace_back(node);
+        nodes.emplace_back(ExprsTestHelper::create_literal<TYPE_INT, int32_t>(value, false));
     }
 
     TExpr t_expr;

--- a/be/test/storage/olap_runtime_range_pruner_test.cpp
+++ b/be/test/storage/olap_runtime_range_pruner_test.cpp
@@ -30,7 +30,7 @@ namespace starrocks {
 class OlapRuntimeRangePrunerTest : public ::testing::Test {
 public:
     void SetUp() override {
-        _tablet_schema = SchemaTestHelper::gen_schema_of_dup(1, 3, 1);
+        _tablet_schema = SchemaTestHelper::gen_schema_of_dup(TYPE_INT, 1, 3, 1);
         _predicate_parser = std::make_unique<OlapPredicateParser>(_tablet_schema);
     }
 


### PR DESCRIPTION
## Why I'm doing:

Currently, only the following pred can be normalized:

* ColumnRef is null
* ColumnRef is no null
* ColumnRef >, >=, <, <=, = const value
* ColumnRef in const values
* ColumnRef not in const values
* The above are combined by `or`, `and`

The `[ColumnRef in (xxx, yyy, zzz)] is null` is not support to be normalized, so the null in `in pred` or `not in pred` can be eliminated.

`in (xxx, yyy, zzz, null)` can be converted to `in (xxx, yyy, zzz)`
`not in (xxx, yyy, zzz, null)` can be converted to `not in (null)`, and then convert to empty range.

Finally the in pred with null can be used to filter with zonemap or other index.

Before the pr:

```
mysql> select count(*) from lineorder_nullable_1_tablet_large where lo_orderkey in (1, 2, null);
+----------+
| count(*) |
+----------+
|        4 |
+----------+
1 row in set (0.64 sec)

mysql> select count(*) from lineorder_nullable_1_tablet_large where lo_orderkey not in (1, 2, null);
+----------+
| count(*) |
+----------+
|        0 |
+----------+
1 row in set (0.59 sec)
```

After the pr

```
mysql> select count(*) from lineorder_nullable_1_tablet_large where lo_orderkey in (1, 2, null);
+----------+
| count(*) |
+----------+
|        4 |
+----------+
1 row in set (0.06 sec)

mysql> select count(*) from lineorder_nullable_1_tablet_large where lo_orderkey not in (1, 2, null);
+----------+
| count(*) |
+----------+
|        0 |
+----------+
1 row in set (0.02 sec)

```

## What I'm doing:

in null/not in null supports normalized to value range

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0