### PR TITLE
[Enhancement] make LIKE operations' statistics consistent

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -613,6 +613,12 @@ public class ExpressionStatisticCalculator {
                     averageRowSize = Math.max(1, left.getAverageRowSize() - right.getAverageRowSize());
                     distinctValues = left.getDistinctValuesCount() * averageRowSize / left.getAverageRowSize();
                     break;
+                case FunctionSet.LIKE:
+                    minValue = left.getMinValue();
+                    maxValue = left.getMaxValue();
+                    averageRowSize = left.getAverageRowSize();
+                    distinctValues = left.getDistinctValuesCount();
+                    break;
                 default:
                     return ColumnStatistic.unknown();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -614,6 +614,7 @@ public class ExpressionStatisticCalculator {
                     distinctValues = left.getDistinctValuesCount() * averageRowSize / left.getAverageRowSize();
                     break;
                 case FunctionSet.LIKE:
+                case FunctionSet.ILIKE:
                     minValue = 0;
                     maxValue = 1;
                     distinctValues = 2;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -614,10 +614,9 @@ public class ExpressionStatisticCalculator {
                     distinctValues = left.getDistinctValuesCount() * averageRowSize / left.getAverageRowSize();
                     break;
                 case FunctionSet.LIKE:
-                    minValue = left.getMinValue();
-                    maxValue = left.getMaxValue();
-                    averageRowSize = left.getAverageRowSize();
-                    distinctValues = left.getDistinctValuesCount();
+                    minValue = 0;
+                    maxValue = 1;
+                    distinctValues = 2;
                     break;
                 default:
                     return ColumnStatistic.unknown();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -506,6 +506,18 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
         Assert.assertEquals(-1, columnStatistic.getMinValue(), 0.001);
         Assert.assertEquals(1, columnStatistic.getMaxValue(), 0.001);
+        
+        callOperator = new CallOperator(FunctionSet.LIKE, Type.BOOLEAN, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(0, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(1, columnStatistic.getMaxValue(), 0.001);
+        Assert.assertEquals(2, columnStatistic.getDistinctValuesCount(), 0.001);
+
+        callOperator = new CallOperator(FunctionSet.ILIKE, Type.BOOLEAN, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(0, columnStatistic.getMinValue(), 0.001);
+        Assert.assertEquals(1, columnStatistic.getMaxValue(), 0.001);
+        Assert.assertEquals(2, columnStatistic.getDistinctValuesCount(), 0.001);
         // test multiply/divide column rang is negative
         builder = Statistics.builder();
         leftStatistic = new ColumnStatistic(-100, -10, 0, 0, 20);


### PR DESCRIPTION
## Why I'm doing:

The `LIKE(column, pattern)` function and the `column LIKE pattern` operator have different statistics in
[ExpressionStatisticCalculator](https://github.com/StarRocks/starrocks/blob/41843adc63d8bb9c968370dc4d97acfb1b1a0685/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java).

This leads to an issue when it's used together with other functions (e.g. `IF`).

Example:
`IF(column LIKE pattern, 'Yes', 'No')` estimates 2 distinct values as expected, however when the same query is executed again as `IF(LIKE(column, pattern), 'Yes', 'No')` the distinct value estimation is now different than 2 because of this check [[1]].

## What I'm doing:
Since they are the same operation, their statistics should be same too. The `LikePredicateOperator` does not have a direct estimation in `ExpressionStatisticCalculator`, instead it takes the statistics of the first child by default [[2]].
With this change, the same applies to the `LIKE` function and it takes the statistics of the first child (left hand side).

[1]: https://github.com/StarRocks/starrocks/blob/41843adc63d8bb9c968370dc4d97acfb1b1a0685/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java#L189
[2]: https://github.com/StarRocks/starrocks/blob/41843adc63d8bb9c968370dc4d97acfb1b1a0685/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java#L74

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0