### PR TITLE
[Feature] Support restoring from a cluster snapshot for shared-data mode (part 5, support downloading image)

### DIFF
--- a/conf/cluster_snapshot.yaml
+++ b/conf/cluster_snapshot.yaml
@@ -1,5 +1,11 @@
 --- # cluster_snapshot.yaml
 
+# information about the cluster snapshot to be downloaded and restored
+#cluster_snapshot:
+#    storage_volume_name: my_s3_volume #defined in storage_volumes
+#    cluster_service_id: f7265e80-631c-44d3-a8ac-cf7cdc7adec811019
+#    cluster_snapshot_name: automated_cluster_snapshot_1704038400000
+
 # do not include leader fe
 #frontends:
 #  - host: 172.26.92.1

--- a/fe/fe-core/src/main/java/com/starrocks/fs/HdfsUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/HdfsUtil.java
@@ -51,11 +51,12 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class HdfsUtil {
     private static final Logger LOG = LogManager.getLogger(HdfsUtil.class);
 
-    private static int READ_BUFFER_SIZE_B = 1024 * 1024;
+    private static final int READ_BUFFER_SIZE_B = 1024 * 1024;
 
     private static HdfsService hdfsService = new HdfsService();
 
@@ -63,6 +64,11 @@ public class HdfsUtil {
     public static void getTProperties(String path, BrokerDesc brokerDesc,  THdfsProperties tProperties) throws
             StarRocksException {
         hdfsService.getTProperties(path, brokerDesc.getProperties(), tProperties);
+    }
+
+    public static void copyToLocal(String srcPath, String destPath, Map<String, String> properties)
+            throws StarRocksException {
+        hdfsService.copyToLocal(srcPath, destPath, properties);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1197,6 +1197,21 @@ public class HdfsFsManager {
         getFileSystem(path, loadProperties, tProperties);
     }
 
+    public void copyToLocal(String srcPath, String destPath, Map<String, String> properties) throws StarRocksException {
+        HdfsFs fileSystem = getFileSystem(srcPath, properties, null);
+        try {
+            fileSystem.getDFSFileSystem().copyToLocalFile(false, new Path(new WildcardURI(srcPath).getPath()),
+                    new Path(destPath), true);
+        } catch (InterruptedIOException e) {
+            Thread.interrupted(); // clear interrupted flag
+            LOG.error("Interrupted while copy {} to local {} ", srcPath, destPath, e);
+            throw new StarRocksException("Failed to copy " + srcPath + "to local " + destPath, e);
+        } catch (Exception e) {
+            LOG.error("Exception while copy {} to local {} ", srcPath, destPath, e);
+            throw new StarRocksException("Failed to copy " + srcPath + "to local " + destPath, e);
+        }
+    }
+
     public List<FileStatus> listFileMeta(String path, Map<String, String> properties) throws StarRocksException {
         WildcardURI pathUri = new WildcardURI(path);
         HdfsFs fileSystem = getFileSystem(path, properties, null);

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsService.java
@@ -54,6 +54,11 @@ public class HdfsService {
         fileSystemManager.getTProperties(path, loadProperties, tProperties);
     }
 
+    public void copyToLocal(String srcPath, String destPath, Map<String, String> properties) throws StarRocksException {
+        fileSystemManager.copyToLocal(srcPath, destPath, properties);
+        LOG.info("Copied {} to local {}", srcPath, destPath);
+    }
+
     public void listPath(TBrokerListPathRequest request, List<TBrokerFileStatus> fileStatuses, boolean skipDir,
                          boolean fileNameOnly) throws StarRocksException {
         LOG.info("receive a list path request, path: {}", request.path);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
@@ -15,8 +15,10 @@
 package com.starrocks.lake.snapshot;
 
 import com.starrocks.common.Config;
-import com.starrocks.common.DdlException;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.fs.HdfsUtil;
 import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.journal.bdbje.BDBEnvironment;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.server.StorageVolumeMgr;
@@ -25,11 +27,14 @@ import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.SystemInfoService;
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class RestoreClusterSnapshotMgr {
     private static final Logger LOG = LogManager.getLogger(RestoreClusterSnapshotMgr.class);
@@ -40,18 +45,13 @@ public class RestoreClusterSnapshotMgr {
     private boolean oldStartWithIncompleteMeta;
     private boolean oldResetElectionGroup;
 
-    private RestoreClusterSnapshotMgr(String clusterSnapshotYamlFile) {
+    private RestoreClusterSnapshotMgr(String clusterSnapshotYamlFile) throws StarRocksException {
         config = ClusterSnapshotConfig.load(clusterSnapshotYamlFile);
-        // Save the old config
-        oldStartWithIncompleteMeta = Config.start_with_incomplete_meta;
-        // Allow starting with only image and no log
-        Config.start_with_incomplete_meta = true;
-        // Save the old config
-        oldResetElectionGroup = Config.bdbje_reset_election_group;
-        Config.bdbje_reset_election_group = true;
+        downloadSnapshot();
+        updateConfig();
     }
 
-    public static void init(String clusterSnapshotYamlFile, String[] args) {
+    public static void init(String clusterSnapshotYamlFile, String[] args) throws StarRocksException {
         for (String arg : args) {
             if (arg.equalsIgnoreCase("-cluster_snapshot")) {
                 LOG.info("FE start to restore from a cluster snapshot");
@@ -73,7 +73,7 @@ public class RestoreClusterSnapshotMgr {
         return self.config;
     }
 
-    public static void finishRestoring() throws DdlException {
+    public static void finishRestoring() throws StarRocksException {
         RestoreClusterSnapshotMgr self = instance;
         if (self == null) {
             return;
@@ -81,20 +81,57 @@ public class RestoreClusterSnapshotMgr {
 
         try {
             self.updateFrontends();
-
             self.updateComputeNodes();
-
             self.updateStorageVolumes();
         } finally {
-            // Rollback config
-            Config.start_with_incomplete_meta = self.oldStartWithIncompleteMeta;
-            Config.bdbje_reset_election_group = self.oldResetElectionGroup;
-
+            self.rollbackConfig();
             instance = null;
         }
     }
 
-    private void updateFrontends() throws DdlException {
+    private void updateConfig() {
+        // Save the old config
+        oldStartWithIncompleteMeta = Config.start_with_incomplete_meta;
+        // Allow starting with only image no bdb log
+        Config.start_with_incomplete_meta = true;
+        // Save the old config
+        oldResetElectionGroup = Config.bdbje_reset_election_group;
+        // Reset election group
+        Config.bdbje_reset_election_group = true;
+    }
+
+    private void rollbackConfig() {
+        Config.start_with_incomplete_meta = oldStartWithIncompleteMeta;
+        Config.bdbje_reset_election_group = oldResetElectionGroup;
+    }
+
+    private void downloadSnapshot() throws StarRocksException {
+        ClusterSnapshotConfig.ClusterSnapshot clusterSnapshot = config.getClusterSnapshot();
+        if (clusterSnapshot == null) {
+            return;
+        }
+
+        String localImagePath = GlobalStateMgr.getImageDirPath();
+        String localBdbPath = BDBEnvironment.getBdbDir();
+
+        if (FileUtils.deleteQuietly(new File(localImagePath))) {
+            LOG.info("Deleted image dir {}", localImagePath);
+        }
+        if (FileUtils.deleteQuietly(new File(localBdbPath))) {
+            LOG.info("Deleted bdb {}", localBdbPath);
+        }
+
+        ClusterSnapshotConfig.StorageVolume storageVolume = clusterSnapshot.getStorageVolume();
+        // TODO: use constant and support no snapshot name
+        String snapshotImagePath = String.join("/", storageVolume.getLocation(), clusterSnapshot.getClusterServiceId(),
+                "meta/image", clusterSnapshot.getClusterSnapshotName());
+        Map<String, String> properties = storageVolume.getProperties();
+
+        LOG.info("Copy snapshot image {} to local dir {}", snapshotImagePath, localImagePath);
+        HdfsUtil.copyToLocal(snapshotImagePath, localImagePath, properties);
+    }
+
+    private void updateFrontends() throws StarRocksException {
         List<ClusterSnapshotConfig.Frontend> frontends = config.getFrontends();
         if (frontends == null) {
             return;
@@ -115,7 +152,7 @@ public class RestoreClusterSnapshotMgr {
         }
     }
 
-    private void updateComputeNodes() throws DdlException {
+    private void updateComputeNodes() throws StarRocksException {
         List<ClusterSnapshotConfig.ComputeNode> computeNodes = config.getComputeNodes();
         if (computeNodes == null) {
             return;
@@ -143,7 +180,7 @@ public class RestoreClusterSnapshotMgr {
         }
     }
 
-    private void updateStorageVolumes() throws DdlException {
+    private void updateStorageVolumes() throws StarRocksException {
         List<ClusterSnapshotConfig.StorageVolume> storageVolumes = config.getStorageVolumes();
         if (storageVolumes == null) {
             return;
@@ -151,6 +188,7 @@ public class RestoreClusterSnapshotMgr {
 
         StorageVolumeMgr storageVolumeMgr = GlobalStateMgr.getCurrentState().getStorageVolumeMgr();
         for (ClusterSnapshotConfig.StorageVolume storageVolume : storageVolumes) {
+            LOG.info("Update storage volume {}", storageVolume.getName());
             storageVolumeMgr.updateStorageVolume(storageVolume.getName(), storageVolume.getType(),
                     Collections.singletonList(storageVolume.getLocation()), storageVolume.getProperties(),
                     storageVolume.getComment());

--- a/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
@@ -250,7 +250,7 @@ public class MetaHelper {
             throw new InvalidMetaDirException();
         }
 
-        Path imageDir = Paths.get(Config.meta_dir + GlobalStateMgr.IMAGE_DIR);
+        Path imageDir = Paths.get(GlobalStateMgr.getImageDirPath());
         Path bdbDir = Paths.get(BDBEnvironment.getBdbDir());
         boolean haveImageData = false;
         if (Files.exists(imageDir)) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1103,6 +1103,10 @@ public class GlobalStateMgr {
         }
     }
 
+    public static String getImageDirPath() {
+        return Config.meta_dir + IMAGE_DIR;
+    }
+
     public String getImageDir() {
         return imageDir;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotConfigTest.java
@@ -25,6 +25,20 @@ public class ClusterSnapshotConfigTest {
     @Test
     public void testLoadFromFile() {
         ClusterSnapshotConfig config = ClusterSnapshotConfig.load("src/test/resources/conf/cluster_snapshot.yaml");
+
+        ClusterSnapshotConfig.ClusterSnapshot clusterSnapshot = config.getClusterSnapshot();
+        Assert.assertNotNull(clusterSnapshot);
+        Assert.assertEquals("my_s3_volume", clusterSnapshot.getStorageVolumeName());
+        Assert.assertNotNull(clusterSnapshot.getStorageVolume());
+        Assert.assertEquals("f7265e80-631c-44d3-a8ac-cf7cdc7adec811019",
+                clusterSnapshot.getClusterServiceId());
+        Assert.assertEquals("automated_cluster_snapshot_1704038400000",
+                clusterSnapshot.getClusterSnapshotName());
+
+        clusterSnapshot.setStorageVolumeName(clusterSnapshot.getStorageVolumeName());
+        clusterSnapshot.setClusterServiceId(clusterSnapshot.getClusterServiceId());
+        clusterSnapshot.setClusterSnapshotName(clusterSnapshot.getClusterSnapshotName());
+
         Assert.assertEquals(2, config.getFrontends().size());
         Assert.assertEquals(2, config.getComputeNodes().size());
         Assert.assertEquals(2, config.getStorageVolumes().size());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgrTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.lake.snapshot;
 
+import com.starrocks.common.StarRocksException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
@@ -30,8 +31,20 @@ public class RestoreClusterSnapshotMgrTest {
     }
 
     @Test
-    public void testRestoreClusterSnapshotMgr() throws Exception {
-        RestoreClusterSnapshotMgr.init("src/test/resources/conf/cluster_snapshot.yaml",
+    public void testDownloadSnapshotFaied() throws Exception {
+        Assert.assertThrows(StarRocksException.class, () -> {
+            RestoreClusterSnapshotMgr.init("src/test/resources/conf/cluster_snapshot.yaml",
+                    new String[] { "-cluster_snapshot" });
+        });
+
+        Assert.assertFalse(RestoreClusterSnapshotMgr.isRestoring());
+        RestoreClusterSnapshotMgr.finishRestoring();
+        Assert.assertFalse(RestoreClusterSnapshotMgr.isRestoring());
+    }
+
+    @Test
+    public void testNormal() throws Exception {
+        RestoreClusterSnapshotMgr.init("src/test/resources/conf/cluster_snapshot2.yaml",
                 new String[] { "-cluster_snapshot" });
         Assert.assertTrue(RestoreClusterSnapshotMgr.isRestoring());
 

--- a/fe/fe-core/src/test/resources/conf/cluster_snapshot2.yaml
+++ b/fe/fe-core/src/test/resources/conf/cluster_snapshot2.yaml
@@ -1,10 +1,10 @@
 --- # cluster_snapshot.yaml
 
 # information about the cluster snapshot to be downloaded and restored
-cluster_snapshot:
-    storage_volume_name: my_s3_volume #defined in storage_volumes
-    cluster_service_id: f7265e80-631c-44d3-a8ac-cf7cdc7adec811019
-    cluster_snapshot_name: automated_cluster_snapshot_1704038400000
+# cluster_snapshot:
+#     storage_volume_name: my_s3_volume #defined in storage_volumes
+#     cluster_service_id: f7265e80-631c-44d3-a8ac-cf7cdc7adec811019
+#     cluster_snapshot_name: automated_cluster_snapshot_1704038400000
 
 # do not include leader fe
 frontends:


### PR DESCRIPTION
## What I'm doing:
Add config in cluster_snapshot.yaml, then the snapshot will be downloaded to local automatically. 
Config example:
```
cluster_snapshot:
    storage_volume_name: my_s3_volume #defined in storage_volumes
    cluster_service_id: f7265e80-631c-44d3-a8ac-cf7cdc7adec811019
    cluster_snapshot_name: automated_cluster_snapshot_1704038400000
```
If there is no cluster_snapshot config in cluster_snapshot.yaml, it will not download a snapshot automatically, users could download a snapshot manually.

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0