### PR TITLE
[Enhancement] statistics query error message retargeting from fe.out to fe.log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorColumnStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorColumnStatsCacheLoader.java
@@ -20,15 +20,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.statistics.ColumnBasicStatsCacheLoader;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.statistic.StatisticExecutor;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.TStatisticData;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.ArrayList;
@@ -60,7 +59,8 @@ public class ConnectorColumnStatsCacheLoader implements
                     return Optional.empty();
                 }
             } catch (RuntimeException e) {
-                throw e;
+                LOG.error(e);
+                return Optional.empty();
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {
@@ -73,6 +73,12 @@ public class ConnectorColumnStatsCacheLoader implements
     public CompletableFuture<Map<@NonNull ConnectorTableColumnKey, @NonNull Optional<ConnectorTableColumnStats>>> asyncLoadAll(
             @NonNull Iterable<? extends @NonNull ConnectorTableColumnKey> keys, @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
+            Map<ConnectorTableColumnKey, Optional<ConnectorTableColumnStats>> result = Maps.newHashMap();
+            // There may be no statistics for the column in BE
+            // Complete the list of statistics information, otherwise the columns without statistics may be called repeatedly
+            for (ConnectorTableColumnKey cacheKey : keys) {
+                result.put(cacheKey, Optional.empty());
+            }
 
             try {
                 String tableUUID = null;
@@ -85,12 +91,6 @@ public class ConnectorColumnStatsCacheLoader implements
                 ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
                 statsConnectCtx.setThreadLocalInfo();
                 List<TStatisticData> statisticData = queryStatisticsData(statsConnectCtx, tableUUID, columns);
-                Map<ConnectorTableColumnKey, Optional<ConnectorTableColumnStats>> result = Maps.newHashMap();
-                // There may be no statistics for the column in BE
-                // Complete the list of statistics information, otherwise the columns without statistics may be called repeatedly
-                for (ConnectorTableColumnKey cacheKey : keys) {
-                    result.put(cacheKey, Optional.empty());
-                }
 
                 for (TStatisticData data : statisticData) {
                     ConnectorTableColumnStats columnStatistic = convert2ColumnStatistics(tableUUID, data);
@@ -99,7 +99,8 @@ public class ConnectorColumnStatsCacheLoader implements
                 }
                 return result;
             } catch (RuntimeException e) {
-                throw e;
+                LOG.error(e);
+                return result;
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {
@@ -115,19 +116,16 @@ public class ConnectorColumnStatsCacheLoader implements
         return asyncLoad(key, executor);
     }
 
-    public List<TStatisticData> queryStatisticsData(ConnectContext context, String tableUUID, String column)
-            throws AnalysisException {
+    public List<TStatisticData> queryStatisticsData(ConnectContext context, String tableUUID, String column) {
         return queryStatisticsData(context, tableUUID, ImmutableList.of(column));
     }
 
-    public List<TStatisticData> queryStatisticsData(ConnectContext context, String tableUUID, List<String> columns)
-            throws AnalysisException {
+    public List<TStatisticData> queryStatisticsData(ConnectContext context, String tableUUID, List<String> columns) {
         Table table = getTableByUUID(tableUUID);
         return statisticExecutor.queryStatisticSync(context, tableUUID, table, columns);
     }
 
-    private ConnectorTableColumnStats convert2ColumnStatistics(String tableUUID, TStatisticData statisticData)
-            throws AnalysisException {
+    private ConnectorTableColumnStats convert2ColumnStatistics(String tableUUID, TStatisticData statisticData) {
         Table table = getTableByUUID(tableUUID);
         Type columnType = StatisticUtils.getQueryStatisticsColumnType(table, statisticData.columnName);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
@@ -63,7 +63,8 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
                     return Optional.empty();
                 }
             } catch (RuntimeException e) {
-                throw e;
+                LOG.error(e);
+                return Optional.empty();
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {
@@ -77,14 +78,15 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
             @NonNull Iterable<? extends @NonNull ColumnStatsCacheKey> keys, @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
             Map<ColumnStatsCacheKey, Optional<Histogram>> result = new HashMap<>();
+            long tableId = -1;
+            List<String> columns = new ArrayList<>();
+            for (ColumnStatsCacheKey key : keys) {
+                tableId = key.tableId;
+                columns.add(key.column);
+                result.put(key, Optional.empty());
+            }
+
             try {
-                long tableId = -1;
-                List<String> columns = new ArrayList<>();
-                for (ColumnStatsCacheKey key : keys) {
-                    tableId = key.tableId;
-                    columns.add(key.column);
-                    result.put(key, Optional.empty());
-                }
                 ConnectContext connectContext = StatisticUtils.buildConnectContext();
                 connectContext.setThreadLocalInfo();
 
@@ -97,7 +99,8 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
 
                 return result;
             } catch (RuntimeException e) {
-                throw e;
+                LOG.error(e);
+                return result;
             } catch (Exception e) {
                 throw new CompletionException(e);
             } finally {


### PR DESCRIPTION

## Why I'm doing:
statistics query error logs should not be printed to fe.out

stderr log 
```
Dec 09, 2024 7:44:34 PM com.github.benmanes.caffeine.cache.LocalAsyncCache$AsyncBulkCompleter accept
WARNING: Exception thrown during asynchronous load
java.util.concurrent.CompletionException: com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Statistics query fail | Error Message [get_applied_rowsets(version 319476) failed tablet:10054 #version:71 [319668.1 319724.1@70 319724.1] #pending:0 cost (0/0/0) backend [id=10004] [host=10.11.3.9]] | QueryId [9c60ad78-b65d-11ef-acdd-000d3aac56ec] | SQL [select cast(3 as INT), partition_id, any_value(row_count) FROM column_statistics WHERE table_id = 6421490 and partition_id in (10620002) GROUP BY partition_id].
        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:314)
        at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:319)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1702)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Statistics query fail | Error Message [get_applied_rowsets(version 319476) failed tablet:10054 #version:71 [319668.1 319724.1@70 319724.1] #pending:0 cost (0/0/0) backend [id=10004] [host=10.11.3.9]] | QueryId [9c60ad78-b65d-11ef-acdd-000d3aac56ec] | SQL [select cast(3 as INT), partition_id, any_value(row_count) FROM column_statistics WHERE table_id = 6421490 and partition_id in (10620002) GROUP BY partition_id].
        at com.starrocks.statistic.StatisticExecutor.executeDQL(StatisticExecutor.java:497)
        at com.starrocks.statistic.StatisticExecutor.executeStatisticDQL(StatisticExecutor.java:447)
        at com.starrocks.statistic.StatisticExecutor.queryTableStats(StatisticExecutor.java:291)
        at com.starrocks.sql.optimizer.statistics.TableStatsCacheLoader.lambda$asyncLoadAll$2(TableStatsCacheLoader.java:70)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
        ... 3 more

Dec 09, 2024 7:44:35 PM com.github.benmanes.caffeine.cache.LocalAsyncCache$AsyncBulkCompleter accept
WARNING: Exception thrown during asynchronous load
java.util.concurrent.CompletionException: com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Statistics query fail | Error Message [get_applied_rowsets(version 319476) failed tablet:10066 #version:71 [319668.1 319724.1@70 319724.1] #pending:0 cost (0/0/0) backend [id=10004] [host=10.11.3.9]] | QueryId [9c75951d-b65d-11ef-acdd-000d3aac56ec] | SQL [select cast(3 as INT), partition_id, any_value(row_count) FROM column_statistics WHERE table_id = 15071 and partition_id in (32579, 32834, 32193, 33344, 22654, 33229, 32649, 34633, 31560, 31816, 7551218, 16337, 21969, 34460, 885772, 32474, 33945, 30936, 32728, 10041211, 33623, 32036, 34084, 22561, 31137, 33057, 15070, 32350, 22765, 31340, 34283, 310819, 21478, 22310, 32949, 60987, 22141, 21564, 33145, 33464, 33784, 22455) GROUP BY partition_id].
        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:314)
        at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:319)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1702)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Statistics query fail | Error Message [get_applied_rowsets(version 319476) failed tablet:10066 #version:71 [319668.1 319724.1@
70 319724.1] #pending:0 cost (0/0/0) backend [id=10004] [host=10.11.3.9]] | QueryId [9c75951d-b65d-11ef-acdd-000d3aac56ec] | SQL [select cast(3 as INT), partition_id, any_value(row_count) FROM column_statistics WHERE table_i
d = 15071 and partition_id in (32579, 32834, 32193, 33344, 22654, 33229, 32649, 34633, 31560, 31816, 7551218, 16337, 21969, 34460, 885772, 32474, 33945, 30936, 32728, 10041211, 33623, 32036, 34084, 22561, 31137, 33057, 15070
, 32350, 22765, 31340, 34283, 310819, 21478, 22310, 32949, 60987, 22141, 21564, 33145, 33464, 33784, 22455) GROUP BY partition_id].
        at com.starrocks.statistic.StatisticExecutor.executeDQL(StatisticExecutor.java:497)
        at com.starrocks.statistic.StatisticExecutor.executeStatisticDQL(StatisticExecutor.java:447)
        at com.starrocks.statistic.StatisticExecutor.queryTableStats(StatisticExecutor.java:291)
        at com.starrocks.sql.optimizer.statistics.TableStatsCacheLoader.lambda$asyncLoadAll$2(TableStatsCacheLoader.java:70)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
        ... 3 more
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0