### PR TITLE
[BugFix] do not set basic auth header if credentials not provided

### DIFF
--- a/be/src/exec/es/es_scan_reader.cpp
+++ b/be/src/exec/es/es_scan_reader.cpp
@@ -127,7 +127,9 @@ Status ESScanReader::open() {
         RETURN_IF_ERROR(_network_client.init(_init_scroll_url));
         LOG(INFO) << "First scroll request URL: " << _init_scroll_url;
     }
-    _network_client.set_basic_auth(_user_name, _passwd);
+    if (!_user_name.empty() && !_passwd.empty()) {
+        _network_client.set_basic_auth(_user_name, _passwd);
+    }
     _network_client.set_content_type("application/json");
     if (_ssl_enabled) {
         _network_client.trust_all_ssl();
@@ -160,7 +162,9 @@ Status ESScanReader::get_next(bool* scan_eos, std::unique_ptr<T>& scroll_parser)
             return Status::OK();
         }
         RETURN_IF_ERROR(_network_client.init(_next_scroll_url));
-        _network_client.set_basic_auth(_user_name, _passwd);
+        if (!_user_name.empty() && !_passwd.empty()) {
+            _network_client.set_basic_auth(_user_name, _passwd);
+        }
         _network_client.set_content_type("application/json");
         _network_client.set_timeout_ms(_http_timeout_ms);
         if (_ssl_enabled) {
@@ -220,7 +224,9 @@ Status ESScanReader::close() {
                                               scroll_id = _scroll_id, scratch_target]() {
         HttpClient client;
         RETURN_IF(!client.init(scratch_target).ok(), (void)0);
-        client.set_basic_auth(user_name, passwd);
+        if (!user_name.empty() && !passwd.empty()) {
+            client.set_basic_auth(user_name, passwd);
+        }
         client.set_method(DELETE);
         client.set_content_type("application/json");
         client.set_timeout_ms(5 * 1000);

--- a/be/src/exec/es/es_scan_reader.cpp
+++ b/be/src/exec/es/es_scan_reader.cpp
@@ -127,7 +127,7 @@ Status ESScanReader::open() {
         RETURN_IF_ERROR(_network_client.init(_init_scroll_url));
         LOG(INFO) << "First scroll request URL: " << _init_scroll_url;
     }
-    if (!_user_name.empty() && !_passwd.empty()) {
+    if (!_user_name.empty() || !_passwd.empty()) {
         _network_client.set_basic_auth(_user_name, _passwd);
     }
     _network_client.set_content_type("application/json");
@@ -162,7 +162,7 @@ Status ESScanReader::get_next(bool* scan_eos, std::unique_ptr<T>& scroll_parser)
             return Status::OK();
         }
         RETURN_IF_ERROR(_network_client.init(_next_scroll_url));
-        if (!_user_name.empty() && !_passwd.empty()) {
+        if (!_user_name.empty() || !_passwd.empty()) {
             _network_client.set_basic_auth(_user_name, _passwd);
         }
         _network_client.set_content_type("application/json");
@@ -224,7 +224,7 @@ Status ESScanReader::close() {
                                               scroll_id = _scroll_id, scratch_target]() {
         HttpClient client;
         RETURN_IF(!client.init(scratch_target).ok(), (void)0);
-        if (!user_name.empty() && !passwd.empty()) {
+        if (!user_name.empty() || !passwd.empty()) {
             client.set_basic_auth(user_name, passwd);
         }
         client.set_method(DELETE);


### PR DESCRIPTION
## Why I'm doing:

While the FE already has this logic, the BE would still send an empty `Authorization: Basic` header to ElasticSearch even if credentials were not provided; this causes a 403 even if the ES cluster has no AuthN/AuthZ settings. This change allows using StarRocks with ElasticSearch external catalogs even with Basic Auth disabled.

## What I'm doing:

Adds a check for empty credentials (both username and password) in the ElasticSearch scan reader, in which case the `Authorization: Basic ...` header is not set.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0