### PR TITLE
[BugFix] fix incorrect part of compaction profile

### DIFF
--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -35,7 +35,7 @@ CompactionTask::CompactionTask(VersionedTablet tablet, std::vector<std::shared_p
 
 Status CompactionTask::execute_index_major_compaction(TxnLogPB* txn_log) {
     if (_tablet.get_schema()->keys_type() == KeysType::PRIMARY_KEYS) {
-        SCOPED_RAW_TIMER(&_context->stats->sst_merge_ns);
+        SCOPED_RAW_TIMER(&_context->stats->pk_sst_merge_ns);
         auto metadata = _tablet.metadata();
         if (metadata->enable_persistent_index() &&
             metadata->persistent_index_type() == PersistentIndexTypePB::CLOUD_NATIVE) {

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -46,6 +46,8 @@ CompactionTaskStats CompactionTaskStats::operator+(const CompactionTaskStats& th
     diff.column_iterator_init_ns = column_iterator_init_ns + that.column_iterator_init_ns;
     diff.io_count_local_disk = io_count_local_disk + that.io_count_local_disk;
     diff.io_count_remote = io_count_remote + that.io_count_remote;
+    diff.in_queue_time_sec = in_queue_time_sec + that.in_queue_time_sec;
+    diff.pk_sst_merge_ns = pk_sst_merge_ns + that.pk_sst_merge_ns;
     return diff;
 }
 
@@ -59,6 +61,8 @@ CompactionTaskStats CompactionTaskStats::operator-(const CompactionTaskStats& th
     diff.column_iterator_init_ns = column_iterator_init_ns - that.column_iterator_init_ns;
     diff.io_count_local_disk = io_count_local_disk - that.io_count_local_disk;
     diff.io_count_remote = io_count_remote - that.io_count_remote;
+    diff.in_queue_time_sec = in_queue_time_sec - that.in_queue_time_sec;
+    diff.pk_sst_merge_ns = pk_sst_merge_ns - that.pk_sst_merge_ns;
     return diff;
 }
 
@@ -77,7 +81,7 @@ std::string CompactionTaskStats::to_json_stats() {
     root.AddMember("column_iterator_init_sec", rapidjson::Value(column_iterator_init_ns / TIME_UNIT_NS_PER_SECOND),
                    allocator);
     root.AddMember("in_queue_sec", rapidjson::Value(in_queue_time_sec), allocator);
-    root.AddMember("sst_merge_sec", rapidjson::Value(sst_merge_ns / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("pk_sst_merge_sec", rapidjson::Value(pk_sst_merge_ns / TIME_UNIT_NS_PER_SECOND), allocator);
 
     rapidjson::StringBuffer strbuf;
     rapidjson::Writer<rapidjson::StringBuffer> writer(strbuf);

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -49,7 +49,7 @@ struct CompactionTaskStats {
     int64_t io_count_local_disk = 0;
     int64_t io_count_remote = 0;
     int64_t in_queue_time_sec = 0;
-    int64_t sst_merge_ns = 0;
+    int64_t pk_sst_merge_ns = 0;
 
     void collect(const OlapReaderStatistics& reader_stats);
     CompactionTaskStats operator+(const CompactionTaskStats& that) const;

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -70,6 +70,8 @@ TEST_F(CompactionTaskContextTest, test_calculation) {
     reader_stats.compressed_bytes_read_remote = 1024;
     reader_stats.compressed_bytes_read_local_disk = 1024;
 
+    stats.in_queue_time_sec = 5;
+    stats.pk_sst_merge_ns = 5;
     stats.collect(reader_stats);
 
     EXPECT_EQ(stats.io_ns_remote, 200);
@@ -80,6 +82,8 @@ TEST_F(CompactionTaskContextTest, test_calculation) {
     EXPECT_EQ(stats.io_count_remote, 700);
     EXPECT_EQ(stats.io_bytes_read_remote, 1024);
     EXPECT_EQ(stats.io_bytes_read_local_disk, 1024);
+    EXPECT_EQ(stats.in_queue_time_sec, 5);
+    EXPECT_EQ(stats.pk_sst_merge_ns, 5);
 
     CompactionTaskStats after_add = stats + stats;
 
@@ -91,6 +95,8 @@ TEST_F(CompactionTaskContextTest, test_calculation) {
     EXPECT_EQ(after_add.io_count_remote, 1400);
     EXPECT_EQ(after_add.io_bytes_read_remote, 2048);
     EXPECT_EQ(after_add.io_bytes_read_local_disk, 2048);
+    EXPECT_EQ(after_add.in_queue_time_sec, 10);
+    EXPECT_EQ(after_add.pk_sst_merge_ns, 10);
 
     CompactionTaskStats after_minus = stats - stats;
 
@@ -102,6 +108,8 @@ TEST_F(CompactionTaskContextTest, test_calculation) {
     EXPECT_EQ(after_minus.io_count_remote, 0);
     EXPECT_EQ(after_minus.io_bytes_read_remote, 0);
     EXPECT_EQ(after_minus.io_bytes_read_local_disk, 0);
+    EXPECT_EQ(after_minus.in_queue_time_sec, 0);
+    EXPECT_EQ(after_minus.pk_sst_merge_ns, 0);
 }
 
 TEST_F(CompactionTaskContextTest, test_to_json_stats) {
@@ -118,6 +126,7 @@ TEST_F(CompactionTaskContextTest, test_to_json_stats) {
     context.stats->segment_init_ns = 3 * TIME_UNIT_NS_PER_SECOND;
     context.stats->column_iterator_init_ns = 4 * TIME_UNIT_NS_PER_SECOND;
     context.stats->in_queue_time_sec = 5;
+    context.stats->pk_sst_merge_ns = 5 * TIME_UNIT_NS_PER_SECOND;
 
     // Call the method under test
     std::string json_stats = context.stats->to_json_stats();
@@ -130,5 +139,6 @@ TEST_F(CompactionTaskContextTest, test_to_json_stats) {
     EXPECT_THAT(json_stats, testing::HasSubstr(R"("read_remote_count":3)"));
     EXPECT_THAT(json_stats, testing::HasSubstr(R"("read_local_count":2)"));
     EXPECT_THAT(json_stats, testing::HasSubstr(R"("in_queue_sec":5)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("pk_sst_merge_sec":5)"));
 }
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

in_queue_time_sec is 0 when it is actually not sometimes.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0