### PR TITLE
[BugFix] fix fragment instance state transition in incremental scan ranges case

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -175,7 +175,7 @@ public class FragmentInstanceExecState {
      * The state transitions to DEPLOYING.
      */
     public void deployAsync() {
-        transitionState(State.DEPLOYING);
+        transitionState(State.CREATED, State.DEPLOYING);
 
         TNetworkAddress brpcAddress = worker.getBrpcAddress();
         try {


### PR DESCRIPTION
## Why I'm doing:


This bug is introduced from incremental scan ranges feature. This feature allows FE to delivery scan ranges in many rounds. https://github.com/StarRocks/starrocks/pull/53661

So for a single fragment instance, there would be multiple delivery rounds.  But there is a race condition:
- First delivery round: change state from CREATED -> DEPLOYING
- Fragment is finished because of short circuit. Then state is changed to FINISHED, and about to call `com.starrocks.qe.scheduler.QueryRuntimeProfile#finishInstance`
- But there is another delivery round, then state could be changed from FINISHED -> DEPLOYING again.
- But when state is “DEPLOYING” in `com.starrocks.qe.scheduler.QueryRuntimeProfile#finishInstance`,  it does not accept the event “fragment instance finished”.
- So that’s why some fragment instances are waiting, even though from BE side they are done.



-----

You can see the state transition of fragment instance 142b78c4-d42b-11ef-b766-524739c46123.

```

2025-01-17 00:58:15.924+08:00 INFO (starrocks-mysql-nio-pool-6|1477) [FragmentInstanceExecState.transitionState():469] [xxx] transition state. to = DEPLOYING, instance_id = 142b78c4-d42b-11ef-b766-524739c46123
java.lang.Throwable: null
        at com.starrocks.qe.scheduler.dag.FragmentInstanceExecState.transitionState(FragmentInstanceExecState.java:469) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.dag.FragmentInstanceExecState.deployAsync(FragmentInstanceExecState.java:178) ~[starrocks-fe.jar:?]
        at java.util.ArrayList.forEach(ArrayList.java:1511) ~[?:?]
        at com.starrocks.qe.scheduler.Deployer.deployFragments(Deployer.java:118) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.dag.AllAtOnceExecutionSchedule.schedule(AllAtOnceExecutionSchedule.java:86) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.deliverExecFragments(DefaultCoordinator.java:659) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.startScheduling(DefaultCoordinator.java:557) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.Coordinator.exec(Coordinator.java:100) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor.java:2409) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDMLStmtWithProfile(StmtExecutor.java:2220) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:750) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:372) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:582) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:920) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
2025-01-17 00:58:15.941+08:00 INFO (thrift-server-pool-0|187) [DefaultCoordinator.updateFragmentExecStatus():1048] [xxx] inst = 142b78c4-d42b-11ef-b766-524739c46123, params.done = true, params.status = TStatus(status_code:OK)
2025-01-17 00:58:15.941+08:00 INFO (thrift-server-pool-0|187) [FragmentInstanceExecState.transitionState():469] [xxx] transition state. to = FINISHED, instance_id = 142b78c4-d42b-11ef-b766-524739c46123
java.lang.Throwable: null
        at com.starrocks.qe.scheduler.dag.FragmentInstanceExecState.transitionState(FragmentInstanceExecState.java:469) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.dag.FragmentInstanceExecState.updateExecStatus(FragmentInstanceExecState.java:330) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.updateFragmentExecStatus(DefaultCoordinator.java:1053) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.QeProcessorImpl.reportExecStatus(QeProcessorImpl.java:214) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.reportExecStatus(FrontendServiceImpl.java:1140) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$reportExecStatus.getResult(FrontendService.java:5253) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$reportExecStatus.getResult(FrontendService.java:5230) ~[starrocks-fe.jar:?]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
2025-01-17 00:58:15.942+08:00 INFO (thrift-server-pool-0|187) [DefaultCoordinator.updateFragmentExecStatus():1056] [xxx] inst = 142b78c4-d42b-11ef-b766-524739c46123, execState finished true, execState = 1567781347
2025-01-17 00:58:15.944+08:00 INFO (starrocks-mysql-nio-pool-6|1477) [FragmentInstanceExecState.transitionState():469] [xxx] transition state. to = DEPLOYING, instance_id = 142b78c4-d42b-11ef-b766-524739c46123
java.lang.Throwable: null
        at com.starrocks.qe.scheduler.dag.FragmentInstanceExecState.transitionState(FragmentInstanceExecState.java:469) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.dag.FragmentInstanceExecState.deployAsync(FragmentInstanceExecState.java:178) ~[starrocks-fe.jar:?]
        at java.util.ArrayList.forEach(ArrayList.java:1511) ~[?:?]
        at com.starrocks.qe.scheduler.Deployer.deployFragments(Deployer.java:118) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.dag.AllAtOnceExecutionSchedule$DeployMoreScanRangesTask.run(AllAtOnceExecutionSchedule.java:56) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.dag.AllAtOnceExecutionSchedule$DeployMoreScanRangesTask.start(AllAtOnceExecutionSchedule.java:69) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.dag.AllAtOnceExecutionSchedule.schedule(AllAtOnceExecutionSchedule.java:96) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.deliverExecFragments(DefaultCoordinator.java:659) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DefaultCoordinator.startScheduling(DefaultCoordinator.java:557) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.scheduler.Coordinator.exec(Coordinator.java:100) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor.java:2409) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDMLStmtWithProfile(StmtExecutor.java:2220) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:750) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:372) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:582) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:920) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

## What I'm doing:

So to solve this problem, I change `deployAsync`, only accept the state from CREATED -> DEPLOYING.


Fixes https://github.com/StarRocks/StarRocksTest/issues/9105

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0