### PR TITLE
[Enhancement] Optimize the performance of reading dictionary pages

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -428,6 +428,8 @@ CONF_Double(dictionary_encoding_ratio, "0.7");
 // performance degradation.
 CONF_Int32(dictionary_page_size, "1048576");
 
+CONF_Int32(small_dictionary_page_size, "4096");
+
 // Just like dictionary_encoding_ratio, dictionary_encoding_ratio_for_non_string_column is used for
 // no-string column.
 CONF_Double(dictionary_encoding_ratio_for_non_string_column, "0");

--- a/be/src/storage/rowset/binary_dict_page.cpp
+++ b/be/src/storage/rowset/binary_dict_page.cpp
@@ -256,9 +256,7 @@ Status BinaryDictPageDecoder<Type>::next_batch(const SparseRange<>& range, Colum
             slices[i] = element;
         }
     } else {
-        for (int i = 0; i < nread; ++i) {
-            slices[i] = _dict_decoder->string_at_index(codewords[i]);
-        }
+        _dict_decoder->batch_string_at_index(slices.data(), codewords, nread);
     }
 
     bool ok = dst->append_strings_overflow(slices, _max_value_legth);


### PR DESCRIPTION
## Why I'm doing:

For the query:
```
select count(lo_shipmode) from lineorder;
```

be.conf
```
pipeline_scan_thread_pool_thread_num=1
```

baseline: 5.51
```
  31.80%  starrocks_be      [.] starrocks::BinaryDictPageDecoder<(starrocks::LogicalType)17>::next_batch
  15.35%  starrocks_be      [.] starrocks::append_fixed_length<unsigned int, 8ul>
   6.13%  libc.so.6         [.] __memmove_evex_unaligned_erms
   2.16%  libc.so.6         [.] pthread_mutex_unlock@@GLIBC_2.2.5
```
patched: 3.59
```
  21.74%  starrocks_be                                     [.] starrocks::append_fixed_length<unsigned int, 8ul>
  11.34%  starrocks_be                                     [.] starrocks::BinaryDictPageDecoder<(starrocks::LogicalTy
   6.71%  starrocks_be                                     [.] starrocks::BinaryPlainPageDecoder<(starrocks::LogicalT
   6.52%  libc.so.6                                        [.] __memmove_evex_unaligned_erms

```

## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0