### PR TITLE
[Enhancement] Implement trino function year_of_week 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -232,6 +232,30 @@ public class Trino2SRFunctionCallTransformer {
         // last_day_of_month(x)  -> last_day(x,'month')
         registerFunctionTransformer("last_day_of_month", 1, new FunctionCallExpr("last_day",
                 List.of(new PlaceholderExpr(1, Expr.class), new StringLiteral("month"))));
+
+        // year_of_week(x) -> floor(divide(yearweek('x', 1),100))
+        registerFunctionTransformer("year_of_week", 1,
+                new FunctionCallExpr("floor", List.of(
+                        new FunctionCallExpr("divide", List.of(
+                                new FunctionCallExpr("yearweek", List.of(
+                                        new PlaceholderExpr(1, Expr.class),
+                                        new IntLiteral(1))
+                                ),
+                                new IntLiteral(100))
+                        )
+                )));
+
+        // yow(x) -> floor(divide(yearweek('x', 1),100))
+        registerFunctionTransformer("yow", 1,
+                new FunctionCallExpr("floor", List.of(
+                        new FunctionCallExpr("divide", List.of(
+                                new FunctionCallExpr("yearweek", List.of(
+                                        new PlaceholderExpr(1, Expr.class),
+                                        new IntLiteral(1))
+                                ),
+                                new IntLiteral(100))
+                        )
+                )));
     }
 
     private static void registerStringFunctionTransformer() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -207,7 +207,7 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         analyzeFail(sql, "date_diff function must have 3 arguments");
 
         sql = "select to_date('2022-02-02', 'yyyy-mm-dd')";
-        assertPlanContains(sql1, "to_tera_date('2022-02-02', 'yyyy-mm-dd')");
+        assertPlanContains(sql, "to_tera_date('2022-02-02', 'yyyy-mm-dd')");
 
         sql = "select to_timestamp('2022-02-02', 'yyyy-mm-dd')";
         assertPlanContains(sql, " to_tera_timestamp('2022-02-02', 'yyyy-mm-dd')");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -211,6 +211,12 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
         sql = "select to_timestamp('2022-02-02', 'yyyy-mm-dd')";
         assertPlanContains(sql, " to_tera_timestamp('2022-02-02', 'yyyy-mm-dd')");
+
+        sql = "select year_of_week('2022-02-02')";
+        assertPlanContains(sql, " floor(divide(yearweek('2022-02-02', 1), 100))");
+
+        sql = "select yow('2022-02-02')";
+        assertPlanContains(sql, " floor(divide(yearweek('2022-02-02', 1), 100))");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -207,16 +207,16 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         analyzeFail(sql, "date_diff function must have 3 arguments");
 
         sql = "select to_date('2022-02-02', 'yyyy-mm-dd')";
-        assertPlanContains(sql, "to_tera_date('2022-02-02', 'yyyy-mm-dd')");
+        assertPlanContains(sql1, "to_tera_date('2022-02-02', 'yyyy-mm-dd')");
 
         sql = "select to_timestamp('2022-02-02', 'yyyy-mm-dd')";
         assertPlanContains(sql, " to_tera_timestamp('2022-02-02', 'yyyy-mm-dd')");
 
         sql = "select year_of_week('2022-02-02')";
-        assertPlanContains(sql, " floor(divide(yearweek('2022-02-02', 1), 100))");
+        assertPlanContains(sql, "<slot 2> : 2022");
 
         sql = "select yow('2022-02-02')";
-        assertPlanContains(sql, " floor(divide(yearweek('2022-02-02', 1), 100))");
+        assertPlanContains(sql, "<slot 2> : 2022");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Implement trino function year_of_week 

## What I'm doing:

In Presto, the year_of_week(x) function is supported, which returns the year of the ISO week from x.

```
SELECT YEAR_OF_WEEK(DATE '2007-01-01') AS iso_year;
```
![image](https://github.com/user-attachments/assets/a7d0b0f3-caae-4775-a08b-b2b5b2f5dc17)

To achieve the same purpose in StarRocks, we can use the iso_week function.
![image](https://github.com/user-attachments/assets/87931b52-316f-4fbe-916e-8ae121b80ea8)

```
SELECT FLOOR(DIVIDE(YEARWEEK('2022-01-01', 1), 100)) AS iso_year;

```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0