### PR TITLE
[Doc] load props are comma separated

### DIFF
--- a/docs/en/loading/Etl_in_loading.md
+++ b/docs/en/loading/Etl_in_loading.md
@@ -272,7 +272,7 @@ If the data of `file1.csv` is published to `topic1` of your Kafka cluster, execu
 ```SQL
 CREATE ROUTINE LOAD test_db.table102 ON table1
 COLUMNS TERMINATED BY ",",
-COLUMNS (user_id, user_gender, event_date, event_type)
+COLUMNS (user_id, user_gender, event_date, event_type),
 WHERE event_type = 1
 FROM KAFKA
 (

--- a/docs/zh/loading/Etl_in_loading.md
+++ b/docs/zh/loading/Etl_in_loading.md
@@ -271,7 +271,7 @@ WITH BROKER;
 ```SQL
 CREATE ROUTINE LOAD test_db.table102 ON table1
 COLUMNS TERMINATED BY ",",
-COLUMNS (user_id, user_gender, event_date, event_type)
+COLUMNS (user_id, user_gender, event_date, event_type),
 WHERE event_type = 1
 FROM KAFKA
 (


### PR DESCRIPTION
Load properties are comma separated. Adding missing commas.

## Reference:
```
[COLUMNS TERMINATED BY '<column_separator>'],
[ROWS TERMINATED BY '<row_separator>'],
[COLUMNS (<column1_name>[, <column2_name>, <column_assignment>, ... ])],
[WHERE <expr>],
[PARTITION (<partition1_name>[, <partition2_name>, ...])]
[TEMPORARY PARTITION (<temporary_partition1_name>[, <temporary_partition2_name>, ...])]
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0