### PR TITLE
[Feature] Supports configuring the default catalog at the global level

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1501,6 +1501,12 @@ public class Config extends ConfigBase {
     public static long catalog_try_lock_timeout_ms = 5000; // 5 sec
 
     /**
+     * Configure the default catalog at the session level.
+     */
+    @ConfField(mutable = true)
+    public static String default_session_catalog = "default_catalog"; // 5 sec
+
+    /**
      * if this is set to true
      * all pending load job will fail when call begin txn api
      * all prepare load job will fail when call commit txn api

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -43,7 +43,7 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.ToNumberPolicy;
-import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.VectorSearchOptions;
@@ -1799,7 +1799,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private String dataCachePopulateMode = DataCachePopulateMode.AUTO.modeName();
 
     @VariableMgr.VarAttr(name = CATALOG, flag = VariableMgr.SESSION_ONLY)
-    private String catalog = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+    private String catalog = Config.default_session_catalog;
 
     public void setCatalog(String catalog) {
         this.catalog = catalog;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AdminSetConfigStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AdminSetConfigStmtTest.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.analysis;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
@@ -76,6 +77,15 @@ public class AdminSetConfigStmtTest {
                 (AdminSetConfigStmt) UtFrameUtils.parseStmtWithNewParser(stmt, connectContext);
         DDLStmtExecutor.execute(adminSetConfigStmt, connectContext);
         Assert.assertEquals("5.1.1", GlobalVariable.version);
+    }
+
+    @Test
+    public void testDefaultSessionCatalog() throws Exception {
+        String stmt = "ADMIN SET FRONTEND CONFIG (\"default_session_catalog\" = \"hive\")";
+        AdminSetConfigStmt adminSetConfigStmt =
+                (AdminSetConfigStmt) UtFrameUtils.parseStmtWithNewParser(stmt, connectContext);
+        DDLStmtExecutor.execute(adminSetConfigStmt, connectContext);
+        Assert.assertEquals(Config.default_session_catalog, "hive");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Supports configuring the default catalog at the session level

**ADMIN SET FRONTEND CONFIG ("default_session_catalog" = "hive")**

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0