### PR TITLE
[BugFix] Fix unlimit delete_txn_log request from FE side

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -569,7 +569,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
             // make sure sync wait for the RPC call to avoid too many RPC call existed in BE/CN side
             Future<DeleteTxnLogResponse> responseFuture = lakeService.deleteTxnLog(request);
             DeleteTxnLogResponse response = responseFuture.get();
-            if (response != null && response.status.statusCode != 0) {
+            if (response != null && response.status != null && response.status.statusCode != 0) {
                 LOG.warn("delete txn log request return with err: " + response.status.errorMsgs.get(0));
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -568,10 +568,9 @@ public class PublishVersionDaemon extends FrontendDaemon {
             // and vacuum will clan the txn log finally if it failed.
             // make sure sync wait for the RPC call to avoid too many RPC call existed in BE/CN side
             Future<DeleteTxnLogResponse> responseFuture = lakeService.deleteTxnLog(request);
-            try {
-                DeleteTxnLogResponse response = responseFuture.get();
-            } catch (Exception e) {
-                LOG.warn("delete txn log error: " + e.getMessage());
+            DeleteTxnLogResponse response = responseFuture.get();
+            if (response.status.statusCode != 0) {
+                LOG.warn("delete txn log request return with err: " + response.status.errorMsgs.get(0));
             }
         } catch (Exception e) {
             LOG.warn("delete txn log error: " + e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -569,7 +569,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
             // make sure sync wait for the RPC call to avoid too many RPC call existed in BE/CN side
             Future<DeleteTxnLogResponse> responseFuture = lakeService.deleteTxnLog(request);
             DeleteTxnLogResponse response = responseFuture.get();
-            if (response.status.statusCode != 0) {
+            if (response != null && response.status.statusCode != 0) {
                 LOG.warn("delete txn log request return with err: " + response.status.errorMsgs.get(0));
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -53,6 +53,7 @@ import com.starrocks.lake.TxnInfoHelper;
 import com.starrocks.lake.Utils;
 import com.starrocks.lake.compaction.Quantiles;
 import com.starrocks.proto.DeleteTxnLogRequest;
+import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
@@ -79,6 +80,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
@@ -564,7 +566,13 @@ public class PublishVersionDaemon extends FrontendDaemon {
             LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
             // just ignore the response, for we don't care the result of delete txn log
             // and vacuum will clan the txn log finally if it failed.
-            lakeService.deleteTxnLog(request);
+            // make sure sync wait for the RPC call to avoid too many RPC call existed in BE/CN side
+            Future<DeleteTxnLogResponse> responseFuture = lakeService.deleteTxnLog(request);
+            try {
+                DeleteTxnLogResponse response = responseFuture.get();
+            } catch (Exception e) {
+                LOG.warn("delete txn log error: " + e.getMessage());
+            }
         } catch (Exception e) {
             LOG.warn("delete txn log error: " + e.getMessage());
         }


### PR DESCRIPTION
## Why I'm doing:
In share data mode, if we use batch publish, when the publish is finished, a deleteTxnLog task will be send
to BE from a thread pool. But in current impl, we just send the RPC request but not wait for its finishing.
It makes that many bthread stack of deleteTxnLog will be accumulated in BE side and if hit the limit max_map_count
of operation system, BE will completely stuck.

## What I'm doing:
Wait the rpc call finished in thread pool

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0