### PR TITLE
[Enhancement] RuntimeFilter::_evaluate_min_max need to consider the open/close interval

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -598,6 +598,8 @@ public:
 
     CppType max_value() const { return _max; }
 
+    void set_left_close_interval(bool close_interval) { _left_close_interval = close_interval; }
+    void set_right_close_interval(bool close_interval) { _right_close_interval = close_interval; }
     bool left_close_interval() const { return _left_close_interval; }
     bool right_close_interval() const { return _right_close_interval; }
 
@@ -888,8 +890,26 @@ private:
     void _evaluate_min_max(const ContainerType& values, uint8_t* selection, size_t size) const {
         if constexpr (!IsSlice<CppType>) {
             const auto* data = values.data();
-            for (size_t i = 0; i < size; i++) {
-                selection[i] = (data[i] >= _min && data[i] <= _max);
+            if (_left_close_interval) {
+                if (_right_close_interval) {
+                    for (size_t i = 0; i < size; i++) {
+                        selection[i] = (data[i] >= _min && data[i] <= _max);
+                    }
+                } else {
+                    for (size_t i = 0; i < size; i++) {
+                        selection[i] = (data[i] >= _min && data[i] < _max);
+                    }
+                }
+            } else {
+                if (_right_close_interval) {
+                    for (size_t i = 0; i < size; i++) {
+                        selection[i] = (data[i] > _min && data[i] <= _max);
+                    }
+                } else {
+                    for (size_t i = 0; i < size; i++) {
+                        selection[i] = (data[i] > _min && data[i] < _max);
+                    }
+                }
             }
         } else {
             memset(selection, 0x1, size);

--- a/be/src/exprs/runtime_filter_bank.h
+++ b/be/src/exprs/runtime_filter_bank.h
@@ -285,10 +285,8 @@ public:
     }
 
 private:
-    void update_selectivity(Chunk* chunk);
     void update_selectivity(Chunk* chunk, RuntimeBloomFilterEvalContext& eval_context);
     // TODO: return a funcion call status
-    void do_evaluate(Chunk* chunk);
     void do_evaluate(Chunk* chunk, RuntimeBloomFilterEvalContext& eval_context);
     void do_evaluate_partial_chunk(Chunk* partial_chunk, RuntimeBloomFilterEvalContext& eval_context);
     // mapping from filter id to runtime filter descriptor.


### PR DESCRIPTION
## Why I'm doing:

RuntimeFilter::evaluate is used by operator to filter rows, it's also need to consider the open/close interval

## What I'm doing:

RuntimeFilter::_evaluate_min_max need to consider the open/close interval

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0