### PR TITLE
[Enhancement] Add slow log in load channel

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -466,6 +466,11 @@ CONF_Int32(make_snapshot_rpc_timeout_ms, "20000");
 // OlapTableSink sender's send interval, should be less than the real response time of a tablet writer rpc.
 CONF_mInt32(olap_table_sink_send_interval_ms, "10");
 
+// If load rpc timeout is larger than this value, slow log will be printed every time,
+// if smaller than this value, will reduce slow log print frequency.
+// 0 is print slow log every time.
+CONF_mInt32(load_rpc_slow_log_frequency_threshold_seconds, "60");
+
 CONF_Bool(enable_load_segment_parallel, "false");
 CONF_Int32(load_segment_thread_pool_num_max, "128");
 CONF_Int32(load_segment_thread_pool_queue_size, "10240");

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -156,7 +156,7 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
     }
 }
 
-void LoadChannel::_add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request,
+void LoadChannel::_add_chunk(Chunk* chunk, const MonotonicStopWatch* watch, const PTabletWriterAddChunkRequest& request,
                              PTabletWriterAddBatchResult* response) {
     _num_chunk++;
     _last_updated_time.store(time(nullptr), std::memory_order_relaxed);
@@ -171,7 +171,8 @@ void LoadChannel::_add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& r
     }
     bool close_channel;
     channel->add_chunk(chunk, request, response, &close_channel);
-    if (close_channel && _should_enable_profile()) {
+    if (close_channel &&
+        (_should_enable_profile() || (watch != nullptr && watch->elapsed_time() > request.timeout_ms() * 1000000))) {
         // If close_channel is true, the channel has been removed from _tablets_channels
         // in TabletsChannel::add_chunk, so there will be no chance to get the channel to
         // update the profile later. So update the profile here
@@ -186,9 +187,9 @@ void LoadChannel::add_chunk(const PTabletWriterAddChunkRequest& request, PTablet
         auto& pchunk = request.chunk();
         RETURN_RESPONSE_IF_ERROR(_build_chunk_meta(pchunk), response);
         RETURN_RESPONSE_IF_ERROR(_deserialize_chunk(pchunk, chunk, &uncompressed_buffer), response);
-        _add_chunk(&chunk, request, response);
+        _add_chunk(&chunk, nullptr, request, response);
     } else {
-        _add_chunk(nullptr, request, response);
+        _add_chunk(nullptr, nullptr, request, response);
     }
     report_profile(response, config::pipeline_print_profile);
 }
@@ -205,6 +206,7 @@ void LoadChannel::add_chunks(const PTabletWriterAddChunksRequest& req, PTabletWr
     faststring uncompressed_buffer;
     std::unique_ptr<Chunk> chunk;
     int eos_count = 0;
+    int64_t timeout_ms = -1;
     for (int i = 0; i < req.requests_size(); i++) {
         auto& request = req.requests(i);
         VLOG_RPC << "tablet writer add chunk, id=" << print_id(request.id()) << ", index_id=" << request.index_id()
@@ -214,13 +216,17 @@ void LoadChannel::add_chunks(const PTabletWriterAddChunksRequest& req, PTabletWr
             eos_count = 1;
         }
 
+        if (timeout_ms == -1) {
+            timeout_ms = request.timeout_ms();
+        }
+
         if (i == 0 && request.has_chunk()) {
             chunk = std::make_unique<Chunk>();
             auto& pchunk = request.chunk();
             RETURN_RESPONSE_IF_ERROR(_build_chunk_meta(pchunk), response);
             RETURN_RESPONSE_IF_ERROR(_deserialize_chunk(pchunk, *chunk, &uncompressed_buffer), response);
         }
-        _add_chunk(chunk.get(), request, response);
+        _add_chunk(chunk.get(), &watch, request, response);
 
         if (response->status().status_code() != TStatusCode::OK) {
             LOG(WARNING) << "tablet writer add chunk, id=" << print_id(request.id())
@@ -230,10 +236,26 @@ void LoadChannel::add_chunks(const PTabletWriterAddChunksRequest& req, PTabletWr
             break;
         }
     }
+
+    int64_t total_time_us = watch.elapsed_time() / 1000;
     StarRocksMetrics::instance()->load_channel_add_chunks_total.increment(1);
     StarRocksMetrics::instance()->load_channel_add_chunks_eos_total.increment(eos_count);
-    StarRocksMetrics::instance()->load_channel_add_chunks_duration_us.increment(watch.elapsed_time() / 1000);
-    report_profile(response, config::pipeline_print_profile);
+    StarRocksMetrics::instance()->load_channel_add_chunks_duration_us.increment(total_time_us);
+
+    if (total_time_us > timeout_ms * 1000) {
+        // update profile
+        auto channels = _get_all_channels();
+        for (auto& channel : channels) {
+            channel->update_profile();
+        }
+
+        std::stringstream ss;
+        _root_profile->pretty_print(&ss);
+        LOG(WARNING) << "tablet writer add chunk timeout. txn_id=" << _txn_id << ", cost=" << total_time_us / 1000
+                     << "ms, timeout=" << timeout_ms << "ms, profile=" << ss.str();
+    } else {
+        report_profile(response, config::pipeline_print_profile);
+    }
 }
 
 void LoadChannel::add_segment(brpc::Controller* cntl, const PTabletWriterAddSegmentRequest* request,

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -254,9 +254,15 @@ void LoadChannel::add_chunks(const PTabletWriterAddChunksRequest& req, PTabletWr
 
         std::stringstream ss;
         _root_profile->pretty_print(&ss);
-        LOG_EVERY_N(WARNING, timeout_ms > config::load_rpc_slow_log_frequency_threshold_seconds ? 1 : 10)
-                << "tablet writer add chunk timeout. txn_id=" << _txn_id << ", cost=" << total_time_us / 1000
-                << "ms, timeout=" << timeout_ms << "ms, profile=" << ss.str();
+        if (timeout_ms > config::load_rpc_slow_log_frequency_threshold_seconds) {
+            LOG(WARNING) << "tablet writer add chunk timeout. txn_id=" << _txn_id << ", cost=" << total_time_us / 1000
+                         << "ms, timeout=" << timeout_ms << "ms, profile=" << ss.str();
+        } else {
+            // reduce slow log print frequency if the log job is small batch and high frequency
+            LOG_EVERY_N(WARNING, 10) << "tablet writer add chunk timeout. txn_id=" << _txn_id
+                                     << ", cost=" << total_time_us / 1000 << "ms, timeout=" << timeout_ms
+                                     << "ms, profile=" << ss.str();
+        }
     }
 }
 

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -123,7 +123,8 @@ public:
     void report_profile(PTabletWriterAddBatchResult* result, bool print_profile);
 
 private:
-    void _add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response);
+    void _add_chunk(Chunk* chunk, const MonotonicStopWatch* watch, const PTabletWriterAddChunkRequest& request,
+                    PTabletWriterAddBatchResult* response);
     Status _build_chunk_meta(const ChunkPB& pb_chunk);
     Status _deserialize_chunk(const ChunkPB& pchunk, Chunk& chunk, faststring* uncompressed_buffer);
     bool _should_enable_profile();

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -76,9 +76,12 @@ LocalTabletsChannel::LocalTabletsChannel(LoadChannel* load_channel, const Tablet
     _add_row_num = ADD_COUNTER(_profile, "AddRowNum", TUnit::UNIT);
     _add_chunk_timer = ADD_TIMER(_profile, "AddChunkRpcTime");
     _wait_flush_timer = ADD_CHILD_TIMER(_profile, "WaitFlushTime", "AddChunkRpcTime");
+    _submit_write_task_timer = ADD_CHILD_TIMER(_profile, "SubmitWriteTaskTime", "AddChunkRpcTime");
+    _submit_commit_task_timer = ADD_CHILD_TIMER(_profile, "SubmitCommitTaskTime", "AddChunkRpcTime");
     _wait_write_timer = ADD_CHILD_TIMER(_profile, "WaitWriteTime", "AddChunkRpcTime");
     _wait_replica_timer = ADD_CHILD_TIMER(_profile, "WaitReplicaTime", "AddChunkRpcTime");
     _wait_txn_persist_timer = ADD_CHILD_TIMER(_profile, "WaitTxnPersistTime", "AddChunkRpcTime");
+    _wait_drain_sender_timer = ADD_CHILD_TIMER(_profile, "WaitDrainSenderTime", "AddChunkRpcTime");
     _tablets_profile = std::make_unique<RuntimeProfile>("TabletsProfile");
 }
 
@@ -248,6 +251,7 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     std::unordered_map<int64_t, std::vector<int64_t>> node_id_to_abort_tablets;
     context->set_node_id_to_abort_tablets(&node_id_to_abort_tablets);
 
+    auto start_submit_write_task_ts = watch.elapsed_time();
     int64_t wait_memtable_flush_time_us = 0;
     int32_t total_row_num = 0;
     for (int i = 0; i < channel_size; ++i) {
@@ -295,15 +299,18 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
 
         delta_writer->write(req, cb);
     }
+    auto finish_submit_write_task_ts = watch.elapsed_time();
 
     // _channel_row_idx_start_points no longer used, release it to free memory.
     context->_channel_row_idx_start_points.reset();
 
     // NOTE: Must close sender *AFTER* the write requests submitted, otherwise a delta writer commit request may
     // be executed ahead of the write requests submitted by other senders.
+    auto finish_submit_commit_task_ts = finish_submit_write_task_ts;
     if (request.eos() && _close_sender(request.partition_ids().data(), request.partition_ids_size()) == 0) {
         close_channel = true;
         _commit_tablets(request, context);
+        finish_submit_commit_task_ts = watch.elapsed_time();
     }
 
     // Must reset the context pointer before waiting on the |count_down_latch|,
@@ -416,7 +423,9 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
         // unlock write lock so that incremental open can aquire read lock
         lk.unlock();
         // wait for all senders closed, may be timed out
+        auto start_wait_drain_sender_ts = watch.elapsed_time();
         drain_senders(remain * 1000, msg);
+        COUNTER_UPDATE(_wait_drain_sender_timer, watch.elapsed_time() - start_wait_drain_sender_ts);
     }
 
     int64_t last_execution_time_us = 0;
@@ -446,6 +455,8 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     COUNTER_UPDATE(_add_chunk_timer, watch.elapsed_time());
     COUNTER_UPDATE(_add_row_num, total_row_num);
     COUNTER_UPDATE(_wait_flush_timer, wait_memtable_flush_time_us * 1000);
+    COUNTER_UPDATE(_submit_write_task_timer, finish_submit_write_task_ts - start_submit_write_task_ts);
+    COUNTER_UPDATE(_submit_commit_task_timer, finish_submit_commit_task_ts - finish_submit_write_task_ts);
     COUNTER_UPDATE(_wait_write_timer, wait_writer_ns);
     COUNTER_UPDATE(_wait_replica_timer, wait_replica_ns);
 
@@ -585,7 +596,6 @@ void LocalTabletsChannel::_commit_tablets(const PTabletWriterAddChunkRequest& re
                 } else {
                     auto cb = new WriteCallback(context);
                     delta_writer->commit(cb);
-                    commit_tablet_ids.emplace_back(tablet_id);
                 }
             }
         }

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -248,12 +248,18 @@ private:
     RuntimeProfile::Counter* _add_row_num = nullptr;
     // Accumulated time to wait for memtable flush in add_chunk()
     RuntimeProfile::Counter* _wait_flush_timer = nullptr;
+    // Accumulated time to submit write task to delta writer thread pool in add_chunk()
+    RuntimeProfile::Counter* _submit_write_task_timer = nullptr;
+    // Accumulated time to submit commit task to delta writer thread pool in add_chunk()
+    RuntimeProfile::Counter* _submit_commit_task_timer = nullptr;
     // Accumulated time to wait for async delta writers in add_chunk()
     RuntimeProfile::Counter* _wait_write_timer = nullptr;
     // Accumulated time to wait for secondary replicas in add_chunk()
     RuntimeProfile::Counter* _wait_replica_timer = nullptr;
     // Accumulated time to wait for txn persist in add_chunk()
     RuntimeProfile::Counter* _wait_txn_persist_timer = nullptr;
+    // Accumulated time to wait sender close in add_chunk()
+    RuntimeProfile::Counter* _wait_drain_sender_timer = nullptr;
 
     std::atomic<bool> _is_updating_profile{false};
     std::unique_ptr<RuntimeProfile> _tablets_profile;

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -667,4 +667,78 @@ TEST_F(LoadChannelTestForLakeTablet, test_final_profile) {
     clear_response(&add_chunk_response);
 }
 
+TEST_F(LoadChannelTestForLakeTablet, test_slow_log_profile) {
+    PTabletWriterOpenRequest open_request = _open_request;
+    open_request.set_num_senders(1);
+    PLoadChannelProfileConfig profile_config;
+    profile_config.set_enable_profile(false);
+    _load_channel->set_profile_config(profile_config);
+    open_request.mutable_load_channel_profile_config()->CopyFrom(profile_config);
+
+    PTabletWriterOpenResult open_response;
+    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
+
+    constexpr int kChunkSize = 128;
+    constexpr int kChunkSizePerTablet = kChunkSize / 4;
+    auto chunk = generate_data(kChunkSize);
+
+    PTabletWriterAddChunksRequest add_chunks_request;
+    add_chunks_request.set_is_repeated_chunk(true);
+    auto& add_chunk_request = *add_chunks_request.add_requests();
+    PTabletWriterAddBatchResult add_chunk_response;
+    {
+        add_chunk_request.set_index_id(kIndexId);
+        add_chunk_request.set_sender_id(0);
+        add_chunk_request.set_eos(true);
+        add_chunk_request.set_packet_seq(0);
+        add_chunk_request.mutable_id()->set_hi(0);
+        add_chunk_request.mutable_id()->set_lo(0);
+        add_chunk_request.set_sink_id(0);
+        add_chunk_request.set_timeout_ms(0);
+
+        ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+        add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+
+        for (int i = 0; i < kChunkSize; i++) {
+            int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
+            add_chunk_request.add_tablet_ids(tablet_id);
+            add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
+        }
+    }
+
+    auto clear_response = [](PTabletWriterAddBatchResult* response) {
+        PTabletWriterAddBatchResult tmp;
+        response->Swap(&tmp);
+    };
+
+    _load_channel->add_chunks(add_chunks_request, &add_chunk_response);
+    ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+    ASSERT_FALSE(add_chunk_response.has_load_channel_profile());
+
+    std::shared_ptr<RuntimeProfile> profile = _load_channel->_root_profile;
+    ASSERT_EQ(print_id(_load_channel->load_id()), *profile->get_info_string("LoadId"));
+    ASSERT_EQ(std::to_string(_load_channel->txn_id()), *profile->get_info_string("TxnId"));
+
+    ASSERT_EQ(1, profile->num_children());
+    RuntimeProfile* channel_profile = profile->get_child(0);
+    ASSERT_EQ(fmt::format("Channel (host={})", BackendOptions::get_localhost()), channel_profile->name());
+    ASSERT_EQ(1, channel_profile->get_counter("IndexNum")->value());
+    ASSERT_EQ(-1, channel_profile->get_counter("LoadMemoryLimit")->value());
+
+    ASSERT_EQ(1, channel_profile->num_children());
+    RuntimeProfile* index_profile = channel_profile->get_child(0);
+    ASSERT_EQ(fmt::format("Index (id={})", kIndexId), index_profile->name());
+    ASSERT_EQ(1, index_profile->get_counter("OpenRpcCount")->value());
+    ASSERT_TRUE(index_profile->get_counter("OpenRpcTime")->value() > 0);
+    ASSERT_EQ(1, index_profile->get_counter("AddChunkRpcCount")->value());
+    ASSERT_TRUE(index_profile->get_counter("AddChunkRpcTime")->value() > 0);
+    ASSERT_EQ(chunk.num_rows(), index_profile->get_counter("AddRowNum")->value());
+    auto* replicas_profile = index_profile->get_child("PeerReplicas");
+    ASSERT_NE(nullptr, replicas_profile);
+    ASSERT_EQ(4, replicas_profile->get_counter("TabletsNum")->value());
+
+    clear_response(&add_chunk_response);
+}
+
 } // namespace starrocks

--- a/be/test/runtime/local_tablets_channel_test.cpp
+++ b/be/test/runtime/local_tablets_channel_test.cpp
@@ -233,6 +233,9 @@ TEST_F(LocalTabletsChannelTest, test_profile) {
     ASSERT_TRUE(profile->get_counter("OpenRpcTime")->value() > 0);
     ASSERT_EQ(1, profile->get_counter("AddChunkRpcCount")->value());
     ASSERT_TRUE(profile->get_counter("AddChunkRpcTime")->value() > 0);
+    ASSERT_TRUE(profile->get_counter("SubmitWriteTaskTime")->value() > 0);
+    ASSERT_TRUE(profile->get_counter("SubmitCommitTaskTime")->value() > 0);
+    ASSERT_EQ(0, profile->get_counter("WaitDrainSenderTime")->value());
     ASSERT_EQ(chunk.num_rows(), profile->get_counter("AddRowNum")->value());
     auto* primary_replicas_profile = profile->get_child("PrimaryReplicas");
     ASSERT_NE(nullptr, primary_replicas_profile);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
in order to know which stage is slow, add slow log in load channel.

1. add slow log in load channel when the rpc reached timeout. the log contains total and each stage execution time.
```
W20250110 18:17:57.977756 139905026795072 load_channel.cpp:256] tablet writer add chunk timeout. txn_id=1691, cost=16728ms, timeout=16500ms, profile=xxx
```

2. add submit write/commit task time, wait drain sender time in profile.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0