### PR TITLE
[BugFix] Fix transaction stream load TXN_IN_PROCESSING error

### DIFF
--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -50,6 +50,7 @@
 #include "runtime/stream_load/stream_load_executor.h"
 #include "runtime/stream_load/stream_load_pipe.h"
 #include "runtime/stream_load/transaction_mgr.h"
+#include "testutil/sync_point.h"
 #include "util/byte_buffer.h"
 #include "util/debug_util.h"
 #include "util/defer_op.h"
@@ -90,6 +91,7 @@ TransactionManagerAction::TransactionManagerAction(ExecEnv* exec_env) : _exec_en
 TransactionManagerAction::~TransactionManagerAction() = default;
 
 static void _send_reply(HttpRequest* req, const std::string& str) {
+    TEST_SYNC_POINT_CALLBACK("TransactionStreamLoad::send_reply", req);
     if (config::enable_stream_load_verbose_log) {
         LOG(INFO) << "transaction streaming load response: " << str;
     }
@@ -132,6 +134,38 @@ void TransactionManagerAction::handle(HttpRequest* req) {
     _send_reply(req, resp);
 }
 
+// Handle the resource acquired by the http request
+class ResourceHandler {
+public:
+    // ctx has been referenced and locked outside
+    ResourceHandler(StreamLoadContext* ctx) : _ctx(ctx) {
+        DCHECK(_ctx != nullptr);
+        DCHECK(!_ctx->lock.try_lock());
+    }
+
+    ~ResourceHandler() { release(); }
+
+    StreamLoadContext* ctx() { return _ctx; }
+
+    void release() {
+        if (_released) {
+            return;
+        }
+        _released = true;
+        _ctx->lock.unlock();
+        if (config::enable_stream_load_verbose_log) {
+            LOG(INFO) << "release resource, " << _ctx->brief();
+        }
+        if (_ctx->unref()) {
+            delete _ctx;
+        }
+    }
+
+private:
+    StreamLoadContext* _ctx;
+    bool _released{false};
+};
+
 TransactionStreamLoadAction::TransactionStreamLoadAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
 
 TransactionStreamLoadAction::~TransactionStreamLoadAction() = default;
@@ -144,15 +178,30 @@ void TransactionStreamLoadAction::_send_error_reply(HttpRequest* req, const Stat
     HttpChannel::send_reply(req, str);
 }
 
+void TransactionStreamLoadAction::_finish_and_reply(HttpRequest* req, const std::string& reply) {
+    ResourceHandler* handler = static_cast<ResourceHandler*>(req->handler_ctx());
+    if (handler != nullptr) {
+        // release StreamLoadContext lock before sending reply to the client,
+        // otherwise client may meet TXN_IN_PROCESSING error. The reason is that
+        // the client can send another load request quickly after receiving the
+        // reply, but the lock has not been released, so the new request can not
+        // acquire the lock, and meet the TXN_IN_PROCESSING error.
+        handler->release();
+    }
+    _send_reply(req, reply);
+}
+
 void TransactionStreamLoadAction::handle(HttpRequest* req) {
     if (config::enable_stream_load_verbose_log) {
         LOG(INFO) << "transaction streaming load request, handle: " << req->debug_string();
     }
 
-    StreamLoadContext* ctx = static_cast<StreamLoadContext*>(req->handler_ctx());
-    if (ctx == nullptr) {
+    ResourceHandler* handler = static_cast<ResourceHandler*>(req->handler_ctx());
+    if (handler == nullptr) {
         return;
     }
+    StreamLoadContext* ctx = handler->ctx();
+    DCHECK(ctx != nullptr);
     ctx->last_active_ts = MonotonicNanos();
 
     if (!ctx->status.ok()) {
@@ -172,7 +221,7 @@ void TransactionStreamLoadAction::handle(HttpRequest* req) {
     }
 
     auto resp = _exec_env->transaction_mgr()->_build_reply(TXN_LOAD, ctx);
-    _send_reply(req, resp);
+    _finish_and_reply(req, resp);
 }
 
 int TransactionStreamLoadAction::on_header(HttpRequest* req) {
@@ -223,7 +272,7 @@ int TransactionStreamLoadAction::on_header(HttpRequest* req) {
     }
     // referenced by the http request
     ctx->ref();
-    req->set_handler_ctx(ctx);
+    req->set_handler_ctx(new ResourceHandler(ctx));
     ctx->last_active_ts = MonotonicNanos();
     ctx->received_data_cost_nanos = 0;
     ctx->receive_bytes = 0;
@@ -237,7 +286,7 @@ int TransactionStreamLoadAction::on_header(HttpRequest* req) {
             (void)_exec_env->transaction_mgr()->_rollback_transaction(ctx);
         }
         auto resp = _exec_env->transaction_mgr()->_build_reply(TXN_LOAD, ctx);
-        _send_reply(req, resp);
+        _finish_and_reply(req, resp);
         return -1;
     }
     return 0;
@@ -494,10 +543,12 @@ Status TransactionStreamLoadAction::_exec_plan_fragment(HttpRequest* http_req, S
 }
 
 void TransactionStreamLoadAction::on_chunk_data(HttpRequest* req) {
-    StreamLoadContext* ctx = static_cast<StreamLoadContext*>(req->handler_ctx());
-    if (ctx == nullptr) {
+    ResourceHandler* handler = static_cast<ResourceHandler*>(req->handler_ctx());
+    if (handler == nullptr) {
         return;
     }
+    StreamLoadContext* ctx = handler->ctx();
+    DCHECK(ctx != nullptr);
 
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(ctx->instance_mem_tracker.get());
 
@@ -570,18 +621,11 @@ void TransactionStreamLoadAction::on_chunk_data(HttpRequest* req) {
 }
 
 void TransactionStreamLoadAction::free_handler_ctx(void* param) {
-    StreamLoadContext* ctx = static_cast<StreamLoadContext*>(param);
-    if (ctx == nullptr) {
+    ResourceHandler* handler = static_cast<ResourceHandler*>(param);
+    if (handler == nullptr) {
         return;
     }
-    DCHECK(!ctx->lock.try_lock());
-    ctx->lock.unlock();
-    if (config::enable_stream_load_verbose_log) {
-        LOG(INFO) << "free handler context, " << ctx->brief();
-    }
-    if (ctx->unref()) {
-        delete ctx;
-    }
+    delete handler;
 }
 
 } // namespace starrocks

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -159,6 +159,7 @@ public:
         if (_ctx->unref()) {
             delete _ctx;
         }
+        _ctx = nullptr;
     }
 
 private:

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -267,8 +267,9 @@ int TransactionStreamLoadAction::on_header(HttpRequest* req) {
         return -1;
     }
 
-    if (!ctx->lock.try_lock()) {
-        _send_error_reply(req, Status::TransactionInProcessing("Transaction in processing, please retry later"));
+    Status lock_st = ctx->try_lock();
+    if (!lock_st.ok()) {
+        _send_error_reply(req, lock_st);
         return -1;
     }
     // referenced by the http request

--- a/be/src/http/action/transaction_stream_load.h
+++ b/be/src/http/action/transaction_stream_load.h
@@ -61,6 +61,7 @@ private:
     Status _on_header(HttpRequest* http_req, StreamLoadContext* ctx);
     Status _channel_on_header(HttpRequest* http_req, StreamLoadContext* ctx);
     Status _exec_plan_fragment(HttpRequest* http_req, StreamLoadContext* ctx);
+    void _finish_and_reply(HttpRequest* req, const std::string& reply);
     void _send_error_reply(HttpRequest* req, const Status& st);
     Status _parse_request(HttpRequest* http_req, StreamLoadContext* ctx, TStreamLoadPutRequest& request);
 

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -316,7 +316,7 @@ bool StreamLoadContext::tsl_reach_idle_timeout(int32_t check_interval) {
     if (idle_timeout_sec <= 0) {
         return false;
     }
-    // if there is data to consume, the load is till active
+    // if there is data to consume, the load is still active
     std::shared_ptr<MessageBodySink> sink = body_sink;
     if (sink && !sink->exhausted()) {
         last_active_ts = UnixSeconds();

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -308,4 +308,21 @@ void StreamLoadContext::release(StreamLoadContext* context) {
     }
 }
 
+bool StreamLoadContext::tsl_reach_timeout() {
+    return timeout_second > 0 && (UnixSeconds() - begin_txn_ts) > timeout_second;
+}
+
+bool StreamLoadContext::tsl_reach_idle_timeout(int32_t check_interval) {
+    if (idle_timeout_sec <= 0) {
+        return false;
+    }
+    // if there is data to consume, the load is till active
+    std::shared_ptr<MessageBodySink> sink = body_sink;
+    if (sink && !sink->exhausted()) {
+        last_active_ts = UnixSeconds();
+        return false;
+    }
+    return (UnixSeconds() - last_active_ts) > idle_timeout_sec + check_interval;
+}
+
 } // namespace starrocks

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -179,7 +179,10 @@ public:
 
     static void release(StreamLoadContext* context);
 
-    // for transaction stream load
+    // ========================== transaction stream load ==========================
+    // try to get the lock when receiving http requests.
+    // Return Status::OK if success, otherwise return the fail reason
+    Status try_lock();
     bool tsl_reach_timeout();
     bool tsl_reach_idle_timeout(int32_t check_interval);
 
@@ -266,6 +269,9 @@ public:
     std::vector<TTabletFailInfo> fail_infos;
 
     std::mutex lock;
+    // Whether the transaction stream load is detected as timeout. This flag is used to tell
+    // the new request that the transaction is timeout and will be aborted
+    std::atomic<bool> timeout_detected{false};
 
     std::shared_ptr<MessageBodySink> body_sink;
     bool need_rollback = false;

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -179,6 +179,10 @@ public:
 
     static void release(StreamLoadContext* context);
 
+    // for transaction stream load
+    bool tsl_reach_timeout();
+    bool tsl_reach_idle_timeout(int32_t check_interval);
+
 public:
     // 1) Before the stream load receiving thread exits, Fragment may have been destructed.
     // At this time, mem_tracker may have been destructed,

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -246,8 +246,8 @@ public:
     int64_t total_received_data_cost_nanos = 0;
     int64_t received_data_cost_nanos = 0;
     int64_t write_data_cost_nanos = 0;
-    int64_t begin_txn_ts = 0;
-    int64_t last_active_ts = 0;
+    std::atomic<int64_t> begin_txn_ts = 0;
+    std::atomic<int64_t> last_active_ts = 0;
 
     std::string error_url;
     std::string rejected_record_path;

--- a/be/src/runtime/stream_load/transaction_mgr.cpp
+++ b/be/src/runtime/stream_load/transaction_mgr.cpp
@@ -405,8 +405,8 @@ void TransactionMgr::_clean_stream_context() {
                         fmt::format("transaction is aborted by idle timeout {} seconds.", ctx->idle_timeout_sec));
             }
             if (!status.ok()) {
-                ctx->timeout_detected.store(true, std::memory_order_release);
                 if (ctx->lock.try_lock()) {
+                    ctx->timeout_detected.store(true, std::memory_order_release);
                     ctx->status = status;
                     auto st = _rollback_transaction(ctx);
                     LOG(INFO) << "Abort transaction " << ctx->brief() << ", reason: " << status.message()


### PR DESCRIPTION
## Why I'm doing:
Users occasionally encounter the exception `TXN_IN_PROCESSING` when using transaction stream load. `TXN_IN_PROCESSING` means someone is holding the `StreamLoadContext` lock and do something, and the new request can't be processed concurrently. This mechanism is designed to prevent the client from sending concurrent requests. But the exception also happens even the client sends requests sequentially which does not meet expectations. There are two possible reasons:
1. there is a background thread [_clean_stream_context](https://github.com/StarRocks/starrocks/blob/main/be/src/runtime/stream_load/transaction_mgr.cpp#L393) to check and clean the timeout load periodically. It will hold the `StreamLoadContext` lock before each check. So it can conflict with the load request.
2. when the last load finishes, it first sends the response to the client, and then releases the lock. It is possible for the client to receive the response before the server releases the lock and then send the next request. When the next request reaches the server, the lock may still not have been released, leading to this issue.

The second is introduced by #53564 recently, but this problem [has been reported before it](https://forum.mirrorship.cn/search?q=TXN_IN_PROCESSING). So the first should be the primary reason, and I have verified it in a user's environment.


## What I'm doing:
1. for cause 1, reduce the conflict by removing the lock when checking the timeout. only hold the lock when aborting it because of timeout
2. for cause 2, #53564 is to solve the lock leak when there is no normal response, but if the request is normal, should release the lock before response. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0