### PR TITLE
[Enhancement] Open or close interval need to be considered when using runtime filter to process zonemap.

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -774,8 +774,16 @@ public:
     // [min_value, max_value] overlapped with [min, max]
     bool filter_zonemap_with_min_max(const CppType* min_value, const CppType* max_value) const {
         if (min_value == nullptr || max_value == nullptr) return false;
-        if (*max_value < _min) return true;
-        if (*min_value > _max) return true;
+        if (_left_close_interval) {
+            if (*max_value < _min) return true;
+        } else {
+            if (*max_value <= _min) return true;
+        }
+        if (_right_close_interval) {
+            if (*min_value > _max) return true;
+        } else {
+            if (*min_value >= _max) return true;
+        }
         return false;
     }
 

--- a/be/test/exprs/runtime_filter_test.cpp
+++ b/be/test/exprs/runtime_filter_test.cpp
@@ -42,6 +42,32 @@ protected:
     ObjectPool _pool;
 };
 
+TEST_F(RuntimeBloomFilterTest, filter_zonemap_with_min_max) {
+    // > 10
+    auto* rf = Int32RF::create_with_range<true>(&_pool, 10, false);
+    int32_t min = 5;
+    int32_t max = 10;
+    ASSERT_TRUE(rf->filter_zonemap_with_min_max(&min, &max));
+
+    // >= 10
+    rf = Int32RF::create_with_range<true>(&_pool, 10, true);
+    min = 5;
+    max = 10;
+    ASSERT_FALSE(rf->filter_zonemap_with_min_max(&min, &max));
+
+    // < 10
+    rf = Int32RF::create_with_range<false>(&_pool, 10, false);
+    min = 10;
+    max = 15;
+    ASSERT_TRUE(rf->filter_zonemap_with_min_max(&min, &max));
+
+    // <= 10
+    rf = Int32RF::create_with_range<false>(&_pool, 10, true);
+    min = 10;
+    max = 15;
+    ASSERT_FALSE(rf->filter_zonemap_with_min_max(&min, &max));
+}
+
 TEST_F(RuntimeBloomFilterTest, create_with_empty_range) {
     auto* rf = Int32RF::create_with_empty_range_without_null(&_pool);
     ASSERT_TRUE(rf->is_empty_range());

--- a/be/test/exprs/runtime_filter_test.cpp
+++ b/be/test/exprs/runtime_filter_test.cpp
@@ -55,6 +55,10 @@ TEST_F(RuntimeBloomFilterTest, filter_zonemap_with_min_max) {
     max = 10;
     ASSERT_FALSE(rf->filter_zonemap_with_min_max(&min, &max));
 
+    min = 5;
+    max = 9;
+    ASSERT_TRUE(rf->filter_zonemap_with_min_max(&min, &max));
+
     // < 10
     rf = Int32RF::create_with_range<false>(&_pool, 10, false);
     min = 10;
@@ -66,6 +70,10 @@ TEST_F(RuntimeBloomFilterTest, filter_zonemap_with_min_max) {
     min = 10;
     max = 15;
     ASSERT_FALSE(rf->filter_zonemap_with_min_max(&min, &max));
+
+    min = 11;
+    max = 15;
+    ASSERT_TRUE(rf->filter_zonemap_with_min_max(&min, &max));
 }
 
 TEST_F(RuntimeBloomFilterTest, create_with_empty_range) {


### PR DESCRIPTION
## Why I'm doing:

When the column using topn runtime filter is low cardinality, the filtering effect is sometimes not very good, so we need to consider the open/close interval.

## What I'm doing:

Open or close interval need to be considered when using runtimeFilter to process zonemap.

```
mysql> select count(*) from t_lineorder;                                                                                                                                                                                                                                          
+----------+                                                                                                                                                                                                                                                                      
| count(*) |                                                                                                                                                                                                                                                                      
+----------+                                                                                                                                                                                                                                                                      
| 20000000 |                                                                                                                                                                                                                                                                      
+----------+                                                                                                                                                                                                                                                                      
1 row in set (0.07 sec)                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                  
mysql> select count(distinct lo_linenumber) from t_lineorder;                                                                                                                                                                                                                     
+-------------------------------+                                                                                                                                                                                                                                                 
| count(DISTINCT lo_linenumber) |                                                                                                                                                                                                                                                 
+-------------------------------+                                                                                                                                                                                                                                                 
|                             1 |                                                                                                                                                                                                                                                 
+-------------------------------+                                                                                                                                                                                                                                                 
1 row in set (0.26 sec)
```

Before the pr: 3.02s
```
mysql> select * from t_lineorder order by lo_linenumber asc limit 5;
...
5 rows in set (3.02 sec)
```

After the pr: 0.69s
```
mysql> select * from t_lineorder order by lo_linenumber asc limit 5;                                                                                                                                                                                                              
...
5 rows in set (0.69 sec)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0