### PR TITLE
[Enhancement] add  session variable parallel_merge_late_materialization_mode control the parallel merge behaviour

### DIFF
--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -259,6 +259,10 @@ pipeline::OpFactories ExchangeNode::decompose_to_pipeline(pipeline::PipelineBuil
             auto exchange_merge_sort_source_operator = std::make_shared<ExchangeParallelMergeSourceOperatorFactory>(
                     context->next_operator_id(), id(), _num_senders, _input_row_desc, &_sort_exec_exprs, _is_asc_order,
                     _nulls_first, _offset, _limit);
+            if (_texchange_node.__isset.parallel_merge_late_materialize_mode) {
+                exchange_merge_sort_source_operator->set_materialized_mode(
+                        _texchange_node.parallel_merge_late_materialize_mode);
+            }
             exchange_merge_sort_source_operator->set_degree_of_parallelism(context->degree_of_parallelism());
             operators.emplace_back(std::move(exchange_merge_sort_source_operator));
             // This particular exchange source will be executed in a concurrent way, and finally we need to gather them into one

--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
@@ -108,7 +108,8 @@ merge_path::MergePathCascadeMerger* ExchangeParallelMergeSourceOperatorFactory::
         SortDescs sort_descs(_is_asc_order, _nulls_first);
         _merger = std::make_unique<merge_path::MergePathCascadeMerger>(
                 state->chunk_size(), degree_of_parallelism(), _sort_exec_exprs->lhs_ordering_expr_ctxs(), sort_descs,
-                _row_desc.tuple_descriptors()[0], TTopNType::ROW_NUMBER, _offset, _limit, chunk_providers);
+                _row_desc.tuple_descriptors()[0], TTopNType::ROW_NUMBER, _offset, _limit, chunk_providers,
+                _late_materialize_mode);
     }
     return _merger.get();
 }

--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.h
@@ -108,6 +108,7 @@ public:
     void close_stream_recvr();
 
     SourceOperatorFactory::AdaptiveState adaptive_initial_state() const override { return AdaptiveState::ACTIVE; }
+    void set_materialized_mode(TLateMaterializeMode::type mode) { _late_materialize_mode = mode; }
 
 private:
     const int32_t _num_sender;
@@ -117,6 +118,7 @@ private:
     const std::vector<bool>& _nulls_first;
     const int64_t _offset;
     const int64_t _limit;
+    TLateMaterializeMode::type _late_materialize_mode = TLateMaterializeMode::AUTO;
 
     std::shared_ptr<DataStreamRecvr> _stream_recvr;
     std::atomic<int64_t> _stream_recvr_cnt = 0;

--- a/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.cpp
@@ -105,7 +105,7 @@ OperatorPtr LocalParallelMergeSortSourceOperatorFactory::create(int32_t degree_o
             _mergers.push_back(std::make_unique<merge_path::MergePathCascadeMerger>(
                     _state->chunk_size(), degree_of_parallelism, sort_context->sort_exprs(), sort_context->sort_descs(),
                     _tuple_desc, sort_context->topn_type(), sort_context->offset(), sort_context->limit(),
-                    chunk_providers));
+                    chunk_providers, _late_materialize_mode));
         }
         return std::make_shared<LocalParallelMergeSortSourceOperator>(
                 this, _id, _plan_node_id, driver_sequence, sort_context.get(), _is_gathered, _mergers[0].get());

--- a/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.h
+++ b/be/src/exec/pipeline/sort/local_parallel_merge_sort_source_operator.h
@@ -94,11 +94,13 @@ public:
 
     void set_tuple_desc(const TupleDescriptor* tuple_desc) { _tuple_desc = tuple_desc; }
     void set_is_gathered(const bool is_gathered) { _is_gathered = is_gathered; }
+    void set_materialized_mode(TLateMaterializeMode::type mode) { _late_materialize_mode = mode; }
 
 private:
     const TupleDescriptor* _tuple_desc;
     bool _is_gathered = true;
     RuntimeState* _state;
+    TLateMaterializeMode::type _late_materialize_mode = TLateMaterializeMode::AUTO;
 
     // share data with multiple partition sort sink opeartor through _sort_context.
     std::shared_ptr<SortContextFactory> _sort_context_factory;

--- a/be/src/exec/sorting/merge_path.h
+++ b/be/src/exec/sorting/merge_path.h
@@ -373,7 +373,8 @@ public:
     MergePathCascadeMerger(const size_t chunk_size, const int32_t degree_of_parallelism,
                            std::vector<ExprContext*> sort_exprs, const SortDescs& sort_descs,
                            const TupleDescriptor* tuple_desc, const TTopNType::type topn_type, const int64_t offset,
-                           const int64_t limit, std::vector<MergePathChunkProvider> chunk_providers);
+                           const int64_t limit, std::vector<MergePathChunkProvider> chunk_providers,
+                           TLateMaterializeMode::type mode = TLateMaterializeMode::AUTO);
     const std::vector<ExprContext*>& sort_exprs() const { return _sort_exprs; }
     const SortDescs& sort_descs() const { return _sort_descs; }
 
@@ -504,6 +505,8 @@ private:
     std::chrono::steady_clock::time_point _pending_start;
     // First pending should not be recorded, because it all comes from the operator dependency
     bool _is_first_pending = true;
+
+    TLateMaterializeMode::type _late_materialization_mode;
 
     starrocks::pipeline::Observable _observable;
 };

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -346,6 +346,10 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> TopNNode::_decompose_to_
                 ->set_tuple_desc(_materialized_tuple_desc);
         down_cast<LocalParallelMergeSortSourceOperatorFactory*>(source_operator.get())->set_is_gathered(need_merge);
     }
+    if (enable_parallel_merge && _tnode.sort_node.__isset.parallel_merge_late_materialize_mode) {
+        down_cast<LocalParallelMergeSortSourceOperatorFactory*>(source_operator.get())
+                ->set_materialized_mode(_tnode.sort_node.parallel_merge_late_materialize_mode);
+    }
 
     ops_sink_with_sort.emplace_back(std::move(sink_operator));
     context->add_pipeline(ops_sink_with_sort);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -50,6 +50,7 @@ import com.starrocks.sql.optimizer.base.DistributionSpec;
 import com.starrocks.sql.optimizer.operator.TopNType;
 import com.starrocks.thrift.TExchangeNode;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TLateMaterializeMode;
 import com.starrocks.thrift.TNormalExchangeNode;
 import com.starrocks.thrift.TNormalPlanNode;
 import com.starrocks.thrift.TNormalSortInfo;
@@ -198,8 +199,10 @@ public class ExchangeNode extends PlanNode {
         if (partitionType != null) {
             msg.exchange_node.setPartition_type(partitionType);
         }
-        SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
-        msg.exchange_node.setEnable_parallel_merge(sessionVariable.isEnableParallelMerge());
+        SessionVariable sv = ConnectContext.get().getSessionVariable();
+        msg.exchange_node.setEnable_parallel_merge(sv.isEnableParallelMerge());
+        TLateMaterializeMode mode = TLateMaterializeMode.valueOf(sv.getParallelMergeLateMaterializationMode().toUpperCase());
+        msg.exchange_node.setParallel_merge_late_materialize_mode(mode);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -53,6 +53,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.operator.TopNType;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TLateMaterializeMode;
 import com.starrocks.thrift.TNormalPlanNode;
 import com.starrocks.thrift.TNormalSortInfo;
 import com.starrocks.thrift.TNormalSortNode;
@@ -231,6 +232,8 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
 
         msg.sort_node.setLate_materialization(sessionVariable.isFullSortLateMaterialization());
         msg.sort_node.setEnable_parallel_merge(sessionVariable.isEnableParallelMerge());
+        TLateMaterializeMode mode = TLateMaterializeMode.valueOf(sessionVariable.getParallelMergeLateMaterializationMode().toUpperCase());
+        msg.sort_node.setParallel_merge_late_materialize_mode(mode);
 
         if (info.getPartitionExprs() != null) {
             msg.sort_node.setPartition_exprs(Expr.treesToThrift(info.getPartitionExprs()));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -498,6 +498,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String GROUP_EXECUTION_MIN_SCAN_ROWS = "group_execution_min_scan_rows";
 
     public static final String ENABLE_PARALLEL_MERGE = "enable_parallel_merge";
+    public static final String PARALLEL_MERGE_LATE_MATERIALIZATION_MODE = "parallel_merge_late_materialization_mode";
     public static final String ENABLE_QUERY_QUEUE = "enable_query_queue";
 
     public static final String WINDOW_PARTITION_MODE = "window_partition_mode";
@@ -1588,6 +1589,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_PARALLEL_MERGE)
     private boolean enableParallelMerge = true;
 
+    // AUTO/ALWAYS/NEVER
+    @VarAttr(name = PARALLEL_MERGE_LATE_MATERIALIZATION_MODE)
+    private String parallelMergeLateMaterializationMode = SessionVariableConstants.AUTO;
+
     @VarAttr(name = ENABLE_QUERY_QUEUE, flag = VariableMgr.INVISIBLE)
     private boolean enableQueryQueue = true;
 
@@ -1779,6 +1784,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableParallelMerge() {
         return enableParallelMerge;
+    }
+
+    public String getParallelMergeLateMaterializationMode() {
+        return parallelMergeLateMaterializationMode;
     }
 
     public void setEnableParallelMerge(boolean enableParallelMerge) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -36,6 +36,10 @@ public class SessionVariableConstants {
 
     public static final String VARCHAR = "varchar";
 
+    public static final String ALWAYS = "always";
+
+    public static final String NEVER = "never";
+
     public enum ChooseInstancesMode {
 
         // the number of chosen instances is the same as the max number of instances from its children fragments

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -802,18 +802,6 @@ enum TAggregationOp {
   PERCENT_RANK
 }
 
-//struct TAggregateFunctionCall {
-  // The aggregate function to call.
-//  1: required Types.TFunction fn
-
-  // The input exprs to this aggregate function
-//  2: required list<Exprs.TExpr> input_exprs
-
-  // If set, this aggregate function udf has varargs and this is the index for the
-  // first variable argument.
-//  3: optional i32 vararg_start_idx
-//}
-
 struct TAggregationNode {
   1: optional list<Exprs.TExpr> grouping_exprs
   // aggregate exprs. The root of each expr is the aggregate function. The
@@ -887,6 +875,12 @@ enum TTopNType {
   DENSE_RANK
 }
 
+enum TLateMaterializeMode {
+  AUTO,
+  ALWAYS,
+  NEVER,
+}
+
 struct TSortNode {
   1: required TSortInfo sort_info
   // Indicates whether the backend service should use topn vs. sorting
@@ -926,6 +920,7 @@ struct TSortNode {
   32: optional list<Exprs.TExpr> pre_agg_exprs;
   33: optional list<Types.TSlotId> pre_agg_output_slot_id;
   34: optional bool pre_agg_insert_local_shuffle;
+  40: optional TLateMaterializeMode parallel_merge_late_materialize_mode;
 }
 
 enum TAnalyticWindowType {
@@ -1084,6 +1079,7 @@ struct TExchangeNode {
   // Sender's partition type
   4: optional Partitions.TPartitionType partition_type;
   5: optional bool enable_parallel_merge
+  6: optional TLateMaterializeMode parallel_merge_late_materialize_mode;
 }
 
 // This contains all of the information computed by the plan as part of the resource

--- a/test/sql/test_sort/R/test_parallel_merge_lazy_materialize
+++ b/test/sql/test_sort/R/test_parallel_merge_lazy_materialize
@@ -1,0 +1,151 @@
+-- name: test_parallel_merge_lazy_materialize
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT "",
+  `c4` int(11) NULL COMMENT "",
+  `c5` int(11) NULL COMMENT "",
+  `c6` int(11) NULL COMMENT "",
+  `c7` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series, generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+40960
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(ORDER BY c5) AS wv FROM t0) a;
+-- result:
+838881280	20480.5	1	40960
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+-- result:
+40960	1.0	1	1
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv), SUM(c1), SUM(c2), SUM(c3), SUM(c4), SUM(c5), SUM(c6) FROM (SELECT c1,c2,c3,c4,c5,c6, COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+-- result:
+40960	1.0	1	1	838881280.0	838881280.0	838881280	838881280	838881280	838881280
+-- !result
+select * from t0 order by 1,2,3,4,5,6 limit 10;
+-- result:
+1	1	1	1	1	1	1	1
+2	2	2	2	2	2	2	2
+3	3	3	3	3	3	3	3
+4	4	4	4	4	4	4	4
+5	5	5	5	5	5	5	5
+6	6	6	6	6	6	6	6
+7	7	7	7	7	7	7	7
+8	8	8	8	8	8	8	8
+9	9	9	9	9	9	9	9
+10	10	10	10	10	10	10	10
+-- !result
+select * from t0 order by 1,2,3,4,5,6 desc limit 10;
+-- result:
+1	1	1	1	1	1	1	1
+2	2	2	2	2	2	2	2
+3	3	3	3	3	3	3	3
+4	4	4	4	4	4	4	4
+5	5	5	5	5	5	5	5
+6	6	6	6	6	6	6	6
+7	7	7	7	7	7	7	7
+8	8	8	8	8	8	8	8
+9	9	9	9	9	9	9	9
+10	10	10	10	10	10	10	10
+-- !result
+set parallel_merge_late_materialization_mode="always";
+-- result:
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(ORDER BY c5) AS wv FROM t0) a;
+-- result:
+838881280	20480.5	1	40960
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+-- result:
+40960	1.0	1	1
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv), SUM(c1), SUM(c2), SUM(c3), SUM(c4), SUM(c5), SUM(c6) FROM (SELECT c1,c2,c3,c4,c5,c6, COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+-- result:
+40960	1.0	1	1	838881280.0	838881280.0	838881280	838881280	838881280	838881280
+-- !result
+select * from t0 order by 1,2,3,4,5,6 limit 10;
+-- result:
+1	1	1	1	1	1	1	1
+2	2	2	2	2	2	2	2
+3	3	3	3	3	3	3	3
+4	4	4	4	4	4	4	4
+5	5	5	5	5	5	5	5
+6	6	6	6	6	6	6	6
+7	7	7	7	7	7	7	7
+8	8	8	8	8	8	8	8
+9	9	9	9	9	9	9	9
+10	10	10	10	10	10	10	10
+-- !result
+select * from t0 order by 1,2,3,4,5,6 desc limit 10;
+-- result:
+1	1	1	1	1	1	1	1
+2	2	2	2	2	2	2	2
+3	3	3	3	3	3	3	3
+4	4	4	4	4	4	4	4
+5	5	5	5	5	5	5	5
+6	6	6	6	6	6	6	6
+7	7	7	7	7	7	7	7
+8	8	8	8	8	8	8	8
+9	9	9	9	9	9	9	9
+10	10	10	10	10	10	10	10
+-- !result
+set parallel_merge_late_materialization_mode="never";
+-- result:
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(ORDER BY c5) AS wv FROM t0) a;
+-- result:
+838881280	20480.5	1	40960
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+-- result:
+40960	1.0	1	1
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv), SUM(c1), SUM(c2), SUM(c3), SUM(c4), SUM(c5), SUM(c6) FROM (SELECT c1,c2,c3,c4,c5,c6, COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+-- result:
+40960	1.0	1	1	838881280.0	838881280.0	838881280	838881280	838881280	838881280
+-- !result
+select * from t0 order by 1,2,3,4,5,6 limit 10;
+-- result:
+1	1	1	1	1	1	1	1
+2	2	2	2	2	2	2	2
+3	3	3	3	3	3	3	3
+4	4	4	4	4	4	4	4
+5	5	5	5	5	5	5	5
+6	6	6	6	6	6	6	6
+7	7	7	7	7	7	7	7
+8	8	8	8	8	8	8	8
+9	9	9	9	9	9	9	9
+10	10	10	10	10	10	10	10
+-- !result
+select * from t0 order by 1,2,3,4,5,6 desc limit 10;
+-- result:
+1	1	1	1	1	1	1	1
+2	2	2	2	2	2	2	2
+3	3	3	3	3	3	3	3
+4	4	4	4	4	4	4	4
+5	5	5	5	5	5	5	5
+6	6	6	6	6	6	6	6
+7	7	7	7	7	7	7	7
+8	8	8	8	8	8	8	8
+9	9	9	9	9	9	9	9
+10	10	10	10	10	10	10	10
+-- !result

--- a/test/sql/test_sort/T/test_parallel_merge_lazy_materialize
+++ b/test/sql/test_sort/T/test_parallel_merge_lazy_materialize
@@ -1,0 +1,47 @@
+-- name: test_parallel_merge_lazy_materialize
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT "",
+  `c4` int(11) NULL COMMENT "",
+  `c5` int(11) NULL COMMENT "",
+  `c6` int(11) NULL COMMENT "",
+  `c7` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series, generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+
+select count(*) from t0;
+-- auto
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(ORDER BY c5) AS wv FROM t0) a;
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv), SUM(c1), SUM(c2), SUM(c3), SUM(c4), SUM(c5), SUM(c6) FROM (SELECT c1,c2,c3,c4,c5,c6, COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+select * from t0 order by 1,2,3,4,5,6 limit 10;
+select * from t0 order by 1,2,3,4,5,6 desc limit 10;
+
+set parallel_merge_late_materialization_mode="always";
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(ORDER BY c5) AS wv FROM t0) a;
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv), SUM(c1), SUM(c2), SUM(c3), SUM(c4), SUM(c5), SUM(c6) FROM (SELECT c1,c2,c3,c4,c5,c6, COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+select * from t0 order by 1,2,3,4,5,6 limit 10;
+select * from t0 order by 1,2,3,4,5,6 desc limit 10;
+
+set parallel_merge_late_materialization_mode="never";
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(ORDER BY c5) AS wv FROM t0) a;
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv), SUM(c1), SUM(c2), SUM(c3), SUM(c4), SUM(c5), SUM(c6) FROM (SELECT c1,c2,c3,c4,c5,c6, COUNT(c2) OVER(PARTITION BY c1 ORDER BY c5) AS wv FROM t0) a;
+select * from t0 order by 1,2,3,4,5,6 limit 10;
+select * from t0 order by 1,2,3,4,5,6 desc limit 10;


### PR DESCRIPTION
## Why I'm doing:

for default behaviour
set parallel_merge_late_materialization_mode = "auto";

force enable lazy materialize
parallel_merge_late_materialization_mode = "always";

disable lazy materialize
parallel_merge_late_materialization_mode = "never";

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0