### PR TITLE
[BugFix] Fix snapshot versions in cross-cluster replication

### DIFF
--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -158,7 +158,9 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
     }
 
     std::vector<Version> missed_versions;
-    tablet->calc_missed_versions(request.src_visible_version, &missed_versions);
+    for (auto v = request.visible_version + 1; v <= request.src_visible_version; ++v) {
+        missed_versions.emplace_back(v, v);
+    }
     if (UNLIKELY(missed_versions.empty())) {
         LOG(WARNING) << "Remote snapshot tablet skipped, no missing version"
                      << ", type: " << KeysType_Name(tablet->keys_type()) << ", txn_id: " << request.transaction_id


### PR DESCRIPTION
## Why I'm doing:
Multi-replicas may has different missed versions, causing the snapshot versions are different.

## What I'm doing:
Use the version in fe to calculate missed versions as snapshot versions  in cross-cluster replication.
As that in shared-data mode.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0