### PR TITLE
[BugFix] flush memtable when too many files need rebuilt in cloud native pk index

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1066,6 +1066,9 @@ CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
 CONF_mDouble(lake_pk_index_cumulative_base_compaction_ratio, "0.1");
 CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
 CONF_mBool(lake_clear_corrupted_cache, "true");
+// The maximum number of files which need to rebuilt in cloud native pk index.
+// If files which need to rebuilt larger than this, we will flush memtable immediately.
+CONF_mInt32(cloud_native_pk_index_rebuild_files_threshold, "50");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -181,6 +181,10 @@ bool LakePersistentIndex::is_memtable_full() const {
     return mem_size_exceed || mem_tracker_exceed;
 }
 
+bool LakePersistentIndex::too_many_rebuild_files() const {
+    return _need_rebuild_file_cnt >= config::cloud_native_pk_index_rebuild_files_threshold;
+}
+
 Status LakePersistentIndex::minor_compact() {
     TRACE_COUNTER_SCOPE_LATENCY_US("minor_compact_latency_us");
     auto filename = gen_sst_filename();
@@ -223,6 +227,8 @@ Status LakePersistentIndex::flush_memtable() {
     auto max_rss_rowid = _memtable->max_rss_rowid();
     _memtable.reset();
     _memtable = std::make_unique<PersistentIndexMemtable>(max_rss_rowid);
+    // Reset rebuild file count, avoid useless flush.
+    _need_rebuild_file_cnt = 0;
     return Status::OK();
 }
 
@@ -526,6 +532,11 @@ Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_c
 }
 
 Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
+    if (too_many_rebuild_files() && !_memtable->empty()) {
+        // If we have too many files need to be rebult,
+        // we need to do flush to reduce rebult cost later.
+        RETURN_IF_ERROR(flush_memtable());
+    }
     PersistentIndexSstableMetaPB sstable_meta;
     int64_t last_max_rss_rowid = 0;
     for (auto& sstable : _sstables) {
@@ -540,18 +551,20 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
         sstable_pb->CopyFrom(sstable->sstable_pb());
     }
     builder->finalize_sstable_meta(sstable_meta);
+    _need_rebuild_file_cnt = need_rebuild_file_cnt(*builder->tablet_meta(), sstable_meta);
     return Status::OK();
 }
 
 // Rebuild index's memtable via del files, it will read from del file and write to index.
 // If it fail, SR will retry publish txn, and this index's memtable will be release and rebuild again.
 Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pkey_schema, int64_t rowset_version) {
-    TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
+    TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_index_del_cost_us");
     // Build pk column struct from schema
     std::unique_ptr<Column> pk_column;
     RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
     // Iterate all del files and insert into index.
     for (int del_idx = 0; del_idx < rowset->metadata().del_files_size(); ++del_idx) {
+        TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
         const auto& del = rowset->metadata().del_files(del_idx);
         RandomAccessFileOptions ropts;
         if (!del.encryption_meta().empty()) {
@@ -639,6 +652,24 @@ bool LakePersistentIndex::needs_rowset_rebuild(const RowsetMetadataPB& rowset, u
     return true;
 }
 
+// Return the files cnt that need to rebuild.
+size_t LakePersistentIndex::need_rebuild_file_cnt(const TabletMetadataPB& metadata,
+                                                  const PersistentIndexSstableMetaPB& sstable_meta) {
+    size_t cnt = 0;
+    const auto& sstables = sstable_meta.sstables();
+    const uint32_t rebuild_rss_id = sstables.empty() ? 0 : sstables.rbegin()->max_rss_rowid() >> 32;
+    for (const auto& rowset : metadata.rowsets()) {
+        if (!needs_rowset_rebuild(rowset, rebuild_rss_id)) {
+            continue; // skip rowset
+        }
+        cnt += rowset.del_files_size();
+        // rowset id + segment id < rebuild_rss_id can be skip.
+        // so only some segments in this rowset need to rebuild
+        cnt += std::min(rowset.id() + rowset.segments_size() - rebuild_rss_id + 1, (uint32_t)rowset.segments_size());
+    }
+    return cnt;
+}
+
 Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
                                                   int64_t base_version, const MetaFileBuilder* builder) {
     // 1. create and set key column schema
@@ -648,6 +679,8 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         pk_columns[i] = (ColumnId)i;
     }
     auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+
+    _need_rebuild_file_cnt = need_rebuild_file_cnt(*metadata, metadata->sstable_meta());
 
     // Init PersistentIndex
     _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema);
@@ -684,6 +717,7 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
         auto& itrs = res.value();
         CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
         for (size_t i = 0; i < itrs.size(); i++) {
+            TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_index_segment_cost_us");
             auto itr = itrs[i].get();
             if (itr == nullptr) {
                 continue;

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -533,8 +533,8 @@ Status LakePersistentIndex::apply_opcompaction(const TxnLogPB_OpCompaction& op_c
 
 Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
     if (too_many_rebuild_files() && !_memtable->empty()) {
-        // If we have too many files need to be rebult,
-        // we need to do flush to reduce rebult cost later.
+        // If we have too many files need to be rebuilt,
+        // we need to do flush to reduce index rebuild cost later.
         RETURN_IF_ERROR(flush_memtable());
     }
     PersistentIndexSstableMetaPB sstable_meta;

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -152,10 +152,16 @@ public:
     // Check if this rowset need to rebuild, return `True` means need to rebuild this rowset.
     static bool needs_rowset_rebuild(const RowsetMetadataPB& rowset, uint32_t rebuild_rss_id);
 
+    // Return the files cnt that need to rebuild.
+    static size_t need_rebuild_file_cnt(const TabletMetadataPB& metadata,
+                                        const PersistentIndexSstableMetaPB& sstable_meta);
+
 private:
     Status flush_memtable();
 
     bool is_memtable_full() const;
+
+    bool too_many_rebuild_files() const;
 
     // batch get
     // |n|: size of key/value array
@@ -184,6 +190,7 @@ private:
     std::unique_ptr<PersistentIndexMemtable> _memtable;
     TabletManager* _tablet_mgr{nullptr};
     int64_t _tablet_id{0};
+    size_t _need_rebuild_file_cnt{0};
     // The size of sstables is not expected to be too large.
     // In major compaction, some sstables will be picked to be merged into one.
     // sstables are ordered with the smaller version on the left.

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -67,6 +67,8 @@ public:
 
     void remove_compacted_sst(const TxnLogPB_OpCompaction& op_compaction);
 
+    const TabletMetadata* tablet_meta() const { return _tablet_meta.get(); }
+
 private:
     // update delvec in tablet meta
     Status _finalize_delvec(int64_t version, int64_t txn_id);

--- a/be/src/storage/lake/persistent_index_memtable.h
+++ b/be/src/storage/lake/persistent_index_memtable.h
@@ -70,6 +70,8 @@ public:
 
     const uint64_t max_rss_rowid() const { return _max_rss_rowid; }
 
+    bool empty() const { return _map.size() == 0; }
+
 private:
     static void update_index_value(IndexValueWithVer* index_value_info, int64_t version, const IndexValue& value);
 

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -29,6 +29,7 @@
 #include "storage/lake/compaction_task.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/lake/join_path.h"
+#include "storage/lake/lake_persistent_index.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/metacache.h"
@@ -1701,6 +1702,89 @@ TEST_P(LakePrimaryKeyPublishTest, test_index_rebuild_with_dels4) {
         version++;
     }
     EXPECT_EQ(kChunkSize, read_rows(tablet_id, version));
+}
+
+TEST_P(LakePrimaryKeyPublishTest, test_cloud_native_index_minor_compact_because_files) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        GTEST_SKIP() << "this case only for cloud native index";
+        return;
+    }
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i <= config::cloud_native_pk_index_rebuild_files_threshold; i++) {
+        auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+        if (i == config::cloud_native_pk_index_rebuild_files_threshold - 2) {
+            // last one, check need rebuilt file cnt
+            ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+            EXPECT_EQ(new_tablet_metadata->sstable_meta().sstables_size(), 0);
+            EXPECT_EQ(LakePersistentIndex::need_rebuild_file_cnt(*new_tablet_metadata,
+                                                                 new_tablet_metadata->sstable_meta()),
+                      config::cloud_native_pk_index_rebuild_files_threshold - 1);
+        }
+    }
+    ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    // make sure generate sst files
+    EXPECT_TRUE(new_tablet_metadata->sstable_meta().sstables_size() > 0);
+}
+
+TEST_P(LakePrimaryKeyPublishTest, test_cloud_native_index_minor_compact_because_del_files) {
+    if (!GetParam().enable_persistent_index ||
+        GetParam().persistent_index_type != PersistentIndexTypePB::CLOUD_NATIVE) {
+        GTEST_SKIP() << "this case only for cloud native index";
+        return;
+    }
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < config::cloud_native_pk_index_rebuild_files_threshold; i++) {
+        auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, false);
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+        if (i == config::cloud_native_pk_index_rebuild_files_threshold / 2 - 1) {
+            // last one, check need rebuilt file cnt
+            ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+            EXPECT_EQ(new_tablet_metadata->sstable_meta().sstables_size(), 0);
+            EXPECT_EQ(LakePersistentIndex::need_rebuild_file_cnt(*new_tablet_metadata,
+                                                                 new_tablet_metadata->sstable_meta()),
+                      config::cloud_native_pk_index_rebuild_files_threshold);
+        }
+    }
+    ASSERT_EQ(0, read_rows(tablet_id, version));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    // make sure generate sst files
+    EXPECT_TRUE(new_tablet_metadata->sstable_meta().sstables_size() > 0);
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_individual_index_compaction) {


### PR DESCRIPTION
## Why I'm doing:
In the cloud-native PK index, when the number of files that need to be rebuilt is too many (including segment and del files), a minor compact can still be triggered even if the data volume has not yet reached the memtable's minor compact threshold. This is done to prevent excessive file reads during the rebuild process, which could otherwise impact the rebuild speed.

## What I'm doing:
This pull request introduces a new feature to handle the rebuilding of cloud-native primary key indexes in the `LakePersistentIndex` class. The changes include adding a threshold for the number of rebuild files, updating relevant methods to check this threshold, and adding new tests to verify the functionality.

Key changes include:

### Configuration and Threshold

* [`be/src/common/config.h`](diffhunk://#diff-46e8c1ada0d43acf8c2965e46e90909089aada1f46531976c10605b837f8da3dR1069-R1071): Added a new configuration parameter `cloud_native_pk_index_rebuild_files_threshold` to set the maximum number of files that need to be rebuilt before triggering a memtable flush.

### Method Updates

* `be/src/storage/lake/lake_persistent_index.cpp`: 
  - Added the method `too_many_rebuild_files` to check if the number of rebuild files exceeds the threshold.
  - Updated various methods (`upsert`, `insert`, `replay_erase`, `erase`, `try_replace`, `replace`) to include the new rebuild files check. [[1]](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1L261-R265) [[2]](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1L270-R274) [[3]](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1L282-R286) [[4]](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1L294-R298) [[5]](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1L315-R319) [[6]](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1L325-R329)
  - Added logic to update the rebuild file count in the `commit` and `load_from_lake_tablet` methods. [[1]](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1R547-R560) [[2]](diffhunk://#diff-687a9117869c9c3cb509971cb9da3d4c7c6e484c64f1bcf0ea476e5bc57f63f1R675-R683)
  - Introduced the `need_rebuild_file_cnt` method to calculate the number of files that need to be rebuilt.

### Header File Updates

* [`be/src/storage/lake/lake_persistent_index.h`](diffhunk://#diff-d7ad440fb6d98ac0f9a31747c9c6a1a112e18fb29d4ef0857ca483687eb7e349R155-R165): Declared the new methods and added a member variable `_need_rebuild_file_cnt` to track the rebuild file count. [[1]](diffhunk://#diff-d7ad440fb6d98ac0f9a31747c9c6a1a112e18fb29d4ef0857ca483687eb7e349R155-R165) [[2]](diffhunk://#diff-d7ad440fb6d98ac0f9a31747c9c6a1a112e18fb29d4ef0857ca483687eb7e349R193)

### Testing

* [`be/test/storage/lake/primary_key_publish_test.cpp`](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0R1707-R1789): Added new test cases to verify the functionality of the new rebuild file threshold mechanism.

These changes enhance the `LakePersistentIndex` class by ensuring that the system can handle a large number of rebuild files efficiently, triggering a memtable flush when necessary to maintain performance.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0