### PR TITLE
[UT] fix test_list_partition_minmax

### DIFF
--- a/test/sql/test_list_partition/R/test_list_partition_minmax
+++ b/test/sql/test_list_partition/R/test_list_partition_minmax
@@ -1,5 +1,5 @@
 -- name: test_list_partition_minmax
-create table t1(user_id int, dt datetime) partition by dt;
+create table t1(user_id int, dt datetime) partition by (dt);
 -- result:
 -- !result
 insert into t1 values (1, '2024-10-05 01:01:01'), (2, '2024-10-06 02:02:02'), (3, '2024-10-07 03:03:03'), (4, NULL);

--- a/test/sql/test_list_partition/T/test_list_partition_minmax
+++ b/test/sql/test_list_partition/T/test_list_partition_minmax
@@ -1,7 +1,7 @@
 -- name: test_list_partition_minmax
 
 -- 1. column
-create table t1(user_id int, dt datetime) partition by dt;
+create table t1(user_id int, dt datetime) partition by (dt);
 
 insert into t1 values (1, '2024-10-05 01:01:01'), (2, '2024-10-06 02:02:02'), (3, '2024-10-07 03:03:03'), (4, NULL);
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`PARTITION BY dt` is not supported until 3.4, it's better to fallback to general syntax.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0