### PR TITLE
[BugFix] Fix set the gtid of null rowset when publish

### DIFF
--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -109,7 +109,6 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                 task.tablet_id = itr.first.tablet_id;
                 task.version = publish_version_req.partition_version_infos[i].version;
                 task.rowset = std::move(itr.second);
-                task.rowset->rowset_meta()->set_gtid(publish_version_req.gtid);
                 task.is_double_write = publish_version_req.partition_version_infos[i].__isset.is_double_write &&
                                        publish_version_req.partition_version_infos[i].is_double_write;
             }
@@ -148,6 +147,7 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                     std::lock_guard lg(affected_dirs_lock);
                     affected_dirs.insert(tablet->data_dir());
                 }
+                task.rowset->rowset_meta()->set_gtid(publish_version_req.gtid);
                 if (is_replication_txn) {
                     task.st = StorageEngine::instance()->replication_txn_manager()->publish_txn(
                             task.txn_id, task.partition_id, tablet, task.version);

--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -109,6 +109,7 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                 task.tablet_id = itr.first.tablet_id;
                 task.version = publish_version_req.partition_version_infos[i].version;
                 task.rowset = std::move(itr.second);
+                task.rowset->rowset_meta()->set_gtid(publish_version_req.gtid);
                 task.is_double_write = publish_version_req.partition_version_infos[i].__isset.is_double_write &&
                                        publish_version_req.partition_version_infos[i].is_double_write;
             }
@@ -147,7 +148,6 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                     std::lock_guard lg(affected_dirs_lock);
                     affected_dirs.insert(tablet->data_dir());
                 }
-                task.rowset->rowset_meta()->set_gtid(publish_version_req.gtid);
                 if (is_replication_txn) {
                     task.st = StorageEngine::instance()->replication_txn_manager()->publish_txn(
                             task.txn_id, task.partition_id, tablet, task.version);

--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -109,7 +109,10 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                 task.tablet_id = itr.first.tablet_id;
                 task.version = publish_version_req.partition_version_infos[i].version;
                 task.rowset = std::move(itr.second);
-                task.rowset->rowset_meta()->set_gtid(publish_version_req.gtid);
+                // rowset can be nullptr if it just prepared but not committed
+                if (task.rowset != nullptr) {
+                    task.rowset->rowset_meta()->set_gtid(publish_version_req.gtid);
+                }
                 task.is_double_write = publish_version_req.partition_version_infos[i].__isset.is_double_write &&
                                        publish_version_req.partition_version_infos[i].is_double_write;
             }


### PR DESCRIPTION
## Why I'm doing:
rowset in TxnManager can be null if it just prepare but not commit, so should check null before rowset->rowset_meta()->set_gtid(publish_version_req.gtid)

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9051

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0