### PR TITLE
[BugFix] Fix LockManager release not notify all waiters that meet the conditions (backport #54922) 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/LockManager.java
@@ -305,7 +305,7 @@ public class LockManager {
         }
     }
 
-    public boolean isOwnerInternal(long rid, Locker locker, LockType lockType, int lockTableIndex) {
+    private boolean isOwnerInternal(long rid, Locker locker, LockType lockType, int lockTableIndex) {
         final Map<Long, Lock> lockTable = lockTables[lockTableIndex];
         final Lock lock = lockTable.get(rid);
         return lock != null && lock.isOwner(locker, lockType);

--- a/fe/fe-core/src/test/java/com/starrocks/common/lock/ReleaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/lock/ReleaseTest.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.lock;
+
+import com.starrocks.common.util.concurrent.lock.LockInfo;
+import com.starrocks.common.util.concurrent.lock.LockManager;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.server.GlobalStateMgr;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Future;
+
+import static com.starrocks.common.lock.LockTestUtils.assertLockSuccess;
+import static com.starrocks.common.lock.LockTestUtils.assertLockWait;
+
+public class ReleaseTest {
+    @Before
+    public void setUp() {
+        GlobalStateMgr.getCurrentState().setLockManager(new LockManager());
+    }
+
+    @Test
+    public void testReleaseInvoke() throws Exception {
+        long rid = 1L;
+
+        TestLocker testLocker1 = new TestLocker();
+        assertLockSuccess(testLocker1.lock(rid, LockType.WRITE));
+
+        TestLocker testLocker2 = new TestLocker();
+        Future<LockResult> f2 = testLocker2.lock(rid, LockType.READ);
+        assertLockWait(f2);
+
+        TestLocker testLocker3 = new TestLocker();
+        Future<LockResult> f3 = testLocker3.lock(rid, LockType.READ);
+        assertLockWait(f3);
+
+        TestLocker testLocker4 = new TestLocker();
+        Future<LockResult> f4 = testLocker4.lock(rid, LockType.READ);
+        assertLockWait(f4);
+
+        assertLockSuccess(testLocker1.release(rid, LockType.WRITE));
+        LockTestUtils.assertLockSuccess(f2);
+        LockTestUtils.assertLockSuccess(f3);
+        LockTestUtils.assertLockSuccess(f4);
+
+        LockManager lockManager = GlobalStateMgr.getCurrentState().getLockManager();
+        LockInfo lockInfo = lockManager.dumpLockManager().get(0);
+        Assert.assertEquals(1, lockInfo.getRid().longValue());
+        Assert.assertEquals(3, lockInfo.getOwners().size());
+        Assert.assertEquals(0, lockInfo.getWaiters().size());
+    }
+}


### PR DESCRIPTION
(cherry picked from commit 1bd593725fb1a2c3e13d1d237776eb5f0dd12e25)

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
