### PR TITLE
[Enhancement] Write combined txn log parallel

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1560,4 +1560,7 @@ CONF_mBool(avro_ignore_union_type_tag, "false");
 // default batch size for simdjson lib
 CONF_mInt32(json_parse_many_batch_size, "1000000");
 CONF_mBool(enable_dynamic_batch_size_for_json_parse_many, "true");
+CONF_mInt32(put_combined_txn_log_thread_pool_num_max, "64");
+CONF_mBool(enable_put_combinded_txn_log_parallel, "false");
+CONF_mBool(output_combined_txn_log, "false");
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1562,5 +1562,4 @@ CONF_mInt32(json_parse_many_batch_size, "1000000");
 CONF_mBool(enable_dynamic_batch_size_for_json_parse_many, "true");
 CONF_mInt32(put_combined_txn_log_thread_pool_num_max, "64");
 CONF_mBool(enable_put_combinded_txn_log_parallel, "false");
-CONF_mBool(output_combined_txn_log, "false");
 } // namespace starrocks::config

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -370,21 +370,13 @@ bool TabletSinkSender::get_immutable_partition_ids(std::set<int64_t>* partition_
 }
 
 Status TabletSinkSender::_write_combined_txn_log() {
-    int64_t t_start = MonotonicMillis();
     if (config::enable_put_combinded_txn_log_parallel) {
-        Status st = write_combined_txn_log(_txn_log_map);
-        if (config::output_combined_txn_log) {
-            LOG(INFO) << "write_combined_txn_log parallel cost time: " << MonotonicMillis() - t_start;
-        }
-        return st;
+        return write_combined_txn_log(_txn_log_map);
     }
 
     for (const auto& [partition_id, logs] : _txn_log_map) {
         (void)partition_id;
         RETURN_IF_ERROR(write_combined_txn_log(logs));
-    }
-    if (config::output_combined_txn_log) {
-        LOG(INFO) << "write_combined_txn_log non-parallel cost time: " << MonotonicMillis() - t_start;
     }
     return Status::OK();
 }

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -370,9 +370,21 @@ bool TabletSinkSender::get_immutable_partition_ids(std::set<int64_t>* partition_
 }
 
 Status TabletSinkSender::_write_combined_txn_log() {
+    int64_t t_start = MonotonicMillis();
+    if (config::enable_put_combinded_txn_log_parallel) {
+        Status st = write_combined_txn_log(_txn_log_map);
+        if (config::output_combined_txn_log) {
+            LOG(INFO) << "write_combined_txn_log parallel cost time: " << MonotonicMillis() - t_start;
+        }
+        return st;
+    }
+
     for (const auto& [partition_id, logs] : _txn_log_map) {
         (void)partition_id;
         RETURN_IF_ERROR(write_combined_txn_log(logs));
+    }
+    if (config::output_combined_txn_log) {
+        LOG(INFO) << "write_combined_txn_log non-parallel cost time: " << MonotonicMillis() - t_start;
     }
     return Status::OK();
 }

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -371,7 +371,7 @@ bool TabletSinkSender::get_immutable_partition_ids(std::set<int64_t>* partition_
 
 Status TabletSinkSender::_write_combined_txn_log() {
     if (config::enable_put_combinded_txn_log_parallel) {
-        return write_combined_txn_log(_txn_log_map);
+        return write_combined_txn_log_parallel(_txn_log_map);
     }
 
     for (const auto& [partition_id, logs] : _txn_log_map) {

--- a/be/src/exec/write_combined_txn_log.cpp
+++ b/be/src/exec/write_combined_txn_log.cpp
@@ -24,7 +24,7 @@ namespace starrocks {
 
 class TxnLogTask : public Runnable {
 public:
-    TxnLogTask(const CombinedTxnLogPB& logs, lake::TabletManager* tablet_mgr, std::promise<Status> promise)
+    TxnLogTask(const CombinedTxnLogPB logs, lake::TabletManager* tablet_mgr, std::promise<Status> promise)
             : _logs(logs), _tablet_mgr(tablet_mgr), _promise(std::move(promise)) {}
 
     void run() override {

--- a/be/src/exec/write_combined_txn_log.cpp
+++ b/be/src/exec/write_combined_txn_log.cpp
@@ -14,14 +14,67 @@
 
 #include "exec/write_combined_txn_log.h"
 
+#include <future>
+#include <vector>
+
 #include "runtime/exec_env.h"
 #include "storage/lake/tablet_manager.h"
 
 namespace starrocks {
 
+class TxnLogTask : public Runnable {
+public:
+    TxnLogTask(const CombinedTxnLogPB& logs, lake::TabletManager* tablet_mgr, std::promise<Status> promise)
+            : _logs(logs), _tablet_mgr(tablet_mgr), _promise(std::move(promise)) {}
+
+    void run() override {
+        try {
+            Status status = _tablet_mgr->put_combined_txn_log(_logs);
+            if (!status.ok()) {
+                throw std::runtime_error("Log write failed");
+            }
+            _promise.set_value(Status::OK());
+        } catch (const std::exception& e) {
+            _promise.set_value(Status::IOError(e.what()));
+        }
+    }
+
+private:
+    CombinedTxnLogPB _logs;
+    lake::TabletManager* _tablet_mgr;
+    std::promise<Status> _promise;
+};
+
 Status write_combined_txn_log(const CombinedTxnLogPB& logs) {
     auto tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
     return tablet_mgr->put_combined_txn_log(logs);
+}
+
+Status write_combined_txn_log(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map) {
+    std::vector<std::future<Status>> futures;
+    std::vector<std::shared_ptr<Runnable>> tasks;
+
+    for (const auto& [partition_id, logs] : txn_log_map) {
+        (void)partition_id;
+        std::promise<Status> promise;
+        futures.push_back(promise.get_future());
+        std::shared_ptr<Runnable> r(
+                std::make_shared<TxnLogTask>(logs, ExecEnv::GetInstance()->lake_tablet_manager(), std::move(promise)));
+        tasks.emplace_back(std::move(r));
+    }
+
+    for (auto& task : tasks) {
+        RETURN_IF_ERROR(ExecEnv::GetInstance()->put_combined_txn_log_thread_pool()->submit(task));
+    }
+
+    for (auto& future : futures) {
+        Status status = future.get();
+        if (!status.ok()) {
+            return status;
+        }
+    }
+
+    return Status::OK();
 }
 
 } // namespace starrocks

--- a/be/src/exec/write_combined_txn_log.cpp
+++ b/be/src/exec/write_combined_txn_log.cpp
@@ -65,7 +65,6 @@ Status write_combined_txn_log_parallel(const std::map<int64_t, CombinedTxnLogPB>
         Status submit_status = ExecEnv::GetInstance()->put_combined_txn_log_thread_pool()->submit(task);
         if (!submit_status.ok()) {
             mark_failure(submit_status, &has_error, &final_status);
-            latch.count_down();
             break;
         }
     }

--- a/be/src/exec/write_combined_txn_log.cpp
+++ b/be/src/exec/write_combined_txn_log.cpp
@@ -14,68 +14,60 @@
 
 #include "exec/write_combined_txn_log.h"
 
-#include <future>
 #include <vector>
 
 #include "runtime/exec_env.h"
 #include "storage/lake/tablet_manager.h"
+#include "util/countdown_latch.h"
 
 namespace starrocks {
-
-class TxnLogTask : public Runnable {
-public:
-    TxnLogTask(const CombinedTxnLogPB* logs, lake::TabletManager* tablet_mgr, std::promise<Status> promise)
-            : _logs(logs), _tablet_mgr(tablet_mgr), _promise(std::move(promise)) {}
-
-    void run() override {
-        try {
-            Status status = _tablet_mgr->put_combined_txn_log(*_logs);
-            if (!status.ok()) {
-                throw std::runtime_error("Log write failed");
-            }
-            _promise.set_value(Status::OK());
-        } catch (const std::exception& e) {
-            _promise.set_value(Status::IOError(e.what()));
-        }
-    }
-
-private:
-    const CombinedTxnLogPB* _logs;
-    lake::TabletManager* _tablet_mgr;
-    std::promise<Status> _promise;
-};
 
 Status write_combined_txn_log(const CombinedTxnLogPB& logs) {
     auto tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
     return tablet_mgr->put_combined_txn_log(logs);
 }
 
+void mark_failure(const Status& status, std::atomic<bool>* has_error, Status* final_status) {
+    if (!has_error->load()) {
+        if (!has_error->exchange(true)) {
+            if (final_status->ok()) {
+                *final_status = status;
+            }
+        }
+    }
+}
+
+std::function<void()> create_txn_log_task(const CombinedTxnLogPB* logs, lake::TabletManager* tablet_mgr,
+                                          std::atomic<bool>* has_error, Status* final_status) {
+    return [logs, tablet_mgr, has_error, final_status]() {
+        try {
+            Status status = tablet_mgr->put_combined_txn_log(*logs);
+            if (!status.ok()) {
+                throw std::runtime_error("Txn log write failed");
+            }
+        } catch (const std::exception& e) {
+            mark_failure(Status::IOError(e.what()), has_error, final_status);
+        } catch (...) {
+            mark_failure(Status::Unknown("Unknown exception in write combined txn log task"), has_error, final_status);
+        }
+    };
+}
+
 Status write_combined_txn_log(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map) {
-    std::vector<std::future<Status>> futures;
-    std::vector<std::shared_ptr<Runnable>> tasks;
+    size_t task_count = txn_log_map.size();
+    CountDownLatch latch(task_count);
+    std::atomic<bool> has_error(false);
+    Status final_status;
 
     for (const auto& [partition_id, logs] : txn_log_map) {
-        (void)partition_id;
-        std::promise<Status> promise;
-        futures.push_back(promise.get_future());
-        std::shared_ptr<Runnable> r(
-                std::make_shared<TxnLogTask>(&logs, ExecEnv::GetInstance()->lake_tablet_manager(), std::move(promise)));
-        tasks.emplace_back(std::move(r));
-    }
-
-    for (auto& task : tasks) {
+        auto task_logic =
+                create_txn_log_task(&logs, ExecEnv::GetInstance()->lake_tablet_manager(), &has_error, &final_status);
+        auto task = std::make_shared<AutoCleanRunnable>(std::move(task_logic), [&latch]() { latch.count_down(); });
         RETURN_IF_ERROR(ExecEnv::GetInstance()->put_combined_txn_log_thread_pool()->submit(task));
     }
 
-    Status st;
-    for (auto& future : futures) {
-        Status status = future.get();
-        if (st.ok() && !status.ok()) {
-            st = status;
-        }
-    }
-
-    return st;
+    latch.wait();
+    return has_error.load() ? final_status : Status::OK();
 }
 
 } // namespace starrocks

--- a/be/src/exec/write_combined_txn_log.cpp
+++ b/be/src/exec/write_combined_txn_log.cpp
@@ -53,17 +53,21 @@ std::function<void()> create_txn_log_task(const CombinedTxnLogPB* logs, lake::Ta
     };
 }
 
-Status write_combined_txn_log(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map) {
-    size_t task_count = txn_log_map.size();
-    CountDownLatch latch(task_count);
+Status write_combined_txn_log_parallel(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map) {
+    CountDownLatch latch(0);
     std::atomic<bool> has_error(false);
     Status final_status;
-
     for (const auto& [partition_id, logs] : txn_log_map) {
         auto task_logic =
                 create_txn_log_task(&logs, ExecEnv::GetInstance()->lake_tablet_manager(), &has_error, &final_status);
         auto task = std::make_shared<AutoCleanRunnable>(std::move(task_logic), [&latch]() { latch.count_down(); });
-        RETURN_IF_ERROR(ExecEnv::GetInstance()->put_combined_txn_log_thread_pool()->submit(task));
+        latch.add_count(1);
+        Status submit_status = ExecEnv::GetInstance()->put_combined_txn_log_thread_pool()->submit(task);
+        if (!submit_status.ok()) {
+            mark_failure(submit_status, &has_error, &final_status);
+            latch.count_down();
+            break;
+        }
     }
 
     latch.wait();

--- a/be/src/exec/write_combined_txn_log.h
+++ b/be/src/exec/write_combined_txn_log.h
@@ -20,5 +20,6 @@ namespace starrocks {
 class CombinedTxnLogPB;
 
 Status write_combined_txn_log(const CombinedTxnLogPB& logs);
+Status write_combined_txn_log(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map);
 
 } // namespace starrocks

--- a/be/src/exec/write_combined_txn_log.h
+++ b/be/src/exec/write_combined_txn_log.h
@@ -20,6 +20,6 @@ namespace starrocks {
 class CombinedTxnLogPB;
 
 Status write_combined_txn_log(const CombinedTxnLogPB& logs);
-Status write_combined_txn_log(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map);
+Status write_combined_txn_log_parallel(const std::map<int64_t, CombinedTxnLogPB>& txn_log_map);
 
 } // namespace starrocks

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -482,6 +482,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
 
     std::unique_ptr<ThreadPool> load_rowset_pool;
     std::unique_ptr<ThreadPool> load_segment_pool;
+    std::unique_ptr<ThreadPool> put_combined_txn_log_thread_pool;
     RETURN_IF_ERROR(
             ThreadPoolBuilder("load_rowset_pool")
                     .set_min_threads(0)
@@ -501,6 +502,14 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _load_segment_thread_pool = load_segment_pool.release();
 
     _broker_mgr = new BrokerMgr(this);
+
+    RETURN_IF_ERROR(ThreadPoolBuilder("put_combined_txn_log_thread_pool")
+                            .set_min_threads(0)
+                            .set_max_threads(config::put_combined_txn_log_thread_pool_num_max)
+                            .set_idle_timeout(MonoDelta::FromMilliseconds(500))
+                            .build(&put_combined_txn_log_thread_pool));
+    _put_combined_txn_log_thread_pool = put_combined_txn_log_thread_pool.release();
+
 #ifndef BE_TEST
     _bfd_parser = BfdParser::create();
 #endif

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -761,6 +761,7 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_lake_update_manager);
     SAFE_DELETE(_lake_replication_txn_manager);
     SAFE_DELETE(_cache_mgr);
+    SAFE_DELETE(_put_combined_txn_log_thread_pool);
     _dictionary_cache_pool.reset();
     _automatic_partition_pool.reset();
     _metrics = nullptr;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -278,6 +278,7 @@ public:
     ThreadPool* streaming_load_thread_pool() { return _streaming_load_thread_pool; }
     ThreadPool* load_rowset_thread_pool() { return _load_rowset_thread_pool; }
     ThreadPool* load_segment_thread_pool() { return _load_segment_thread_pool; }
+    ThreadPool* put_combined_txn_log_thread_pool() { return _put_combined_txn_log_thread_pool; }
 
     pipeline::DriverExecutor* wg_driver_executor();
     workgroup::ScanExecutor* scan_executor();
@@ -369,6 +370,7 @@ private:
 
     ThreadPool* _load_segment_thread_pool = nullptr;
     ThreadPool* _load_rowset_thread_pool = nullptr;
+    ThreadPool* _put_combined_txn_log_thread_pool = nullptr;
 
     PriorityThreadPool* _udf_call_pool = nullptr;
     PriorityThreadPool* _pipeline_prepare_pool = nullptr;

--- a/be/src/util/countdown_latch.h
+++ b/be/src/util/countdown_latch.h
@@ -80,6 +80,11 @@ public:
     // If the count is already zero, this has no effect.
     void count_down() { count_down(1); }
 
+    void add_count(int delta) {
+        std::lock_guard lock(lock_);
+        count_ += delta;
+    }
+
     // Wait until the count on the latch reaches zero.
     // If the count is already zero, this returns immediately.
     void wait() const {

--- a/be/src/util/countdown_latch.h
+++ b/be/src/util/countdown_latch.h
@@ -80,11 +80,6 @@ public:
     // If the count is already zero, this has no effect.
     void count_down() { count_down(1); }
 
-    void add_count(int delta) {
-        std::lock_guard lock(lock_);
-        count_ += delta;
-    }
-
     // Wait until the count on the latch reaches zero.
     // If the count is already zero, this returns immediately.
     void wait() const {

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -498,6 +498,7 @@ set(EXEC_FILES
         ./storage/lake/lake_persistent_index_test.cpp
         ./storage/lake/replication_txn_manager_test.cpp
         ./storage/lake/persistent_index_sstable_test.cpp
+        ./storage/lake/write_combined_txn_log_test.cpp
         ./block_cache/datacache_utils_test.cpp
         ./block_cache/block_cache_hit_rate_counter_test.cpp
         ./util/thrift_rpc_helper_test.cpp

--- a/be/test/storage/lake/write_combined_txn_log_test.cpp
+++ b/be/test/storage/lake/write_combined_txn_log_test.cpp
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/write_combined_txn_log.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+
+#include "testutil/assert.h"
+#include "util/failpoint/fail_point.h"
+
+namespace starrocks::lake {
+
+class WriteCombinedTxnLogTest : public testing::Test {
+public:
+    WriteCombinedTxnLogTest() {}
+};
+
+TEST_F(WriteCombinedTxnLogTest, test_write_combined_txn_log_parallel) {
+    std::map<int64_t, CombinedTxnLogPB> txn_log_map;
+    size_t N = 2;
+    for (int64_t i = 0; i < N; i++) {
+        CombinedTxnLogPB combinde_txn_log_pb;
+        txn_log_map.insert(std::make_pair(i, std::move(combinde_txn_log_pb)));
+    }
+    PFailPointTriggerMode trigger_mode;
+    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+    auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("put_combined_txn_log_success");
+    fp->setMode(trigger_mode);
+    ASSERT_TRUE(write_combined_txn_log(txn_log_map).ok());
+    trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+    fp->setMode(trigger_mode);
+
+    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+    fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("put_combined_txn_log_fail");
+    fp->setMode(trigger_mode);
+    ASSERT_FALSE(write_combined_txn_log(txn_log_map).ok());
+    trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+    fp->setMode(trigger_mode);
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/write_combined_txn_log_test.cpp
+++ b/be/test/storage/lake/write_combined_txn_log_test.cpp
@@ -39,14 +39,14 @@ TEST_F(WriteCombinedTxnLogTest, test_write_combined_txn_log_parallel) {
     trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
     auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("put_combined_txn_log_success");
     fp->setMode(trigger_mode);
-    ASSERT_TRUE(write_combined_txn_log(txn_log_map).ok());
+    ASSERT_TRUE(write_combined_txn_log_parallel(txn_log_map).ok());
     trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
     fp->setMode(trigger_mode);
 
     trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
     fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get("put_combined_txn_log_fail");
     fp->setMode(trigger_mode);
-    ASSERT_FALSE(write_combined_txn_log(txn_log_map).ok());
+    ASSERT_FALSE(write_combined_txn_log_parallel(txn_log_map).ok());
     trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
     fp->setMode(trigger_mode);
 }


### PR DESCRIPTION
## Why I'm doing:
If the import task involves multiple partitions, the combined transaction log will be written one by one, which may slowdown the import speed.

## What I'm doing:
Write combined txn log parallel

write combined txn log for 100 partitions.
before this pr
```
I20250110 15:44:43.331159 139757477246720 tablet_sink_sender.cpp:384] write_combined_txn_log non-parallel cost time: 1545
```
after this pr
```
I20250110 15:46:47.941779 139757477246720 tablet_sink_sender.cpp:376] write_combined_txn_log parallel cost time: 140
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0