### PR TITLE
[BugFix] Cancel lake compaction task proactively when FE's transaction is aborted

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -819,7 +819,7 @@ void LakeServiceImpl::abort_compaction(::google::protobuf::RpcController* contro
     }
 
     auto scheduler = _tablet_mgr->compaction_scheduler();
-    auto st = scheduler->abort(request->txn_id());
+    auto st = scheduler->abort(request->txn_id(), request->reason());
     TEST_SYNC_POINT("LakeServiceImpl::abort_compaction:aborted");
     st.to_protobuf(response->mutable_status());
 }

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -413,7 +413,7 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     return status;
 }
 
-Status CompactionScheduler::abort(int64_t txn_id) {
+Status CompactionScheduler::abort(int64_t txn_id, const std::string& reason) {
     std::unique_lock l(_contexts_lock);
     for (butil::LinkNode<CompactionTaskContext>* node = _contexts.head(); node != _contexts.end();
          node = node->next()) {
@@ -424,7 +424,7 @@ Status CompactionScheduler::abort(int64_t txn_id) {
             // Do NOT touch |context| since here, it may have been destroyed.
             TEST_SYNC_POINT("lake::CompactionScheduler::abort:unlock:1");
             TEST_SYNC_POINT("lake::CompactionScheduler::abort:unlock:2");
-            cb->update_status(Status::Aborted("aborted on demand"));
+            cb->update_status(Status::Aborted(reason));
             return Status::OK();
         }
     }

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -213,7 +213,7 @@ public:
     // for the tasks to exit.
     // Returns Status::NotFound if no task with the given txn_id is found,
     // otherwise returns Status::OK.
-    Status abort(int64_t txn_id);
+    Status abort(int64_t txn_id, const std::string& reason);
 
     void list_tasks(std::vector<CompactionTaskInfo>* infos);
 

--- a/be/test/storage/lake/compaction_scheduler_test.cpp
+++ b/be/test/storage/lake/compaction_scheduler_test.cpp
@@ -155,7 +155,7 @@ TEST_F(LakeCompactionSchedulerTest, test_issue44136) {
     auto cb = ::google::protobuf::NewCallback(notify, latch);
     _compaction_scheduler.compact(nullptr, &request, &response, cb);
 
-    _compaction_scheduler.abort(txn_id);
+    _compaction_scheduler.abort(txn_id, "test" /* reason */);
 
     latch->wait();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
@@ -146,8 +146,8 @@ public class CompactionJob {
         this.finishTs = System.currentTimeMillis();
     }
 
-    public void abort() {
-        tasks.forEach(CompactionTask::abort);
+    public void abort(String reason) {
+        tasks.forEach(task -> task.abort(reason));
     }
 
     public PhysicalPartition getPartition() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -188,8 +188,11 @@ public class CompactionMgr implements MemoryTrackable {
         }
     }
 
+    /**
+     * Used for cancelling compaction manually.
+     */
     public void cancelCompaction(long txnId) {
-        compactionScheduler.cancelCompaction(txnId);
+        compactionScheduler.cancelCompaction(txnId, "Canceled by user");
     }
 
     public boolean existCompaction(long txnId) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
@@ -116,11 +116,12 @@ public class CompactionTask {
         }
     }
 
-    public void abort() {
+    public void abort(String reason) {
         TaskResult taskResult = getResult();
         if (taskResult == TaskResult.NOT_FINISHED || taskResult == TaskResult.NONE_SUCCESS) {
             AbortCompactionRequest abortRequest = new AbortCompactionRequest();
             abortRequest.txnId = request.txnId;
+            abortRequest.reason = request.reason;
             try {
                 Future<AbortCompactionResponse> ignored = rpcChannel.abortCompaction(abortRequest);
                 LOG.info("aborted compaction task, txn_id: {}, node: {}", request.txnId, nodeId);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
@@ -121,7 +121,7 @@ public class CompactionTask {
         if (taskResult == TaskResult.NOT_FINISHED || taskResult == TaskResult.NONE_SUCCESS) {
             AbortCompactionRequest abortRequest = new AbortCompactionRequest();
             abortRequest.txnId = request.txnId;
-            abortRequest.reason = request.reason;
+            abortRequest.reason = reason;
             try {
                 Future<AbortCompactionResponse> ignored = rpcChannel.abortCompaction(abortRequest);
                 LOG.info("aborted compaction task, txn_id: {}, node: {}", request.txnId, nodeId);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionTaskTest.java
@@ -40,7 +40,7 @@ public class CompactionTaskTest {
             }
         };
 
-        task.abort();
+        task.abort("");
     }
 
     @Test
@@ -57,6 +57,6 @@ public class CompactionTaskTest {
             }
         };
 
-        task.abort();
+        task.abort("");
     }
 }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -236,6 +236,7 @@ message RestoreSnapshotsResponse {
 
 message AbortCompactionRequest {
     optional int64 txn_id = 1;
+    optional string reason = 2;
 }
 
 message AbortCompactionResponse {


### PR DESCRIPTION
## Why I'm doing:

1. Lake compaction tasks may still try to run and complete when txn in FE has already aborted
2. The current implementation is a passive mechanism and is not sensitive enough to the txn abort event in FE.

## What I'm doing:

Fixes #54071

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0