### PR TITLE
[Feature] Support hive catalog to read json format tables.

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -718,7 +718,8 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     } else if (format == THdfsFileFormat::TEXT) {
         scanner = new HdfsTextScanner();
     } else if ((format == THdfsFileFormat::AVRO || format == THdfsFileFormat::RC_BINARY ||
-                format == THdfsFileFormat::RC_TEXT || format == THdfsFileFormat::SEQUENCE_FILE) &&
+                format == THdfsFileFormat::RC_TEXT || format == THdfsFileFormat::SEQUENCE_FILE ||
+                format == THdfsFileFormat::JSON_TEXT) &&
                (dynamic_cast<const HdfsTableDescriptor*>(_hive_table) != nullptr ||
                 dynamic_cast<const FileTableDescriptor*>(_hive_table) != nullptr)) {
         scanner = create_hive_jni_scanner(jni_scanner_create_options).release();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveClassNames.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveClassNames.java
@@ -47,6 +47,8 @@ public class HiveClassNames {
     public static final String SEQUENCE_INPUT_FORMAT_CLASS =
             "org.apache.hadoop.mapred.SequenceFileInputFormat";
 
+    public static final String TEXT_JSON_SERDE_CLASS = "org.apache.hive.hcatalog.data.JsonSerDe";
+
     public static final String SEQUENCE_OUTPUT_FORMAT_CLASS =
             "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat";
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
@@ -36,6 +36,7 @@ import static com.starrocks.connector.hive.HiveClassNames.RCFILE_OUTPUT_FORMAT_C
 import static com.starrocks.connector.hive.HiveClassNames.SEQUENCE_INPUT_FORMAT_CLASS;
 import static com.starrocks.connector.hive.HiveClassNames.SEQUENCE_OUTPUT_FORMAT_CLASS;
 import static com.starrocks.connector.hive.HiveClassNames.TEXT_INPUT_FORMAT_CLASS;
+import static com.starrocks.connector.hive.HiveClassNames.TEXT_JSON_SERDE_CLASS;
 import static com.starrocks.connector.hive.HiveMetastoreOperations.FILE_FORMAT;
 import static java.util.Objects.requireNonNull;
 
@@ -71,6 +72,11 @@ public enum HiveStorageFormat {
             LAZY_SIMPLE_SERDE_CLASS,
             SEQUENCE_INPUT_FORMAT_CLASS,
             SEQUENCE_OUTPUT_FORMAT_CLASS
+    ),
+    JSONTEXT(
+            TEXT_JSON_SERDE_CLASS,
+            TEXT_INPUT_FORMAT_CLASS,
+            HIVE_IGNORE_KEY_OUTPUT_FORMAT_CLASS
     ),
     UNSUPPORTED("UNSUPPORTED", "UNSUPPORTED", "UNSUPPORTED");
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
@@ -33,6 +33,7 @@ public enum RemoteFileInputFormat {
     RCBINARY,
     RCTEXT,
     SEQUENCE,
+    JSONTEXT,
     UNKNOWN;
     private static final ImmutableMap<String, RemoteFileInputFormat> CLASS_NAME_TO_INPUT_FORMAT =
             new ImmutableMap.Builder<String, RemoteFileInputFormat>()
@@ -97,6 +98,8 @@ public enum RemoteFileInputFormat {
                 return THdfsFileFormat.RC_TEXT;
             case SEQUENCE:
                 return THdfsFileFormat.SEQUENCE_FILE;
+            case JSONTEXT:
+                return THdfsFileFormat.JSON_TEXT;
             default:
                 return THdfsFileFormat.UNKNOWN;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
@@ -260,7 +260,7 @@ public class HiveTableTest {
         targetFormats.add("RCBINARY");
         targetFormats.add("RCTEXT");
         targetFormats.add("SEQUENCE");
-
+        targetFormats.add("JSONTEXT");
         for (String targetFormat : targetFormats) {
             HiveTable oTable = createExternalTableByFormat(targetFormat);
             String inputFormatClass = HiveStorageFormat.get(targetFormat).getInputFormat();
@@ -290,6 +290,8 @@ public class HiveTableTest {
             TTableDescriptor tTableDescriptor = hiveTable.toThrift(partitions);
 
             Assert.assertEquals(tTableDescriptor.getHdfsTable().getInput_format(), inputFormatClass);
+            Assert.assertNotEquals(tTableDescriptor.getHdfsTable().getInput_format(),"UNSUPPORTED");
+            Assert.assertNotEquals(tTableDescriptor.getHdfsTable().getSerde_lib(),"UNSUPPORTED");
             Assert.assertEquals(tTableDescriptor.getHdfsTable().getSerde_lib(), serde);
             Assert.assertEquals(tTableDescriptor.getHdfsTable().getHive_column_names(), "col2");
             Assert.assertEquals(tTableDescriptor.getHdfsTable().getHive_column_types(), "INT");

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -75,6 +75,7 @@ enum THdfsFileFormat {
   PARQUET = 5,
   ORC = 6,
   SEQUENCE_FILE = 7,
+  JSON_TEXT = 8,
 
   UNKNOWN = 100
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

- Support hivecata to read json format tables.
- Support hive's own json class org.apache.hive.hcatalog.data.JsonSerDe

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0