### PR TITLE
[Enhancement] support separate thread pool for load spill block merge & improve block merge memory usage

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1530,7 +1530,9 @@ CONF_mInt64(load_spill_max_chunk_bytes, "10485760");
 // Max merge input bytes during spill merge. Default is 1024MB.
 CONF_mInt64(load_spill_max_merge_bytes, "1073741824");
 // Max memory used for merge load spill blocks.
-CONF_mInt64(load_spill_memory_limit_percent, "40");
+CONF_mInt64(load_spill_merge_memory_limit_percent, "30");
+// Upper bound of spill merge thread count
+CONF_mInt64(load_spill_merge_max_thread, "16");
 
 // ignore union type tag in avro kafka routine load
 CONF_mBool(avro_ignore_union_type_tag, "false");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1529,6 +1529,8 @@ CONF_mBool(enable_load_spill, "false");
 CONF_mInt64(load_spill_max_chunk_bytes, "10485760");
 // Max merge input bytes during spill merge. Default is 1024MB.
 CONF_mInt64(load_spill_max_merge_bytes, "1073741824");
+// Max memory used for merge load spill blocks.
+CONF_mInt64(load_spill_memory_limit_percent, "40");
 
 // ignore union type tag in avro kafka routine load
 CONF_mBool(avro_ignore_union_type_tag, "false");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -54,6 +54,7 @@
 #include "http/http_status.h"
 #include "storage/compaction_manager.h"
 #include "storage/lake/compaction_scheduler.h"
+#include "storage/lake/load_spill_block_manager.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/update_manager.h"
 #include "storage/memtable_flush_executor.h"
@@ -315,6 +316,16 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 tablet_manager->compaction_scheduler()->update_compact_threads(config::compact_threads);
             }
             return Status::OK();
+        });
+        _config_callback.emplace("load_spill_merge_memory_limit_percent", [&]() -> Status {
+            // The change of load spill merge memory will be reflected in the max thread cnt of load spill merge pool.
+            return StorageEngine::instance()->load_spill_block_merge_executor()->refresh_max_thread_num();
+        });
+        _config_callback.emplace("load_spill_merge_max_thread", [&]() -> Status {
+            return StorageEngine::instance()->load_spill_block_merge_executor()->refresh_max_thread_num();
+        });
+        _config_callback.emplace("load_spill_max_merge_bytes", [&]() -> Status {
+            return StorageEngine::instance()->load_spill_block_merge_executor()->refresh_max_thread_num();
         });
 
 #ifdef USE_STAROS

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -152,6 +152,8 @@ public:
         return _flush_token == nullptr ? nullptr : &(_flush_token->get_stats());
     }
 
+    bool has_spill_block() const;
+
 private:
     Status reset_memtable();
 
@@ -250,6 +252,10 @@ Status DeltaWriterImpl::check_immutable() {
 
 int64_t DeltaWriterImpl::last_write_ts() const {
     return _last_write_ts;
+}
+
+bool DeltaWriterImpl::has_spill_block() const {
+    return _load_spill_block_mgr != nullptr && _load_spill_block_mgr->has_spill_block();
 }
 
 Status DeltaWriterImpl::build_schema_and_writer() {
@@ -834,6 +840,10 @@ const DeltaWriterStat& DeltaWriter::get_writer_stat() const {
 
 const FlushStatistic* DeltaWriter::get_flush_stats() const {
     return _impl->get_flush_stats();
+}
+
+bool DeltaWriter::has_spill_block() const {
+    return _impl->has_spill_block();
 }
 
 ThreadPool* DeltaWriter::io_threads() {

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -156,6 +156,8 @@ public:
 
     const FlushStatistic* get_flush_stats() const;
 
+    bool has_spill_block() const;
+
 private:
     DeltaWriterImpl* _impl;
 };

--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -25,6 +25,23 @@
 
 namespace starrocks::lake {
 
+Status LoadSpillBlockMergeExecutor::init() {
+    // The starting point for setting the maximum number of threads for load spill:
+    // 1. Meet the memory limit requirements (by config::load_spill_memory_limit_percent) for load spill.
+    // 2. Each thread can use 1GB(by config::load_spill_max_merge_bytes) of memory.
+    int max_merge_blocks_thread = (GlobalEnv::GetInstance()->process_mem_tracker()->limit() *
+                                   config::load_spill_memory_limit_percent / (int64_t)100) /
+                                  config::load_spill_max_merge_bytes;
+    int cpu_cores = CpuInfo::num_cores();
+    RETURN_IF_ERROR(ThreadPoolBuilder("load_spill_block_merge")
+                            .set_min_threads(1)
+                            .set_max_threads(std::max<int>(1, std::min<int>(max_merge_blocks_thread, cpu_cores)))
+                            .set_max_queue_size(40960 /*a random chosen number that should big enough*/)
+                            .set_idle_timeout(MonoDelta::FromMilliseconds(/*5 minutes=*/5 * 60 * 1000))
+                            .build(&_merge_pool));
+    return Status::OK();
+}
+
 void LoadSpillBlockContainer::append_block(const spill::BlockPtr& block) {
     std::lock_guard guard(_mutex);
     _block_groups.back().append(block);

--- a/be/src/storage/lake/load_spill_block_manager.h
+++ b/be/src/storage/lake/load_spill_block_manager.h
@@ -17,11 +17,9 @@
 #include "exec/spill/block_manager.h"
 #include "exec/spill/dir_manager.h"
 #include "exec/spill/input_stream.h"
+#include "util/threadpool.h"
 
 namespace starrocks {
-
-class ThreadPool;
-
 namespace lake {
 
 class LoadSpillBlockMergeExecutor {
@@ -31,6 +29,7 @@ public:
     Status init();
 
     ThreadPool* get_thread_pool() { return _merge_pool.get(); }
+    Status refresh_max_thread_num();
 
 private:
     // ThreadPool for merge.

--- a/be/src/storage/lake/load_spill_block_manager.h
+++ b/be/src/storage/lake/load_spill_block_manager.h
@@ -20,7 +20,22 @@
 
 namespace starrocks {
 
+class ThreadPool;
+
 namespace lake {
+
+class LoadSpillBlockMergeExecutor {
+public:
+    LoadSpillBlockMergeExecutor() {}
+    ~LoadSpillBlockMergeExecutor() {}
+    Status init();
+
+    ThreadPool* get_thread_pool() { return _merge_pool.get(); }
+
+private:
+    // ThreadPool for merge.
+    std::unique_ptr<ThreadPool> _merge_pool;
+};
 
 class LoadSpillBlockContainer {
 public:
@@ -63,6 +78,8 @@ public:
 
     spill::BlockManager* block_manager() { return _block_manager.get(); }
     LoadSpillBlockContainer* block_container() { return _block_container.get(); }
+
+    bool has_spill_block() const { return _block_container != nullptr && !_block_container->empty(); }
 
 private:
     TUniqueId _load_id;                                        // Unique ID for the load.

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -78,6 +78,8 @@ private:
     spill::SpillerFactoryPtr _spiller_factory;
     std::shared_ptr<spill::Spiller> _spiller;
     SchemaPtr _schema;
+    // used for spill merge, parent trakcer is compaction tracker
+    std::unique_ptr<MemTracker> _merge_mem_tracker = nullptr;
 };
 
 } // namespace lake

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -59,6 +59,7 @@
 #include "storage/compaction_manager.h"
 #include "storage/data_dir.h"
 #include "storage/dictionary_cache_manager.h"
+#include "storage/lake/load_spill_block_manager.h"
 #include "storage/lake/local_pk_index_manager.h"
 #include "storage/memtable_flush_executor.h"
 #include "storage/publish_version_manager.h"
@@ -238,6 +239,10 @@ Status StorageEngine::_open(const EngineOptions& options) {
     REGISTER_THREAD_POOL_METRICS(
             async_delta_writer,
             static_cast<bthreads::ThreadPoolExecutor*>(_async_delta_writer_executor.get())->get_thread_pool());
+
+    _load_spill_block_merge_executor = std::make_unique<lake::LoadSpillBlockMergeExecutor>();
+    RETURN_IF_ERROR(_load_spill_block_merge_executor->init());
+    REGISTER_THREAD_POOL_METRICS(load_spill_block_merge, _load_spill_block_merge_executor->get_thread_pool());
 
     _memtable_flush_executor = std::make_unique<MemTableFlushExecutor>();
     RETURN_IF_ERROR_WITH_WARN(_memtable_flush_executor->init(dirs), "init MemTableFlushExecutor failed");

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -71,6 +71,7 @@ class Executor;
 
 namespace starrocks::lake {
 class LocalPkIndexManager;
+class LoadSpillBlockMergeExecutor;
 }
 
 namespace starrocks {
@@ -234,6 +235,10 @@ public:
     DictionaryCacheManager* dictionary_cache_manager() { return _dictionary_cache_manager.get(); }
 
     bthread::Executor* async_delta_writer_executor() { return _async_delta_writer_executor.get(); }
+
+    lake::LoadSpillBlockMergeExecutor* load_spill_block_merge_executor() {
+        return _load_spill_block_merge_executor.get();
+    }
 
     MemTableFlushExecutor* memtable_flush_executor() { return _memtable_flush_executor.get(); }
 
@@ -491,6 +496,8 @@ private:
     std::unique_ptr<RowsetIdGenerator> _rowset_id_generator;
 
     std::unique_ptr<bthread::Executor> _async_delta_writer_executor;
+
+    std::unique_ptr<lake::LoadSpillBlockMergeExecutor> _load_spill_block_merge_executor;
 
     std::unique_ptr<MemTableFlushExecutor> _memtable_flush_executor;
 

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -72,7 +72,7 @@ class Executor;
 namespace starrocks::lake {
 class LocalPkIndexManager;
 class LoadSpillBlockMergeExecutor;
-}
+} // namespace starrocks::lake
 
 namespace starrocks {
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -342,6 +342,7 @@ public:
     // thread pool metrics
     METRICS_DEFINE_THREAD_POOL(publish_version);
     METRICS_DEFINE_THREAD_POOL(async_delta_writer);
+    METRICS_DEFINE_THREAD_POOL(load_spill_block_merge);
     METRICS_DEFINE_THREAD_POOL(memtable_flush);
     METRICS_DEFINE_THREAD_POOL(lake_memtable_flush);
     METRICS_DEFINE_THREAD_POOL(segment_replicate);


### PR DESCRIPTION
## Why I'm doing:
I try to improve two things in this PR:
1. Add a separate thread pool to handle block merge so they won't block other ingestion finish which are not bulk data ingestion. And the thread pool worker count will be decided by `load_spill_memory_limit_percent` and `load_spill_max_merge_bytes`. We need to make sure each worker will have 1GB (`load_spill_max_merge_bytes`) for merge and whole memory usage won't exceed `load_spill_memory_limit_percent`.
2. Control the merge chunks by `load_spill_max_chunk_bytes` and `load_spill_max_merge_bytes`. Max merges chunk should be `load_spill_max_merge_bytes` / `load_spill_max_chunk_bytes`.

## What I'm doing:

Fixes #53954

This pull request introduces significant changes to the load spill handling mechanism in the storage engine. The changes include adding new configurations, modifying the `AsyncDeltaWriterImpl` class, and adding a new test case to validate the functionality.

### Enhancements to Load Spill Handling:

* **Configuration Updates:**
  - Added a new configuration `load_spill_memory_limit_percent` to set the maximum memory used for merging load spill blocks in `be/src/common/config.h`.

* **AsyncDeltaWriterImpl Modifications:**
  - Introduced a new execution queue `_load_spill_queue_id` for handling load spill tasks in `be/src/storage/lake/async_delta_writer.cpp`.
  - Modified the `do_open` method to initialize the load spill execution queue.
  - Updated the `finish` method to use the load spill execution queue if there are spill blocks. [[1]](diffhunk://#diff-872223d282bb757d320985cfacac0a022d171585f340504dc1cad8065c10ddccR258-R265) [[2]](diffhunk://#diff-872223d282bb757d320985cfacac0a022d171585f340504dc1cad8065c10ddccR274)
  - Enhanced the `close` method to stop and join the load spill execution queue. [[1]](diffhunk://#diff-872223d282bb757d320985cfacac0a022d171585f340504dc1cad8065c10ddccR283-R284) [[2]](diffhunk://#diff-872223d282bb757d320985cfacac0a022d171585f340504dc1cad8065c10ddccR306-R318)

* **DeltaWriter Enhancements:**
  - Added a `has_spill_block` method to the `DeltaWriterImpl` and `DeltaWriter` classes to check for spill blocks in `be/src/storage/lake/delta_writer.cpp` and `be/src/storage/lake/delta_writer.h`. [[1]](diffhunk://#diff-24e44403f5e4c75144f9645f2fcff77dcdd9269836bafd5b79d5b2d6589e49fdR155-R156) [[2]](diffhunk://#diff-24e44403f5e4c75144f9645f2fcff77dcdd9269836bafd5b79d5b2d6589e49fdR257-R260) [[3]](diffhunk://#diff-24e44403f5e4c75144f9645f2fcff77dcdd9269836bafd5b79d5b2d6589e49fdR845-R848) [[4]](diffhunk://#diff-3f911d26ed4783825a745c34cd6076c422efefd6a0e7d808eb452353dc6038f5R159-R160)

* **Load Spill Block Manager:**
  - Added a `has_spill_block` method to the `LoadSpillBlockManager` class in `be/src/storage/lake/load_spill_block_manager.h`.

* **Storage Engine Updates:**
  - Added a new thread pool executor for load spill block merging and registered its metrics in `be/src/storage/storage_engine.cpp` and `be/src/storage/storage_engine.h`. [[1]](diffhunk://#diff-293a0c0006651efa2ab8d5c65ba19731ae232a61da1e04c2710b75c75c671fe6R242-R261) [[2]](diffhunk://#diff-d6ec362ebf3bde41b2b68452c120e061f9b7ae729547a195fa4edf23726c4398R238-R239) [[3]](diffhunk://#diff-d6ec362ebf3bde41b2b68452c120e061f9b7ae729547a195fa4edf23726c4398R497-R498) [[4]](diffhunk://#diff-5f7ae46075bcd4cd9c8cca632f8a0a0ac6fff95f57211a970eaf731648408223R345)

* **New Test Case:**
  - Added a test case `test_block_merger` in `be/test/storage/lake/async_delta_writer_test.cpp` to validate the block merging functionality during load spills.

These changes improve the efficiency and robustness of handling load spills in the storage engine.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0