### PR TITLE
[BugFix] Add exhausted check for MultiJoinBinder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3981,6 +3981,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return analyzeTypeForMV;
     }
 
+    public void setAnalyzeForMv(String analyzeTypeForMV) {
+        this.analyzeTypeForMV = analyzeTypeForMV;
+    }
+
     public boolean isEnableBigQueryLog() {
         return enableBigQueryLog;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/GroupExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/GroupExpression.java
@@ -69,6 +69,8 @@ public class GroupExpression {
     private boolean isUnused = false;
 
     private Optional<Boolean> isAppliedMVRules = Optional.empty();
+    // all mv rewrite rules
+    private static final List<Rule> ALL_MV_REWRITE_RULES = RuleSet.getRewriteRulesByType(RuleSetType.ALL_MV_REWRITE);
 
     public GroupExpression(Operator op, List<Group> inputs) {
         this.op = op;
@@ -347,9 +349,8 @@ public class GroupExpression {
     }
 
     public boolean hasAppliedMVRules() {
-        if (!isAppliedMVRules.isPresent()) {
-            final List<Rule> mvRules = RuleSet.getRewriteRulesByType(RuleSetType.ALL_MV_REWRITE);
-            isAppliedMVRules = Optional.of(mvRules.stream().anyMatch(rule -> hasRuleApplied(rule)));
+        if (isAppliedMVRules.isEmpty()) {
+            isAppliedMVRules = Optional.of(ALL_MV_REWRITE_RULES.stream().anyMatch(rule -> hasRuleApplied(rule)));
         }
         return isAppliedMVRules.get();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -205,8 +205,12 @@ public class OptimizerContext {
         return optimizerTimer.elapsed(TimeUnit.MILLISECONDS);
     }
 
+    public Stopwatch getStopwatch(RuleType ruleType) {
+        return ruleWatchMap.computeIfAbsent(ruleType, (k) -> Stopwatch.createStarted());
+    }
+
     public boolean ruleExhausted(RuleType ruleType) {
-        Stopwatch watch = ruleWatchMap.computeIfAbsent(ruleType, (k) -> Stopwatch.createStarted());
+        Stopwatch watch = getStopwatch(ruleType);
         long elapsed = watch.elapsed(TimeUnit.MILLISECONDS);
         long timeLimit = Math.min(sessionVariable.getOptimizerMaterializedViewTimeLimitMillis(),
                 sessionVariable.getOptimizerExecuteTimeout());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Binder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Binder.java
@@ -14,18 +14,23 @@
 
 package com.starrocks.sql.optimizer.rule;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
+import com.starrocks.common.profile.Tracers;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.Group;
 import com.starrocks.sql.optimizer.GroupExpression;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 // Used to extract matched expression from GroupExpression
 public class Binder {
-
+    private final OptimizerContext optimizerContext;
     private final Pattern pattern;
     private final GroupExpression groupExpression;
     // binder status
@@ -36,7 +41,7 @@ public class Binder {
     private final List<Integer> groupExpressionIndex;
 
     // `multiJoinBinder` is used for MULTI_JOIN pattern and is stateless so can be used in recursive.
-    private final MultiJoinBinder multiJoinBinder = new MultiJoinBinder();
+    private final MultiJoinBinder multiJoinBinder;
     // `isPatternWithoutChildren` is to mark whether the input pattern can be used for zero child optimization.
     private final boolean isPatternWithoutChildren;
     // `nextIdx` marks the current idx which iterates calling `next()` method and it's used for MULTI_JOIN pattern
@@ -50,11 +55,13 @@ public class Binder {
      * @param groupExpression Search this for binding. Because GroupExpression's inputs are groups,
      *                        several Expressions matched the pattern should be bound from it
      */
-    public Binder(Pattern pattern, GroupExpression groupExpression) {
+    public Binder(OptimizerContext optimizerContext, Pattern pattern, GroupExpression groupExpression) {
+        this.optimizerContext = optimizerContext;
         this.pattern = pattern;
         this.groupExpression = groupExpression;
         this.groupExpressionIndex = Lists.newArrayList(0);
 
+        this.multiJoinBinder = new MultiJoinBinder(optimizerContext);
         // MULTI_JOIN is a special pattern which can contain children groups if the input group expression
         // is not a scan node.
         this.isPatternWithoutChildren = pattern.isPatternMultiJoin()
@@ -89,8 +96,8 @@ public class Binder {
             this.groupTraceKey = 0;
 
             // Match with the next groupExpression of the last group node
-            int lastNode = this.groupExpressionIndex.size() - 1;
-            int lastNodeIndex = this.groupExpressionIndex.get(lastNode);
+            final int lastNode = this.groupExpressionIndex.size() - 1;
+            final int lastNodeIndex = this.groupExpressionIndex.get(lastNode);
             this.groupExpressionIndex.set(lastNode, lastNodeIndex + 1);
 
             expression = match(pattern, groupExpression);
@@ -119,11 +126,14 @@ public class Binder {
         int patternIndex = 0;
         int groupExpressionIndex = 0;
 
-        while (patternIndex < pattern.children().size() && groupExpressionIndex < groupExpression.getInputs().size()) {
+        final int patternSize = pattern.children().size();
+        final int geSize = groupExpression.getInputs().size();
+        while (patternIndex < patternSize && groupExpressionIndex < geSize) {
             trace();
-            Group group = groupExpression.getInputs().get(groupExpressionIndex);
-            Pattern childPattern = pattern.childAt(patternIndex);
-            OptExpression opt = match(childPattern, extractGroupExpression(childPattern, group));
+
+            final Group group = groupExpression.getInputs().get(groupExpressionIndex);
+            final Pattern childPattern = pattern.childAt(patternIndex);
+            final OptExpression opt = match(childPattern, extractGroupExpression(childPattern, group));
 
             if (opt == null) {
                 return null;
@@ -132,8 +142,7 @@ public class Binder {
             }
 
             if (!(childPattern.isPatternMultiLeaf() &&
-                    groupExpression.getInputs().size() - groupExpressionIndex >
-                            pattern.children().size() - patternIndex)) {
+                    geSize - groupExpressionIndex > patternSize - patternIndex)) {
                 patternIndex++;
             }
 
@@ -154,7 +163,7 @@ public class Binder {
      * extract GroupExpression by groupExpressionIndex
      */
     private GroupExpression extractGroupExpression(Pattern pattern, Group group) {
-        int valueIndex = groupExpressionIndex.get(groupTraceKey);
+        final int valueIndex = groupExpressionIndex.get(groupTraceKey);
         if (pattern.isPatternLeaf() || pattern.isPatternMultiLeaf()) {
             if (valueIndex > 0) {
                 groupExpressionIndex.remove(groupTraceKey);
@@ -180,6 +189,18 @@ public class Binder {
      * binding state and check the expression at the same time. But MULTI_JOIN could enumerate the GE without any check
      */
     private class MultiJoinBinder {
+        private final SessionVariable sessionVariable;
+        // Stopwatch to void infinite loop
+        private final Stopwatch watch;
+        // to avoid stop watch costing too much time, only check exhausted every CHECK_EXHAUSTED_INTERVAL times
+        private static final int CHECK_EXHAUSTED_INTERVAL = 100;
+        private long loopCount = 0;
+
+        public MultiJoinBinder(OptimizerContext optimizerContext) {
+            this.sessionVariable = optimizerContext.getSessionVariable();
+            this.watch = Stopwatch.createStarted();
+        }
+
         public OptExpression match(GroupExpression ge) {
             // 1. Check if the entire tree is MULTI_JOIN
             // 2. Enumerate GE
@@ -190,26 +211,45 @@ public class Binder {
             return enumerate(ge);
         }
 
+        private boolean exhausted() {
+            if (++loopCount % CHECK_EXHAUSTED_INTERVAL == 0) {
+                long elapsed = watch.elapsed(TimeUnit.MILLISECONDS);
+                long timeLimit = Math.min(sessionVariable.getOptimizerMaterializedViewTimeLimitMillis(),
+                        sessionVariable.getOptimizerExecuteTimeout());
+                boolean exhausted = elapsed > timeLimit;
+                if (exhausted) {
+                    Tracers.log(Tracers.Module.MV, args -> String.format("[MV TRACE] MultiJoinBinder %s exhausted\n", this));
+                }
+                return exhausted;
+            }
+            return false;
+        }
+
         private OptExpression enumerate(GroupExpression ge) {
-            List<OptExpression> resultInputs = Lists.newArrayList();
+            final List<OptExpression> resultInputs = Lists.newArrayList();
+            final int geSize = ge.getInputs().size();
+
             int groupExpressionIndex = 0;
-            while (groupExpressionIndex < ge.getInputs().size()) {
+            while (groupExpressionIndex < geSize) {
+                // to avoid infinite loop
+                if (exhausted()) {
+                    return null;
+                }
                 trace();
 
-                Group group = ge.getInputs().get(groupExpressionIndex);
-                GroupExpression nextGroupExpression = extractGroupExpression(group);
+                final Group group = ge.getInputs().get(groupExpressionIndex);
+                final GroupExpression nextGroupExpression = extractGroupExpression(group);
                 // avoid recursive
                 if (nextGroupExpression == null || !isMultiJoinOp(nextGroupExpression)) {
                     return null;
                 }
 
-                OptExpression opt = enumerate(nextGroupExpression);
+                final OptExpression opt = enumerate(nextGroupExpression);
                 if (opt == null) {
                     return null;
                 } else {
                     resultInputs.add(opt);
                 }
-
                 groupExpressionIndex++;
             }
 
@@ -222,14 +262,14 @@ public class Binder {
                 groupExpressionIndex.remove(groupTraceKey);
                 return null;
             }
-            List<GroupExpression> groupExpressions = group.getLogicalExpressions();
+            final List<GroupExpression> groupExpressions = group.getLogicalExpressions();
             GroupExpression next = groupExpressions.get(valueIndex);
             if (nextIdx == 0) {
                 return next;
             }
 
             // shortcut for no child group expression
-            if (Pattern.ALL_SCAN_TYPES.contains(next.getOp().getOpType()) && valueIndex > 0) {
+            if (valueIndex > 0 && Pattern.ALL_SCAN_TYPES.contains(next.getOp().getOpType())) {
                 groupExpressionIndex.remove(groupTraceKey);
                 return null;
             }
@@ -241,8 +281,13 @@ public class Binder {
             // NOTE: To avoid iterating all children group expressions which may take a lot of time, only iterate
             // group expressions which are already rewritten by mv except the first iteration, so can be used for
             // nested mv rewritten.
-            int geSize = groupExpressions.size();
+            final int geSize = groupExpressions.size();
             while (++valueIndex < geSize) {
+                if (exhausted()) {
+                    groupExpressionIndex.remove(groupTraceKey);
+                    return null;
+                }
+
                 next = group.getLogicalExpressions().get(valueIndex);
                 if (next.hasAppliedMVRules()) {
                     groupExpressionIndex.set(groupTraceKey, valueIndex);
@@ -271,9 +316,13 @@ public class Binder {
             if (!isMultiJoinOp(ge)) {
                 return false;
             }
-
-            for (int i = 0; i < ge.getInputs().size(); i++) {
-                Group child = ge.inputAt(i);
+            final int geSize = ge.getInputs().size();
+            for (int i = 0; i < geSize; i++) {
+                // to avoid infinite loop
+                if (exhausted()) {
+                    return false;
+                }
+                final Group child = ge.inputAt(i);
                 if (isMultiJoinRecursive(child.getFirstLogicalExpression())) {
                     continue;
                 }
@@ -294,17 +343,5 @@ public class Binder {
                     .skip(1) // since first logical expression has already been checked.
                     .anyMatch(ge -> ge.getOp().getOpType() == OperatorType.LOGICAL_OLAP_SCAN && ge.hasAppliedMVRules());
         }
-    }
-
-    /**
-     * Extract a expression from GroupExpression which match the given pattern once
-     *
-     * @param pattern         Bound expression should be matched
-     * @param groupExpression Search this for binding. Because GroupExpression's inputs are groups,
-     *                        several Expressions matched the pattern should be bound from it
-     */
-    public static OptExpression bind(Pattern pattern, GroupExpression groupExpression) {
-        Binder binder = new Binder(pattern, groupExpression);
-        return binder.next();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
@@ -66,11 +66,11 @@ public class ApplyRuleTask extends OptimizerTask {
             return;
         }
         // Apply rule and get all new OptExpressions
-        Pattern pattern = rule.getPattern();
-        Binder binder = new Binder(pattern, groupExpression);
+        final Pattern pattern = rule.getPattern();
+        final Binder binder = new Binder(context.getOptimizerContext(), pattern, groupExpression);
+        final List<OptExpression> newExpressions = Lists.newArrayList();
+        final List<OptExpression> extractExpressions = Lists.newArrayList();
         OptExpression extractExpr = binder.next();
-        List<OptExpression> newExpressions = Lists.newArrayList();
-        List<OptExpression> extractExpressions = Lists.newArrayList();
         while (extractExpr != null) {
             // Check if the rule has exhausted or not to avoid optimization time exceeding the limit.:
             // 1. binder.next() may be infinite loop if something is wrong.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.task;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
@@ -22,6 +23,7 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.GroupExpression;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.OptimizerTraceUtil;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.rule.Binder;
@@ -67,7 +69,9 @@ public class ApplyRuleTask extends OptimizerTask {
         }
         // Apply rule and get all new OptExpressions
         final Pattern pattern = rule.getPattern();
-        final Binder binder = new Binder(context.getOptimizerContext(), pattern, groupExpression);
+        final OptimizerContext optimizerContext = context.getOptimizerContext();
+        final Stopwatch ruleStopWatch = optimizerContext.getStopwatch(rule.type());
+        final Binder binder = new Binder(optimizerContext, pattern, groupExpression, ruleStopWatch);
         final List<OptExpression> newExpressions = Lists.newArrayList();
         final List<OptExpression> extractExpressions = Lists.newArrayList();
         OptExpression extractExpr = binder.next();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManyJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManyJoinTest.java
@@ -14,7 +14,12 @@
 
 package com.starrocks.planner;
 
+import com.google.api.client.util.Lists;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.starrocks.sql.plan.PlanTestBase;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
@@ -24,7 +29,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.MessageFormat;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 /**
@@ -33,6 +41,13 @@ import java.util.stream.Stream;
  * the query/mv is very complex
  */
 public class MaterializedViewManyJoinTest extends MaterializedViewTestBase {
+
+    private static final AtomicLong MV_ID = new AtomicLong(0);
+    private static final AtomicLong NESTED_MV_ID = new AtomicLong(0);
+    private static final AtomicLong NESTED_NESTED_MV_ID = new AtomicLong(0);
+    private static final AtomicLong NESTED_NESTED_NESTED_MV_ID = new AtomicLong(0);
+    private static final Map<String, String> MV_TO_DEFINED_QUERY = Maps.newHashMap();
+    private static final List<Arguments> ARGUMENTS = Lists.newArrayList();
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -77,39 +92,77 @@ public class MaterializedViewManyJoinTest extends MaterializedViewTestBase {
                                     "\"compression\"=\"LZ4\"\n" +
                                     ")", i));
         }
+        connectContext.getSessionVariable().setEnableMaterializedViewTextMatchRewrite(false);
+        connectContext.getSessionVariable().setCboMaterializedViewRewriteCandidateLimit(3);
+        connectContext.getSessionVariable().setCboMaterializedViewRewriteRuleOutputLimit(3);
+        List<Arguments> arguments = generateManyJoinArguments();
+        for (Arguments argument : arguments) {
+            String name = (String) argument.get()[0];
+            String mvQuery = (String) argument.get()[1];
+            String testQuery = (String) argument.get()[2];
+            boolean expectHitMv = (boolean) argument.get()[3];
+            long mvId = MV_ID.getAndAdd(1);
+            String mvName = String.format("mv_manyjoin_%s", mvId);
+            String createMv = "CREATE MATERIALIZED VIEW " + mvName + "\n" +
+                    "REFRESH  DEFERRED MANUAL \n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\"=\"1\"\n" +
+                    ")\n" +
+                    "AS " + mvQuery;
+            starRocksAssert.withMaterializedView(createMv);
+            MV_TO_DEFINED_QUERY.put(mvName, mvQuery);
+
+            ARGUMENTS.add(Arguments.of(name, testQuery, false));
+            if (mvId > 1) {
+                long nestedMVId = NESTED_MV_ID.getAndAdd(1);
+                String sql = generateNestedMV("mv_manyjoin", "nested_mv", nestedMVId, mvId);
+                ARGUMENTS.add(Arguments.of(name, sql, expectHitMv));
+                if (nestedMVId > 1) {
+                    long nestedNestedMVId = NESTED_NESTED_MV_ID.getAndAdd(1);
+                    sql = generateNestedMV("nested_mv", "nested_nested_mv", nestedNestedMVId, nestedMVId);
+                    ARGUMENTS.add(Arguments.of(name, sql, expectHitMv));
+                    if (nestedNestedMVId > 1) {
+                        long nestedNestedNestedMVId = NESTED_NESTED_NESTED_MV_ID.getAndAdd(1);
+                        sql = generateNestedMV("nested_nested_mv", "nested_nested_nested_mv", nestedNestedNestedMVId,
+                                nestedNestedMVId);
+                        ARGUMENTS.add(Arguments.of(name, sql, expectHitMv));
+                    }
+                }
+            }
+        }
     }
 
     @ParameterizedTest(name = "{index}-{0}")
-    @MethodSource("generateManyJoinArguments")
+    @MethodSource("generateArguments")
     @Timeout(30)
-    public void testManyJoins(String name, String mvQuery, String query, boolean expectHitMv) throws Exception {
-        LOG.info("create mv {}", mvQuery);
-        String mvName = "mv_manyjoin";
-        String createMv = "CREATE MATERIALIZED VIEW " + mvName + "\n" +
-                "REFRESH  DEFERRED MANUAL \n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\"=\"1\"\n" +
-                ")\n" +
-                "AS " + mvQuery;
-        starRocksAssert.withMaterializedView(createMv);
-
+    public void testManyJoins(String name, String query, boolean expectHitMv) throws Exception {
         Stopwatch watch = Stopwatch.createStarted();
         // Make sure it's not empty
-        starRocksAssert.query(query).explainContains("OlapScanNode");
+        String plan = getFragmentPlan(query, "MV");
+        PlanTestBase.assertContains(plan, "OlapScanNode");
+        if (expectHitMv) {
+            PlanTestBase.assertContains(plan, "MaterializedView: true");
+        }
         LOG.info("query takes {}ms: {}", watch.elapsed(TimeUnit.MILLISECONDS), query);
-
-        starRocksAssert.dropMaterializedView(mvName);
     }
 
-    private static Stream<Arguments> generateManyJoinArguments() {
+    private static Stream<Arguments> generateArguments() {
+        return ARGUMENTS.stream();
+    }
+
+    private static List<Arguments> generateManyJoinArguments() {
         final String smallQuery = generateJoinQuery(3);
         final String bigQuery = generateJoinQuery(20);
-        return Stream.of(
+        return ImmutableList.of(
                 // join query
                 Arguments.of("small_query-small_mv", smallQuery, smallQuery, true),
-                Arguments.of("small_query-big_mv", smallQuery, bigQuery, false),
-                Arguments.of("big_query-small_mv", bigQuery, smallQuery, false),
+                Arguments.of("small_query-big_mv", smallQuery, bigQuery, true),
+                Arguments.of("big_query-small_mv", bigQuery, smallQuery, true),
                 Arguments.of("big_query-big_mv", bigQuery, bigQuery, true),
+                Arguments.of("multi join mv(10-10)", generateJoinQuery(10),
+                        generateJoinQuery(10), true),
+                Arguments.of("multi join mv(5-5)", generateJoinQuery(5),
+                        generateJoinQuery(5), true),
 
                 // union&join query
                 Arguments.of("union small-query and small mv",
@@ -126,20 +179,65 @@ public class MaterializedViewManyJoinTest extends MaterializedViewTestBase {
                         generateUnionAndJoinQuery(20), generateUnionQuery(20), false),
 
                 // query with predicate
-                Arguments.of("query with predicates ",
+                Arguments.of("query with predicates(10-5) ",
                         generateJoinWithManyPredicates(10),
                         generateJoinWithManyPredicates(5), false),
-                Arguments.of("query with predicates ",
+                Arguments.of("query with predicates(5-10) ",
                         generateJoinWithManyPredicates(5),
                         generateJoinWithManyPredicates(10), false),
-                Arguments.of("query with predicates ",
+                Arguments.of("query with predicates(10-10) ",
                         generateJoinWithManyPredicates(10),
-                        generateJoinWithManyPredicates(10), false),
-                Arguments.of("query with predicates ",
+                        generateJoinWithManyPredicates(10), true),
+                Arguments.of("query with predicates(1-50) ",
                         generateJoinWithManyPredicates(1),
-                        generateJoinWithManyPredicates(50), false)
-
+                        generateJoinWithManyPredicates(50), true),
+                Arguments.of("query with predicates(5-50) ",
+                        generateJoinWithManyPredicates(5),
+                        generateJoinWithManyPredicates(50), true)
         );
+    }
+
+    @NotNull
+    private static String generateNestedMV(String tablePrefix, String nestMVPrefix,
+                                           long nestedMVId, long numTables) throws Exception {
+        String nestedMVName = String.format("%s_%s", nestMVPrefix, nestedMVId);
+        String nestedMVQuery = generateNestedMVJoinQuery(tablePrefix, numTables);
+        String nestedMv = "CREATE MATERIALIZED VIEW " + nestedMVName + "\n" +
+                "REFRESH  DEFERRED MANUAL \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\"=\"1\"\n" +
+                ")\n" +
+                "AS " + nestedMVQuery;
+        MV_TO_DEFINED_QUERY.put(nestedMVName, nestedMVQuery);
+        starRocksAssert.withMaterializedView(nestedMv);
+        // generate unwrapped mv defined query
+        return generateUnNestedMVJoinQuery(tablePrefix, numTables);
+    }
+
+    private static String generateUnNestedMVJoinQuery(String tablePrefix, long numTables) {
+        String sourceTableName = String.format("%s_%d", tablePrefix, 0);
+        Preconditions.checkArgument(MV_TO_DEFINED_QUERY.containsKey(sourceTableName));
+        String mvDefinedQuery = MV_TO_DEFINED_QUERY.get(sourceTableName);
+        StringBuilder query = new StringBuilder(String.format("SELECT p0.dt FROM (%s) AS p0 ", mvDefinedQuery));
+        for (int i = 1; i < numTables; i++) {
+            String alias = "p" + i;
+            sourceTableName = String.format("%s_%d", tablePrefix, i);
+            Preconditions.checkArgument(MV_TO_DEFINED_QUERY.containsKey(sourceTableName));
+            mvDefinedQuery = MV_TO_DEFINED_QUERY.get(sourceTableName);
+            query.append(String.format("LEFT OUTER JOIN (%s) AS %s ON %s.dt=p1.dt\n", mvDefinedQuery, alias, alias));
+        }
+        return query.toString();
+    }
+
+    @NotNull
+    private static String generateNestedMVJoinQuery(String tablePrefix, long numTables) {
+        StringBuilder query = new StringBuilder(String.format("SELECT p0.dt FROM %s AS p0 ", tablePrefix + "_0"));
+        for (int i = 1; i < numTables; i++) {
+            String alias = "p" + i;
+            String sourceTableName = String.format("%s_%d", tablePrefix, i);
+            query.append(String.format("LEFT OUTER JOIN %s AS %s ON %s.dt=p1.dt\n", sourceTableName, alias, alias));
+        }
+        return query.toString();
     }
 
     @NotNull

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/BinderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/BinderTest.java
@@ -20,6 +20,8 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.sql.optimizer.GroupExpression;
 import com.starrocks.sql.optimizer.Memo;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
@@ -31,6 +33,25 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class BinderTest {
+
+    private Binder buildBinder(Pattern pattern, OptExpression expr) {
+        Memo memo = new Memo();
+        OptimizerContext optimizerContext = new OptimizerContext(memo, new ColumnRefFactory());
+        return new Binder(optimizerContext, pattern, memo.init(expr));
+    }
+
+    private Binder buildBinder(Pattern pattern, GroupExpression qe) {
+        Memo memo = new Memo();
+        OptimizerContext optimizerContext = new OptimizerContext(memo, new ColumnRefFactory());
+        return new Binder(optimizerContext, pattern, qe);
+    }
+
+    private OptExpression bindNext(Pattern pattern, OptExpression expr) {
+        Memo memo = new Memo();
+        OptimizerContext optimizerContext = new OptimizerContext(memo, new ColumnRefFactory());
+        Binder binder = new Binder(optimizerContext, pattern, memo.init(expr));
+        return binder.next();
+    }
 
     @Test
     public void testBinder() {
@@ -46,8 +67,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF))
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF));
 
-        Memo memo = new Memo();
-        OptExpression result = Binder.bind(pattern, memo.init(expr));
+        OptExpression result = bindNext(pattern, expr);
 
         assertEquals(OperatorType.LOGICAL_JOIN, result.getOp().getOpType());
         assertEquals(OperatorType.LOGICAL_OLAP_SCAN, result.inputAt(0).getOp().getOpType());
@@ -64,8 +84,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.LOGICAL_JOIN))
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF));
 
-        Memo memo = new Memo();
-        OptExpression result = Binder.bind(pattern, memo.init(expr));
+        OptExpression result = bindNext(pattern, expr);
 
         assertNull(result);
     }
@@ -78,20 +97,18 @@ public class BinderTest {
 
         Pattern pattern = Pattern.create(OperatorType.LOGICAL_JOIN);
 
-        Memo memo = new Memo();
-        OptExpression result = Binder.bind(pattern, memo.init(expr));
+        OptExpression result = bindNext(pattern, expr);
 
         assertEquals(OperatorType.LOGICAL_JOIN, result.getOp().getOpType());
     }
 
+
+
     @Test
     public void testBinderOne() {
         OptExpression expr = OptExpression.create(new MockOperator(OperatorType.LOGICAL_JOIN));
-
         Pattern pattern = Pattern.create(OperatorType.LOGICAL_JOIN);
-
-        Memo memo = new Memo();
-        Binder binder = new Binder(pattern, memo.init(expr));
+        Binder binder = buildBinder(pattern, expr);
         OptExpression result = binder.next();
 
         assertEquals(OperatorType.LOGICAL_JOIN, result.getOp().getOpType());
@@ -109,8 +126,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.LOGICAL_JOIN))
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF));
 
-        Memo memo = new Memo();
-        OptExpression result = Binder.bind(pattern, memo.init(expr));
+        OptExpression result = bindNext(pattern, expr);
 
         assertEquals(OperatorType.LOGICAL_OLAP_SCAN, result.getOp().getOpType());
         assertEquals(OperatorType.LOGICAL_JOIN, result.inputAt(0).getOp().getOpType());
@@ -131,8 +147,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.LOGICAL_JOIN))
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF));
 
-        Memo memo = new Memo();
-        OptExpression result = Binder.bind(pattern1, memo.init(expr));
+        OptExpression result = bindNext(pattern1, expr);
 
         assertEquals(OperatorType.LOGICAL_PROJECT, result.getOp().getOpType());
         assertEquals(OperatorType.LOGICAL_JOIN, result.inputAt(0).getOp().getOpType());
@@ -142,8 +157,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.LOGICAL_JOIN))
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF));
 
-        memo = new Memo();
-        assertNull(Binder.bind(pattern2, memo.init(expr)));
+        assertNull(bindNext(pattern2, expr));
 
         Pattern pattern3 = Pattern.create(OperatorType.LOGICAL_PROJECT)
                 .addChildren(Pattern.create(OperatorType.LOGICAL_JOIN).addChildren(
@@ -151,8 +165,7 @@ public class BinderTest {
                         Pattern.create(OperatorType.PATTERN_LEAF)))
                 .addChildren(Pattern.create(OperatorType.LOGICAL_JOIN));
 
-        memo = new Memo();
-        result = Binder.bind(pattern3, memo.init(expr));
+        result = bindNext(pattern3, expr);
 
         assertEquals(OperatorType.LOGICAL_PROJECT, result.getOp().getOpType());
         assertEquals(OperatorType.LOGICAL_JOIN, result.inputAt(0).getOp().getOpType());
@@ -178,7 +191,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.LOGICAL_OLAP_SCAN))
                 .addChildren(Pattern.create(OperatorType.LOGICAL_OLAP_SCAN));
 
-        Binder binder = new Binder(pattern, ge);
+        Binder binder = buildBinder(pattern, ge);
         OptExpression result;
 
         result = binder.next();
@@ -235,7 +248,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.LOGICAL_OLAP_SCAN))
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF));
 
-        Binder binder = new Binder(pattern, ge);
+        Binder binder = buildBinder(pattern, ge);
         OptExpression result;
 
         result = binder.next();
@@ -276,7 +289,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF))
                 .addChildren(Pattern.create(OperatorType.PATTERN_LEAF));
 
-        Binder binder = new Binder(pattern, ge);
+        Binder binder = buildBinder(pattern, expr1);
         OptExpression result;
 
         result = binder.next();
@@ -306,7 +319,7 @@ public class BinderTest {
         Pattern pattern = Pattern.create(OperatorType.LOGICAL_JOIN)
                 .addChildren(Pattern.create(OperatorType.PATTERN_MULTI_LEAF));
 
-        Binder binder = new Binder(pattern, ge);
+        Binder binder = buildBinder(pattern, expr1);
         OptExpression result;
 
         result = binder.next();
@@ -347,7 +360,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.PATTERN_MULTI_LEAF))
                 .addChildren(Pattern.create(OperatorType.LOGICAL_OLAP_SCAN));
 
-        Binder binder = new Binder(pattern, ge);
+        Binder binder = buildBinder(pattern, expr1);
         assertNull(binder.next());
     }
 
@@ -368,7 +381,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.PATTERN_MULTI_LEAF))
                 .addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT));
 
-        Binder binder = new Binder(pattern, ge);
+        Binder binder = buildBinder(pattern, expr1);
         OptExpression result;
 
         result = binder.next();
@@ -410,7 +423,7 @@ public class BinderTest {
         Pattern pattern = Pattern.create(OperatorType.LOGICAL_JOIN)
                 .addChildren(Pattern.create(OperatorType.PATTERN_MULTI_LEAF));
 
-        Binder binder = new Binder(pattern, ge);
+        Binder binder = buildBinder(pattern, expr1);
         OptExpression result;
 
         result = binder.next();
@@ -444,7 +457,7 @@ public class BinderTest {
                 .addChildren(Pattern.create(OperatorType.LOGICAL_OLAP_SCAN))
                 .addChildren(Pattern.create(OperatorType.PATTERN_MULTI_LEAF));
 
-        Binder binder = new Binder(pattern, ge);
+        Binder binder = buildBinder(pattern, ge);
         OptExpression result;
 
         result = binder.next();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/BinderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/BinderTest.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.rule;
 
+import com.google.common.base.Stopwatch;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.sql.optimizer.GroupExpression;
@@ -37,19 +38,22 @@ public class BinderTest {
     private Binder buildBinder(Pattern pattern, OptExpression expr) {
         Memo memo = new Memo();
         OptimizerContext optimizerContext = new OptimizerContext(memo, new ColumnRefFactory());
-        return new Binder(optimizerContext, pattern, memo.init(expr));
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        return new Binder(optimizerContext, pattern, memo.init(expr), stopwatch);
     }
 
     private Binder buildBinder(Pattern pattern, GroupExpression qe) {
         Memo memo = new Memo();
         OptimizerContext optimizerContext = new OptimizerContext(memo, new ColumnRefFactory());
-        return new Binder(optimizerContext, pattern, qe);
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        return new Binder(optimizerContext, pattern, qe, stopwatch);
     }
 
     private OptExpression bindNext(Pattern pattern, OptExpression expr) {
         Memo memo = new Memo();
         OptimizerContext optimizerContext = new OptimizerContext(memo, new ColumnRefFactory());
-        Binder binder = new Binder(optimizerContext, pattern, memo.init(expr));
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        Binder binder = new Binder(optimizerContext, pattern, memo.init(expr), stopwatch);
         return binder.next();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -1321,6 +1321,8 @@ public class UtFrameUtils {
 
             // Disable text based rewrite by default.
             connectContext.getSessionVariable().setEnableMaterializedViewTextMatchRewrite(false);
+            // disable mv analyze stats in FE UTs
+            connectContext.getSessionVariable().setAnalyzeForMv("");
         }
 
         new MockUp<PlanTestBase>() {


### PR DESCRIPTION
## Why I'm doing:
MultiJoinBinder may hold lock too long time:
```
;lockHoldTime: 447230 ms;dump thread: starrocks-mysql-nio-pool-53, id: 367
    app//com.google.common.collect.RegularImmutableSet.contains(RegularImmutableSet.java:64)
    app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.isMultiJoinOp(Binder.java:258)
    app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.isMultiJoinRecursive(Binder.java:271)
    app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.isMultiJoinRecursive(Binder.java:277)
    app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.isMultiJoin(Binder.java:262)
    app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.match(Binder.java:186)
    app//com.starrocks.sql.optimizer.rule.Binder.match(Binder.java:109)
    app//com.starrocks.sql.optimizer.rule.Binder.next(Binder.java:96)
    app//com.starrocks.sql.optimizer.task.ApplyRuleTask.execute(ApplyRuleTask.java:103)
    app//com.starrocks.sql.optimizer.task.SeriallyTaskScheduler.executeTasks(SeriallyTaskScheduler.java:65)
    app//com.starrocks.sql.optimizer.Optimizer.memoOptimize(Optimizer.java:754)
    app//com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:253)
    app//com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:177)
    app//com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:256)
    app//com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:134)
    app//com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:96)
    app//com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:556)
    app//com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:347)
    app//com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:541)
    app//com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:853)
    app//com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69)
    app//com.starrocks.mysql.nio.ReadListener$$Lambda$1620/0x00007f36a99fa440.run(Unknown Source)
    java.base@11.0.20.1/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    java.base@11.0.20.1/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    java.base@11.0.20.1/java.lang.Thread.run(Thread.java:829)
;lockHoldTime: 432884 ms;dump thread: starrocks-mysql-nio-pool-54, id: 368
    app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.isMultiJoinRecursive(Binder.java:275)
    app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.isMultiJoin(Binder.java:262)
    app//com.starrocks.sql.optimizer.rule.Binder$MultiJoinBinder.match(Binder.java:186)
    app//com.starrocks.sql.optimizer.rule.Binder.match(Binder.java:109)
    app//com.starrocks.sql.optimizer.rule.Binder.next(Binder.java:96)
    app//com.starrocks.sql.optimizer.task.ApplyRuleTask.execute(ApplyRuleTask.java:103)
    app//com.starrocks.sql.optimizer.task.SeriallyTaskScheduler.executeTasks(SeriallyTaskScheduler.java:65)
    app//com.starrocks.sql.optimizer.Optimizer.memoOptimize(Optimizer.java:754)
    app//com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:253)
    app//com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:177)
    app//com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:256)
    app//com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:134)
    app//com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:96)
    app//com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:556)
    app//com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:347)
    app//com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:541)
    app//com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:853)
    app//com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69)
    app//com.starrocks.mysql.nio.ReadListener$$Lambda$1620/0x00007f36a99fa440.run(Unknown Source)
    java.base@11.0.20.1/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    java.base@11.0.20.1/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    java.base@11.0.20.1/java.lang.Thread.run(Thread.java:829)
```

## What I'm doing:
- Add a `exhausted` check policy in MultiJoinBinder;
- Add more nested mv tests.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0