### PR TITLE
[BugFix] Ensure mv rewrite plan output column refs unique

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -103,7 +103,7 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
     //      query:
     //      select a+1, abs(a), sum(c) from t group by a
     @Override
-    protected OptExpression viewBasedRewrite(RewriteContext rewriteContext, OptExpression mvOptExpr) {
+    protected OptExpression doViewBasedRewrite(RewriteContext rewriteContext, OptExpression mvOptExpr) {
         LogicalAggregationOperator mvAggOp = (LogicalAggregationOperator) rewriteContext.getMvExpression().getOp();
         LogicalAggregationOperator queryAggOp = (LogicalAggregationOperator) rewriteContext.getQueryExpression().getOp();
 
@@ -153,8 +153,6 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         EquationRewriter queryExprToMvExprRewriter =
                 buildEquationRewriter(mvProjection, rewriteContext, false);
 
-        // TODO:duplicate if mv has already outputted.
-        // mvOptExpr = duplicateMvOptExpression(rewriteContext, mvOptExpr, queryExprToMvExprRewriter);
         if (isRollup) {
             return rewriteForRollup(queryAggOp, queryGroupingKeys, columnRewriter, queryExprToMvExprRewriter,
                     rewriteContext, mvOptExpr);
@@ -386,7 +384,6 @@ public final class AggregatedMaterializedViewRewriter extends MaterializedViewRe
         }
         return rewriteGroupingKeys;
     }
-
 
     private Map<ColumnRefOperator, CallOperator> rewriteAggregations(RewriteContext rewriteContext,
                                                                        ColumnRewriter columnRewriter,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/IMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/IMaterializedViewRewriter.java
@@ -17,11 +17,33 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 /**
  * Base interface to implement materialized view rewrite rule.
  */
 public interface IMaterializedViewRewriter {
+
+    /**
+     * Do rewrite query's plan based on materialized view's plan.
+     */
+    OptExpression doViewBasedRewrite(RewriteContext rewriteContext,
+                                     OptExpression mvScanOptExpression);
+
+    /**
+     * Do rewrite mv's defined query plan based on query's plan.
+     */
+    OptExpression doQueryBasedRewrite(RewriteContext rewriteContext,
+                                      ScalarOperator compensationPredicates,
+                                      OptExpression queryExpression);
+    /**
+     * Union Rewrite by viewBasedRewrite and queryBasedRewrite.
+     * NOTE: Ensure plan's output column refs are unique even for the same query/mv plans.
+     * NOTE: viewInput's column ref's uniqueness is ensured by viewBasedRewrite.
+     */
+    OptExpression doUnionRewrite(OptExpression queryInput, OptExpression viewInput,
+                                 RewriteContext rewriteContext);
+
     /**
      * Rewrite the query with the given materialized view context.
      * @param mvContext: materialized view context of query and associated mv.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -266,12 +266,9 @@ public class MvPartitionCompensator {
      */
     public static OptExpression getMvTransparentPlan(MaterializationContext mvContext,
                                                      MVCompensation mvCompensation,
-                                                     List<ColumnRefOperator> expectOutputColumns) {
+                                                     List<ColumnRefOperator> originalOutputColumns) {
+        Preconditions.checkArgument(originalOutputColumns != null);
         Preconditions.checkState(mvCompensation.getState().isCompensate());
-        final LogicalOlapScanOperator mvScanOperator = mvContext.getScanMvOperator();
-        final MaterializedView mv = mvContext.getMv();
-        final List<ColumnRefOperator> originalOutputColumns = expectOutputColumns == null ?
-                MvUtils.getMvScanOutputColumnRefs(mv, mvScanOperator) : expectOutputColumns;
 
         Pair<OptExpression, List<ColumnRefOperator>> mvScanPlans = getMvScanPlan(mvContext);
         if (mvScanPlans == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -204,6 +204,10 @@ public class MVTestBase extends StarRocksTestBase {
         starRocksAssert.dropMaterializedView(mvName);
     }
 
+    public static OptExpression getOptimizedPlan(String sql) {
+        return getOptimizedPlan(sql, connectContext);
+    }
+
     public static OptExpression getOptimizedPlan(String sql, ConnectContext connectContext) {
         StatementBase mvStmt;
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -260,7 +260,6 @@ public class MvRewriteTest extends MVTestBase {
 
     @Test
     public void testJoinMvRewriteByForceRuleRewrite() throws Exception {
-        connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000000);
         {
             createAndRefreshMv("create materialized view join_mv_1" +
                     " distributed by hash(v1)" +
@@ -343,6 +342,7 @@ public class MvRewriteTest extends MVTestBase {
         String plan6 = getFragmentPlan(query6);
         PlanTestBase.assertNotContains(plan6, "join_mv_1");
 
+        connectContext.getSessionVariable().setEnableMaterializedViewUnionRewrite(true);
         dropMv("test", "join_mv_1");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -2383,13 +2383,13 @@ public class MvRewriteTest extends MVTestBase {
                                                         List<String> queries) throws Exception {
         createAndRefreshMv(mvQuery);
         for (String query : queries) {
-            OptExpression plan = getOptimizedPlan(query);
-            List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(plan);
-            Set<ColumnRefOperator> mvColumnRefSet = new HashSet<>();
+            final OptExpression plan = getOptimizedPlan(query);
+            final List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(plan);
+            final Set<ColumnRefOperator> mvColumnRefSet = new HashSet<>();
             for (LogicalScanOperator scanOperator : scanOperators) {
                 Assert.assertTrue(scanOperator instanceof LogicalOlapScanOperator);
                 Assert.assertTrue(scanOperator.getTable().getName().equalsIgnoreCase("test_mv1"));
-                LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) scanOperator;
+                final LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) scanOperator;
                 for (ColumnRefOperator colRef : olapScanOperator.getColumnMetaToColRefMap().values()) {
                     Assert.assertTrue(!mvColumnRefSet.contains(colRef));
                     mvColumnRefSet.add(colRef);
@@ -2490,7 +2490,7 @@ public class MvRewriteTest extends MVTestBase {
                     String query = "SELECT * FROM (SELECT * FROM s1 where num > 3 " +
                             "UNION ALL SELECT * FROM s1 where num > 3) t order by 1, 2 limit 3;";
                     connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(2);
-                    String plan = getFragmentPlan(query);
+                    final String plan = getFragmentPlan(query);
                     PlanTestBase.assertContains(plan, "test_mv1");
                     connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(0);
                 });

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -2483,15 +2483,16 @@ public class MvRewriteTest extends MVTestBase {
                 "  (2,\"2020-06-15\"),(3,\"2020-06-18\"),(4,\"2020-06-21\"),(5,\"2020-06-24\"),\n" +
                 "  (2,\"2020-07-02\"),(3,\"2020-07-05\"),(4,\"2020-07-08\"),(5,\"2020-07-11\");");
         withRefreshedMV("CREATE MATERIALIZED VIEW test_mv1 \n" +
-                "PARTITION BY dt \n" +
-                "REFRESH DEFERRED MANUAL \n" +
-                "AS SELECT * FROM s1 where dt > '2020-07-01';", () -> {
-            String query = "SELECT * FROM (SELECT * FROM s1 where num > 3 UNION ALL SELECT * FROM s1 where num > 3) t " +
-                    "order by 1, 2 limit 3;";
-            connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(2);
-            String plan = getFragmentPlan(query);
-            PlanTestBase.assertContains(plan, "test_mv1");
-            connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(0);
-        });
+                        "PARTITION BY dt \n" +
+                        "REFRESH DEFERRED MANUAL \n" +
+                        "AS SELECT * FROM s1 where dt > '2020-07-01';",
+                () -> {
+                    String query = "SELECT * FROM (SELECT * FROM s1 where num > 3 " +
+                            "UNION ALL SELECT * FROM s1 where num > 3) t order by 1, 2 limit 3;";
+                    connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(2);
+                    String plan = getFragmentPlan(query);
+                    PlanTestBase.assertContains(plan, "test_mv1");
+                    connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(0);
+                });
     }
 }


### PR DESCRIPTION
## Why I'm doing:

PR https://github.com/StarRocks/starrocks/pull/22150 can only ensure MV rewrite result's column refs unique for not-aggregate node rule rewrite.

We need to ensure all MV Rule rewrite's results' columns refs unique to avoid generating bad plans.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0