### PR TITLE
[UT] Fix unstable CoordinatorBackendAssignerTest

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/CoordinatorBackendAssignerImpl.java
@@ -151,11 +151,14 @@ public final class CoordinatorBackendAssignerImpl implements CoordinatorBackendA
                         task.getScheduleType(), task.getTaskId(), System.currentTimeMillis() - startTime, e);
                 throwable = e;
             } finally {
+                // numExecutedTasks is just for testing. Should update it before calling task.finish()
+                // which may notify the waiting thread. So that after the thread wakes up, it can get
+                // the correct numExecutedTasks including this one.
+                numExecutedTasks.incrementAndGet();
                 task.finish(throwable);
                 if (task.getScheduleType() == EventType.DETECT_UNAVAILABLE_NODES) {
                     numPendingTasksForDetectUnavailableNodes.decrementAndGet();
                 }
-                numExecutedTasks.incrementAndGet();
             }
         }
     }


### PR DESCRIPTION
## Why I'm doing:
`CoordinatorBackendAssignerTest.testUnRegisterBatchWrite` is unstable because  `numExecutedTasks` of `CoordinatorBackendAssignerImpl` may not be updated correctly
```
 [^[[1;31mERROR^[[m] testUnRegisterBatchWrite  Time elapsed: 5.215 s  <<< ERROR!
 org.awaitility.core.ConditionTimeoutException: Condition with com.starrocks.load.batchwrite.CoordinatorBackendAssignerTest was not fulfilled within 5 seconds.
     at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
     at org.awaitility.core.CallableCondition.await(CallableCondition.java:78)
     at org.awaitility.core.CallableCondition.await(CallableCondition.java:26)
     at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:985)
     at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:954)
     at com.starrocks.load.batchwrite.CoordinatorBackendAssignerTest.testUnRegisterBatchWrite(CoordinatorBackendAssignerTest.java:100)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0