### PR TITLE
[Feature] Support Cluster Snapshot Backup: deletion control (part4)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -127,7 +127,9 @@ public abstract class AlterHandler extends FrontendDaemon {
         Iterator<Map.Entry<Long, AlterJobV2>> iterator = alterJobsV2.entrySet().iterator();
         while (iterator.hasNext()) {
             AlterJobV2 alterJobV2 = iterator.next().getValue();
-            if (alterJobV2.isExpire()) {
+            long validDeletionTimeMs = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
+                                                                       .getValidDeletionTimeMsByAutomatedSnapshot();
+            if (alterJobV2.isExpire() && alterJobV2.getFinishedTimeMs() < validDeletionTimeMs) {
                 iterator.remove();
                 RemoveAlterJobV2OperationLog log =
                         new RemoveAlterJobV2OperationLog(alterJobV2.getJobId(), alterJobV2.getType());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -303,7 +303,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         if (!idToRecycleTime.containsKey(id)) {
             return true;
         }
-        return idToRecycleTime.get(id) > GlobalStateMgr.getCurrentState()
+        return idToRecycleTime.get(id) < GlobalStateMgr.getCurrentState()
                               .getClusterSnapshotMgr().getValidDeletionTimeMsByAutomatedSnapshot();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -300,10 +300,11 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     }
 
     private synchronized boolean checkValidDeletionByClusterSnapshot(long id) {
-        if (!idToRecycleTime.containsKey(id)) {
+        Long originalRecycleTime = idToRecycleTime.get(id);
+        if (originalRecycleTime == null) {
             return true;
         }
-        return idToRecycleTime.get(id) < GlobalStateMgr.getCurrentState()
+        return originalRecycleTime < GlobalStateMgr.getCurrentState()
                               .getClusterSnapshotMgr().getValidDeletionTimeMsByAutomatedSnapshot();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -996,7 +996,6 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         long currentTimeMs = System.currentTimeMillis();
         // should follow the partition/table/db order
         // in case of partition(table) is still in recycle bin but table(db) is missing
-        LOG.info("catalog recycle begin");
         try {
             erasePartition(currentTimeMs);
             // synchronized is unfair lock, sleep here allows other high-priority operations to obtain a lock
@@ -1008,7 +1007,6 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         } catch (InterruptedException e) {
             LOG.warn("Failed to execute runAfterCatalogReady", e);
         }
-        LOG.info("catalog recycle finished");
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -79,7 +79,9 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             locker.lockDatabase(db.getId(), LockType.READ);
             try {
                 for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTablesIncludeRecycleBin(db)) {
-                    if (table.isCloudNativeTableOrMaterializedView()) {
+                    if (table.isCloudNativeTableOrMaterializedView() &&
+                            GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
+                                                            .checkValidDeletionForTableFromAlterJob(table.getId())) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore()
                                 .getAllPartitionsIncludeRecycleBin((OlapTable) table)
                                 .stream()

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshot.java
@@ -31,10 +31,10 @@ public class ClusterSnapshot {
     private ClusterSnapshotType type;
     @SerializedName(value = "storageVolumeName")
     private String storageVolumeName;
-    @SerializedName(value = "createdTime")
-    private long createdTime;
-    @SerializedName(value = "finishedTime")
-    private long finishedTime;
+    @SerializedName(value = "createdTimeMs")
+    private long createdTimeMs;
+    @SerializedName(value = "finishedTimeMs")
+    private long finishedTimeMs;
     @SerializedName(value = "feJournalId")
     private long feJournalId;
     @SerializedName(value = "starMgrJournal")
@@ -42,14 +42,14 @@ public class ClusterSnapshot {
 
     public ClusterSnapshot() {}
 
-    public ClusterSnapshot(long id, String snapshotName, String storageVolumeName, long createdTime,
-                           long finishedTime, long feJournalId, long starMgrJournalId) {
+    public ClusterSnapshot(long id, String snapshotName, String storageVolumeName, long createdTimeMs,
+                           long finishedTimeMs, long feJournalId, long starMgrJournalId) {
         this.id = id;
         this.snapshotName = snapshotName;
         this.type = ClusterSnapshotType.AUTOMATED;
         this.storageVolumeName = storageVolumeName;
-        this.createdTime = createdTime;
-        this.finishedTime = finishedTime;
+        this.createdTimeMs = createdTimeMs;
+        this.finishedTimeMs = finishedTimeMs;
         this.feJournalId = feJournalId;
         this.starMgrJournalId = starMgrJournalId;
     }
@@ -59,8 +59,8 @@ public class ClusterSnapshot {
         this.starMgrJournalId = starMgrJournalId;
     }
 
-    public void setFinishedTime(long finishedTime) {
-        this.finishedTime = finishedTime;
+    public void setFinishedTimeMs(long finishedTimeMs) {
+        this.finishedTimeMs = finishedTimeMs;
     }
 
     public String getSnapshotName() {
@@ -71,12 +71,12 @@ public class ClusterSnapshot {
         return storageVolumeName;
     }
 
-    public long getCreatedTime() {
-        return createdTime;
+    public long getCreatedTimeMs() {
+        return createdTimeMs;
     }
 
-    public long getFinishedTime() {
-        return finishedTime;
+    public long getFinishedTimeMs() {
+        return finishedTimeMs;
     }
 
     public long getFeJournalId() {
@@ -95,8 +95,8 @@ public class ClusterSnapshot {
         TClusterSnapshotsItem item = new TClusterSnapshotsItem();
         item.setSnapshot_name(snapshotName);
         item.setSnapshot_type(type.name());
-        item.setCreated_time(createdTime / 1000);
-        item.setFinished_time(finishedTime / 1000);
+        item.setCreated_time(createdTimeMs / 1000);
+        item.setFinished_time(finishedTimeMs / 1000);
         item.setFe_jouranl_id(feJournalId);
         item.setStarmgr_jouranl_id(starMgrJournalId);
         item.setProperties("");

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
@@ -33,6 +33,8 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
     private final CheckpointController feController;
     private final CheckpointController starMgrController;
 
+    private boolean hasfinished = false;
+
     public ClusterSnapshotCheckpointScheduler(CheckpointController feController, CheckpointController starMgrController) {
         super("cluster_snapshot_checkpoint_scheduler", Config.automated_cluster_snapshot_interval_seconds * 1000L);
         this.feController = feController;
@@ -42,6 +44,10 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
     @Override
     protected void runAfterCatalogReady() {
         if (!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isAutomatedSnapshotOn()) {
+            return;
+        }
+
+        if (hasfinished) {
             return;
         }
 
@@ -115,6 +121,7 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
             job.addAutomatedClusterSnapshot();
             LOG.info("Finish Cluster Snapshot checkpoint, FE checkpoint journal Id: {}, StarMgr checkpoint journal Id: {}",
                      job.getFeJournalId(), job.getStarMgrJournalId());
+            hasfinished = true;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
@@ -33,8 +33,6 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
     private final CheckpointController feController;
     private final CheckpointController starMgrController;
 
-    private boolean hasfinished = false;
-
     public ClusterSnapshotCheckpointScheduler(CheckpointController feController, CheckpointController starMgrController) {
         super("cluster_snapshot_checkpoint_scheduler", Config.automated_cluster_snapshot_interval_seconds * 1000L);
         this.feController = feController;
@@ -44,10 +42,6 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
     @Override
     protected void runAfterCatalogReady() {
         if (!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isAutomatedSnapshotOn()) {
-            return;
-        }
-
-        if (hasfinished) {
             return;
         }
 
@@ -121,7 +115,6 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
             job.addAutomatedClusterSnapshot();
             LOG.info("Finish Cluster Snapshot checkpoint, FE checkpoint journal Id: {}, StarMgr checkpoint journal Id: {}",
                      job.getFeJournalId(), job.getStarMgrJournalId());
-            hasfinished = true;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJob.java
@@ -105,7 +105,7 @@ public class ClusterSnapshotJob implements Writable {
                state == ClusterSnapshotJobState.FINISHED;
     }
 
-    public boolean isSuccess() {
+    public boolean isFinished() {
         return state == ClusterSnapshotJobState.FINISHED;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJob.java
@@ -46,8 +46,8 @@ public class ClusterSnapshotJob implements Writable {
     @SerializedName(value = "errMsg")
     private String errMsg;
 
-    public ClusterSnapshotJob(long id, String snapshotName, String storageVolumeName, long createdTime) {
-        this.snapshot = new ClusterSnapshot(id, snapshotName, storageVolumeName, createdTime, -1, 0, 0);
+    public ClusterSnapshotJob(long id, String snapshotName, String storageVolumeName, long createdTimeMs) {
+        this.snapshot = new ClusterSnapshot(id, snapshotName, storageVolumeName, createdTimeMs, -1, 0, 0);
         this.state = ClusterSnapshotJobState.INITIALIZING;
         this.errMsg = "";
     }
@@ -55,7 +55,7 @@ public class ClusterSnapshotJob implements Writable {
     public void setState(ClusterSnapshotJobState state) {
         this.state = state;
         if (state == ClusterSnapshotJobState.FINISHED) {
-            snapshot.setFinishedTime(System.currentTimeMillis());
+            snapshot.setFinishedTimeMs(System.currentTimeMillis());
         }
     }
 
@@ -75,12 +75,12 @@ public class ClusterSnapshotJob implements Writable {
         return snapshot.getStorageVolumeName();
     }
 
-    public long getCreatedTime() {
-        return snapshot.getCreatedTime();
+    public long getCreatedTimeMs() {
+        return snapshot.getCreatedTimeMs();
     }
 
-    public long getFinishedTime() {
-        return snapshot.getFinishedTime();
+    public long getFinishedTimeMs() {
+        return snapshot.getFinishedTimeMs();
     }
 
     public long getFeJournalId() {
@@ -105,6 +105,10 @@ public class ClusterSnapshotJob implements Writable {
                state == ClusterSnapshotJobState.FINISHED;
     }
 
+    public boolean isSuccess() {
+        return state == ClusterSnapshotJobState.FINISHED;
+    }
+
     public void logJob() {
         ClusterSnapshotLog log = new ClusterSnapshotLog();
         log.setSnapshotJob(this);
@@ -123,8 +127,8 @@ public class ClusterSnapshotJob implements Writable {
         TClusterSnapshotJobsItem item = new TClusterSnapshotJobsItem();
         item.setSnapshot_name(getSnapshotName());
         item.setJob_id(getId());
-        item.setCreated_time(getCreatedTime() / 1000);
-        item.setFinished_time(getFinishedTime() / 1000);
+        item.setCreated_time(getCreatedTimeMs() / 1000);
+        item.setFinished_time(getFinishedTimeMs() / 1000);
         item.setState(state.name());
         item.setDetail_info("");
         item.setError_message(errMsg);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -185,6 +185,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
 
         boolean valid = true;
         Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
+        alterJobs.putAll(GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2());
         for (Map.Entry<Long, AlterJobV2> entry : alterJobs.entrySet()) {
             AlterJobV2 alterJob = entry.getValue();
             if (alterJob.getTableId() == tableId) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -165,7 +165,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         long previousAutomatedSnapshotCreatedTimsMs = 0;
         for (Map.Entry<Long, ClusterSnapshotJob> entry : historyAutomatedSnapshotJobs.descendingMap().entrySet()) {
             ClusterSnapshotJob job = entry.getValue();
-            if (job.isSuccess()) {
+            if (job.isFinished()) {
                 if (findLastSuccess) {
                     previousAutomatedSnapshotCreatedTimsMs = job.getCreatedTimeMs();
                     break;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -162,7 +162,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         }
         
         boolean findLastSuccess = false;
-        long previousAutomatedSnapshotCreatedTimsMs = 1; // init as 1 not 0 for vacuum
+        long previousAutomatedSnapshotCreatedTimsMs = 0;
         for (Map.Entry<Long, ClusterSnapshotJob> entry : historyAutomatedSnapshotJobs.descendingMap().entrySet()) {
             ClusterSnapshotJob job = entry.getValue();
             if (job.isSuccess()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -15,6 +15,7 @@
 package com.starrocks.lake.snapshot;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.alter.AlterJobV2;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.lake.snapshot.ClusterSnapshotJob.ClusterSnapshotJobState;
@@ -117,11 +118,11 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
     }
 
     public ClusterSnapshotJob createAutomatedSnapshotJob() {
-        long createTime = System.currentTimeMillis();
+        long createTimeMs = System.currentTimeMillis();
         long id = GlobalStateMgr.getCurrentState().getNextId();
-        String snapshotName = AUTOMATED_NAME_PREFIX + '_' + String.valueOf(createTime);
+        String snapshotName = AUTOMATED_NAME_PREFIX + '_' + String.valueOf(createTimeMs);
         String storageVolumeName = automatedSnapshotSvName;
-        ClusterSnapshotJob job = new ClusterSnapshotJob(id, snapshotName, storageVolumeName, createTime);
+        ClusterSnapshotJob job = new ClusterSnapshotJob(id, snapshotName, storageVolumeName, createTimeMs);
         job.logJob();
 
         addJob(job);
@@ -148,11 +149,50 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
     }
 
     public synchronized void addJob(ClusterSnapshotJob job) {
-        if (Config.max_historical_automated_cluster_snapshot_jobs >= 1 &&
-                historyAutomatedSnapshotJobs.size() == Config.max_historical_automated_cluster_snapshot_jobs) {
+        int maxSize = Math.max(Config.max_historical_automated_cluster_snapshot_jobs, 2);
+        if (historyAutomatedSnapshotJobs.size() == maxSize) {
             historyAutomatedSnapshotJobs.pollFirstEntry();
         }
         historyAutomatedSnapshotJobs.put(job.getId(), job);
+    }
+
+    public synchronized long getValidDeletionTimeMsByAutomatedSnapshot() {
+        if (!isAutomatedSnapshotOn()) {
+            return Long.MAX_VALUE;
+        }
+        
+        boolean findLastSuccess = false;
+        long previousAutomatedSnapshotCreatedTimsMs = 0;
+        for (Map.Entry<Long, ClusterSnapshotJob> entry : historyAutomatedSnapshotJobs.descendingMap().entrySet()) {
+            ClusterSnapshotJob job = entry.getValue();
+            if (job.isSuccess()) {
+                if (findLastSuccess) {
+                    previousAutomatedSnapshotCreatedTimsMs = job.getCreatedTimeMs();
+                    break;
+                }
+
+                findLastSuccess = true;
+            }
+        }
+
+        return previousAutomatedSnapshotCreatedTimsMs;
+    }
+
+    public synchronized boolean checkValidDeletionForTableFromAlterJob(long tableId) {
+        if (!isAutomatedSnapshotOn()) {
+            return true;
+        }
+
+        boolean valid = true;
+        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
+        for (Map.Entry<Long, AlterJobV2> entry : alterJobs.entrySet()) {
+            AlterJobV2 alterJob = entry.getValue();
+            if (alterJob.getTableId() == tableId) {
+                valid = (alterJob.getFinishedTimeMs() < getValidDeletionTimeMsByAutomatedSnapshot());
+                break;
+            }
+        }
+        return valid;
     }
 
     public TClusterSnapshotJobsResponse getAllJobsInfo() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -160,7 +160,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         if (!isAutomatedSnapshotOn()) {
             return Long.MAX_VALUE;
         }
-        
+
         boolean findLastSuccess = false;
         long previousAutomatedSnapshotCreatedTimsMs = 0;
         for (Map.Entry<Long, ClusterSnapshotJob> entry : historyAutomatedSnapshotJobs.descendingMap().entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -162,7 +162,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         }
         
         boolean findLastSuccess = false;
-        long previousAutomatedSnapshotCreatedTimsMs = 0;
+        long previousAutomatedSnapshotCreatedTimsMs = 1; // init as 1 not 0 for vacuum
         for (Map.Entry<Long, ClusterSnapshotJob> entry : historyAutomatedSnapshotJobs.descendingMap().entrySet()) {
             ClusterSnapshotJob job = entry.getValue();
             if (job.isSuccess()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -167,8 +167,8 @@ public class AutovacuumDaemon extends FrontendDaemon {
             vacuumRequest.graceTimestamp =
                     startTime / MILLISECONDS_PER_SECOND - Config.lake_autovacuum_grace_period_minutes * 60;
             vacuumRequest.graceTimestamp = Math.min(vacuumRequest.graceTimestamp,
-                            GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
-                                          .getValidDeletionTimeMsByAutomatedSnapshot() / MILLISECONDS_PER_SECOND);
+                            Math.max(GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
+                                                   .getValidDeletionTimeMsByAutomatedSnapshot() / MILLISECONDS_PER_SECOND, 1));
             vacuumRequest.minActiveTxnId = minActiveTxnId;
             vacuumRequest.partitionId = partition.getId();
             vacuumRequest.deleteTxnLog = needDeleteTxnLog;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -166,6 +166,9 @@ public class AutovacuumDaemon extends FrontendDaemon {
             vacuumRequest.minRetainVersion = minRetainVersion;
             vacuumRequest.graceTimestamp =
                     startTime / MILLISECONDS_PER_SECOND - Config.lake_autovacuum_grace_period_minutes * 60;
+            vacuumRequest.graceTimestamp = Math.min(vacuumRequest.graceTimestamp,
+                            GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
+                                          .getValidDeletionTimeMsByAutomatedSnapshot() / MILLISECONDS_PER_SECOND);
             vacuumRequest.minActiveTxnId = minActiveTxnId;
             vacuumRequest.partitionId = partition.getId();
             vacuumRequest.deleteTxnLog = needDeleteTxnLog;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.persist.EditLog;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.PartitionValue;
@@ -186,15 +187,19 @@ public class CatalogRecycleBinTest {
     @Test
     public void testReplayEraseTableEx(@Mocked GlobalStateMgr globalStateMgr) {
 
+        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
         new Expectations() {
             {
                 GlobalStateMgr.getCurrentState();
                 result = globalStateMgr;
 
-                globalStateMgr.getEditLog().logEraseMultiTables((List<Long>) any);
+                globalStateMgr.getCurrentState().getEditLog().logEraseMultiTables((List<Long>) any);
                 minTimes = 1;
                 maxTimes = 1;
                 result = null;
+
+                globalStateMgr.getCurrentState().getClusterSnapshotMgr();
+                result = clusterSnapshotMgr;
             }
         };
 
@@ -207,9 +212,9 @@ public class CatalogRecycleBinTest {
         bin.recycleTable(13, table3, true);
 
         bin.eraseTable(System.currentTimeMillis() + Config.catalog_trash_expire_second * 1000L + 10000);
-        waitPartitionClearFinished(bin, 11L, System.currentTimeMillis() + Config.catalog_trash_expire_second * 1000L + 10000);
-        waitPartitionClearFinished(bin, 12L, System.currentTimeMillis() + Config.catalog_trash_expire_second * 1000L + 10000);
-        waitPartitionClearFinished(bin, 13L, System.currentTimeMillis() + Config.catalog_trash_expire_second * 1000L + 10000);
+        waitTableClearFinished(bin, 1L, System.currentTimeMillis() + Config.catalog_trash_expire_second * 1000L + 10000);
+        waitTableClearFinished(bin, 2L, System.currentTimeMillis() + Config.catalog_trash_expire_second * 1000L + 10000);
+        waitTableClearFinished(bin, 3L, System.currentTimeMillis() + Config.catalog_trash_expire_second * 1000L + 10000);
 
         Assert.assertEquals(0, bin.getTables(11L).size());
         Assert.assertEquals(0, bin.getTables(12L).size());
@@ -357,6 +362,14 @@ public class CatalogRecycleBinTest {
 
     @Test
     public void testEnsureEraseLater() {
+        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getClusterSnapshotMgr();
+                result = clusterSnapshotMgr;
+            }
+        };
+
         Config.catalog_trash_expire_second = 600; // set expire in 10 minutes
         CatalogRecycleBin recycleBin = new CatalogRecycleBin();
         Database db = new Database(111, "uno");
@@ -428,6 +441,13 @@ public class CatalogRecycleBinTest {
                 minTimes = 0;
             }
         };
+        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getClusterSnapshotMgr();
+                result = clusterSnapshotMgr;
+            }
+        };
 
         recycleBin.eraseDatabase(now);
 
@@ -486,6 +506,13 @@ public class CatalogRecycleBinTest {
                 result = null;
             }
         };
+        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getClusterSnapshotMgr();
+                result = clusterSnapshotMgr;
+            }
+        };
         CatalogRecycleBin recycleBin = new CatalogRecycleBin();
         for (int i = 0; i < CatalogRecycleBin.getMaxEraseOperationsPerCycle() + 1; i++) {
             Table t = new Table(i, String.format("t%d", i), Table.TableType.VIEW, null);
@@ -521,6 +548,13 @@ public class CatalogRecycleBinTest {
                 editLog.logEraseMultiTables((List<Long>) any);
                 minTimes = 0;
                 result = null;
+            }
+        };
+        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getClusterSnapshotMgr();
+                result = clusterSnapshotMgr;
             }
         };
 
@@ -603,6 +637,13 @@ public class CatalogRecycleBinTest {
             {
                 editLog.logErasePartition(anyLong);
                 minTimes = 0;
+            }
+        };
+        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getClusterSnapshotMgr();
+                result = clusterSnapshotMgr;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -37,6 +37,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.concurrent.lock.LockManager;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.persist.EditLog;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -138,6 +139,10 @@ public class TabletSchedulerTest {
                 globalStateMgr.getVariableMgr();
                 minTimes = 0;
                 result = variableMgr;
+
+                globalStateMgr.getClusterSnapshotMgr();
+                minTimes = 0;
+                result = new ClusterSnapshotMgr();
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
@@ -14,7 +14,11 @@
 
 package com.starrocks.lake.snapshot;
 
+import com.starrocks.alter.AlterJobV2;
 import com.starrocks.alter.AlterTest;
+import com.starrocks.alter.MaterializedViewHandler;
+import com.starrocks.alter.SchemaChangeHandler;
+import com.starrocks.alter.SchemaChangeJobV2;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -66,6 +70,8 @@ public class ClusterSnapshotTest {
     private ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
     private boolean initSv = false;
 
+    private long nextId = 0;
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         AlterTest.beforeClass();
@@ -103,7 +109,8 @@ public class ClusterSnapshotTest {
 
             @Mock
             public long getNextId() {
-                return 0L;
+                nextId = nextId + 1;
+                return nextId;
             }
         };
 
@@ -309,5 +316,71 @@ public class ClusterSnapshotTest {
             }
         }
         setAutomatedSnapshotOff(false);
+    }
+
+    @Test
+    public void testDeletionControl() {
+        new MockUp<RunMode>() {
+            @Mock
+            public boolean isSharedDataMode() {
+                return true;
+            }
+        };
+
+        ClusterSnapshotMgr localClusterSnapshotMgr = new ClusterSnapshotMgr();
+        Assert.assertTrue(localClusterSnapshotMgr.getValidDeletionTimeMsByAutomatedSnapshot() == Long.MAX_VALUE);
+        localClusterSnapshotMgr.setAutomatedSnapshotOn(storageVolumeName);
+        Assert.assertEquals(localClusterSnapshotMgr.getValidDeletionTimeMsByAutomatedSnapshot(), 0L);
+
+        ClusterSnapshotJob job1 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
+        job1.setState(ClusterSnapshotJobState.FINISHED);
+        Assert.assertEquals(localClusterSnapshotMgr.getValidDeletionTimeMsByAutomatedSnapshot(), 0L);
+        ClusterSnapshotJob job2 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
+        job2.setState(ClusterSnapshotJobState.FINISHED);
+        Assert.assertEquals(localClusterSnapshotMgr.getValidDeletionTimeMsByAutomatedSnapshot(), job1.getCreatedTimeMs());
+        localClusterSnapshotMgr.setAutomatedSnapshotOff();
+
+        localClusterSnapshotMgr = new ClusterSnapshotMgr();
+        Assert.assertTrue(localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(10));
+        AlterJobV2 alterjob1 = new SchemaChangeJobV2(1, 2, 10, "table1", 100000);
+        AlterJobV2 alterjob2 = new SchemaChangeJobV2(2, 2, 11, "table2", 100000);
+        alterjob1.setJobState(AlterJobV2.JobState.FINISHED);
+        alterjob1.setFinishedTimeMs(1000);
+        alterjob2.setJobState(AlterJobV2.JobState.FINISHED);
+        alterjob2.setFinishedTimeMs(1000);
+
+
+        MaterializedViewHandler rollupHandler = new MaterializedViewHandler();
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+        schemaChangeHandler.addAlterJobV2(alterjob1);
+        schemaChangeHandler.addAlterJobV2(alterjob2);
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public SchemaChangeHandler getSchemaChangeHandler() {
+                return schemaChangeHandler;
+            }
+
+            @Mock
+            public MaterializedViewHandler getRollupHandler() {
+                return rollupHandler;
+            }
+        };
+
+        localClusterSnapshotMgr.setAutomatedSnapshotOn(storageVolumeName);
+        Assert.assertTrue(!localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(10));
+        Assert.assertTrue(!localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(11));
+        ClusterSnapshotJob j1 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
+        j1.setState(ClusterSnapshotJobState.FINISHED);
+
+        Assert.assertTrue(!localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(10));
+        Assert.assertTrue(!localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(11));
+
+        ClusterSnapshotJob j2 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
+        j2.setState(ClusterSnapshotJobState.FINISHED);
+
+        Assert.assertTrue(localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(10));
+        Assert.assertTrue(localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(11));
+        localClusterSnapshotMgr.setAutomatedSnapshotOff();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -43,6 +43,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.concurrent.lock.LockManager;
+import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.proto.DeleteTabletRequest;
 import com.starrocks.proto.DeleteTabletResponse;
 import com.starrocks.proto.StatusPB;
@@ -148,6 +149,10 @@ public class StarMgrMetaSyncerTest {
                 globalStateMgr.getGtidGenerator();
                 minTimes = 0;
                 result = new GtidGenerator();
+
+                globalStateMgr.getClusterSnapshotMgr();
+                minTimes = 0;
+                result = new ClusterSnapshotMgr();
             }
         };
 


### PR DESCRIPTION
## What I'm doing:
This is part 4 for Support Cluster Snapshot Backup
In this pr, we support deletion control to keep the files in BE/CN side needed by the
current cluster snapshot. The basic idea is following:
1. Introduce the deletion valid time stamp, which is the previous created time for automated
   cluster snapshot, called `ValidDeletionTimeMs`
2. Use `ValidDeletionTimeMs` for vacuum.
3. Use `ValidDeletionTimeMs` to filter for partition/table in recycleBin
4. Use `ValidDeletionTimeMs` to filter alter job

Fixes #53867
https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0