### PR TITLE
[BugFix] Fix shared UDF concurrent load issue

### DIFF
--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -263,7 +263,7 @@ Status UserFunctionCache::_load_cache_entry(const std::string& url, UserFunction
     }
 
     if (!entry->is_loaded.load()) {
-        RETURN_IF_ERROR(_load_cache_entry_internal(entry, loader));
+        RETURN_IF_ERROR(_load_cache_entry_internal(url, entry, loader));
     }
     return Status::OK();
 }

--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -262,7 +262,9 @@ Status UserFunctionCache::_load_cache_entry(const std::string& url, UserFunction
         RETURN_IF_ERROR(_download_lib(url, entry));
     }
 
-    RETURN_IF_ERROR(_load_cache_entry_internal(url, entry, loader));
+    if (!entry->is_loaded.load()) {
+        RETURN_IF_ERROR(_load_cache_entry_internal(entry, loader));
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
## Why I'm doing:

If a UDF is created with SHARED mode, suppose the UDF packages would be load only once in a single BE process. While, there is a concurrent issue int the current implementation, which may result in that a shared UDF may be load multiple times when there are concurrent UDF calls.

## What I'm doing:

Fixes the concurrent issue, check if the UDF has already been load before load it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0