### PR TITLE
[BugFix] Fix mv partition compensation for iceberg table with transform partition in range materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3135,6 +3135,10 @@ public class Config extends ConfigBase {
             "occupying too much meta memory")
     public static int max_mv_task_run_meta_message_values_length = 16;
 
+    @ConfField(mutable = true, comment = "Whether enable to use list partition rather than range partition for " +
+            "all external table partition types")
+    public static boolean enable_mv_list_partition_for_external_table = false;
+
     /**
      * The refresh partition number when refreshing materialized view at once by default.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -59,6 +59,7 @@ import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -1028,14 +1029,19 @@ public class MaterializedViewAnalyzer {
                 // - otherwise use range partition as before.
                 // To be compatible with old implementations, if the partition column is not a string type,
                 // still use range partition.
-                // TODO: remove this compatibility code in the future, use list partition directly later.
-                if (partitionExprType.isStringType() &&
-                        mvPartitionByExprs.stream().allMatch(t -> t instanceof SlotRef) &&
-                        !(partitionRefTableExpr instanceof FunctionCallExpr)) {
+                // NOTE: If enable_mv_list_partition_for_external_table is true, create list partition mv
+                // for all external tables. Otherwise, use original range partition instead.
+                if (Config.enable_mv_list_partition_for_external_table) {
                     statement.setPartitionType(PartitionType.LIST);
                 } else {
-                    statement.setPartitionType(PartitionType.RANGE);
-                    checkRangePartitionColumnLimit(mvPartitionByExprs);
+                    if (partitionExprType.isStringType() &&
+                            mvPartitionByExprs.stream().allMatch(t -> t instanceof SlotRef) &&
+                            !(partitionRefTableExpr instanceof FunctionCallExpr)) {
+                        statement.setPartitionType(PartitionType.LIST);
+                    } else {
+                        statement.setPartitionType(PartitionType.RANGE);
+                        checkRangePartitionColumnLimit(mvPartitionByExprs);
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCell.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCell.java
@@ -31,6 +31,14 @@ public final class PRangeCell extends PCell implements Comparable<PRangeCell> {
         this.range = partitionKeyRange;
     }
 
+    public static PRangeCell of(PartitionKey partitionKey) {
+        return new PRangeCell(Range.singleton(partitionKey));
+    }
+
+    public static PRangeCell of(Range<PartitionKey> partitionKeyRange) {
+        return new PRangeCell(partitionKeyRange);
+    }
+
     public Range<PartitionKey> getRange() {
         return range;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -61,6 +61,7 @@ import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RandomDistributionDesc;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.sql.common.PRangeCell;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.JoinHelper;
@@ -1472,21 +1473,32 @@ public class MvUtils {
         return baseTableInfos.stream().map(BaseTableInfo::getReadableString).collect(Collectors.joining(","));
     }
 
+    public static ScalarOperator convertPartitionKeyRangesToListPredicate(List<? extends ScalarOperator> partitionColRefs,
+                                                                          Collection<PRangeCell> pRangeCells) {
+        final List<Range<PartitionKey>> partitionRanges = pRangeCells
+                .stream()
+                .map(PRangeCell::getRange)
+                .collect(Collectors.toList());
+        final boolean areAllRangePartitionsSingleton = partitionRanges
+                .stream().allMatch(x -> x.lowerEndpoint().equals(x.upperEndpoint()));
+        return convertPartitionKeysToListPredicate(partitionColRefs, partitionRanges, areAllRangePartitionsSingleton);
+    }
+
     public static ScalarOperator convertPartitionKeysToListPredicate(List<? extends ScalarOperator> partitionColRefs,
                                                                      Collection<PartitionKey> partitionRanges) {
-        List<ScalarOperator> values = Lists.newArrayList();
+        final List<ScalarOperator> values = Lists.newArrayList();
         if (partitionColRefs.size() == 1) {
-            for (PartitionKey partitionKey : partitionRanges) {
-                List<LiteralExpr> literalExprs = partitionKey.getKeys();
+            for (PartitionKey key : partitionRanges) {
+                final List<LiteralExpr> literalExprs = key.getKeys();
                 Preconditions.checkArgument(literalExprs.size() == partitionColRefs.size());
-                LiteralExpr literalExpr = literalExprs.get(0);
-                ConstantOperator upperBound = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
+                final LiteralExpr literalExpr = literalExprs.get(0);
+                final ConstantOperator upperBound = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
                 values.add(upperBound);
             }
             return MvUtils.convertToInPredicate(partitionColRefs.get(0), values);
         } else {
-            for (PartitionKey partitionKey : partitionRanges) {
-                List<LiteralExpr> literalExprs = partitionKey.getKeys();
+            for (PartitionKey key : partitionRanges) {
+                List<LiteralExpr> literalExprs = key.getKeys();
                 Preconditions.checkArgument(literalExprs.size() == partitionColRefs.size());
                 // TODO: use row operator instead
                 List<ScalarOperator> predicates = Lists.newArrayList();
@@ -1501,6 +1513,48 @@ public class MvUtils {
             }
             return Utils.compoundOr(values);
         }
+    }
+
+    private static ScalarOperator convertPartitionKeysToListPredicate(List<? extends ScalarOperator> partitionColRefs,
+                                                                      Collection<Range<PartitionKey>> partitionRanges,
+                                                                      boolean areAllRangePartitionsSingleton) {
+
+        if (areAllRangePartitionsSingleton) {
+            List<PartitionKey> partitionKeys = partitionRanges
+                    .stream()
+                    .map(Range::lowerEndpoint)
+                    .collect(Collectors.toList());
+            return convertPartitionKeysToListPredicate(partitionColRefs, partitionKeys);
+        } else {
+            final List<ScalarOperator> values = Lists.newArrayList();
+            partitionRanges
+                    .stream()
+                    .map(range -> getPartitionKeyRangePredicate(partitionColRefs, range))
+                    .forEach(values::add);
+            return Utils.compoundOr(values);
+        }
+    }
+
+    private static ScalarOperator getPartitionKeyRangePredicate(List<? extends ScalarOperator> partitionColRefs,
+                                                                Range<PartitionKey> range) {
+        final List<LiteralExpr> lowerLiteralExprs = range.lowerEndpoint().getKeys();
+        final List<LiteralExpr> upperLiteralExprs = range.upperEndpoint().getKeys();
+        Preconditions.checkArgument(lowerLiteralExprs.size() == upperLiteralExprs.size());
+        Preconditions.checkArgument(lowerLiteralExprs.size() == partitionColRefs.size());
+        final List<ScalarOperator> predicates = Lists.newArrayList();
+        for (int i = 0; i < lowerLiteralExprs.size(); i++) {
+            final ScalarOperator partitionColRef = partitionColRefs.get(i);
+            final LiteralExpr lowerLiteralExpr = lowerLiteralExprs.get(i);
+            final LiteralExpr upperLiteralExpr = upperLiteralExprs.get(i);
+            final ConstantOperator lowerBound =
+                    (ConstantOperator) SqlToScalarOperatorTranslator.translate(lowerLiteralExpr);
+            final ConstantOperator upperBound =
+                    (ConstantOperator) SqlToScalarOperatorTranslator.translate(upperLiteralExpr);
+            final ScalarOperator gt = new BinaryPredicateOperator(BinaryType.GE, partitionColRef, lowerBound);
+            final ScalarOperator ls = new BinaryPredicateOperator(BinaryType.LT, partitionColRef, upperBound);
+            predicates.add(Utils.compoundAnd(gt, ls));
+        }
+        return Utils.compoundAnd(predicates);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1474,13 +1474,13 @@ public class MvUtils {
     }
 
     public static ScalarOperator convertPartitionKeyRangesToListPredicate(List<? extends ScalarOperator> partitionColRefs,
-                                                                          Collection<PRangeCell> pRangeCells) {
+                                                                          Collection<PRangeCell> pRangeCells,
+                                                                          boolean areAllRangePartitionsSingleton) {
         final List<Range<PartitionKey>> partitionRanges = pRangeCells
                 .stream()
                 .map(PRangeCell::getRange)
                 .collect(Collectors.toList());
-        final boolean areAllRangePartitionsSingleton = partitionRanges
-                .stream().allMatch(x -> x.lowerEndpoint().equals(x.upperEndpoint()));
+
         return convertPartitionKeysToListPredicate(partitionColRefs, partitionRanges, areAllRangePartitionsSingleton);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManyJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManyJoinTest.java
@@ -138,7 +138,7 @@ public class MaterializedViewManyJoinTest extends MaterializedViewTestBase {
     public void testManyJoins(String name, String query, boolean expectHitMv) throws Exception {
         Stopwatch watch = Stopwatch.createStarted();
         // Make sure it's not empty
-        String plan = getFragmentPlan(query, "MV");
+        String plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "OlapScanNode");
         if (expectHitMv) {
             PlanTestBase.assertContains(plan, "MaterializedView: true");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -146,6 +146,10 @@ public class MVTestBase extends StarRocksTestBase {
         return table;
     }
 
+    protected MaterializedView getMv(String mvName) {
+        return getMv(DB_NAME, mvName);
+    }
+
     protected MaterializedView getMv(String dbName, String mvName) {
         Table table = getTable(dbName, mvName);
         Assert.assertTrue(table instanceof MaterializedView);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
+import com.starrocks.common.Config;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
@@ -1953,5 +1954,64 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
         }
         starRocksAssert.dropMaterializedView(mvName);
         connectContext.getSessionVariable().setEnableViewBasedMvRewrite(false);
+    }
+
+    @Test
+    public void testListMVWithIcebergTable1() {
+        final String mvName = "test_mv1";
+        Config.enable_mv_list_partition_for_external_table = true;
+        try {
+            starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                    "partition by str2date(d,'%Y-%m-%d') " +
+                    "distributed by hash(a) " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "'replication_num' = '1'" +
+                    ") " +
+                    "as select a, b, d, bitmap_union(to_bitmap(t1.c))" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " group by a, b, d;");
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("List partition expression can only be ref-base-table's " +
+                    "partition expression but contain"));
+        }
+        Config.enable_mv_list_partition_for_external_table = false;
+    }
+
+    @Test
+    public void testListMVWithIcebergTable2() throws Exception {
+        Config.enable_mv_list_partition_for_external_table = true;
+        final String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by d " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select a, b, d, bitmap_union(to_bitmap(t1.c))" +
+                " from iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " group by a, b, d;");
+        final MaterializedView mv = getMv(mvName);
+        Assert.assertTrue(mv.getPartitionInfo().isListPartition());
+        Config.enable_mv_list_partition_for_external_table = false;
+    }
+
+    @Test
+    public void testListMVWithIcebergTable3() throws Exception {
+        String mvName = "test_mv1";
+        Config.enable_mv_list_partition_for_external_table = true;
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_mv1\n" +
+                "PARTITION BY date_trunc('month', ts)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` as a;");
+        final MaterializedView mv = getMv(mvName);
+        Assert.assertTrue(mv.getPartitionInfo().isListPartition());
+        Config.enable_mv_list_partition_for_external_table = false;
     }
 }

--- a/test/sql/test_transparent_mv/R/test_mv_with_iceberg_partition_transform
+++ b/test/sql/test_transparent_mv/R/test_mv_with_iceberg_partition_transform
@@ -1,0 +1,162 @@
+-- name: test_mv_with_iceberg_partition_transform
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY (date_trunc('month', prcdate))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+  SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION start('2025-01-01') end('2025-01-03') WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;
+-- result:
+2025-01-01
+2025-01-02
+2025-02-03
+2025-03-03
+2025-04-01
+-- !result
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;
+-- result:
+2025-01-01
+2025-01-02
+-- !result
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;
+-- result:
+2025-02-03
+2025-03-03
+2025-04-01
+-- !result
+select distinct prcdate from test_mv1 order by prcdate;
+-- result:
+2025-01-01
+2025-01-02
+-- !result
+select * from test_mv1 order by prcdate;
+-- result:
+2025-01-01	b	1.0
+2025-01-02	b	2.0
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION start('2025-01-03') end('2025-01-04') WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;
+-- result:
+2025-01-01
+2025-01-02
+2025-02-03
+2025-03-03
+2025-04-01
+-- !result
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;
+-- result:
+2025-01-01
+2025-01-02
+-- !result
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;
+-- result:
+2025-02-03
+2025-03-03
+2025-04-01
+-- !result
+select distinct prcdate from test_mv1 order by prcdate;
+-- result:
+2025-01-01
+2025-01-02
+-- !result
+select * from test_mv1 order by prcdate;
+-- result:
+2025-01-01	b	1.0
+2025-01-02	b	2.0
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;", "test_mv1")
+-- result:
+True
+-- !result
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;
+-- result:
+2025-01-01
+2025-01-02
+2025-02-03
+2025-03-03
+2025-04-01
+-- !result
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;
+-- result:
+2025-01-01
+2025-01-02
+-- !result
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;
+-- result:
+2025-02-03
+2025-03-03
+2025-04-01
+-- !result
+select distinct prcdate from test_mv1 order by prcdate;
+-- result:
+2025-01-01
+2025-01-02
+2025-02-03
+2025-03-03
+2025-04-01
+-- !result
+select * from test_mv1 order by prcdate;
+-- result:
+2025-01-01	b	1.0
+2025-01-02	b	2.0
+2025-02-03	b	3.0
+2025-03-03	b	4.0
+2025-04-01	b	5.0
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+drop catalog mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/T/test_mv_with_iceberg_partition_transform
+++ b/test/sql/test_transparent_mv/T/test_mv_with_iceberg_partition_transform
@@ -1,0 +1,57 @@
+-- name: test_mv_with_iceberg_partition_transform
+
+-- create mv
+create database db_${uuid0};
+use db_${uuid0};
+
+-- admin set frontend config("enable_mv_list_partition_for_external_table"="false");
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY (date_trunc('month', prcdate))
+REFRESH DEFERRED MANUAL
+PROPERTIES ("replication_num" = "1")
+AS
+  SELECT * FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month;
+
+-- partial refresh
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION start('2025-01-01') end('2025-01-03') WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;", "test_mv1")
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;", "test_mv1")
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;", "test_mv1")
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;
+select distinct prcdate from test_mv1 order by prcdate;
+select * from test_mv1 order by prcdate;
+
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION start('2025-01-03') end('2025-01-04') WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;", "test_mv1")
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;", "test_mv1")
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;", "test_mv1")
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;
+select distinct prcdate from test_mv1 order by prcdate;
+select * from test_mv1 order by prcdate;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;", "test_mv1")
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;", "test_mv1")
+function: print_hit_materialized_view("SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;", "test_mv1")
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month order by prcdate;
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate < '2025-01-03' order by prcdate;
+SELECT distinct prcdate FROM mv_iceberg_${uuid0}.sql_test_db.test_iceberg_with_month where prcdate > '2025-01-03' order by prcdate;
+select distinct prcdate from test_mv1 order by prcdate;
+select * from test_mv1 order by prcdate;
+
+drop database db_${uuid0} force;
+drop catalog mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
In old version, `Iceberg` table with date/datetime partition time will create materialized view with range partition type.

When mv's refreshness is stale, partition compensation in older version can only generate `equal` predicate rather than `range` predicate, this is fine for `hive-like` partition values since `hive-like` partition is always list partition, but for `iceberg partition transforms` we need to generate a range predicate to cover transform range.



## What I'm doing:
- Support generating range predicate for iceberg transform partitions;
- add a config to create a list partition for all external tables, it's fine in the list partition mv. 

TODO:
- Enable `enable_mv_list_partition_for_external_table` by default in the next pr.


https://github.com/StarRocks/starrocks/issues/54536


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0