### PR TITLE
[Enhancement] support cumulative algorithm for max/min

### DIFF
--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -227,6 +227,8 @@ public:
 
     NullColumn* mutable_null_column() { return _null_column.get(); }
 
+    const NullColumn* immutable_null_column() const { return _null_column.get(); }
+
     const Column& data_column_ref() const { return *_data_column; }
 
     const ColumnPtr& data_column() const { return _data_column; }

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -813,7 +813,7 @@ CONF_Double(pipeline_driver_queue_ratio_of_adjacent_queue, "1.2");
 CONF_Int32(pipeline_analytic_max_buffer_size, "128");
 CONF_Int32(pipeline_analytic_removable_chunk_num, "128");
 CONF_Bool(pipeline_analytic_enable_streaming_process, "true");
-CONF_Bool(pipeline_analytic_enable_removable_cumulative_process, "true");
+CONF_mBool(pipeline_analytic_enable_removable_cumulative_process, "true");
 CONF_Int32(pipline_limit_max_delivery, "4096");
 
 CONF_mBool(use_default_dop_when_shared_scan, "true");

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -985,7 +985,7 @@ void Analytor::_update_window_batch_removable_cumulatively() {
         _agg_functions[i]->update_state_removable_cumulatively(
                 _agg_fn_ctxs[i], _managed_fn_states[0]->mutable_data() + _agg_states_offsets[i], &agg_column,
                 _current_row_position, _partition.start, _partition.end, _rows_start_offset, _rows_end_offset, false,
-                false);
+                false, false);
     }
 }
 

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -177,7 +177,8 @@ Status Analytor::prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* 
             _need_partition_materializing = true;
         }
 
-        if (!(fn.name.function_name == "sum" || fn.name.function_name == "avg" || fn.name.function_name == "count")) {
+        if (!(fn.name.function_name == "sum" || fn.name.function_name == "avg" || fn.name.function_name == "count" ||
+              fn.name.function_name == "max" || fn.name.function_name == "min")) {
             _use_removable_cumulative_process = false;
         }
 

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -193,7 +193,8 @@ public:
                                                      const Column** columns, int64_t current_row_position,
                                                      int64_t partition_start, int64_t partition_end,
                                                      int64_t rows_start_offset, int64_t rows_end_offset,
-                                                     bool ignore_subtraction, bool ignore_addition) const {}
+                                                     bool ignore_subtraction, bool ignore_addition,
+                                                     [[maybe_unused]] bool has_null) const {}
 
     // Contains a loop with calls to "merge" function.
     // You can collect arguments into array "states"

--- a/be/src/exprs/agg/aggregate_traits.h
+++ b/be/src/exprs/agg/aggregate_traits.h
@@ -44,6 +44,8 @@ struct AggDataTypeTraits<lt, FixedLengthLTGuard<lt>> {
     static void update_min(ValueType& current, const RefType& input) { current = std::min<ValueType>(current, input); }
 
     static bool is_equal(const RefType& lhs, const RefType& rhs) { return lhs == rhs; }
+
+    static bool equals(const ValueType& lhs, const RefType& rhs) { return lhs == rhs; }
 };
 
 // For pointer ref types
@@ -66,6 +68,7 @@ struct AggDataTypeTraits<lt, ObjectFamilyLTGuard<lt>> {
     static void update_min(ValueType& current, const RefType& input) { current = std::min<ValueType>(current, *input); }
 
     static bool is_equal(const RefType& lhs, const RefType& rhs) { return *lhs == *rhs; }
+    static bool equals(const ValueType& lhs, const RefType& rhs) { return lhs == *rhs; }
 };
 
 template <LogicalType lt>

--- a/be/src/exprs/agg/avg.h
+++ b/be/src/exprs/agg/avg.h
@@ -139,7 +139,8 @@ public:
     void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                              int64_t current_row_position, int64_t partition_start,
                                              int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
-                                             bool ignore_subtraction, bool ignore_addition) const override {
+                                             bool ignore_subtraction, bool ignore_addition,
+                                             [[maybe_unused]] bool has_null) const override {
         const int64_t previous_frame_first_position = current_row_position - 1 + rows_start_offset;
         const int64_t current_frame_last_position = current_row_position + rows_end_offset;
         if (!ignore_subtraction && previous_frame_first_position >= partition_start &&

--- a/be/src/exprs/agg/count.h
+++ b/be/src/exprs/agg/count.h
@@ -75,7 +75,8 @@ public:
     void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                              int64_t current_row_position, int64_t partition_start,
                                              int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
-                                             bool ignore_subtraction, bool ignore_addition) const override {
+                                             bool ignore_subtraction, bool ignore_addition,
+                                             [[maybe_unused]] bool has_null) const override {
         if constexpr (IsWindowFunc) {
             DCHECK(!ignore_subtraction);
             DCHECK(!ignore_addition);
@@ -241,7 +242,8 @@ public:
     void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                              int64_t current_row_position, int64_t partition_start,
                                              int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
-                                             bool ignore_subtraction, bool ignore_addition) const override {
+                                             bool ignore_subtraction, bool ignore_addition,
+                                             [[maybe_unused]] bool has_null) const override {
         if constexpr (IsWindowFunc) {
             DCHECK(!ignore_subtraction);
             DCHECK(!ignore_addition);

--- a/be/src/exprs/agg/maxmin.h
+++ b/be/src/exprs/agg/maxmin.h
@@ -87,6 +87,9 @@ struct MaxElement {
     // need sync details from detail state table.
     static bool is_sync(State& state, const T& right) { return state.result <= right; }
     void operator()(State& state, const T& right) const { AggDataTypeTraits<LT>::update_max(state.result, right); }
+    static bool equals(const State& state, const T& right) {
+        return AggDataTypeTraits<LT>::equals(state.result, right);
+    }
 };
 
 template <LogicalType LT, typename State, typename = guard::Guard>
@@ -97,6 +100,9 @@ struct MinElement {
     // need sync details from detail state table.
     static bool is_sync(State& state, const T& right) { return state.result >= right; }
     void operator()(State& state, const T& right) const { AggDataTypeTraits<LT>::update_min(state.result, right); }
+    static bool equals(const State& state, const T& right) {
+        return AggDataTypeTraits<LT>::equals(state.result, right);
+    }
 };
 
 template <LogicalType LT, typename State>
@@ -114,6 +120,10 @@ struct MaxElement<LT, State, StringLTGuard<LT>> {
             state.size = right.size;
         }
     }
+
+    static bool equals(const State& state, const Slice& right) {
+        return !state.has_value() || state.slice().compare(right) == 0;
+    }
 };
 
 template <LogicalType LT, typename State>
@@ -130,6 +140,10 @@ struct MinElement<LT, State, StringLTGuard<LT>> {
             memcpy(state.buffer.data(), right.data, right.size);
             state.size = right.size;
         }
+    }
+
+    static bool equals(const State& state, const Slice& right) {
+        return !state.has_value() || state.slice().compare(right) == 0;
     }
 };
 
@@ -156,6 +170,32 @@ public:
                                               int64_t frame_end) const override {
         for (size_t i = frame_start; i < frame_end; ++i) {
             update(ctx, columns, state, i);
+        }
+    }
+
+    void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                             int64_t current_row_position, int64_t partition_start,
+                                             int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
+                                             bool ignore_subtraction, bool ignore_addition) const override {
+        [[maybe_unused]] const auto& column = down_cast<const InputColumnType&>(*columns[0]);
+
+        const int64_t previous_frame_first_position = current_row_position - 1 + rows_start_offset;
+        int64_t current_frame_last_position = current_row_position + rows_end_offset;
+        if (!ignore_subtraction && previous_frame_first_position >= partition_start &&
+            previous_frame_first_position < partition_end) {
+            if (OP::equals(this->data(state), column.get_data()[previous_frame_first_position])) {
+                current_frame_last_position = std::min(current_frame_last_position, partition_end - 1);
+                this->data(state).reset();
+                update_batch_single_state_with_frame(ctx, state, columns, partition_start, partition_end,
+                                                     previous_frame_first_position + 1,
+                                                     current_frame_last_position + 1);
+                return;
+            }
+        }
+
+        if (!ignore_addition && current_frame_last_position >= partition_start &&
+            current_frame_last_position < partition_end) {
+            update(ctx, columns, state, current_frame_last_position);
         }
     }
 

--- a/be/src/exprs/agg/maxmin.h
+++ b/be/src/exprs/agg/maxmin.h
@@ -176,7 +176,8 @@ public:
     void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                              int64_t current_row_position, int64_t partition_start,
                                              int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
-                                             bool ignore_subtraction, bool ignore_addition) const override {
+                                             bool ignore_subtraction, bool ignore_addition,
+                                             [[maybe_unused]] bool has_null) const override {
         [[maybe_unused]] const auto& column = down_cast<const InputColumnType&>(*columns[0]);
 
         const int64_t previous_frame_first_position = current_row_position - 1 + rows_start_offset;
@@ -186,9 +187,20 @@ public:
             if (OP::equals(this->data(state), column.get_data()[previous_frame_first_position])) {
                 current_frame_last_position = std::min(current_frame_last_position, partition_end - 1);
                 this->data(state).reset();
-                update_batch_single_state_with_frame(ctx, state, columns, partition_start, partition_end,
-                                                     previous_frame_first_position + 1,
-                                                     current_frame_last_position + 1);
+                int64_t frame_start = previous_frame_first_position + 1;
+                int64_t frame_end = current_frame_last_position + 1;
+                if (has_null) {
+                    const auto null_column = down_cast<const NullColumn*>(columns[1]);
+                    const uint8_t* f_data = null_column->raw_data();
+                    for (size_t i = frame_start; i < frame_end; ++i) {
+                        if (f_data[i] == 0) {
+                            update(ctx, columns, state, i);
+                        }
+                    }
+                } else {
+                    update_batch_single_state_with_frame(ctx, state, columns, partition_start, partition_end,
+                                                         frame_start, frame_end);
+                }
                 return;
             }
         }

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -628,7 +628,8 @@ public:
     void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                              int64_t current_row_position, int64_t partition_start,
                                              int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
-                                             bool ignore_subtraction, bool ignore_addition) const override {
+                                             bool ignore_subtraction, bool ignore_addition,
+                                             [[maybe_unused]] bool has_null) const override {
         if constexpr (IsWindowFunc) {
             DCHECK(!ignore_subtraction);
             DCHECK(!ignore_addition);
@@ -656,7 +657,7 @@ public:
                         this->nested_function->update_state_removable_cumulatively(
                                 ctx, this->data(state).mutable_nest_state(), &data_column, current_row_position,
                                 partition_start, partition_end, rows_start_offset, rows_end_offset, ignore_subtraction,
-                                ignore_addition);
+                                ignore_addition, false);
                     } else {
                         // Build the frame for the first time
                         this->nested_function->update_batch_single_state_with_frame(
@@ -684,10 +685,11 @@ public:
                         is_current_frame_end_null = true;
                         this->data(state).null_count++;
                     }
+                    const Column* columns[2]{data_column, column->immutable_null_column()};
                     this->nested_function->update_state_removable_cumulatively(
-                            ctx, this->data(state).mutable_nest_state(), &data_column, current_row_position,
-                            partition_start, partition_end, rows_start_offset, rows_end_offset,
-                            is_previous_frame_start_null, is_current_frame_end_null);
+                            ctx, this->data(state).mutable_nest_state(), columns, current_row_position, partition_start,
+                            partition_end, rows_start_offset, rows_end_offset, is_previous_frame_start_null,
+                            is_current_frame_end_null, true);
                     if (frame_size != this->data(state).null_count) {
                         this->data(state).is_null = false;
                     }
@@ -708,7 +710,7 @@ public:
                 this->data(state).is_null = false;
                 this->nested_function->update_state_removable_cumulatively(
                         ctx, this->data(state).mutable_nest_state(), columns, current_row_position, partition_start,
-                        partition_end, rows_start_offset, rows_end_offset, ignore_subtraction, ignore_addition);
+                        partition_end, rows_start_offset, rows_end_offset, ignore_subtraction, ignore_addition, false);
             }
         }
     }

--- a/be/src/exprs/agg/sum.h
+++ b/be/src/exprs/agg/sum.h
@@ -93,7 +93,8 @@ public:
     void update_state_removable_cumulatively(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                              int64_t current_row_position, int64_t partition_start,
                                              int64_t partition_end, int64_t rows_start_offset, int64_t rows_end_offset,
-                                             bool ignore_subtraction, bool ignore_addition) const override {
+                                             bool ignore_subtraction, bool ignore_addition,
+                                             [[maybe_unused]] bool has_null) const override {
         const auto* column = down_cast<const InputColumnType*>(columns[0]);
         const auto* data = column->get_data().data();
 


### PR DESCRIPTION
## Why I'm doing:
without cumulative algorithm,  sql like "SELECT max(fn_int) OVER (ORDER BY fn_int ROWS BETWEEN 4096 PRECEDING AND 34096 FOLLOWING) AS wv FROM t_small " 's time complexsity is O(N*M), where N is row numbers, M is 4096+34086. with cumulative algorithm, time complexsity is O(N).

max/min's cumulative algorithm is like below:
when sliding window move forward on step, we need to check the previous_frame_first_position（The leftmost data in previous sliding window). if it euqals  this->data(state), which means column[previous_frame_first_position] is the maximun/minimum value in the previous sliding window，in this case we need to back forward to the old way to calculate the whole sliding window. 

in other cases, we only need to update column[current_frame_last_position] to move forward  sliding window  on step, because column[previous_frame_first_position]  is not the maximun/minimum value in the previous sliding window, so it won't change the  this->data(state) without column[previous_frame_first_position]


## What I'm doing:
befor this pr:
```
mysql> SELECT SUM(wv) FROM ( SELECT max(fn_int) OVER (ORDER BY fn_int ROWS BETWEEN 4096 PRECEDING AND 34096 FOLLOWING) AS wv FROM t_small ) AS sub;
+--------------+
| sum(wv)      |
+--------------+
| 533514214344 |
+--------------+
1 row in set (1.78 sec)
```

after this pr:
```
mysql> SELECT SUM(wv) FROM ( SELECT max(fn_int) OVER (ORDER BY fn_int ROWS BETWEEN 4096 PRECEDING AND 34096 FOLLOWING) AS wv FROM t_small ) AS sub;
+--------------+
| sum(wv)      |
+--------------+
| 533514214344 |
+--------------+
1 row in set (0.11 sec)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0