### PR TITLE
[BugFix] Fixed compatibility bug when using jdk17 to compile into jdk8 bytecode

### DIFF
--- a/fe/fe-common/pom.xml
+++ b/fe/fe-common/pom.xml
@@ -35,9 +35,6 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
         <starrocks.home>${basedir}/../../</starrocks.home>
         <!-- There is no unit tests for this project, ignore the error if no case found -->
         <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
@@ -80,6 +77,14 @@ under the License.
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <failIfNoSpecifiedTests>${failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>8</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/fe/hive-udf/pom.xml
+++ b/fe/hive-udf/pom.xml
@@ -31,10 +31,6 @@
     </dependencies>
 
     <properties>
-        <!-- Do not change the version unless all udf runtime environments have upgraded JDK to a higher version.  -->
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
         <!-- There is no unit tests for this project, ignore the error if no case found -->
         <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
     </properties>
@@ -84,6 +80,15 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <failIfNoSpecifiedTests>${failIfNoSpecifiedTests}</failIfNoSpecifiedTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <!-- Do not change the version unless all udf runtime environments have upgraded JDK to a higher version.  -->
+                <configuration>
+                    <release>8</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/fe/plugin-common/pom.xml
+++ b/fe/plugin-common/pom.xml
@@ -33,9 +33,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
         <starrocks.home>${basedir}/../../</starrocks.home>
         <fe_ut_parallel>1</fe_ut_parallel>
     </properties>
@@ -54,6 +51,14 @@
                     <argLine>
                         -javaagent:${settings.localRepository}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar
                     </argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>8</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/fe/spark-dpp/pom.xml
+++ b/fe/spark-dpp/pom.xml
@@ -35,10 +35,6 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <!-- Do not change the version unless all external Spark clusters have upgraded JDK to a higher version.  -->
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
         <starrocks.home>${basedir}/../../</starrocks.home>
         <fe_ut_parallel>1</fe_ut_parallel>
     </properties>
@@ -434,6 +430,15 @@ under the License.
                             </pluginExecutions>
 
                         </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                    <!-- Do not change the version unless all external Spark clusters have upgraded JDK to a higher version.  -->
+                    <configuration>
+                        <release>8</release>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
## Why I'm doing:
Using the <maven.compiler.release>8</maven.compiler.release> configuration will use a too old version of the maven-compiler-plugin.

Use the latest version of maven-compiler-plugin to use the `javac -release` function

https://openjdk.org/jeps/247

## What I'm doing:

Fixes #https://github.com/StarRocks/StarRocksTest/issues/9011

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0