### PR TITLE
[BugFix] Fix Timer-check NPE and errorMsg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -923,7 +923,9 @@ public class DefaultCoordinator extends Coordinator {
                     ec = InternalErrorCode.CANCEL_NODE_NOT_ALIVE_ERR;
                 } else if (copyStatus.isTimeout()) {
                     ErrorReport.reportTimeoutException(
-                            ErrorCode.ERR_TIMEOUT, "Query", jobSpec.getQueryOptions().query_timeout, errMsg);
+                            ErrorCode.ERR_TIMEOUT, "Query", jobSpec.getQueryOptions().query_timeout,
+                            String.format("please increase the '%s' session variable and retry",
+                                    SessionVariable.QUERY_TIMEOUT));
                 }
                 throw new StarRocksException(ec, errMsg);
             }


### PR DESCRIPTION
## Why I'm doing:

seems introduced in #50644

fix NPE:
```
 2025-01-09 14:18:29.023+08:00 WARN (Connect-Scheduler-Check-Timer-0|13) [ConnectScheduler$TimeoutChecker.run():121] Timeout checker exception, Internal error : Cannot invoke "com.starrocks.qe.ConnectContext.getSessionVariable()" because the return value of "com.starrocks.qe.ConnectContext.get()" is null
 java.lang.NullPointerException: Cannot invoke "com.starrocks.qe.ConnectContext.getSessionVariable()" because the return value of "com.starrocks.qe.ConnectContext.get()" is null
        at com.starrocks.sql.ast.StatementBase.getTimeout(StatementBase.java:175)
        at com.starrocks.qe.StmtExecutor.getExecTimeout(StmtExecutor.java:492)
        at com.starrocks.qe.ConnectContext.getExecTimeout(ConnectContext.java:997)
        at com.starrocks.qe.ConnectContext.checkTimeout(ConnectContext.java:1035)
        at com.starrocks.qe.ConnectScheduler$TimeoutChecker.run(ConnectScheduler.java:108)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
```

Fix timeout msg:
```
ERROR 5024 (HY000): Query reached its timeout of 2 seconds, Query exceeded time limit of 2 seconds
```
patched:
```
ERROR 5024 (HY000): Query reached its timeout of 2 seconds, please increase the 'query_timeout' session variable and retry
```

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0