### PR TITLE
[Enhancement] Support dynamic modification of `datacache.enable` in shared-data cluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -49,6 +49,7 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.persist.AlterViewInfo;
 import com.starrocks.persist.BatchModifyPartitionsInfo;
 import com.starrocks.persist.ModifyPartitionInfo;
@@ -100,6 +101,7 @@ import org.threeten.extra.PeriodDuration;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -711,6 +713,10 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
         if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
             throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
         }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE) &&
+                !olapTable.isCloudNativeTableOrMaterializedView()) {
+            throw new DdlException("Property 'datacache.enable' is only supported in shared-data mode");
+        }
 
         for (String partitionName : partitionNames) {
             Partition partition = olapTable.getPartition(partitionName);
@@ -747,7 +753,11 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
         TTabletType tTabletType =
                 PropertyAnalyzer.analyzeTabletType(properties);
 
+        // 5. enable data cache
+        boolean newEnableDataCache = PropertyAnalyzer.analyzeDataCacheEnable(properties);
+
         // modify meta here
+        List<Partition> partitionsToUpdateShardGroup = new ArrayList<>();
         for (String partitionName : partitionNames) {
             Partition partition = olapTable.getPartition(partitionName);
             // 1. date property
@@ -799,9 +809,40 @@ public class AlterJobExecutor implements AstVisitor<Void, ConnectContext> {
             if (tTabletType != partitionInfo.getTabletType(partition.getId())) {
                 partitionInfo.setTabletType(partition.getId(), tTabletType);
             }
+            // 5. enable data cache
+            if (olapTable.isCloudNativeTableOrMaterializedView()) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                if (dataCacheInfo == null || newEnableDataCache != dataCacheInfo.isEnabled()) {
+                    partitionsToUpdateShardGroup.add(olapTable.getPartition(partitionName));
+                    boolean asyncWriteBack = dataCacheInfo != null && dataCacheInfo.isAsyncWriteBack();
+                    partitionInfo.setDataCacheInfo(partition.getId(), new DataCacheInfo(newEnableDataCache, asyncWriteBack));
+                }
+            }
             ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), olapTable.getId(), partition.getId(),
-                    newDataProperty, newReplicationNum, hasInMemory ? newInMemory : oldInMemory);
+                    newDataProperty, newReplicationNum, hasInMemory ? newInMemory : oldInMemory, newEnableDataCache);
             modifyPartitionInfos.add(info);
+        }
+
+        if (!partitionsToUpdateShardGroup.isEmpty()) {
+            // The updateShardGroup function is called centrally here, rather than iteratively within a for-loop, to
+            // ensure that updateShardGroup and the persistence of ModifyPartitionInfo are closely enough,
+            // thereby preventing metadata inconsistency.
+            try {
+                GlobalStateMgr.getCurrentState().getStarOSAgent().updateShardGroup(
+                        partitionsToUpdateShardGroup, newEnableDataCache);
+            } catch (DdlException e) {
+                // Revert changes above and then CONTINUE the alter job for the other properties
+                // This means that if multiple properties are set at the same time, there may be only partial success!
+                for (ModifyPartitionInfo info : modifyPartitionInfos) {
+                    // revert changes in partitionInfo
+                    DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(info.getPartitionId());
+                    partitionInfo.setDataCacheInfo(info.getPartitionId(),
+                            new DataCacheInfo(dataCacheInfo.isAsyncWriteBack(), !newEnableDataCache));
+                    // revert changes in modifyPartitionInfos
+                    info.setDataCacheEnable(!newEnableDataCache);
+                }
+                LOG.error(e.getMessage());
+            }
         }
 
         // log here

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -61,6 +61,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
 import com.starrocks.persist.AlterMaterializedViewStatusLog;
 import com.starrocks.persist.AlterViewInfo;
@@ -567,6 +568,12 @@ public class AlterJobMgr {
                 if (partitionInfo.getType() == PartitionType.UNPARTITIONED) {
                     olapTable.setReplicationNum(replicationNum);
                 }
+            }
+            if (olapTable.isCloudNativeTable()) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(info.getPartitionId());
+                boolean asyncWriteBack = dataCacheInfo == null ? false : dataCacheInfo.isAsyncWriteBack();
+                partitionInfo.setDataCacheInfo(info.getPartitionId(),
+                        new DataCacheInfo(info.getDataCacheEnable(), asyncWriteBack));
             }
             partitionInfo.setIsInMemory(info.getPartitionId(), info.isInMemory());
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2737,6 +2737,15 @@ public class OlapTable extends Table {
         tableProperty.buildDataCachePartitionDuration();
     }
 
+    public void setDataCacheEnable(boolean isEnable) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE,
+                Boolean.valueOf(isEnable).toString());
+        tableProperty.buildDataCacheEnable();
+    }
+
     public void setStorageCoolDownTTL(PeriodDuration duration) {
         if (tableProperty == null) {
             tableProperty = new TableProperty(new HashMap<>());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -396,6 +396,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildDataCachePartitionDuration();
                 buildLocation();
                 buildStorageCoolDownTTL();
+                buildDataCacheEnable();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -773,6 +774,19 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildDataCacheEnable() {
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            boolean dataCacheEnable = Boolean.parseBoolean(
+                    properties.getOrDefault(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false"));
+            if (this.storageInfo != null) {
+                this.storageInfo.setDataCacheEnable(dataCacheEnable);
+            } else {
+                LOG.warn("Setting datacache.enable to {} while storage info is null", dataCacheEnable);
+            }
+        }
+        return this;
+    }
+
     public TableProperty buildStorageCoolDownTTL() {
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)) {
             String storageCoolDownTTL = properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL);
@@ -1111,5 +1125,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildMvProperties();
         buildLocation();
         buildBaseCompactionForbiddenTimeRanges();
+        buildDataCacheEnable();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1371,6 +1371,10 @@ public class PropertyAnalyzer {
         }
     }
 
+    public static boolean analyzeDataCacheEnable(Map<String, String> properties) throws AnalysisException {
+        return analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, true);
+    }
+
     public static TPersistentIndexType analyzePersistentIndexType(Map<String, String> properties) throws AnalysisException {
         if (properties != null && properties.containsKey(PROPERTIES_PERSISTENT_INDEX_TYPE)) {
             String type = properties.get(PROPERTIES_PERSISTENT_INDEX_TYPE);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import com.staros.client.StarClient;
 import com.staros.client.StarClientException;
 import com.staros.manager.StarManagerServer;
+import com.staros.proto.CacheEnableState;
 import com.staros.proto.CreateMetaGroupInfo;
 import com.staros.proto.CreateShardGroupInfo;
 import com.staros.proto.CreateShardInfo;
@@ -42,10 +43,12 @@ import com.staros.proto.ShardGroupInfo;
 import com.staros.proto.ShardInfo;
 import com.staros.proto.StatusCode;
 import com.staros.proto.UpdateMetaGroupInfo;
+import com.staros.proto.UpdateShardGroupInfo;
 import com.staros.proto.WorkerGroupDetailInfo;
 import com.staros.proto.WorkerGroupSpec;
 import com.staros.proto.WorkerInfo;
 import com.staros.util.LockCloseable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.InternalErrorCode;
@@ -513,6 +516,27 @@ public class StarOSAgent {
 
         Preconditions.checkState(shardInfos.size() == numShards);
         return shardInfos.stream().map(ShardInfo::getShardId).collect(Collectors.toList());
+    }
+
+    public void updateShardGroup(List<Partition> partitionsList, boolean enableCache) throws DdlException {
+        try {
+            List<UpdateShardGroupInfo> updateShardGroupInfoList = new ArrayList<>(partitionsList.size());
+            for (Partition partition : partitionsList) {
+                updateShardGroupInfoList.add(
+                        UpdateShardGroupInfo.newBuilder()
+                                .setGroupId(partition.getShardGroupId())
+                                .setEnableCache(enableCache ? CacheEnableState.ENABLED : CacheEnableState.DISABLED)
+                                .build());
+            }
+            client.updateShardGroup(serviceId, updateShardGroupInfoList);
+        } catch (StarClientException e) {
+            StringBuilder partitionNamesBuilder = new StringBuilder();
+            for (Partition partition : partitionsList) {
+                partitionNamesBuilder.append(partition.getName()).append(" ");
+            }
+            throw new DdlException("Failed to alter partition shardGroups, PartitionNames: " +
+                    partitionNamesBuilder.toString().trim() + e.getMessage());
+        }
     }
 
     public List<Long> listShard(long groupId) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
@@ -59,6 +59,10 @@ public class StorageInfo implements GsonPreProcessable, GsonPostProcessable {
         return new DataCacheInfo(getCacheInfo());
     }
 
+    public void setDataCacheEnable(boolean isEnable) {
+        this.cacheInfo = this.cacheInfo.toBuilder().setEnableCache(isEnable).build();
+    }
+
     @Override
     public void gsonPreProcess() throws IOException {
         if (storeInfo != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ModifyPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ModifyPartitionInfo.java
@@ -53,6 +53,8 @@ public class ModifyPartitionInfo implements Writable {
     private short replicationNum;
     @SerializedName(value = "isInMemory")
     private boolean isInMemory;
+    @SerializedName(value = "dataCacheEnable")
+    private boolean dataCacheEnable;
 
     public ModifyPartitionInfo() {
         // for persist
@@ -60,13 +62,14 @@ public class ModifyPartitionInfo implements Writable {
 
     public ModifyPartitionInfo(long dbId, long tableId, long partitionId,
                                DataProperty dataProperty, short replicationNum,
-                               boolean isInMemory) {
+                               boolean isInMemory, boolean dataCacheEnable) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.partitionId = partitionId;
         this.dataProperty = dataProperty;
         this.replicationNum = replicationNum;
         this.isInMemory = isInMemory;
+        this.dataCacheEnable = dataCacheEnable;
     }
 
     public long getDbId() {
@@ -93,6 +96,14 @@ public class ModifyPartitionInfo implements Writable {
         return isInMemory;
     }
 
+    public boolean getDataCacheEnable() {
+        return dataCacheEnable;
+    }
+
+    public void setDataCacheEnable(boolean isEnable) {
+        this.dataCacheEnable = isEnable;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hashCode(dbId, tableId);
@@ -109,7 +120,7 @@ public class ModifyPartitionInfo implements Writable {
         ModifyPartitionInfo otherInfo = (ModifyPartitionInfo) other;
         return dbId == otherInfo.getDbId() && tableId == otherInfo.getTableId() &&
                 dataProperty.equals(otherInfo.getDataProperty()) && replicationNum == otherInfo.getReplicationNum()
-                && isInMemory == otherInfo.isInMemory();
+                && isInMemory == otherInfo.isInMemory() && dataCacheEnable == otherInfo.getDataCacheEnable();
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -140,6 +140,7 @@ import com.starrocks.persist.AutoIncrementInfo;
 import com.starrocks.persist.BackendIdsUpdateInfo;
 import com.starrocks.persist.BackendTabletsInfo;
 import com.starrocks.persist.BatchDeleteReplicaInfo;
+import com.starrocks.persist.BatchModifyPartitionsInfo;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.persist.ColumnRenameInfo;
 import com.starrocks.persist.CreateDbInfo;
@@ -2708,7 +2709,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                                             partition.getId(),
                                             hdd,
                                             (short) -1,
-                                            partitionInfo.getIsInMemory(partition.getId()));
+                                            partitionInfo.getIsInMemory(partition.getId()),
+                                            partitionInfo.getDataCacheInfo(partition.getId()) != null &&
+                                                    partitionInfo.getDataCacheInfo(partition.getId()).isEnabled());
                             GlobalStateMgr.getCurrentState().getEditLog().logModifyPartition(info);
                         }
                     } // end for partitions
@@ -3602,7 +3605,6 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                                 ImmutableMap.of(key, propertiesToPersist.get(key)));
                 GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
             }
-
             if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
                 Pair<String, PeriodDuration> ttlDuration = (Pair<String, PeriodDuration>) results.get(key);
                 tableProperty.getProperties().put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL, ttlDuration.first);
@@ -3624,12 +3626,56 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                     GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().removeTtlPartitionTable(db.getId(),
                             table.getId());
                 } else {
-                    GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().registerTtlPartitionTable(db.getId(),
-                            table.getId());
+                    GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler()
+                            .registerTtlPartitionTable(db.getId(),
+                                    table.getId());
                 }
                 ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(),
                         ImmutableMap.of(key, propertiesToPersist.get(key)));
                 GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
+            }
+            if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+                String dataCacheEnable = propertiesToPersist.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE);
+                boolean isEnable = Boolean.parseBoolean(dataCacheEnable);
+
+                Locker locker = new Locker();
+                locker.lockDatabase(db, LockType.WRITE);
+                try {
+                    if ((table instanceof LakeTable) || (table instanceof LakeMaterializedView)) {
+                        Collection<Partition> partitions = table.getPartitions();
+                        List<Partition> partitionsList = new ArrayList<>(partitions);
+                        GlobalStateMgr.getCurrentState().getStarOSAgent().updateShardGroup(partitionsList, isEnable);
+                    } else {
+                        throw new DdlException("Property 'datacache.enable' is only supported in shared-data mode");
+                    }
+                    tableProperty.getProperties().put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, dataCacheEnable);
+                    tableProperty.buildDataCacheEnable();
+
+                    // When modifying table's datacache.enable, you also need to modify the datacache info in the partitions.
+                    Collection<Partition> partitions = table.getPartitions();
+                    PartitionInfo partitionInfo = table.getPartitionInfo();
+                    List<ModifyPartitionInfo> modifyPartitionInfos = Lists.newArrayList();
+                    for (Partition partition : partitions) {
+                        DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                        boolean asyncWriteBack = dataCacheInfo != null && dataCacheInfo.isAsyncWriteBack();
+                        partitionInfo.setDataCacheInfo(partition.getId(), new DataCacheInfo(isEnable, asyncWriteBack));
+
+                        ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), table.getId(), partition.getId(),
+                                null, // DataProperty, Setting it to null means it will have no effect during replay.
+                                (short) -1,   // ReplicationNum, Setting it to -1 means it will have no effect during replay.
+                                partitionInfo.getIsInMemory(partition.getId()), isEnable);
+                        modifyPartitionInfos.add(info);
+                    }
+                    GlobalStateMgr.getCurrentState().getEditLog().logBatchModifyPartition(
+                            new BatchModifyPartitionsInfo(modifyPartitionInfos));
+
+                    ModifyTablePropertyOperationLog info =
+                            new ModifyTablePropertyOperationLog(db.getId(), table.getId(),
+                                    ImmutableMap.of(key, propertiesToPersist.get(key)));
+                    GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
+                } finally {
+                    locker.unLockDatabase(db, LockType.WRITE);
+                }
             }
         }
     }
@@ -3709,6 +3755,14 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             String locations = PropertyAnalyzer.analyzeLocation(properties, true);
             results.put(PropertyAnalyzer.PROPERTIES_LABELS_LOCATION, locations);
         }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            try {
+                PropertyAnalyzer.analyzeDataCacheEnable(properties);
+                results.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, null);
+            } catch (AnalysisException ex) {
+                throw new RuntimeException(ex.getMessage());
+            }
+        }
         if (!properties.isEmpty()) {
             throw new DdlException("Modify failed because unknown properties: " + properties);
         }
@@ -3758,7 +3812,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         // log
         ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), table.getId(), partition.getId(),
-                newDataProperty, replicationNum, isInMemory);
+                newDataProperty, replicationNum, isInMemory,
+                partitionInfo.getDataCacheInfo(partition.getId()) != null &&
+                        partitionInfo.getDataCacheInfo(partition.getId()).isEnabled());
         GlobalStateMgr.getCurrentState().getEditLog().logModifyPartition(info);
         LOG.info("modify partition[{}-{}-{}] replication num to {}", db.getOriginName(), table.getName(),
                 partition.getName(), replicationNum);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -341,6 +341,13 @@ public class AlterTableClauseAnalyzer implements AstVisitor<Void, ConnectContext
             } catch (DateTimeParseException e) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, e.getMessage());
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE).equalsIgnoreCase("true") &&
+                    !properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE).equalsIgnoreCase("false")) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE +
+                                " must be bool type(false/true)");
+            }
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/PropertyAnalyzerTest.java
@@ -57,4 +57,33 @@ public class PropertyAnalyzerTest {
             Assert.assertEquals("Cannot parse text to Duration", e.getMessage());
         }
     }
+
+    @Test
+    public void testAnalyzeDataCacheEnable() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+
+        try {
+            Assert.assertTrue(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assert.assertTrue(false);
+        }
+
+        Assert.assertTrue(properties.size() == 0);
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false");
+        try {
+            Assert.assertFalse(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assert.assertTrue(false);
+        }
+
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "abcd");
+        // If the string passed in is not "true" (ignoring case),
+        // analyzeDataCacheEnable will return false instead of throwing an exception
+        try {
+            Assert.assertFalse(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assert.assertTrue(false);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ModifyDatacaheEnableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ModifyDatacaheEnableTest.java
@@ -1,0 +1,356 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ModifyDatacaheEnableTest {
+    private static final Logger LOG = LogManager.getLogger(ModifyDatacaheEnableTest.class);
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        // create database
+        String createDbStmtStr = "create database lake_test;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
+
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "CREATE TABLE IF NOT EXISTS `lake_test`.`lake_table` (\n" +
+                        "    `recruit_date`  DATE           NOT NULL COMMENT 'YYYY-MM-DD',\n" +
+                        "    `region_num`    TINYINT        COMMENT 'range [-128, 127]',\n" +
+                        "    `num_plate`     SMALLINT       COMMENT 'range [-32768, 32767]',\n" +
+                        "    `tel`           INT            COMMENT 'range [-2147483648, 2147483647]',\n" +
+                        "    `id`            BIGINT         COMMENT 'range [-2^63 + 1 ~ 2^63 - 1]',\n" +
+                        "    `password`      LARGEINT       COMMENT 'range [-2^127 + 1 ~ 2^127 - 1]',\n" +
+                        "    `name`          CHAR(20)       NOT NULL COMMENT 'range char(m),m in (1-255)',\n" +
+                        "    `profile`       VARCHAR(500)   NOT NULL COMMENT 'upper limit value 1048576 bytes',\n" +
+                        "    `hobby`         STRING         NOT NULL COMMENT 'upper limit value 65533 bytes',\n" +
+                        "    `leave_time`    DATETIME       COMMENT 'YYYY-MM-DD HH:MM:SS'\n" +
+                        ") ENGINE=OLAP\n" +
+                        "DUPLICATE KEY(`recruit_date`, `region_num`)\n" +
+                        "PARTITION BY RANGE(`recruit_date`)\n" +
+                        "(\n" +
+                        "    PARTITION p1 VALUES [('2022-03-11'), ('2022-03-12')),\n" +
+                        "    PARTITION p2 VALUES [('2022-03-12'), ('2022-03-13')),\n" +
+                        "    PARTITION p3 VALUES [('2022-03-13'), ('2022-03-14')),\n" +
+                        "    PARTITION p4 VALUES [('2022-03-14'), ('2022-03-15')),\n" +
+                        "    PARTITION p5 VALUES [('2022-03-15'), ('2022-03-16'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(`recruit_date`, `region_num`) BUCKETS 100\n" +
+                        "PROPERTIES (\n" +
+                        "    'datacache.partition_duration' = '1 days',\n" +
+                        "    'datacache.enable' = 'true',\n" +
+                        "    'storage_volume' = 'builtin_storage_volume',\n" +
+                        "    'enable_async_write_back' = 'false',\n" +
+                        "    'enable_persistent_index' = 'false'\n" +
+                        ");"
+        ));
+
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "CREATE TABLE IF NOT EXISTS `lake_test`.`base` (\n" +
+                        "    `k1` date NULL,\n" +
+                        "    `k2` int(11) NULL,\n" +
+                        "    `v1` int(11) SUM NULL\n" +
+                        ") ENGINE=OLAP\n" +
+                        "AGGREGATE KEY(`k1`, `k2`)\n" +
+                        "COMMENT 'OLAP'\n" +
+                        "PARTITION BY RANGE(`k1`)\n" +
+                        "(\n" +
+                        "    PARTITION p1 VALUES [('0000-01-01'), ('2020-02-01')),\n" +
+                        "    PARTITION p2 VALUES [('2020-02-01'), ('2020-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n" +
+                        "PROPERTIES (\n" +
+                        "    'replication_num' = '1',\n" +
+                        "    'datacache.enable' = 'true'\n" +
+                        ");"
+        ));
+        checkLakeTable("lake_test", "base");
+        ExceptionChecker.expectThrowsNoException(() -> createMaterializedView(
+                "CREATE MATERIALIZED VIEW `lake_test`.`lake_mv`\n" +
+                        "DISTRIBUTED BY HASH(`k1`)\n" +
+                        "PROPERTIES (\n" +
+                        "    'replication_num' = '1',\n" +
+                        "    'datacache.enable' = 'true',\n" +
+                        "    'datacache.partition_duration' = '25 hour'\n" +
+                        ")\n" +
+                        "AS SELECT `k1` FROM `lake_test`.`base`;"
+        ));
+        checkMaterializedView("lake_test", "lake_mv");
+
+        new MockUp<Preconditions>() {
+            @Mock
+            public void checkArgument(boolean param) {
+
+            }
+        };
+    }
+
+    @AfterClass
+    public static void afterClass() {
+    }
+
+    private static void createTable(String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+    }
+
+    private static void createMaterializedView(String sql) throws Exception {
+        CreateMaterializedViewStatement createMVStmt =
+                (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createMVStmt);
+    }
+
+    private static void checkLakeTable(String dbName, String tableName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Table table = db.getTable(tableName);
+        Assert.assertTrue(table.isCloudNativeTable());
+    }
+
+    private static void checkMaterializedView(String dbName, String mvName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        List<MaterializedView> mvsList = db.getMaterializedViews();
+        for (MaterializedView lakeMv : mvsList) {
+            Assert.assertTrue(lakeMv.isCloudNativeMaterializedView());
+        }
+    }
+
+    private LakeTable getLakeTable(String dbName, String tableName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Table table = db.getTable(tableName);
+        Assert.assertTrue(table.isCloudNativeTable());
+        return (LakeTable) table;
+    }
+
+    private LakeMaterializedView getMaterializedView(String dbName, String mvName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        List<MaterializedView> mvsList = db.getMaterializedViews();
+        for (MaterializedView lakeMv : mvsList) {
+            if (lakeMv.getName().equals(mvName)) {
+                return (LakeMaterializedView) lakeMv;
+            }
+        }
+        return null;
+    }
+
+    private static void alterTableProperties(String dbName, String tableName, boolean isEnable) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        OlapTable table = (OlapTable) db.getTable(tableName);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, String.valueOf(isEnable));
+        ExceptionChecker.expectThrowsNoException(() ->
+                GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, table, properties));
+    }
+
+    private static void alterPartitionProperties(String dbName, String tableName,
+            List<String> partitionNames, boolean isEnable) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        OlapTable table = (OlapTable) db.getTable(tableName);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, String.valueOf(isEnable));
+        ExceptionChecker.expectThrowsNoException(() ->
+                GlobalStateMgr.getCurrentState().getAlterJobMgr().modifyPartitionsProperty(
+                        db, table, partitionNames, properties));
+    }
+
+    @Test
+    public void testModifyTableDatacacheEnable() throws UserException {
+        LakeTable table = getLakeTable("lake_test", "lake_table");
+        { // check the original state of datacache.enable
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertTrue(dataCacheInfo.isEnabled());
+            }
+        }
+        alterTableProperties("lake_test", "lake_table", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertFalse(dataCacheInfo.isEnabled());
+            }
+        }
+        alterPartitionProperties("lake_test", "lake_table", List.of("p1", "p2"), true);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                if (partition.getName().equals("p1") || partition.getName().equals("p2")) {
+                    Assert.assertTrue(dataCacheInfo.isEnabled());
+                } else {
+                    Assert.assertFalse(dataCacheInfo.isEnabled());
+                }
+            }
+        }
+        alterTableProperties("lake_test", "lake_table", true);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertTrue(dataCacheInfo.isEnabled());
+            }
+        }
+        alterPartitionProperties("lake_test", "lake_table", List.of("p4", "p5"), false);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                if (partition.getName().equals("p4") || partition.getName().equals("p5")) {
+                    Assert.assertFalse(dataCacheInfo.isEnabled());
+                } else {
+                    Assert.assertTrue(dataCacheInfo.isEnabled());
+                }
+            }
+        }
+        alterTableProperties("lake_test", "lake_table", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertFalse(dataCacheInfo.isEnabled());
+            }
+        }
+    }
+
+    @Test
+    public void testModifyPartitionDatacacheEnable() throws UserException {
+        LakeMaterializedView lakeMv = getMaterializedView("lake_test", "lake_mv");
+        { // check the original state of datacache.enable
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertTrue(dataCacheInfo.isEnabled());
+        }
+        alterTableProperties("lake_test", "lake_mv", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertFalse(dataCacheInfo.isEnabled());
+        }
+        alterPartitionProperties("lake_test", "lake_mv", List.of("lake_mv"), true);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertTrue(dataCacheInfo.isEnabled());
+        }
+        alterTableProperties("lake_test", "lake_mv", true);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertTrue(dataCacheInfo.isEnabled());
+        }
+        alterPartitionProperties("lake_test", "lake_mv", List.of("lake_mv"), false);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertFalse(dataCacheInfo.isEnabled());
+        }
+        alterTableProperties("lake_test", "lake_mv", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertFalse(dataCacheInfo.isEnabled());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/persist/BatchModifyPartitionsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/BatchModifyPartitionsInfoTest.java
@@ -56,7 +56,7 @@ public class BatchModifyPartitionsInfoTest {
         List<Long> partitionIds = Lists.newArrayList(PARTITION_ID_1, PARTITION_ID_2, PARTITION_ID_3);
         for (long partitionId : partitionIds) {
             partitionInfos.add(new ModifyPartitionInfo(DB_ID, TB_ID, partitionId,
-                    DataProperty.DEFAULT_DATA_PROPERTY, (short) 3, true));
+                    DataProperty.DEFAULT_DATA_PROPERTY, (short) 3, true, false));
         }
 
         BatchModifyPartitionsInfo batchModifyPartitionsInfo = new BatchModifyPartitionsInfo(partitionInfos);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -133,6 +133,9 @@ public class AnalyzeAlterTableStatementTest {
         analyzeSuccess("ALTER TABLE test.t0 SET (\"default.replication_num\" = \"2\");");
         analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.partition_duration\" = \"10 days\");");
         analyzeFail("ALTER TABLE test.t0 SET (\"datacache.partition_duration\" = \"abcd\");", "Cannot parse text to Duration");
+        analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"true\");");
+        analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"false\");");
+        analyzeFail("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"abcd\");", "must be bool type(false/true)");
         analyzeFail("ALTER TABLE test.t0 SET (\"default.replication_num\" = \"2\", \"dynamic_partition.enable\" = \"true\");",
                 "Can only set one table property at a time");
         analyzeFail("ALTER TABLE test.t0 SET (\"abc\" = \"2\");",


### PR DESCRIPTION
## Why I'm doing:
`datacache.enable` property is not modifiable 

## What I'm doing:
Support dynamic modification of datacache.enable

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0