### PR TITLE
[Enhancement] Support some math function for trino parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -82,6 +82,7 @@ public class Trino2SRFunctionCallTransformer {
         registerMapFunctionTransformer();
         registerBinaryFunctionTransformer();
         registerHLLFunctionTransformer();
+        registerMathFunctionTransformer();
         // todo: support more function transform
     }
 
@@ -357,6 +358,13 @@ public class Trino2SRFunctionCallTransformer {
 
         // merge -> HLL_RAW_AGG
         registerFunctionTransformer("merge", 1, "hll_raw_agg", List.of(Expr.class));
+    }
+
+    private static void registerMathFunctionTransformer() {
+        // truncate(x) -> truncate(x, 0)
+        registerFunctionTransformer("truncate", 1, new FunctionCallExpr("truncate",
+                List.of(new PlaceholderExpr(1, Expr.class), new IntLiteral(0))));
+
     }
 
     private static void registerFunctionTransformer(String trinoFnName, int trinoFnArgNums, String starRocksFnName,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -379,6 +379,12 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
     }
 
     @Test
+    public void testMathFnTransform() throws Exception {
+        String sql = "select truncate(19.25)";
+        assertPlanContains(sql, "truncate(19.25, 0)");
+    }
+
+    @Test
     public void testUnicodeFnTransform() throws Exception {
         String sql = "select to_utf8('123')";
         assertPlanContains(sql, "to_binary('123', 'utf8')");


### PR DESCRIPTION
## Why I'm doing:

In Trino, the truncate function supports a single parameter, Returns x rounded to integer by dropping digits after decimal point.

![image](https://github.com/user-attachments/assets/ee42856a-fd57-45af-a5a2-b24fdce55f93)

In StarRocks, the truncate function supports only two parameters.

![image](https://github.com/user-attachments/assets/58154297-830e-44e0-aefd-99ae37c60002)

Causes a query error.

![image](https://github.com/user-attachments/assets/b6dcb4a5-d91c-4f3c-94c7-d63085bebe62)

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0