### PR TITLE
[Enhancement] support pk column lazy load

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1545,6 +1545,8 @@ CONF_mInt64(load_spill_max_merge_bytes, "1073741824");
 CONF_mInt64(load_spill_merge_memory_limit_percent, "30");
 // Upper bound of spill merge thread count
 CONF_mInt64(load_spill_merge_max_thread, "16");
+// Do lazy load when PK column larger than this threshold. Default is 300MB.
+CONF_mInt64(pk_column_lazy_load_threshold_bytes, "314572800");
 
 // ignore union type tag in avro kafka routine load
 CONF_mBool(avro_ignore_union_type_tag, "false");

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -206,8 +206,8 @@ public:
 private:
     // print memory tracker state
     void _print_memory_stats();
-    Status _do_update(uint32_t rowset_id, int32_t upsert_idx, const ColumnUniquePtr& upsert, PrimaryIndex& index,
-                      DeletesMap* new_deletes);
+    Status _do_update(uint32_t rowset_id, int32_t upsert_idx, const SegmentPKEncodeResultPtr& upsert,
+                      PrimaryIndex& index, DeletesMap* new_deletes);
 
     Status _do_update_with_condition(const RowsetUpdateStateParams& params, uint32_t rowset_id, int32_t upsert_idx,
                                      int32_t condition_column, const ColumnUniquePtr& upsert, PrimaryIndex& index,

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -71,7 +71,7 @@ protected:
     explicit TestBase(std::string test_dir, int64_t cache_limit = 1024 * 1024)
             : _test_dir(std::move(test_dir)),
               _parent_tracker(std::make_unique<MemTracker>(-1)),
-              _mem_tracker(std::make_unique<MemTracker>(1024 * 1024, "", _parent_tracker.get())),
+              _mem_tracker(std::make_unique<MemTracker>(10 * 1024 * 1024, "", _parent_tracker.get())),
               _lp(std::make_shared<FixedLocationProvider>(_test_dir)),
               _update_mgr(std::make_unique<UpdateManager>(_lp, _mem_tracker.get())),
               _tablet_mgr(std::make_unique<TabletManager>(_lp, _update_mgr.get(), cache_limit)) {}


### PR DESCRIPTION
## Why I'm doing:
After we support bulk load optimization (#53954) , load finish will generate large segment file and its PK column after encoded will cost memory more than 1GB. And in PK publish phase, we will load PK encoded column at once will cause cause too much memory can lead to OOM.

## What I'm doing:
Fix #53954

Support PK column lazy load strategy, which can load PK encoded column when needed and piece by piece under control (`pk_column_lazy_load_threshold_bytes`). Not supported in partial update and condition update yet.

This pull request introduces significant changes to the primary key (PK) column handling and memory management in the `RowsetUpdateState` and related components. The changes include adding a new class for encoding and managing PK columns, updating methods to utilize this new class, and modifying memory limits for tests.

### Key Changes:

#### Primary Key Column Management:
* Introduced the `SegmentPKEncodeResult` class to handle the encoding and management of PK columns in segments. This includes methods for initialization, loading, and memory usage tracking (`be/src/storage/lake/rowset_update_state.h`). [[1]](diffhunk://#diff-dfaaabd9e716e28d85f81fe3b94654ae7c5a14f5dd83cc61830a394a716ab2f0R85-R128) [[2]](diffhunk://#diff-dfaaabd9e716e28d85f81fe3b94654ae7c5a14f5dd83cc61830a394a716ab2f0L129-R173) [[3]](diffhunk://#diff-dfaaabd9e716e28d85f81fe3b94654ae7c5a14f5dd83cc61830a394a716ab2f0L170-R214)
* Updated methods in `RowsetUpdateState` to use `SegmentPKEncodeResult` for managing PK columns, replacing direct column handling with the new class (`be/src/storage/lake/rowset_update_state.cpp`). [[1]](diffhunk://#diff-3f55f953546eac4ddf76385c1d45307e493d7b6eae3e9993a16ae0340dc45cfaR37-R103) [[2]](diffhunk://#diff-3f55f953546eac4ddf76385c1d45307e493d7b6eae3e9993a16ae0340dc45cfaL204-R282) [[3]](diffhunk://#diff-3f55f953546eac4ddf76385c1d45307e493d7b6eae3e9993a16ae0340dc45cfaL291-R345) [[4]](diffhunk://#diff-3f55f953546eac4ddf76385c1d45307e493d7b6eae3e9993a16ae0340dc45cfaL354-R401) [[5]](diffhunk://#diff-3f55f953546eac4ddf76385c1d45307e493d7b6eae3e9993a16ae0340dc45cfaL370-R417) [[6]](diffhunk://#diff-3f55f953546eac4ddf76385c1d45307e493d7b6eae3e9993a16ae0340dc45cfaL390-R437) [[7]](diffhunk://#diff-3f55f953546eac4ddf76385c1d45307e493d7b6eae3e9993a16ae0340dc45cfaL399-R446) [[8]](diffhunk://#diff-3f55f953546eac4ddf76385c1d45307e493d7b6eae3e9993a16ae0340dc45cfaL542-R591) [[9]](diffhunk://#diff-3f55f953546eac4ddf76385c1d45307e493d7b6eae3e9993a16ae0340dc45cfaL694-R741) [[10]](diffhunk://#diff-3f55f953546eac4ddf76385c1d45307e493d7b6eae3e9993a16ae0340dc45cfaL710-R757)

#### Memory Management:
* Adjusted memory limits in test cases to reflect the new default values for memory trackers (`be/test/storage/lake/primary_key_publish_test.cpp`, `be/test/storage/lake/test_util.h`). [[1]](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0L1239-R1242) [[2]](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0R1809-R1839) [[3]](diffhunk://#diff-5f91a25da865ae4d1df5d0d7e74dd13c37bc77662732c921b94713113ac6dc8cL74-R74)

#### Configuration Changes:
* Added a new configuration parameter `pk_column_lazy_load_threshold_bytes` to control lazy loading of PK columns based on their size (`be/src/common/config.h`).

#### Update Methods:
* Updated the `UpdateManager` methods to work with the `SegmentPKEncodeResult` class for PK column updates (`be/src/storage/lake/update_manager.cpp`, `be/src/storage/lake/update_manager.h`). [[1]](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66L260-R260) [[2]](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66L378-R385) [[3]](diffhunk://#diff-2768600385797fde42b2f80cfde477f3c59bbabce02adc2660602e044dbcb464L209-R210)

These changes aim to improve the handling and performance of PK column operations, especially for large datasets, by using a more structured approach to manage PK columns and their memory usage.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0