### PR TITLE
[BugFix] Fix NPE in HeartbeatMgr when FE node is not available

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -356,7 +356,7 @@ public class Util {
     //      Base64.encodeBase64String("user:passwd".getBytes());
     // If no auth info, pass a null.
     public static String getResultForUrl(String urlStr, String encodedAuthInfo, int connectTimeoutMs,
-                                         int readTimeoutMs) {
+                                         int readTimeoutMs) throws Exception {
         StringBuilder sb = new StringBuilder();
         InputStream stream = null;
         String safeUrl = urlStr;
@@ -379,7 +379,7 @@ public class Util {
             }
         } catch (Exception e) {
             LOG.warn("failed to get result from url: {}. {}", safeUrl, e.getMessage());
-            return null;
+            throw e;
         } finally {
             if (stream != null) {
                 try {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/UtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/UtilTest.java
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UtilTest {
+
+    @Test
+    public void testGetResultForUrl() {
+        Assert.assertThrows(Exception.class,
+                () -> Util.getResultForUrl("http://127.0.0.1:23/invalid", null, 1000, 1000));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes 
```
Cannot invoke "com.starrocks.http.rest.BootstrapFinishAction$BootstrapResult.getStatus()" because "result" is null
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0