### PR TITLE
[BugFix] Fix wrong plan when apply offset limit in PushDown Project limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownProjectLimitRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownProjectLimitRule.java
@@ -54,6 +54,11 @@ public class PushDownProjectLimitRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression project, OptimizerContext context) {
         LogicalLimitOperator limit = (LogicalLimitOperator) project.getInputs().get(0).getOp();
+        if (project.getOp().hasLimit() && limit.hasOffset()) {
+            long projectLimit = project.getOp().getLimit();
+            project.getOp().setLimit(limit.getOffset() + limit.getLimit());
+            limit.setLimit(Math.min(projectLimit, limit.getLimit()));
+        }
         return Lists.newArrayList(OptExpression.create(limit,
                 OptExpression.create(project.getOp(), project.getInputs().get(0).getInputs())));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownProjectLimitRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownProjectLimitRule.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.optimizer.rule.transformation;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
@@ -54,10 +55,9 @@ public class PushDownProjectLimitRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression project, OptimizerContext context) {
         LogicalLimitOperator limit = (LogicalLimitOperator) project.getInputs().get(0).getOp();
+        // clear the project limit when limit has offset
         if (project.getOp().hasLimit() && limit.hasOffset()) {
-            long projectLimit = project.getOp().getLimit();
-            project.getOp().setLimit(limit.getOffset() + limit.getLimit());
-            limit.setLimit(Math.min(projectLimit, limit.getLimit()));
+            project.getOp().setLimit(Operator.DEFAULT_LIMIT);
         }
         return Lists.newArrayList(OptExpression.create(limit,
                 OptExpression.create(project.getOp(), project.getInputs().get(0).getInputs())));


### PR DESCRIPTION
## Why I'm doing:
for such query:
```
select count(*) from (select c0 from (   select * from (   select c0, c1 from tx3 order by c0 asc limit 1000, 600   ) l  union all select 0 as c0, '0' as c1 ) b limit 100)t;
```
the local sort expected limit with 1100.

```
  2:TOP-N
  |  order by: <slot 1> 1: v1 ASC
  |  offset: 0
  |  limit: 1100
  |  
  1:OlapScanNode
     TABLE: t0
     PREAGGREGATION: ON
     partitions=0/1
     rollup: t0
     tabletRatio=0/0
     tabletList=
     cardinality=1
     avgRowSize=1.0
```
but we got a limit 100
```
  2:TOP-N
  |  order by: <slot 1> 1: v1 ASC
  |  offset: 0
  |  limit: 100
  |  
  1:OlapScanNode
     TABLE: t0
     PREAGGREGATION: ON
     partitions=0/1
     rollup: t0
     tabletRatio=0/0
     tabletList=
     cardinality=1
     avgRowSize=1.0
```


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0