### PR TITLE
[UT] Fix the problem that jmockit jar was not found in run-fe-ut.sh execution.

### DIFF
--- a/fe/plugin-common/pom.xml
+++ b/fe/plugin-common/pom.xml
@@ -78,5 +78,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.hazendaz.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Why I'm doing:
It will fail when run fe ut with `./run-fe-ut.sh `
![image](https://github.com/user-attachments/assets/94bf49ea-1761-4d59-8755-fce428fb02bd)

The error is caused by `Error opening zip file or JAR manifest missing : /home/root/.m2/repository/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar`

So it's best to import jmockit's maven configuration

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0