### PR TITLE
[BugFix] Fix MemTracker::release_without_root

### DIFF
--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -267,7 +267,7 @@ public:
     }
 
     void release_without_root(int64_t bytes) {
-        if (bytes == 0) {
+        if (bytes == 0 || _all_trackers.empty()) {
             return;
         }
 


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/StarRocksTest/issues/9106

```
#1  0x0000000003c16434 in starrocks::MemTracker::release_without_root (this=<optimized out>, bytes=<optimized out>) at be/src/runtime/mem_tracker.h:275
275	            _all_trackers[i]->_consumption->add(-bytes);
(gdb) p -i
$2 = 18446744073709551615
(gdb) l
270	        if (bytes == 0) {
271	            return;
272	        }
273	
274	        for (size_t i = 0; i < _all_trackers.size() - 1; i++) {
275	            _all_trackers[i]->_consumption->add(-bytes);
276	        }
277	    }
278	
279	    // Returns true if a valid limit of this tracker or one of its ancestors is exceeded.
(gdb) p _all_trackers
value has been optimized out
(gdb) p (uint64_t)0-1
$3 = 18446744073709551615

```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [] This pr needs user documentation (for new or modified features or behaviors)
  - [] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0