### PR TITLE
[Refactor] remove unused member in CascadeChunkMerger

### DIFF
--- a/be/src/runtime/sorted_chunks_merger.h
+++ b/be/src/runtime/sorted_chunks_merger.h
@@ -127,7 +127,6 @@ public:
 private:
     const std::vector<ExprContext*>* _sort_exprs;
     SortDescs _sort_desc;
-    std::vector<std::unique_ptr<SimpleChunkSortCursor>> _cursors;
 
     std::unique_ptr<MergeCursorsCascade> _merger;
     ChunkSlice _current_chunk;


### PR DESCRIPTION
## Why I'm doing:
Remove unused class member(`_cursors`) in `CascadeChunkMerger`

## What I'm doing:
Remove unused class member(`_cursors`) in `CascadeChunkMerger`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0