### PR TITLE
[BugFix] ensure the latch can be counted down

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -176,78 +176,80 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         rebuild_pindex_tablets.insert(id);
     }
     for (auto tablet_id : request->tablet_ids()) {
-        auto task = [&, tablet_id]() {
-            DeferOp defer([&] { latch.count_down(); });
-            scoped_refptr<Trace> child_trace(new Trace);
-            Trace* sub_trace = child_trace.get();
-            trace->AddChildTrace("PublishTablet", sub_trace);
+        auto task = std::make_shared<AutoCleanRunnable>(
+                [&, tablet_id] {
+                    scoped_refptr<Trace> child_trace(new Trace);
+                    Trace* sub_trace = child_trace.get();
+                    trace->AddChildTrace("PublishTablet", sub_trace);
 
-            ADOPT_TRACE(sub_trace);
-            TRACE("start publish tablet $0 at thread $1", tablet_id, Thread::current_thread()->tid());
+                    ADOPT_TRACE(sub_trace);
+                    TRACE("start publish tablet $0 at thread $1", tablet_id, Thread::current_thread()->tid());
 
-            auto run_ts = butil::gettimeofday_us();
-            auto queuing_latency = run_ts - start_ts;
-            g_publish_tablet_version_queuing_latency << queuing_latency;
+                    auto run_ts = butil::gettimeofday_us();
+                    auto queuing_latency = run_ts - start_ts;
+                    g_publish_tablet_version_queuing_latency << queuing_latency;
 
-            auto base_version = request->base_version();
-            auto new_version = request->new_version();
-            auto txns = std::vector<TxnInfoPB>();
-            if (request->txn_infos_size() > 0) {
-                txns.insert(txns.begin(), request->txn_infos().begin(), request->txn_infos().end());
-                if (rebuild_pindex_tablets.count(tablet_id) > 0) {
-                    for (auto& txn : txns) {
-                        txn.set_rebuild_pindex(true);
+                    auto base_version = request->base_version();
+                    auto new_version = request->new_version();
+                    auto txns = std::vector<TxnInfoPB>();
+                    if (request->txn_infos_size() > 0) {
+                        txns.insert(txns.begin(), request->txn_infos().begin(), request->txn_infos().end());
+                        if (rebuild_pindex_tablets.count(tablet_id) > 0) {
+                            for (auto& txn : txns) {
+                                txn.set_rebuild_pindex(true);
+                            }
+                        }
+                    } else { // This is a request from older version FE
+                        // Construct TxnInfoPB from other fields
+                        txns.reserve(request->txn_ids_size());
+                        for (auto i = 0, sz = request->txn_ids_size(); i < sz; i++) {
+                            auto& info = txns.emplace_back();
+                            info.set_txn_id(request->txn_ids(i));
+                            info.set_txn_type(TXN_NORMAL);
+                            info.set_combined_txn_log(false);
+                            info.set_commit_time(request->commit_time());
+                            info.set_force_publish(false);
+                            if (rebuild_pindex_tablets.count(tablet_id) > 0) {
+                                info.set_rebuild_pindex(true);
+                            }
+                        }
                     }
-                }
-            } else { // This is a request from older version FE
-                // Construct TxnInfoPB from other fields
-                txns.reserve(request->txn_ids_size());
-                for (auto i = 0, sz = request->txn_ids_size(); i < sz; i++) {
-                    auto& info = txns.emplace_back();
-                    info.set_txn_id(request->txn_ids(i));
-                    info.set_txn_type(TXN_NORMAL);
-                    info.set_combined_txn_log(false);
-                    info.set_commit_time(request->commit_time());
-                    info.set_force_publish(false);
-                    if (rebuild_pindex_tablets.count(tablet_id) > 0) {
-                        info.set_rebuild_pindex(true);
+
+                    TRACE_COUNTER_INCREMENT("tablet_id", tablet_id);
+                    TRACE_COUNTER_INCREMENT("queuing_latency_us", queuing_latency);
+
+                    StatusOr<TabletMetadataPtr> res;
+                    if (std::chrono::system_clock::now() < timeout_deadline) {
+                        res = lake::publish_version(_tablet_mgr, tablet_id, base_version, new_version, txns);
+                    } else {
+                        auto t = MilliSecondsSinceEpochFromTimePoint(timeout_deadline);
+                        res = Status::TimedOut(fmt::format("reached deadline={}/timeout={}", t, timeout_ms));
                     }
-                }
-            }
+                    if (res.ok()) {
+                        auto metadata = std::move(res).value();
+                        auto score = compaction_score(_tablet_mgr, metadata);
+                        std::lock_guard l(response_mtx);
+                        response->mutable_compaction_scores()->insert({tablet_id, score});
+                    } else {
+                        g_publish_version_failed_tasks << 1;
+                        if (res.status().is_resource_busy()) {
+                            VLOG(2) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
+                                    << " txns=" << JoinMapped(txns, txn_info_string, ",") << " version=" << new_version;
+                        } else {
+                            LOG(WARNING) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
+                                         << " txn_ids=" << JoinMapped(txns, txn_info_string, ",")
+                                         << " version=" << new_version;
+                        }
+                        std::lock_guard l(response_mtx);
+                        response->add_failed_tablets(tablet_id);
+                        res.status().to_protobuf(response->mutable_status());
+                    }
+                    TRACE("finished");
+                    g_publish_tablet_version_latency << (butil::gettimeofday_us() - run_ts);
+                },
+                [&] { latch.count_down(); });
 
-            TRACE_COUNTER_INCREMENT("tablet_id", tablet_id);
-            TRACE_COUNTER_INCREMENT("queuing_latency_us", queuing_latency);
-
-            StatusOr<TabletMetadataPtr> res;
-            if (std::chrono::system_clock::now() < timeout_deadline) {
-                res = lake::publish_version(_tablet_mgr, tablet_id, base_version, new_version, txns);
-            } else {
-                auto t = MilliSecondsSinceEpochFromTimePoint(timeout_deadline);
-                res = Status::TimedOut(fmt::format("reached deadline={}/timeout={}", t, timeout_ms));
-            }
-            if (res.ok()) {
-                auto metadata = std::move(res).value();
-                auto score = compaction_score(_tablet_mgr, metadata);
-                std::lock_guard l(response_mtx);
-                response->mutable_compaction_scores()->insert({tablet_id, score});
-            } else {
-                g_publish_version_failed_tasks << 1;
-                if (res.status().is_resource_busy()) {
-                    VLOG(2) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
-                            << " txns=" << JoinMapped(txns, txn_info_string, ",") << " version=" << new_version;
-                } else {
-                    LOG(WARNING) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
-                                 << " txn_ids=" << JoinMapped(txns, txn_info_string, ",") << " version=" << new_version;
-                }
-                std::lock_guard l(response_mtx);
-                response->add_failed_tablets(tablet_id);
-                res.status().to_protobuf(response->mutable_status());
-            }
-            TRACE("finished");
-            g_publish_tablet_version_latency << (butil::gettimeofday_us() - run_ts);
-        };
-
-        auto st = thread_pool_token.submit_func(std::move(task), timeout_deadline);
+        auto st = thread_pool_token.submit(std::move(task), timeout_deadline);
         if (!st.ok()) {
             g_publish_version_failed_tasks << 1;
             LOG(WARNING) << "Fail to submit publish version task: " << st << ". tablet_id=" << tablet_id
@@ -255,7 +257,6 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
             std::lock_guard l(response_mtx);
             response->add_failed_tablets(tablet_id);
             st.to_protobuf(response->mutable_status());
-            latch.count_down();
         }
     }
 
@@ -284,20 +285,21 @@ void LakeServiceImpl::_submit_publish_log_version_task(const int64_t* tablet_ids
 
     for (int i = 0; i < tablet_size; i++) {
         auto tablet_id = tablet_ids[i];
-        auto task = [&, tablet_id]() {
-            DeferOp defer([&] { latch.count_down(); });
-            auto st = lake::publish_log_version(_tablet_mgr, tablet_id, txn_infos, log_versions);
-            if (!st.ok()) {
-                g_publish_version_failed_tasks << 1;
-                LOG(WARNING) << "Fail to publish log version: " << st << " tablet_id=" << tablet_id
-                             << " txns=" << JoinMapped(txn_infos, txn_info_string, ",")
-                             << " versions=" << JoinElementsIterator(log_versions, log_versions + txn_size, ",");
-                std::lock_guard l(response_mtx);
-                response->add_failed_tablets(tablet_id);
-            }
-        };
+        auto task = std::make_shared<AutoCleanRunnable>(
+                [&, tablet_id] {
+                    auto st = lake::publish_log_version(_tablet_mgr, tablet_id, txn_infos, log_versions);
+                    if (!st.ok()) {
+                        g_publish_version_failed_tasks << 1;
+                        LOG(WARNING) << "Fail to publish log version: " << st << " tablet_id=" << tablet_id
+                                     << " txns=" << JoinMapped(txn_infos, txn_info_string, ",") << " versions="
+                                     << JoinElementsIterator(log_versions, log_versions + txn_size, ",");
+                        std::lock_guard l(response_mtx);
+                        response->add_failed_tablets(tablet_id);
+                    }
+                },
+                [&] { latch.count_down(); });
 
-        auto st = thread_pool->submit_func(task);
+        auto st = thread_pool->submit(std::move(task));
         if (!st.ok()) {
             g_publish_version_failed_tasks << 1;
             LOG(WARNING) << "Fail to submit publish log version task: " << st << " tablet_id=" << tablet_id
@@ -305,7 +307,6 @@ void LakeServiceImpl::_submit_publish_log_version_task(const int64_t* tablet_ids
                          << " versions=" << JoinElementsIterator(log_versions, log_versions + txn_size, ",");
             std::lock_guard l(response_mtx);
             response->add_failed_tablets(tablet_id);
-            latch.count_down();
         }
     }
 
@@ -410,30 +411,30 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
 
     auto thread_pool = abort_txn_thread_pool(_env);
     auto latch = BThreadCountDownLatch(1);
-    auto task = [&]() {
-        DeferOp defer([&] { latch.count_down(); });
-        std::vector<TxnInfoPB> txn_infos;
-        if (request->txn_infos_size() > 0) {
-            txn_infos.insert(txn_infos.begin(), request->txn_infos().begin(), request->txn_infos().end());
-        } else {
-            // Construct TxnInfoPB from txn_id and txn_type
-            txn_infos.reserve(request->txn_ids_size());
-            auto has_txn_type = request->txn_types_size() == request->txn_ids_size();
-            for (int i = 0, sz = request->txn_ids_size(); i < sz; i++) {
-                auto& info = txn_infos.emplace_back();
-                info.set_txn_id(request->txn_ids(i));
-                info.set_txn_type(has_txn_type ? request->txn_types(i) : TXN_NORMAL);
-                info.set_combined_txn_log(false);
-            }
-        }
-        for (auto tablet_id : request->tablet_ids()) {
-            lake::abort_txn(_tablet_mgr, tablet_id, txn_infos);
-        }
-    };
-    auto st = thread_pool->submit_func(task);
+    auto task = std::make_shared<AutoCleanRunnable>(
+            [&] {
+                std::vector<TxnInfoPB> txn_infos;
+                if (request->txn_infos_size() > 0) {
+                    txn_infos.insert(txn_infos.begin(), request->txn_infos().begin(), request->txn_infos().end());
+                } else {
+                    // Construct TxnInfoPB from txn_id and txn_type
+                    txn_infos.reserve(request->txn_ids_size());
+                    auto has_txn_type = request->txn_types_size() == request->txn_ids_size();
+                    for (int i = 0, sz = request->txn_ids_size(); i < sz; i++) {
+                        auto& info = txn_infos.emplace_back();
+                        info.set_txn_id(request->txn_ids(i));
+                        info.set_txn_type(has_txn_type ? request->txn_types(i) : TXN_NORMAL);
+                        info.set_combined_txn_log(false);
+                    }
+                }
+                for (auto tablet_id : request->tablet_ids()) {
+                    lake::abort_txn(_tablet_mgr, tablet_id, txn_infos);
+                }
+            },
+            [&] { latch.count_down(); });
+    auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit abort transaction task: " << st;
-        latch.count_down();
     }
 
     latch.wait();
@@ -456,14 +457,12 @@ void LakeServiceImpl::delete_tablet(::google::protobuf::RpcController* controlle
         return;
     }
     auto latch = BThreadCountDownLatch(1);
-    auto st = thread_pool->submit_func([&]() {
-        DeferOp defer([&] { latch.count_down(); });
-        lake::delete_tablets(_tablet_mgr, *request, response);
-    });
+    auto task = std::make_shared<AutoCleanRunnable>([&] { lake::delete_tablets(_tablet_mgr, *request, response); },
+                                                    [&] { latch.count_down(); });
+    auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit delete tablet task: " << st;
         st.to_protobuf(response->mutable_status());
-        latch.count_down();
     }
 
     latch.wait();
@@ -497,15 +496,12 @@ void LakeServiceImpl::delete_txn_log(::google::protobuf::RpcController* controll
     }
 
     auto latch = BThreadCountDownLatch(1);
-    auto st = thread_pool->submit_func([&]() {
-        DeferOp defer([&] { latch.count_down(); });
-        lake::delete_txn_log(_tablet_mgr, *request, response);
-    });
-
+    auto task = std::make_shared<AutoCleanRunnable>([&] { lake::delete_txn_log(_tablet_mgr, *request, response); },
+                                                    [&] { latch.count_down(); });
+    auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit vacuum task: " << st;
         st.to_protobuf(response->mutable_status());
-        latch.count_down();
     } else {
         Status::OK().to_protobuf(response->mutable_status());
     }
@@ -570,27 +566,27 @@ void LakeServiceImpl::drop_table(::google::protobuf::RpcController* controller,
               << " queued_tasks=" << thread_pool->num_queued_tasks();
 
     auto latch = BThreadCountDownLatch(1);
-    auto task = [&]() {
-        TEST_SYNC_POINT("LakeService::drop_table:task_run");
-        DeferOp defer([&] { latch.count_down(); });
-        auto location = _tablet_mgr->tablet_root_location(request->tablet_id());
-        auto st = fs::remove_all(location);
-        if (!st.ok() && !st.is_not_found()) {
-            LOG(ERROR) << "Fail to remove " << location << ": " << st << ". tablet_id=" << request->tablet_id()
-                       << " path=" << request->path();
-            st.to_protobuf(response->mutable_status());
-        } else {
-            LOG(INFO) << "Removed " << location << ". tablet_id=" << request->tablet_id() << " path=" << request->path()
-                      << " is_not_found=" << st.is_not_found();
-        }
-    };
+    auto task = std::make_shared<AutoCleanRunnable>(
+            [&] {
+                TEST_SYNC_POINT("LakeService::drop_table:task_run");
+                auto location = _tablet_mgr->tablet_root_location(request->tablet_id());
+                auto st = fs::remove_all(location);
+                if (!st.ok() && !st.is_not_found()) {
+                    LOG(ERROR) << "Fail to remove " << location << ": " << st << ". tablet_id=" << request->tablet_id()
+                               << " path=" << request->path();
+                    st.to_protobuf(response->mutable_status());
+                } else {
+                    LOG(INFO) << "Removed " << location << ". tablet_id=" << request->tablet_id()
+                              << " path=" << request->path() << " is_not_found=" << st.is_not_found();
+                }
+            },
+            [&] { latch.count_down(); });
 
-    auto st = thread_pool->submit_func(task);
+    auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit drop table task: " << st << " tablet_id=" << request->tablet_id()
                      << " path=" << request->path();
         st.to_protobuf(response->mutable_status());
-        latch.count_down();
     }
 
     latch.wait();
@@ -619,30 +615,30 @@ void LakeServiceImpl::delete_data(::google::protobuf::RpcController* controller,
     auto latch = BThreadCountDownLatch(request->tablet_ids_size());
     bthread::Mutex response_mtx;
     for (auto tablet_id : request->tablet_ids()) {
-        auto task = [&, tablet_id]() {
-            DeferOp defer([&] { latch.count_down(); });
-            auto tablet = _tablet_mgr->get_tablet(tablet_id);
-            if (!tablet.ok()) {
-                LOG(WARNING) << "Fail to get tablet " << tablet_id << ": " << tablet.status();
-                std::lock_guard l(response_mtx);
-                response->add_failed_tablets(tablet_id);
-                return;
-            }
-            auto res = tablet->delete_data(request->txn_id(), request->delete_predicate());
-            if (!res.ok()) {
-                LOG(WARNING) << "Fail to delete data. tablet_id: " << tablet_id << ", txn_id: " << request->txn_id()
-                             << ", error: " << res;
-                std::lock_guard l(response_mtx);
-                response->add_failed_tablets(tablet_id);
-            }
-        };
+        auto task = std::make_shared<AutoCleanRunnable>(
+                [&, tablet_id] {
+                    auto tablet = _tablet_mgr->get_tablet(tablet_id);
+                    if (!tablet.ok()) {
+                        LOG(WARNING) << "Fail to get tablet " << tablet_id << ": " << tablet.status();
+                        std::lock_guard l(response_mtx);
+                        response->add_failed_tablets(tablet_id);
+                        return;
+                    }
+                    auto res = tablet->delete_data(request->txn_id(), request->delete_predicate());
+                    if (!res.ok()) {
+                        LOG(WARNING) << "Fail to delete data. tablet_id: " << tablet_id
+                                     << ", txn_id: " << request->txn_id() << ", error: " << res;
+                        std::lock_guard l(response_mtx);
+                        response->add_failed_tablets(tablet_id);
+                    }
+                },
+                [&] { latch.count_down(); });
 
-        auto st = thread_pool->submit_func(task);
+        auto st = thread_pool->submit(std::move(task));
         if (!st.ok()) {
             LOG(WARNING) << "Fail to submit delete data task: " << st;
             std::lock_guard l(response_mtx);
             response->add_failed_tablets(tablet_id);
-            latch.count_down();
         }
     }
 
@@ -672,44 +668,43 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
     auto latch = BThreadCountDownLatch(request->tablet_infos_size());
     bthread::Mutex response_mtx;
     for (const auto& tablet_info : request->tablet_infos()) {
-        auto task = [&, tablet_info]() {
-            DeferOp defer([&] { latch.count_down(); });
+        auto task = std::make_shared<AutoCleanRunnable>(
+                [&, tablet_info] {
+                    int64_t tablet_id = tablet_info.tablet_id();
+                    int64_t version = tablet_info.version();
+                    if (std::chrono::system_clock::now() >= timeout_deadline) {
+                        LOG(WARNING) << "Cancelled tablet stat collection task due to timeout exceeded. tablet_id: "
+                                     << tablet_id << ", version: " << version;
+                        return;
+                    }
 
-            int64_t tablet_id = tablet_info.tablet_id();
-            int64_t version = tablet_info.version();
-            if (std::chrono::system_clock::now() >= timeout_deadline) {
-                LOG(WARNING) << "Cancelled tablet stat collection task due to timeout exceeded. tablet_id: "
-                             << tablet_id << ", version: " << version;
-                return;
-            }
+                    auto tablet_metadata = _tablet_mgr->get_tablet_metadata(tablet_id, version, /*fill_cache=*/false);
+                    if (!tablet_metadata.ok()) {
+                        LOG(WARNING) << "Fail to get tablet metadata. tablet_id: " << tablet_id
+                                     << ", version: " << version << ", error: " << tablet_metadata.status();
+                        return;
+                    }
 
-            auto tablet_metadata = _tablet_mgr->get_tablet_metadata(tablet_id, version, /*fill_cache=*/false);
-            if (!tablet_metadata.ok()) {
-                LOG(WARNING) << "Fail to get tablet metadata. tablet_id: " << tablet_id << ", version: " << version
-                             << ", error: " << tablet_metadata.status();
-                return;
-            }
+                    int64_t num_rows = 0;
+                    int64_t data_size = 0;
+                    for (const auto& rowset : (*tablet_metadata)->rowsets()) {
+                        num_rows += rowset.num_rows();
+                        data_size += rowset.data_size();
+                    }
+                    for (const auto& [_, file] : (*tablet_metadata)->delvec_meta().version_to_file()) {
+                        data_size += file.size();
+                    }
 
-            int64_t num_rows = 0;
-            int64_t data_size = 0;
-            for (const auto& rowset : (*tablet_metadata)->rowsets()) {
-                num_rows += rowset.num_rows();
-                data_size += rowset.data_size();
-            }
-            for (const auto& [_, file] : (*tablet_metadata)->delvec_meta().version_to_file()) {
-                data_size += file.size();
-            }
-
-            std::lock_guard l(response_mtx);
-            auto tablet_stat = response->add_tablet_stats();
-            tablet_stat->set_tablet_id(tablet_id);
-            tablet_stat->set_num_rows(num_rows);
-            tablet_stat->set_data_size(data_size);
-        };
+                    std::lock_guard l(response_mtx);
+                    auto tablet_stat = response->add_tablet_stats();
+                    tablet_stat->set_tablet_id(tablet_id);
+                    tablet_stat->set_num_rows(num_rows);
+                    tablet_stat->set_data_size(data_size);
+                },
+                [&] { latch.count_down(); });
         TEST_SYNC_POINT_CALLBACK("LakeServiceImpl::get_tablet_stats:before_submit", nullptr);
-        if (auto st = thread_pool_token.submit_func(std::move(task), timeout_deadline); !st.ok()) {
+        if (auto st = thread_pool_token.submit(std::move(task), timeout_deadline); !st.ok()) {
             LOG(WARNING) << "Fail to get tablet stats task: " << st;
-            latch.count_down();
         }
     }
 
@@ -748,19 +743,19 @@ void LakeServiceImpl::upload_snapshots(::google::protobuf::RpcController* contro
 
     auto thread_pool = _env->agent_server()->get_thread_pool(TTaskType::UPLOAD);
     auto latch = BThreadCountDownLatch(1);
-    auto task = [&]() {
-        DeferOp defer([&] { latch.count_down(); });
-        auto loader = std::make_unique<LakeSnapshotLoader>(_env);
-        auto st = loader->upload(request);
-        if (!st.ok()) {
-            cntl->SetFailed("Fail to upload snapshot");
-        }
-    };
-    auto st = thread_pool->submit_func(task);
+    auto task = std::make_shared<AutoCleanRunnable>(
+            [&] {
+                auto loader = std::make_unique<LakeSnapshotLoader>(_env);
+                auto st = loader->upload(request);
+                if (!st.ok()) {
+                    cntl->SetFailed("Fail to upload snapshot");
+                }
+            },
+            [&] { latch.count_down(); });
+    auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit upload snapshots task: " << st;
         cntl->SetFailed(std::string(st.message()));
-        latch.count_down();
     }
     latch.wait();
 }
@@ -779,19 +774,19 @@ void LakeServiceImpl::restore_snapshots(::google::protobuf::RpcController* contr
 
     auto thread_pool = _env->agent_server()->get_thread_pool(TTaskType::DOWNLOAD);
     auto latch = BThreadCountDownLatch(1);
-    auto task = [&]() {
-        DeferOp defer([&] { latch.count_down(); });
-        auto loader = std::make_unique<LakeSnapshotLoader>(_env);
-        auto st = loader->restore(request);
-        if (!st.ok()) {
-            cntl->SetFailed("Fail to restore snapshot");
-        }
-    };
-    auto st = thread_pool->submit_func(task);
+    auto task = std::make_shared<AutoCleanRunnable>(
+            [&] {
+                auto loader = std::make_unique<LakeSnapshotLoader>(_env);
+                auto st = loader->restore(request);
+                if (!st.ok()) {
+                    cntl->SetFailed("Fail to restore snapshot");
+                }
+            },
+            [&] { latch.count_down(); });
+    auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit restore snapshots task: " << st;
         cntl->SetFailed(std::string(st.message()));
-        latch.count_down();
     }
     latch.wait();
 }
@@ -870,14 +865,12 @@ void LakeServiceImpl::vacuum(::google::protobuf::RpcController* controller, cons
     TEST_SYNC_POINT("LakeServiceImpl::vacuum:2");
 
     auto latch = BThreadCountDownLatch(1);
-    auto st = thread_pool->submit_func([&]() {
-        DeferOp defer([&] { latch.count_down(); });
-        lake::vacuum(_tablet_mgr, *request, response);
-    });
+    auto task = std::make_shared<AutoCleanRunnable>([&] { lake::vacuum(_tablet_mgr, *request, response); },
+                                                    [&] { latch.count_down(); });
+    auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit vacuum task: " << st;
         st.to_protobuf(response->mutable_status());
-        latch.count_down();
     }
 
     latch.wait();
@@ -894,14 +887,12 @@ void LakeServiceImpl::vacuum_full(::google::protobuf::RpcController* controller,
         return;
     }
     auto latch = BThreadCountDownLatch(1);
-    auto st = thread_pool->submit_func([&]() {
-        DeferOp defer([&] { latch.count_down(); });
-        lake::vacuum_full(_tablet_mgr, *request, response);
-    });
+    auto task = std::make_shared<AutoCleanRunnable>([&] { lake::vacuum_full(_tablet_mgr, *request, response); },
+                                                    [&] { latch.count_down(); });
+    auto st = thread_pool->submit(std::move(task));
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit vacuum task: " << st;
         st.to_protobuf(response->mutable_status());
-        latch.count_down();
     }
 
     latch.wait();

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -704,6 +704,22 @@ void ThreadPool::check_not_pool_thread_unlocked() {
     }
 }
 
+Status ConcurrencyLimitedThreadPoolToken::submit(std::shared_ptr<Runnable> task,
+                                                 std::chrono::system_clock::time_point deadline) {
+    if (!_sem->try_acquire_until(deadline)) {
+        auto t = MilliSecondsSinceEpochFromTimePoint(deadline);
+        return Status::TimedOut(fmt::format("acquire semaphore reached deadline={}", t));
+    }
+    auto token_task =
+            std::make_shared<AutoCleanRunnable>([t = std::move(task)] { t->run(); }, [sem = _sem] { sem->release(); });
+    return _pool->submit(std::move(token_task));
+}
+
+Status ConcurrencyLimitedThreadPoolToken::submit_func(std::function<void()> f,
+                                                      std::chrono::system_clock::time_point deadline) {
+    return submit(std::make_shared<FunctionRunnable>(std::move(f)), deadline);
+}
+
 std::ostream& operator<<(std::ostream& o, ThreadPoolToken::State s) {
     return o << ThreadPoolToken::state_to_string(s);
 }

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -70,6 +70,26 @@ public:
     virtual ~Runnable() = default;
 };
 
+// A helper class implements the `Runnable` interface together with a cleaner
+// when the instance is destroyed.
+// NOTE:
+//  The function or the runnable submit to a ThreadPool successfully, may not be running
+// at all because of threadpool shutdown. The caller who depends on the function/runnable
+// execution to signal or clean resources, needs to inject a `cleaner` to ensure the clean-
+// up work can be done under no condition.
+class AutoCleanRunnable : public Runnable {
+public:
+    AutoCleanRunnable(std::function<void()> runner, std::function<void()> cleaner)
+            : _runnable(std::move(runner)), _cleaner(std::move(cleaner)) {}
+    virtual ~AutoCleanRunnable() { _cleaner(); }
+
+    virtual void run() override { _runnable(); }
+
+protected:
+    std::function<void()> _runnable;
+    std::function<void()> _cleaner;
+};
+
 // ThreadPool takes a lot of arguments. We provide sane defaults with a builder.
 //
 // name: Used for debugging output and default names of the worker threads.
@@ -193,17 +213,23 @@ public:
     bool is_pool_status_ok();
 
     // Wait for the running tasks to complete and then shutdown the threads.
-    // All the other pending tasks in the queue will be removed.
+    // All the other `pending tasks` in the queue will be removed without execution.
     // NOTE: That the user may implement an external abort logic for the
     //       runnable, that must be called before Shutdown(), if the system
     //       should know about the non-execution of these tasks, or the runnable
     //       required an explicit "abort" notification to exit from the run loop.
+    // NOTE: Try to leverage `AutoCleanRunnable` to inject exit hook if the caller
+    //       relies on the task to be executed to free resources or send signals.
     void shutdown();
 
     // Submits a Runnable class.
+    // Be aware that the `r` may not be executed even though the submit returns OK
+    // in case a shutdown is issued right after the submission.
     Status submit(std::shared_ptr<Runnable> r, Priority pri = LOW_PRIORITY);
 
     // Submits a function bound using std::bind(&FuncName, args...).
+    // Be aware that the `r` may not be executed even though the submit returns OK
+    // in case a shutdown is issued right after the submission.
     Status submit_func(std::function<void()> f, Priority pri = LOW_PRIORITY);
 
     // Waits until all the tasks are completed.
@@ -523,24 +549,9 @@ public:
 
     DISALLOW_COPY_AND_MOVE(ConcurrencyLimitedThreadPoolToken);
 
-    Status submit_func(std::function<void()> task, std::chrono::system_clock::time_point deadline) {
-        if (!_sem->try_acquire_until(deadline)) {
-            auto t = MilliSecondsSinceEpochFromTimePoint(deadline);
-            return Status::TimedOut(fmt::format("acquire semaphore reached deadline={}", t));
-        }
-        auto task_with_semaphore_release = [sem = _sem, task = std::move(task)]() {
-            task();
-            // The `ConcurrencyLimitedThreadPoolToken` object may have been destroyed
-            // before `release()` the semaphore, so we use `std::shared_ptr` to manage
-            // the semaphore to ensure it's still alive when calling `release()`.
-            sem->release();
-        };
-        auto st = _pool->submit_func(std::move(task_with_semaphore_release));
-        if (!st.ok()) {
-            _sem->release();
-        }
-        return st;
-    }
+    Status submit(std::shared_ptr<Runnable> task, std::chrono::system_clock::time_point deadline);
+
+    Status submit_func(std::function<void()> f, std::chrono::system_clock::time_point deadline);
 
 private:
     ThreadPool* _pool;

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1582,6 +1582,39 @@ TEST_F(LakeServiceTest, test_get_tablet_stats) {
     ASSERT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
     ASSERT_EQ(0, response.tablet_stats(0).num_rows());
     ASSERT_EQ(0, response.tablet_stats(0).data_size());
+
+    // Write some data into the tablet, num_rows = 1024, data_size=65536
+    size_t expected_num_rows = 1024;
+    size_t expected_data_size = 65536;
+    auto txn_log = generate_write_txn_log(2, expected_num_rows, expected_data_size);
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    { // Publish version request
+        PublishVersionRequest request;
+        request.set_base_version(1);
+        request.set_new_version(3);
+        request.add_tablet_ids(_tablet_id);
+        request.add_txn_ids(txn_log.txn_id());
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
+        // Publish txn batch
+        PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(0, response.failed_tablets_size());
+    }
+
+    { // get the tablet stat again
+        TabletStatRequest request;
+        TabletStatResponse response;
+        auto* info = request.add_tablet_infos();
+        info->set_tablet_id(_tablet_id);
+        info->set_version(3);
+        _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+        EXPECT_EQ(1, response.tablet_stats_size());
+        EXPECT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
+        EXPECT_EQ(expected_num_rows, response.tablet_stats(0).num_rows());
+        EXPECT_EQ(expected_data_size, response.tablet_stats(0).data_size());
+    }
+
     // get_tablet_stats() should not fill metadata cache
     auto cache_key = _tablet_mgr->tablet_metadata_location(_tablet_id, 1);
     ASSERT_TRUE(_tablet_mgr->metacache()->lookup_tablet_metadata(cache_key) == nullptr);
@@ -2228,6 +2261,20 @@ TEST_F(LakeServiceTest, test_abort_with_combined_txn_log) {
         }
         EXPECT_FALSE(fs::path_exist(_tablet_mgr->combined_txn_log_location(_tablet_id, txn_id)));
     }
+}
+
+TEST_F(LakeServiceTest, test_delete_data_ok) {
+    // delete the data from a tablet, but the tablet is not found from TabletManager
+    DeleteDataRequest request;
+    request.add_tablet_ids(_tablet_id);
+    request.set_txn_id(12345);
+    request.mutable_delete_predicate()->set_version(1);
+
+    DeleteDataResponse response;
+    _tablet_mgr->prune_metacache();
+    _lake_service.delete_data(nullptr, &request, &response, nullptr);
+
+    EXPECT_EQ(0L, response.failed_tablets().size());
 }
 
 } // namespace starrocks

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -43,6 +43,7 @@
 #include "gutil/strings/substitute.h"
 #include "gutil/sysinfo.h"
 #include "gutil/walltime.h"
+#include "util/await.h"
 #include "util/countdown_latch.h"
 #include "util/metrics.h"
 #include "util/monotime.h"
@@ -823,6 +824,127 @@ TEST_F(ThreadPoolTest, TestTokenConcurrency) {
     LOG(INFO) << strings::Substitute("Tokens waited ($0 threads): $1", kWaitThreads, total_num_tokens_waited.load());
     LOG(INFO) << strings::Substitute("Tokens submitted ($0 threads): $1", kSubmitThreads,
                                      total_num_tokens_submitted.load());
+}
+
+TEST_F(ThreadPoolTest, TestAutoCleanRunnable) {
+    int run_count = 0;
+    int exit_count = 0;
+
+    auto run1 = std::make_shared<AutoCleanRunnable>([&] { ++run_count; }, [&] { ++exit_count; });
+    run1.reset();
+    // run1 doesn't run but will definitely exit
+    EXPECT_EQ(0, run_count);
+    EXPECT_EQ(1, exit_count);
+
+    auto run2 = std::make_shared<AutoCleanRunnable>([&] { ++run_count; }, [&] { ++exit_count; });
+    run2->run();
+    run2.reset();
+    // run2 runs and exits
+    EXPECT_EQ(1, run_count);
+    EXPECT_EQ(2, exit_count);
+}
+
+TEST_F(ThreadPoolTest, ConcurrencyLimitedThreadPoolTokenTest) {
+    // set init capacity to 0, so it will never succeed
+    auto thread_token = std::make_unique<ConcurrencyLimitedThreadPoolToken>(_pool.get(), 0);
+
+    int run_count = 0;
+    int exit_count = 0;
+    auto task = std::make_shared<AutoCleanRunnable>([&] { ++run_count; }, [&] { ++exit_count; });
+
+    auto deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(400);
+    auto st = thread_token->submit(std::move(task), deadline);
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_time_out());
+    // task destroyed without run
+    EXPECT_EQ(0, run_count);
+    EXPECT_EQ(1, exit_count);
+
+    // submit_func, fails the same way
+    deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(400);
+    auto st2 = thread_token->submit_func([&] { ++run_count; }, deadline);
+    EXPECT_FALSE(st2.ok());
+    EXPECT_TRUE(st2.is_time_out());
+    EXPECT_EQ(0, run_count);
+}
+
+TEST_F(ThreadPoolTest, ThreadPoolShutdownWithTaskAbandoned) {
+    // Create tasks into two groups, one is associated with latchA,
+    // the other is associated with latchB.
+    // submit all of them into the pool with only single thread
+    rebuild_pool_with_min_max(1, 1);
+    CountDownLatch latchA(1), latchB(1);
+    int run_count = 0;
+    int run_count_A = 0;
+    int run_count_B = 0;
+    int exit_count = 0;
+    int exit_count_A = 0;
+    int exit_count_B = 0;
+
+    int task_num = 10;
+    // group-A
+    for (int i = 0; i < task_num; ++i) {
+        auto st = _pool->submit(std::make_shared<AutoCleanRunnable>(
+                [&] {
+                    latchA.wait();
+                    ++run_count;
+                    ++run_count_A;
+                },
+                [&] {
+                    ++exit_count;
+                    ++exit_count_A;
+                }));
+        EXPECT_TRUE(st.ok());
+    }
+
+    // group-B
+    for (int i = 0; i < task_num; ++i) {
+        auto st = _pool->submit(std::make_shared<AutoCleanRunnable>(
+                [&] {
+                    latchB.wait();
+                    ++run_count;
+                    ++run_count_B;
+                },
+                [&] {
+                    ++exit_count;
+                    ++exit_count_B;
+                }));
+        EXPECT_TRUE(st.ok());
+    }
+    // suppose some of or all of the tasks in groupA can be executed
+    latchA.count_down();
+    EXPECT_TRUE(_pool->is_pool_status_ok());
+
+    // start a thread to stop the pool asynchronously
+    std::thread stop_async([&] { _pool->shutdown(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // wait until the pool enters shutdown status
+    Awaitility().timeout(1000 * 1000).until([&] { return !_pool->is_pool_status_ok(); });
+    ASSERT_FALSE(_pool->is_pool_status_ok());
+    latchB.count_down();
+    stop_async.join();
+
+    auto done_tasks = _pool->total_executed_tasks();
+    EXPECT_EQ(task_num * 2, exit_count);
+    EXPECT_EQ(task_num, exit_count_A);
+    // 0 <= run_count_A <= task_num
+    if (done_tasks <= task_num) {
+        EXPECT_EQ(done_tasks, run_count_A);
+    } else {
+        EXPECT_EQ(task_num, run_count_A);
+    }
+
+    EXPECT_EQ(task_num, exit_count_B);
+    // 0 <= run_count_B <= 1, at most one task get chance to execute
+    EXPECT_LE(0, run_count_B);
+    EXPECT_GE(1, run_count_B);
+
+    // done_tasks = run_count_A + run_count_B
+    EXPECT_EQ(done_tasks, run_count_A + run_count_B);
+
+    // run_count < exit_count
+    EXPECT_LT(run_count, exit_count);
 }
 
 /*


### PR DESCRIPTION
* latch may not be countdown due to threadpool abortion
* add cleaner to the runnable task, ensure the countdown is ticked when the task is destroyed

## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9033

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0