### PR TITLE
[Enhancement] Improve deletion vector performance using roaring bitmap instead of set

### DIFF
--- a/be/src/connector/CMakeLists.txt
+++ b/be/src/connector/CMakeLists.txt
@@ -32,4 +32,5 @@ add_library(Connector STATIC
         async_flush_stream_poller.cpp
         sink_memory_manager.cpp
         deletion_vector/deletion_vector.cpp
+        deletion_vector/deletion_bitmap.cpp
 )

--- a/be/src/connector/deletion_vector/deletion_bitmap.cpp
+++ b/be/src/connector/deletion_vector/deletion_bitmap.cpp
@@ -15,6 +15,7 @@
 #include "deletion_bitmap.h"
 
 #include "column/vectorized_fwd.h"
+#include "util/defer_op.h"
 
 namespace starrocks {
 
@@ -23,8 +24,8 @@ StatusOr<bool> DeletionBitmap::fill_filter(uint64_t start, uint64_t end, Filter&
         return false;
     }
     roaring64_iterator_t* it = roaring64_iterator_create(_bitmap);
+    DeferOp defer([&it] { roaring64_iterator_free(it); });
     if (!roaring64_iterator_move_equalorlarger(it, start)) {
-        roaring64_iterator_free(it);
         return false;
     }
 
@@ -36,7 +37,6 @@ StatusOr<bool> DeletionBitmap::fill_filter(uint64_t start, uint64_t end, Filter&
         roaring64_iterator_advance(it);
     }
 
-    roaring64_iterator_free(it);
     return has_filter;
 }
 

--- a/be/src/connector/deletion_vector/deletion_bitmap.cpp
+++ b/be/src/connector/deletion_vector/deletion_bitmap.cpp
@@ -28,14 +28,16 @@ StatusOr<bool> DeletionBitmap::fill_filter(uint64_t start, uint64_t end, Filter&
         return false;
     }
 
+    bool has_filter = false;
     while (roaring64_iterator_has_value(it) && roaring64_iterator_value(it) < end) {
         uint64_t value = roaring64_iterator_value(it);
         filter[value - start] = 0;
+        has_filter = true;
         roaring64_iterator_advance(it);
     }
 
     roaring64_iterator_free(it);
-    return true;
+    return has_filter;
 }
 
 uint64_t DeletionBitmap::get_range_cardinality(uint64_t start, uint64_t end) const {

--- a/be/src/connector/deletion_vector/deletion_bitmap.cpp
+++ b/be/src/connector/deletion_vector/deletion_bitmap.cpp
@@ -24,6 +24,7 @@ StatusOr<bool> DeletionBitmap::fill_filter(uint64_t start, uint64_t end, Filter&
     }
     roaring64_iterator_t* it = roaring64_iterator_create(_bitmap);
     if (!roaring64_iterator_move_equalorlarger(it, start)) {
+        roaring64_iterator_free(it);
         return false;
     }
 
@@ -50,6 +51,10 @@ uint64_t DeletionBitmap::get_cardinality() const {
 
 void DeletionBitmap::to_array(std::vector<uint64_t>& array) const {
     roaring64_bitmap_to_uint64_array(_bitmap, array.data());
+}
+
+void DeletionBitmap::add_value(uint64_t val) {
+    roaring64_bitmap_add(_bitmap, val);
 }
 
 } // namespace starrocks

--- a/be/src/connector/deletion_vector/deletion_bitmap.cpp
+++ b/be/src/connector/deletion_vector/deletion_bitmap.cpp
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "deletion_bitmap.h"
+
+#include "column/vectorized_fwd.h"
+
+namespace starrocks {
+
+StatusOr<bool> DeletionBitmap::fill_filter(uint64_t start, uint64_t end, Filter& filter) {
+    if (start >= end) {
+        return false;
+    }
+    roaring64_iterator_t* it = roaring64_iterator_create(_bitmap);
+    if (!roaring64_iterator_move_equalorlarger(it, start)) {
+        return false;
+    }
+
+    while (roaring64_iterator_has_value(it) && roaring64_iterator_value(it) < end) {
+        uint64_t value = roaring64_iterator_value(it);
+        filter[value - start] = 0;
+        roaring64_iterator_advance(it);
+    }
+
+    roaring64_iterator_free(it);
+    return true;
+}
+
+uint64_t DeletionBitmap::get_range_cardinality(uint64_t start, uint64_t end) const {
+    if (start >= end) {
+        return 0;
+    }
+    return roaring64_bitmap_range_cardinality(_bitmap, start, end);
+}
+
+uint64_t DeletionBitmap::get_cardinality() const {
+    return roaring64_bitmap_get_cardinality(_bitmap);
+}
+
+void DeletionBitmap::to_array(std::vector<uint64_t>& array) const {
+    roaring64_bitmap_to_uint64_array(_bitmap, array.data());
+}
+
+} // namespace starrocks

--- a/be/src/connector/deletion_vector/deletion_bitmap.h
+++ b/be/src/connector/deletion_vector/deletion_bitmap.h
@@ -35,6 +35,7 @@ public:
     bool empty() const { return roaring64_bitmap_is_empty(_bitmap); };
     StatusOr<bool> fill_filter(uint64_t start, uint64_t end, Filter& filter);
     uint64_t get_range_cardinality(uint64_t start, uint64_t end) const;
+    void add_value(uint64_t val);
     uint64_t get_cardinality() const;
     void to_array(std::vector<uint64_t>& array) const;
 

--- a/be/src/connector/deletion_vector/deletion_bitmap.h
+++ b/be/src/connector/deletion_vector/deletion_bitmap.h
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <roaring/roaring64.h>
+
+#include <memory>
+
+#include "column/vectorized_fwd.h"
+#include "common/statusor.h"
+
+namespace starrocks {
+
+class DeletionBitmap {
+public:
+    DeletionBitmap(roaring64_bitmap_t* bitmap) : _bitmap(bitmap) {}
+    ~DeletionBitmap() {
+        if (_bitmap != nullptr) {
+            roaring::api::roaring64_bitmap_free(_bitmap);
+        }
+    }
+
+    bool empty() const { return roaring64_bitmap_is_empty(_bitmap); };
+    StatusOr<bool> fill_filter(uint64_t start, uint64_t end, Filter& filter);
+    uint64_t get_range_cardinality(uint64_t start, uint64_t end) const;
+    uint64_t get_cardinality() const;
+    void to_array(std::vector<uint64_t>& array) const;
+
+private:
+    roaring64_bitmap_t* _bitmap = nullptr;
+};
+
+using DeletionBitmapPtr = std::shared_ptr<DeletionBitmap>;
+
+} // namespace starrocks

--- a/be/src/connector/deletion_vector/deletion_vector.cpp
+++ b/be/src/connector/deletion_vector/deletion_vector.cpp
@@ -117,7 +117,7 @@ Status DeletionVector::deserialized_deletion_vector(uint32_t magic_number, std::
                                                     int64_t serialized_bitmap_length,
                                                     const SkipRowsContextPtr& skip_rows_ctx) {
     {
-        SCOPED_RAW_TIMER(&_build_stats.bitmap_deserialized_ns);
+        SCOPED_RAW_TIMER(&_build_stats.bitmap_deserialize_ns);
         if (magic_number != MAGIC_NUMBER) {
             std::stringstream ss;
             ss << "Unexpected magic number : " << magic_number;
@@ -285,10 +285,10 @@ void DeletionVector::update_dv_build_counter(RuntimeProfile* parent_profile,
         static const char* prefix = "DV_BuildTime";
         ADD_CHILD_COUNTER(parent_profile, prefix, TUnit::NONE, DV_TIMER);
 
-        RuntimeProfile::Counter* bitmap_deserialized_timer =
-                ADD_CHILD_COUNTER(parent_profile, "DV_BitmapDeserializedTime", TUnit::TIME_NS, prefix);
+        RuntimeProfile::Counter* bitmap_deserialize_timer =
+                ADD_CHILD_COUNTER(parent_profile, "DV_BitmapDeserializeTime", TUnit::TIME_NS, prefix);
 
-        COUNTER_UPDATE(bitmap_deserialized_timer, build_stats.bitmap_deserialized_ns);
+        COUNTER_UPDATE(bitmap_deserialize_timer, build_stats.bitmap_deserialize_ns);
     }
 }
 

--- a/be/src/connector/deletion_vector/deletion_vector.h
+++ b/be/src/connector/deletion_vector/deletion_vector.h
@@ -20,13 +20,17 @@
 
 namespace starrocks {
 
+struct DeletionVectorBuildStats {
+    int64_t bitmap_deserialized_ns = 0;
+};
+
 class DeletionVector {
 public:
     DeletionVector(const HdfsScannerParams& scanner_params)
             : _deletion_vector_descriptor(scanner_params.deletion_vector_descriptor), _params(scanner_params) {}
 
-    Status fill_row_indexes(std::set<int64_t>* need_skip_rowids);
-    Status deserialized_inline_dv(std::string& encoded_bitmap_data, std::set<int64_t>* need_skip_rowids) const;
+    Status fill_row_indexes(const SkipRowsContextPtr& skip_rows_ctx);
+    Status deserialized_inline_dv(std::string& encoded_bitmap_data, const SkipRowsContextPtr& skip_rows_ctx);
     StatusOr<std::string> get_absolute_path(const std::string& table_location) const;
 
     const bool is_inline() {
@@ -46,8 +50,8 @@ private:
             std::shared_ptr<io::SharedBufferedInputStream>& shared_buffered_input_stream,
             std::shared_ptr<io::CacheInputStream>& cache_input_stream) const;
 
-    Status deserialized_deletion_vector(uint32_t magic_number, std::unique_ptr<char[]> serialized_dv,
-                                        int64_t serialized_bitmap_length, std::set<int64_t>* need_skip_rowids) const;
+    Status deserialized_deletion_vector(uint32_t magic_number, std::vector<char>& serialized_dv,
+                                        int64_t serialized_bitmap_length, const SkipRowsContextPtr& skip_rows_ctx);
 
     std::string assemble_deletion_vector_path(const std::string& table_location, std::string&& uuid,
                                               std::string& prefix) const;
@@ -57,7 +61,10 @@ private:
                                    const std::shared_ptr<io::CacheInputStream>& cache_input_stream,
                                    const std::shared_ptr<io::SharedBufferedInputStream>& shared_buffered_input_stream);
 
+    void update_dv_build_counter(RuntimeProfile* parent_profile, const DeletionVectorBuildStats& build_stats);
+
     const std::shared_ptr<TDeletionVectorDescriptor> _deletion_vector_descriptor;
     const HdfsScannerParams& _params;
+    DeletionVectorBuildStats _build_stats;
 };
 } // namespace starrocks

--- a/be/src/connector/deletion_vector/deletion_vector.h
+++ b/be/src/connector/deletion_vector/deletion_vector.h
@@ -21,7 +21,7 @@
 namespace starrocks {
 
 struct DeletionVectorBuildStats {
-    int64_t bitmap_deserialized_ns = 0;
+    int64_t bitmap_deserialize_ns = 0;
 };
 
 class DeletionVector {

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -333,6 +333,9 @@ void HdfsScanner::do_update_iceberg_v2_counter(RuntimeProfile* parent_profile, c
 }
 
 void HdfsScanner::do_update_deletion_vector_counter(RuntimeProfile* parent_profile) {
+    if (_scanner_ctx.enable_split_tasks && !has_split_tasks()) {
+        return;
+    }
     const std::string DV_TIMER = DeletionVector::DELETION_VECTOR;
     ADD_COUNTER(parent_profile, DV_TIMER, TUnit::NONE);
 

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <boost/algorithm/string.hpp>
 
+#include "connector/deletion_vector/deletion_bitmap.h"
 #include "exec/olap_scan_prepare.h"
 #include "exec/pipeline/scan/morsel.h"
 #include "exprs/expr.h"
@@ -41,7 +42,9 @@ struct HdfsSplitContext : public pipeline::ScanSplitContext {
 using HdfsSplitContextPtr = std::unique_ptr<HdfsSplitContext>;
 
 struct SkipRowsContext {
-    std::set<int64_t> need_skip_rowids;
+    DeletionBitmapPtr deletion_bitmap;
+
+    bool has_skip_rows() { return deletion_bitmap != nullptr && !deletion_bitmap->empty(); }
 };
 using SkipRowsContextPtr = std::shared_ptr<SkipRowsContext>;
 

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -323,7 +323,7 @@ Status HdfsOrcScanner::build_iceberg_delete_builder() {
     if (_scanner_params.deletes.empty()) return Status::OK();
     SCOPED_RAW_TIMER(&_app_stats.iceberg_delete_file_build_ns);
     const auto iceberg_delete_builder =
-            std::make_unique<IcebergDeleteBuilder>(&_need_skip_rowids, _runtime_state, _scanner_params);
+            std::make_unique<IcebergDeleteBuilder>(_skip_rows_ctx, _runtime_state, _scanner_params);
 
     for (const auto& delete_file : _scanner_params.deletes) {
         if (delete_file->file_content == TIcebergFileContent::POSITION_DELETES) {
@@ -345,7 +345,7 @@ Status HdfsOrcScanner::build_paimon_delete_file_builder() {
         return Status::OK();
     }
     std::unique_ptr<PaimonDeleteFileBuilder> paimon_delete_file_builder(
-            new PaimonDeleteFileBuilder(_scanner_params.fs, &_need_skip_rowids));
+            new PaimonDeleteFileBuilder(_scanner_params.fs, _skip_rows_ctx));
     RETURN_IF_ERROR(paimon_delete_file_builder->build(_scanner_params.paimon_deletion_file.get()));
     return Status::OK();
 }
@@ -595,8 +595,8 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next_count(ChunkPtr* chunk) {
             }
         }
         read_num_values += _orc_reader->get_cvb_size();
-        if (!_need_skip_rowids.empty()) {
-            read_num_values -= _orc_reader->get_row_delete_number(_need_skip_rowids);
+        if (_skip_rows_ctx != nullptr && _skip_rows_ctx->has_skip_rows()) {
+            read_num_values -= _orc_reader->get_row_delete_number(_skip_rows_ctx);
         }
     }
 
@@ -619,7 +619,7 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
             RETURN_IF_ERROR(_orc_reader->read_next(&position));
             {
                 SCOPED_RAW_TIMER(&_app_stats.build_rowid_filter_ns);
-                row_delete_filter = _orc_reader->get_row_delete_filter(_need_skip_rowids);
+                ASSIGN_OR_RETURN(row_delete_filter, _orc_reader->get_row_delete_filter(_skip_rows_ctx));
             }
             // read num values is how many rows actually read before doing dict filtering.
             read_num_values = position.num_values;

--- a/be/src/exec/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner_orc.h
@@ -27,7 +27,7 @@ class OrcRowReaderFilter;
 
 class HdfsOrcScanner final : public HdfsScanner {
 public:
-    HdfsOrcScanner() = default;
+    HdfsOrcScanner() : _skip_rows_ctx(std::make_shared<SkipRowsContext>()){};
     ~HdfsOrcScanner() override = default;
 
     Status do_open(RuntimeState* runtime_state) override;
@@ -67,7 +67,7 @@ private:
     std::shared_ptr<OrcRowReaderFilter> _orc_row_reader_filter;
     Filter _dict_filter;
     Filter _chunk_filter;
-    std::set<int64_t> _need_skip_rowids;
+    SkipRowsContextPtr _skip_rows_ctx;
     std::unique_ptr<ORCHdfsFileStream> _input_stream;
 };
 

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -29,8 +29,8 @@ static const std::string kParquetProfileSectionPrefix = "Parquet";
 Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
     if (!scanner_params.deletes.empty()) {
         SCOPED_RAW_TIMER(&_app_stats.iceberg_delete_file_build_ns);
-        auto iceberg_delete_builder = std::make_unique<IcebergDeleteBuilder>(&_skip_rows_ctx->need_skip_rowids,
-                                                                             runtime_state, scanner_params);
+        auto iceberg_delete_builder =
+                std::make_unique<IcebergDeleteBuilder>(_skip_rows_ctx, runtime_state, scanner_params);
         for (const auto& delete_file : scanner_params.deletes) {
             if (delete_file->file_content == TIcebergFileContent::POSITION_DELETES) {
                 RETURN_IF_ERROR(iceberg_delete_builder->build_parquet(*delete_file));
@@ -44,7 +44,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
         _app_stats.iceberg_delete_files_per_scan += scanner_params.deletes.size();
     } else if (scanner_params.paimon_deletion_file != nullptr) {
         std::unique_ptr<PaimonDeleteFileBuilder> paimon_delete_file_builder(
-                new PaimonDeleteFileBuilder(scanner_params.fs, &_skip_rows_ctx->need_skip_rowids));
+                new PaimonDeleteFileBuilder(scanner_params.fs, _skip_rows_ctx));
         RETURN_IF_ERROR(paimon_delete_file_builder->build(scanner_params.paimon_deletion_file.get()));
     } else if (scanner_params.deletion_vector_descriptor != nullptr) {
         if (scanner_params.split_context != nullptr) {
@@ -54,7 +54,7 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
         }
         SCOPED_RAW_TIMER(&_app_stats.deletion_vector_build_ns);
         std::unique_ptr<DeletionVector> dv = std::make_unique<DeletionVector>(scanner_params);
-        RETURN_IF_ERROR(dv->fill_row_indexes(&_skip_rows_ctx->need_skip_rowids));
+        RETURN_IF_ERROR(dv->fill_row_indexes(_skip_rows_ctx));
         _app_stats.deletion_vector_build_count += 1;
     }
     return Status::OK();

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -68,7 +68,7 @@ Status IcebergDeleteBuilder::fill_skip_rowids(const ChunkPtr& chunk) const {
     const ColumnPtr& pos = chunk->get_column_by_slot_id(k_delete_file_pos.id);
     for (int i = 0; i < chunk->num_rows(); i++) {
         if (file_path->get(i).get_slice() == _params.path) {
-            roaring64_bitmap_add(_deletion_bitmap, pos->get(i).get_int64());
+            _deletion_bitmap->add_value(pos->get(i).get_int64());
         }
     }
     return Status::OK();
@@ -147,7 +147,7 @@ Status IcebergDeleteBuilder::build_parquet(const TIcebergDeleteFile& delete_file
         RETURN_IF_ERROR(status);
         RETURN_IF_ERROR(fill_skip_rowids(chunk));
     }
-    _skip_rows_ctx->deletion_bitmap = std::make_shared<DeletionBitmap>(_deletion_bitmap);
+    _skip_rows_ctx->deletion_bitmap = _deletion_bitmap;
     update_delete_file_io_counter(_params.profile->runtime_profile, app_scan_stats, fs_scan_stats, cache_input_stream,
                                   shared_buffered_input_stream);
     return Status::OK();
@@ -200,7 +200,7 @@ Status IcebergDeleteBuilder::build_orc(const TIcebergDeleteFile& delete_file) co
         }
         RETURN_IF_ERROR(fill_skip_rowids(ret.value()));
     }
-    _skip_rows_ctx->deletion_bitmap = std::make_shared<DeletionBitmap>(_deletion_bitmap);
+    _skip_rows_ctx->deletion_bitmap = _deletion_bitmap;
     update_delete_file_io_counter(_params.profile->runtime_profile, app_scan_stats, fs_scan_stats, cache_input_stream,
                                   shared_buffered_input_stream);
     return Status::OK();

--- a/be/src/exec/iceberg/iceberg_delete_builder.h
+++ b/be/src/exec/iceberg/iceberg_delete_builder.h
@@ -23,9 +23,11 @@ struct IcebergColumnMeta;
 
 class IcebergDeleteBuilder {
 public:
-    IcebergDeleteBuilder(std::set<int64_t>* need_skip_rowids, RuntimeState* state,
-                         const HdfsScannerParams& scanner_params)
-            : _need_skip_rowids(need_skip_rowids), _params(scanner_params), _runtime_state(state) {}
+    IcebergDeleteBuilder(SkipRowsContextPtr skip_rows_ctx, RuntimeState* state, const HdfsScannerParams& scanner_params)
+            : _skip_rows_ctx(std::move(skip_rows_ctx)),
+              _params(scanner_params),
+              _runtime_state(state),
+              _deletion_bitmap(roaring64_bitmap_create()) {}
 
     ~IcebergDeleteBuilder() = default;
 
@@ -45,9 +47,10 @@ private:
             const std::shared_ptr<io::SharedBufferedInputStream>& shared_buffered_input_stream);
     Status fill_skip_rowids(const ChunkPtr& chunk) const;
 
-    std::set<int64_t>* _need_skip_rowids;
+    SkipRowsContextPtr _skip_rows_ctx;
     const HdfsScannerParams& _params;
     RuntimeState* _runtime_state;
+    roaring64_bitmap_t* _deletion_bitmap;
 };
 
 class IcebergDeleteFileMeta {

--- a/be/src/exec/iceberg/iceberg_delete_builder.h
+++ b/be/src/exec/iceberg/iceberg_delete_builder.h
@@ -27,7 +27,7 @@ public:
             : _skip_rows_ctx(std::move(skip_rows_ctx)),
               _params(scanner_params),
               _runtime_state(state),
-              _deletion_bitmap(roaring64_bitmap_create()) {}
+              _deletion_bitmap(std::make_shared<DeletionBitmap>(roaring64_bitmap_create())) {}
 
     ~IcebergDeleteBuilder() = default;
 
@@ -50,7 +50,7 @@ private:
     SkipRowsContextPtr _skip_rows_ctx;
     const HdfsScannerParams& _params;
     RuntimeState* _runtime_state;
-    roaring64_bitmap_t* _deletion_bitmap;
+    DeletionBitmapPtr _deletion_bitmap;
 };
 
 class IcebergDeleteFileMeta {

--- a/be/src/exec/paimon/paimon_delete_file_builder.h
+++ b/be/src/exec/paimon/paimon_delete_file_builder.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "exec/hdfs_scanner.h"
 #include "fs/fs.h"
 #include "gen_cpp/PlanNodes_types.h"
 
@@ -21,8 +22,8 @@ namespace starrocks {
 
 class PaimonDeleteFileBuilder {
 public:
-    PaimonDeleteFileBuilder(FileSystem* fs, std::set<int64_t>* need_skip_rowids)
-            : _fs(fs), _need_skip_rowids(need_skip_rowids) {}
+    PaimonDeleteFileBuilder(FileSystem* fs, SkipRowsContextPtr skip_rows_ctx)
+            : _fs(fs), _skip_rows_ctx(std::move(skip_rows_ctx)) {}
     ~PaimonDeleteFileBuilder() = default;
     Status build(const TPaimonDeletionFile* paimon_deletion_file);
 
@@ -33,7 +34,7 @@ private:
     }
 
     FileSystem* _fs;
-    std::set<int64_t>* _need_skip_rowids;
+    SkipRowsContextPtr _skip_rows_ctx;
 
     // Structure of a deletion file is: 1 byte version num + n * {4 bytes deletion vector length + 4 bytes magic num
     // + (length - 4) bytes bitmap + 4 bytes CRC num}, n is equal to num of data files

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -19,6 +19,7 @@
 
 #include "column/vectorized_fwd.h"
 #include "common/object_pool.h"
+#include "exec/hdfs_scanner.h"
 #include "exprs/expr.h"
 #include "exprs/runtime_filter_bank.h"
 #include "formats/orc/column_reader.h"
@@ -125,8 +126,8 @@ public:
     Status lazy_seek_to(uint64_t rowInStripe);
     void lazy_filter_on_cvb(Filter* filter);
     StatusOr<ChunkPtr> get_lazy_chunk();
-    ColumnPtr get_row_delete_filter(const std::set<int64_t>& deleted_pos);
-    size_t get_row_delete_number(const std::set<int64_t>& deleted_pos);
+    StatusOr<ColumnPtr> get_row_delete_filter(const SkipRowsContextPtr& skip_rows_ctx);
+    size_t get_row_delete_number(const SkipRowsContextPtr& skip_rows_ctx);
 
     bool is_implicit_castable(TypeDescriptor& starrocks_type, const TypeDescriptor& orc_type);
 

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -110,7 +110,7 @@ class GroupReader {
     friend class PageIndexReader;
 
 public:
-    GroupReader(GroupReaderParam& param, int row_group_number, const std::set<int64_t>* need_skip_rowids,
+    GroupReader(GroupReaderParam& param, int row_group_number, SkipRowsContextPtr skip_rows_ctx,
                 int64_t row_group_first_row);
     ~GroupReader();
 
@@ -163,7 +163,7 @@ private:
     // row group meta
     const tparquet::RowGroup* _row_group_metadata = nullptr;
     int64_t _row_group_first_row = 0;
-    const std::set<int64_t>* _need_skip_rowids;
+    SkipRowsContextPtr _skip_rows_ctx;
     int64_t _raw_rows_read = 0;
 
     // column readers for column chunk in row group

--- a/be/test/exec/paimon/paimon_delete_file_builder_test.cpp
+++ b/be/test/exec/paimon/paimon_delete_file_builder_test.cpp
@@ -32,12 +32,12 @@ protected:
     int64_t _offset = 1;
     int64_t _length = 22;
 
-    std::set<int64_t> _need_skip_rowids;
+    SkipRowsContextPtr _skip_rows_ctx = std::make_shared<SkipRowsContext>();
 };
 
 TEST_F(PaimonDeleteFileBuilderTest, TestParquetBuilder) {
     std::unique_ptr<PaimonDeleteFileBuilder> builder(
-            new PaimonDeleteFileBuilder(FileSystem::Default(), &_need_skip_rowids));
+            new PaimonDeleteFileBuilder(FileSystem::Default(), _skip_rows_ctx));
     TPaimonDeletionFile paimonDeletionFile;
     paimonDeletionFile.__set_path(_path);
     paimonDeletionFile.__set_offset(_offset);
@@ -45,7 +45,7 @@ TEST_F(PaimonDeleteFileBuilderTest, TestParquetBuilder) {
     std::shared_ptr<TPaimonDeletionFile> paimon_deletion_file =
             std::make_shared<TPaimonDeletionFile>(paimonDeletionFile);
     ASSERT_OK(builder->build(paimon_deletion_file.get()));
-    ASSERT_EQ(1, _need_skip_rowids.size());
+    ASSERT_EQ(1, _skip_rows_ctx->deletion_bitmap->get_cardinality());
 }
 
 } // namespace starrocks

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -1079,10 +1079,11 @@ TEST_F(FileReaderTest, TestGetNext) {
 }
 
 TEST_F(FileReaderTest, TestGetNextWithSkipID) {
-    int64_t ids[] = {1};
-    std::set<int64_t> need_skip_rowids(ids, ids + 1);
+    roaring64_bitmap_t* bitmap = roaring64_bitmap_create();
+    roaring64_bitmap_add(bitmap, 1);
+
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
-    skip_rows_ctx->need_skip_rowids = need_skip_rowids;
+    skip_rows_ctx->deletion_bitmap = std::make_shared<DeletionBitmap>(bitmap);
     auto file = _create_file(_file1_path);
     auto file_reader =
             std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(_file1_path),

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -371,8 +371,8 @@ TEST_F(GroupReaderTest, TestInit) {
     param->chunk_size = config::vector_chunk_size;
     param->file = file;
     param->file_metadata = file_meta;
-    std::set<int64_t> need_skip_rowids;
-    auto* group_reader = _pool.add(new GroupReader(*param, 0, &need_skip_rowids, 0));
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     // init row group reader
     status = group_reader->init();
@@ -414,8 +414,8 @@ TEST_F(GroupReaderTest, TestGetNext) {
     param->chunk_size = config::vector_chunk_size;
     param->file = file;
     param->file_metadata = file_meta;
-    std::set<int64_t> need_skip_rowids;
-    auto* group_reader = _pool.add(new GroupReader(*param, 0, &need_skip_rowids, 0));
+    SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
+    auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
 
     // init row group reader
     status = group_reader->init();

--- a/test/sql/test_iceberg/R/test_iceberg_v2
+++ b/test/sql/test_iceberg/R/test_iceberg_v2
@@ -1,5 +1,5 @@
 -- name: test_iceberg_v2
-create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
 -- !result
 /*

--- a/test/sql/test_iceberg/T/test_iceberg_v2
+++ b/test/sql/test_iceberg/T/test_iceberg_v2
@@ -1,6 +1,6 @@
 -- name: test_iceberg_v2
 
-create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true");
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 
 -- Currently only flink can write iceberg equality delete file. The table in the case was created in advance and some test data was inserted using flink. If you want test more cases, you could contact stephen5217@163.com
 


### PR DESCRIPTION
## Why I'm doing:
Query delta lake table with deletion vector takes lots of time because of building skip rowid set
## What I'm doing:
1. do not build skip row id set, using roaing bitmap to replace set
2. add some meric of deserialized deletion vector

## performance

<meta charset="utf-8"><div data-page-id="KlrddwSRGoDeQHxnPTFc3ScWnJg" data-lark-html-role="root" data-docx-has-block-data="true"><div>
 deletion percent | 0 percent | 5 percent | 10 percent | 30 percent | 50 percent
-- | -- | -- | -- | -- | --
before | 4.9s | 6.5s | 8.6s | 16.4s | 23.1s
with PR 54847 | 4.3s | 5.2s | 5.3s | 5.8s | 5.6s


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0