### PR TITLE
[Enhancement] To keep the behavior of integer division is consistent with Trino

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -299,14 +299,12 @@ public class Log4jConfig extends XmlConfiguration {
                     "{'@timestamp':{'$resolver':'timestamp','pattern':{'format':'yyyy-MM-dd HH:mm:ss.SSSXXX','timeZone':'UTC'}}," +
                             "'level':{'$resolver':'level','field':'name'}," +
                             "'thread.name':{'$resolver':'thread','field':'name'}," +
-                            "'thread.id':{'$resolver':'thread','field':'id'}," +
-                            "'line':{'$resolver':'source','field':'lineNumber'}," +
-                            "'file':{'$resolver':'source','field':'fileName'}," +
-                            "'method':{'$resolver':'source','field':'methodName'}," +
+                            "'thread.id':{'$resolver':'thread','id'}," +
+                            "'logger':{'$resolver':'logger','field':'name'}," +
                             "'message':{'$resolver':'message','stringfield':'true'}," +
                             "'exception':{'$resolver':'exception','field':'stackTrace','stackTrace':{'stringified':true,'full':true}}}";
             jsonConfig = jsonConfig.replace("'", "\"");
-            String jsonLayoutFormatter = "<JsonTemplateLayout maxStringLength=\"%d\" locationInfoEnabled=\"true\">\n" +
+            String jsonLayoutFormatter = "<JsonTemplateLayout maxStringLength=\"%d\" locationInfoEnabled=\"false\">\n" +
                     "<EventTemplate><![CDATA[" + jsonConfig + "]]></EventTemplate>\n" + "</JsonTemplateLayout>";
             String jsonLayoutDefault = String.format(jsonLayoutFormatter, Config.sys_log_json_max_string_length);
             String jsonLayoutProfile = String.format(jsonLayoutFormatter, Config.sys_log_json_profile_max_string_length);
@@ -319,9 +317,9 @@ public class Log4jConfig extends XmlConfiguration {
         } else {
             // fallback to plaintext logging
             properties.put("syslog_default_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m%n\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%c{1}] %m%n\"/>");
             properties.put("syslog_warning_layout",
-                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%C{1}.%M():%L] %m%n %ex\"/>");
+                    "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} %p (%t|%tid) [%c{1}] %m%n%ex\"/>");
             properties.put("syslog_audit_layout",
                     "<PatternLayout charset=\"UTF-8\" pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSSXXX} [%c{1}] %m%n\"/>");
             properties.put("syslog_dump_layout",


### PR DESCRIPTION
## Why I'm doing:
When performing integer division in StarRocks, the result is converted to a double type. This behavior causes discrepancies in the query results between StarRocks and Trino, as Trino retains the result as an integer.

Here are details
```
CREATE TABLE test_table (
    timestamp BIGINT,
    dt DATE
);


INSERT INTO test_table (timestamp, dt) VALUES
(1735246800000, DATE '2024-12-27'),
(1735246890000, DATE '2024-12-27'),
(1735246980000, DATE '2024-12-27'),
(1735247070000, DATE '2024-12-27'),
(1735247160000, DATE '2024-12-27'),
(1735247250000, DATE '2024-12-27'),
(1735247340000, DATE '2024-12-27'),
(1735247430000, DATE '2024-12-27'),
(1735247520000, DATE '2024-12-27'),
(1735247610000, DATE '2024-12-27'),
(1735247700000, DATE '2024-12-27'),
(1735250399999, DATE '2024-12-27');

SELECT timestamp / 3600000 AS tm, COUNT(*) AS doc_count
FROM test_table
WHERE dt >= DATE '2024-12-27'
    AND dt <= DATE '2024-12-27'
    AND timestamp >= 1735246800000
    AND timestamp <= 1735250399999
GROUP BY timestamp / 3600000;

--- trino result
   tm   | doc_count 
--------+-----------
 482013 |        12 
(1 row)

-- starrocks result
+--------------------+-----------+
| tm                 | doc_count |
+--------------------+-----------+
|           482013.1 |         1 |
|          482013.15 |         1 |
|         482013.225 |         1 |
| 482013.99999972223 |         1 |
|          482013.05 |         1 |
|         482013.075 |         1 |
|         482013.125 |         1 |
|          482013.25 |         1 |
|             482013 |         1 |
|         482013.025 |         1 |
|         482013.175 |         1 |
|           482013.2 |         1 |
+--------------------+-----------+
12 rows in set (0.28 sec)

```
## What I'm doing:
Keeping the same behavior as Trino when set sql_dialect='trino'

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0