### PR TITLE
[Enhancement] pushdown join runtime filter into storage layer

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -654,7 +654,7 @@ template <typename T>
 void BinaryColumnBase<T>::crc32_hash_with_selection(uint32_t* hashes, uint8_t* selection, uint16_t from,
                                                     uint16_t to) const {
     for (uint32_t i = from; i < to && !_bytes.empty(); ++i) {
-        if (selection[i]) {
+        if (!selection[i]) {
             continue;
         }
         hashes[i] = HashUtil::zlib_crc_hash(_bytes.data() + _offsets[i],

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -620,6 +620,26 @@ void BinaryColumnBase<T>::fnv_hash(uint32_t* hashes, uint32_t from, uint32_t to)
                                        static_cast<uint32_t>(_offsets[i + 1] - _offsets[i]), hashes[i]);
     }
 }
+template <typename T>
+void BinaryColumnBase<T>::fnv_hash_with_selection(uint32_t* hashes, uint8_t* selection, uint16_t from,
+                                                  uint16_t to) const {
+    for (uint32_t i = from; i < to; ++i) {
+        if (!selection[i]) {
+            continue;
+        }
+        hashes[i] = HashUtil::fnv_hash(_bytes.data() + _offsets[i],
+                                       static_cast<uint32_t>(_offsets[i + 1] - _offsets[i]), hashes[i]);
+    }
+}
+
+template <typename T>
+void BinaryColumnBase<T>::fnv_hash_selective(uint32_t* hashes, uint16_t* sel, uint16_t sel_size) const {
+    for (uint16_t i = 0; i < sel_size; i++) {
+        uint16_t idx = sel[i];
+        hashes[idx] = HashUtil::fnv_hash(_bytes.data() + _offsets[idx],
+                                         static_cast<uint32_t>(_offsets[idx + 1] - _offsets[idx]), hashes[idx]);
+    }
+}
 
 template <typename T>
 void BinaryColumnBase<T>::crc32_hash(uint32_t* hashes, uint32_t from, uint32_t to) const {
@@ -627,6 +647,27 @@ void BinaryColumnBase<T>::crc32_hash(uint32_t* hashes, uint32_t from, uint32_t t
     for (uint32_t i = from; i < to && !_bytes.empty(); ++i) {
         hashes[i] = HashUtil::zlib_crc_hash(_bytes.data() + _offsets[i],
                                             static_cast<uint32_t>(_offsets[i + 1] - _offsets[i]), hashes[i]);
+    }
+}
+
+template <typename T>
+void BinaryColumnBase<T>::crc32_hash_with_selection(uint32_t* hashes, uint8_t* selection, uint16_t from,
+                                                    uint16_t to) const {
+    for (uint32_t i = from; i < to && !_bytes.empty(); ++i) {
+        if (selection[i]) {
+            continue;
+        }
+        hashes[i] = HashUtil::zlib_crc_hash(_bytes.data() + _offsets[i],
+                                            static_cast<uint32_t>(_offsets[i + 1] - _offsets[i]), hashes[i]);
+    }
+}
+
+template <typename T>
+void BinaryColumnBase<T>::crc32_hash_selective(uint32_t* hashes, uint16_t* sel, uint16_t sel_size) const {
+    for (uint16_t i = 0; i < sel_size; i++) {
+        uint16_t idx = sel[i];
+        hashes[idx] = HashUtil::zlib_crc_hash(_bytes.data() + _offsets[idx],
+                                              static_cast<uint32_t>(_offsets[idx + 1] - _offsets[idx]), hashes[idx]);
     }
 }
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -264,8 +264,12 @@ public:
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 
     void fnv_hash(uint32_t* hashes, uint32_t from, uint32_t to) const override;
+    void fnv_hash_with_selection(uint32_t* seed, uint8_t* selection, uint16_t from, uint16_t to) const override;
+    void fnv_hash_selective(uint32_t* hashes, uint16_t* sel, uint16_t sel_size) const override;
 
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
+    void crc32_hash_with_selection(uint32_t* seed, uint8_t* selection, uint16_t from, uint16_t to) const override;
+    void crc32_hash_selective(uint32_t* hashes, uint16_t* sel, uint16_t sel_size) const override;
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -153,6 +153,7 @@ public:
 
     void set_slot_id_to_index(SlotId slot_id, size_t idx) { _slot_id_to_index[slot_id] = idx; }
     bool is_slot_exist(SlotId id) const { return _slot_id_to_index.contains(id); }
+    bool is_cid_exist(ColumnId cid) const { return _cid_to_index.contains(cid); }
     void reset_slot_id_to_index() { _slot_id_to_index.clear(); }
     size_t get_index_by_slot_id(SlotId slot_id) { return _slot_id_to_index[slot_id]; }
 
@@ -219,6 +220,7 @@ public:
     DelCondSatisfied delete_state() const { return _delete_state; }
 
     const SlotHashMap& get_slot_id_to_index_map() const { return _slot_id_to_index; }
+    const ColumnIdHashMap& get_column_id_to_index_map() const { return _cid_to_index; }
 
     // Call `Column::reserve` on each column of |chunk|, with |cap| passed as argument.
     void reserve(size_t cap);

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -374,9 +374,21 @@ public:
     // Compute fvn hash, mainly used by shuffle column data
     // Note: shuffle hash function should be different from Aggregate and Join Hash map hash function
     virtual void fnv_hash(uint32_t* seed, uint32_t from, uint32_t to) const = 0;
+    virtual void fnv_hash_with_selection(uint32_t* seed, uint8_t* selection, uint16_t from, uint16_t to) const {
+        throw std::runtime_error("not support fnv_hash_with_selection");
+    }
+    virtual void fnv_hash_selective(uint32_t* seed, uint16_t* sel, uint16_t sel_size) const {
+        throw std::runtime_error("not support fnv_hash_selective: " + get_name());
+    }
 
     // used by data loading compute tablet bucket
     virtual void crc32_hash(uint32_t* seed, uint32_t from, uint32_t to) const = 0;
+    virtual void crc32_hash_with_selection(uint32_t* seed, uint8_t* selection, uint16_t from, uint16_t to) const {
+        throw std::runtime_error("not support crc32_hash_with_selection");
+    }
+    virtual void crc32_hash_selective(uint32_t* seed, uint16_t* sel, uint16_t sel_size) const {
+        throw std::runtime_error("not support crc32_hash_selective: " + get_name());
+    }
 
     virtual void crc32_hash_at(uint32_t* seed, uint32_t idx) const { crc32_hash(seed - idx, idx, idx + 1); }
 

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -200,8 +200,12 @@ public:
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 
     void fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
+    void fnv_hash_with_selection(uint32_t* seed, uint8_t* selection, uint16_t from, uint16_t to) const override;
+    void fnv_hash_selective(uint32_t* hash, uint16_t* sel, uint16_t sel_size) const override;
 
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
+    void crc32_hash_with_selection(uint32_t* seed, uint8_t* selection, uint16_t from, uint16_t to) const override;
+    void crc32_hash_selective(uint32_t* hash, uint16_t* sel, uint16_t sel_size) const override;
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -211,8 +211,11 @@ public:
     int equals(size_t left, const Column& rhs, size_t right, bool safe_eq = true) const override;
 
     void fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
-
+    void fnv_hash_with_selection(uint32_t* seed, uint8_t* selection, uint16_t from, uint16_t to) const override;
+    void fnv_hash_selective(uint32_t* hash, uint16_t* sel, uint16_t sel_size) const override;
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
+    void crc32_hash_with_selection(uint32_t* seed, uint8_t* selection, uint16_t from, uint16_t to) const override;
+    void crc32_hash_selective(uint32_t* hash, uint16_t* sel, uint16_t sel_size) const override;
 
     int64_t xor_checksum(uint32_t from, uint32_t to) const override;
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1582,4 +1582,9 @@ CONF_mInt32(put_combined_txn_log_thread_pool_num_max, "64");
 CONF_mBool(enable_put_combinded_txn_log_parallel, "false");
 // used to control whether the metrics/ interface collects table metrics
 CONF_mBool(enable_collect_table_metrics, "true");
+// some internal parameters are used to control the execution strategy of join runtime filter pushdown.
+// Do not modify them unless necessary.
+CONF_mInt64(rf_sample_rows, "1024");
+CONF_mInt64(rf_sample_ratio, "32");
+CONF_mInt64(rf_branchless_ratio, "8");
 } // namespace starrocks::config

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -27,9 +27,11 @@
 #include "exprs/runtime_filter.h"
 #include "gutil/map_util.h"
 #include "runtime/descriptors.h"
+#include "storage/column_placeholder_predicate.h"
 #include "storage/column_predicate.h"
 #include "storage/predicate_parser.h"
 #include "storage/predicate_tree/predicate_tree.hpp"
+#include "storage/runtime_filter_predicate.h"
 #include "storage/runtime_range_pruner.h"
 #include "storage/runtime_range_pruner.hpp"
 #include "types/date_value.hpp"
@@ -1044,6 +1046,32 @@ Status ChunkPredicateBuilder<E, Type>::_get_column_predicates(PredicateParser* p
             }
         }
     }
+    if (_opts.runtime_state->enable_join_runtime_filter_pushdown()) {
+        for (const auto& it : _opts.runtime_filters->descriptors()) {
+            RuntimeFilterProbeDescriptor* desc = it.second;
+            SlotId slot_id;
+            if (!desc->is_probe_slot_ref(&slot_id)) {
+                continue;
+            }
+            auto slot_desc = _opts.tuple_desc->get_slot_by_id(slot_id);
+            if (slot_desc == nullptr) {
+                continue;
+            }
+            if (desc->is_topn_filter()) {
+                continue;
+            }
+
+            auto column_id = parser->column_id(*slot_desc);
+            desc->set_has_push_down_to_storage(true);
+            // add placeholder predicates, so that the columns needed by runtime filter can be read in the first stage of late materialization
+            std::unique_ptr<ColumnPredicate> p(
+                    new_column_placeholder_predicate(get_type_info(slot_desc->type().type), column_id));
+            VLOG_FILE << "add runtime filter predicate, slot_id=" << slot_id << ", column_id:" << column_id
+                      << ", rf=" << desc->debug_string() << ", driver_sequence: " << _opts.driver_sequence
+                      << ", desc:" << (void*)desc << ", " << (void*)(p.get());
+            col_preds_owner.emplace_back(std::move(p));
+        }
+    }
 
     return Status::OK();
 }
@@ -1213,6 +1241,29 @@ StatusOr<PredicateTree> ScanConjunctsManager::get_predicate_tree(PredicateParser
                                                                  ColumnPredicatePtrs& col_preds_owner) {
     ASSIGN_OR_RETURN(auto pred_root, _root_builder.get_predicate_tree_root(parser, col_preds_owner));
     return PredicateTree::create(std::move(pred_root));
+}
+
+StatusOr<RuntimeFilterPredicates> ScanConjunctsManager::get_runtime_filter_predicates(ObjectPool* obj_pool,
+                                                                                      PredicateParser* parser) {
+    RuntimeFilterPredicates predicates(_opts.driver_sequence);
+    for (const auto& it : _opts.runtime_filters->descriptors()) {
+        RuntimeFilterProbeDescriptor* desc = it.second;
+        SlotId slot_id;
+        if (!desc->is_probe_slot_ref(&slot_id)) {
+            continue;
+        }
+        auto slot_desc = _opts.tuple_desc->get_slot_by_id(slot_id);
+        if (slot_desc == nullptr) {
+            continue;
+        }
+        if (desc->is_topn_filter()) {
+            continue;
+        }
+        auto column_id = parser->column_id(*slot_desc);
+        desc->set_has_push_down_to_storage(true);
+        predicates.add_predicate(obj_pool->add(new RuntimeFilterPredicate(desc, column_id)));
+    }
+    return predicates;
 }
 
 Status ScanConjunctsManager::get_key_ranges(std::vector<std::unique_ptr<OlapScanRange>>* key_ranges) {

--- a/be/src/exec/olap_scan_prepare.h
+++ b/be/src/exec/olap_scan_prepare.h
@@ -21,6 +21,7 @@
 #include "runtime/descriptors.h"
 #include "storage/predicate_tree/predicate_tree_fwd.h"
 #include "storage/predicate_tree_params.h"
+#include "storage/runtime_filter_predicate.h"
 #include "storage/runtime_range_pruner.h"
 
 namespace starrocks {
@@ -176,6 +177,7 @@ public:
     static Status eval_const_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs, Status* status);
 
     StatusOr<PredicateTree> get_predicate_tree(PredicateParser* parser, ColumnPredicatePtrs& col_preds_owner);
+    StatusOr<RuntimeFilterPredicates> get_runtime_filter_predicates(ObjectPool* obj_pool, PredicateParser* parser);
 
     Status get_key_ranges(std::vector<std::unique_ptr<OlapScanRange>>* key_ranges);
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -193,6 +193,9 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _block_seek_counter = ADD_CHILD_COUNTER(_runtime_profile, "BlockSeekCount", TUnit::UNIT, segment_read_name);
     _pred_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "PredFilter", segment_read_name);
     _pred_filter_counter = ADD_CHILD_COUNTER(_runtime_profile, "PredFilterRows", TUnit::UNIT, segment_read_name);
+    _rf_pred_filter_timer = ADD_TIMER(_runtime_profile, "RuntimeFilterEvalTime");
+    _rf_pred_input_rows = ADD_COUNTER(_runtime_profile, "RuntimeFilterInputRows", TUnit::UNIT);
+    _rf_pred_output_rows = ADD_COUNTER(_runtime_profile, "RuntimeFilterOutputRows", TUnit::UNIT);
     _del_vec_filter_counter = ADD_CHILD_COUNTER(_runtime_profile, "DelVecFilterRows", TUnit::UNIT, segment_read_name);
     _chunk_copy_timer = ADD_CHILD_TIMER(_runtime_profile, "ChunkCopy", segment_read_name);
     _decompress_timer = ADD_CHILD_TIMER(_runtime_profile, "DecompressT", segment_read_name);
@@ -266,16 +269,23 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     if (thrift_olap_scan_node.__isset.sorted_by_keys_per_tablet) {
         _params.sorted_by_keys_per_tablet = thrift_olap_scan_node.sorted_by_keys_per_tablet;
     }
+
     _params.runtime_range_pruner =
             RuntimeScanRangePruner(parser, _scan_ctx->conjuncts_manager().unarrived_runtime_filters());
     _morsel->init_tablet_reader_params(&_params);
 
     ASSIGN_OR_RETURN(auto pred_tree, _scan_ctx->conjuncts_manager().get_predicate_tree(parser, _predicate_free_pool));
+    _params.enable_join_runtime_filter_pushdown = _runtime_state->enable_join_runtime_filter_pushdown();
+    if (_params.enable_join_runtime_filter_pushdown) {
+        ASSIGN_OR_RETURN(_params.runtime_filter_preds,
+                         _scan_ctx->conjuncts_manager().get_runtime_filter_predicates(&_obj_pool, parser));
+    }
     _decide_chunk_size(!pred_tree.empty());
     PredicateAndNode pushdown_pred_root;
     PredicateAndNode non_pushdown_pred_root;
     pred_tree.root().partition_copy([parser](const auto& node) { return parser->can_pushdown(node); },
                                     &pushdown_pred_root, &non_pushdown_pred_root);
+
     _params.pred_tree = PredicateTree::create(std::move(pushdown_pred_root));
     _non_pushdown_pred_tree = PredicateTree::create(std::move(non_pushdown_pred_root));
 
@@ -666,6 +676,10 @@ void OlapChunkSource::_update_counter() {
     cond_evaluate_ns += _reader->stats().expr_cond_evaluate_ns;
     // In order to avoid exposing too detailed metrics, we still record these infos on `_pred_filter_timer`
     // When we support metric classification, we can disassemble it again.
+    COUNTER_UPDATE(_rf_pred_filter_timer, _reader->stats().rf_cond_evaluate_ns);
+    COUNTER_UPDATE(_rf_pred_input_rows, _reader->stats().rf_cond_input_rows);
+    COUNTER_UPDATE(_rf_pred_output_rows, _reader->stats().rf_cond_output_rows);
+
     COUNTER_UPDATE(_pred_filter_timer, cond_evaluate_ns);
     COUNTER_UPDATE(_pred_filter_counter, _reader->stats().rows_vec_cond_filtered);
     COUNTER_UPDATE(_del_vec_filter_counter, _reader->stats().rows_del_vec_filtered);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -129,6 +129,9 @@ private:
     RuntimeProfile::Counter* _pred_filter_counter = nullptr;
     RuntimeProfile::Counter* _del_vec_filter_counter = nullptr;
     RuntimeProfile::Counter* _pred_filter_timer = nullptr;
+    RuntimeProfile::Counter* _rf_pred_filter_timer = nullptr;
+    RuntimeProfile::Counter* _rf_pred_input_rows = nullptr;
+    RuntimeProfile::Counter* _rf_pred_output_rows = nullptr;
     RuntimeProfile::Counter* _chunk_copy_timer = nullptr;
     RuntimeProfile::Counter* _get_rowsets_timer = nullptr;
     RuntimeProfile::Counter* _get_delvec_timer = nullptr;

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -159,7 +159,6 @@ size_t RuntimeBloomFilter::serialize(int serialize_version, uint8_t* data) const
 
     if (num_partitions == 0) {
         offset += _bf.serialize(data + offset);
-
     } else {
         for (const auto& bf : _hash_partition_bf) {
             offset += bf.serialize(data + offset);

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -31,6 +31,7 @@
 #include "gen_cpp/PlanNodes_types.h"
 #include "gen_cpp/Types_types.h"
 #include "types/logical_type.h"
+#include "util/hash_util.hpp"
 
 namespace starrocks {
 // 0x1. initial global runtime filter impl
@@ -219,9 +220,20 @@ public:
 
     virtual size_t num_hash_partitions() const { return 0; }
 
-    virtual void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<Column*>& columns,
+    virtual void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
                                          RunningContext* ctx) const = 0;
-    virtual void evaluate(Column* input_column, RunningContext* ctx) const = 0;
+    virtual void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                                         uint16_t* sel, uint16_t sel_size,
+                                         std::vector<uint32_t>& hash_values) const = 0;
+    virtual void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                                         uint8_t* selection, uint16_t from, uint16_t to,
+                                         std::vector<uint32_t>& hash_values) const = 0;
+    virtual void evaluate(const Column* input_column, RunningContext* ctx) const = 0;
+    virtual uint16_t evaluate(const Column* input_column, const std::vector<uint32_t>& hash_values, uint16_t* sel,
+                              uint16_t sel_size, uint16_t* dst_sel) const = 0;
+
+    virtual void evaluate(const Column* input_column, const std::vector<uint32_t>& hash_values, uint8_t* selection,
+                          uint16_t from, uint16_t to) const = 0;
 
     bool always_true() const { return _always_true; }
 
@@ -279,68 +291,149 @@ protected:
     std::vector<RuntimeFilter*> _group_colocate_filters;
 };
 
-template <typename ModuloFunc>
+struct HashValueIterator {
+    HashValueIterator(std::vector<uint32_t>& hash_values) : hash_values(hash_values) {}
+    virtual ~HashValueIterator() = default;
+    virtual void for_each(const std::function<void(size_t, uint32_t&)>& func) = 0;
+
+    std::vector<uint32_t>& hash_values;
+};
+
+struct FullScanIterator final : HashValueIterator {
+    typedef void (Column::*HashFuncType)(uint32_t*, uint32_t, uint32_t) const;
+    static constexpr HashFuncType FNV_HASH = &Column::fnv_hash;
+    static constexpr HashFuncType CRC32_HASH = &Column::crc32_hash;
+
+    FullScanIterator(std::vector<uint32_t>& hash_values, size_t num_rows)
+            : HashValueIterator(hash_values), num_rows(num_rows) {}
+
+    void for_each(const std::function<void(size_t, uint32_t&)>& func) override {
+        for (size_t i = 0; i < num_rows; i++) {
+            func(i, hash_values[i]);
+        }
+    }
+
+    void compute_hash(const std::vector<const Column*>& columns, HashFuncType hash_func) {
+        for (const Column* input_column : columns) {
+            (input_column->*hash_func)(hash_values.data(), 0, num_rows);
+        }
+    }
+
+    size_t num_rows;
+};
+
+struct SelectionIterator final : HashValueIterator {
+    typedef void (Column::*HashFuncType)(uint32_t*, uint8_t*, uint16_t, uint16_t) const;
+    static constexpr HashFuncType FNV_HASH = &Column::fnv_hash_with_selection;
+    static constexpr HashFuncType CRC32_HASH = &Column::crc32_hash_with_selection;
+
+    SelectionIterator(std::vector<uint32_t>& hash_values, uint8_t* selection, uint16_t from, uint16_t to)
+            : HashValueIterator(hash_values), selection(selection), from(from), to(to) {}
+
+    void for_each(const std::function<void(size_t, uint32_t&)>& func) override {
+        for (size_t i = from; i < to; i++) {
+            if (selection[i]) {
+                func(i, hash_values[i]);
+            }
+        }
+    }
+
+    void compute_hash(const std::vector<const Column*>& columns, HashFuncType hash_func) {
+        for (const Column* input_column : columns) {
+            (input_column->*hash_func)(hash_values.data(), selection, from, to);
+        }
+    }
+
+    uint8_t* selection;
+    uint16_t from;
+    uint16_t to;
+};
+
+struct SelectedIndexIterator final : HashValueIterator {
+    typedef void (Column::*HashFuncType)(uint32_t*, uint16_t*, uint16_t) const;
+    static constexpr HashFuncType FNV_HASH = &Column::fnv_hash_selective;
+    static constexpr HashFuncType CRC32_HASH = &Column::crc32_hash_selective;
+
+    SelectedIndexIterator(std::vector<uint32_t>& hash_values, uint16_t* sel, uint16_t sel_size)
+            : HashValueIterator(hash_values), sel(sel), sel_size(sel_size) {}
+
+    void for_each(const std::function<void(size_t, uint32_t&)>& func) override {
+        for (uint16_t i = 0; i < sel_size; i++) {
+            func(sel[i], hash_values[sel[i]]);
+        }
+    }
+
+    void compute_hash(const std::vector<const Column*>& columns, HashFuncType hash_func) {
+        for (const Column* input_column : columns) {
+            (input_column->*hash_func)(hash_values.data(), sel, sel_size);
+        }
+    }
+    uint16_t* sel;
+    uint16_t sel_size;
+};
+
+template <typename ModuloFunc, typename IteratorType = FullScanIterator>
 struct WithModuloArg {
     template <TRuntimeFilterLayoutMode::type M>
     struct HashValueCompute {
-        void operator()(const RuntimeFilterLayout& layout, const std::vector<Column*>& columns, size_t num_rows,
-                        size_t real_num_partitions, std::vector<uint32_t>& hash_values) const {
+        void operator()(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                        size_t real_num_partitions, IteratorType iterator) const {
             if constexpr (layout_is_singleton<M>) {
-                hash_values.assign(num_rows, 0);
+                iterator.for_each([&](size_t i, uint32_t& hash_value) { hash_value = 0; });
                 return;
             }
-
-            typedef void (Column::*HashFuncType)(uint32_t*, uint32_t, uint32_t) const;
-            auto compute_hash = [&columns, &num_rows, &hash_values](HashFuncType hash_func) {
-                for (Column* input_column : columns) {
-                    (input_column->*hash_func)(hash_values.data(), 0, num_rows);
-                }
-            };
-
             if constexpr (layout_is_shuffle<M>) {
-                hash_values.assign(num_rows, HashUtil::FNV_SEED);
-                compute_hash(&Column::fnv_hash);
-                [[maybe_unused]] const auto num_instances = layout.num_instances();
-                [[maybe_unused]] const auto num_drivers_per_instance = layout.num_drivers_per_instance();
-                [[maybe_unused]] const auto num_partitions = num_instances * num_drivers_per_instance;
-                for (auto i = 0; i < num_rows; ++i) {
-                    auto& hash_value = hash_values[i];
-                    if constexpr (layout_is_pipeline_shuffle<M>) {
-                        hash_value = ModuloFunc()(HashUtil::xorshift32(hash_value), num_drivers_per_instance);
-                    } else if constexpr (layout_is_global_shuffle_1l<M>) {
-                        hash_value = ModuloFunc()(hash_value, real_num_partitions);
-                    } else if constexpr (layout_is_global_shuffle_2l<M>) {
-                        auto instance_id = ModuloFunc()(hash_value, num_instances);
-                        auto driver_id = ModuloFunc()(HashUtil::xorshift32(hash_value), num_drivers_per_instance);
-                        hash_value = instance_id * num_drivers_per_instance + driver_id;
-                    }
-                }
+                process_shuffle(layout, columns, real_num_partitions, iterator);
             } else if (layout_is_bucket<M>) {
-                hash_values.assign(num_rows, 0);
-                compute_hash(&Column::crc32_hash);
-                [[maybe_unused]] const auto& bucketseq_to_instance = layout.bucketseq_to_instance();
-                [[maybe_unused]] const auto& bucketseq_to_driverseq = layout.bucketseq_to_driverseq();
-                [[maybe_unused]] const auto& bucketseq_to_partition = layout.bucketseq_to_partition();
-                [[maybe_unused]] const auto num_drivers_per_instance = layout.num_drivers_per_instance();
-                for (auto i = 0; i < num_rows; ++i) {
-                    auto& hash_value = hash_values[i];
-                    if constexpr (layout_is_pipeline_bucket<M>) {
-                        hash_value = bucketseq_to_driverseq[ModuloFunc()(hash_value, bucketseq_to_driverseq.size())];
-                    } else if constexpr (layout_is_pipeline_bucket_lx<M>) {
-                        hash_value = ModuloFunc()(HashUtil::xorshift32(hash_value), num_drivers_per_instance);
-                    } else if constexpr (layout_is_global_bucket_1l<M>) {
-                        hash_value = bucketseq_to_instance[ModuloFunc()(hash_value, bucketseq_to_instance.size())];
-                    } else if constexpr (layout_is_global_bucket_2l<M>) {
-                        hash_value = bucketseq_to_partition[ModuloFunc()(hash_value, bucketseq_to_partition.size())];
-                    } else if constexpr (layout_is_global_bucket_2l_lx<M>) {
-                        const auto bucketseq = ModuloFunc()(hash_value, bucketseq_to_instance.size());
-                        const auto instance = bucketseq_to_instance[bucketseq];
-                        const auto driverseq = ModuloFunc()(HashUtil::xorshift32(hash_value), num_drivers_per_instance);
-                        hash_value = (instance == BUCKET_ABSENT) ? BUCKET_ABSENT
-                                                                 : instance * num_drivers_per_instance + driverseq;
-                    }
-                }
+                process_bucket(layout, columns, real_num_partitions, iterator);
             }
+        }
+
+        void process_shuffle(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                             size_t real_num_partitions, IteratorType& iterator) const {
+            [[maybe_unused]] const auto num_instances = layout.num_instances();
+            [[maybe_unused]] const auto num_drivers_per_instance = layout.num_drivers_per_instance();
+            [[maybe_unused]] const auto num_partitions = num_instances * num_drivers_per_instance;
+            iterator.for_each([&](size_t i, uint32_t& hash_value) { hash_value = HashUtil::FNV_SEED; });
+            iterator.compute_hash(columns, IteratorType::FNV_HASH);
+            iterator.for_each([&](size_t i, uint32_t& hash_value) {
+                if constexpr (layout_is_pipeline_shuffle<M>) {
+                    hash_value = ModuloFunc()(HashUtil::xorshift32(hash_value), num_drivers_per_instance);
+                } else if constexpr (layout_is_global_shuffle_1l<M>) {
+                    hash_value = ModuloFunc()(hash_value, real_num_partitions);
+                } else if constexpr (layout_is_global_shuffle_2l<M>) {
+                    auto instance_id = ModuloFunc()(hash_value, num_instances);
+                    auto driver_id = ModuloFunc()(HashUtil::xorshift32(hash_value), num_drivers_per_instance);
+                    hash_value = instance_id * num_drivers_per_instance + driver_id;
+                }
+            });
+        }
+
+        void process_bucket(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                            size_t real_num_partitions, IteratorType& iterator) const {
+            [[maybe_unused]] const auto& bucketseq_to_instance = layout.bucketseq_to_instance();
+            [[maybe_unused]] const auto& bucketseq_to_driverseq = layout.bucketseq_to_driverseq();
+            [[maybe_unused]] const auto& bucketseq_to_partition = layout.bucketseq_to_partition();
+            [[maybe_unused]] const auto num_drivers_per_instance = layout.num_drivers_per_instance();
+            iterator.for_each([&](size_t i, uint32_t& hash_value) { hash_value = 0; });
+            iterator.compute_hash(columns, IteratorType::CRC32_HASH);
+            iterator.for_each([&](size_t i, uint32_t& hash_value) {
+                if constexpr (layout_is_pipeline_bucket<M>) {
+                    hash_value = bucketseq_to_driverseq[ModuloFunc()(hash_value, bucketseq_to_driverseq.size())];
+                } else if constexpr (layout_is_pipeline_bucket_lx<M>) {
+                    hash_value = ModuloFunc()(HashUtil::xorshift32(hash_value), num_drivers_per_instance);
+                } else if constexpr (layout_is_global_bucket_1l<M>) {
+                    hash_value = bucketseq_to_instance[ModuloFunc()(hash_value, bucketseq_to_instance.size())];
+                } else if constexpr (layout_is_global_bucket_2l<M>) {
+                    hash_value = bucketseq_to_partition[ModuloFunc()(hash_value, bucketseq_to_partition.size())];
+                } else if constexpr (layout_is_global_bucket_2l_lx<M>) {
+                    const auto bucketseq = ModuloFunc()(hash_value, bucketseq_to_instance.size());
+                    const auto instance = bucketseq_to_instance[bucketseq];
+                    const auto driverseq = ModuloFunc()(HashUtil::xorshift32(hash_value), num_drivers_per_instance);
+                    hash_value = (instance == BUCKET_ABSENT) ? BUCKET_ABSENT
+                                                             : instance * num_drivers_per_instance + driverseq;
+                }
+            });
         }
     };
 };
@@ -519,7 +612,7 @@ public:
     }
 
     template <bool evaluate_null>
-    void t_evaluate(Column* input_column, RunningContext* ctx) const {
+    void t_evaluate(const Column* input_column, RunningContext* ctx) const {
         size_t size = input_column->size();
         Filter& selection_filter = ctx->use_merged_selection ? ctx->merged_selection : ctx->selection;
         selection_filter.resize(size);
@@ -552,6 +645,57 @@ public:
         }
     }
 
+    uint16_t t_evaluate(const Column* column, uint16_t* sel, uint16_t sel_size, uint16_t* dst_sel) const {
+        DCHECK(_has_min_max);
+        CHECK(dst_sel != nullptr) << "dst_sel must be set";
+        CHECK(!column->is_constant()) << "not support constant column";
+        uint16_t new_size = 0;
+        if (column->is_nullable()) {
+            const auto* nullable_column = down_cast<const NullableColumn*>(column);
+            const auto& data = GetContainer<Type>::get_data(nullable_column->data_column());
+            if (nullable_column->has_null()) {
+                const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
+                for (int i = 0; i < sel_size; i++) {
+                    uint16_t idx = sel[i];
+                    dst_sel[new_size] = idx;
+                    if (null_data[idx]) {
+                        new_size += _has_null;
+                    } else {
+                        new_size += evaluate_min_max(data[idx]);
+                    }
+                }
+            } else {
+                new_size = evaluate_min_max(data, sel, sel_size, dst_sel);
+            }
+        } else {
+            const auto& data = GetContainer<Type>::get_data(column);
+            new_size = evaluate_min_max(data, sel, sel_size, dst_sel);
+        }
+        return new_size;
+    }
+
+    void t_evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const {
+        DCHECK(_has_min_max);
+        CHECK(!column->is_constant()) << "not support constant column";
+
+        if (column->is_nullable()) {
+            const auto* nullable_column = down_cast<const NullableColumn*>(column);
+            const auto& data = GetContainer<Type>::get_data(nullable_column->data_column());
+            evaluate_min_max(data, selection, from, to);
+            if (nullable_column->has_null()) {
+                const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
+                for (int i = from; i < to; i++) {
+                    if (null_data[i]) {
+                        selection[i] = _has_null;
+                    }
+                }
+            }
+        } else {
+            const auto& data = GetContainer<Type>::get_data(column);
+            evaluate_min_max(data, selection, from, to);
+        }
+    }
+
     void evaluate_min_max(const ContainerType& values, uint8_t* selection, size_t size) const {
         DCHECK(_has_min_max);
         if constexpr (!IsSlice<CppType>) {
@@ -579,6 +723,41 @@ public:
             }
         } else {
             memset(selection, 0x1, size);
+        }
+    }
+
+    ALWAYS_INLINE bool evaluate_min_max(const CppType& value) const {
+        if constexpr (!IsSlice<CppType>) {
+            bool left = _left_close_interval ? value >= _min : value > _min;
+            bool right = _right_close_interval ? value <= _max : value < _max;
+            return left && right;
+        }
+        return true;
+    }
+
+    uint16_t evaluate_min_max(const ContainerType& values, uint16_t* sel, uint16_t sel_size, uint16_t* dst_sel) const {
+        if constexpr (!IsSlice<CppType>) {
+            const auto* data = values.data();
+            uint16_t new_size = 0;
+            for (int i = 0; i < sel_size; i++) {
+                uint16_t idx = sel[i];
+                dst_sel[new_size] = idx;
+                new_size += evaluate_min_max(data[idx]);
+            }
+            return new_size;
+        } else {
+            return sel_size;
+        }
+    }
+
+    void evaluate_min_max(const ContainerType& values, uint8_t* selection, uint16_t from, uint16_t to) const {
+        if constexpr (!IsSlice<CppType>) {
+            const auto* data = values.data();
+            for (uint16_t i = from; i < to; i++) {
+                if (selection[i]) {
+                    selection[i] = evaluate_min_max(data[i]);
+                }
+            }
         }
     }
 
@@ -717,9 +896,25 @@ public:
         return dst - begin;
     }
 
-    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<Column*>& columns,
+    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
                                  RunningContext* ctx) const override {}
-    void evaluate(Column* input_column, RunningContext* ctx) const override { t_evaluate<true>(input_column, ctx); }
+    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                                 uint16_t* sel, uint16_t sel_size, std::vector<uint32_t>& hash_values) const override {}
+    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                                 uint8_t* selection, uint16_t from, uint16_t to,
+                                 std::vector<uint32_t>& hash_values) const override {}
+
+    void evaluate(const Column* input_column, RunningContext* ctx) const override {
+        t_evaluate<true>(input_column, ctx);
+    }
+    uint16_t evaluate(const Column* input_column, const std::vector<uint32_t>& hash_values, uint16_t* sel,
+                      uint16_t sel_size, uint16_t* dst_sel) const override {
+        return t_evaluate(input_column, sel, sel_size, dst_sel);
+    }
+    void evaluate(const Column* input_column, const std::vector<uint32_t>& hash_values, uint8_t* selection,
+                  uint16_t from, uint16_t to) const override {
+        t_evaluate(input_column, selection, from, to);
+    }
 
 private:
     void _init_min_max() {
@@ -912,13 +1107,37 @@ public:
 
     void insert_null() { _has_null = true; }
 
-    void evaluate(Column* input_column, RunningContext* ctx) const override {
+    void evaluate(const Column* input_column, RunningContext* ctx) const override {
         if (!_hash_partition_bf.empty()) {
             return _hash_partition_bf[0].can_use() ? _t_evaluate<true, true>(input_column, ctx)
                                                    : _t_evaluate<true, false>(input_column, ctx);
         } else {
             return _bf.can_use() ? _t_evaluate<false, true>(input_column, ctx)
                                  : _t_evaluate<false, false>(input_column, ctx);
+        }
+    }
+
+    uint16_t evaluate(const Column* input_column, const std::vector<uint32_t>& hash_values, uint16_t* sel,
+                      uint16_t sel_size, uint16_t* dst_sel) const override {
+        if (!_hash_partition_bf.empty()) {
+            return _hash_partition_bf[0].can_use()
+                           ? _t_evaluate<true, true>(input_column, hash_values, sel, sel_size, dst_sel)
+                           : _t_evaluate<true, false>(input_column, hash_values, sel, sel_size, dst_sel);
+        } else {
+            return _bf.can_use() ? _t_evaluate<false, true>(input_column, hash_values, sel, sel_size, dst_sel)
+                                 : _t_evaluate<false, false>(input_column, hash_values, sel, sel_size, dst_sel);
+        }
+    }
+
+    void evaluate(const Column* input_column, const std::vector<uint32_t>& hash_values, uint8_t* selection,
+                  uint16_t from, uint16_t to) const override {
+        if (!_hash_partition_bf.empty()) {
+            return _hash_partition_bf[0].can_use()
+                           ? _t_evaluate<true, true>(input_column, hash_values, selection, from, to)
+                           : _t_evaluate<true, false>(input_column, hash_values, selection, from, to);
+        } else {
+            return _bf.can_use() ? _t_evaluate<false, true>(input_column, hash_values, selection, from, to)
+                                 : _t_evaluate<false, false>(input_column, hash_values, selection, from, to);
         }
     }
 
@@ -938,7 +1157,7 @@ public:
         return size;
     }
 
-    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<Column*>& columns,
+    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
                                  RunningContext* ctx) const override {
         if (columns.empty() || _join_mode == TRuntimeFilterBuildJoinMode::NONE) return;
         size_t num_rows = columns[0]->size();
@@ -946,15 +1165,55 @@ public:
         // initialize hash_values.
         // reuse ctx's hash_values object.
         std::vector<uint32_t>& _hash_values = ctx->hash_values;
+        _hash_values.resize(num_rows);
         // compute hash_values
         auto use_reduce = !ctx->compatibility && (_join_mode == TRuntimeFilterBuildJoinMode::PARTITIONED ||
                                                   _join_mode == TRuntimeFilterBuildJoinMode::SHUFFLE_HASH_BUCKET);
         if (use_reduce) {
-            dispatch_layout<WithModuloArg<ReduceOp>::HashValueCompute>(_global, layout, columns, num_rows,
-                                                                       _hash_partition_bf.size(), _hash_values);
+            dispatch_layout<WithModuloArg<ReduceOp, FullScanIterator>::HashValueCompute>(
+                    _global, layout, columns, _hash_partition_bf.size(), FullScanIterator(_hash_values, num_rows));
         } else {
-            dispatch_layout<WithModuloArg<ModuloOp>::HashValueCompute>(_global, layout, columns, num_rows,
-                                                                       _hash_partition_bf.size(), _hash_values);
+            dispatch_layout<WithModuloArg<ModuloOp, FullScanIterator>::HashValueCompute>(
+                    _global, layout, columns, _hash_partition_bf.size(), FullScanIterator(_hash_values, num_rows));
+        }
+    }
+    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                                 uint16_t* sel, uint16_t sel_size, std::vector<uint32_t>& hash_values) const override {
+        if (columns.empty() || _join_mode == TRuntimeFilterBuildJoinMode::NONE) return;
+
+        size_t num_rows = columns[0]->size();
+        DCHECK_EQ(hash_values.size(), num_rows);
+
+        auto use_reduce = (_join_mode == TRuntimeFilterBuildJoinMode::PARTITIONED ||
+                           _join_mode == TRuntimeFilterBuildJoinMode::SHUFFLE_HASH_BUCKET);
+        if (use_reduce) {
+            dispatch_layout<WithModuloArg<ReduceOp, SelectedIndexIterator>::HashValueCompute>(
+                    _global, layout, columns, _hash_partition_bf.size(),
+                    SelectedIndexIterator(hash_values, sel, sel_size));
+        } else {
+            dispatch_layout<WithModuloArg<ModuloOp, SelectedIndexIterator>::HashValueCompute>(
+                    _global, layout, columns, _hash_partition_bf.size(),
+                    SelectedIndexIterator(hash_values, sel, sel_size));
+        }
+    }
+
+    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                                 uint8_t* selection, uint16_t from, uint16_t to,
+                                 std::vector<uint32_t>& hash_values) const override {
+        if (columns.empty() || _join_mode == TRuntimeFilterBuildJoinMode::NONE) return;
+        size_t num_rows = columns[0]->size();
+        DCHECK_EQ(hash_values.size(), num_rows);
+        auto use_reduce = (_join_mode == TRuntimeFilterBuildJoinMode::PARTITIONED ||
+                           _join_mode == TRuntimeFilterBuildJoinMode::SHUFFLE_HASH_BUCKET);
+        if (use_reduce) {
+            dispatch_layout<WithModuloArg<ReduceOp, SelectionIterator>::HashValueCompute>(
+                    _global, layout, columns, _hash_partition_bf.size(),
+                    SelectionIterator(hash_values, selection, from, to));
+
+        } else {
+            dispatch_layout<WithModuloArg<ModuloOp, SelectionIterator>::HashValueCompute>(
+                    _global, layout, columns, _hash_partition_bf.size(),
+                    SelectionIterator(hash_values, selection, from, to));
         }
     }
 
@@ -991,13 +1250,22 @@ private:
         }
     }
 
+    template <bool hash_partition>
+    bool _rf_test_data(const CppType& data, const uint32_t hash_value) const {
+        if constexpr (hash_partition) {
+            return _test_data_with_hash(data, hash_value);
+        } else {
+            return _test_data(data);
+        }
+    }
+
     // `multi_partition` parameters means if this runtime filter has multiple `simd-block-filter` underneath.
     // for local runtime filter, it only has once `simd-block-filter`, and `multi_partition` is false.
     // and for global runtime filter, since it concates multiple runtime filters from partitions
     // so it has multiple `simd-block-filter` and `multi_partition` is true.
     // For more information, you can refers to doc `shuffle-aware runtime filter`.
     template <bool multi_partition = false, bool can_use_bf = true>
-    void _t_evaluate(Column* input_column, RunningContext* ctx) const {
+    void _t_evaluate(const Column* input_column, RunningContext* ctx) const {
         size_t size = input_column->size();
         Filter& selection_filter = ctx->use_merged_selection ? ctx->merged_selection : ctx->selection;
         selection_filter.resize(size);
@@ -1050,6 +1318,106 @@ private:
             }
         }
     }
+
+    template <bool multi_partition = false, bool can_use_bf = true>
+    uint16_t _t_evaluate(const Column* column, const std::vector<uint32_t>& hash_values, uint16_t* sel,
+                         uint16_t sel_size, uint16_t* dst_sel) const {
+        if constexpr (multi_partition) {
+            CHECK_EQ(column->size(), hash_values.size())
+                    << "hash values size not equal to sel_size, " << column->size() << ", " << hash_values.size();
+        }
+        CHECK(dst_sel != nullptr) << "dst_sel must be set";
+        CHECK(!column->is_constant()) << "not support constant column";
+        uint16_t new_size = 0;
+        if (column->is_nullable()) {
+            const auto* nullable_column = down_cast<const NullableColumn*>(column);
+            const auto& data = GetContainer<Type>::get_data(nullable_column->data_column());
+            if (nullable_column->has_null()) {
+                const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
+                for (int i = 0; i < sel_size; i++) {
+                    uint16_t idx = sel[i];
+                    dst_sel[new_size] = idx;
+                    if (null_data[idx]) {
+                        new_size += _has_null;
+                    } else {
+                        if constexpr (can_use_bf) {
+                            new_size +=
+                                    _rf_test_data<multi_partition>(data[idx], multi_partition ? hash_values[idx] : 0);
+                        } else {
+                            new_size++;
+                        }
+                    }
+                }
+            } else {
+                if constexpr (can_use_bf) {
+                    for (int i = 0; i < sel_size; ++i) {
+                        uint16_t idx = dst_sel[i];
+                        dst_sel[new_size] = idx;
+                        new_size += _rf_test_data<multi_partition>(data[idx], multi_partition ? hash_values[idx] : 0);
+                    }
+                } else {
+                    new_size = sel_size;
+                }
+            }
+        } else {
+            const auto& data = GetContainer<Type>::get_data(column);
+            if constexpr (can_use_bf) {
+                for (int i = 0; i < sel_size; ++i) {
+                    uint16_t idx = dst_sel[i];
+                    dst_sel[new_size] = idx;
+                    new_size += _rf_test_data<multi_partition>(data[idx], multi_partition ? hash_values[idx] : 0);
+                }
+            } else {
+                new_size = sel_size;
+            }
+        }
+        return new_size;
+    }
+
+    template <bool multi_partition = false, bool can_use_bf = true>
+    void _t_evaluate(const Column* column, const std::vector<uint32_t>& hash_values, uint8_t* selection, uint16_t from,
+                     uint16_t to) const {
+        if constexpr (multi_partition) {
+            CHECK_EQ(column->size(), hash_values.size())
+                    << "hash values size not equal to column size, " << column->size() << ", " << hash_values.size();
+        }
+        CHECK(!column->is_constant()) << "not support constant column";
+        if (column->is_nullable()) {
+            const auto* nullable_column = down_cast<const NullableColumn*>(column);
+            const auto& data = GetContainer<Type>::get_data(nullable_column->data_column());
+            if (nullable_column->has_null()) {
+                const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
+                for (uint16_t i = from; i < to; i++) {
+                    if (null_data[i]) {
+                        selection[i] = _has_null;
+                    } else if (selection[i]) {
+                        if constexpr (can_use_bf) {
+                            selection[i] =
+                                    _rf_test_data<multi_partition>(data[i], multi_partition ? hash_values[i] : 0);
+                        }
+                    }
+                }
+            } else {
+                if constexpr (can_use_bf) {
+                    for (uint16_t i = from; i < to; i++) {
+                        if (selection[i]) {
+                            selection[i] =
+                                    _rf_test_data<multi_partition>(data[i], multi_partition ? hash_values[i] : 0);
+                        }
+                    }
+                }
+            }
+        } else {
+            const auto& data = GetContainer<Type>::get_data(column);
+            if constexpr (can_use_bf) {
+                for (uint16_t i = from; i < to; i++) {
+                    if (selection[i]) {
+                        selection[i] = _rf_test_data<multi_partition>(data[i], multi_partition ? hash_values[i] : 0);
+                    }
+                }
+            }
+        }
+    }
 };
 
 template <LogicalType Type>
@@ -1089,9 +1457,22 @@ public:
     TRuntimeBloomFilter<Type>& bloom_filter() { return _bloom_filter; }
     const TRuntimeBloomFilter<Type>& bloom_filter() const { return _bloom_filter; }
 
-    void evaluate(Column* input_column, RunningContext* ctx) const override {
+    void evaluate(const Column* input_column, RunningContext* ctx) const override {
         _min_max_filter.template t_evaluate<false>(input_column, ctx);
         bloom_filter().evaluate(input_column, ctx);
+    }
+
+    uint16_t evaluate(const Column* input_column, const std::vector<uint32_t>& hash_values, uint16_t* sel,
+                      uint16_t sel_size, uint16_t* dst_sel) const override {
+        uint16_t new_size = _min_max_filter.t_evaluate(input_column, sel, sel_size, dst_sel);
+        new_size = bloom_filter().evaluate(input_column, hash_values, dst_sel, new_size, dst_sel);
+        return new_size;
+    }
+
+    void evaluate(const Column* input_column, const std::vector<uint32_t>& hash_values, uint8_t* selection,
+                  uint16_t from, uint16_t to) const override {
+        _min_max_filter.t_evaluate(input_column, selection, from, to);
+        bloom_filter().evaluate(input_column, hash_values, selection, from, to);
     }
 
     void merge(const RuntimeFilter* rf) override {
@@ -1161,9 +1542,18 @@ public:
         return offset;
     }
 
-    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<Column*>& columns,
+    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
                                  RunningContext* ctx) const override {
         bloom_filter().compute_partition_index(layout, columns, ctx);
+    }
+    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                                 uint16_t* sel, uint16_t sel_size, std::vector<uint32_t>& hash_values) const override {
+        bloom_filter().compute_partition_index(layout, columns, sel, sel_size, hash_values);
+    }
+    void compute_partition_index(const RuntimeFilterLayout& layout, const std::vector<const Column*>& columns,
+                                 uint8_t* selection, uint16_t from, uint16_t to,
+                                 std::vector<uint32_t>& hash_values) const override {
+        bloom_filter().compute_partition_index(layout, columns, selection, from, to, hash_values);
     }
 
 private:

--- a/be/src/exprs/runtime_filter_bank.h
+++ b/be/src/exprs/runtime_filter_bank.h
@@ -197,6 +197,9 @@ public:
         _observable.add_observer(state, observer);
     }
 
+    void set_has_push_down_to_storage(bool v) { _has_push_down_to_storage = v; }
+    bool has_push_down_to_storage() const { return _has_push_down_to_storage; }
+
 private:
     friend class HashJoinNode;
     friend class hashJoiner;
@@ -221,6 +224,7 @@ private:
     std::atomic<const RuntimeFilter*> _runtime_filter = nullptr;
     std::shared_ptr<const RuntimeFilter> _shared_runtime_filter = nullptr;
     pipeline::Observable _observable;
+    bool _has_push_down_to_storage = false;
 };
 
 // RuntimeFilterProbeCollector::do_evaluate function apply runtime bloom filter to Operators to filter chunk.

--- a/be/src/exprs/runtime_filter_layout.h
+++ b/be/src/exprs/runtime_filter_layout.h
@@ -127,4 +127,31 @@ auto dispatch_layout(bool global, const RuntimeFilterLayout& layout, Args&&... a
     }
 }
 
+template <template <TRuntimeFilterLayoutMode::type> typename F, typename... Args>
+auto dispatch_layout_v2(bool global, const RuntimeFilterLayout& layout, Args&&... args) {
+    TRuntimeFilterLayoutMode::type layout_mode = global ? layout.global_layout() : layout.local_layout();
+    switch (layout_mode) {
+    case TRuntimeFilterLayoutMode::SINGLETON:
+        return F<TRuntimeFilterLayoutMode::SINGLETON>()(layout, std::forward<Args>(args)...);
+    case TRuntimeFilterLayoutMode::PIPELINE_SHUFFLE:
+        return F<TRuntimeFilterLayoutMode::PIPELINE_SHUFFLE>()(layout, std::forward<Args>(args)...);
+    case TRuntimeFilterLayoutMode::GLOBAL_SHUFFLE_2L:
+        return F<TRuntimeFilterLayoutMode::GLOBAL_SHUFFLE_2L>()(layout, std::forward<Args>(args)...);
+    case TRuntimeFilterLayoutMode::GLOBAL_SHUFFLE_1L:
+        return F<TRuntimeFilterLayoutMode::GLOBAL_SHUFFLE_1L>()(layout, std::forward<Args>(args)...);
+    case TRuntimeFilterLayoutMode::PIPELINE_BUCKET_LX:
+        return F<TRuntimeFilterLayoutMode::PIPELINE_BUCKET_LX>()(layout, std::forward<Args>(args)...);
+    case TRuntimeFilterLayoutMode::PIPELINE_BUCKET:
+        return F<TRuntimeFilterLayoutMode::PIPELINE_BUCKET>()(layout, std::forward<Args>(args)...);
+    case TRuntimeFilterLayoutMode::GLOBAL_BUCKET_2L_LX:
+        return F<TRuntimeFilterLayoutMode::GLOBAL_BUCKET_2L_LX>()(layout, std::forward<Args>(args)...);
+    case TRuntimeFilterLayoutMode::GLOBAL_BUCKET_2L:
+        return F<TRuntimeFilterLayoutMode::GLOBAL_BUCKET_2L>()(layout, std::forward<Args>(args)...);
+    case TRuntimeFilterLayoutMode::GLOBAL_BUCKET_1L:
+        return F<TRuntimeFilterLayoutMode::GLOBAL_BUCKET_1L>()(layout, std::forward<Args>(args)...);
+    default:
+        CHECK(false) << "Unknown type: " << layout_mode;
+        __builtin_unreachable();
+    }
+}
 } // namespace starrocks

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -168,7 +168,6 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         *row_count = 0;
         return Status::EndOfFile("");
     }
-
     _read_chunk->reset();
 
     ChunkPtr active_chunk = _create_read_chunk(_active_column_indices);

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -509,6 +509,11 @@ public:
     bool enable_event_scheduler() const { return _enable_event_scheduler; }
     void set_enable_event_scheduler(bool enable) { _enable_event_scheduler = enable; }
 
+    bool enable_join_runtime_filter_pushdown() const {
+        return _query_options.__isset.enable_join_runtime_filter_pushdown &&
+               _query_options.enable_join_runtime_filter_pushdown;
+    }
+
     DebugActionMgr& debug_action_mgr() { return _debug_action_mgr; }
 
 private:

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -139,6 +139,7 @@ set(STORAGE_FILES
     column_and_predicate.cpp
     column_expr_predicate.cpp
     conjunctive_predicates.cpp
+    runtime_filter_predicate.cpp
     predicate_tree/predicate_tree.cpp
     convert_helper.cpp
     delete_predicates.cpp

--- a/be/src/storage/column_placeholder_predicate.h
+++ b/be/src/storage/column_placeholder_predicate.h
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstring>
+
+#include "column/column.h"
+#include "column/column_helper.h"
+#include "common/compiler_util.h"
+#include "common/statusor.h"
+#include "storage/column_predicate.h"
+
+namespace starrocks {
+
+class ColumnPlaceholderPredicate final : public ColumnPredicate {
+public:
+    explicit ColumnPlaceholderPredicate(const TypeInfoPtr& type_info, ColumnId id) : ColumnPredicate(type_info, id) {}
+
+    Status evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const override {
+        return Status::OK();
+    }
+    Status evaluate_and(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const override {
+        return Status::OK();
+    }
+    Status evaluate_or(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const override {
+        return Status::OK();
+    }
+    StatusOr<uint16_t> evaluate_branchless(const Column* column, uint16_t* sel, uint16_t sel_size) const override {
+        return sel_size;
+    }
+    bool can_vectorized() const override { return false; }
+    PredicateType type() const override { return PredicateType::kPlaceHolder; }
+    Status convert_to(const ColumnPredicate** output, const TypeInfoPtr& target_type_info,
+                      ObjectPool* obj_pool) const override {
+        return Status::NotSupported("not implemented");
+    }
+    std::string debug_string() const override {
+        std::stringstream ss;
+        ss << "placeholder " << ColumnPredicate::debug_string();
+        return ss.str();
+    }
+};
+
+ColumnPredicate* new_column_placeholder_predicate(const TypeInfoPtr& type_info, ColumnId id) {
+    return new ColumnPlaceholderPredicate(type_info, id);
+}
+} // namespace starrocks

--- a/be/src/storage/column_predicate.h
+++ b/be/src/storage/column_predicate.h
@@ -48,6 +48,7 @@ class RuntimeState;
 class SlotDescriptor;
 class BitmapIndexIterator;
 struct NgramBloomFilterReaderOptions;
+class RuntimeFilterProbeDescriptor;
 } // namespace starrocks
 
 namespace starrocks {
@@ -79,6 +80,7 @@ enum class PredicateType {
     kExpr = 13,
     kTrue = 14,
     kMap = 15,
+    kPlaceHolder = 16,
 };
 
 std::ostream& operator<<(std::ostream& os, PredicateType p);
@@ -255,5 +257,7 @@ ColumnPredicate* new_column_null_predicate(const TypeInfoPtr& type, ColumnId, bo
 
 ColumnPredicate* new_column_dict_conjuct_predicate(const TypeInfoPtr& type_info, ColumnId id,
                                                    std::vector<uint8_t> dict_mapping);
+
+ColumnPredicate* new_column_placeholder_predicate(const TypeInfoPtr& type_info, ColumnId id);
 
 } //namespace starrocks

--- a/be/src/storage/column_predicate_cmp.cpp
+++ b/be/src/storage/column_predicate_cmp.cpp
@@ -996,6 +996,9 @@ std::ostream& operator<<(std::ostream& os, PredicateType p) {
     case PredicateType::kMap:
         os << "map";
         break;
+    case PredicateType::kPlaceHolder:
+        os << "placeholder";
+        break;
     default:
         CHECK(false) << "unknown predicate " << p;
     }

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -179,7 +179,6 @@ StatusOr<ColumnPredicateRewriter::RewriteStatus> ColumnPredicateRewriter::_rewri
         return RewriteStatus::UNCHANGED;
     }
     DCHECK(_column_iterators[cid]->all_page_dict_encoded());
-
     if (PredicateType::kEQ == pred->type()) {
         Datum value = pred->value();
         int code = _column_iterators[cid]->dict_lookup(value.get_slice());
@@ -316,6 +315,9 @@ StatusOr<ColumnPredicateRewriter::RewriteStatus> ColumnPredicateRewriter::_rewri
         const auto& [dict_column, code_column] = *dict_and_codes_ptr;
 
         return _rewrite_expr_predicate(pool, dict_column, code_column, field->is_nullable(), pred, dest_pred);
+    }
+    if (PredicateType::kPlaceHolder == pred->type()) {
+        return RewriteStatus::ALWAYS_TRUE;
     }
 
     return RewriteStatus::UNCHANGED;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -235,6 +235,9 @@ struct OlapReaderStatistics {
     int64_t rows_vec_cond_filtered = 0;
     int64_t vec_cond_ns = 0;
     int64_t vec_cond_evaluate_ns = 0;
+    int64_t rf_cond_input_rows = 0;
+    int64_t rf_cond_output_rows = 0;
+    int64_t rf_cond_evaluate_ns = 0;
     int64_t vec_cond_chunk_copy_ns = 0;
     int64_t branchless_cond_evaluate_ns = 0;
     int64_t expr_cond_evaluate_ns = 0;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -714,6 +714,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     seg_options.stats = options.stats;
     seg_options.ranges = options.ranges;
     seg_options.pred_tree = options.pred_tree;
+    seg_options.runtime_filter_preds = options.runtime_filter_preds;
     seg_options.pred_tree_for_zone_map = options.pred_tree_for_zone_map;
     seg_options.use_page_cache = options.use_page_cache;
     seg_options.profile = options.profile;
@@ -727,6 +728,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     seg_options.use_vector_index = options.use_vector_index;
     seg_options.vector_search_option = options.vector_search_option;
     seg_options.sample_options = options.sample_options;
+    seg_options.enable_join_runtime_filter_pushdown = options.enable_join_runtime_filter_pushdown;
 
     if (options.delete_predicates != nullptr) {
         seg_options.delete_predicates = options.delete_predicates->get_predicates(end_version());

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -23,6 +23,7 @@
 #include "storage/olap_common.h"
 #include "storage/options.h"
 #include "storage/predicate_tree/predicate_tree.hpp"
+#include "storage/runtime_filter_predicate.h"
 #include "storage/runtime_range_pruner.h"
 #include "storage/seek_range.h"
 #include "storage/tablet_schema.h"
@@ -57,6 +58,7 @@ public:
 
     PredicateTree pred_tree;
     PredicateTree pred_tree_for_zone_map;
+    RuntimeFilterPredicates runtime_filter_preds;
 
     // whether rowset should return rows in sorted order.
     bool sorted = true;
@@ -96,6 +98,7 @@ public:
     VectorSearchOptionPtr vector_search_option = nullptr;
 
     TTableSampleOptions sample_options;
+    bool enable_join_runtime_filter_pushdown = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -59,6 +59,7 @@
 #include "storage/rowset/rowid_column_iterator.h"
 #include "storage/rowset/segment.h"
 #include "storage/rowset/short_key_range_option.h"
+#include "storage/runtime_filter_predicate.h"
 #include "storage/runtime_range_pruner.h"
 #include "storage/runtime_range_pruner.hpp"
 #include "storage/types.h"
@@ -333,6 +334,7 @@ private:
 
     PredicateTree _non_expr_pred_tree;
     PredicateTree _expr_pred_tree;
+    RuntimeFilterPredicates _runtime_filter_preds;
 
     // _selection is used to accelerate
     Buffer<uint8_t> _selection;
@@ -834,7 +836,6 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
 template <bool check_global_dict>
 Status SegmentIterator::_init_column_iterators(const Schema& schema) {
     SCOPED_RAW_TIMER(&_opts.stats->column_iterator_init_ns);
-
     const size_t n = std::max<size_t>(1 + ChunkHelper::max_column_id(schema), _column_iterators.size());
     _column_iterators.resize(n);
     if constexpr (check_global_dict) {
@@ -859,7 +860,6 @@ Status SegmentIterator::_init_column_iterators(const Schema& schema) {
             } else {
                 check_dict_enc = has_predicate;
             }
-
             RETURN_IF_ERROR(_init_column_iterator_by_cid(cid, f->uid(), check_dict_enc));
 
             if constexpr (check_global_dict) {
@@ -928,6 +928,7 @@ void SegmentIterator::_init_column_predicates() {
                                   &non_expr_pred_root);
     _expr_pred_tree = PredicateTree::create(std::move(expr_pred_root));
     _non_expr_pred_tree = PredicateTree::create(std::move(non_expr_pred_root));
+    _runtime_filter_preds = _opts.runtime_filter_preds;
 }
 
 Status SegmentIterator::_get_row_ranges_by_keys() {
@@ -1652,6 +1653,15 @@ StatusOr<uint16_t> SegmentIterator::_filter_by_non_expr_predicates(Chunk* chunk,
     }
 
     auto hit_count = SIMD::count_nonzero(&_selection[from], to - from);
+    if (_opts.enable_join_runtime_filter_pushdown && !_runtime_filter_preds.empty()) {
+        SCOPED_RAW_TIMER(&_opts.stats->rf_cond_evaluate_ns);
+        size_t input_count = hit_count;
+        RETURN_IF_ERROR(_runtime_filter_preds.evaluate(chunk, _selection.data(), from, to));
+        hit_count = SIMD::count_nonzero(&_selection[from], to - from);
+        _opts.stats->rf_cond_input_rows += input_count;
+        _opts.stats->rf_cond_output_rows += hit_count;
+    }
+
     uint16_t chunk_size = to;
     SCOPED_RAW_TIMER(&_opts.stats->vec_cond_chunk_copy_ns);
     if (hit_count == 0) {
@@ -1876,7 +1886,6 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
 
 Status SegmentIterator::_init_context() {
     _late_materialization_ratio = config::late_materialization_ratio;
-
     RETURN_IF_ERROR(_init_global_dict_decoder());
 
     if (_predicate_columns == 0 || _opts.pred_tree.empty() ||
@@ -1930,6 +1939,10 @@ Status SegmentIterator::_rewrite_predicates() {
         ColumnPredicateRewriter rewriter(_column_iterators, _schema, _predicate_need_rewrite, _predicate_columns,
                                          _scan_range);
         RETURN_IF_ERROR(rewriter.rewrite_predicate(&_obj_pool, _opts.pred_tree));
+    }
+    if (_opts.enable_join_runtime_filter_pushdown) {
+        RETURN_IF_ERROR(RuntimeFilterPredicatesRewriter::rewrite(&_obj_pool, _opts.runtime_filter_preds,
+                                                                 _column_iterators, _schema));
     }
 
     // for each delete predicate,
@@ -2537,7 +2550,6 @@ void SegmentIterator::close() {
 // materialization easier.
 inline Schema reorder_schema(const Schema& input, const PredicateTree& pred_tree) {
     const std::vector<FieldPtr>& fields = input.fields();
-
     Schema output;
     output.reserve(fields.size());
     for (const auto& field : fields) {

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -25,6 +25,7 @@
 #include "storage/disjunctive_predicates.h"
 #include "storage/options.h"
 #include "storage/predicate_tree/predicate_tree.hpp"
+#include "storage/runtime_filter_predicate.h"
 #include "storage/runtime_range_pruner.h"
 #include "storage/seek_range.h"
 #include "storage/tablet_schema.h"
@@ -57,6 +58,7 @@ public:
 
     PredicateTree pred_tree;
     PredicateTree pred_tree_for_zone_map;
+    RuntimeFilterPredicates runtime_filter_preds;
 
     DisjunctivePredicates delete_predicates;
 
@@ -116,6 +118,8 @@ public:
     // 1. Regular block smapling: Bernoulli sampling on page-id
     // 2. Partial-Sorted block: leverage data ordering to improve the evenness
     TTableSampleOptions sample_options;
+
+    bool enable_join_runtime_filter_pushdown = false;
 
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<LogicalType>& new_types, ObjectPool* obj_pool) const;

--- a/be/src/storage/runtime_filter_predicate.cpp
+++ b/be/src/storage/runtime_filter_predicate.cpp
@@ -1,0 +1,357 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/runtime_filter_predicate.h"
+
+#include <cstring>
+
+#include "common/config.h"
+#include "gutil/strings/fastmem.h"
+#include "runtime/mem_tracker.h"
+#include "simd/simd.h"
+#include "storage/rowset/column_iterator.h"
+
+namespace starrocks {
+
+bool RuntimeFilterPredicate::init(int32_t driver_sequence) {
+    if (_rf) {
+        return true;
+    }
+    _rf = _rf_desc->runtime_filter(driver_sequence);
+    return _rf != nullptr;
+}
+
+Status RuntimeFilterPredicate::evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) {
+    auto column = chunk->get_column_by_id(_column_id);
+    if (_rf->num_hash_partitions() > 0) {
+        hash_values.resize(column->size());
+        _rf->compute_partition_index(_rf_desc->layout(), {column.get()}, selection, from, to, hash_values);
+    }
+    _rf->evaluate(column.get(), hash_values, selection, from, to);
+    return Status::OK();
+}
+
+StatusOr<uint16_t> RuntimeFilterPredicate::evaluate(Chunk* chunk, uint16_t* sel, uint16_t sel_size,
+                                                    uint16_t* target_sel) {
+    if (sel_size == 0) {
+        return sel_size;
+    }
+    auto column = chunk->get_column_by_id(_column_id);
+    if (_rf->num_hash_partitions() > 0) {
+        hash_values.resize(column->size());
+        _rf->compute_partition_index(_rf_desc->layout(), {column.get()}, sel, sel_size, hash_values);
+    }
+    uint16_t ret = _rf->evaluate(column.get(), hash_values, sel, sel_size, target_sel);
+    return ret;
+}
+
+Status DictColumnRuntimeFilterPredicate::evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) {
+    RETURN_IF_ERROR(prepare());
+    auto column = chunk->get_column_by_id(_column_id).get();
+    if (column->is_nullable()) {
+        const auto* nullable_column = down_cast<const NullableColumn*>(column);
+        // dict code column must be int column
+        const auto& data = GetContainer<TYPE_INT>::get_data(nullable_column->data_column());
+        if (nullable_column->has_null()) {
+            const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
+            for (uint16_t i = from; i < to; i++) {
+                if (!selection[i]) continue;
+                if (null_data[i]) {
+                    selection[i] = _rf->has_null();
+                } else {
+                    selection[i] = _result[data[i]];
+                }
+            }
+        } else {
+            for (uint16_t i = from; i < to; i++) {
+                if (!selection[i]) continue;
+                selection[i] = _result[data[i]];
+            }
+        }
+    } else {
+        const auto& data = GetContainer<TYPE_INT>::get_data(column);
+        for (uint16_t i = from; i < to; i++) {
+            if (!selection[i]) continue;
+            selection[i] = _result[data[i]];
+        }
+    }
+    return Status::OK();
+}
+
+StatusOr<uint16_t> DictColumnRuntimeFilterPredicate::evaluate(Chunk* chunk, uint16_t* sel, uint16_t sel_size,
+                                                              uint16_t* target_sel) {
+    if (sel_size == 0) {
+        return sel_size;
+    }
+    RETURN_IF_ERROR(prepare());
+    auto column = chunk->get_column_by_id(_column_id).get();
+    uint16_t new_size = 0;
+    if (column->is_nullable()) {
+        const auto* nullable_column = down_cast<const NullableColumn*>(column);
+        const auto& data = GetContainer<TYPE_INT>::get_data(nullable_column->data_column());
+        if (nullable_column->has_null()) {
+            const uint8_t* null_data = nullable_column->immutable_null_column_data().data();
+            for (uint16_t i = 0; i < sel_size; i++) {
+                uint16_t idx = sel[i];
+                target_sel[new_size] = idx;
+                if (null_data[idx]) {
+                    new_size += _rf->has_null();
+                } else {
+                    new_size += _result[data[idx]];
+                }
+            }
+        } else {
+            for (uint16_t i = 0; i < sel_size; i++) {
+                uint16_t idx = sel[i];
+                target_sel[new_size] = idx;
+                new_size += _result[data[idx]];
+            }
+        }
+    } else {
+        const auto& data = GetContainer<TYPE_INT>::get_data(column);
+        for (uint16_t i = 0; i < sel_size; i++) {
+            uint16_t idx = sel[i];
+            target_sel[new_size] = idx;
+            new_size += _result[data[idx]];
+        }
+    }
+    return new_size;
+}
+
+Status DictColumnRuntimeFilterPredicate::prepare() {
+    DCHECK(_rf != nullptr);
+    if (!_result.empty()) {
+        return Status::OK();
+    }
+    auto binary_column = BinaryColumn::create();
+    std::vector<Slice> data_slice;
+    for (const auto& word : _dict_words) {
+        data_slice.emplace_back(word.data(), word.size());
+    }
+    binary_column->append_strings(data_slice.data(), data_slice.size());
+
+    RuntimeFilter::RunningContext ctx;
+    ctx.use_merged_selection = false;
+    ctx.selection.assign(_dict_words.size(), 1);
+
+    if (_rf->num_hash_partitions() > 0) {
+        // compute hash
+        ctx.hash_values.resize(binary_column->size());
+        _rf->compute_partition_index(_rf_desc->layout(), {binary_column.get()}, &ctx);
+    }
+    _rf->evaluate(binary_column.get(), &ctx);
+    _result.resize(_dict_words.size());
+
+    for (size_t i = 0; i < _dict_words.size(); ++i) {
+        _result[i] = ctx.selection[i];
+    }
+
+    return Status::OK();
+}
+
+void RuntimeFilterPredicates::_update_selectivity_map() {
+    _selectivity_map.clear();
+    std::sort(_sampling_ctxs.begin(), _sampling_ctxs.end(),
+              [](const SamplingCtx& a, const SamplingCtx& b) { return a.filter_rows > b.filter_rows; });
+    for (size_t i = 0; i < _sampling_ctxs.size() && _selectivity_map.size() < 3; i++) {
+        auto pred = _sampling_ctxs[i].pred;
+        double filter_ratio = _sampling_ctxs[i].filter_rows * 1.0 / _sample_rows;
+
+        if (filter_ratio >= 0.95) {
+            // very good, only keep one
+            _selectivity_map.clear();
+            _selectivity_map.emplace(filter_ratio, pred);
+            break;
+        }
+        if (filter_ratio >= 0.5) {
+            _selectivity_map.emplace(filter_ratio, pred);
+        }
+    }
+}
+
+Status RuntimeFilterPredicates::evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) {
+    if (_rf_predicates.empty()) {
+        return Status::OK();
+    }
+    _input_count = SIMD::count_nonzero(selection + from, to - from);
+    if (_input_count == 0) {
+        return Status::OK();
+    }
+    size_t num_rows = chunk->num_rows();
+    // We will decide which execution mode to use based on the sparseness of the rows selected in the chunk.
+    bool use_branchless_mode = (num_rows >= config::rf_branchless_ratio * _input_count);
+    switch (_state) {
+    case INIT: {
+        CHECK(_sampling_ctxs.empty()) << "sampling ctxs must be empty";
+        for (auto pred : _rf_predicates) {
+            if (pred->init(_driver_sequence)) {
+                _sampling_ctxs.emplace_back(SamplingCtx{pred, 0});
+            }
+        }
+        if (!_sampling_ctxs.empty()) {
+            _state = SAMPLE;
+            _sample_rows = 0;
+        } else {
+            // no rf can be used, just return
+            return Status::OK();
+        }
+    }
+    case SAMPLE: {
+        if (use_branchless_mode) {
+            RETURN_IF_ERROR(_evaluate_branchless<true>(chunk, selection, from, to));
+        } else {
+            RETURN_IF_ERROR(_evaluate_selection<true>(chunk, selection, from, to));
+        }
+        _sample_rows += _input_count;
+        if (_sample_rows >= config::rf_sample_rows) {
+            _update_selectivity_map();
+            _state = NORMAL;
+            _skip_rows = 0;
+            _target_skip_rows = _sample_rows * config::rf_sample_ratio;
+        }
+        return Status::OK();
+    }
+    case NORMAL: {
+        if (use_branchless_mode) {
+            RETURN_IF_ERROR(_evaluate_branchless<false>(chunk, selection, from, to));
+        } else {
+            RETURN_IF_ERROR(_evaluate_selection<false>(chunk, selection, from, to));
+        }
+        _skip_rows += _input_count;
+        if (_skip_rows >= _target_skip_rows) {
+            _state = INIT;
+            _sampling_ctxs.clear();
+            _sample_rows = 0;
+        }
+        return Status::OK();
+    }
+    default:
+        break;
+    }
+    __builtin_unreachable();
+}
+
+template <bool is_sample>
+Status RuntimeFilterPredicates::_evaluate_branchless(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) {
+    _input_sel.clear();
+    for (uint16_t i = from; i < to; i++) {
+        if (selection[i]) {
+            _input_sel.emplace_back(i);
+        }
+    }
+    CHECK(!_input_sel.empty()) << "input selection must not be empty";
+    uint16_t output_count = _input_count;
+    if constexpr (is_sample) {
+        if (_sampling_ctxs.size() == 1) {
+            auto pred = _sampling_ctxs[0].pred;
+            auto& filter_rows = _sampling_ctxs[0].filter_rows;
+            ASSIGN_OR_RETURN(output_count,
+                             pred->evaluate(chunk, _input_sel.data(), _input_sel.size(), _input_sel.data()));
+            memset(selection + from, 0, to - from);
+            for (uint16_t i = 0; i < output_count; i++) {
+                selection[_input_sel[i]] = 1;
+            }
+            filter_rows += _input_count - output_count;
+        } else {
+            // if there are multiple runtime filters, we need to record the number of times each row hits the RF.
+            // only when all runtime filters do not filter out the data, the corresponding row is retained.
+            _hit_count.resize(chunk->num_rows());
+            memset(_hit_count.data() + from, 0, (to - from) * sizeof(uint16_t));
+            _tmp_sel.resize(_input_sel.size());
+            for (size_t i = 0; i < _sampling_ctxs.size(); i++) {
+                auto pred = _sampling_ctxs[i].pred;
+                auto& filter_rows = _sampling_ctxs[i].filter_rows;
+                ASSIGN_OR_RETURN(output_count,
+                                 pred->evaluate(chunk, _input_sel.data(), _input_sel.size(), _tmp_sel.data()));
+                for (uint16_t j = 0; j < output_count; j++) {
+                    _hit_count[_tmp_sel[j]]++;
+                }
+                filter_rows += _input_count - output_count;
+            }
+            uint16_t target_num = _sampling_ctxs.size();
+            for (uint16_t i = from; i < to; i++) {
+                selection[i] = (_hit_count[i] == target_num);
+            }
+        }
+    } else {
+        for (auto& [_, pred] : _selectivity_map) {
+            ASSIGN_OR_RETURN(output_count, pred->evaluate(chunk, _input_sel.data(), output_count, _input_sel.data()));
+        }
+        memset(selection + from, 0, to - from);
+        for (uint16_t i = 0; i < output_count; i++) {
+            selection[_input_sel[i]] = 1;
+        }
+    }
+    return Status::OK();
+}
+
+template <bool is_sample>
+Status RuntimeFilterPredicates::_evaluate_selection(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) {
+    CHECK_GT(_input_count, 0) << "input count must be greater than 0";
+    if constexpr (is_sample) {
+        if (_sampling_ctxs.size() == 1) {
+            // only one filter, no need to merge selection
+            auto pred = _sampling_ctxs[0].pred;
+            auto& filter_rows = _sampling_ctxs[0].filter_rows;
+            RETURN_IF_ERROR(pred->evaluate(chunk, selection, from, to));
+            uint16_t output_count = SIMD::count_nonzero(selection + from, to - from);
+            filter_rows += _input_count - output_count;
+        } else {
+            _input_selection.resize(chunk->num_rows());
+            _tmp_selection.resize(chunk->num_rows());
+            strings::memcpy_inlined(_input_selection.data() + from, selection + from, to - from);
+            for (size_t i = 0; i < _sampling_ctxs.size(); i++) {
+                auto pred = _sampling_ctxs[i].pred;
+                auto& filter_rows = _sampling_ctxs[i].filter_rows;
+                strings::memcpy_inlined(_tmp_selection.data() + from, _input_selection.data() + from, to - from);
+                RETURN_IF_ERROR(pred->evaluate(chunk, _tmp_selection.data(), from, to));
+                uint16_t output_count = SIMD::count_nonzero(_tmp_selection.data() + from, to - from);
+                filter_rows += _input_count - output_count;
+                for (uint16_t j = from; j < to; j++) {
+                    selection[j] = selection[j] & _tmp_selection[j];
+                }
+            }
+        }
+    } else {
+        for (auto& [_, pred] : _selectivity_map) {
+            RETURN_IF_ERROR(pred->evaluate(chunk, selection, from, to));
+        }
+    }
+    return Status::OK();
+}
+
+Status RuntimeFilterPredicatesRewriter::rewrite(ObjectPool* obj_pool, RuntimeFilterPredicates& preds,
+                                                const std::vector<std::unique_ptr<ColumnIterator>>& column_iterators,
+                                                const Schema& schema) {
+    auto& predicates = preds._rf_predicates;
+    for (size_t i = 0; i < predicates.size(); i++) {
+        auto* pred = predicates[i];
+        ColumnId column_id = pred->get_column_id();
+        if (!column_iterators[column_id]->all_page_dict_encoded()) {
+            continue;
+        }
+        auto* rf_desc = pred->get_rf_desc();
+        // For dictionary-encoded columns, we can directly calculate the runtime filter based on the dictionary words
+        // instead of decoding it first.
+        std::vector<Slice> all_words;
+        RETURN_IF_ERROR(column_iterators[column_id]->fetch_all_dict_words(&all_words));
+        std::vector<std::string> dict_words;
+        for (const auto& word : all_words) {
+            dict_words.emplace_back(std::string(word.get_data(), word.get_size()));
+        }
+        predicates[i] = obj_pool->add(new DictColumnRuntimeFilterPredicate(rf_desc, column_id, std::move(dict_words)));
+    }
+    return Status::OK();
+}
+} // namespace starrocks

--- a/be/src/storage/runtime_filter_predicate.cpp
+++ b/be/src/storage/runtime_filter_predicate.cpp
@@ -143,6 +143,7 @@ Status DictColumnRuntimeFilterPredicate::prepare() {
 
     RuntimeFilter::RunningContext ctx;
     ctx.use_merged_selection = false;
+    ctx.compatibility = false;
     ctx.selection.assign(_dict_words.size(), 1);
 
     if (_rf->num_hash_partitions() > 0) {

--- a/be/src/storage/runtime_filter_predicate.h
+++ b/be/src/storage/runtime_filter_predicate.h
@@ -1,0 +1,127 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
+#include "common/status.h"
+#include "exprs/runtime_filter_bank.h"
+
+namespace starrocks {
+class RuntimeFilterProbeDescriptor;
+
+class RuntimeFilterPredicate {
+public:
+    RuntimeFilterPredicate(RuntimeFilterProbeDescriptor* desc, ColumnId column_id)
+            : _rf_desc(desc), _column_id(column_id) {}
+    virtual ~RuntimeFilterPredicate() = default;
+
+    virtual Status evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to);
+    virtual StatusOr<uint16_t> evaluate(Chunk* chunk, uint16_t* sel, uint16_t sel_size, uint16_t* target_sel);
+
+    ColumnId get_column_id() const { return _column_id; }
+    RuntimeFilterProbeDescriptor* get_rf_desc() const { return _rf_desc; }
+    bool init(int32_t driver_sequence);
+
+protected:
+    RuntimeFilterProbeDescriptor* _rf_desc;
+    const RuntimeFilter* _rf = nullptr;
+    ColumnId _column_id;
+    std::vector<uint32_t> hash_values;
+};
+
+class DictColumnRuntimeFilterPredicate : public RuntimeFilterPredicate {
+public:
+    DictColumnRuntimeFilterPredicate(RuntimeFilterProbeDescriptor* rf_desc, ColumnId column_id,
+                                     std::vector<std::string> dict_words)
+            : RuntimeFilterPredicate(rf_desc, column_id), _dict_words(std::move(dict_words)) {}
+    ~DictColumnRuntimeFilterPredicate() override = default;
+
+    Status evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) override;
+    StatusOr<uint16_t> evaluate(Chunk* chunk, uint16_t* sel, uint16_t sel_size, uint16_t* dst_sel) override;
+
+private:
+    Status prepare();
+
+    std::vector<std::string> _dict_words;
+    std::vector<uint8_t> _result;
+};
+
+class RuntimeFilterPredicatesRewriter;
+// RuntimeFilterPredicates is used to evaluate runtime filter predicates in the storage layer.
+// The general workflow is as follows:
+// 1. INIT stage: collect all available runtime filters. If there is at least one runtime filter, enter the SAMPLE stage.
+// 2. SAMPLE stage: evaluate each avaiable runtime filter on a small portion of data and record the selectivity of each run time filter,
+//    at the end of SAMPLE, select and retain the runtime filters with the best selectivity.
+// 3. NORMAL stage: execute all selected runtime filters on the input data. after processing enough data, it will return to the INIT stage and start the next stage of sampling.
+class RuntimeFilterPredicates {
+    friend class RuntimeFilterPredicatesRewriter;
+
+public:
+    enum State : uint8_t {
+        INIT = 0,
+        SAMPLE = 1,
+        NORMAL = 2,
+    };
+    RuntimeFilterPredicates() = default;
+    RuntimeFilterPredicates(int32_t driver_sequence) : _driver_sequence(driver_sequence) {}
+
+    void add_predicate(RuntimeFilterPredicate* pred) { _rf_predicates.emplace_back(pred); }
+    bool empty() const { return _rf_predicates.empty(); }
+
+    Status evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to);
+
+private:
+    template <bool is_sample>
+    Status _evaluate_selection(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to);
+
+    template <bool is_sample>
+    Status _evaluate_branchless(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to);
+
+    void _update_selectivity_map();
+
+    State _state = INIT;
+    std::vector<RuntimeFilterPredicate*> _rf_predicates;
+    struct SamplingCtx {
+        RuntimeFilterPredicate* pred = nullptr;
+        size_t filter_rows = 0;
+    };
+    std::vector<SamplingCtx> _sampling_ctxs;
+    // some variables that need to be reused for each evaluation
+    std::vector<uint8_t> _input_selection;
+    std::vector<uint8_t> _tmp_selection;
+    std::vector<uint16_t> _input_sel;
+    std::vector<uint16_t> _tmp_sel;
+    std::vector<uint16_t> _hit_count;
+    uint16_t _input_count = 0;
+
+    size_t _sample_rows = 0;
+    size_t _skip_rows = 0;
+    size_t _target_skip_rows = 0;
+
+    std::map<double, RuntimeFilterPredicate*, std::greater<double>> _selectivity_map;
+
+    int32_t _driver_sequence = -1;
+};
+
+using RuntimeFilterPredicatesPtr = std::shared_ptr<RuntimeFilterPredicates>;
+class ColumnIterator;
+class Schema;
+class RuntimeFilterPredicatesRewriter {
+public:
+    static Status rewrite(ObjectPool* obj_pool, RuntimeFilterPredicates& preds,
+                          const std::vector<std::unique_ptr<ColumnIterator>>& column_iterators, const Schema& schema);
+};
+
+} // namespace starrocks

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -288,6 +288,7 @@ Status TabletReader::_init_collector_for_pk_index_read() {
     rs_opts.is_primary_keys = false;
     rs_opts.use_vector_index = _reader_params->use_vector_index;
     rs_opts.vector_search_option = _reader_params->vector_search_option;
+    rs_opts.enable_join_runtime_filter_pushdown = _reader_params->enable_join_runtime_filter_pushdown;
 
     rs_opts.rowid_range_option = std::make_shared<RowidRangeOption>();
     auto rowid_range = std::make_shared<SparseRange<>>();
@@ -344,6 +345,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     RETURN_IF_ERROR(parse_seek_range(_tablet_schema, params.range, params.end_range, params.start_key, params.end_key,
                                      &rs_opts.ranges, &_mempool));
     rs_opts.pred_tree = params.pred_tree;
+    rs_opts.runtime_filter_preds = params.runtime_filter_preds;
     PredicateTree pred_tree_for_zone_map;
     RETURN_IF_ERROR(ZonemapPredicatesRewriter::rewrite_predicate_tree(&_obj_pool, rs_opts.pred_tree,
                                                                       rs_opts.pred_tree_for_zone_map));
@@ -363,6 +365,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.use_vector_index = params.use_vector_index;
     rs_opts.vector_search_option = params.vector_search_option;
     rs_opts.sample_options = params.sample_options;
+    rs_opts.enable_join_runtime_filter_pushdown = params.enable_join_runtime_filter_pushdown;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
         rs_opts.version = _version.second;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -24,6 +24,7 @@
 #include "storage/chunk_iterator.h"
 #include "storage/olap_common.h"
 #include "storage/predicate_tree/predicate_tree.hpp"
+#include "storage/runtime_filter_predicate.h"
 #include "storage/runtime_range_pruner.h"
 #include "storage/tuple.h"
 
@@ -72,6 +73,7 @@ struct TabletReaderParams {
     std::vector<OlapTuple> start_key;
     std::vector<OlapTuple> end_key;
     PredicateTree pred_tree;
+    RuntimeFilterPredicates runtime_filter_preds;
 
     RuntimeState* runtime_state = nullptr;
 
@@ -104,6 +106,7 @@ struct TabletReaderParams {
     VectorSearchOptionPtr vector_search_option = nullptr;
 
     TTableSampleOptions sample_options;
+    bool enable_join_runtime_filter_pushdown = false;
 
 public:
     std::string to_string() const;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -423,6 +423,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY = "runtime_filter_early_return_selectivity";
     public static final String ENABLE_TOPN_RUNTIME_FILTER = "enable_topn_runtime_filter";
     public static final String GLOBAL_RUNTIME_FILTER_RPC_HTTP_MIN_SIZE = "global_runtime_filter_rpc_http_min_size";
+    public static final String ENABLE_JOIN_RUNTIME_FILTER_PUSH_DOWN = "enable_join_runtime_filter_push_down";
 
     public static final String ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF =
             "enable_pipeline_level_multi_partitioned_rf";
@@ -1483,6 +1484,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private float runtimeFilterEarlyReturnSelectivity = 0.05f;
     @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_RPC_HTTP_MIN_SIZE, flag = VariableMgr.INVISIBLE)
     private long globalRuntimeFilterRpcHttpMinSize = 64L * 1024 * 1024;
+    @VariableMgr.VarAttr(name = ENABLE_JOIN_RUNTIME_FILTER_PUSH_DOWN, flag = VariableMgr.INVISIBLE)
+    private boolean enableJoinRuntimeFilterPushDown = true;
 
     @VarAttr(name = ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF)
     private boolean enablePipelineLevelMultiPartitionedRf = false;
@@ -4705,6 +4708,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setRuntime_filter_send_timeout_ms(globalRuntimeFilterRpcTimeout);
         tResult.setRuntime_filter_scan_wait_time_ms(runtimeFilterScanWaitTime);
         tResult.setRuntime_filter_rpc_http_min_size(globalRuntimeFilterRpcHttpMinSize);
+        tResult.setEnable_join_runtime_filter_pushdown(enableJoinRuntimeFilterPushDown);
         tResult.setPipeline_dop(pipelineDop);
         if (pipelineProfileLevel == 2) {
             tResult.setPipeline_profile_level(TPipelineProfileLevel.DETAIL);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -326,6 +326,8 @@ struct TQueryOptions {
   150: optional map<string, string> ann_params;
   151: optional double pq_refine_factor;
   152: optional double k_factor;
+
+  160: optional bool enable_join_runtime_filter_pushdown;
 }
 
 // A scan range plus the parameters needed to execute that scan.

--- a/test/sql/test_colocate/R/test_colocate
+++ b/test/sql/test_colocate/R/test_colocate
@@ -147,130 +147,66 @@ INSERT INTO t4 (c0, c1, c2, c3) VALUES
   (null, 'o', 'Value15', 150);
 -- result:
 -- !result
-select t1.c0, t2.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0=t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1;
+select t1.c0, t2.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0=t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 order by 1,2,3,4,5,6;
 -- result:
-5	5	None	f	f	None
-2	2	2	b	b	b
-8	8	8	h	h	h
-8	8	8	h	h	h
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-4	4	None	d	d	None
-10	10	10	j	j	j
-14	None	None	l	None	None
-1	None	None	a	None	None
-5	None	None	None	None	None
 None	None	None	None	None	None
-None	None	None	k	None	None
-15	None	None	o	None	None
 None	None	None	c	None	None
--- !result
-select t1.c0, t2.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1;
--- result:
-None	None	None	c	c	None
-8	8	8	h	h	h
-8	8	8	h	h	h
-10	10	10	j	j	j
-4	4	None	d	d	None
-14	None	None	l	None	None
+None	None	None	k	None	None
 1	None	None	a	None	None
-None	None	None	None	None	None
+2	2	2	b	b	b
+4	4	None	d	d	None
 5	None	None	None	None	None
+5	5	None	f	f	None
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+14	None	None	l	None	None
 15	None	None	o	None	None
-5	5	None	f	f	None
-None	None	None	k	k	None
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-2	2	2	b	b	b
 -- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1;
+select t1.c0, t2.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 order by 1,2,3,4,5,6;
 -- result:
-14	14	None	l	None	None
-None	None	None	c	c	None
-8	8	8	h	h	h
-8	8	8	h	h	h
-5	5	None	f	f	None
-4	4	None	d	d	None
-2	2	2	b	b	b
-None	None	None	k	k	k
-10	10	10	j	j	j
 None	None	None	None	None	None
-1	1	None	a	None	None
-5	5	None	None	None	None
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-15	15	None	o	None	None
--- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1;
--- result:
-4	4	None	d	d	None
-5	5	None	None	None	None
-1	1	None	a	None	None
-14	14	None	l	None	None
-None	None	None	None	None	None
-15	15	None	o	None	None
 None	None	None	c	c	None
-5	5	None	f	f	None
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
 None	None	None	k	k	None
-8	8	8	h	h	h
-8	8	8	h	h	h
+1	None	None	a	None	None
 2	2	2	b	b	b
-10	10	10	j	j	j
--- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1;
--- result:
 4	4	None	d	d	None
-14	14	None	l	None	None
-2	2	2	b	b	b
+5	None	None	None	None	None
+5	5	None	f	f	None
+8	8	8	h	h	h
+8	8	8	h	h	h
 10	10	10	j	j	j
-5	5	None	None	None	None
-15	15	None	o	None	None
-1	1	None	a	None	None
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+14	None	None	l	None	None
+15	None	None	o	None	None
+-- !result
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 order by 1,2,3,4,5,6;
+-- result:
+None	None	None	None	None	None
 None	None	None	c	c	None
 None	None	None	k	k	k
-8	8	8	h	h	h
-8	8	8	h	h	h
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-None	None	None	None	None	None
-5	5	None	f	f	None
--- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1;
--- result:
-5	5	None	f	f	None
+1	1	None	a	None	None
 2	2	2	b	b	b
+4	4	None	d	d	None
+5	5	None	None	None	None
+5	5	None	f	f	None
+8	8	8	h	h	h
+8	8	8	h	h	h
 10	10	10	j	j	j
 12	12	12	l	l	l
 12	12	12	l	l	l
@@ -280,861 +216,913 @@ select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>
 12	12	12	l	l	l
 12	12	12	l	l	l
 12	12	12	l	l	l
-4	4	None	d	d	None
+14	14	None	l	None	None
+15	15	None	o	None	None
+-- !result
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 order by 1,2,3,4,5,6;
+-- result:
+None	None	None	None	None	None
 None	None	None	c	c	None
+None	None	None	k	k	None
+1	1	None	a	None	None
+2	2	2	b	b	b
+4	4	None	d	d	None
+5	5	None	None	None	None
+5	5	None	f	f	None
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+14	14	None	l	None	None
+15	15	None	o	None	None
+-- !result
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 order by 1,2,3,4,5,6;
+-- result:
+None	None	None	None	None	None
+None	None	None	c	c	None
+None	None	None	k	k	k
+1	1	None	a	None	None
+2	2	2	b	b	b
+4	4	None	d	d	None
+5	5	None	None	None	None
+5	5	None	f	f	None
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+14	14	None	l	None	None
+15	15	None	o	None	None
+-- !result
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 order by 1,2,3,4,5,6;
+-- result:
+None	None	None	None	None	None
+None	None	None	c	c	None
+None	None	None	k	k	k
+1	1	None	a	None	None
+2	2	2	b	b	b
+4	4	None	d	d	None
+5	5	None	f	f	None
 5	5	5	None	None	None
-None	None	None	k	k	k
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
 14	14	None	l	None	None
-8	8	8	h	h	h
-8	8	8	h	h	h
-None	None	None	None	None	None
-1	1	None	a	None	None
 15	15	None	o	None	None
 -- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
 -- result:
-14	14	None	l	None	None
+None	None	None	None	None	None
 None	None	None	c	None	None
-5	5	None	f	f	None
 None	None	None	k	None	None
 1	1	None	a	None	None
-None	None	None	None	None	None
-5	5	None	None	None	None
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
 2	2	2	b	b	b
-15	15	None	o	None	None
 4	4	None	d	d	None
-8	8	8	h	h	h
-8	8	8	h	h	h
-10	10	10	j	j	j
--- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1;
--- result:
-None	None	None	None	None	None
-15	15	None	o	None	None
-8	8	8	h	h	h
-8	8	8	h	h	h
-None	None	None	c	c	None
-10	10	10	j	j	j
-1	1	None	a	None	None
-14	14	None	l	None	None
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-4	4	None	d	d	None
+5	5	None	None	None	None
 5	5	None	f	f	None
-5	5	None	None	None	None
-None	None	None	k	k	None
-2	2	2	b	b	b
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+14	14	None	l	None	None
+15	15	None	o	None	None
 -- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 <=> t3.c0 and t1.c1 =t3.c1;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
 -- result:
 None	None	None	None	None	None
+None	None	None	c	c	None
+None	None	None	k	k	None
+1	1	None	a	None	None
+2	2	2	b	b	b
+4	4	None	d	d	None
+5	5	None	None	None	None
+5	5	None	f	f	None
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
 14	14	None	l	None	None
+15	15	None	o	None	None
+-- !result
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 <=> t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
+-- result:
+None	None	None	None	None	None
 None	None	None	c	c	None
 None	None	None	k	k	k
+1	1	None	a	None	None
+2	2	2	b	b	b
+4	4	None	d	d	None
+5	5	None	None	None	None
+5	5	None	f	f	None
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+14	14	None	l	None	None
 15	15	None	o	None	o
-1	1	None	a	None	None
-8	8	8	h	h	h
-8	8	8	h	h	h
-2	2	2	b	b	b
-5	5	None	f	f	None
-10	10	10	j	j	j
-5	5	None	None	None	None
-4	4	None	d	d	None
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
 -- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 = t4.c0 and t2.c3 = t4.c1;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 = t4.c0 and t2.c3 = t4.c1 order by 1,2,3,4,5,6;
 -- result:
-None	None	None	None	None	k
-None	None	5	None	None	h
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-8	8	8	h	h	h
-8	8	8	h	h	h
-None	None	3	None	None	c
-None	None	1	None	None	a
-None	None	14	None	None	m
-10	10	10	j	j	j
-None	None	3	None	None	d
-None	None	None	None	None	o
-None	None	5	None	None	None
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-2	2	2	b	b	b
-None	None	8	None	None	None
 None	None	None	None	None	f
--- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 <=> t4.c0 and t2.c3 = t4.c1;
--- result:
 None	None	None	None	None	k
-10	10	10	j	j	j
-None	None	14	None	None	m
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
+None	None	None	None	None	o
+None	None	1	None	None	a
 None	None	3	None	None	c
+None	None	3	None	None	d
+None	None	5	None	None	None
+None	None	5	None	None	h
+None	None	8	None	None	None
+None	None	14	None	None	m
 2	2	2	b	b	b
 8	8	8	h	h	h
 8	8	8	h	h	h
-None	None	5	None	None	None
-None	None	1	None	None	a
-None	None	None	None	None	o
-None	None	5	None	None	h
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-None	None	3	None	None	d
-None	None	8	None	None	None
-None	None	None	None	None	f
--- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1;
--- result:
 10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+-- !result
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 <=> t4.c0 and t2.c3 = t4.c1 order by 1,2,3,4,5,6;
+-- result:
+None	None	None	None	None	f
+None	None	None	None	None	k
+None	None	None	None	None	o
+None	None	1	None	None	a
+None	None	3	None	None	c
+None	None	3	None	None	d
+None	None	5	None	None	None
+None	None	5	None	None	h
+None	None	8	None	None	None
+None	None	14	None	None	m
+2	2	2	b	b	b
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+-- !result
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 order by 1,2,3,4,5,6;
+-- result:
+None	None	None	None	None	None
+None	None	None	None	c	None
+None	None	None	None	k	k
 None	None	None	None	o	o
-8	8	8	h	h	h
-8	8	8	h	h	h
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-None	None	8	None	None	None
-None	None	None	k	k	k
-None	None	None	None	None	None
-4	4	None	d	d	None
-None	None	14	None	m	m
 None	None	5	None	h	h
-5	5	None	f	f	None
-2	2	2	b	b	b
-None	None	None	c	c	None
-5	5	5	None	None	None
--- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 right join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1;
--- result:
-None	None	5	None	None	None
-None	None	5	None	None	h
-None	None	14	None	None	m
-None	None	None	None	None	o
-None	None	3	None	None	d
-8	8	8	h	h	h
-8	8	8	h	h	h
-None	None	1	None	None	a
-None	None	3	None	None	c
-2	2	2	b	b	b
-10	10	10	j	j	j
-None	None	None	None	None	k
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
 None	None	8	None	None	None
-None	None	None	None	None	f
--- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1;
--- result:
-None	None	5	None	None	None
-None	None	3	None	None	d
-None	None	None	None	None	o
-None	None	14	None	None	m
-10	10	10	j	j	j
-8	8	8	h	h	h
-8	8	8	h	h	h
-None	None	3	None	None	c
-None	None	None	None	None	k
-None	None	5	None	None	h
+None	None	14	None	m	m
 2	2	2	b	b	b
-None	None	1	None	None	a
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-None	None	None	None	None	f
-None	None	8	None	None	None
--- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 <=> t3.c0 and t1.c1 =t3.c1;
--- result:
-None	None	None	None	m	None
-None	None	None	None	h	None
-5	5	None	None	None	None
-None	None	None	None	None	None
-None	None	None	None	o	None
-8	8	8	h	h	h
-8	8	8	h	h	h
 4	4	None	d	d	None
-None	None	None	k	k	k
-10	10	10	j	j	j
-2	2	2	b	b	b
 5	5	None	f	f	None
-None	None	None	c	c	None
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-12	12	12	l	l	l
-None	None	None	None	None	None
--- !result
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 = t4.c0 and t2.c3 = t4.c1;
--- result:
-None	None	5	None	None	None
-None	None	3	None	None	c
+5	5	5	None	None	None
+8	8	8	h	h	h
+8	8	8	h	h	h
 10	10	10	j	j	j
-None	None	1	None	None	a
-None	None	None	None	None	k
-None	None	14	None	None	m
 12	12	12	l	l	l
 12	12	12	l	l	l
 12	12	12	l	l	l
 12	12	12	l	l	l
-None	None	3	None	None	d
 12	12	12	l	l	l
 12	12	12	l	l	l
 12	12	12	l	l	l
 12	12	12	l	l	l
-8	8	8	h	h	h
-8	8	8	h	h	h
-None	None	5	None	None	h
+-- !result
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 right join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
+-- result:
 None	None	None	None	None	f
-None	None	8	None	None	None
+None	None	None	None	None	k
 None	None	None	None	None	o
+None	None	1	None	None	a
+None	None	3	None	None	c
+None	None	3	None	None	d
+None	None	5	None	None	None
+None	None	5	None	None	h
+None	None	8	None	None	None
+None	None	14	None	None	m
 2	2	2	b	b	b
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
 -- !result
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0=t2.c0 and t1.c1=t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
 -- result:
-2	2	b	b	b
-5	5	f	f	None
-4	4	d	d	None
-8	8	h	h	h
-14	None	l	None	None
-8	None	h	None	None
+None	None	None	None	None	f
+None	None	None	None	None	k
+None	None	None	None	None	o
+None	None	1	None	None	a
+None	None	3	None	None	c
+None	None	3	None	None	d
+None	None	5	None	None	None
+None	None	5	None	None	h
+None	None	8	None	None	None
+None	None	14	None	None	m
+2	2	2	b	b	b
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+-- !result
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 <=> t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
+-- result:
+None	None	None	None	None	None
+None	None	None	None	None	None
+None	None	None	None	c	None
+None	None	None	None	h	None
+None	None	None	None	k	None
+None	None	None	None	m	None
+None	None	None	None	o	None
+2	2	2	b	b	b
+4	4	None	d	d	None
+5	5	None	None	None	None
+5	5	None	f	f	None
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+-- !result
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 = t4.c0 and t2.c3 = t4.c1 order by 1,2,3,4,5,6;
+-- result:
+None	None	None	None	None	f
+None	None	None	None	None	k
+None	None	None	None	None	o
+None	None	1	None	None	a
+None	None	3	None	None	c
+None	None	3	None	None	d
+None	None	5	None	None	None
+None	None	5	None	None	h
+None	None	8	None	None	None
+None	None	14	None	None	m
+2	2	2	b	b	b
+8	8	8	h	h	h
+8	8	8	h	h	h
+10	10	10	j	j	j
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+12	12	12	l	l	l
+-- !result
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0=t2.c0 and t1.c1=t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+-- result:
 None	None	None	None	None
-15	None	o	None	None
-5	None	None	None	None
-None	None	k	None	None
 None	None	c	None	None
+None	None	k	None	None
 1	None	a	None	None
-10	10	j	j	j
-12	12	l	l	l
-12	12	l	l	l
--- !result
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
--- result:
-4	4	d	d	None
 2	2	b	b	b
-8	None	h	None	None
-1	None	a	None	None
-None	None	None	None	None
+4	4	d	d	None
 5	None	None	None	None
-15	None	o	None	None
-14	None	l	None	None
-None	None	k	k	None
-8	8	h	h	h
-None	None	c	c	None
-12	12	l	l	l
-10	10	j	j	j
-12	12	l	l	l
 5	5	f	f	None
--- !result
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
--- result:
-None	None	c	c	None
-2	2	b	b	b
-12	12	l	l	l
-8	8	h	h	h
-5	5	None	None	None
 8	None	h	None	None
-None	None	None	None	None
+8	8	h	h	h
+10	10	j	j	j
+12	12	l	l	l
+12	12	l	l	l
 14	None	l	None	None
 15	None	o	None	None
-1	None	a	None	None
-12	12	l	l	l
-5	5	f	f	None
-4	4	d	d	None
-10	10	j	j	j
-None	None	k	k	None
 -- !result
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
 -- result:
+None	None	None	None	None
 None	None	c	c	None
-5	5	None	None	None
-8	None	h	None	None
-None	None	None	None	None
+None	None	k	k	None
+1	None	a	None	None
+2	2	b	b	b
 4	4	d	d	None
-None	None	k	k	k
-15	None	o	None	None
+5	None	None	None	None
+5	5	f	f	None
+8	None	h	None	None
+8	8	h	h	h
+10	10	j	j	j
+12	12	l	l	l
 12	12	l	l	l
 14	None	l	None	None
-1	None	a	None	None
-10	10	j	j	j
-12	12	l	l	l
-5	5	f	f	None
-2	2	b	b	b
-8	8	h	h	h
+15	None	o	None	None
 -- !result
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
 -- result:
-None	None	None	None	c
-None	None	k	k	k
-8	8	h	h	h
-5	5	None	None	None
-None	5	None	h	h
-None	8	None	None	None
+None	None	None	None	None
+None	None	c	c	None
+None	None	k	k	None
+1	None	a	None	None
 2	2	b	b	b
-None	14	None	m	m
-12	12	l	l	l
+4	4	d	d	None
+5	5	None	None	None
+5	5	f	f	None
+8	None	h	None	None
+8	8	h	h	h
 10	10	j	j	j
+12	12	l	l	l
+12	12	l	l	l
+14	None	l	None	None
+15	None	o	None	None
+-- !result
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+-- result:
+None	None	None	None	None
+None	None	c	c	None
+None	None	k	k	k
+1	None	a	None	None
+2	2	b	b	b
+4	4	d	d	None
+5	5	None	None	None
+5	5	f	f	None
+8	None	h	None	None
+8	8	h	h	h
+10	10	j	j	j
+12	12	l	l	l
+12	12	l	l	l
+14	None	l	None	None
+15	None	o	None	None
+-- !result
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+-- result:
 None	None	None	None	a
-12	12	l	l	l
-None	None	None	None	f
-None	None	None	o	o
-None	None	None	None	d
--- !result
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
--- result:
 None	None	None	None	c
-12	12	l	l	l
-None	None	None	None	o
 None	None	None	None	d
-None	None	None	None	h
-None	None	None	None	m
-None	None	None	None	None
-2	2	b	b	b
-12	12	l	l	l
 None	None	None	None	f
 None	None	None	None	k
-None	None	None	None	None
-10	10	j	j	j
-None	None	None	None	a
-8	8	h	h	h
--- !result
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
--- result:
-5	5	f	f	None
-None	None	k	k	k
-None	None	c	c	None
-5	5	None	None	None
-None	8	None	None	None
-None	None	None	None	None
-8	8	h	h	h
-4	4	d	d	None
-10	10	j	j	j
-12	12	l	l	l
-None	5	None	h	h
-None	14	None	m	m
-12	12	l	l	l
-None	None	None	o	o
-2	2	b	b	b
--- !result
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2;
--- result:
-None	None	None	None	f
-None	None	None	None	None
-2	2	b	b	b
-None	None	None	None	h
-12	12	l	l	l
-None	None	None	None	a
-12	12	l	l	l
-5	5	None	None	None
-None	None	k	k	k
 None	None	None	None	o
-None	None	None	None	c
-None	None	None	None	m
-10	10	j	j	j
-None	None	None	None	d
+None	5	None	h	h
+None	8	None	None	None
+None	14	None	m	m
+2	2	b	b	b
+5	5	None	None	None
 8	8	h	h	h
+10	10	j	j	j
+12	12	l	l	l
+12	12	l	l	l
 -- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
 -- result:
-5	None	None	None	None
-14	m	None	None	None
-None	k	None	None	None
-3	d	None	None	None
-1	a	None	None	None
-None	o	None	None	None
-5	h	None	None	None
-3	c	None	None	None
-2	b	2	b	1
-10	j	10	j	1
-12	l	12	l	4
-12	l	12	l	4
-8	None	None	None	None
+None	None	None	None	None
+None	None	None	None	None
+None	None	None	None	a
+None	None	None	None	c
+None	None	None	None	d
+None	None	None	None	f
+None	None	None	None	h
+None	None	None	None	k
+None	None	None	None	m
+None	None	None	None	o
+2	2	b	b	b
+8	8	h	h	h
+10	10	j	j	j
+12	12	l	l	l
+12	12	l	l	l
+-- !result
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+-- result:
+None	None	None	None	None
+None	None	None	c	None
+None	None	None	k	k
+None	None	None	o	o
+None	5	None	h	h
+None	8	None	None	None
+None	14	None	m	m
+2	2	b	b	b
+4	4	d	d	None
+5	5	None	None	None
+5	5	f	f	None
+8	8	h	h	h
+10	10	j	j	j
+12	12	l	l	l
+12	12	l	l	l
+-- !result
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+-- result:
+None	None	None	None	None
+None	None	None	None	a
+None	None	None	None	c
+None	None	None	None	d
+None	None	None	None	f
+None	None	None	None	h
+None	None	None	None	m
+None	None	None	None	o
+None	None	k	k	k
+2	2	b	b	b
+5	5	None	None	None
+8	8	h	h	h
+10	10	j	j	j
+12	12	l	l	l
+12	12	l	l	l
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+-- result:
 None	f	None	None	None
-8	h	8	h	2
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
--- result:
-3	d	None	None	None
-5	None	None	None	None
 None	k	None	None	None
-3	c	None	None	None
-8	h	8	h	2
-14	m	None	None	None
-10	j	10	j	1
 None	o	None	None	None
 1	a	None	None	None
-5	h	None	None	None
-12	l	12	l	4
-12	l	12	l	4
-8	None	None	None	None
-None	f	None	None	None
-2	b	2	b	1
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1;
--- result:
 2	b	2	b	1
 3	c	None	None	None
-8	h	8	h	2
-8	None	None	None	None
-5	h	None	None	None
 3	d	None	None	None
-10	j	10	j	1
-None	f	None	None	None
-14	m	None	None	None
-None	k	None	None	None
-1	a	None	None	None
-None	o	None	None	None
-12	l	12	l	4
-12	l	12	l	4
 5	None	None	None	None
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1<=>t.c1;
--- result:
-None	k	None	None	None
-5	None	None	None	None
-12	l	12	l	4
-12	l	12	l	4
-14	m	None	None	None
-1	a	None	None	None
+5	h	None	None	None
 8	None	None	None	None
+8	h	8	h	2
+10	j	10	j	1
+12	l	12	l	4
+12	l	12	l	4
+14	m	None	None	None
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+-- result:
+None	f	None	None	None
+None	k	None	None	None
+None	o	None	None	None
+1	a	None	None	None
+2	b	2	b	1
 3	c	None	None	None
-10	j	10	j	1
-None	f	None	None	None
 3	d	None	None	None
-None	o	None	None	None
-5	h	None	None	None
-2	b	2	b	1
-8	h	8	h	2
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1;
--- result:
 5	None	None	None	None
-None	k	None	None	None
+5	h	None	None	None
+8	None	None	None	None
+8	h	8	h	2
 10	j	10	j	1
-2	b	2	b	1
+12	l	12	l	4
+12	l	12	l	4
 14	m	None	None	None
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+-- result:
+None	f	None	None	None
+None	k	None	None	None
+None	o	None	None	None
+1	a	None	None	None
+2	b	2	b	1
+3	c	None	None	None
+3	d	None	None	None
+5	None	None	None	None
+5	h	None	None	None
+8	None	None	None	None
+8	h	8	h	2
+10	j	10	j	1
+12	l	12	l	4
+12	l	12	l	4
+14	m	None	None	None
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1<=>t.c1 order by 1,2,3,4,5;
+-- result:
+None	f	None	None	None
+None	k	None	None	None
+None	o	None	None	None
+1	a	None	None	None
+2	b	2	b	1
+3	c	None	None	None
+3	d	None	None	None
+5	None	None	None	None
+5	h	None	None	None
+8	None	None	None	None
+8	h	8	h	2
+10	j	10	j	1
+12	l	12	l	4
+12	l	12	l	4
+14	m	None	None	None
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+-- result:
+None	f	None	None	None
+None	k	None	None	None
+None	o	None	None	None
+1	a	None	None	None
+2	b	2	b	1
+3	c	None	None	None
+3	d	None	None	None
+5	None	None	None	None
+5	h	None	None	None
+8	None	None	None	None
+8	h	8	h	2
+10	j	10	j	1
 12	l	12	l	2
 12	l	12	l	2
 12	l	12	l	2
 12	l	12	l	2
-8	None	None	None	None
-None	f	None	None	None
-8	h	8	h	2
-5	h	None	None	None
-3	c	None	None	None
-1	a	None	None	None
-3	d	None	None	None
-None	o	None	None	None
+14	m	None	None	None
 -- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 -- result:
-12	l	12	l	4
-12	l	12	l	4
-None	None	4	d	1
-10	j	10	j	1
 None	None	None	None	7
+None	None	4	d	1
 None	None	5	f	1
 2	b	2	b	1
 8	h	8	h	2
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
--- result:
-8	h	8	h	2
 10	j	10	j	1
 12	l	12	l	4
 12	l	12	l	4
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+-- result:
+None	None	None	None	7
+None	None	4	d	1
 None	None	5	f	1
 2	b	2	b	1
-None	None	4	d	1
-None	None	None	None	7
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1;
--- result:
-5	None	None	None	None
-12	l	12	l	4
-12	l	12	l	4
-8	None	None	None	None
-None	f	None	None	None
-10	j	10	j	1
 8	h	8	h	2
+10	j	10	j	1
+12	l	12	l	4
+12	l	12	l	4
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+-- result:
+None	f	None	None	None
+None	k	None	None	None
+None	o	None	None	None
+1	a	None	None	None
+2	b	2	b	1
+3	c	None	None	None
+3	d	None	None	None
+5	None	None	None	None
 5	h	5	h	1
-None	o	None	o	1
-1	a	None	None	None
-3	d	None	None	None
-None	k	None	k	1
-2	b	2	b	1
-14	m	14	m	1
-3	c	None	None	None
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1<=>t.c1;
--- result:
-3	d	None	None	None
-1	a	None	None	None
-None	k	None	k	1
-3	c	None	None	None
+8	None	None	None	None
 8	h	8	h	2
+10	j	10	j	1
+12	l	12	l	4
+12	l	12	l	4
 14	m	14	m	1
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1<=>t.c1 order by 1,2,3,4,5;
+-- result:
+None	f	None	None	None
+None	k	None	None	None
+None	o	None	None	None
+1	a	None	None	None
+2	b	2	b	1
+3	c	None	None	None
+3	d	None	None	None
 5	None	5	None	1
-10	j	10	j	1
-None	o	None	o	1
 5	h	5	h	1
-2	b	2	b	1
-12	l	12	l	4
-12	l	12	l	4
 8	None	8	None	1
-None	f	None	None	None
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1;
--- result:
-10	j	10	j	1
-2	b	2	b	1
-None	None	None	c	1
-14	m	14	m	1
 8	h	8	h	2
-5	h	5	h	1
-None	None	5	None	1
-None	None	4	d	1
-None	None	5	f	1
-None	None	None	k	1
-12	l	12	l	2
-12	l	12	l	2
-None	None	8	None	1
-12	l	12	l	2
-12	l	12	l	2
-None	None	None	None	1
-None	None	None	o	1
+10	j	10	j	1
+12	l	12	l	4
+12	l	12	l	4
+14	m	14	m	1
 -- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 and t3.c2=t.c2;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 -- result:
-5	None	None	None	None
+None	None	None	None	1
+None	None	None	c	1
+None	None	None	k	1
+None	None	None	o	1
+None	None	4	d	1
+None	None	5	None	1
+None	None	5	f	1
+None	None	8	None	1
+2	b	2	b	1
+5	h	5	h	1
+8	h	8	h	2
+10	j	10	j	1
+12	l	12	l	2
+12	l	12	l	2
+12	l	12	l	2
+12	l	12	l	2
+14	m	14	m	1
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 and t3.c2=t.c2 order by 1,2,3,4,5;
+-- result:
+None	f	None	None	None
+None	k	None	None	None
+None	o	None	None	None
+1	a	None	None	None
+2	b	2	b	1
 3	c	None	None	None
+3	d	None	None	None
+5	None	None	None	None
+5	h	None	None	None
+8	None	None	None	None
+8	h	8	h	2
+10	j	10	j	1
 12	l	None	None	None
-8	None	None	None	None
-3	d	None	None	None
-None	o	None	None	None
-None	k	None	None	None
-8	h	8	h	2
-2	b	2	b	1
-5	h	None	None	None
 12	l	12	l	4
-None	f	None	None	None
-10	j	10	j	1
-1	a	None	None	None
 14	m	None	None	None
 -- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 -- result:
-5	None	None	None	None
-8	h	8	h	2
-None	o	None	None	None
-14	m	None	None	None
-3	d	None	None	None
-1	a	None	None	None
-2	b	2	b	1
-5	h	None	None	None
-None	k	None	None	None
-3	c	None	None	None
-12	l	12	l	4
-12	l	12	l	4
 None	f	None	None	None
-8	None	None	None	None
-10	j	10	j	1
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1;
--- result:
-5	h	None	None	None
-5	None	None	None	None
-1	a	None	None	None
 None	k	None	None	None
-8	None	None	None	None
 None	o	None	None	None
-8	h	8	h	2
+1	a	None	None	None
 2	b	2	b	1
-14	m	None	None	None
-12	l	12	l	4
-12	l	12	l	4
 3	c	None	None	None
 3	d	None	None	None
-10	j	10	j	1
-None	f	None	None	None
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, t2.c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1;
--- result:
-None	k	None	None	None
-None	o	None	None	None
 5	None	None	None	None
-14	m	None	None	None
 5	h	None	None	None
-1	a	None	None	None
-10	j	10	j	1
-3	c	None	None	None
-2	b	2	b	1
-12	l	12	l	2
-12	l	12	l	2
-12	l	12	l	2
-12	l	12	l	2
-None	f	None	None	None
 8	None	None	None	None
 8	h	8	h	2
-3	d	None	None	None
+10	j	10	j	1
+12	l	12	l	4
+12	l	12	l	4
+14	m	None	None	None
 -- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 and t3.c2=t.c2;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 -- result:
-None	None	4	d	1
+None	f	None	None	None
+None	k	None	None	None
+None	o	None	None	None
+1	a	None	None	None
+2	b	2	b	1
+3	c	None	None	None
+3	d	None	None	None
+5	None	None	None	None
+5	h	None	None	None
+8	None	None	None	None
+8	h	8	h	2
+10	j	10	j	1
+12	l	12	l	4
+12	l	12	l	4
+14	m	None	None	None
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, t2.c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+-- result:
+None	f	None	None	None
+None	k	None	None	None
+None	o	None	None	None
+1	a	None	None	None
+2	b	2	b	1
+3	c	None	None	None
+3	d	None	None	None
+5	None	None	None	None
+5	h	None	None	None
+8	None	None	None	None
+8	h	8	h	2
+10	j	10	j	1
+12	l	12	l	2
+12	l	12	l	2
+12	l	12	l	2
+12	l	12	l	2
+14	m	None	None	None
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 and t3.c2=t.c2 order by 1,2,3,4,5;
+-- result:
 None	None	None	None	7
-12	l	12	l	4
-10	j	10	j	1
-8	h	8	h	2
-2	b	2	b	1
+None	None	4	d	1
 None	None	5	f	1
+2	b	2	b	1
+8	h	8	h	2
+10	j	10	j	1
+12	l	12	l	4
 -- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 -- result:
 None	None	None	None	1
-None	None	5	f	1
-None	None	None	k	1
-8	h	8	h	2
-2	b	2	b	1
-5	h	5	h	1
-14	m	14	m	1
 None	None	None	c	1
-None	None	8	None	1
-12	l	12	l	4
-12	l	12	l	4
+None	None	None	k	1
 None	None	None	o	1
+None	None	4	d	1
 None	None	5	None	1
-None	None	4	d	1
-10	j	10	j	1
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1;
--- result:
-5	None	None	None	None
-8	h	8	h	2
-3	d	None	None	None
-None	k	None	k	1
-5	h	5	h	1
-1	a	None	None	None
-None	o	None	o	1
-3	c	None	None	None
-2	b	2	b	1
-12	l	12	l	4
-12	l	12	l	4
-None	f	None	None	None
-8	None	None	None	None
-14	m	14	m	1
-10	j	10	j	1
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, t2.c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1;
--- result:
 None	None	5	f	1
-None	None	None	None	7
-None	None	4	d	1
-8	h	8	h	2
+None	None	8	None	1
 2	b	2	b	1
+5	h	5	h	1
+8	h	8	h	2
 10	j	10	j	1
-12	l	12	l	2
-12	l	12	l	2
-12	l	12	l	2
-12	l	12	l	2
+12	l	12	l	4
+12	l	12	l	4
+14	m	14	m	1
 -- !result
-select t4.c0, t4.c1, t.c01, t.c13 from t4 left join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1 order by 1,2,3,4,5; 
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, t2.c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 -- result:
-None	k	None	None
-5	h	None	None
-8	h	8	h
-4	d	None	None
-1	None	None	None
-12	l	12	l
-8	None	None	None
-12	None	None	None
-14	m	None	None
-5	None	None	None
-None	o	None	None
-5	f	None	None
+None	f	None	None	None
+None	k	None	None	None
+None	o	None	None	None
+1	a	None	None	None
+2	b	2	b	1
+3	c	None	None	None
+3	d	None	None	None
+5	None	None	None	None
+5	h	5	h	1
+8	None	None	None	None
+8	h	8	h	2
+10	j	10	j	1
+12	l	12	l	4
+12	l	12	l	4
+14	m	14	m	1
+-- !result
+select t4.c0, t4.c1, t.c01, t.c13 from t4 left join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13 order by 1,2,3,4;
+-- result:
 None	c	None	None
-2	b	2	b
-10	j	10	j
--- !result
-select t4.c0, t4.c1, t.c01, t.c13 from t4 left join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13;
--- result:
-5	h	None	None
+None	k	None	None
+None	o	None	None
 1	None	None	None
+2	b	2	b
+4	d	None	None
+5	None	None	None
+5	f	None	None
+5	h	None	None
+8	None	None	None
+8	h	8	h
+10	j	10	j
 12	None	None	None
 12	l	12	l
-None	c	None	None
-10	j	10	j
 14	m	None	None
-5	None	None	None
-8	None	None	None
-None	k	None	None
-5	f	None	None
-4	d	None	None
-8	h	8	h
-None	o	None	None
-2	b	2	b
 -- !result
-select t4.c0, t4.c1, t.c01, t.c13 from t4 right join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13;
+select t4.c0, t4.c1, t.c01, t.c13 from t4 left join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13 order by 1,2,3,4;
 -- result:
+None	c	None	None
+None	k	None	None
+None	o	None	None
+1	None	None	None
+2	b	2	b
+4	d	None	None
+5	None	None	None
+5	f	None	None
+5	h	None	None
+8	None	None	None
 8	h	8	h
-None	None	5	None
-None	None	5	None
-None	None	15	None
+10	j	10	j
+12	None	None	None
+12	l	12	l
+14	m	None	None
+-- !result
+select t4.c0, t4.c1, t.c01, t.c13 from t4 right join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13 order by 1,2,3,4;
+-- result:
+None	None	None	None
 None	None	None	None
 None	None	None	None
 None	None	1	None
-None	None	8	None
-None	None	None	None
-None	None	14	None
-12	l	12	l
-10	j	10	j
 None	None	4	None
-2	b	2	b
--- !result
-select t4.c0, t4.c1, t.c01, t.c13 from t4 right join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13;
--- result:
-None	None	None	None
-None	None	None	None
 None	None	5	None
 None	None	5	None
-10	j	10	j
-None	None	None	k
-12	l	12	l
-None	None	None	None
-5	h	None	h
+None	None	8	None
+None	None	14	None
+None	None	15	None
 2	b	2	b
 8	h	8	h
+10	j	10	j
+12	l	12	l
+-- !result
+select t4.c0, t4.c1, t.c01, t.c13 from t4 right join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13 order by 1,2,3,4;
+-- result:
+None	None	None	None
+None	None	None	None
+None	None	None	None
+None	None	None	k
 None	None	None	o
 None	None	4	None
+None	None	5	None
+None	None	5	None
+2	b	2	b
+5	h	None	h
+8	h	8	h
+10	j	10	j
+12	l	12	l
 14	m	None	m
 -- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5,6;
 -- result:
-5	None	None	None	None	None
+None	f	None	None	None	None
 None	k	None	None	None	None
-14	m	None	None	None	None
+None	o	None	None	None	None
+1	a	None	None	None	None
+2	b	2	b	1	1
 3	c	None	None	None	None
 3	d	None	None	None	None
-None	o	None	None	None	None
-2	b	2	b	1	1
-1	a	None	None	None	None
-5	h	None	None	None	None
-8	h	8	h	2	2
-12	l	12	l	4	2
-12	l	12	l	4	2
-None	f	None	None	None	None
-8	None	None	None	None	None
-10	j	10	j	1	1
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
--- result:
-None	k	None	None	None	None
-12	l	12	l	4	2
-12	l	12	l	4	2
-8	None	None	None	None	None
-None	f	None	None	None	None
-10	j	10	j	1	1
 5	None	None	None	None	None
-3	d	None	None	None	None
-14	m	None	None	None	None
 5	h	None	None	None	None
-1	a	None	None	None	None
+8	None	None	None	None	None
+8	h	8	h	2	2
+10	j	10	j	1	1
+12	l	12	l	4	2
+12	l	12	l	4	2
+14	m	None	None	None	None
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5,6;
+-- result:
+None	f	None	None	None	None
+None	k	None	None	None	None
 None	o	None	None	None	None
+1	a	None	None	None	None
 2	b	2	b	1	1
 3	c	None	None	None	None
-8	h	8	h	2	2
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 join t4 on t3.c0 = t4.c0 and t.c1 = t4.c1;
--- result:
-10	j	10	j	1	1
-8	h	8	h	2	2
-12	l	12	l	4	2
-12	l	12	l	4	2
-2	b	2	b	1	1
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 right join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1;
--- result:
-None	None	5	f	1	1
+3	d	None	None	None	None
+5	None	None	None	None	None
+5	h	None	None	None	None
+8	None	None	None	None	None
 8	h	8	h	2	2
 10	j	10	j	1	1
+12	l	12	l	4	2
+12	l	12	l	4	2
+14	m	None	None	None	None
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 join t4 on t3.c0 = t4.c0 and t.c1 = t4.c1 order by 1,2,3,4,5,6;
+-- result:
 2	b	2	b	1	1
-None	None	4	d	1	1
+8	h	8	h	2	2
+10	j	10	j	1	1
+12	l	12	l	4	2
+12	l	12	l	4	2
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 right join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5,6;
+-- result:
 None	None	None	None	7	7
+None	None	4	d	1	1
+None	None	5	f	1	1
+2	b	2	b	1	1
+8	h	8	h	2	2
+10	j	10	j	1	1
 12	l	12	l	4	2
 12	l	12	l	4	2
 -- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5,6;
 -- result:
-None	k	None	None	None	None
-3	d	None	None	None	None
-10	j	10	j	1	1
-2	b	2	b	1	1
-1	a	None	None	None	None
-None	o	None	None	None	None
-5	h	5	h	1	0
-12	l	12	l	4	2
-12	l	12	l	4	2
 None	f	None	None	None	None
-8	None	None	None	None	None
-14	m	14	m	1	0
-8	h	8	h	2	2
-3	c	None	None	None	None
-5	None	None	None	None	None
--- !result
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 right join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 join t4 on t3.c0 = t4.c0 and t.c1 = t4.c1;
--- result:
-14	m	14	m	1	0
-10	j	10	j	1	1
-8	h	8	h	2	2
-12	l	12	l	4	2
-12	l	12	l	4	2
-5	h	5	h	1	0
+None	k	None	None	None	None
+None	o	None	None	None	None
+1	a	None	None	None	None
 2	b	2	b	1	1
+3	c	None	None	None	None
+3	d	None	None	None	None
+5	None	None	None	None	None
+5	h	5	h	1	0
+8	None	None	None	None	None
+8	h	8	h	2	2
+10	j	10	j	1	1
+12	l	12	l	4	2
+12	l	12	l	4	2
+14	m	14	m	1	0
+-- !result
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 right join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 join t4 on t3.c0 = t4.c0 and t.c1 = t4.c1 order by 1,2,3,4,5,6;
+-- result:
+2	b	2	b	1	1
+5	h	5	h	1	0
+8	h	8	h	2	2
+10	j	10	j	1	1
+12	l	12	l	4	2
+12	l	12	l	4	2
+14	m	14	m	1	0
 -- !result

--- a/test/sql/test_colocate/R/test_colocate
+++ b/test/sql/test_colocate/R/test_colocate
@@ -416,9 +416,9 @@ None	None	14	None	None	m
 select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 order by 1,2,3,4,5,6;
 -- result:
 None	None	None	None	None	None
-None	None	None	None	c	None
-None	None	None	None	k	k
 None	None	None	None	o	o
+None	None	None	c	c	None
+None	None	None	k	k	k
 None	None	5	None	h	h
 None	None	8	None	None	None
 None	None	14	None	m	m
@@ -492,11 +492,11 @@ select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0 <
 -- result:
 None	None	None	None	None	None
 None	None	None	None	None	None
-None	None	None	None	c	None
 None	None	None	None	h	None
-None	None	None	None	k	None
 None	None	None	None	m	None
 None	None	None	None	o	None
+None	None	None	c	c	None
+None	None	None	k	k	k
 2	2	2	b	b	b
 4	4	None	d	d	None
 5	5	None	None	None	None
@@ -616,8 +616,8 @@ None	None	None	None	a
 None	None	None	None	c
 None	None	None	None	d
 None	None	None	None	f
-None	None	None	None	k
-None	None	None	None	o
+None	None	None	o	o
+None	None	k	k	k
 None	5	None	h	h
 None	8	None	None	None
 None	14	None	m	m
@@ -649,9 +649,9 @@ None	None	None	None	o
 select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
 -- result:
 None	None	None	None	None
-None	None	None	c	None
-None	None	None	k	k
 None	None	None	o	o
+None	None	c	c	None
+None	None	k	k	k
 None	5	None	h	h
 None	8	None	None	None
 None	14	None	m	m
@@ -799,8 +799,8 @@ None	None	5	f	1
 select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 -- result:
 None	f	None	None	None
-None	k	None	None	None
-None	o	None	None	None
+None	k	None	k	1
+None	o	None	o	1
 1	a	None	None	None
 2	b	2	b	1
 3	c	None	None	None
@@ -817,8 +817,8 @@ None	o	None	None	None
 select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1<=>t.c1 order by 1,2,3,4,5;
 -- result:
 None	f	None	None	None
-None	k	None	None	None
-None	o	None	None	None
+None	k	None	k	1
+None	o	None	o	1
 1	a	None	None	None
 2	b	2	b	1
 3	c	None	None	None
@@ -958,8 +958,8 @@ select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt
 select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, t2.c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 -- result:
 None	f	None	None	None
-None	k	None	None	None
-None	o	None	None	None
+None	k	None	k	1
+None	o	None	o	1
 1	a	None	None	None
 2	b	2	b	1
 3	c	None	None	None

--- a/test/sql/test_colocate/T/test_colocate
+++ b/test/sql/test_colocate/T/test_colocate
@@ -141,67 +141,67 @@ INSERT INTO t4 (c0, c1, c2, c3) VALUES
   (14, 'm', 'Value14', 140),
   (null, 'o', 'Value15', 150);
 
-select t1.c0, t2.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0=t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1;
-select t1.c0, t2.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 <=> t3.c0 and t1.c1 =t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 = t4.c0 and t2.c3 = t4.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 <=> t4.c0 and t2.c3 = t4.c1;
+select t1.c0, t2.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0=t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t2.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 left join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 <=> t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 = t4.c0 and t2.c3 = t4.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 <=> t4.c0 and t2.c3 = t4.c1 order by 1,2,3,4,5,6;
 
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 right join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 <=> t3.c0 and t1.c1 =t3.c1;
-select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 = t4.c0 and t2.c3 = t4.c1;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 right join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t2.c0 = t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 left join t3 on t2.c0 <=> t3.c0 and t1.c1 =t3.c1 order by 1,2,3,4,5,6;
+select t1.c0, t1.c0, t3.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0 <=>t2.c0 and t1.c1<=>t2.c1 right join t3 on t1.c0 = t3.c0 and t2.c1 = t3.c1 left join t4 on t2.c0 = t4.c0 and t2.c3 = t4.c1 order by 1,2,3,4,5,6;
 
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0=t2.c0 and t1.c1=t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2;
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2;
-select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0=t2.c0 and t1.c1=t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1=t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
+select t1.c0, t2.c0, t1.c1, t2.c1, t3.c1 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 right join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 order by 1,2,3,4,5;
 
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1<=>t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1<=>t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1<=>t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1<=>t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 and t3.c2=t.c2;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, t2.c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 and t3.c2=t.c2 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, t2.c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 and t3.c2=t.c2;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, t2.c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 and t3.c2=t.c2 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 left join (select count(*) as cnt, t2.c0, t2.c1, max(t2.c2) from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0<=>t.c0 and t3.c1= t.c1 order by 1,2,3,4,5; 
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt from t3 right join (select count(*) as cnt, t2.c0, t2.c1, t2.c2 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1,t2.c2) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5;
 
-select t4.c0, t4.c1, t.c01, t.c13 from t4 left join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13;
-select t4.c0, t4.c1, t.c01, t.c13 from t4 left join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13;
+select t4.c0, t4.c1, t.c01, t.c13 from t4 left join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13 order by 1,2,3,4;
+select t4.c0, t4.c1, t.c01, t.c13 from t4 left join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13 order by 1,2,3,4;
 
-select t4.c0, t4.c1, t.c01, t.c13 from t4 right join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13;
-select t4.c0, t4.c1, t.c01, t.c13 from t4 right join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13;
+select t4.c0, t4.c1, t.c01, t.c13 from t4 right join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 left join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0=t3.c0 and t2.c1=t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13 order by 1,2,3,4;
+select t4.c0, t4.c1, t.c01, t.c13 from t4 right join (select t1.c0 as c01, t2.c0 as c02, t1.c1 as c11, t2.c1 as c12, t3.c1 as c13 from t1 right join t2 on t1.c0<=>t2.c0 and t1.c1<=>t2.c1 and t1.c2=t2.c2 left join t3 on t2.c0<=>t3.c0 and t2.c1<=>t3.c1 and t2.c2=t3.c2 group by t1.c0, t2.c0, t1.c1, t2.c1, t3.c1) t on t4.c0 = t.c02 and t4.c1 = t.c13 order by 1,2,3,4;
 
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 join t4 on t3.c0 = t4.c0 and t.c1 = t4.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5,6;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5,6;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 join t4 on t3.c0 = t4.c0 and t.c1 = t4.c1 order by 1,2,3,4,5,6;
 
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 right join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1;
-select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 right join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 join t4 on t3.c0 = t4.c0 and t.c1 = t4.c1;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 right join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 left join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c0, t2.c1) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5,6;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 left join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 order by 1,2,3,4,5,6;
+select t3.c0, t3.c1, t.c0, t.c1, t.cnt, t.c3 from t3 right join (select count(*) as cnt, count(distinct t1.c3) c3,t2.c0, t2.c1 from t1 right join t2 on t1.c0 =t2.c0 and t1.c1=t2.c1 group by t2.c1, t2.c0) t on t3.c0=t.c0 and t3.c1= t.c1 join t4 on t3.c0 = t4.c0 and t.c1 = t4.c1 order by 1,2,3,4,5,6;
 
 


### PR DESCRIPTION
## Why I'm doing:

Currently, the runtime filter of our scan operator is executed after the storage layer has read all the data. This means that we lose the opportunity to use storage layer optimization, such as late materialization.

## What I'm doing:

In this PR, I support pushing the runtime filter down to the storage layer. When querying, it will be treated as a specific predicate and evaluated in the first stage of late materialization, so that we have the opportunity to use late materialization to reduce the amount of data read. 

In addition, since each scan operator will generate multiple parallel io tasks, after pushing the runtime filter down, the number of threads evaluating the runtime filters in parallel will increase, which will also improve the computing efficiency to a certain extent.


Design points
1. How to represent the runtime filter predicate in the storage layer?

somewhat different from ordinary single-column predicates, multiple runtime filter predicates may be related. 
For example, when there are multiple runtime filters, in order to balance the execution efficiency, we do not need to execute each runtime filter once, but only select a few runtime filters with good filterability. Similarly, when their filtering effects are not good, we can choose to skip all of them.

our storage layer currently only supports single-column predicates, which is not suitable for the above scenario. so I added `RuntimeFilterPredicates`, which is responsible for collecting all relevant runtime filters and selecting the appropriate runtime filters to execute based on the selectivity.
`RuntimeFilterPredicates` will be executed in the first stage of late materialization. If the filterability is good, we can read less data.

2. How to ensure that these columns have been read when evaluating the runtime filters？
When applying late materialization, we will only choose to read the columns with predicates first, and the columns required by the runtime filters may not have predicates. The implementation here is a bit complicated. In order to reduce the cost of modification, I used a tricky method and introduced `ColumnPlaceHolderPredicate`, which is only used as a placeholder and will not produce any filtering effect.

In the ChunkSource init stage, ColumnPlaceHolderPredicates are generated for the columns required by the runtime filter and placed in the PredicateTree. In this way, the existing column selection strategy can ensure that these columns will be read out in the first stage of delayed materialization.
Then, in SegmentIterator init stage, we remove the ColumnPlaceHolderPredicate by `ColumnPredicateRewriter`, so that it will not generate additional overhead.


Test Result

I tested on a tpch 1TB data set, using four 16c 64g BEs, each with two disks(each have 5000 iops and 140MB/s throughput), and the baseline code is `main-9a6445a`.

Below are the test results, and the query time unit in the table is milliseconds.

| Query | baseline | patched | patched/baseline |
|----------|---------------|-------------|------------|
| Q01      | 15909         | 15802       | 99.33%     |
| Q02      | 559           | 410         | 73.35%     |
| Q03      | 7988          | 7252        | 90.79%     |
| Q04      | 5093          | 4098        | 80.46%     |
| Q05      | 10720         | 9135        | 85.21%     |
| Q06      | 257           | 258         | 100.39%    |
| Q07      | 8781          | 7709        | 87.79%     |
| Q08      | 7791          | 7767        | 99.69%     |
| Q09      | 32526         | 29677       | 91.24%     |
| Q10      | 10393         | 9465        | 91.07%     |
| Q11      | 1354          | 983         | 72.60%     |
| Q12      | 1392          | 1135        | 81.54%     |
| Q13      | 19735         | 19834       | 100.50%    |
| Q14      | 2179          | 1861        | 85.41%     |
| Q15      | 1116          | 1091        | 97.76%     |
| Q16      | 2387          | 1843        | 77.21%     |
| Q17      | 4303          | 4018        | 93.38%     |
| Q18      | 18646         | 18337       | 98.34%     |
| Q19      | 5231          | 5269        | 100.73%    |
| Q20      | 2530          | 1938        | 76.60%     |
| Q21      | 16875         | 13046       | 77.31%     |
| Q22      | 2898          | 2648        | 91.37%     |
| **Total**| **178663**    | **163576**  | **91.56%** |


TODO: in this pr, I only support this enhancement in internal olap table under shared_nothing mode, will support other tables in other pr.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0