### PR TITLE
[BugFix] make max_by/min_by's  output result column always nullable

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -42,8 +42,8 @@
 
 namespace starrocks {
 
-static const std::unordered_set<std::string> ALWAYS_NULLABLE_RESULT_AGG_FUNCS = {"variance_samp", "var_samp",
-                                                                                 "stddev_samp", "covar_samp", "corr"};
+static const std::unordered_set<std::string> ALWAYS_NULLABLE_RESULT_AGG_FUNCS = {
+        "variance_samp", "var_samp", "stddev_samp", "covar_samp", "corr", "max_by_v2", "min_by_v2"};
 
 static const std::string AGG_STATE_UNION_SUFFIX = "_union";
 static const std::string AGG_STATE_MERGE_SUFFIX = "_merge";

--- a/test/sql/test_max_min_by_not_filter_nulls_with_nulls/R/test_max_min_by_with_empty_table
+++ b/test/sql/test_max_min_by_not_filter_nulls_with_nulls/R/test_max_min_by_with_empty_table
@@ -1,0 +1,36 @@
+-- name: test_max_min_by_with_empty_table
+CREATE TABLE `primary_table_with_null_partition` (
+                `k1` date not null,
+                `k2` datetime not null,
+                `k3` varchar(20) not null,
+                `k4` varchar(20) not null,
+                `k5` boolean not null,
+                `v1` tinyint,
+                `v2` smallint,
+                `v3` int,
+                `v4` bigint,
+                `v5` largeint,
+                `v6` float,
+                `v7` double,
+                `v8` decimal(27,9)
+            ) 
+            PRIMARY KEY(`k1`, `k2`,`k3`)
+            COMMENT "OLAP"
+            PARTITION BY RANGE(`k1`)
+            (
+                PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
+                PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
+                PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
+            )
+            DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 3
+            PROPERTIES (
+                "replication_num" = "1",
+                "enable_persistent_index" = "true",
+                "storage_format" = "v2" 
+            );
+-- result:
+-- !result
+select max_by(k1,k1) from primary_table_with_null_partition;
+-- result:
+None
+-- !result

--- a/test/sql/test_max_min_by_not_filter_nulls_with_nulls/T/test_max_min_by_with_empty_table
+++ b/test/sql/test_max_min_by_not_filter_nulls_with_nulls/T/test_max_min_by_with_empty_table
@@ -1,0 +1,32 @@
+-- name: test_max_min_by_with_empty_table
+CREATE TABLE `primary_table_with_null_partition` (
+                `k1` date not null,
+                `k2` datetime not null,
+                `k3` varchar(20) not null,
+                `k4` varchar(20) not null,
+                `k5` boolean not null,
+                `v1` tinyint,
+                `v2` smallint,
+                `v3` int,
+                `v4` bigint,
+                `v5` largeint,
+                `v6` float,
+                `v7` double,
+                `v8` decimal(27,9)
+            ) 
+            PRIMARY KEY(`k1`, `k2`,`k3`)
+            COMMENT "OLAP"
+            PARTITION BY RANGE(`k1`)
+            (
+                PARTITION `p202006` VALUES LESS THAN ("2020-07-01"),
+                PARTITION `p202007` VALUES LESS THAN ("2020-08-01"),
+                PARTITION `p202008` VALUES LESS THAN ("2020-09-01")
+            )
+            DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 3
+            PROPERTIES (
+                "replication_num" = "1",
+                "enable_persistent_index" = "true",
+                "storage_format" = "v2" 
+            );
+
+select max_by(k1,k1) from primary_table_with_null_partition;


### PR DESCRIPTION
## Why I'm doing:
max_by/min_by's output result column should be always nullable. for example, max_by(col1, col2), if col2's max value is still  null, then even if col1 is not nullable, it must output null. 

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9104

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0