### PR TITLE
[BugFix] Fix the bug of SpillMemTableSink checking keys type

### DIFF
--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -218,7 +218,7 @@ Status SpillMemTableSink::merge_blocks_to_segments() {
         total_merges++;
         // PK shouldn't do agg because pk support order key different from primary key,
         // in that case, data is sorted by order key and cannot be aggregated by primary key
-        bool do_agg = _schema->keys_type() == TKeysType::AGG_KEYS || _schema->keys_type() == TKeysType::UNIQUE_KEYS;
+        bool do_agg = _schema->keys_type() == KeysType::AGG_KEYS || _schema->keys_type() == KeysType::UNIQUE_KEYS;
         auto tmp_itr = new_heap_merge_iterator(merge_inputs);
         auto merge_itr = do_agg ? new_aggregate_iterator(tmp_itr) : tmp_itr;
         RETURN_IF_ERROR(merge_itr->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));


### PR DESCRIPTION
## Why I'm doing:

```
struct TKeysType {
  enum type {
    PRIMARY_KEYS = 0,
    DUP_KEYS = 1,
    UNIQUE_KEYS = 2,
    AGG_KEYS = 3
  };
};
```

```
enum KeysType {
  DUP_KEYS = 0,
  UNIQUE_KEYS = 1,
  AGG_KEYS = 2,
  PRIMARY_KEYS = 10
};
```

## What I'm doing:

Fix the bug of SpillMemTableSink checking keys type

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0