### PR TITLE
[Enhancement] Make HMS connection count properties can be configurable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
@@ -31,6 +31,7 @@ public class HiveConnector implements Connector {
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
     public static final String HIVE_METASTORE_TYPE = "hive.metastore.type";
     public static final String HIVE_METASTORE_TIMEOUT = "hive.metastore.timeout";
+    public static final String HIVE_METASTORE_CONNECTION_POOL_SIZE = "hive.metastore.connection.pool.size";
     private final Map<String, String> properties;
     private final String catalogName;
     private final HiveConnectorInternalMgr internalMgr;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -43,6 +43,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_CONNECTION_POOL_SIZE;
+
 public class HiveMetaClientTest {
     @Test
     public void testClientPool(@Mocked HiveMetaStoreClient metaStoreClient) throws Exception {
@@ -127,8 +129,10 @@ public class HiveMetaClientTest {
         };
 
         HiveConf hiveConf = new HiveConf();
+        hiveConf.set(HIVE_METASTORE_CONNECTION_POOL_SIZE, "48");
         hiveConf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), "thrift://127.0.0.1:90300");
         HiveMetaClient client = new HiveMetaClient(hiveConf);
+        Assert.assertEquals(48, client.getMaxClientPoolSize());
         try {
             client.getTable("db", "tbl");
         } catch (Exception e) {


### PR DESCRIPTION
## Why I'm doing:
In the `HiveMetaClient` class, the HMS_MAX_POOL_SIZE is hard coded.
But actually speaking, users need to choose the correct pool size with the considering for there company's HMS service stability.
## What I'm doing:
Introduce `hive.metastore.connection.pool.size` parameter in the catalog, that user can set as the max pool size.
## How to use:
User can set `hive.metastore.connection.pool.size` parameter in the catalog.
Otherwise the default max pool size will be 32.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0