### PR TITLE
[Refactor] Remove unused mv rewrite codes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -83,8 +83,6 @@ public class MaterializationContext {
     // used to reduce the rewrite times for the same group and mv
     private final List<Integer> matchedGroups;
 
-    private final ScalarOperator mvPartialPartitionPredicate;
-
     // The output column refs of the MV which is ordered by user's select list.
     private final List<ColumnRefOperator> mvOutputColumnRefs;
 
@@ -111,7 +109,6 @@ public class MaterializationContext {
                                   ColumnRefFactory mvColumnRefFactory,
                                   List<Table> baseTables,
                                   List<Table> intersectingTables,
-                                  ScalarOperator mvPartialPartitionPredicate,
                                   MvUpdateInfo mvUpdateInfo,
                                   List<ColumnRefOperator> mvOutputColumnRefs) {
         this.optimizerContext = optimizerContext;
@@ -122,7 +119,6 @@ public class MaterializationContext {
         this.baseTables = baseTables;
         this.intersectingTables = intersectingTables;
         this.matchedGroups = Lists.newArrayList();
-        this.mvPartialPartitionPredicate = mvPartialPartitionPredicate;
         this.mvUpdateInfo = mvUpdateInfo;
         this.mvOutputColumnRefs = mvOutputColumnRefs;
         this.scanOpToPartitionCompensatePredicates = Maps.newHashMap();
@@ -186,10 +182,6 @@ public class MaterializationContext {
 
     public boolean isMatchedGroup(int groupId) {
         return matchedGroups.contains(groupId);
-    }
-
-    public ScalarOperator getMvPartialPartitionPredicate() {
-        return mvPartialPartitionPredicate;
     }
 
     public long getMVUsedCount() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -26,7 +26,6 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
-import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
@@ -100,7 +99,7 @@ public class MaterializationContext {
     private MVCompensation mvCompensation = null;
 
     // Cache partition compensates predicates for each ScanNode and isCompensate pair.
-    private Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOpToPartitionCompensatePredicates;
+    private Map<LogicalScanOperator, List<ScalarOperator>> scanOpToPartitionCompensatePredicates;
 
     public MaterializationContext(OptimizerContext optimizerContext,
                                   MaterializedView mv,
@@ -524,7 +523,7 @@ public class MaterializationContext {
         return false;
     }
 
-    public Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> getScanOpToPartitionCompensatePredicates() {
+    public Map<LogicalScanOperator, List<ScalarOperator>> getScanOpToPartitionCompensatePredicates() {
         return scanOpToPartitionCompensatePredicates;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -65,8 +65,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections.CollectionUtils;
@@ -87,7 +85,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
-import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator.getMvPartialPartitionPredicates;
 
 public class MvRewritePreprocessor {
     private static final Logger LOG = LogManager.getLogger(MvRewritePreprocessor.class);
@@ -764,16 +761,8 @@ public class MvRewritePreprocessor {
                 logMVPrepare(mv, "MV' partitions to refresh: {}/{}", partitionNamesToRefresh.size(),
                         MvUtils.shrinkToSize(partitionNamesToRefresh, Config.max_mv_task_run_meta_message_values_length));
 
-                // mv's partial partition predicates
-                ScalarOperator mvPartialPartitionPredicates =
-                        mvPartialPartitionPredicate(mv, mvPlanContext, partitionNamesToRefresh);
-                if (mvPartialPartitionPredicates == null) {
-                    OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "partition compensate fail");
-                    continue;
-                }
-                logMVPrepare(mv, "MV compensate partition predicate: {}", mvPartialPartitionPredicates);
                 MaterializationContext materializationContext = buildMaterializationContext(context, mv, mvPlanContext,
-                        mvPartialPartitionPredicates, mvUpdateInfo, queryTables);
+                        mvUpdateInfo, queryTables);
                 if (materializationContext == null) {
                     continue;
                 }
@@ -850,33 +839,6 @@ public class MvRewritePreprocessor {
     }
 
     /**
-     * Get mv's compensated partial partition predicates for partitioned MV.
-     */
-    private static ScalarOperator mvPartialPartitionPredicate(MaterializedView mv,
-                                                              MvPlanContext mvPlanContext,
-                                                              Set<String> partitionNamesToRefresh) {
-        OptExpression mvPlan = mvPlanContext.getLogicalPlan();
-        ScalarOperator mvPartialPartitionPredicates = ConstantOperator.TRUE;
-        if (mv.getPartitionInfo().isRangePartition() && !partitionNamesToRefresh.isEmpty()) {
-            // when mv is partitioned and there are some refreshed partitions,
-            // when should calculate the latest partition range predicates for partition-by base table
-            try {
-                mvPartialPartitionPredicates = getMvPartialPartitionPredicates(mv, mvPlan, partitionNamesToRefresh);
-                if (mvPartialPartitionPredicates == null) {
-                    logMVPrepare(mv, "Partitioned MV {} is outdated which contains some partitions " +
-                            "to be refreshed: {}, and cannot compensate it to predicate", mv.getName(), partitionNamesToRefresh);
-                    return null;
-                }
-            } catch (AnalysisException e) {
-                logMVPrepare(mv, "Get partitioned MV {} with to-refresh partitions {} predicate failed: " +
-                        "{}", mv.getName(), partitionNamesToRefresh, DebugUtil.getStackTrace(e));
-                return null;
-            }
-        }
-        return mvPartialPartitionPredicates;
-    }
-
-    /**
      * Build materialization context for the given materialized view.
      * @param mv: the input materialized view
      * @param mvPlanContext: the associated materialized view context
@@ -887,7 +849,6 @@ public class MvRewritePreprocessor {
     public static MaterializationContext buildMaterializationContext(OptimizerContext context,
                                                                      MaterializedView mv,
                                                                      MvPlanContext mvPlanContext,
-                                                                     ScalarOperator mvPartialPartitionPredicates,
                                                                      MvUpdateInfo mvUpdateInfo,
                                                                      Set<Table> queryTables) {
         Preconditions.checkState(mvPlanContext != null);
@@ -910,7 +871,7 @@ public class MvRewritePreprocessor {
         MaterializationContext materializationContext =
                 new MaterializationContext(context, copiedMV, mvPlan, context.getColumnRefFactory(),
                         mvPlanContext.getRefFactory(), baseTables, intersectingTables,
-                        mvPartialPartitionPredicates, mvUpdateInfo, mvOutputColumns);
+                        mvUpdateInfo, mvOutputColumns);
         // generate scan mv plan here to reuse it in rule applications
         LogicalOlapScanOperator scanMvOp = createScanMvOperator(mv,
                 materializationContext.getQueryRefFactory(), mvUpdateInfo.getMvToRefreshPartitionNames());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -433,19 +433,21 @@ public class Optimizer {
     private void ruleBasedMaterializedViewRewrite(OptExpression tree,
                                                   TaskContext rootTaskContext,
                                                   ColumnRefSet requiredColumns) {
-        if (!mvRewriteStrategy.enableMaterializedViewRewrite || context.getQueryMaterializationContext() == null ||
-                context.getQueryMaterializationContext().hasRewrittenSuccess()) {
+        if (!mvRewriteStrategy.enableMaterializedViewRewrite || context.getQueryMaterializationContext() == null) {
             return;
         }
 
         // do rule based mv rewrite
-        doRuleBasedMaterializedViewRewrite(tree, rootTaskContext);
+        if (!context.getQueryMaterializationContext().hasRewrittenSuccess()) {
+            doRuleBasedMaterializedViewRewrite(tree, rootTaskContext);
+        }
 
         // NOTE: Since union rewrite will generate Filter -> Union -> OlapScan -> OlapScan, need to push filter below Union
         // and do partition predicate again.
         // TODO: move this into doRuleBasedMaterializedViewRewrite
         // TODO: Do it in CBO if needed later.
         boolean isNeedFurtherPartitionPrune = Utils.isOptHasAppliedRule(tree, op -> op.isOpRuleBitSet(OP_MV_UNION_REWRITE));
+        OptimizerTraceUtil.logMVPrepare("is further partition prune: {}", isNeedFurtherPartitionPrune);
         if (isNeedFurtherPartitionPrune && context.getQueryMaterializationContext().hasRewrittenSuccess()) {
             // reset partition prune bit to do partition prune again.
             MvUtils.getScanOperator(tree).forEach(scan -> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -37,7 +37,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
@@ -158,7 +157,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
         logMVRewrite(context, this, "MV to refresh partition info: {}", mvUpdateInfo);
 
         MaterializationContext mvContext = MvRewritePreprocessor.buildMaterializationContext(context,
-                mv, mvPlanContext, ConstantOperator.TRUE, mvUpdateInfo, queryTables);
+                mv, mvPlanContext, mvUpdateInfo, queryTables);
 
         Map<Column, ColumnRefOperator> columnToColumnRefMap = olapScanOperator.getColumnMetaToColRefMap();
         List<Column> mvColumns = mv.getBaseSchemaWithoutGeneratedColumn();
@@ -205,7 +204,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
         mvUpdateInfo.addMvToRefreshPartitionNames(mv.getPartitionNames());
 
         MaterializationContext mvContext = MvRewritePreprocessor.buildMaterializationContext(context,
-                mv, mvPlanContext, ConstantOperator.TRUE, mvUpdateInfo, queryTables);
+                mv, mvPlanContext, mvUpdateInfo, queryTables);
         logMVRewrite(mvContext, "Get mv transparent plan failed, and redirect to mv's defined query");
         Map<Column, ColumnRefOperator> columnToColumnRefMap = olapScanOperator.getColumnMetaToColRefMap();
         List<Column> mvColumns = mv.getBaseSchemaWithoutGeneratedColumn();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -388,9 +388,8 @@ public class MvPartitionCompensator {
         if (mvCompensation.getState().isNoRewrite()) {
             return null;
         }
-        boolean isCompensatePartition = mvCompensation.isCompensatePartitionPredicate();
         // Compensate partition predicates and add them into query predicate.
-        Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOperatorScalarOperatorMap =
+        Map<LogicalScanOperator, List<ScalarOperator>> scanOperatorScalarOperatorMap =
                 mvContext.getScanOpToPartitionCompensatePredicates();
         MaterializedView mv = mvContext.getMv();
         final Set<Table> baseTables = new HashSet<>(mvContext.getBaseTables());
@@ -405,12 +404,11 @@ public class MvPartitionCompensator {
                 return null;
             }
             List<ScalarOperator> partitionPredicate = scanOperatorScalarOperatorMap
-                    .computeIfAbsent(Pair.create(scanOperator, isCompensatePartition), x -> {
+                    .computeIfAbsent(scanOperator, x -> {
                         if (!baseTables.contains(scanOperator.getTable())) {
                             return Collections.emptyList();
                         }
-                        return isCompensatePartition ? getCompensatePartitionPredicates(mvContext, columnRefFactory,
-                                scanOperator) : getScanOpPrunedPartitionPredicates(mv, scanOperator);
+                        return getScanOpPrunedPartitionPredicates(mv, scanOperator);
                     });
             if (partitionPredicate == null) {
                 logMVRewrite(mvContext.getMv().getName(), "Compensate partition failed for scan {}",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensation.java
@@ -98,30 +98,14 @@ public class MVCompensation {
         return compensations;
     }
 
-    private boolean useTransparentRewrite() {
-        return sessionVariable.isEnableMaterializedViewTransparentUnionRewrite();
-    }
-
     public boolean isTransparentRewrite() {
-        if (!useTransparentRewrite()) {
-            return false;
-        }
-        // No compensate once if mv's freshness is satisfied.
-        if (state.isCompensate()) {
-            return true;
-        }
-        return false;
+        return state.isCompensate();
     }
 
     public boolean isCompensatePartitionPredicate() {
         // always false if it's set to false from session variable
-        if (!sessionVariable.isEnableMaterializedViewRewritePartitionCompensate()) {
+        if (state.isNoCompensate() || state.isCompensate()) {
             return false;
-        }
-        if (state.isNoCompensate()) {
-            return false;
-        } else if (state.isCompensate()) {
-            return !useTransparentRewrite();
         } else {
             return true;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -510,9 +510,7 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
         query = "SELECT `o_orderkey`, `o_orderstatus`, `o_orderdate`  FROM `hive0`.`partitioned_db`.`orders` ";
         plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "hive_parttbl_mv_5", "orders",
-                "PARTITION PREDICATES: (((15: o_orderdate < '1991-01-01') OR (15: o_orderdate >= '1991-02-01'))" +
-                        " AND ((15: o_orderdate < '1991-03-01') OR (15: o_orderdate >= '1993-12-31')))" +
-                        " OR (15: o_orderdate IS NULL)");
+                "     partitions=28/1095");
 
         // updated partitions are not in the query's partition range
         query = "SELECT `o_orderkey`, `o_orderstatus`, `o_orderdate`  FROM `hive0`.`partitioned_db`.`orders` " +
@@ -861,7 +859,7 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
         {
             String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
                     " FROM base_tbl1 where date_trunc('minute', `k1`)  = '2020-02-11' group by ds";
-            String plan = getFragmentPlan(query, "MV");
+            String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "test_mv1", "ds = '2020-02-11 00:00:00'");
         }
 
@@ -1189,6 +1187,7 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
 
         String query = "select col1, col2, 'server' source_meta_type, count(1) " +
                 "from test_base_table1 where col2 between '2022-04-01' and '2022-04-05'  group by col1, col2;\n";
+        connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(1);
         {
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "UNION");
@@ -1197,8 +1196,7 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
             // input query's partition range is [2022-04-01, 2022-04-05] and should not be changed.
             PlanTestBase.assertContains(plan, "     TABLE: test_base_table1\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: ((13: col0 != 123456789) OR (14: col2 < '2022-04-01')) " +
-                    "OR ((14: col2 >= '2022-04-04') OR (15: col3 != 'Guangdong'))\n" +
+                    "     PREDICATES: (23: col0 != 123456789) OR (25: col3 != 'Guangdong')\n" +
                     "     partitions=5/9");
         }
 
@@ -1209,10 +1207,10 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
             // input query's partition range is [2022-04-01, 2022-04-05] and should not be changed.
             PlanTestBase.assertContains(plan, "     TABLE: test_base_table1\n" +
                     "     PREAGGREGATION: ON\n" +
-                    "     PREDICATES: ((13: col0 != 123456789) OR (14: col2 < '2022-04-01')) " +
-                    "OR ((14: col2 >= '2022-04-04') OR (15: col3 != 'Guangdong'))\n" +
+                    "     PREDICATES: (23: col0 != 123456789) OR (25: col3 != 'Guangdong')\n" +
                     "     partitions=5/9");
         }
+        connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(0);
         connectContext.getSessionVariable().setEnableMaterializedViewTransparentUnionRewrite(true);
         starRocksAssert.dropTable("test_base_table1");
         starRocksAssert.dropMaterializedView("test_mv1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartitionTest.java
@@ -636,6 +636,7 @@ public class MvRewritePartitionTest extends MVTestBase {
                     cluster.runSql("test", String.format("refresh materialized view %s partition " +
                             "start('%s') end('%s') with sync mode;", mvName, param.refreshStart, param.refreshEnd));
                     for (PCompensateExpect expect : param.expectPartitionPredicates) {
+                        System.out.println(expect);
                         if (!Strings.isNullOrEmpty(expect.partitionPredicate)) {
                             String query = String.format("select a.t1a, a.id_date, sum(a.t1b), sum(b.t1b) \n" +
                                     "from table_with_day_partition a\n" +
@@ -669,7 +670,7 @@ public class MvRewritePartitionTest extends MVTestBase {
                                 // no partition expressions
                                 PCompensateExpect.create("a.id_date='1991-03-30'", false, true),
                                 PCompensateExpect.create("a.id_date>='1991-03-30'", true, true),
-                                PCompensateExpect.create("a.id_date!='1991-03-30'", false),
+                                PCompensateExpect.create("a.id_date!='1991-03-30'", true, true),
                                 // with partition expressions && partition expressions can be pruned
                                 PCompensateExpect.create("date_format(a.id_date, '%Y%m%d')='19910330'", false, true),
                                 PCompensateExpect.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", false, true),
@@ -678,8 +679,8 @@ public class MvRewritePartitionTest extends MVTestBase {
                                 PCompensateExpect.create("subdate(a.id_date, interval 1 day)='1991-03-29'", false, true),
                                 PCompensateExpect.create("adddate(a.id_date, interval 1 day)='1991-03-31'", false, true),
                                 // with partition expressions && partition expressions can be pruned
-                                PCompensateExpect.create("cast(a.id_date as string)='1991-03-30'", false),
-                                PCompensateExpect.create("cast(a.id_date as string) >='1991-03-30'", false)
+                                PCompensateExpect.create("cast(a.id_date as string)='1991-03-30'", true, true),
+                                PCompensateExpect.create("cast(a.id_date as string) >='1991-03-30'", true, true)
                         )
                 ),
                 // partition: slot
@@ -689,7 +690,7 @@ public class MvRewritePartitionTest extends MVTestBase {
                                 // no partition expressions
                                 PCompensateExpect.create("a.id_date='1991-03-30'", false, true),
                                 PCompensateExpect.create("a.id_date>='1991-03-30'", true, true),
-                                PCompensateExpect.create("a.id_date!='1991-03-30'", false),
+                                PCompensateExpect.create("a.id_date!='1991-03-30'", true, true),
                                 // with partition expressions && partition expressions can be pruned
                                 PCompensateExpect.create("date_format(a.id_date, '%Y%m%d')='19910330'", false, true),
                                 PCompensateExpect.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", false, true),
@@ -698,12 +699,13 @@ public class MvRewritePartitionTest extends MVTestBase {
                                 PCompensateExpect.create("subdate(a.id_date, interval 1 day)='1991-03-29'", false, true),
                                 PCompensateExpect.create("adddate(a.id_date, interval 1 day)='1991-03-31'", false, true),
                                 // with partition expressions && partition expressions can be pruned
-                                PCompensateExpect.create("cast(a.id_date as string)='1991-03-30'", false),
-                                PCompensateExpect.create("cast(a.id_date as string) >='1991-03-30'", false)
+                                PCompensateExpect.create("cast(a.id_date as string)='1991-03-30'", true, true),
+                                PCompensateExpect.create("cast(a.id_date as string) >='1991-03-30'", true, true)
                         )
                 )
         );
         for (PartitionCompensateParam param : params) {
+            System.out.println(param);
             testRefreshAndRewriteWithMultiJoinMV(param);
         }
         connectContext.getSessionVariable().setEnableMaterializedViewTransparentUnionRewrite(true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -42,10 +42,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
-import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.rule.RuleType;
@@ -225,12 +221,6 @@ public class MvRewritePreprocessorTest extends MVTestBase {
             Pair<Table, Column> partitionTableAndColumn = getRefBaseTablePartitionColumn(mv);
             Assert.assertEquals("tbl_with_mv", partitionTableAndColumn.first.getName());
 
-            ScalarOperator scalarOperator = materializationContext.getMvPartialPartitionPredicate();
-            if (scalarOperator != null) {
-                Assert.assertTrue(scalarOperator instanceof CompoundPredicateOperator);
-                Assert.assertTrue(((CompoundPredicateOperator) scalarOperator).isAnd());
-            }
-
             refreshMaterializedView("test", "mv_4");
             executeInsertSql(connectContext, "insert into tbl_with_mv partition(p2) values(\"2020-02-20\", 20, 30)");
             Optimizer optimizer2 = new Optimizer();
@@ -240,10 +230,6 @@ public class MvRewritePreprocessorTest extends MVTestBase {
             MaterializationContext materializationContext2 =
                     optimizer2.getContext().getCandidateMvs().iterator().next();
             Assert.assertEquals("mv_4", materializationContext2.getMv().getName());
-            ScalarOperator scalarOperator2 = materializationContext2.getMvPartialPartitionPredicate();
-            if (scalarOperator2 != null) {
-                Assert.assertTrue(scalarOperator2 instanceof CompoundPredicateOperator);
-            }
             starRocksAssert.dropMaterializedView("mv_4");
         }
 
@@ -272,16 +258,6 @@ public class MvRewritePreprocessorTest extends MVTestBase {
             Assert.assertEquals("mv_5", materializationContext3.getMv().getName());
             List<LogicalScanOperator> scanExpr3 = MvUtils.getScanOperator(materializationContext3.getMvExpression());
             Assert.assertEquals(1, scanExpr3.size());
-            ScalarOperator scalarOperator3 = materializationContext3.getMvPartialPartitionPredicate();
-            if (scalarOperator3 != null) {
-                Assert.assertNotNull(scalarOperator3);
-                Assert.assertTrue(scalarOperator3 instanceof CompoundPredicateOperator);
-                Assert.assertTrue(((CompoundPredicateOperator) scalarOperator3).isAnd());
-                Assert.assertTrue(scalarOperator3.getChild(0) instanceof BinaryPredicateOperator);
-                Assert.assertTrue(scalarOperator3.getChild(0).getChild(0) instanceof ColumnRefOperator);
-                ColumnRefOperator columnRef = (ColumnRefOperator) scalarOperator3.getChild(0).getChild(0);
-                Assert.assertEquals("k1", columnRef.getName());
-            }
             LogicalOlapScanOperator scanOperator = materializationContext3.getScanMvOperator();
             Assert.assertEquals(1, scanOperator.getSelectedPartitionId().size());
         }

--- a/test/sql/test_materialized_view/R/test_materialized_view_union_all_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_union_all_rewrite
@@ -34,45 +34,45 @@ REFRESH MATERIALIZED VIEW mv0 PARTITION START ('1') END ('3') with sync mode;
 set materialized_view_union_rewrite_mode = 0;
 -- result:
 -- !result
-function: check_hit_materialized_view("select * from mt1 where k1 < 3 and v2 != 2", "mv0")
+function: print_hit_materialized_view("select * from mt1 where k1 < 3 and v2 != 2", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("select * from mt1 where k1 = 1 and v2 >= 4 ", "mv0")
+function: print_hit_materialized_view("select * from mt1 where k1 = 1 and v2 >= 4 ", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 != 3", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 != 3", "mv0", "UNION")
 -- result:
-None
+False
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0")
 -- result:
-None
+False
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0")
 -- result:
-None
+False
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0")
 -- result:
-None
+False
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0")
 -- result:
-None
+False
 -- !result
 select * from mt1 where k1 < 3 and v2 != 2 order by 1;
 -- result:
@@ -132,37 +132,37 @@ SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 >= 4  order by 1;
 set materialized_view_union_rewrite_mode = 1;
 -- result:
 -- !result
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 >= 4 ", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 >= 4 ", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0")
 -- result:
-None
+False
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0")
 -- result:
-None
+False
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0")
 -- result:
-None
+False
 -- !result
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0")
 -- result:
-None
+False
 -- !result
 select * from mt1 where k1 < 3 and v2 != 2 order by 1;
 -- result:
@@ -222,37 +222,37 @@ SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 >= 4  order by 1;
 set materialized_view_union_rewrite_mode = 2;
 -- result:
 -- !result
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 != 3", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 != 3", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0", "UNION")
 -- result:
-None
+True
 -- !result
 select * from mt1 where k1 < 3 and v2 != 2 order by 1;
 -- result:
@@ -325,29 +325,29 @@ REFRESH MATERIALIZED VIEW mv0 PARTITION START ('1') END ('3') with sync mode;
 set materialized_view_union_rewrite_mode = 0;
 -- result:
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
 -- result:
-None
+False
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
 -- result:
-None
+False
 -- !result
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
 select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1 order by 1;
 -- result:
@@ -393,29 +393,29 @@ select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1 order by 1;
 set materialized_view_union_rewrite_mode = 1;
 -- result:
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
 select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1 order by 1;
 -- result:
@@ -461,29 +461,29 @@ select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1 order by 1;
 set materialized_view_union_rewrite_mode = 2;
 -- result:
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
 -- result:
-None
+True
 -- !result
 select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1 order by 1;
 -- result:

--- a/test/sql/test_materialized_view/T/test_materialized_view_union_all_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_union_all_rewrite
@@ -30,17 +30,17 @@ REFRESH MATERIALIZED VIEW mv0 PARTITION START ('1') END ('3') with sync mode;
 
 -- default mode
 set materialized_view_union_rewrite_mode = 0;
-function: check_hit_materialized_view("select * from mt1 where k1 < 3 and v2 != 2", "mv0")
-function: check_hit_materialized_view("select * from mt1 where k1 = 1 and v2 >= 4 ", "mv0")
+function: print_hit_materialized_view("select * from mt1 where k1 < 3 and v2 != 2", "mv0")
+function: print_hit_materialized_view("select * from mt1 where k1 = 1 and v2 >= 4 ", "mv0")
 
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
-function: check_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 != 3", "mv0", "UNION")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 != 3", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0")
 
 select * from mt1 where k1 < 3 and v2 != 2 order by 1;
 select * from mt1 where k1 = 1 and v2 >= 4  order by 1;
@@ -55,14 +55,14 @@ SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 >= 4  order by 1;
 
 -- mode 1
 set materialized_view_union_rewrite_mode = 1;
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
-function: check_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 >= 4 ", "mv0", "UNION")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0")
-function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 >= 4 ", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0")
 
 select * from mt1 where k1 < 3 and v2 != 2 order by 1;
 select * from mt1 where k1 = 1 and v2 >= 4  order by 1;
@@ -77,14 +77,14 @@ SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 >= 4  order by 1;
 
 -- mode 2
 set materialized_view_union_rewrite_mode = 2;
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0", "UNION")
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0", "UNION")
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 != 3", "mv0", "UNION")
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0", "UNION")
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
-function: check_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0", "UNION")
-function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 = 'a' and v2 != 4", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 = 'a' and v2 >= 4", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 WHERE k1 <6 and v2 != 3", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 != 4", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT distinct k1,k2, v1,v2 from mt1", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 = 2", "mv0", "UNION")
+function: print_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where v2 <= 2", "mv0", "UNION")
 
 select * from mt1 where k1 < 3 and v2 != 2 order by 1;
 select * from mt1 where k1 = 1 and v2 >= 4  order by 1;
@@ -110,12 +110,12 @@ group by k1, k2 ;
 REFRESH MATERIALIZED VIEW mv0 PARTITION START ('1') END ('3') with sync mode;
 
 set materialized_view_union_rewrite_mode = 0;
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
 
 select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1 order by 1;
 select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1 order by 1;
@@ -125,12 +125,12 @@ select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1 order by 1;
 select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1 order by 1;
 
 set materialized_view_union_rewrite_mode = 1;
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
-function: check_no_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
 
 select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1 order by 1;
 select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1 order by 1;
@@ -140,12 +140,12 @@ select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1 order by 1;
 select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1 order by 1;
 
 set materialized_view_union_rewrite_mode = 2;
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
-function: check_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 > 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 != 1 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 < 5 group by k1;", "mv0")
+function: print_hit_materialized_view("select k1, sum(v1), sum(v2) from mt1 where k1 <= 3 group by k1;", "mv0")
 
 select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' group by k1 order by 1;
 select k1, sum(v1), sum(v2) from mt1 where k2 != 'a' and k1 >= 1 group by k1 order by 1;


### PR DESCRIPTION
## Why I'm doing:

Since PR https://github.com/StarRocks/starrocks/pull/44764 has been merged, we can remove original compensated partition expression codes, use transparent union rewrite by default.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0