### PR TITLE
[BugFix] Fix mv rewrite bug for force_mv rewrite mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -326,11 +326,8 @@ public abstract class MVTimelinessArbiter {
             return null;
         }
         Map<String, PCell> adds = diff.getAdds();
-        // no partition added
-        if (CollectionUtils.sizeIsEmpty(adds)) {
-            return MvUpdateInfo.noRefresh(mv);
-        }
         MvUpdateInfo mvUpdateInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.FORCE_MV);
+        addEmptyPartitionsToRefresh(mvUpdateInfo);
         if (!CollectionUtils.sizeIsEmpty(adds)) {
             adds.keySet().stream().forEach(mvPartitionName ->
                     mvUpdateInfo.getMvToRefreshPartitionNames().add(mvPartitionName));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTimelinessMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTimelinessMgr.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvRefreshArbiter;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.memory.MemoryTrackable;
 
@@ -59,6 +60,10 @@ public class MVTimelinessMgr implements MemoryTrackable {
     }
 
     public static boolean isEnableMVTimelinessGlobalCache(MaterializedView mv) {
+        // To avoid bad cases, we disable the global cache for MV timeliness
+        if (!Config.enable_mv_query_context_cache) {
+            return false;
+        }
         TableProperty.QueryRewriteConsistencyMode consistencyMode =
                 mv.getTableProperty().getQueryRewriteConsistencyMode();
         return consistencyMode == TableProperty.QueryRewriteConsistencyMode.FORCE_MV;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -433,11 +433,12 @@ public class Optimizer {
     private void ruleBasedMaterializedViewRewrite(OptExpression tree,
                                                   TaskContext rootTaskContext,
                                                   ColumnRefSet requiredColumns) {
+        // skip if mv rewrite is disabled
         if (!mvRewriteStrategy.enableMaterializedViewRewrite || context.getQueryMaterializationContext() == null) {
             return;
         }
 
-        // do rule based mv rewrite
+        // do rule based mv rewrite if needed
         if (!context.getQueryMaterializationContext().hasRewrittenSuccess()) {
             doRuleBasedMaterializedViewRewrite(tree, rootTaskContext);
         }
@@ -490,7 +491,7 @@ public class Optimizer {
 
     private void doMVRewriteWithMultiStages(OptExpression tree,
                                             TaskContext rootTaskContext) {
-        if (!mvRewriteStrategy.mvStrategy.isMultiStages()) {
+        if (!mvRewriteStrategy.enableMaterializedViewRewrite || !mvRewriteStrategy.mvStrategy.isMultiStages()) {
             return;
         }
         ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PARTITION_PRUNE);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/PartitionRetentionTableCompensation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/PartitionRetentionTableCompensation.java
@@ -26,9 +26,9 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.rewrite.scalar.NegateFilterShuttle;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTransparentState;
 
 import java.util.List;
@@ -68,7 +68,7 @@ public final class PartitionRetentionTableCompensation extends TableCompensation
             return scanOperator;
         }
         // build final predicate
-        ScalarOperator compensate = CompoundPredicateOperator.not(scalarOperator);
+        ScalarOperator compensate =  NegateFilterShuttle.getInstance().negateFilter(scalarOperator);
         compensate.setRedundant(true);
         ScalarOperator finalPredicate = Utils.compoundAnd(scanOperator.getPredicate(), compensate);
         // build new scan operator
@@ -80,7 +80,8 @@ public final class PartitionRetentionTableCompensation extends TableCompensation
 
     @Override
     public String toString() {
-        return String.format("NOT(%s)", compensateOperator.debugString());
+        ScalarOperator compensate =  NegateFilterShuttle.getInstance().negateFilter(compensateOperator);
+        return String.format("%)", compensate.debugString());
     }
 
     public static TableCompensation build(Table refBaseTable,


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Fix bugs for e2e tests:
1. disable Iceberg compensate tables by default, only enabled when ` set materialized_view_rewrite_mode='force'`;
2. use `NegateFilterShuttle.getInstance().negateFilter(scalarOperator)` to compensate rather than `CompoundPredicateOperator.not(scalarOperator)` to avoid `is null` bug.
3. use `enable_mv_query_context_cache` to control `MVTimelinessMgr.java`


### Performance Test(Default)

  |   | Disable MV Rerwrite |   | Enable MV Rewrite（force_mv)
-- | -- | -- | -- | --
  |   | Query appearance | Query internal table | Opt After
1 concurrency, executed 10 times, total time spent s | Q1 (all hits) | 0.247 | 0.182 | 0.329
  | Q2 (partially hit) | 0.382 | 0.284 | 0.501
  | Q3 (all misses) | 0.309 | 0.225 | 0.338
10 concurrency (execute 10 times/concurrency, time-consuming s) | Q1 (all hits) | 0.375 | 0.346 | 0.634
  | Q2 (partially hit) | 0.924 | 0.831 | 1.4
  | Q3 (all misses) | 0.593 | 0.453 | 0.667
20 concurrency (execute 10 times/concurrency, time consumption s) | Q1 (all hits) | 0.577 | 0.57 | 0.931
  | Q2 (partially hit) | 1.355 | 1.275 | 2.309
  | Q3 (all misses) | 0.84 | 0.751 | 1.073
50 concurrency (execute 10 times/concurrency, time consumption s) | Q1 (all hits) | 1.207 | 1.341 | 2.134
  | Q2 (partially hit) | 2.953 | 3.156 | 5.564
  | Q3 (all misses) | 1.777 | 1.698 | 2.356
100 concurrency (execute 10 times/concurrency, time consumption s) | Q1 (all hits) | 2.195 | 3.544 | 4.274
  | Q2 (partially hit) | 5.972 | 6.334 | 11.473
  | Q3 (all misses) | 3.491 | 3.647 | 4.669


### Performance Test(materialized_view_rewrite_mode=force)


  |   | Disable MV Rerwrite |   | Enable MV Rewrite（force_mv)
-- | -- | -- | -- | --
  |   | Query appearance | Query internal table | Opt After
1 concurrency, executed 10 times, total time spent s | Q1 (all hits) | 0.238 | 0.233 | 0.155
  | Q2 (partially hit) | 0.353 | 0.334 | 0.465
  | Q3 (all misses) | 0.288 | 0.246 | 0.335
10 concurrency (execute 10 times/concurrency, time-consuming s) | Q1 (all hits) | 0.355 | 0.437 | 0.291
  | Q2 (partially hit) | 0.912 | 0.869 | 1.392
  | Q3 (all misses) | 0.558 | 0.49 | 0.69
20 concurrency (execute 10 times/concurrency, time consumption s) | Q1 (all hits) | 0.511 | 0.705 | 0.493
  | Q2 (partially hit) | 1.34 | 1.348 | 2.35
  | Q3 (all misses) | 0.824 | 0.781 | 1.06
50 concurrency (execute 10 times/concurrency, time consumption s) | Q1 (all hits) | 1.175 | 1.739 | 1.121
  | Q2 (partially hit) | 2.94 | 3.128 | 5.735
  | Q3 (all misses) | 1.773 | 1.874 | 2.342
100 concurrency (execute 10 times/concurrency, time consumption s) | Q1 (all hits) | 2.278 | 3.545 | 2.232
  | Q2 (partially hit) | 5.831 | 6.437 | 11.808
  | Q3 (all misses) | 3.464 | 3.906 | 4.649


<!-- notionvc: cdc12245-58fa-41a1-801b-d9f11ea82916 -->


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0