### PR TITLE
[Feature] pinot sql transformation to sr sql with date function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.ast.MapExpr;
 import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
+import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
@@ -169,6 +170,15 @@ public class AstToSQLBuilder {
 
             if (selectList.isDistinct()) {
                 sqlBuilder.append("DISTINCT ");
+            }
+
+            //get catalog. database, tablename
+            Relation selectRelation = stmt.getRelation();
+            if (selectRelation instanceof TableRelation) {
+                TableRelation tableRelation = (TableRelation) stmt.getRelation();
+                QueryContext queryContext = new QueryContext(tableRelation.getName().getCatalog(),
+                        tableRelation.getName().getDb(), tableRelation.getName().getTbl());
+                QueryContext.setContext(queryContext);
             }
 
             List<String> selectListString = new ArrayList<>();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -163,86 +163,91 @@ public class AstToSQLBuilder {
             SelectList selectList = stmt.getSelectList();
             sqlBuilder.append("SELECT ");
 
-            // add hint
-            if (selectList.getHintNodes() != null) {
-                sqlBuilder.append(extractHintStr(selectList.getHintNodes()));
-            }
+            try {
+                // add hint
+                if (selectList.getHintNodes() != null) {
+                    sqlBuilder.append(extractHintStr(selectList.getHintNodes()));
+                }
 
-            if (selectList.isDistinct()) {
-                sqlBuilder.append("DISTINCT ");
-            }
+                if (selectList.isDistinct()) {
+                    sqlBuilder.append("DISTINCT ");
+                }
 
-            //get catalog. database, tablename
-            Relation selectRelation = stmt.getRelation();
-            if (selectRelation instanceof TableRelation) {
-                TableRelation tableRelation = (TableRelation) stmt.getRelation();
-                QueryContext queryContext = new QueryContext(tableRelation.getName().getCatalog(),
-                        tableRelation.getName().getDb(), tableRelation.getName().getTbl());
-                QueryContext.setContext(queryContext);
-            }
+                // get catalog. database, table name
+                Relation selectRelation = stmt.getRelation();
+                if (selectRelation instanceof TableRelation) {
+                    TableRelation tableRelation = (TableRelation) stmt.getRelation();
+                    QueryContext queryContext = new QueryContext(tableRelation.getName().getCatalog(),
+                            tableRelation.getName().getDb(), tableRelation.getName().getTbl());
+                    QueryContext.setContext(queryContext);
+                }
 
-            List<String> selectListString = new ArrayList<>();
-            if (CollectionUtils.isNotEmpty(stmt.getOutputExpression())) {
-                for (int i = 0; i < stmt.getOutputExpression().size(); ++i) {
-                    Expr expr = stmt.getOutputExpression().get(i);
-                    String columnName = stmt.getColumnOutputNames().get(i);
+                List<String> selectListString = new ArrayList<>();
+                if (CollectionUtils.isNotEmpty(stmt.getOutputExpression())) {
+                    for (int i = 0; i < stmt.getOutputExpression().size(); ++i) {
+                        Expr expr = stmt.getOutputExpression().get(i);
+                        String columnName = stmt.getColumnOutputNames().get(i);
 
-                    if (expr instanceof FieldReference) {
-                        Field field = stmt.getScope().getRelationFields().getFieldByIndex(i);
-                        selectListString.add(buildColumnName(field.getRelationAlias(), field.getName(), columnName));
-                    } else if (expr instanceof SlotRef) {
-                        SlotRef slot = (SlotRef) expr;
-                        if (slot.getOriginType().isStructType()) {
-                            selectListString.add(buildStructColumnName(slot.getTblNameWithoutAnalyzed(),
-                                    slot.getColumnName(), columnName));
+                        if (expr instanceof FieldReference) {
+                            Field field = stmt.getScope().getRelationFields().getFieldByIndex(i);
+                            selectListString.add(buildColumnName(field.getRelationAlias(), field.getName(), columnName));
+                        } else if (expr instanceof SlotRef) {
+                            SlotRef slot = (SlotRef) expr;
+                            if (slot.getOriginType().isStructType()) {
+                                selectListString.add(buildStructColumnName(slot.getTblNameWithoutAnalyzed(),
+                                        slot.getColumnName(), columnName));
+                            } else {
+                                selectListString.add(buildColumnName(slot.getTblNameWithoutAnalyzed(), slot.getColumnName(),
+                                        columnName));
+                            }
                         } else {
-                            selectListString.add(buildColumnName(slot.getTblNameWithoutAnalyzed(), slot.getColumnName(),
-                                    columnName));
+                            selectListString.add(visit(expr) + " AS `" + columnName + "`");
                         }
-                    } else {
-                        selectListString.add(visit(expr) + " AS `" + columnName + "`");
+                    }
+                } else {
+                    for (SelectListItem item : stmt.getSelectList().getItems()) {
+                        if (item.isStar()) {
+                            if (item.getTblName() != null) {
+                                selectListString.add(item.getTblName() + ".*");
+                            } else {
+                                selectListString.add("*");
+                            }
+                        } else if (item.getExpr() != null) {
+                            Expr expr = item.getExpr();
+                            String str = visit(expr);
+                            if (StringUtils.isNotEmpty(item.getAlias())) {
+                                str += " AS " + ParseUtil.backquote(item.getAlias());
+                            }
+                            selectListString.add(str);
+                        }
                     }
                 }
-            } else {
-                for (SelectListItem item : stmt.getSelectList().getItems()) {
-                    if (item.isStar()) {
-                        if (item.getTblName() != null) {
-                            selectListString.add(item.getTblName() + ".*");
-                        } else {
-                            selectListString.add("*");
-                        }
-                    } else if (item.getExpr() != null) {
-                        Expr expr = item.getExpr();
-                        String str = visit(expr);
-                        if (StringUtils.isNotEmpty(item.getAlias())) {
-                            str += " AS " + ParseUtil.backquote(item.getAlias());
-                        }
-                        selectListString.add(str);
-                    }
+
+                sqlBuilder.append(Joiner.on(", ").join(selectListString));
+
+                String fromClause = visit(stmt.getRelation());
+                if (fromClause != null) {
+                    sqlBuilder.append("\nFROM ");
+                    sqlBuilder.append(fromClause);
                 }
-            }
 
-            sqlBuilder.append(Joiner.on(", ").join(selectListString));
+                if (stmt.hasWhereClause()) {
+                    sqlBuilder.append("\nWHERE ");
+                    sqlBuilder.append(visit(stmt.getWhereClause()));
+                }
 
-            String fromClause = visit(stmt.getRelation());
-            if (fromClause != null) {
-                sqlBuilder.append("\nFROM ");
-                sqlBuilder.append(fromClause);
-            }
+                if (stmt.hasGroupByClause()) {
+                    sqlBuilder.append("\nGROUP BY ");
+                    sqlBuilder.append(visit(stmt.getGroupByClause()));
+                }
 
-            if (stmt.hasWhereClause()) {
-                sqlBuilder.append("\nWHERE ");
-                sqlBuilder.append(visit(stmt.getWhereClause()));
-            }
-
-            if (stmt.hasGroupByClause()) {
-                sqlBuilder.append("\nGROUP BY ");
-                sqlBuilder.append(visit(stmt.getGroupByClause()));
-            }
-
-            if (stmt.hasHavingClause()) {
-                sqlBuilder.append("\nHAVING ");
-                sqlBuilder.append(visit(stmt.getHavingClause()));
+                if (stmt.hasHavingClause()) {
+                    sqlBuilder.append("\nHAVING ");
+                    sqlBuilder.append(visit(stmt.getHavingClause()));
+                }
+            } finally {
+                // clear context
+                QueryContext.clearContext();
             }
 
             return sqlBuilder.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PinotFunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PinotFunctionSet.java
@@ -1,0 +1,141 @@
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.Table;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class PinotFunctionSet {
+    public static final String DATETRUNC = "datetrunc";
+    public static final String DATETIMECONVERT = "datetimeconvert";
+    public static final String TODATETIME = "todatetime";
+    public static final String FROMDATETIME = "fromdatetime";
+
+    private static final Map<String, String> formatMapping = new HashMap<>();
+
+    private static final Set<String> dateFunctions = Set.of(FunctionSet.STR_TO_DATE, FunctionSet.DATE_SUB, FunctionSet.DATE_ADD, FunctionSet.TO_DATE, FunctionSet.DAYS_SUB, FunctionSet.TIMEDIFF,
+            FunctionSet.DATE_TRUNC, FunctionSet.CURRENT_TIMESTAMP, FunctionSet.NOW, FunctionSet.LOCALTIME, FunctionSet.LOCALTIMESTAMP, FunctionSet.TIMESTAMPADD, FunctionSet.YEARS_ADD, FunctionSet.WEEKS_SUB,
+            FunctionSet.WEEKS_ADD, FunctionSet.TIMESTAMP, FunctionSet.TIME_SLICE, FunctionSet.SECONDS_SUB, FunctionSet.SECONDS_ADD, FunctionSet.MONTHS_SUB, FunctionSet.MONTHS_ADD, FunctionSet.MINUTES_SUB, FunctionSet.MINUTES_ADD,
+            FunctionSet.MICROSECONDS_SUB, FunctionSet.MICROSECONDS_ADD, FunctionSet.HOURS_SUB, FunctionSet.HOURS_ADD, FunctionSet.CONVERT_TZ, FunctionSet.ADD_MONTHS);
+
+    static {
+        formatMapping.put("yyyy", "%Y");
+        formatMapping.put("MM", "%m");
+        formatMapping.put("dd", "%d");
+        formatMapping.put("HH", "%H");
+        formatMapping.put("mm", "%i");
+        formatMapping.put("ss", "%s");
+        formatMapping.put("SSS", "%f");
+        formatMapping.put("T", "T"); // Literal character
+        formatMapping.put("Z", "");  // Ignoring timezone as no direct mapping is provided
+    }
+
+    public static String getShortenedTimeUnit(String timeUnit) {
+        switch (timeUnit) {
+            case "DAYS":
+                return "day";
+            case "HOURS":
+                return "hour";
+            case "MINUTES":
+                return "minute";
+            case "SECONDS":
+                return "second";
+            case "MILLISECONDS":
+                return "millisecond";
+            case "MICROSECONDS":
+                return "microsecond";
+            case "NANOSECONDS":
+                return "nanosecond";
+            default:
+                throw new IllegalArgumentException("Invalid time unit: " + timeUnit);
+        }
+    }
+
+    public static void replaceAll(StringBuilder sb, String oldStr, String newStr) {
+        int index = 0;
+        while ((index = sb.indexOf(oldStr, index)) != -1) {
+            sb.replace(index, index + oldStr.length(), newStr);
+            index += newStr.length();
+        }
+    }
+
+    public static String convertDateFormat(String javaFormat) {
+        StringBuilder specifiedFormat = new StringBuilder();
+        int i = 0;
+
+        while (i < javaFormat.length()) {
+            boolean matched = false;
+
+            // Check for multi-character patterns first
+            for (String javaPattern : formatMapping.keySet()) {
+                if (javaFormat.startsWith(javaPattern, i)) {
+                    specifiedFormat.append(formatMapping.get(javaPattern));
+                    i += javaPattern.length();
+                    matched = true;
+                    break;
+                }
+            }
+
+            // If no pattern matched, append the character as is
+            if (!matched) {
+                specifiedFormat.append(javaFormat.charAt(i));
+                i++;
+            }
+        }
+
+        return specifiedFormat.toString();
+    }
+
+    public static boolean isBigIntReturned(String nodeContent, Table table) {
+        if (table.containColumn(nodeContent)) {
+            PrimitiveType type = table.getColumn(nodeContent).getPrimitiveType();
+            return type == PrimitiveType.BIGINT;
+        }
+
+        if (isBigIntConstant(nodeContent) || isDatetimeConstant(nodeContent)) {
+            return isBigIntConstant(nodeContent);
+        }
+
+        if (isFunctionString(nodeContent)) {
+            return nodeContent.equalsIgnoreCase(DATETRUNC) || nodeContent.equalsIgnoreCase(DATETIMECONVERT);
+
+        }
+        return false;
+    }
+
+    public static boolean isDateTimeReturned(String nodeContent, Table table) {
+        if (table.containColumn(nodeContent)) {
+            PrimitiveType type = table.getColumn(nodeContent).getPrimitiveType();
+            return type == PrimitiveType.DATETIME;
+        }
+
+        if (isBigIntConstant(nodeContent) || isDatetimeConstant(nodeContent)) {
+            return isDatetimeConstant(nodeContent);
+        }
+
+        if (isFunctionString(nodeContent)) {
+            return dateFunctions.contains(nodeContent.toLowerCase());
+
+        }
+        return false;
+    }
+
+    private static boolean isBigIntConstant(String value) {
+        try {
+            Long.parseLong(value);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private static boolean isDatetimeConstant(String value) {
+        return value.matches("(\\d{4}-\\d{2}-\\d{2}( \\d{2}:\\d{2}:\\d{2})?)");
+    }
+
+    private static boolean isFunctionString(String value) {
+        return !isBigIntConstant(value) && !isDatetimeConstant(value) && value.matches("\\w+");
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PinotFunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PinotFunctionSet.java
@@ -4,6 +4,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Table;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -116,8 +117,8 @@ public class PinotFunctionSet {
         }
 
         if (isFunctionString(nodeContent)) {
-            return dateFunctions.contains(nodeContent.toLowerCase());
-
+            // Convert both the node content and the set entries to lower case for comparison, ensuring consistent case handling
+            return dateFunctions.contains(nodeContent.toLowerCase(Locale.ROOT));
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryContext.java
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.analyzer;
+
+public class QueryContext {
+    private static final ThreadLocal<QueryContext> CONTEXT_HOLDER = new ThreadLocal<>();
+
+    private String catalog;
+    private String database;
+    private String tableName;
+
+    public QueryContext(String catalog, String database, String tableName) {
+        this.catalog = catalog;
+        this.database = database;
+        this.tableName = tableName;
+    }
+
+    public static void setContext(QueryContext context) {
+        CONTEXT_HOLDER.set(context);
+    }
+
+    public static QueryContext getContext() {
+        return CONTEXT_HOLDER.get();
+    }
+
+    public static void clearContext() {
+        CONTEXT_HOLDER.remove();
+    }
+
+    public String getCatalog() {
+        return catalog;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryContext.java
@@ -27,7 +27,11 @@ public class QueryContext {
     }
 
     public static void setContext(QueryContext context) {
-        CONTEXT_HOLDER.set(context);
+        if (context == null) {
+            CONTEXT_HOLDER.remove();
+        } else {
+            CONTEXT_HOLDER.set(context);
+        }
     }
 
     public static QueryContext getContext() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/pinot/PinotQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/pinot/PinotQueryTest.java
@@ -1,0 +1,335 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.parser.pinot;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class PinotQueryTest extends PinotTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PinotTestBase.beforeClass();
+        starRocksAssert.getCtx().getSessionVariable().setCboPushDownAggregateMode(-1);
+    }
+
+    @Test
+    public void testSelectClause() throws Exception {
+        String sql = "select * from test.t0;";
+        assertPlanContains(sql, "OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3");
+
+        sql = "select * from test.t0 limit 100;";
+        assertPlanContains(sql, "limit: 100");
+
+        sql = "select \"v1\", \"v2\" from test.t0";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 4> : 'v1'\n" +
+                "  |  <slot 5> : 'v2'");
+    }
+
+    @Test
+    public void testSelectAggregation() throws Exception {
+        String sql = "select count(*) from test.t0";
+        assertPlanContains(sql, "2:AGGREGATE (update finalize)\n" +
+                "  |  output: count(*)");
+
+        sql = "select max(v1) from test.t0";
+        assertPlanContains(sql, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: max(1: v1)");
+
+        sql = "select sum(v2) from test.t0";
+        assertPlanContains(sql, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(2: v2)");
+    }
+
+    @Test
+    public void testSelectGroupingOnAggregation() throws Exception {
+        String sql = "select min(v1), max(v2) from test.t0 group by v3";
+        assertPlanContains(sql, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: min(1: v1), max(2: v2)\n" +
+                "  |  group by: 3: v3");
+    }
+
+    @Test
+    public void testSelectOrderingOnAggregation() throws Exception {
+        String sql = "select min(v1), max(v2) from test.t0 group by v3 order by min(v1)";
+
+        assertPlanContains(sql, "3:SORT\n" +
+                "  |  order by: <slot 4> 4: min ASC\n" +
+                "  |  offset: 0");
+    }
+
+    @Test
+    public void testSelectFilter() throws Exception {
+        String sql = "select * from test.t0 where v1 > 10";
+        assertPlanContains(sql, "PREDICATES: 1: v1 > 10");
+
+        sql = "select * from test.t0 where v1 > 10 and v2 < 20";
+        assertPlanContains(sql, "PREDICATES: 1: v1 > 10, 2: v2 < 20");
+
+        sql = "select * from test.t0 where v1 > 10 or v2 < 20";
+        assertPlanContains(sql, "PREDICATES: (1: v1 > 10) OR (2: v2 < 20)");
+
+        sql = "SELECT COUNT(*) \n" +
+                "FROM test.tall\n" +
+                "  WHERE ta = 'foo'\n" +
+                "  AND td BETWEEN 1 AND 20\n" +
+                "  OR (tg < 42 AND ta IN ('hello', 'goodbye') AND ta NOT IN (42, 69));";
+
+        assertPlanContains(sql, "PREDICATES: ((1: ta = 'foo') AND ((4: td >= 1) AND (4: td <= 20))) OR (((7: tg < 42) " +
+                "AND (1: ta IN ('hello', 'goodbye'))) AND (1: ta NOT IN ('42', '69'))), " +
+                "1: ta IN ('foo', 'hello', 'goodbye')");
+    }
+
+    @Test
+    public void testOrderOnSelection() throws Exception {
+        String sql = "select * from test.t0 order by v1";
+        assertPlanContains(sql, "1:SORT\n" +
+                "  |  order by: <slot 1> 1: v1 ASC\n" +
+                "  |  offset: 0");
+
+        sql = "select * from test.t0 order by v1 desc";
+        assertPlanContains(sql, "1:SORT\n" +
+                "  |  order by: <slot 1> 1: v1 DESC\n" +
+                "  |  offset: 0");
+
+        sql = "select * from test.t0 order by v1 desc, v2 asc";
+        assertPlanContains(sql, "1:SORT\n" +
+                "  |  order by: <slot 1> 1: v1 DESC, <slot 2> 2: v2 ASC\n" +
+                "  |  offset: 0");
+    }
+
+    @Test
+    public void testPaginationOnSelection() throws Exception {
+        String sql = "select v1, v2 from test.t0 where v2 > 10 order by v2 desc limit 10, 20";
+        assertPlanContains(sql, "2:MERGING-EXCHANGE\n" +
+                "     offset: 10\n" +
+                "     limit: 20");
+    }
+
+    @Test
+    public void testCaseWhen() throws Exception {
+        String sql = "select case when v1 > 10 then 1 else 0 end from test.t0";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 4> : if(1: v1 > 10, 1, 0)");
+
+        sql = "select sum(case when v1 > 10 then 1 when v1 < 10 then 0 else 2 end) as total_cost from test.t0";
+        assertPlanContains(sql, "");
+    }
+
+    @Test
+    public void testJoin() throws Exception {
+        String sql = "select * from test.t0 join test.t1 on t0.v1 = t1.v4";
+        assertPlanContains(sql, "4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select * from test.t0 join test.t1 on t0.v1 = t1.v4 join test.t2 on t0.v1 = t2.v7";
+        assertPlanContains(sql, "7:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 7: v7\n" +
+                "  |  \n" +
+                "  |----6:EXCHANGE\n" +
+                "  |    \n" +
+                "  4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select * from test.t0 left join test.t1 on t0.v1 = t1.v4";
+        assertPlanContains(sql, " 4:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select * from test.t0 right join test.t1 on t0.v1 = t1.v4";
+        assertPlanContains(sql, "4:HASH JOIN\n" +
+                "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select * from test.t0 full join test.t1 on t0.v1 = t1.v4";
+        assertPlanContains(sql, "4:HASH JOIN\n" +
+                "  |  join op: FULL OUTER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4");
+
+        sql = "select * from test.t0 join test.t1 on t0.v1 = t1.v4 where t0.v1 > 10";
+        assertPlanContains(sql, "PREDICATES: 1: v1 > 10");
+    }
+
+    @Test
+    public void testDateTruncFunction() throws Exception {
+        String sql = "select CAST(DATETRUNC('HOUR', th, 'MILLISECONDS') AS LARGEINT) AS \"time\" from test.tall";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : date_trunc('hour', 8: th)");
+
+        sql = "select DATETRUNC('DAY', tg) from test.tall";
+
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : date_trunc('day', CAST(from_unixtime(" +
+                "CAST(CAST(7: tg AS DOUBLE) / 1000.0 AS BIGINT)) AS DATETIME))");
+
+    }
+
+    @Test
+    public void testDateTimeConvertFunction() throws Exception {
+        String sql = "select DATETIMECONVERT(th, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '10:MINUTES') from test.tall";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : minutes_sub(date_trunc('minute', 8: th), CAST(minute(8: th) % 10 AS INT))");
+
+        sql = "select DATETIMECONVERT(tg, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '10:MINUTES') from test.tall";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : minutes_sub(date_trunc('minute', CAST(7: tg AS DATETIME)), " +
+                "CAST(minute(CAST(from_unixtime(CAST(CAST(7: tg AS DOUBLE) / 1000.0 AS BIGINT)) " +
+                "AS DATETIME)) % 10 AS INT))");
+    }
+
+    @Test
+    public void testToDateTimeFunction() throws Exception {
+        String sql = "select ToDateTime(th, 'yyyy-MM-dd') from test.tall";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : date_format(8: th, '%Y-%m-%d')");
+
+        sql = "select ToDateTime(tg, 'yyyy-MM-dd') from test.tall";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : from_unixtime(CAST(CAST(7: tg AS DOUBLE) / 1000.0 AS BIGINT), 'yyyy-MM-dd')");
+    }
+
+    @Test
+    public void testFromDateTimeFunction() throws Exception {
+        String sql = "select FromDateTime(tg, 'yyyy-MM-dd''T''HH:mm:ss.SSSZ') from test.tall";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : str_to_date(CAST(7: tg AS VARCHAR), '%Y-%m-%d\\'T\\'%H:%i:%s.%f')");
+    }
+
+    //actual case in the working environment
+    @Test
+    public void testDateTruncComplexFunction() throws Exception {
+        String sql = "SELECT\n" +
+                "    dateTrunc(\n" +
+                "        'hour',\n" +
+                "        td,\n" +
+                "        'MILLISECONDS',\n" +
+                "        'UTC',\n" +
+                "        'MILLISECONDS'\n" +
+                "    ) AS \"time\"\n" +
+                "FROM\n" +
+                "    test.tall";
+
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : date_trunc('hour', CAST(from_unixtime(CAST(CAST(4: td AS DOUBLE) " +
+                "/ 1000.0 AS BIGINT)) AS DATETIME))");
+
+        sql = "SELECT\n" +
+                "    DATETRUNC('DAY', th, 'MILLISECONDS') AS \"date\"\n" +
+                "FROM\n" +
+                "    test.tall\n";
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : date_trunc('day', 8: th)");
+
+        sql = "select CAST(\n" +
+                "        DATETRUNC(\n" +
+                "            'week',\n" +
+                "            th,\n" +
+                "            'MILLISECONDS',\n" +
+                "            'UTC',\n" +
+                "            'MILLISECONDS'\n" +
+                "        ) AS LARGEINT\n" +
+                "    ) AS \"time\" FROM\n" +
+                "    test.tall\n" +
+                "WHERE\n" +
+                "    \"th\" >= 1719541399910\n" +
+                "    AND \"th\" <= 1735093399910";
+
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : CAST(date_trunc('week', 8: th) AS LARGEINT)\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: tall\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: CAST('th' AS DOUBLE) >= 1.71954139991E12, " +
+                "CAST('th' AS DOUBLE) <= 1.73509339991E12");
+    }
+
+    @Test
+    public void testToDateTimeComplexFunction() throws Exception {
+        String sql = "select\n" +
+                "    Todatetime(datetrunc('DAY', tg), 'yyyy-MM-dd') as _timestamp from\n" +
+                "    test.tall\n" +
+                "where\n" +
+                "        tg >= Fromdatetime(\n" +
+                "        concat('2024-12-19', '00:00:00', ' '),\n" +
+                "        'yyyy-MM-dd HH:mm:ss'\n" +
+                "    )\n" +
+                "    AND tg <= Fromdatetime(\n" +
+                "        concat('2024-12-25', '23:59:59', ' '),\n" +
+                "        'yyyy-MM-dd HH:mm:ss'\n" +
+                "    )\n" +
+                "    AND Fromdatetime('2024-12-19', 'yyyy-MM-dd') <= tg";
+
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : from_unixtime(CAST(CAST(date_trunc('day', CAST(from_unixtime(CAST(CAST(7: tg AS DOUBLE) " +
+                "/ 1000.0 AS BIGINT)) AS DATETIME)) AS DOUBLE) / 1000.0 AS BIGINT), 'yyyy-MM-dd')\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: tall\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: CAST(7: tg AS DOUBLE) >= CAST(str_to_date('2024-12-1900:00:00 ', " +
+                "'%Y-%m-%d %H:%i:%s') AS DOUBLE), CAST(7: tg AS DOUBLE) " +
+                "<= CAST(str_to_date('2024-12-2523:59:59 ', '%Y-%m-%d %H:%i:%s') " +
+                "AS DOUBLE), 7: tg >= 20241219");
+
+
+        sql = "SELECT\n" +
+                "    Todatetime(\n" +
+                "        dateTrunc(\n" +
+                "            'day',\n" +
+                "            FromDateTime(\n" +
+                "                ToDateTime(\n" +
+                "                    FromDateTime(th, 'yyyy-MM-dd HH:mm:ss'),\n" +
+                "                    'yyyy-MM-dd',\n" +
+                "                    '+08:00'\n" +
+                "                ),\n" +
+                "                'yyyy-MM-dd'\n" +
+                "            ),\n" +
+                "            'MILLISECONDS'\n" +
+                "        ),\n" +
+                "        'YYYY-MM-dd'\n" +
+                "    ) AS __timestamp from\n" +
+                "    test.tall\n" +
+                "where\n" +
+                "     th >= SUBSTR('2024-12-17 16:04:12.151', 0, 19)\n" +
+                "    AND th <= '2024-12-24 16:04:12.151'\n" +
+                "    AND Fromdatetime(\n" +
+                "        '2024-12-17 16:04:12.151',\n" +
+                "        'yyyy-MM-dd HH:mm:ss.SSS'\n" +
+                "    ) <= tg";
+
+        assertPlanContains(sql, "1:Project\n" +
+                "  |  <slot 12> : from_unixtime(CAST(CAST(date_trunc('day', " +
+                "CAST(from_unixtime(CAST(CAST(str_to_date(from_unixtime(CAST(CAST(" +
+                "str_to_date(CAST(8: th AS VARCHAR), '%Y-%m-%d %H:%i:%s') AS DOUBLE) / 1000.0 AS BIGINT), 'yyyy-MM-dd'), " +
+                "'%Y-%m-%d') AS DOUBLE) / 1000.0 AS BIGINT)) AS DATETIME)) AS DOUBLE) / 1000.0 AS BIGINT), 'YYYY-MM-dd')\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: tall\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 8: th >= CAST('' AS DATETIME), 8: th <= '2024-12-24 16:04:12.151000', " +
+                "CAST(7: tg AS DOUBLE) >= CAST('2024-12-17 16:04:12.151000' AS DOUBLE)");
+    }
+
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/pinot/PinotTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/pinot/PinotTestBase.java
@@ -1,0 +1,172 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.parser.pinot;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import com.starrocks.planner.TpchSQL;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.LogicalPlanPrinter;
+import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.ErrorCollector;
+
+import java.util.List;
+
+public class PinotTestBase {
+    public static ConnectContext connectContext;
+    public static StarRocksAssert starRocksAssert;
+
+    @Rule
+    public ErrorCollector collector = new ErrorCollector();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        FeConstants.enablePruneEmptyOutputScan = false;
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        String dbName = "test";
+        starRocksAssert.withDatabase(dbName).useDatabase(dbName);
+        starRocksAssert.withTable("CREATE TABLE `t0` (\n" +
+                "  `v1` bigint NULL COMMENT \"\",\n" +
+                "  `v2` bigint NULL COMMENT \"\",\n" +
+                "  `v3` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`, `v2`, v3)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE `t1` (\n" +
+                "  `v4` bigint NULL COMMENT \"\",\n" +
+                "  `v5` bigint NULL COMMENT \"\",\n" +
+                "  `v6` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v4`, `v5`, v6)\n" +
+                "DISTRIBUTED BY HASH(`v4`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE `t2` (\n" +
+                "  `v7` bigint NULL COMMENT \"\",\n" +
+                "  `v8` bigint NULL COMMENT \"\",\n" +
+                "  `v9` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v7`, `v8`, v9)\n" +
+                "DISTRIBUTED BY HASH(`v7`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE `t3` (\n" +
+                "`day` int NULL COMMENT \"\") \n" +
+                "PROPERTIES ('replication_num' = '1')");
+
+        starRocksAssert.withTable("CREATE TABLE `tall` (\n" +
+                "  `ta` varchar(20) NULL COMMENT \"\",\n" +
+                "  `tb` smallint(6) NULL COMMENT \"\",\n" +
+                "  `tc` int(11) NULL COMMENT \"\",\n" +
+                "  `td` bigint(20) NULL COMMENT \"\",\n" +
+                "  `te` float NULL COMMENT \"\",\n" +
+                "  `tf` double NULL COMMENT \"\",\n" +
+                "  `tg` bigint(20) NULL COMMENT \"\",\n" +
+                "  `th` datetime NULL COMMENT \"\",\n" +
+                "  `ti` date NULL COMMENT \"\",\n" +
+                "  `tj` decimal(9, 3) NULL COMMENT \"\",\n" +
+                "  `tk` varbinary NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`ta`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`ta`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
+        starRocksAssert.withTable(TpchSQL.REGION);
+        starRocksAssert.withTable(TpchSQL.SUPPLIER);
+        starRocksAssert.withTable(TpchSQL.PARTSUPP);
+        starRocksAssert.withTable(TpchSQL.ORDERS);
+        starRocksAssert.withTable(TpchSQL.CUSTOMER);
+        starRocksAssert.withTable(TpchSQL.NATION);
+        starRocksAssert.withTable(TpchSQL.PART);
+        starRocksAssert.withTable(TpchSQL.LINEITEM);
+
+        starRocksAssert.withTable("create table test_array(c0 INT, " +
+                "c1 array<varchar(65533)>, " +
+                "c2 array<int>) " +
+                " duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+
+        FeConstants.runningUnitTest = true;
+        starRocksAssert.withTable("create table test_struct(c0 INT, " +
+                "c1 struct<a array<struct<b int>>>," +
+                "c2 struct<a int,b double>) " +
+                " duplicate key(c0) distributed by hash(c0) buckets 1 " +
+                "properties('replication_num'='1');");
+
+        starRocksAssert.withTable("create table test_map(c0 int, " +
+                "c1 map<int,int>, " +
+                "c2 array<map<int,int>>, " +
+                "c3 map<varchar(65533), date>) " +
+                "engine=olap distributed by hash(c0) buckets 10 " +
+                "properties('replication_num'='1');");
+
+        FeConstants.runningUnitTest = false;
+
+        connectContext.getSessionVariable().setSqlDialect("pinot");
+        connectContext.getSessionVariable().setCboPushDownGroupingSet(false);
+    }
+
+    protected void assertPlanContains(String sql, String... explain) throws Exception {
+        String explainString = getFragmentPlan(sql);
+
+        for (String expected : explain) {
+            Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
+                    StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
+        }
+    }
+
+    public String getFragmentPlan(String sql) throws Exception {
+        return getPlanAndFragment(connectContext, sql).second.getExplainString(TExplainLevel.NORMAL);
+    }
+
+    public static Pair<String, ExecPlan> getPlanAndFragment(ConnectContext connectContext, String originStmt)
+            throws Exception {
+        connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
+
+        List<StatementBase> statements =
+                com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable());
+        connectContext.getDumpInfo().setOriginStmt(originStmt);
+        StatementBase statementBase = statements.get(0);
+
+        ExecPlan execPlan = StatementPlanner.plan(statementBase, connectContext);
+        return new Pair<>(LogicalPlanPrinter.print(execPlan.getPhysicalPlan()), execPlan);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
We have many pinot sqls in the prod environment when we try to migrate the pinot to starrocks. We hope the starrocks can support the sql transformation automatically.


## What I'm doing:
To support the sql transformation from pinot sql to starrocks sql when use some date functions.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0