### PR TITLE
[Enhancement] Optimize Tablet Report

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -43,6 +43,7 @@
 #include <sstream>
 
 #include "agent/master_info.h"
+#include "agent/task_worker_pool.h"
 #include "common/process_exit.h"
 #include "common/status.h"
 #include "gen_cpp/HeartbeatService.h"
@@ -105,15 +106,6 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
         bool r = update_master_info(master_info);
         LOG_IF(WARNING, !r) << "Fail to update master info, maybe the master info has been updated by another thread "
                                "with a larger epoch";
-    } else if (*res == kNeedUpdateAndReport) {
-        LOG(INFO) << "Updating master info: " << print_master_info(master_info);
-        bool r = update_master_info(master_info);
-        LOG_IF(WARNING, !r) << "Fail to update master info, maybe the master info has been updated by another thread "
-                               "with a larger epoch";
-        if (r) {
-            LOG(INFO) << "Master FE is changed or restarted. report tablet and disk info immediately";
-            _olap_engine->trigger_report();
-        }
     } else {
         DCHECK_EQ(kUnchanged, *res);
         // nothing to do
@@ -125,6 +117,12 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
 
     if (master_info.__isset.decommissioned_disks) {
         _olap_engine->decommission_disks(master_info.decommissioned_disks);
+    }
+
+    if (master_info.__isset.stop_regular_tablet_report) {
+        ReportOlapTableTaskWorkerPool::set_regular_report_stopped(master_info.stop_regular_tablet_report);
+    } else {
+        ReportOlapTableTaskWorkerPool::set_regular_report_stopped(false);
     }
 
     static auto num_hardware_cores = static_cast<int32_t>(CpuInfo::num_cores());
@@ -270,9 +268,6 @@ StatusOr<HeartbeatServer::CmpResult> HeartbeatServer::compare_master_info(const 
         heartbeat_flags->update(master_info.heartbeat_flags);
     }
 
-    if (curr_master_info->network_address != master_info.network_address) {
-        return kNeedUpdateAndReport;
-    }
     if (*curr_master_info != master_info) {
         return kNeedUpdate;
     }

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -76,14 +76,26 @@
 namespace starrocks {
 
 namespace {
-static void wait_for_notify_small_steps(int32_t timeout_sec, bool from_report_tablet_thread,
-                                        const std::function<bool()>& stop_waiting) {
-    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeout_sec);
+static void wait_for_disk_report_notify(const std::function<bool()>& stop_waiting) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(config::report_disk_state_interval_seconds);
     bool notified = false;
     do {
         // take 1 second per step
-        notified = StorageEngine::instance()->wait_for_report_notify(1, from_report_tablet_thread);
+        notified = StorageEngine::instance()->wait_for_report_notify(1, false);
     } while (!notified && std::chrono::steady_clock::now() < deadline && !stop_waiting());
+}
+
+static void wait_for_tablet_report_notify(const std::function<bool()>& stop_waiting) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(config::report_tablet_interval_seconds);
+    bool notified = false;
+    do {
+        // take 1 second per step
+        notified = StorageEngine::instance()->wait_for_report_notify(1, true);
+    } while (!notified
+             // if the regular report is stopped, there will be no deadline
+             && (ReportOlapTableTaskWorkerPool::is_regular_report_stopped() ||
+                 std::chrono::steady_clock::now() < deadline) &&
+             !stop_waiting());
 }
 } // namespace
 
@@ -665,8 +677,7 @@ void* ReportDiskStateTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         }
 
         // wait for notifying until timeout
-        wait_for_notify_small_steps(config::report_disk_state_interval_seconds, false,
-                                    [&] { return worker_pool_this->_stopped.load(); });
+        wait_for_disk_report_notify([&] { return worker_pool_this->_stopped.load(); });
     }
 
     return nullptr;
@@ -695,8 +706,7 @@ void* ReportOlapTableTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         if (!st_report.ok()) {
             LOG(WARNING) << "Fail to report all tablets info, err=" << st_report.to_string();
             // wait for notifying until timeout
-            wait_for_notify_small_steps(config::report_tablet_interval_seconds, true,
-                                        [&] { return worker_pool_this->_stopped.load(); });
+            wait_for_tablet_report_notify([&] { return worker_pool_this->_stopped.load(); });
             continue;
         }
         int64_t max_compaction_score =
@@ -717,12 +727,13 @@ void* ReportOlapTableTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         }
 
         // wait for notifying until timeout
-        wait_for_notify_small_steps(config::report_tablet_interval_seconds, true,
-                                    [&] { return worker_pool_this->_stopped.load(); });
+        wait_for_tablet_report_notify([&] { return worker_pool_this->_stopped.load(); });
     }
 
     return nullptr;
 }
+
+std::atomic<bool> ReportOlapTableTaskWorkerPool::_regular_report_stopped(false);
 
 void* ReportWorkgroupTaskWorkerPool::_worker_thread_callback(void* arg_this) {
     auto* worker_pool_this = (ReportWorkgroupTaskWorkerPool*)arg_this;

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -194,7 +194,13 @@ public:
         _callback_function = _worker_thread_callback;
     }
 
+    static void set_regular_report_stopped(bool stop) { _regular_report_stopped.store(stop); }
+
+    static bool is_regular_report_stopped() { return _regular_report_stopped.load(); }
+
 private:
+    static std::atomic<bool> _regular_report_stopped;
+
     static void* _worker_thread_callback(void* arg_this);
 
     AgentTaskRequestPtr _convert_task(const TAgentTaskRequest& task, time_t recv_time) override {

--- a/be/src/service/service_be/backend_service.h
+++ b/be/src/service/service_be/backend_service.h
@@ -58,6 +58,8 @@ public:
 
     void get_tablet_stat(TTabletStatResult& result) override;
 
+    void get_tablets_info(TGetTabletsInfoResult& result_, const TGetTabletsInfoRequest& request) override;
+
 private:
     AgentServer* _agent_server;
 };

--- a/be/test/agent/heartbeat_server_test.cpp
+++ b/be/test/agent/heartbeat_server_test.cpp
@@ -50,7 +50,7 @@ TEST(HeartbeatServerTest, test_print_master_info_with_token_null) {
             "cluster_id=12345, epoch=100, token=<null>, backend_ip=192.168.1.1, "
             "http_port=<null>, heartbeat_flags=<null>, backend_id=<null>, "
             "min_active_txn_id=0, run_mode=<null>, disabled_disks=<null>, "
-            "decommissioned_disks=<null>, encrypted=<null>)";
+            "decommissioned_disks=<null>, encrypted=<null>, stop_regular_tablet_report=<null>)";
 
     EXPECT_EQ(server.print_master_info(master_info), expected_output);
 }
@@ -71,7 +71,7 @@ TEST(HeartbeatServerTest, test_print_master_info_with_token_hidden) {
             "cluster_id=12345, epoch=100, token=<hidden>, backend_ip=192.168.1.1, "
             "http_port=<null>, heartbeat_flags=<null>, backend_id=<null>, "
             "min_active_txn_id=0, run_mode=<null>, disabled_disks=<null>, "
-            "decommissioned_disks=<null>, encrypted=<null>)";
+            "decommissioned_disks=<null>, encrypted=<null>, stop_regular_tablet_report=<null>)";
 
     EXPECT_EQ(server.print_master_info(master_info), expected_output);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1493,6 +1493,12 @@ public class Config extends ConfigBase {
     @ConfField
     public static int tablet_stat_update_interval_second = 300;  // 5 min
 
+    @ConfField(mutable = true, comment = "time interval to collect tablet info from backend")
+    public static long tablet_collect_interval_seconds = 60;
+
+    @ConfField(mutable = true, comment = "Timeout for calling BE get_tablets_info rpc")
+    public static int tablet_collect_timeout_seconds = 60;
+
     /**
      * The tryLock timeout configuration of globalStateMgr lock.
      * Normally it does not need to change, unless you need to test something.

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -83,7 +83,6 @@ import com.starrocks.lake.LakeTablet;
 import com.starrocks.load.DeleteJob;
 import com.starrocks.load.OlapDeleteJob;
 import com.starrocks.load.loadv2.SparkLoadJob;
-import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -174,13 +173,6 @@ import static com.starrocks.catalog.Replica.ReplicaState.NORMAL;
 
 public class LeaderImpl {
     private static final Logger LOG = LogManager.getLogger(LeaderImpl.class);
-
-    private final ReportHandler reportHandler = new ReportHandler();
-
-    public LeaderImpl() {
-        reportHandler.start();
-        MemoryUsageTracker.registerMemoryTracker("Report", reportHandler);
-    }
 
     public TMasterResult finishTask(TFinishTaskRequest request) {
         // if current node is not master, reject the request
@@ -873,7 +865,7 @@ public class LeaderImpl {
             result.setStatus(status);
             return result;
         }
-        return reportHandler.handleReport(request);
+        return GlobalStateMgr.getCurrentState().getReportHandler().handleReport(request);
     }
 
     private void finishAlterTask(AgentTask task) {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/TabletCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/TabletCollector.java
@@ -1,0 +1,146 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.leader;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.rpc.ThriftConnectionPool;
+import com.starrocks.rpc.ThriftRPCRequestExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TGetTabletsInfoRequest;
+import com.starrocks.thrift.TGetTabletsInfoResult;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TStatusCode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+public class TabletCollector extends FrontendDaemon {
+    private static final Logger LOG = LogManager.getLogger(TabletCollector.class);
+    private static final long CHECK_INTERVAL_MS = 100;
+
+    private final PriorityQueue<CollectStat> collectQueue;
+    private final Set<Long> queuedBeIds;
+
+    public TabletCollector() {
+        super("TabletCollector", CHECK_INTERVAL_MS);
+        collectQueue = new PriorityQueue<>();
+        queuedBeIds = new HashSet<>();
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (RunMode.isSharedDataMode()) {
+            return;
+        }
+
+        updateQueue();
+
+        collect(collectQueue.poll());
+    }
+
+    private void updateQueue() {
+        List<Backend> backends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends();
+        for (Backend backend : backends) {
+            if (backend.isAlive() && !queuedBeIds.contains(backend.getId())) {
+                queuedBeIds.add(backend.getId());
+                collectQueue.add(new CollectStat(backend.getId(), -1L));
+            }
+        }
+    }
+
+    private void collect(CollectStat collectStat) {
+        if (collectStat == null) {
+            return;
+        }
+
+        // 1. If there are more than 1 pending report task in ReportHandler
+        // or
+        // 2. The time since the last collection is less than Config.tablet_collect_interval_seconds.
+        // return back the stat to collectQueue and do nothing.
+        if (GlobalStateMgr.getCurrentState().getReportHandler().getPendingTabletReportTaskCnt() > 1
+                || System.currentTimeMillis() - collectStat.lastCollectTime < Config.tablet_collect_interval_seconds * 1000) {
+            collectQueue.add(collectStat);
+            return;
+        }
+
+        // If backend is invalid, remove this backend from queue.
+        // If resumed, the backend will be added back to the queue via updateQueue().
+        Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(collectStat.beId);
+        if (backend == null || !backend.isAlive()) {
+            queuedBeIds.remove(collectStat.beId);
+            return;
+        }
+
+        try {
+            long startMs = System.currentTimeMillis();
+            TGetTabletsInfoResult result = ThriftRPCRequestExecutor.call(
+                    ThriftConnectionPool.backendPool,
+                    new TNetworkAddress(backend.getHost(), backend.getBePort()),
+                    Config.tablet_collect_timeout_seconds * 1000,
+                    2,
+                    client -> client.get_tablets_info(new TGetTabletsInfoRequest()));
+
+            if (result.getStatus().getStatus_code() == TStatusCode.OK) {
+                GlobalStateMgr.getCurrentState().getReportHandler()
+                        .putTabletReportTask(backend.getId(), result.getReport_version(), result.getTablets());
+                LOG.debug("collect tablet from backend {} successfully, time used: {}ms", backend.getId(),
+                        System.currentTimeMillis() - startMs);
+            } else {
+                String errMsg = "";
+                if (result.getStatus().getError_msgs() != null) {
+                    errMsg = String.join(",", result.getStatus().getError_msgs());
+                }
+                LOG.warn("collect tablet from backend {} failed, error: {}", backend.getId(), errMsg);
+            }
+        } catch (Exception e) {
+            LOG.warn("collect tablets from backend {} failed", backend.getId(), e);
+        }
+
+        // Regardless of whether the collection succeeds or fails, lastCollectTime must be updated,
+        // otherwise it will block the collection of other backends.
+        collectStat.lastCollectTime = System.currentTimeMillis();
+        collectQueue.add(collectStat);
+    }
+
+    public static class CollectStat implements Comparable<CollectStat> {
+        long beId;
+        long lastCollectTime;
+
+        CollectStat(long beId, long lastCollectTime) {
+            this.beId = beId;
+            this.lastCollectTime = lastCollectTime;
+        }
+
+        public long getBeId() {
+            return beId;
+        }
+
+        public long getLastCollectTime() {
+            return lastCollectTime;
+        }
+
+        @Override
+        public int compareTo(CollectStat other) {
+            return Long.compare(lastCollectTime, other.lastCollectTime);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
@@ -70,6 +70,7 @@ public class MemoryUsageTracker extends FrontendDaemon {
         registerMemoryTracker("Task", currentState.getTaskManager().getTaskRunManager());
         registerMemoryTracker("TabletInvertedIndex", currentState.getTabletInvertedIndex());
         registerMemoryTracker("LocalMetastore", currentState.getLocalMetastore());
+        registerMemoryTracker("Report", currentState.getReportHandler());
 
         // MV
         registerMemoryTracker("MV", currentState.getMaterializedViewMgr().getMvTimelinessMgr());

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -414,6 +414,15 @@ public final class MetricRepo {
         GAUGE_SAFE_MODE.setValue(0);
         STARROCKS_METRIC_REGISTER.addMetric(GAUGE_SAFE_MODE);
 
+        GaugeMetric<Long> gaugeReportQueueSize = new GaugeMetric<Long>(
+                "report_queue_size", MetricUnit.NOUNIT, "report queue size") {
+            @Override
+            public Long getValue() {
+                return (long) GlobalStateMgr.getCurrentState().getReportHandler().getReportQueueSize();
+            }
+        };
+        STARROCKS_METRIC_REGISTER.addMetric(gaugeReportQueueSize);
+
         // 2. counter
         COUNTER_REQUEST_ALL = new LongCounterMetric("request_total", MetricUnit.REQUESTS, "total request");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_REQUEST_ALL);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -143,6 +143,8 @@ import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.lake.vacuum.AutovacuumDaemon;
 import com.starrocks.leader.CheckpointController;
+import com.starrocks.leader.ReportHandler;
+import com.starrocks.leader.TabletCollector;
 import com.starrocks.leader.TaskRunStateSynchronizer;
 import com.starrocks.listener.GlobalLoadJobListenerBus;
 import com.starrocks.load.DeleteMgr;
@@ -521,6 +523,8 @@ public class GlobalStateMgr {
     private final ClusterSnapshotMgr clusterSnapshotMgr;
 
     private final SqlBlackList sqlBlackList;
+    private final ReportHandler reportHandler;
+    private final TabletCollector tabletCollector;
 
     public NodeMgr getNodeMgr() {
         return nodeMgr;
@@ -827,6 +831,9 @@ public class GlobalStateMgr {
                         "query-deploy", true);
 
         this.warehouseIdleChecker = new WarehouseIdleChecker();
+
+        this.reportHandler = new ReportHandler();
+        this.tabletCollector = new TabletCollector();
     }
 
     public static void destroyCheckpoint() {
@@ -1434,6 +1441,8 @@ public class GlobalStateMgr {
             clusterSnapshotMgr.startCheckpointScheduler(checkpointController,
                                                         StarMgrServer.getCurrentState().getCheckpointController());
         }
+        reportHandler.start();
+        tabletCollector.start();
     }
 
     // start threads that should run on all FE
@@ -2710,5 +2719,9 @@ public class GlobalStateMgr {
     public void shutdown() {
         // in a single thread.
         connectorMgr.shutdown();
+    }
+
+    public ReportHandler getReportHandler() {
+        return reportHandler;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -273,6 +273,7 @@ public class HeartbeatMgr extends FrontendDaemon {
                 copiedMasterInfo.setMin_active_txn_id(
                         GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getMinActiveTxnId());
                 copiedMasterInfo.setRun_mode(RunMode.toTRunMode(RunMode.getCurrentRunMode()));
+                copiedMasterInfo.setStop_regular_tablet_report(true);
                 if (computeNode instanceof Backend) {
                     copiedMasterInfo.setDisabled_disks(((Backend) computeNode).getDisabledDisks());
                     copiedMasterInfo.setDecommissioned_disks(((Backend) computeNode).getDecommissionedDisks());

--- a/fe/fe-core/src/test/java/com/starrocks/common/GenericPoolTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/GenericPoolTest.java
@@ -32,6 +32,8 @@ import com.starrocks.thrift.TExportStatusResult;
 import com.starrocks.thrift.TExportTaskRequest;
 import com.starrocks.thrift.TFetchDataParams;
 import com.starrocks.thrift.TFetchDataResult;
+import com.starrocks.thrift.TGetTabletsInfoRequest;
+import com.starrocks.thrift.TGetTabletsInfoResult;
 import com.starrocks.thrift.TMiniLoadEtlStatusRequest;
 import com.starrocks.thrift.TMiniLoadEtlStatusResult;
 import com.starrocks.thrift.TMiniLoadEtlTaskRequest;
@@ -196,6 +198,11 @@ public class GenericPoolTest {
         @Override
         public TTabletStatResult get_tablet_stat() throws TException {
             // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public TGetTabletsInfoResult get_tablets_info(TGetTabletsInfoRequest request) throws TException {
             return null;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -469,4 +469,16 @@ public class ReportHandlerTest {
         ready = ReportHandler.checkReadyToBeDropped(tabletId, backendId);
         Assert.assertTrue(ready);
     }
+
+    @Test
+    public void testGetPendingTabletReportTaskCnt() throws Exception {
+        ReportHandler reportHandler = new ReportHandler();
+        Assert.assertEquals(0, reportHandler.getPendingTabletReportTaskCnt());
+        reportHandler.putTabletReportTask(1L, 1L, new HashMap<>());
+        Assert.assertEquals(1, reportHandler.getPendingTabletReportTaskCnt());
+        reportHandler.putTabletReportTask(1L, 1L, new HashMap<>());
+        Assert.assertEquals(1, reportHandler.getPendingTabletReportTaskCnt());
+        reportHandler.putTabletReportTask(2L, 1L, new HashMap<>());
+        Assert.assertEquals(2, reportHandler.getPendingTabletReportTaskCnt());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/leader/TabletCollectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/TabletCollectorTest.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.leader;
+
+import com.starrocks.leader.TabletCollector.CollectStat;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.PriorityQueue;
+
+public class TabletCollectorTest {
+
+    @Test
+    public void testCollectStat() {
+        PriorityQueue<CollectStat> queue = new PriorityQueue();
+        queue.add(new CollectStat(1L, 1L));
+        queue.add(new CollectStat(2L, 2L));
+        queue.add(new CollectStat(3L, 3L));
+        Assert.assertEquals(1L, queue.poll().lastCollectTime);
+        Assert.assertEquals(2L, queue.poll().lastCollectTime);
+        Assert.assertEquals(3L, queue.poll().lastCollectTime);
+    }
+}

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -42,6 +42,7 @@ include "AgentService.thrift"
 include "InternalService.thrift"
 include "StarrocksExternalService.thrift"
 include "MVMaintenance.thrift"
+include "MasterService.thrift"
 
 struct TExportTaskRequest {
     1: required InternalService.TExecPlanFragmentParams params
@@ -116,6 +117,15 @@ struct TStreamLoadChannel {
     2: optional i32 channel_id
 }
 
+struct TGetTabletsInfoRequest {
+}
+
+struct TGetTabletsInfoResult {
+    1: required Status.TStatus status;
+    2: optional i64 report_version;
+    3: optional map<Types.TTabletId, MasterService.TTablet> tablets;
+}
+
 service BackendService {
     // Called by coord to start asynchronous execution of plan fragment in backend.
     // Returns as soon as all incoming data streams have been set up.
@@ -171,4 +181,5 @@ service BackendService {
     // release the context resource associated with the context_id
     StarrocksExternalService.TScanCloseResult close_scanner(1: StarrocksExternalService.TScanCloseParams params);
 
+    TGetTabletsInfoResult get_tablets_info(1: TGetTabletsInfoRequest request);
 }

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -34,6 +34,7 @@ struct TMasterInfo {
     11: optional list<string> disabled_disks
     12: optional list<string> decommissioned_disks
     13: optional bool encrypted;
+    14: optional bool stop_regular_tablet_report; // used for upgrade/downgrade compatibility, can be removed after 3.5
 }
 
 struct TBackendInfo {


### PR DESCRIPTION
## Why I'm doing:
In StarRocks, FE will periodically diff the tablets in BE and the tablets recorded in metadata, and then process the inconsistent tablets. The current implementation is that BE reports the full number of tablets to the FE Leader regularly (default 1 minute), and the Leader maintains a reporting queue, and then retrieves one BE tablet from the queue each time for single-threaded processing. For large-scale clusters, the speed of FE processing usually cannot keep up with the speed of BE reporting, resulting in the existence of all BE tablets in the reporting queue, which causes memory waste. This optimization uses the Leader's active pull mode to control the tablets in the reporting queue within a BE range.

## What I'm doing:
![image](https://github.com/user-attachments/assets/bfab21dc-9740-4e13-aa8c-a483a867d341)

After optimization, a new TabletController daemon is added to regularly pull the full number of tablets from the Backend. The pull condition is
1. For a certain BE, it has been more than collect_tablet_inverval_seconds since the last pull.
2. The processing queue of ReportHandler is empty.

BE still retains the ability to actively report tablets to FE Leader, but only for emergency situations, such as disk corruption and the need to immediately remove replicas from FE metadata.

## Test(a cluster with 5 million tablets)
after optimization
![image](https://github.com/user-attachments/assets/1eea3c3e-a430-4711-8b8c-62695222ad6d)

before optimization
![image](https://github.com/user-attachments/assets/d658afbd-74c9-40ac-8274-021d508f348c)

We can see the GC time has become smoother.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0