### PR TITLE
[Enhancement] Support replication from another cluster  with compaction enabled in shared-data mode

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -999,7 +999,10 @@ void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskReque
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->replication_mem_tracker());
     DeferOp op([prev_tracker] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
-    const TRemoteSnapshotRequest& remote_snapshot_req = agent_task_req->task_req;
+    TRemoteSnapshotRequest& remote_snapshot_req = agent_task_req->task_req;
+    if (remote_snapshot_req.data_version == 0) {
+        remote_snapshot_req.__set_data_version(remote_snapshot_req.visible_version);
+    }
 
     // Return result to fe
     TStatus task_status;
@@ -1046,7 +1049,10 @@ void run_replicate_snapshot_task(const std::shared_ptr<ReplicateSnapshotAgentTas
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->replication_mem_tracker());
     DeferOp op([prev_tracker] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
-    const TReplicateSnapshotRequest& replicate_snapshot_req = agent_task_req->task_req;
+    TReplicateSnapshotRequest& replicate_snapshot_req = agent_task_req->task_req;
+    if (replicate_snapshot_req.data_version == 0) {
+        replicate_snapshot_req.__set_data_version(replicate_snapshot_req.visible_version);
+    }
 
     TStatusCode::type status_code = TStatusCode::OK;
     std::vector<std::string> error_msgs;

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -308,23 +308,29 @@ private:
     }
 
     Status apply_replication_log(const TxnLogPB_OpReplication& op_replication, int64_t txn_id) {
-        if (op_replication.txn_meta().txn_state() != ReplicationTxnStatePB::TXN_REPLICATED) {
+        const auto& txn_meta = op_replication.txn_meta();
+
+        if (txn_meta.txn_state() != ReplicationTxnStatePB::TXN_REPLICATED) {
             LOG(WARNING) << "Fail to apply replication log, invalid txn meta state: "
-                         << ReplicationTxnStatePB_Name(op_replication.txn_meta().txn_state());
-            return Status::Corruption("Invalid txn meta state: " +
-                                      ReplicationTxnStatePB_Name(op_replication.txn_meta().txn_state()));
-        }
-        if (op_replication.txn_meta().snapshot_version() != _new_version) {
-            LOG(WARNING) << "Fail to apply replication log, mismatched snapshot version and new version"
-                         << ", snapshot version: " << op_replication.txn_meta().snapshot_version()
-                         << ", new version: " << _new_version;
-            return Status::Corruption("mismatched snapshot version and new version");
+                         << ReplicationTxnStatePB_Name(txn_meta.txn_state());
+            return Status::Corruption("Invalid txn meta state: " + ReplicationTxnStatePB_Name(txn_meta.txn_state()));
         }
 
-        if (op_replication.txn_meta().incremental_snapshot()) {
-            DCHECK(_new_version - _base_version == op_replication.op_writes_size())
-                    << ", base_version: " << _base_version << ", new_version: " << _new_version
-                    << ", op_write_size: " << op_replication.op_writes_size();
+        if (txn_meta.data_version() == 0) {
+            if (txn_meta.snapshot_version() != _new_version) {
+                LOG(WARNING) << "Fail to apply replication log, mismatched snapshot version and new version"
+                             << ", snapshot version: " << txn_meta.snapshot_version()
+                             << ", base version: " << txn_meta.visible_version() << ", new version: " << _new_version;
+                return Status::Corruption("mismatched snapshot version and new version");
+            }
+        } else if (txn_meta.snapshot_version() - txn_meta.data_version() + txn_meta.visible_version() != _new_version) {
+            LOG(WARNING) << "Fail to apply replication log, mismatched version, snapshot version: "
+                         << txn_meta.snapshot_version() << ", data version: " << txn_meta.data_version()
+                         << ", old version: " << txn_meta.visible_version() << ", new version: " << _new_version;
+            return Status::Corruption("mismatched version");
+        }
+
+        if (txn_meta.incremental_snapshot()) {
             for (const auto& op_write : op_replication.op_writes()) {
                 RETURN_IF_ERROR(apply_write_log(op_write, txn_id));
             }
@@ -582,26 +588,35 @@ private:
     }
 
     Status apply_replication_log(const TxnLogPB_OpReplication& op_replication) {
-        if (op_replication.txn_meta().txn_state() != ReplicationTxnStatePB::TXN_REPLICATED) {
+        const auto& txn_meta = op_replication.txn_meta();
+
+        if (txn_meta.txn_state() != ReplicationTxnStatePB::TXN_REPLICATED) {
             LOG(WARNING) << "Fail to apply replication log, invalid txn meta state: "
-                         << ReplicationTxnStatePB_Name(op_replication.txn_meta().txn_state());
-            return Status::Corruption("Invalid txn meta state: " +
-                                      ReplicationTxnStatePB_Name(op_replication.txn_meta().txn_state()));
-        }
-        if (op_replication.txn_meta().snapshot_version() != _new_version) {
-            LOG(WARNING) << "Fail to apply replication log, mismatched snapshot version and new version"
-                         << ", snapshot version: " << op_replication.txn_meta().snapshot_version()
-                         << ", new version: " << _new_version;
-            return Status::Corruption("mismatched snapshot version and new version");
+                         << ReplicationTxnStatePB_Name(txn_meta.txn_state());
+            return Status::Corruption("Invalid txn meta state: " + ReplicationTxnStatePB_Name(txn_meta.txn_state()));
         }
 
-        if (op_replication.txn_meta().incremental_snapshot()) {
+        if (txn_meta.data_version() == 0) {
+            if (txn_meta.snapshot_version() != _new_version) {
+                LOG(WARNING) << "Fail to apply replication log, mismatched snapshot version and new version"
+                             << ", snapshot version: " << txn_meta.snapshot_version()
+                             << ", base version: " << txn_meta.visible_version() << ", new version: " << _new_version;
+                return Status::Corruption("mismatched snapshot version and new version");
+            }
+        } else if (txn_meta.snapshot_version() - txn_meta.data_version() + txn_meta.visible_version() != _new_version) {
+            LOG(WARNING) << "Fail to apply replication log, mismatched version, snapshot version: "
+                         << txn_meta.snapshot_version() << ", data version: " << txn_meta.data_version()
+                         << ", old version: " << txn_meta.visible_version() << ", new version: " << _new_version;
+            return Status::Corruption("mismatched version");
+        }
+
+        if (txn_meta.incremental_snapshot()) {
             for (const auto& op_write : op_replication.op_writes()) {
                 RETURN_IF_ERROR(apply_write_log(op_write));
             }
             LOG(INFO) << "Apply incremental replication log finish. tablet_id: " << _tablet.id()
                       << ", base_version: " << _metadata->version() << ", new_version: " << _new_version
-                      << ", txn_id: " << op_replication.txn_meta().txn_id();
+                      << ", txn_id: " << txn_meta.txn_id();
         } else {
             auto old_rowsets = std::move(*_metadata->mutable_rowsets());
             _metadata->mutable_rowsets()->Clear();
@@ -615,7 +630,7 @@ private:
 
             LOG(INFO) << "Apply full replication log finish. tablet_id: " << _tablet.id()
                       << ", base_version: " << _metadata->version() << ", new_version: " << _new_version
-                      << ", txn_id: " << op_replication.txn_meta().txn_id();
+                      << ", txn_id: " << txn_meta.txn_id();
         }
 
         if (op_replication.has_source_schema()) {

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -233,6 +233,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) 
     remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
     remote_snapshot_request.__set_schema_hash(_schema_hash);
     remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_data_version(_version);
     remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
     remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
     remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
@@ -254,6 +255,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
     remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
     remote_snapshot_request.__set_schema_hash(_schema_hash);
     remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_data_version(_version);
     remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
     remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
     remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
@@ -275,6 +277,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
     remote_snapshot_request.__set_schema_hash(_schema_hash);
     remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_data_version(_version);
     remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
     remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
     remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
@@ -297,6 +300,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
     replicate_snapshot_request.__set_schema_hash(_schema_hash);
     replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_data_version(_version);
     replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
     replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
     replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
@@ -323,6 +327,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_publish_failed) {
     remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
     remote_snapshot_request.__set_schema_hash(_schema_hash);
     remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_data_version(_version);
     remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
     remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
     remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
@@ -355,6 +360,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_run_normal) {
     remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
     remote_snapshot_request.__set_schema_hash(_schema_hash);
     remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_data_version(_version);
     remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
     remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
     remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
@@ -374,6 +380,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_run_normal) {
     replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
     replicate_snapshot_request.__set_schema_hash(_schema_hash);
     replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_data_version(_version);
     replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
     replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
     replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
@@ -421,6 +428,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_run_normal_encrypted) {
     remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
     remote_snapshot_request.__set_schema_hash(_schema_hash);
     remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_data_version(_version);
     remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
     remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
     remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
@@ -440,6 +448,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_run_normal_encrypted) {
     replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
     replicate_snapshot_request.__set_schema_hash(_schema_hash);
     replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_data_version(_version);
     replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
     replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
     replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationTxnCommitAttachment.java
@@ -30,7 +30,7 @@ import java.util.Map;
  */
 public class ReplicationTxnCommitAttachment extends TxnCommitAttachment {
     @SerializedName("partitionVersions")
-    private Map<Long, Long> partitionVersions; // The version of partitions
+    private Map<Long, Long> partitionVersions; // The data version of partitions, not the visible version
 
     @SerializedName("partitionVersionEpochs")
     private Map<Long, Long> partitionVersionEpochs; // The version epoch of partitions

--- a/fe/fe-core/src/main/java/com/starrocks/task/RemoteSnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/RemoteSnapshotTask.java
@@ -27,6 +27,7 @@ public class RemoteSnapshotTask extends AgentTask {
     private final TTabletType tabletType;
     private final int schemaHash;
     private final long visibleVersion;
+    private final long dataVersion;
 
     private final String srcToken;
     private final long srcTabletId;
@@ -38,7 +39,7 @@ public class RemoteSnapshotTask extends AgentTask {
     private final int timeoutSec;
 
     public RemoteSnapshotTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-            TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion,
+            TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion, long dataVersion,
             String srcToken, long srcTabletId, TTabletType srcTabletType, int srcSchemaHash,
             long srcVisibleVersion, List<TBackend> srcBackends, int timeoutSec) {
         super(null, backendId, TTaskType.REMOTE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId,
@@ -47,6 +48,7 @@ public class RemoteSnapshotTask extends AgentTask {
         this.tabletType = tabletType;
         this.schemaHash = schemaHash;
         this.visibleVersion = visibleVersion;
+        this.dataVersion = dataVersion;
         this.srcToken = srcToken;
         this.srcTabletId = srcTabletId;
         this.srcTabletType = srcTabletType;
@@ -66,6 +68,7 @@ public class RemoteSnapshotTask extends AgentTask {
         request.setTablet_type(tabletType);
         request.setSchema_hash(schemaHash);
         request.setVisible_version(visibleVersion);
+        request.setData_version(dataVersion);
 
         request.setSrc_token(srcToken);
         request.setSrc_tablet_id(srcTabletId);
@@ -85,6 +88,7 @@ public class RemoteSnapshotTask extends AgentTask {
         sb.append(", tablet id: ").append(tabletId).append(", tablet type: ").append(tabletType);
         sb.append(", schema hash: ").append(schemaHash);
         sb.append(", visible version: ").append(visibleVersion);
+        sb.append(", data version: ").append(dataVersion);
         sb.append(", src token: ").append(srcToken).append(", src tablet id: ").append(srcTabletId);
         sb.append(", src tablet type:").append(srcTabletType).append(", src schema hash: ").append(srcSchemaHash);
         sb.append(", src visible version: ").append(srcVisibleVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
@@ -27,6 +27,7 @@ public class ReplicateSnapshotTask extends AgentTask {
     private final TTabletType tabletType;
     private final int schemaHash;
     private final long visibleVersion;
+    private final long dataVersion;
 
     private final String srcToken;
     private final long srcTabletId;
@@ -37,15 +38,16 @@ public class ReplicateSnapshotTask extends AgentTask {
     private final byte[] encryptionMeta;
 
     public ReplicateSnapshotTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
-                                 TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion, String srcToken,
-                                 long srcTabletId, TTabletType srcTabletType, int srcSchemaHash, long srcVisibleVersion,
-                                 List<TSnapshotInfo> srcSnapshotInfos, byte[] encryptionMeta) {
+            TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion, long dataVersion,
+            String srcToken, long srcTabletId, TTabletType srcTabletType, int srcSchemaHash,
+            long srcVisibleVersion, List<TSnapshotInfo> srcSnapshotInfos, byte[] encryptionMeta) {
         super(null, backendId, TTaskType.REPLICATE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId,
                 System.currentTimeMillis());
         this.transactionId = transactionId;
         this.tabletType = tabletType;
         this.schemaHash = schemaHash;
         this.visibleVersion = visibleVersion;
+        this.dataVersion = dataVersion;
         this.srcToken = srcToken;
         this.srcTabletId = srcTabletId;
         this.srcTabletType = srcTabletType;
@@ -65,6 +67,7 @@ public class ReplicateSnapshotTask extends AgentTask {
         request.setTablet_type(tabletType);
         request.setSchema_hash(schemaHash);
         request.setVisible_version(visibleVersion);
+        request.setData_version(dataVersion);
 
         request.setSrc_token(srcToken);
         request.setSrc_tablet_id(srcTabletId);
@@ -84,6 +87,7 @@ public class ReplicateSnapshotTask extends AgentTask {
         sb.append(", tablet id: ").append(tabletId).append(", tablet type: ").append(tabletType);
         sb.append(", schema hash: ").append(schemaHash);
         sb.append(", visible version: ").append(visibleVersion);
+        sb.append(", data version: ").append(dataVersion);
         sb.append(", src token: ").append(srcToken).append(", src tablet id: ").append(srcTabletId);
         sb.append(", src tablet type:").append(srcTabletType).append(", src schema hash: ").append(srcSchemaHash);
         sb.append(", src visible version: ").append(srcVisibleVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1271,10 +1271,10 @@ public class DatabaseTransactionMgr {
                             (ReplicationTxnCommitAttachment) transactionState
                                     .getTxnCommitAttachment();
                     Map<Long, Long> partitionVersions = replicationTxnAttachment.getPartitionVersions();
-                    long newVersion = partitionVersions.get(partitionCommitInfo.getPhysicalPartitionId());
-                    long versionDiff = newVersion - partition.getVisibleVersion();
-                    partitionCommitInfo.setVersion(newVersion);
-                    partitionCommitInfo.setDataVersion(partition.getDataVersion() + versionDiff);
+                    long newDataVersion = partitionVersions.get(partitionCommitInfo.getPhysicalPartitionId());
+                    long dataVersionDiff = newDataVersion - partition.getDataVersion();
+                    partitionCommitInfo.setVersion(partition.getCommittedVersion() + dataVersionDiff);
+                    partitionCommitInfo.setDataVersion(newDataVersion);
                     Map<Long, Long> partitionVersionEpochs = replicationTxnAttachment.getPartitionVersionEpochs();
                     if (partitionVersionEpochs != null) {
                         long newVersionEpoch = partitionVersionEpochs.get(partitionCommitInfo.getPhysicalPartitionId());

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -50,9 +50,8 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
 
             // The version of a replication transaction may not continuously
             if (txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
-                long versionDiff = partitionCommitInfo.getVersion() - partition.getNextVersion();
                 partition.setNextVersion(partitionCommitInfo.getVersion() + 1);
-                partition.setNextDataVersion(partition.getNextDataVersion() + versionDiff + 1);
+                partition.setNextDataVersion(partitionCommitInfo.getDataVersion() + 1);
             } else {
                 partition.setNextVersion(partition.getNextVersion() + 1);
                 if (txnState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION) {

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
@@ -23,6 +23,7 @@ import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.leader.LeaderImpl;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.system.Backend;
@@ -68,7 +69,7 @@ public class ReplicationJobTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_NOTHING);
         AnalyzeTestUtil.init();
         starRocksAssert = new StarRocksAssert(AnalyzeTestUtil.getConnectContext());
         starRocksAssert.withDatabase("test").useDatabase("test");
@@ -76,13 +77,13 @@ public class ReplicationJobTest {
         db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
         String sql = "create table single_partition_duplicate_key (key1 int, key2 varchar(10))\n" +
-                    "distributed by hash(key1) buckets 1\n" +
-                    "properties('replication_num' = '1'); ";
+                "distributed by hash(key1) buckets 1\n" +
+                "properties('replication_num' = '1'); ";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql,
-                    AnalyzeTestUtil.getConnectContext());
+                AnalyzeTestUtil.getConnectContext());
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(db.getFullName(), "single_partition_duplicate_key");
+                .getTable(db.getFullName(), "single_partition_duplicate_key");
         srcTable = DeepCopy.copyWithGson(table, OlapTable.class);
 
         partition = table.getPartitions().iterator().next();
@@ -106,16 +107,16 @@ public class ReplicationJobTest {
         srcPartition.getDefaultPhysicalPartition().setNextDataVersion(99);
 
         job = new ReplicationJob(null, "test_token", db.getId(), table, srcTable,
-                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
     }
 
     @Test
     public void testJobId() {
         ReplicationJob jobWithoutId = new ReplicationJob(null, "test_token", db.getId(), table, srcTable,
-                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
         Assert.assertFalse(jobWithoutId.getJobId().isEmpty());
         ReplicationJob jobWithId = new ReplicationJob("fake_id", "test_token", db.getId(), table, srcTable,
-                    GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
         Assert.assertEquals("fake_id", jobWithId.getJobId());
     }
 
@@ -141,7 +142,7 @@ public class ReplicationJobTest {
             job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
 
             Deencapsulation.invoke(new LeaderImpl(), "finishRemoteSnapshotTask",
-                        (RemoteSnapshotTask) task, request);
+                    (RemoteSnapshotTask) task, request);
             ((RemoteSnapshotTask) task).toThrift();
             task.toString();
         }
@@ -155,7 +156,7 @@ public class ReplicationJobTest {
             job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
 
             Deencapsulation.invoke(new LeaderImpl(), "finishReplicateSnapshotTask",
-                        (ReplicateSnapshotTask) task, request);
+                    (ReplicateSnapshotTask) task, request);
             ((ReplicateSnapshotTask) task).toThrift();
             task.toString();
         }
@@ -165,8 +166,9 @@ public class ReplicationJobTest {
 
         Assert.assertEquals(partition.getDefaultPhysicalPartition().getCommittedVersion(),
                 srcPartition.getDefaultPhysicalPartition().getVisibleVersion());
+        // data version == visible version in shared-nothing mode
         Assert.assertEquals(partition.getDefaultPhysicalPartition().getCommittedDataVersion(),
-                srcPartition.getDefaultPhysicalPartition().getDataVersion());
+                srcPartition.getDefaultPhysicalPartition().getVisibleVersion());
     }
 
     @Test
@@ -349,7 +351,7 @@ public class ReplicationJobTest {
             tabletInfo.replica_replication_infos = new ArrayList<TReplicaReplicationInfo>();
             TReplicaReplicationInfo replicaInfo = new TReplicaReplicationInfo();
             Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends().iterator()
-                        .next();
+                    .next();
             replicaInfo.src_backend = new TBackend(backend.getHost(), backend.getBePort(), backend.getHttpPort());
             tabletInfo.replica_replication_infos.add(replicaInfo);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -25,6 +25,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.proc.ReplicationsProcNode;
 import com.starrocks.leader.LeaderImpl;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.system.Backend;
@@ -71,7 +72,7 @@ public class ReplicationMgrTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         AnalyzeTestUtil.init();
         starRocksAssert = new StarRocksAssert(AnalyzeTestUtil.getConnectContext());
         starRocksAssert.withDatabase("test").useDatabase("test");

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -134,6 +134,7 @@ enum IndexType {
      optional string src_snapshot_path = 7;
      optional int64 snapshot_version = 8;
      optional bool incremental_snapshot = 9;
+     optional int64 data_version = 10;
  }
 
 // Used to store additional information about a txn when it is finished/visible

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -392,6 +392,7 @@ struct TRemoteSnapshotRequest {
      12: optional Types.TVersion src_visible_version
      13: optional list<Types.TBackend> src_backends
      14: optional i32 timeout_sec
+     15: optional Types.TVersion data_version
  }
 
  struct TReplicateSnapshotRequest {
@@ -409,6 +410,7 @@ struct TRemoteSnapshotRequest {
      12: optional Types.TVersion src_visible_version
      13: optional list<Types.TSnapshotInfo> src_snapshot_infos
      14: optional binary encryption_meta
+     15: optional Types.TVersion data_version
  }
 
 enum TTabletMetaType {


### PR DESCRIPTION
## Why I'm doing:
When a shared-data cluster replicating from another cluster, the compaction needs to be disabled. It's not user-friendly.

## What I'm doing:
Use data version not visible version to align with source cluster, support replication from another cluster  with compaction enabled in shared-data mode.
Compaction will increase visible version but not data version in shared-data mode. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0