### PR TITLE
[BugFix] Fix date_format function error when input with microsecond

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -838,6 +838,7 @@ TimestampValue timestamp_add(TimestampValue tsv, int count) {
 #define DEFINE_TIME_ADD_FN(FN, UNIT)                                                                               \
     DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { return timestamp_add<UNIT>(timestamp, value); } \
                                                                                                                    \
+    DEFINE_TIME_CALC_FN(FN, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME);
 
 #define DEFINE_TIME_SUB_FN(FN, UNIT)                                                                                \
     DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { return timestamp_add<UNIT>(timestamp, -value); } \

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -835,14 +835,18 @@ TimestampValue timestamp_add(TimestampValue tsv, int count) {
     return tsv.add<UNIT>(count);
 }
 
-#define DEFINE_TIME_ADD_FN(FN, UNIT)                                                                               \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { return timestamp_add<UNIT>(timestamp, value); } \
-                                                                                                                   \
+#define DEFINE_TIME_ADD_FN(FN, UNIT)                               \
+    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { \
+        return timestamp_add<UNIT>(timestamp, value);              \
+    }                                                              \
+                                                                   \
     DEFINE_TIME_CALC_FN(FN, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME);
 
-#define DEFINE_TIME_SUB_FN(FN, UNIT)                                                                                \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { return timestamp_add<UNIT>(timestamp, -value); } \
-                                                                                                                    \
+#define DEFINE_TIME_SUB_FN(FN, UNIT)                               \
+    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { \
+        return timestamp_add<UNIT>(timestamp, -value);             \
+    }                                                              \
+                                                                   \
     DEFINE_TIME_CALC_FN(FN, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME);
 
 #define DEFINE_TIME_ADD_AND_SUB_FN(FN_PREFIX, UNIT) \
@@ -2118,7 +2122,7 @@ DEFINE_STRING_UNARY_FN_WITH_IMPL(yyyy_MM_dd_Impl, v) {
 }
 
 std::string format_for_yyyyMMddHHmmssImpl(const TimestampValue& date_value) {
-    return date_value.to_string();
+    return date_value.to_string(true);
 }
 
 DEFINE_STRING_UNARY_FN_WITH_IMPL(yyyyMMddHHmmssImpl, v) {

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -835,18 +835,13 @@ TimestampValue timestamp_add(TimestampValue tsv, int count) {
     return tsv.add<UNIT>(count);
 }
 
-#define DEFINE_TIME_ADD_FN(FN, UNIT)                               \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { \
-        return timestamp_add<UNIT>(timestamp, value);              \
-    }                                                              \
-                                                                   \
-    DEFINE_TIME_CALC_FN(FN, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME);
+#define DEFINE_TIME_ADD_FN(FN, UNIT)                                                                               \
+    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { return timestamp_add<UNIT>(timestamp, value); } \
+                                                                                                                   \
 
-#define DEFINE_TIME_SUB_FN(FN, UNIT)                               \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { \
-        return timestamp_add<UNIT>(timestamp, -value);             \
-    }                                                              \
-                                                                   \
+#define DEFINE_TIME_SUB_FN(FN, UNIT)                                                                                \
+    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { return timestamp_add<UNIT>(timestamp, -value); } \
+                                                                                                                    \
     DEFINE_TIME_CALC_FN(FN, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME);
 
 #define DEFINE_TIME_ADD_AND_SUB_FN(FN_PREFIX, UNIT) \

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -220,12 +220,12 @@ public:
     template <TimeUnit UNIT>
     static Timestamp sub(Timestamp timestamp, int count);
 
-    template <bool use_iso8601_format = false>
+    template <bool use_iso8601_format = false, bool igonre_microsecond = false>
     static std::string to_string(Timestamp timestamp);
 
     // Returns the length of formatted string or -1 if the size of buffer too
     // small to fill the formatted string.
-    template <bool use_iso8601_format = false>
+    template <bool use_iso8601_format = false, bool igonre_microsecond = false>
     static int to_string(Timestamp timestamp, char* s, size_t n);
 
     inline static double time_to_literal(double time);
@@ -482,16 +482,16 @@ inline void date::to_date_with_cache(JulianDate julian, int* year, int* month, i
     return to_date(julian, year, month, day);
 }
 
-template <bool use_iso8601_format>
+template <bool use_iso8601_format, bool igonre_microsecond>
 std::string timestamp::to_string(Timestamp timestamp) {
     std::string s;
     raw::make_room(&s, 26);
-    int len = to_string<use_iso8601_format>(timestamp, s.data(), s.size());
+    int len = to_string<use_iso8601_format, igonre_microsecond>(timestamp, s.data(), s.size());
     s.resize(len);
     return s;
 }
 
-template <bool use_iso8601_format>
+template <bool use_iso8601_format, bool igonre_microsecond>
 int timestamp::to_string(Timestamp timestamp, char* to, size_t n) {
     int year, month, day;
     int hour, minute, second, microsecond;
@@ -519,6 +519,9 @@ int timestamp::to_string(Timestamp timestamp, char* to, size_t n) {
     /* Second */
     to[17] = (char)('0' + (second / 10));
     to[18] = (char)('0' + (second % 10));
+    if constexpr (igonre_microsecond) {
+        return 19;
+    }
     if (use_iso8601_format || microsecond > 0) {
         if (n < 26) {
             return -1;

--- a/be/src/types/timestamp_value.cpp
+++ b/be/src/types/timestamp_value.cpp
@@ -892,8 +892,11 @@ bool TimestampValue::is_valid_non_strict() const {
     return is_valid();
 }
 
-std::string TimestampValue::to_string() const {
-    return timestamp::to_string(_timestamp);
+std::string TimestampValue::to_string(bool igonre_microsecond) const {
+    if (igonre_microsecond) {
+        return timestamp::to_string<false, true>(_timestamp);
+    }
+    return timestamp::to_string<false, false>(_timestamp);
 }
 
 int TimestampValue::to_string(char* s, size_t n) const {

--- a/be/src/types/timestamp_value.h
+++ b/be/src/types/timestamp_value.h
@@ -142,7 +142,7 @@ public:
     // direct return microsecond will over int64
     int64_t diff_microsecond(TimestampValue other) const;
 
-    std::string to_string() const;
+    std::string to_string(bool igonre_microsecond = false) const;
 
     // Returns the formatted string length or -1 on error.
     int to_string(char* s, size_t n) const;

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -1722,6 +1722,23 @@ TEST_F(TimeFunctionsTest, date_format) {
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("%Y-%m-%d %H:%i:%s"), 1);
 
+        auto dts_col = TimestampColumn::create();
+        dts_col->append(TimestampValue::create(2020, 6, 25, 15, 58, 21, 111000));
+        Columns columns;
+        columns.emplace_back(dts_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::datetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("2020-06-25 15:58:21"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("%Y-%m-%d %H:%i:%s"), 1);
+
         Columns columns;
         columns.emplace_back(dt_col);
         columns.emplace_back(fmt_col);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
before:
![image](https://github.com/user-attachments/assets/17b077b3-d794-4fdb-875f-e48b977a2b4f)

after:
![image](https://github.com/user-attachments/assets/c7954aab-42c3-4d47-8751-f2bdc905b198)

Fixes https://github.com/StarRocks/starrocks/issues/54781

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0