### PR TITLE
[BugFix] Fix wrong decimal32 type when converted from thrift

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
@@ -265,7 +265,7 @@ public enum PrimitiveType {
             case PERCENTILE:
                 return PERCENTILE;
             case DECIMAL32:
-                return DECIMALV2;
+                return DECIMAL32;
             case DECIMAL64:
                 return DECIMAL64;
             case DECIMAL128:


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

https://github.com/StarRocks/starrocks/pull/54583 this pr promotes decimal type by precision, and `decimal32` will be used.
but `decimal32` type is converted to `decimalv2` in FE `PrimitiveType.fromThrift`.
fix this.

Fixes https://github.com/StarRocks/StarRocksTest/issues/9052

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0