### PR TITLE
[BugFix] fix iceberg timestamp without timezone should use the system timezone

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -412,9 +412,9 @@ public class ScalarOperatorToIcebergExpr {
                 case DATETIME:
                     ZoneId zoneId;
                     if (Types.TimestampType.withZone().equals(context)) {
-                        zoneId = TimeUtils.getTimeZone().toZoneId();
-                    } else {
                         zoneId = ZoneOffset.UTC;
+                    } else {
+                        zoneId = TimeUtils.getTimeZone().toZoneId();
                     }
 
                     long value = operator.getDatetime().atZone(zoneId).toEpochSecond() * 1000


### PR DESCRIPTION
## Why I'm doing:
When starrocks query iceberg table with filter express like timestamp1 = CAST('2024-12-18 00:00:00.000' AS datetime) will select empty files but we have the timestamp values can be query.
But interestingly, if I switch to another one like timestamp1 = CAST('2024-12-18 00:00:00:000' AS datetime), it will return filtered results because it cast literal error so it skips the iceberg filter.
After checking the source code, I found that the iceberg type only timestamp with zone should using UTC, if the type is timestamp with out zone should using query time zone
![image](https://github.com/user-attachments/assets/7ae3b5d4-221f-43e5-9012-efc4be2d76d2)

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0