### PR TITLE
[BugFix] InactiveRelatedMaterializedView not working across databases

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -335,9 +335,9 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
                 }
 
                 // inactive the related MVs
-                AlterMVJobExecutor.inactiveRelatedMaterializedView(db, origTable,
+                AlterMVJobExecutor.inactiveRelatedMaterializedView(origTable,
                         MaterializedViewExceptions.inactiveReasonForBaseTableSwapped(origTblName), false);
-                AlterMVJobExecutor.inactiveRelatedMaterializedView(db, olapNewTbl,
+                AlterMVJobExecutor.inactiveRelatedMaterializedView(olapNewTbl,
                         MaterializedViewExceptions.inactiveReasonForBaseTableSwapped(newTblName), false);
 
                 SwapTableOperationLog log = new SwapTableOperationLog(db.getId(), origTable.getId(), olapNewTbl.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -537,7 +537,7 @@ public class AlterJobMgr {
             }
             view.setNewFullSchema(newFullSchema);
             view.setComment(comment);
-            AlterMVJobExecutor.inactiveRelatedMaterializedView(db, view,
+            AlterMVJobExecutor.inactiveRelatedMaterializedView(view,
                     MaterializedViewExceptions.inactiveReasonForBaseViewChanged(viewName), isReplay);
             db.dropTable(viewName);
             db.registerTableUnlocked(view);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -494,7 +494,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
     /**
      * Inactive related materialized views because of base table/view is changed or dropped in the leader background.
      */
-    public static void inactiveRelatedMaterializedView(Database db, Table olapTable, String reason, boolean isReplay) {
+    public static void inactiveRelatedMaterializedView(Table olapTable, String reason, boolean isReplay) {
         if (!Config.enable_mv_automatic_inactive_by_base_table_changes) {
             LOG.warn("Skip to inactive related materialized views because of automatic inactive is disabled, " +
                     "table:{}, reason:{}", olapTable.getName(), reason);
@@ -508,8 +508,15 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             return;
         }
         for (MvId mvId : olapTable.getRelatedMaterializedViews()) {
-            MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getTable(db.getId(), mvId.getId());
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(mvId.getDbId());
+            if (db == null) {
+                LOG.warn("Table {} inactive MaterializedView, viewId {} ,db {} not found",
+                        olapTable.getName(),
+                        mvId.getId(),
+                        mvId.getDbId());
+                continue;
+            }
+            MaterializedView mv = (MaterializedView) db.getTable(mvId.getId());
             if (mv != null) {
                 LOG.warn("Inactive MV {}/{} because {}", mv.getName(), mv.getId(), reason);
                 // inactive mv by reason
@@ -525,7 +532,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                     mv.setInactiveAndReason(reason);
                 }
                 // recursive inactive
-                inactiveRelatedMaterializedView(db, mv,
+                inactiveRelatedMaterializedView(mv,
                         MaterializedViewExceptions.inactiveReasonForBaseTableActive(mv.getName()), false);
             } else {
                 LOG.info("Ignore materialized view {} does not exists", mvId);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3288,7 +3288,7 @@ public class OlapTable extends Table {
         // in recycle bin,
         // which make things easier.
         dropAllTempPartitions();
-        AlterMVJobExecutor.inactiveRelatedMaterializedView(db, this,
+        AlterMVJobExecutor.inactiveRelatedMaterializedView(this,
                 MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(getName()), replay);
         if (!replay && hasAutoIncrementColumn()) {
             sendDropAutoIncrementMapTask();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3317,7 +3317,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         db.dropTable(oldTableName);
         db.registerTableUnlocked(olapTable);
-        AlterMVJobExecutor.inactiveRelatedMaterializedView(db, olapTable,
+        AlterMVJobExecutor.inactiveRelatedMaterializedView(olapTable,
                 MaterializedViewExceptions.inactiveReasonForBaseTableRenamed(oldTableName), false);
 
         TableInfo tableInfo = TableInfo.createForTableRename(db.getId(), olapTable.getId(), newTableName);


### PR DESCRIPTION
## Why I'm doing:
When a table is altered, the materialized views associated with the table need to execute the "inactiveRelatedMaterializedView" operation. However, there is an issue with how this method retrieves the database to which the materialized view belongs. The database of the materialized view should not be determined based on the method's parameters. If the altered table and the materialized view are not in the same database, the "inactiveRelatedMaterializedView" operation will not take effect.
## What I'm doing:
Remove the db parameter from the inactiveRelatedMaterializedView method and retrieve the database of the materialized view through the MvId object.
Fixes #issue
https://github.com/StarRocks/starrocks/issues/54843
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0