### PR TITLE
[BugFix] reset delta rows of basic meta after collecting statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -245,6 +245,10 @@ public class BasicStatsMeta implements Writable {
         this.columnStatsMetaMap.put(columnStatsMeta.getColumnName(), columnStatsMeta);
     }
 
+    public void resetDeltaRows() {
+        this.deltaRows = 0;
+    }
+
     public BasicStatsMeta clone() {
         String json = GsonUtils.GSON.toJson(this);
         return GsonUtils.GSON.fromJson(json, BasicStatsMeta.class);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -422,6 +422,7 @@ public class StatisticExecutor {
                     basicStatsMeta.setUpdateTime(analyzeStatus.getEndTime());
                     basicStatsMeta.setProperties(statsJob.getProperties());
                     basicStatsMeta.setAnalyzeType(statsJob.getType());
+                    basicStatsMeta.resetDeltaRows();
                 }
 
                 for (String column : ListUtils.emptyIfNull(statsJob.getColumnNames())) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -84,6 +84,8 @@ public class BasicStatsMetaTest extends PlanTestBase {
             basicStatsMeta.increaseDeltaRows(5000L);
             basicStatsMeta.setUpdateRows(10000L);
             Assert.assertEquals(0.5, basicStatsMeta.getHealthy(), 0.01);
+            basicStatsMeta.resetDeltaRows();
+            Assert.assertEquals(1.0, basicStatsMeta.getHealthy(), 0.01);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
we should reset delta row of basic meta after collecting statistics for next time calculating table healthy.
introduced by this patch https://github.com/StarRocks/starrocks/pull/50683

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0