### PR TITLE
[BugFix] Fix can not get statistics for collection type for external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -160,7 +160,7 @@ public class StatisticSQLBuilder {
     }
 
     public static String buildQueryFullStatisticsSQL(Long tableId, List<String> columnNames, List<Type> columnTypes) {
-        Map<String, List<String>> nameGroups = groupByTypes(columnNames, columnTypes);
+        Map<String, List<String>> nameGroups = groupByTypes(columnNames, columnTypes, false);
 
         List<String> querySQL = new ArrayList<>();
         nameGroups.forEach((type, names) -> {
@@ -181,7 +181,7 @@ public class StatisticSQLBuilder {
 
     public static String buildQueryExternalFullStatisticsSQL(String tableUUID, List<String> columnNames,
                                                              List<Type> columnTypes) {
-        Map<String, List<String>> nameGroups = groupByTypes(columnNames, columnTypes);
+        Map<String, List<String>> nameGroups = groupByTypes(columnNames, columnTypes, true);
 
         List<String> querySQL = new ArrayList<>();
         nameGroups.forEach((type, names) -> {
@@ -196,13 +196,14 @@ public class StatisticSQLBuilder {
         return Joiner.on(" UNION ALL ").join(querySQL);
     }
 
-    private static Map<String, List<String>> groupByTypes(List<String> columnNames, List<Type> columnTypes) {
+    private static Map<String, List<String>> groupByTypes(List<String> columnNames, List<Type> columnTypes,
+                                                          boolean isExternal) {
         Map<String, List<String>> groupByTypeNames = Maps.newHashMap();
         for (int i = 0; i < columnNames.size(); i++) {
             String columnName = columnNames.get(i);
             Type columnType = columnTypes.get(i);
 
-            if (columnType.isStringType() || !columnType.canStatistic()) {
+            if (columnType.isStringType() || !columnType.canStatistic() || (isExternal && columnType.isComplexType())) {
                 groupByTypeNames.computeIfAbsent("string", k -> Lists.newArrayList()).add(columnName);
             } else if (columnType.isIntegerType()) {
                 groupByTypeNames.computeIfAbsent("bigint", k -> Lists.newArrayList()).add(columnName);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MapType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PrimitiveType;
@@ -396,10 +397,9 @@ public class StatisticsSQLTest extends PlanTestBase {
                         Type.DATE));
         assertContains(sql, "column_name in (\"col1\", \"col2\")");
         assertContains(sql, "column_name in (\"col3\")");
-        assertContains(sql, "column_name in (\"col4\", \"col5\")");
+        assertContains(sql, "column_name in (\"col4\", \"col5\", \"col6\")");
         assertContains(sql, "column_name in (\"col7\")");
-        assertContains(sql, "column_name in (\"col6\")");
-        Assert.assertEquals(4, StringUtils.countMatches(sql, "UNION ALL"));
+        Assert.assertEquals(3, StringUtils.countMatches(sql, "UNION ALL"));
 
         sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL("a",
                 Lists.newArrayList("col1", "col2", "col3", "col4", "col5", "col6", "col7"),
@@ -413,6 +413,13 @@ public class StatisticsSQLTest extends PlanTestBase {
                         ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 23, 8)));
         assertContains(sql, "column_name in (\"col1\", \"col2\")");
         Assert.assertEquals(5, StringUtils.countMatches(sql, "UNION ALL"));
+    }
+
+    @Test
+    public void testExternalTableCollectionStatsType() {
+        String sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL("a", Lists.newArrayList("col1", "col2"),
+                Lists.newArrayList(Type.ARRAY_INT, new MapType(Type.INT, Type.STRING)));
+        assertContains(sql, "cast(max(cast(max as string)) as string), cast(min(cast(min as string)) as string)");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
because the PR #53862 support collection type stats for native table, but there do not support collection type stats for external table, need to keep the origin type cast for external table
## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9102

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0