### PR TITLE
[Enhancement] Use cluster_snapshot_path to specify the cluster snapshot to be restored

### DIFF
--- a/conf/cluster_snapshot.yaml
+++ b/conf/cluster_snapshot.yaml
@@ -2,9 +2,8 @@
 
 # information about the cluster snapshot to be downloaded and restored
 #cluster_snapshot:
+#    cluster_snapshot_path: s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta/image/automated_cluster_snapshot_1704038400000
 #    storage_volume_name: my_s3_volume #defined in storage_volumes
-#    cluster_service_id: f7265e80-631c-44d3-a8ac-cf7cdc7adec811019
-#    cluster_snapshot_name: automated_cluster_snapshot_1704038400000
 
 # do not include leader fe
 #frontends:

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotConfig.java
@@ -42,16 +42,21 @@ public class ClusterSnapshotConfig {
     private static final Logger LOG = LogManager.getLogger(ClusterSnapshotConfig.class);
 
     public static class ClusterSnapshot {
+        @JsonProperty("cluster_snapshot_path")
+        private String clusterSnapshotPath;
+
         @JsonProperty("storage_volume_name")
         private String storageVolumeName;
 
         private StorageVolume storageVolume;
 
-        @JsonProperty("cluster_service_id")
-        private String clusterServiceId;
+        public String getClusterSnapshotPath() {
+            return clusterSnapshotPath;
+        }
 
-        @JsonProperty("cluster_snapshot_name")
-        private String clusterSnapshotName;
+        public void setClusterSnapshotPath(String clusterSnapshotPath) {
+            this.clusterSnapshotPath = clusterSnapshotPath;
+        }
 
         public String getStorageVolumeName() {
             return storageVolumeName;
@@ -67,22 +72,6 @@ public class ClusterSnapshotConfig {
 
         public void setStorageVolume(StorageVolume storageVolume) {
             this.storageVolume = storageVolume;
-        }
-
-        public String getClusterServiceId() {
-            return clusterServiceId;
-        }
-
-        public void setClusterServiceId(String clusterServiceId) {
-            this.clusterServiceId = clusterServiceId;
-        }
-
-        public String getClusterSnapshotName() {
-            return clusterSnapshotName;
-        }
-
-        public void setClusterSnapshotName(String clusterSnapshotName) {
-            this.clusterSnapshotName = clusterSnapshotName;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
@@ -34,7 +34,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 public class RestoreClusterSnapshotMgr {
     private static final Logger LOG = LogManager.getLogger(RestoreClusterSnapshotMgr.class);
@@ -86,6 +85,7 @@ public class RestoreClusterSnapshotMgr {
         } finally {
             self.rollbackConfig();
             instance = null;
+            LOG.info("FE finished to restore from a cluster snapshot");
         }
     }
 
@@ -118,17 +118,13 @@ public class RestoreClusterSnapshotMgr {
             LOG.info("Deleted image dir {}", localImagePath);
         }
         if (FileUtils.deleteQuietly(new File(localBdbPath))) {
-            LOG.info("Deleted bdb {}", localBdbPath);
+            LOG.info("Deleted bdb dir {}", localBdbPath);
         }
 
-        ClusterSnapshotConfig.StorageVolume storageVolume = clusterSnapshot.getStorageVolume();
-        // TODO: use constant and support no snapshot name
-        String snapshotImagePath = String.join("/", storageVolume.getLocation(), clusterSnapshot.getClusterServiceId(),
-                "meta/image", clusterSnapshot.getClusterSnapshotName());
-        Map<String, String> properties = storageVolume.getProperties();
+        String snapshotImagePath = clusterSnapshot.getClusterSnapshotPath();
 
-        LOG.info("Copy snapshot image {} to local dir {}", snapshotImagePath, localImagePath);
-        HdfsUtil.copyToLocal(snapshotImagePath, localImagePath, properties);
+        LOG.info("Download cluster snapshot {} to local dir {}", snapshotImagePath, localImagePath);
+        HdfsUtil.copyToLocal(snapshotImagePath, localImagePath, clusterSnapshot.getStorageVolume().getProperties());
     }
 
     private void updateFrontends() throws StarRocksException {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotConfigTest.java
@@ -28,16 +28,14 @@ public class ClusterSnapshotConfigTest {
 
         ClusterSnapshotConfig.ClusterSnapshot clusterSnapshot = config.getClusterSnapshot();
         Assert.assertNotNull(clusterSnapshot);
+        Assert.assertEquals(
+                "s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta/image/automated_cluster_snapshot_1704038400000",
+                clusterSnapshot.getClusterSnapshotPath());
         Assert.assertEquals("my_s3_volume", clusterSnapshot.getStorageVolumeName());
         Assert.assertNotNull(clusterSnapshot.getStorageVolume());
-        Assert.assertEquals("f7265e80-631c-44d3-a8ac-cf7cdc7adec811019",
-                clusterSnapshot.getClusterServiceId());
-        Assert.assertEquals("automated_cluster_snapshot_1704038400000",
-                clusterSnapshot.getClusterSnapshotName());
 
+        clusterSnapshot.setClusterSnapshotPath(clusterSnapshot.getClusterSnapshotPath());
         clusterSnapshot.setStorageVolumeName(clusterSnapshot.getStorageVolumeName());
-        clusterSnapshot.setClusterServiceId(clusterSnapshot.getClusterServiceId());
-        clusterSnapshot.setClusterSnapshotName(clusterSnapshot.getClusterSnapshotName());
 
         Assert.assertEquals(2, config.getFrontends().size());
         Assert.assertEquals(2, config.getComputeNodes().size());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgrTest.java
@@ -31,7 +31,7 @@ public class RestoreClusterSnapshotMgrTest {
     }
 
     @Test
-    public void testDownloadSnapshotFaied() throws Exception {
+    public void testDownloadSnapshotFailed() throws Exception {
         Assert.assertThrows(StarRocksException.class, () -> {
             RestoreClusterSnapshotMgr.init("src/test/resources/conf/cluster_snapshot.yaml",
                     new String[] { "-cluster_snapshot" });

--- a/fe/fe-core/src/test/resources/conf/cluster_snapshot.yaml
+++ b/fe/fe-core/src/test/resources/conf/cluster_snapshot.yaml
@@ -2,9 +2,8 @@
 
 # information about the cluster snapshot to be downloaded and restored
 cluster_snapshot:
+    cluster_snapshot_path: s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta/image/automated_cluster_snapshot_1704038400000
     storage_volume_name: my_s3_volume #defined in storage_volumes
-    cluster_service_id: f7265e80-631c-44d3-a8ac-cf7cdc7adec811019
-    cluster_snapshot_name: automated_cluster_snapshot_1704038400000
 
 # do not include leader fe
 frontends:

--- a/fe/fe-core/src/test/resources/conf/cluster_snapshot2.yaml
+++ b/fe/fe-core/src/test/resources/conf/cluster_snapshot2.yaml
@@ -2,9 +2,8 @@
 
 # information about the cluster snapshot to be downloaded and restored
 # cluster_snapshot:
+#     cluster_snapshot_path: s3://defaultbucket/test/f7265e80-631c-44d3-a8ac-cf7cdc7adec811019/meta/image/automated_cluster_snapshot_1704038400000
 #     storage_volume_name: my_s3_volume #defined in storage_volumes
-#     cluster_service_id: f7265e80-631c-44d3-a8ac-cf7cdc7adec811019
-#     cluster_snapshot_name: automated_cluster_snapshot_1704038400000
 
 # do not include leader fe
 frontends:


### PR DESCRIPTION
## Why I'm doing:
Previously, using cluster_service_id and cluster_snapshot_name to specify the cluster snapshot to be restored is not user-friendly.

## What I'm doing:
Use cluster_snapshot_path to specify the cluster snapshot to be restored.

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0