### PR TITLE
[BugFix] StreamLoadScanNode should use ComputeNode under shared data mode (backport #54726) 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
@@ -16,8 +16,7 @@ package com.starrocks.load.batchwrite;
 
 import com.starrocks.common.Config;
 import com.starrocks.common.ThreadPoolManager;
-import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.RunMode;
+import com.starrocks.planner.LoadScanNode;
 import com.starrocks.system.ComputeNode;
 import org.apache.arrow.util.VisibleForTesting;
 import org.slf4j.Logger;
@@ -682,19 +681,7 @@ public final class CoordinatorBackendAssignerImpl implements CoordinatorBackendA
 
     // Note that warehouse id may be invalid after the warehouse is dropped, and an exception can be thrown
     List<ComputeNode> getAvailableNodes(long warehouseId) throws Exception {
-        List<ComputeNode> nodes = new ArrayList<>();
-        if (RunMode.isSharedDataMode()) {
-            List<Long> computeIds = GlobalStateMgr.getCurrentState().getWarehouseMgr().getAllComputeNodeIds(warehouseId);
-            for (long nodeId : computeIds) {
-                ComputeNode node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(nodeId);
-                if (node != null && node.isAvailable()) {
-                    nodes.add(node);
-                }
-            }
-        } else {
-            nodes.addAll(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableBackends());
-        }
-        return nodes;
+        return LoadScanNode.getAvailableComputeNodes(warehouseId);
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/com/starrocks/planner/LoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/LoadScanNode.java
@@ -45,7 +45,10 @@ import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.UserException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.system.ComputeNode;
 
 import java.util.List;
 import java.util.Map;
@@ -100,6 +103,30 @@ public abstract class LoadScanNode extends ScanNode {
                 throw new AnalysisException(errorMsg);
             }
         }
+    }
+
+    // Return all available nodes under the warehouse to run load scan. Should consider different deployment modes
+    // 1. Share-nothing: only backends can be used for scan
+    // 2. Share-data: both backends and compute nodes can be used for scan
+    public static List<ComputeNode> getAvailableComputeNodes(long warehouseId) {
+        List<ComputeNode> nodes = Lists.newArrayList();
+        // TODO: need to refactor after be split into cn + dn
+        if (RunMode.isSharedDataMode()) {
+            List<Long> computeNodeIds = GlobalStateMgr.getCurrentState().getWarehouseMgr().getAllComputeNodeIds(warehouseId);
+            for (long cnId : computeNodeIds) {
+                ComputeNode cn = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(cnId);
+                if (cn != null && cn.isAvailable()) {
+                    nodes.add(cn);
+                }
+            }
+        } else {
+            for (ComputeNode be : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend().values()) {
+                if (be.isAvailable()) {
+                    nodes.add(be);
+                }
+            }
+        }
+        return nodes;
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -62,7 +62,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.load.Load;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TBrokerRangeDesc;
 import com.starrocks.thrift.TBrokerScanRange;
 import com.starrocks.thrift.TBrokerScanRangeParams;
@@ -125,7 +125,7 @@ public class StreamLoadScanNode extends LoadScanNode {
     private ImmutableMap<String, String> batchWriteParameters;
     private Set<Long> batchWriteBackendIds;
 
-    private List<Backend> backends;
+    private List<ComputeNode> computeNodes;
     private int nextBe = 0;
     private final Random random = new Random(System.currentTimeMillis());
     private String dbName;
@@ -267,27 +267,25 @@ public class StreamLoadScanNode extends LoadScanNode {
     }
 
     private void assignBackends() throws UserException {
-        backends = Lists.newArrayList();
         if (enableBatchWrite) {
+            computeNodes = Lists.newArrayList();
             for (long backendId : batchWriteBackendIds) {
-                Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(backendId);
-                if (backend == null) {
+                // backendId is assigned by CoordinatorBackendAssignerImpl which have considered to use
+                // backend or cn for different deployment mode. Here just try to get the node from both
+                ComputeNode computeNode = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(backendId);
+                if (computeNode == null) {
                     throw new UserException(String.format("Can't find batch write backend [%s]", backendId));
                 }
-                if (!backend.isAvailable()) {
+                if (!computeNode.isAvailable()) {
                     throw new UserException(String.format("Batch write backend [%s] is not available", backendId));
                 }
-                backends.add(backend);
+                computeNodes.add(computeNode);
             }
         } else {
-            for (Backend be : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdToBackend().values()) {
-                if (be.isAvailable()) {
-                    backends.add(be);
-                }
-            }
-            Collections.shuffle(backends, random);
+            computeNodes = getAvailableComputeNodes(warehouseId);
+            Collections.shuffle(computeNodes, random);
         }
-        if (backends.isEmpty()) {
+        if (computeNodes.isEmpty()) {
             throw new UserException("No available backends");
         }
     }
@@ -437,8 +435,8 @@ public class StreamLoadScanNode extends LoadScanNode {
             locations.setScan_range(scanRange);
 
             if (needAssignBE) {
-                Backend selectedBackend = backends.get(nextBe++);
-                nextBe = nextBe % backends.size();
+                ComputeNode selectedBackend = computeNodes.get(nextBe++);
+                nextBe = nextBe % computeNodes.size();
                 TScanRangeLocation location = new TScanRangeLocation();
                 location.setBackend_id(selectedBackend.getId());
                 location.setServer(new TNetworkAddress(selectedBackend.getHost(), selectedBackend.getBePort()));

--- a/fe/fe-core/src/test/java/com/starrocks/planner/LoadPlanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/LoadPlanNodeTest.java
@@ -1,0 +1,141 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class LoadPlanNodeTest {
+
+    @Mocked
+    private GlobalStateMgr globalStateMgr;
+
+    @Test
+    public void testAvailableNodesForSharedDataWithCn() {
+        testAvailableNodesForSharedDataBase(true);
+    }
+
+    @Test
+    public void testAvailableNodesForSharedDataWithBackend() {
+        testAvailableNodesForSharedDataBase(false);
+    }
+
+    private void testAvailableNodesForSharedDataBase(boolean useCn) {
+        SystemInfoService service = new SystemInfoService();
+        List<Long> nodeIds = new ArrayList<>();
+        if (useCn) {
+            for (int i = 1; i <= 4; i++) {
+                ComputeNode computeNode = new ComputeNode(i, "127.0.0." + i, 9050);
+                service.addComputeNode(computeNode);
+                if (i % 2 == 0) {
+                    computeNode.setAlive(true);
+                }
+                nodeIds.add((long) i);
+            }
+        } else {
+            for (int i = 5; i <= 8; i++) {
+                Backend backend = new Backend(i, "127.0.0." + i, 9050);
+                service.addBackend(backend);
+                if (i % 2 == 0) {
+                    backend.setAlive(true);
+                }
+                nodeIds.add((long) i);
+            }
+        }
+
+        new MockUp<RunMode>() {
+            @Mock
+            boolean isSharedDataMode() {
+                return true;
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getWarehouseMgr().getAllComputeNodeIds(1L);
+                result = nodeIds;
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+                result = service;
+            }
+        };
+
+        List<ComputeNode> nodes = LoadScanNode.getAvailableComputeNodes(1L);
+        assertNotNull(nodes);
+        assertEquals(2, nodes.size());
+        nodes.sort((o1, o2) -> (int) (o1.getId() - o2.getId()));
+        if (useCn) {
+            assertEquals(2, nodes.get(0).getId());
+            assertEquals(4, nodes.get(1).getId());
+        } else {
+            assertEquals(6, nodes.get(0).getId());
+            assertEquals(8, nodes.get(1).getId());
+        }
+    }
+
+    @Test
+    public void testAvailableNodesForSharedNothing() {
+        SystemInfoService service = new SystemInfoService();
+        for (int i = 1; i <= 4; i++) {
+            ComputeNode computeNode = new ComputeNode(i, "127.0.0." + i, 9050);
+            service.addComputeNode(computeNode);
+            if (i % 2 == 0) {
+                computeNode.setAlive(true);
+            }
+        }
+
+        for (int i = 5; i <= 8; i++) {
+            Backend backend = new Backend(i, "127.0.0." + i, 9050);
+            service.addBackend(backend);
+            if (i % 2 == 0) {
+                backend.setAlive(true);
+            }
+        }
+
+        new MockUp<RunMode>() {
+            @Mock
+            boolean isSharedDataMode() {
+                return false;
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+                result = service;
+            }
+        };
+
+        List<ComputeNode> nodes = LoadScanNode.getAvailableComputeNodes(0L);
+        assertNotNull(nodes);
+        assertEquals(2, nodes.size());
+        nodes.sort((o1, o2) -> (int) (o1.getId() - o2.getId()));
+        assertEquals(6, nodes.get(0).getId());
+        assertEquals(8, nodes.get(1).getId());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
#54726

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
