### PR TITLE
[Enhancement] deletion bitmap fill skip rows filter in batches

### DIFF
--- a/be/src/connector/deletion_vector/deletion_bitmap.h
+++ b/be/src/connector/deletion_vector/deletion_bitmap.h
@@ -40,6 +40,8 @@ public:
     void to_array(std::vector<uint64_t>& array) const;
 
 private:
+    static const uint64_t kBatchSize = 256;
+
     roaring64_bitmap_t* _bitmap = nullptr;
 };
 

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -335,8 +335,8 @@ void HdfsScanner::do_update_iceberg_v2_counter(RuntimeProfile* parent_profile, c
     COUNTER_UPDATE(delete_file_per_scan_counter, _app_stats.iceberg_delete_files_per_scan);
 }
 
-void HdfsScanner::do_update_deletion_vector_counter(RuntimeProfile* parent_profile) {
-    if (_scanner_ctx.enable_split_tasks && !has_split_tasks()) {
+void HdfsScanner::do_update_deletion_vector_build_counter(RuntimeProfile* parent_profile) {
+    if (_app_stats.deletion_vector_build_count == 0) {
         return;
     }
     const std::string DV_TIMER = DeletionVector::DELETION_VECTOR;
@@ -344,14 +344,22 @@ void HdfsScanner::do_update_deletion_vector_counter(RuntimeProfile* parent_profi
 
     RuntimeProfile::Counter* delete_build_timer =
             ADD_CHILD_COUNTER(parent_profile, "DeletionVectorBuildTime", TUnit::TIME_NS, DV_TIMER);
-    RuntimeProfile::Counter* delete_file_build_filter_timer =
-            ADD_CHILD_COUNTER(parent_profile, "DeletionVectorBuildRowIdFilterTime", TUnit::TIME_NS, DV_TIMER);
+
     RuntimeProfile::Counter* delete_file_per_scan_counter =
             ADD_CHILD_COUNTER(parent_profile, "DeletionVectorBuildCount", TUnit::UNIT, DV_TIMER);
 
     COUNTER_UPDATE(delete_build_timer, _app_stats.deletion_vector_build_ns);
-    COUNTER_UPDATE(delete_file_build_filter_timer, _app_stats.build_rowid_filter_ns);
+
     COUNTER_UPDATE(delete_file_per_scan_counter, _app_stats.deletion_vector_build_count);
+}
+
+void HdfsScanner::do_update_deletion_vector_filter_counter(RuntimeProfile* parent_profile) {
+    const std::string DV_TIMER = DeletionVector::DELETION_VECTOR;
+    ADD_COUNTER(parent_profile, DV_TIMER, TUnit::NONE);
+
+    RuntimeProfile::Counter* delete_file_build_filter_timer =
+            ADD_CHILD_COUNTER(parent_profile, "DeletionVectorBuildRowIdFilterTime", TUnit::TIME_NS, DV_TIMER);
+    COUNTER_UPDATE(delete_file_build_filter_timer, _app_stats.build_rowid_filter_ns);
 }
 
 int64_t HdfsScanner::estimated_mem_usage() const {

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -419,7 +419,8 @@ protected:
     static CompressionTypePB get_compression_type_from_path(const std::string& filename);
 
     void do_update_iceberg_v2_counter(RuntimeProfile* parquet_profile, const std::string& parent_name);
-    void do_update_deletion_vector_counter(RuntimeProfile* parent_profile);
+    void do_update_deletion_vector_build_counter(RuntimeProfile* parent_profile);
+    void do_update_deletion_vector_filter_counter(RuntimeProfile* parent_profile);
 
 private:
     bool _opened = false;

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -62,9 +62,9 @@ Status HdfsParquetScanner::do_init(RuntimeState* runtime_state, const HdfsScanne
 
 void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile* root = profile->runtime_profile;
-    // deletion vector build only in the first task which used for splite sub-tasks,
+    // deletion vector build only in the first task which used for split sub-tasks,
     // and do not need to re-build in sub io tasks.
-    do_update_deletion_vector_counter(root);
+    do_update_deletion_vector_build_counter(root);
     // if we have split tasks, we don't need to update counter
     // and we will update those counters in sub io tasks.
     if (has_split_tasks()) {
@@ -171,6 +171,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     COUNTER_UPDATE(page_skip, _app_stats.page_skip);
     group_min_round_cost->set(_app_stats.group_min_round_cost);
     do_update_iceberg_v2_counter(root, kParquetProfileSectionPrefix);
+    do_update_deletion_vector_filter_counter(root);
     COUNTER_UPDATE(rows_before_page_index, _app_stats.rows_before_page_index);
     COUNTER_UPDATE(page_index_timer, _app_stats.page_index_ns);
     COUNTER_UPDATE(total_row_groups, _app_stats.parquet_total_row_groups);


### PR DESCRIPTION
## Why I'm doing:
In DeletionBitmap, we use `roaring64_iterator_value` and `roaring64_iterator_advance` get value one by one, we could use `roaring64_iterator_read` to read batch size value and fill filter
## What I'm doing:
1. use `roaring64_iterator_read` to replace `roaring64_iterator_value` and `roaring64_iterator_advance`
2. put metric `DeletionVectorBuildRowIdFilterTime` at right place which compute wrong before

## performance
<meta charset="utf-8"><div data-page-id="KlrddwSRGoDeQHxnPTFc3ScWnJg" data-lark-html-role="root" data-docx-has-block-data="true"><div>
  | 0 percent | 5 percent | 10 percent | 30 percent | 50 percent
-- | -- | -- | -- | -- | --
StarRocks  | 4.3s | 5.2s | 5.3s | 5.8s | 5.6s
StarRocks with PR 55022 | 4.3s | 5.0s | 5.2s | **4.9s** | **4.5s**

For query scenarios with a high deletion percent, this optimization can provide better performance.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0