### PR TITLE
[Doc]completed_task_count is a cumulative value and should not be used as the Excessive FE Thread Count Alert.

### DIFF
--- a/docs/en/administration/management/monitoring/alert.md
+++ b/docs/en/administration/management/monitoring/alert.md
@@ -345,7 +345,7 @@ In the **fe.log** of the Leader FE node, search for records like `begin to gener
 **PromSQL**
 
 ```Bash
-starrocks_fe_thread_pool{job="$job_name"} > 3000
+starrocks_fe_thread_pool{job="$job_name", type!="completed_task_count"} > 3000
 ```
 
 **Alert Description**

--- a/docs/zh/administration/management/monitoring/alert.md
+++ b/docs/zh/administration/management/monitoring/alert.md
@@ -344,7 +344,7 @@ starrocks_fe_meta_log_count{job="$job_name",instance="$fe_master"} > 100000
 **PromSQL**
 
 ```Bash
-starrocks_fe_thread_pool{job="$job_name"} > 3000
+starrocks_fe_thread_pool{job="$job_name", type!="completed_task_count"} > 3000
 ```
 
 **报警描述**


### PR DESCRIPTION
## Why I'm doing:
completed_task_count is a cumulative value and should not be used as the Excessive FE Thread Count Alert.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0