### PR TITLE
[Doc] use safe package.json yarn.lock

### DIFF
--- a/.github/workflows/ci-doc-checker.yml
+++ b/.github/workflows/ci-doc-checker.yml
@@ -76,17 +76,6 @@ jobs:
           echo "branch=${{github.base_ref}}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-          # `2` gives us `main` and the PR branch. We need main to use an approved package.json
-
-      - name: Store package.json from main in temp dir
-        run: |
-            mkdir -p ${{github.workspace}}/tmp
-            git checkout -q HEAD^ && \
-              cp docs/docusaurus/package.json ${{github.workspace}}/tmp && \
-              cp docs/docusaurus/yarn.lock ${{github.workspace}}/tmp && 
-              git switch -q -
 
       - name: Checkout PR
         run: |
@@ -139,8 +128,8 @@ jobs:
           rm -rf ./docs/release_notes ./docs/ecosystem_release
           mv ../zh ./i18n/zh/docusaurus-plugin-content-docs/current
           rm -rf ./i18n/zh/docusaurus-plugin-content-docs/current/release_notes ./i18n/zh/docusaurus-plugin-content-docs/current/ecosystem_release
-          cp ${{github.workspace}}/tmp/package.json package.json
-          cp ${{github.workspace}}/tmp/yarn.lock yarn.lock          
+          git fetch
+          git checkout origin/main -- docs/docusaurus/package.json docs/docusaurus/yarn.lock         
           yarn install --frozen-lockfile
           yarn clear
           yarn build

--- a/.github/workflows/ci-doc-checker.yml
+++ b/.github/workflows/ci-doc-checker.yml
@@ -77,7 +77,16 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
+          # `2` gives us `main` and the PR branch. We need main to use an approved package.json
+
+      - name: Store package.json from main in temp dir
+        run: |
+            mkdir -p ${{github.workspace}}/tmp
+            git checkout -q HEAD^ && \
+              cp docs/docusaurus/package.json ${{github.workspace}}/tmp && \
+              cp docs/docusaurus/yarn.lock ${{github.workspace}}/tmp && 
+              git switch -q -
 
       - name: Checkout PR
         run: |
@@ -130,6 +139,8 @@ jobs:
           rm -rf ./docs/release_notes ./docs/ecosystem_release
           mv ../zh ./i18n/zh/docusaurus-plugin-content-docs/current
           rm -rf ./i18n/zh/docusaurus-plugin-content-docs/current/release_notes ./i18n/zh/docusaurus-plugin-content-docs/current/ecosystem_release
+          cp ${{github.workspace}}/tmp/package.json package.json
+          cp ${{github.workspace}}/tmp/yarn.lock yarn.lock          
           yarn install --frozen-lockfile
           yarn clear
           yarn build

--- a/docs/en/quick_start/routine-load.md
+++ b/docs/en/quick_start/routine-load.md
@@ -45,7 +45,7 @@ There is a lot of information in this document, and it is presented with step-by
 
 ### SQL client
 
-You can use the SQL client provided in the Docker environment, or use one on your system. Many MySQL-compatible clients will work, and this guide covers the configuration of DBeaver and MySQL WorkBench.
+You can use the SQL client provided in the Docker environment, or use one on your system. Many MySQL-compatible clients will work, and this guide covers the configuration of DBeaver and MySQL Workbench.
 
 ### curl
 

--- a/docs/en/quick_start/routine-load.md
+++ b/docs/en/quick_start/routine-load.md
@@ -45,7 +45,7 @@ There is a lot of information in this document, and it is presented with step-by
 
 ### SQL client
 
-You can use the SQL client provided in the Docker environment, or use one on your system. Many MySQL-compatible clients will work, and this guide covers the configuration of DBeaver and MySQL Workbench.
+You can use the SQL client provided in the Docker environment, or use one on your system. Many MySQL-compatible clients will work, and this guide covers the configuration of DBeaver and MySQL WorkBench.
 
 ### curl
 


### PR DESCRIPTION
Building and running using package.json/yarn.lock files from a PR is not safe. This workflow grabs the files package.json and yarn.lock from `main`

Tested in https://github.com/DanRoscigno/docusarurs-workflow-test/pull/1

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0