### PR TITLE
[BugFix] add limit to chunk rows when generate blocks in load spill

### DIFF
--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -106,7 +106,8 @@ Status SpillMemTableSink::_prepare(const ChunkPtr& chunk_ptr) {
 Status SpillMemTableSink::_do_spill(const Chunk& chunk, const spill::SpillOutputDataStreamPtr& output) {
     // 1. caclulate per row memory usage
     const int64_t per_row_memory_usage = chunk.memory_usage() / chunk.num_rows();
-    const int64_t spill_rows = config::load_spill_max_chunk_bytes / (per_row_memory_usage + 1) + 1;
+    const int64_t spill_rows = std::min(config::load_spill_max_chunk_bytes / (per_row_memory_usage + 1) + 1,
+                                        (int64_t)max_merge_chunk_size);
     // 2. serialize chunk
     for (int64_t rowid = 0; rowid < chunk.num_rows(); rowid += spill_rows) {
         int64_t rows = std::min(spill_rows, (int64_t)chunk.num_rows() - rowid);

--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -50,8 +50,6 @@ inline int compare_chunk(size_t key_columns, const std::vector<uint32_t>& sort_k
     return 0;
 }
 
-static const size_t max_merge_chunk_size = 65536;
-
 // MergingChunk contains a chunk for merge and an index of compared row.
 class MergingChunk {
 public:

--- a/be/src/storage/merge_iterator.h
+++ b/be/src/storage/merge_iterator.h
@@ -21,6 +21,8 @@
 
 namespace starrocks {
 
+static const size_t max_merge_chunk_size = 65536;
+
 // new_heap_merge_iterator create a sorted iterator based on merge-sort algorithm.
 // the order of rows is determined by the key columns.
 // if two rows compared equal, their order is determinate by the index of the source iterator

--- a/be/src/storage/merge_iterator.h
+++ b/be/src/storage/merge_iterator.h
@@ -21,7 +21,9 @@
 
 namespace starrocks {
 
-static const size_t max_merge_chunk_size = 65536;
+// max_merge_chunk_size is the maximum number of rows in a chunk that can be merged.
+// We have this limitation because `_compared_row` in ComparableChunk is uint16_t.
+static const size_t max_merge_chunk_size = 65535;
 
 // new_heap_merge_iterator create a sorted iterator based on merge-sort algorithm.
 // the order of rows is determined by the key columns.


### PR DESCRIPTION
## Why I'm doing:
We have a limitation in merge iterator which chunk row count must less or equal than `65536`. So if we generate a chunk which over this limit, it will cause error:
```
      ErrorMsg: type:LOAD_RUN_FAIL; msg:172.26.81.16: Merge iterator only supports merging chunks with rows less than 65536
```

## What I'm doing:
Add limit to chunk rows count when generate blocks in load spill

Fix #53954

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0