### PR TITLE
[BugFix] Fix several problem for cluster snapshot backup

### DIFF
--- a/be/src/exec/schema_scanner/schema_cluster_snapshot_jobs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_cluster_snapshot_jobs_scanner.cpp
@@ -51,13 +51,18 @@ Status SchemaClusterSnapshotJobsScanner::start(RuntimeState* state) {
 Status SchemaClusterSnapshotJobsScanner::_fill_chunk(ChunkPtr* chunk) {
     auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
     const TClusterSnapshotJobsItem& info = _result.items[_index];
+    Datum d_created_time(info.finished_time);
+    if (info.finished_time == -1) {
+        d_created_time.set_null();
+    }
+
     DatumArray datum_array{
             Slice(info.snapshot_name),
             info.job_id,
 
             TimestampValue::create_from_unixtime(info.created_time, _runtime_state->timezone_obj()),
 
-            TimestampValue::create_from_unixtime(info.finished_time, _runtime_state->timezone_obj()),
+            d_created_time,
 
             Slice(info.state),
             Slice(info.detail_info),

--- a/be/src/exec/schema_scanner/schema_cluster_snapshot_jobs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_cluster_snapshot_jobs_scanner.cpp
@@ -57,7 +57,9 @@ Status SchemaClusterSnapshotJobsScanner::_fill_chunk(ChunkPtr* chunk) {
 
             TimestampValue::create_from_unixtime(info.created_time, _runtime_state->timezone_obj()),
 
-            info.finished_time != 0 ? TimestampValue::create_from_unixtime(info.finished_time, _runtime_state->timezone_obj()) : kNullDatum,
+            info.finished_time > 0
+                    ? TimestampValue::create_from_unixtime(info.finished_time, _runtime_state->timezone_obj())
+                    : kNullDatum,
 
             Slice(info.state),
             Slice(info.detail_info),

--- a/be/src/exec/schema_scanner/schema_cluster_snapshot_jobs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_cluster_snapshot_jobs_scanner.cpp
@@ -57,7 +57,7 @@ Status SchemaClusterSnapshotJobsScanner::_fill_chunk(ChunkPtr* chunk) {
 
             TimestampValue::create_from_unixtime(info.created_time, _runtime_state->timezone_obj()),
 
-            TimestampValue::create_from_unixtime(info.finished_time, _runtime_state->timezone_obj()),
+            info.finished_time != 0 ? TimestampValue::create_from_unixtime(info.finished_time, _runtime_state->timezone_obj()) : kNullDatum,
 
             Slice(info.state),
             Slice(info.detail_info),
@@ -67,13 +67,7 @@ Status SchemaClusterSnapshotJobsScanner::_fill_chunk(ChunkPtr* chunk) {
 
     for (const auto& [slot_id, index] : slot_id_map) {
         Column* column = (*chunk)->get_column_by_slot_id(slot_id).get();
-
-        // finished time
-        if (slot_id == 4 && info.finished_time == 0) {
-            column->append_nulls(1);
-        } else {
-            column->append_datum(datum_array[slot_id - 1]);
-        }
+        column->append_datum(datum_array[slot_id - 1]);
     }
     _index++;
     return {};

--- a/be/src/exec/schema_scanner/schema_cluster_snapshots_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_cluster_snapshots_scanner.cpp
@@ -26,7 +26,6 @@ SchemaScanner::ColumnDesc SchemaClusterSnapshotsScanner::_s_columns[] = {
         {"SNAPSHOT_NAME", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
         {"SNAPSHOT_TYPE", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
         {"CREATED_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
-        {"FINISHED_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
         {"FE_JOURNAL_ID", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(long), true},
         {"STARMGR_JOURNAL_ID", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(long), true},
         {"PROPERTIES", TypeDescriptor::create_varchar_type(sizeof(StringValue)), sizeof(StringValue), true},
@@ -58,8 +57,6 @@ Status SchemaClusterSnapshotsScanner::_fill_chunk(ChunkPtr* chunk) {
             Slice(info.snapshot_type),
 
             TimestampValue::create_from_unixtime(info.created_time, _runtime_state->timezone_obj()),
-
-            TimestampValue::create_from_unixtime(info.finished_time, _runtime_state->timezone_obj()),
 
             info.fe_jouranl_id,
             info.starmgr_jouranl_id,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -128,7 +128,7 @@ public abstract class AlterHandler extends FrontendDaemon {
         while (iterator.hasNext()) {
             AlterJobV2 alterJobV2 = iterator.next().getValue();
             if (alterJobV2.isExpire() && GlobalStateMgr.getCurrentState()
-                    .getClusterSnapshotMgr().isDeletionSafeToExecution(alterJobV2.getFinishedTimeMs())) {
+                    .getClusterSnapshotMgr().isDeletionSafeToExecute(alterJobV2.getFinishedTimeMs())) {
                 iterator.remove();
                 RemoveAlterJobV2OperationLog log =
                         new RemoveAlterJobV2OperationLog(alterJobV2.getJobId(), alterJobV2.getType());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -127,9 +127,8 @@ public abstract class AlterHandler extends FrontendDaemon {
         Iterator<Map.Entry<Long, AlterJobV2>> iterator = alterJobsV2.entrySet().iterator();
         while (iterator.hasNext()) {
             AlterJobV2 alterJobV2 = iterator.next().getValue();
-            long validDeletionTimeMs = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
-                                                                       .getValidDeletionTimeMsByAutomatedSnapshot();
-            if (alterJobV2.isExpire() && alterJobV2.getFinishedTimeMs() < validDeletionTimeMs) {
+            if (alterJobV2.isExpire() && GlobalStateMgr.getCurrentState()
+                    .getClusterSnapshotMgr().isDeletionSafeToExecution(alterJobV2.getFinishedTimeMs())) {
                 iterator.remove();
                 RemoveAlterJobV2OperationLog log =
                         new RemoveAlterJobV2OperationLog(alterJobV2.getJobId(), alterJobV2.getType());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -57,7 +57,6 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.journal.JournalTask;
 import com.starrocks.lake.LakeTablet;
-import com.starrocks.lake.StarMgrMetaSyncer;
 import com.starrocks.lake.Utils;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
@@ -743,13 +742,6 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         }
 
         EditLog.waitInfinity(editLogFuture);
-
-        // Delete tablet and shards
-        for (MaterializedIndex droppedIndex : droppedIndexes) {
-            List<Long> shards = droppedIndex.getTablets().stream().map(Tablet::getId).collect(Collectors.toList());
-            // TODO: what if unusedShards deletion is partially successful?
-            StarMgrMetaSyncer.dropTabletAndDeleteShard(shards, GlobalStateMgr.getCurrentState().getStarOSAgent());
-        }
 
         // since we use same shard group to do schema change, must clear old shard before
         // updating colocation info. it's possible that after edit log above is written, fe crashes,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -415,7 +415,9 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             Map.Entry<Long, RecycleDatabaseInfo> entry = dbIter.next();
             RecycleDatabaseInfo dbInfo = entry.getValue();
             Database db = dbInfo.getDb();
-            if (timeExpired(db.getId(), currentTimeMs) && checkValidDeletionByClusterSnapshot(db.getId())) {
+            // No need to check cluster snapshot for database dropping.
+            // Because database is just meta data in FE image and not files or data in BE/CN side
+            if (timeExpired(db.getId(), currentTimeMs)) {
                 // erase db
                 dbIter.remove();
                 removeRecycleMarkers(entry.getKey());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -304,8 +304,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         if (originalRecycleTime == null) {
             return true;
         }
-        return originalRecycleTime < GlobalStateMgr.getCurrentState()
-                              .getClusterSnapshotMgr().getValidDeletionTimeMsByAutomatedSnapshot();
+        return GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isDeletionSafeToExecution(originalRecycleTime);
     }
 
     private synchronized long getAdjustedRecycleTimestamp(long id) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -304,7 +304,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         if (originalRecycleTime == null) {
             return true;
         }
-        return GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isDeletionSafeToExecution(originalRecycleTime);
+        return GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isDeletionSafeToExecute(originalRecycleTime);
     }
 
     private synchronized long getAdjustedRecycleTimestamp(long id) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ClusterSnapshotsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ClusterSnapshotsTable.java
@@ -34,7 +34,6 @@ public class ClusterSnapshotsTable {
                         .column("SNAPSHOT_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("SNAPSHOT_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("CREATED_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("FINISHED_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("FE_JOURNAL_ID", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("STARMGR_JOURNAL_ID", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("PROPERTIES", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -460,8 +460,8 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             throw new DdlException("only support cloud table or cloud mv.");
         }
         if (!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isTableSafeToDeleteTablet(table.getId())) {
-            throw new DdlException("table: {} can not be synced meta for now, because of automated cluster snapshot",
-                                   table.getName());
+            throw new DdlException("table: " + table.getName() +
+                                   " can not be synced meta for now, because of automated cluster snapshot");
         }
 
         syncTableMetaAndColocationInfoInternal(db, (OlapTable) table, forceDeleteData);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -79,9 +79,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             locker.lockDatabase(db.getId(), LockType.READ);
             try {
                 for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTablesIncludeRecycleBin(db)) {
-                    if (table.isCloudNativeTableOrMaterializedView() &&
-                            GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
-                                                            .checkValidDeletionForTableFromAlterJob(table.getId())) {
+                    if (table.isCloudNativeTableOrMaterializedView()) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore()
                                 .getAllPartitionsIncludeRecycleBin((OlapTable) table)
                                 .stream()
@@ -311,6 +309,10 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                 if (!table.isCloudNativeTableOrMaterializedView()) {
                     continue;
                 }
+                if (!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isTableSafeToDeleteTablet(table.getId())) {
+                    LOG.debug("table: {} can not be synced meta for now, because of automated cluster snapshot", table.getName());
+                    continue;
+                }
                 try {
                     syncTableMetaAndColocationInfoInternal(db, (OlapTable) table, true /* forceDeleteData */);
                 } catch (Exception e) {
@@ -456,6 +458,10 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         }
         if (!table.isCloudNativeTableOrMaterializedView()) {
             throw new DdlException("only support cloud table or cloud mv.");
+        }
+        if (!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isTableSafeToDeleteTablet(table.getId())) {
+            throw new DdlException("table: {} can not be synced meta for now, because of automated cluster snapshot",
+                                   table.getName());
         }
 
         syncTableMetaAndColocationInfoInternal(db, (OlapTable) table, forceDeleteData);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshot.java
@@ -96,7 +96,6 @@ public class ClusterSnapshot {
         item.setSnapshot_name(snapshotName);
         item.setSnapshot_type(type.name());
         item.setCreated_time(createdTimeMs / 1000);
-        item.setFinished_time(finishedTimeMs / 1000);
         item.setFe_jouranl_id(feJournalId);
         item.setStarmgr_jouranl_id(starMgrJournalId);
         item.setProperties("");

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
@@ -51,7 +51,7 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
 
         // skip first run when the scheduler start
         if (firstRun) {
-            GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().resetJobsStateForTheFirstRun();
+            GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().resetAutomatedJobsStateForTheFirstRun();
             firstRun = false;
             return;
         }
@@ -126,6 +126,10 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
             LOG.info("Finish upload image for Cluster Snapshot, FE checkpoint journal Id: {}, StarMgr checkpoint journal Id: {}",
                      job.getFeJournalId(), job.getStarMgrJournalId());
         } while (false);
+
+        if (!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isAutomatedSnapshotOn()) {
+            errMsg = "Job: " + job.getSnapshotName() + " has been cancelled because automated cluster snapshot has been turn off";
+        }
 
         if (!errMsg.isEmpty()) {
             job.setErrMsg(errMsg);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
@@ -48,7 +48,6 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
             return;
         }
 
-
         // skip first run when the scheduler start
         if (firstRun) {
             GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().resetAutomatedJobsStateForTheFirstRun();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJob.java
@@ -39,7 +39,7 @@ public class ClusterSnapshotJob implements Writable {
      * EXPIRED: Not the latest finished backup snapshot
      * DELETED: Not the lastest finished backup snapshot and the cluster snapshot has been deleted from remote
      */
-    public enum ClusterSnapshotJobState { INITIALIZING, SNAPSHOTING, UPLOADING, FINISHED, ERROR, EXPIRED, DELETED }
+    public enum ClusterSnapshotJobState { INITIALIZING, SNAPSHOTING, UPLOADING, FINISHED, EXPIRED, DELETED, ERROR }
 
     @SerializedName(value = "snapshot")
     private ClusterSnapshot snapshot;
@@ -128,7 +128,7 @@ public class ClusterSnapshotJob implements Writable {
         return state == ClusterSnapshotJobState.DELETED;
     }
 
-    public boolean isFinalizeState() {
+    public boolean isFinalState() {
         return state == ClusterSnapshotJobState.DELETED || state == ClusterSnapshotJobState.ERROR;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJob.java
@@ -58,7 +58,7 @@ public class ClusterSnapshotJob implements Writable {
         this.state = state;
         if (state == ClusterSnapshotJobState.FINISHED) {
             snapshot.setFinishedTimeMs(System.currentTimeMillis());
-            GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().clearFinishedClusterSnapshot(getSnapshotName());
+            GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().clearFinishedAutomatedClusterSnapshot(getSnapshotName());
         }
     }
 
@@ -110,6 +110,10 @@ public class ClusterSnapshotJob implements Writable {
         return state == ClusterSnapshotJobState.INITIALIZING ||
                state == ClusterSnapshotJobState.SNAPSHOTING ||
                state == ClusterSnapshotJobState.UPLOADING;
+    }
+
+    public boolean isError() {
+        return state == ClusterSnapshotJobState.ERROR;
     }
 
     public boolean isFinished() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -221,22 +221,20 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
     }
 
     public void resetAutomatedJobsStateForTheFirstRun() {
-        resetAllAutomatedFinishedJobsIntoExpiredExceptLastest();
         resetLastUnFinishedAutomatedSnapshotJob();
+        clearFinishedAutomatedClusterSnapshotExceptLastestFinished();
     }
 
-    public void resetAllAutomatedFinishedJobsIntoExpiredExceptLastest() {
-        boolean meetFirstFinished = false;
+    public void clearFinishedAutomatedClusterSnapshotExceptLastestFinished() {
+        ClusterSnapshotJob lastestFinishedJob = null;
         for (Map.Entry<Long, ClusterSnapshotJob> entry : automatedSnapshotJobs.descendingMap().entrySet()) {
             ClusterSnapshotJob job = entry.getValue();
             if (job.isFinished()) {
-                if (meetFirstFinished) {
-                    job.setState(ClusterSnapshotJobState.EXPIRED);
-                    continue;
-                }
-                meetFirstFinished = true;
+                lastestFinishedJob = job;
+                break;
             }
         }
+        clearFinishedAutomatedClusterSnapshot(lastestFinishedJob.getSnapshotName());
     }
 
     public void resetLastUnFinishedAutomatedSnapshotJob() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -167,7 +167,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
     public synchronized void addJob(ClusterSnapshotJob job) {
         int maxSize = Math.max(Config.max_historical_automated_cluster_snapshot_jobs, 2);
         if (automatedSnapshotJobs.size() > maxSize) {
-            removeOldestAutomatedFinalizeJob();
+            removeAutomatedFinalizeJobs(automatedSnapshotJobs.size() - maxSize + 1);
         }
         automatedSnapshotJobs.put(job.getId(), job);
     }
@@ -251,20 +251,23 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         }
     }
 
-    public void removeOldestAutomatedFinalizeJob() {
-        long removeId = -1;
+    public void removeAutomatedFinalizeJobs(int removeCount) {
+        if (removeCount <= 0) {
+            return;
+        }
+
         for (Map.Entry<Long, ClusterSnapshotJob> entry : automatedSnapshotJobs.entrySet()) {
             long id = entry.getKey();
             ClusterSnapshotJob job = entry.getValue();
 
             if (job.isFinalState()) {
-                removeId = id;
+                automatedSnapshotJobs.remove(id);
+                --removeCount;
+            }
+
+            if (removeCount == 0) {
                 break;
             }
-        }
-
-        if (removeId != -1) {
-            automatedSnapshotJobs.remove(removeId);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -194,7 +194,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         return previousAutomatedSnapshotCreatedTimsMs;
     }
 
-    public synchronized boolean checkValidDeletionForTableFromAlterJob(long tableId) {
+    public synchronized boolean isTableSafeToDeleteTablet(long tableId) {
         if (!isAutomatedSnapshotOn()) {
             return true;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -40,6 +40,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -62,7 +62,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         setAutomatedSnapshotOn(storageVolumeName);
 
         ClusterSnapshotLog log = new ClusterSnapshotLog();
-        log.setCreateSnapshotNamePrefix(AUTOMATED_NAME_PREFIX, storageVolumeName);
+        log.setAutomatedON(storageVolumeName);
         GlobalStateMgr.getCurrentState().getEditLog().logClusterSnapshotLog(log);
     }
 
@@ -81,7 +81,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
     // Turn off automated snapshot, use stmt for extension in future
     public void setAutomatedSnapshotOff(AdminSetAutomatedSnapshotOffStmt stmt) {
         ClusterSnapshotLog log = new ClusterSnapshotLog();
-        log.setDropSnapshot(AUTOMATED_NAME_PREFIX);
+        log.setAutomatedOFF();
         GlobalStateMgr.getCurrentState().getEditLog().logClusterSnapshotLog(log);
 
         clearFinishedAutomatedClusterSnapshot(null);
@@ -294,19 +294,13 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
     public void replayLog(ClusterSnapshotLog log) {
         ClusterSnapshotLog.ClusterSnapshotLogType logType = log.getType();
         switch (logType) {
-            case CREATE_SNAPSHOT_PREFIX: {
-                String createSnapshotNamePrefix = log.getCreateSnapshotNamePrefix();
+            case AUTOMATED_ON: {
                 String storageVolumeName = log.getStorageVolumeName();
-                if (createSnapshotNamePrefix.equals(AUTOMATED_NAME_PREFIX)) {
-                    setAutomatedSnapshotOn(storageVolumeName);
-                }
+                setAutomatedSnapshotOn(storageVolumeName);
                 break;
             }
-            case DROP_SNAPSHOT: {
-                String dropSnapshotName = log.getDropSnapshotName();
-                if (dropSnapshotName.equals(AUTOMATED_NAME_PREFIX)) {
-                    setAutomatedSnapshotOff();
-                }
+            case AUTOMATED_OFF: {
+                setAutomatedSnapshotOff();
                 break;
             }
             case UPDATE_SNAPSHOT_JOB: {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -167,7 +167,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
     public synchronized void addJob(ClusterSnapshotJob job) {
         int maxSize = Math.max(Config.max_historical_automated_cluster_snapshot_jobs, 2);
         if (automatedSnapshotJobs.size() > maxSize) {
-            removeLastestAutomatedFinalizeJob();
+            removeOldestAutomatedFinalizeJob();
         }
         automatedSnapshotJobs.put(job.getId(), job);
     }
@@ -251,9 +251,9 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         }
     }
 
-    public void removeLastestAutomatedFinalizeJob() {
+    public void removeOldestAutomatedFinalizeJob() {
         long removeId = -1;
-        for (Map.Entry<Long, ClusterSnapshotJob> entry : automatedSnapshotJobs.descendingMap().entrySet()) {
+        for (Map.Entry<Long, ClusterSnapshotJob> entry : automatedSnapshotJobs.entrySet()) {
             long id = entry.getKey();
             ClusterSnapshotJob job = entry.getValue();
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.lake.snapshot;
 
+import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.common.Config;
@@ -256,18 +257,23 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
             return;
         }
 
+        List<Long> removeIds = Lists.newArrayList();
         for (Map.Entry<Long, ClusterSnapshotJob> entry : automatedSnapshotJobs.entrySet()) {
             long id = entry.getKey();
             ClusterSnapshotJob job = entry.getValue();
 
             if (job.isFinalState()) {
-                automatedSnapshotJobs.remove(id);
+                removeIds.add(id);
                 --removeCount;
             }
 
             if (removeCount == 0) {
                 break;
             }
+        }
+
+        for (Long removeId : removeIds) {
+            automatedSnapshotJobs.remove(removeId);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -212,6 +212,10 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         return valid;
     }
 
+    public boolean isDeletionSafeToExecution(long deletionCreatedTimeMs) {
+        return deletionCreatedTimeMs < getValidDeletionTimeMsByAutomatedSnapshot();
+    }
+
     public TreeMap<Long, ClusterSnapshotJob> getHistoryAutomatedSnapshotJobs() {
         return historyAutomatedSnapshotJobs;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotUtils.java
@@ -45,8 +45,7 @@ public class ClusterSnapshotUtils {
 
         StorageVolume sv = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getAutomatedSnapshotSv();
         BrokerDesc brokerDesc = new BrokerDesc(sv.getProperties());
-        String snapshotImagePath = String.join("/", sv.getLocations().get(0),
-                GlobalStateMgr.getCurrentState().getStarOSAgent().getRawServiceId(), "meta/image", snapshotName);
+        String snapshotImagePath = getSnapshotImagePath(sv, snapshotName);
 
         HdfsUtil.deletePath(snapshotImagePath, brokerDesc);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
@@ -132,10 +132,10 @@ public class CheckpointController extends FrontendDaemon {
         init();
 
         // ignore return value in normal checkpoint controller
-        runCheckpointControllerWithIds(getImageJournalId(), getCheckpointJournalIds());
+        runCheckpointControllerWithIds(getImageJournalId(), getCheckpointJournalId());
     }
 
-    public long getCheckpointJournalIds() {
+    public long getCheckpointJournalId() {
         return journal.getFinalizedJournalId();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
@@ -131,35 +131,29 @@ public class CheckpointController extends FrontendDaemon {
     protected void runCheckpointController() {
         init();
 
-        Pair<Long, Long> getIdsRet = getCheckpointJournalIds();
-        if (getIdsRet == null) {
-            return;
-        }
-
         // ignore return value in normal checkpoint controller
-        runCheckpointControllerWithIds(getIdsRet.first, getIdsRet.second);
+        runCheckpointControllerWithIds(getImageJournalId(), getCheckpointJournalIds());
     }
 
-    public Pair<Long, Long> getCheckpointJournalIds() {
-        long imageJournalId = 0;
-        long maxJournalId = 0;
+    public long getCheckpointJournalIds() {
+        return journal.getFinalizedJournalId();
+    }
 
+    public long getImageJournalId() {
+        long imageJournalId = 0;
         try {
             Storage storage = new Storage(imageDir);
             // get max image version
             imageJournalId = storage.getImageJournalId();
-            // get max finalized journal id
-            maxJournalId = journal.getFinalizedJournalId();
-            LOG.info("checkpoint imageJournalId {}, logJournalId {}", imageJournalId, maxJournalId);
         } catch (IOException e) {
             LOG.error("Failed to get storage info", e);
-            return null;
         }
-
-        return Pair.create(imageJournalId, maxJournalId);
+        return imageJournalId;
     }
 
     public Pair<Boolean, String> runCheckpointControllerWithIds(long imageJournalId, long maxJournalId) {
+        LOG.info("checkpoint imageJournalId {}, logJournalId {}", imageJournalId, maxJournalId);
+
         // Step 1: create image
         Pair<Boolean, String> createImageRet = Pair.create(false, "");
         if (imageJournalId < maxJournalId) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ClusterSnapshotLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ClusterSnapshotLog.java
@@ -24,32 +24,24 @@ import java.io.DataInput;
 import java.io.IOException;
 
 public class ClusterSnapshotLog implements Writable {
-    public enum ClusterSnapshotLogType { NONE, CREATE_SNAPSHOT_PREFIX, DROP_SNAPSHOT, UPDATE_SNAPSHOT_JOB }
+    public enum ClusterSnapshotLogType { NONE, AUTOMATED_ON, AUTOMATED_OFF, UPDATE_SNAPSHOT_JOB }
     @SerializedName(value = "type")
     private ClusterSnapshotLogType type = ClusterSnapshotLogType.NONE;
-    // For CREATE_SNAPSHOT_PREFIX
-    @SerializedName(value = "createSnapshotNamePrefix")
-    private String createSnapshotNamePrefix = "";
     @SerializedName(value = "storageVolumeName")
     private String storageVolumeName = "";
-    // For DROP_SNAPSHOT
-    @SerializedName(value = "dropSnapshotName")
-    private String dropSnapshotName = "";
     // For UPDATE_SNAPSHOT_JOB
     @SerializedName(value = "snapshotJob")
     private ClusterSnapshotJob snapshotJob = null;
 
     public ClusterSnapshotLog() {}
 
-    public void setCreateSnapshotNamePrefix(String createSnapshotNamePrefix, String storageVolumeName) {
-        this.type = ClusterSnapshotLogType.CREATE_SNAPSHOT_PREFIX;
-        this.createSnapshotNamePrefix = createSnapshotNamePrefix;
+    public void setAutomatedON(String storageVolumeName) {
+        this.type = ClusterSnapshotLogType.AUTOMATED_ON;
         this.storageVolumeName = storageVolumeName;
     }
 
-    public void setDropSnapshot(String dropSnapshotName) {
-        this.type = ClusterSnapshotLogType.DROP_SNAPSHOT;
-        this.dropSnapshotName = dropSnapshotName;
+    public void setAutomatedOFF() {
+        this.type = ClusterSnapshotLogType.AUTOMATED_OFF;
     }
 
     public void setSnapshotJob(ClusterSnapshotJob job) {
@@ -61,16 +53,8 @@ public class ClusterSnapshotLog implements Writable {
         return type;
     }
 
-    public String getCreateSnapshotNamePrefix() {
-        return this.createSnapshotNamePrefix;
-    }
-
     public String getStorageVolumeName() {
         return this.storageVolumeName;
-    }
-
-    public String getDropSnapshotName() {
-        return this.dropSnapshotName;
     }
 
     public ClusterSnapshotJob getSnapshotJob() {
@@ -81,6 +65,5 @@ public class ClusterSnapshotLog implements Writable {
         String json = Text.readString(in);
         return GsonUtils.GSON.fromJson(json, ClusterSnapshotLog.class);
     }
-
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ClusterSnapshotLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ClusterSnapshotLog.java
@@ -17,7 +17,6 @@ package com.starrocks.persist;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
-import com.starrocks.lake.snapshot.ClusterSnapshot;
 import com.starrocks.lake.snapshot.ClusterSnapshotJob;
 import com.starrocks.persist.gson.GsonUtils;
 
@@ -25,7 +24,7 @@ import java.io.DataInput;
 import java.io.IOException;
 
 public class ClusterSnapshotLog implements Writable {
-    public enum ClusterSnapshotLogType { NONE, CREATE_SNAPSHOT_PREFIX, DROP_SNAPSHOT, CREATE_SNAPSHOT, UPDATE_SNAPSHOT_JOB }
+    public enum ClusterSnapshotLogType { NONE, CREATE_SNAPSHOT_PREFIX, DROP_SNAPSHOT, UPDATE_SNAPSHOT_JOB }
     @SerializedName(value = "type")
     private ClusterSnapshotLogType type = ClusterSnapshotLogType.NONE;
     // For CREATE_SNAPSHOT_PREFIX
@@ -36,9 +35,6 @@ public class ClusterSnapshotLog implements Writable {
     // For DROP_SNAPSHOT
     @SerializedName(value = "dropSnapshotName")
     private String dropSnapshotName = "";
-    // For CREATE_SNAPSHOT
-    @SerializedName(value = "snapshot")
-    private ClusterSnapshot snapshot = null;
     // For UPDATE_SNAPSHOT_JOB
     @SerializedName(value = "snapshotJob")
     private ClusterSnapshotJob snapshotJob = null;
@@ -54,11 +50,6 @@ public class ClusterSnapshotLog implements Writable {
     public void setDropSnapshot(String dropSnapshotName) {
         this.type = ClusterSnapshotLogType.DROP_SNAPSHOT;
         this.dropSnapshotName = dropSnapshotName;
-    }
-
-    public void setCreateSnapshot(ClusterSnapshot snapshot) {
-        this.type = ClusterSnapshotLogType.CREATE_SNAPSHOT;
-        this.snapshot = snapshot;
     }
 
     public void setSnapshotJob(ClusterSnapshotJob job) {
@@ -80,10 +71,6 @@ public class ClusterSnapshotLog implements Writable {
 
     public String getDropSnapshotName() {
         return this.dropSnapshotName;
-    }
-
-    public ClusterSnapshot getSnapshot() {
-        return this.snapshot;
     }
 
     public ClusterSnapshotJob getSnapshotJob() {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ClusterSnapshotLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ClusterSnapshotLog.java
@@ -24,7 +24,7 @@ import java.io.DataInput;
 import java.io.IOException;
 
 public class ClusterSnapshotLog implements Writable {
-    public enum ClusterSnapshotLogType { NONE, AUTOMATED_ON, AUTOMATED_OFF, UPDATE_SNAPSHOT_JOB }
+    public enum ClusterSnapshotLogType { NONE, AUTOMATED_SNAPSHOT_ON, AUTOMATED_SNAPSHOT_OFF, UPDATE_SNAPSHOT_JOB }
     @SerializedName(value = "type")
     private ClusterSnapshotLogType type = ClusterSnapshotLogType.NONE;
     @SerializedName(value = "storageVolumeName")
@@ -35,12 +35,12 @@ public class ClusterSnapshotLog implements Writable {
 
     public ClusterSnapshotLog() {}
 
-    public void setAutomatedON(String storageVolumeName) {
+    public void setAutomatedSnapshotOn(String storageVolumeName) {
         this.type = ClusterSnapshotLogType.AUTOMATED_ON;
         this.storageVolumeName = storageVolumeName;
     }
 
-    public void setAutomatedOFF() {
+    public void setAutomatedSnapshotOff() {
         this.type = ClusterSnapshotLogType.AUTOMATED_OFF;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ClusterSnapshotLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ClusterSnapshotLog.java
@@ -36,12 +36,12 @@ public class ClusterSnapshotLog implements Writable {
     public ClusterSnapshotLog() {}
 
     public void setAutomatedSnapshotOn(String storageVolumeName) {
-        this.type = ClusterSnapshotLogType.AUTOMATED_ON;
+        this.type = ClusterSnapshotLogType.AUTOMATED_SNAPSHOT_ON;
         this.storageVolumeName = storageVolumeName;
     }
 
     public void setAutomatedSnapshotOff() {
-        this.type = ClusterSnapshotLogType.AUTOMATED_OFF;
+        this.type = ClusterSnapshotLogType.AUTOMATED_SNAPSHOT_OFF;
     }
 
     public void setSnapshotJob(ClusterSnapshotJob job) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1430,8 +1430,10 @@ public class GlobalStateMgr {
 
         connectorTableTriggerAnalyzeMgr.start();
 
-        clusterSnapshotMgr.startCheckpointScheduler(checkpointController,
-                                                    StarMgrServer.getCurrentState().getCheckpointController());
+        if (RunMode.isSharedDataMode()) {
+            clusterSnapshotMgr.startCheckpointScheduler(checkpointController,
+                                                        StarMgrServer.getCurrentState().getCheckpointController());
+        }
     }
 
     // start threads that should run on all FE

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -140,7 +140,6 @@ import com.starrocks.lake.StarMgrMetaSyncer;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.compaction.CompactionControlScheduler;
 import com.starrocks.lake.compaction.CompactionMgr;
-import com.starrocks.lake.snapshot.ClusterSnapshotCheckpointScheduler;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.lake.vacuum.AutovacuumDaemon;
 import com.starrocks.leader.CheckpointController;
@@ -364,8 +363,6 @@ public class GlobalStateMgr {
     private CheckpointController checkpointController;
     private CheckpointWorker checkpointWorker;
     private boolean checkpointWorkerStarted = false;
-
-    private ClusterSnapshotCheckpointScheduler clusterSnapshotCheckpointScheduler = null;
 
     private HAProtocol haProtocol = null;
 
@@ -1333,12 +1330,6 @@ public class GlobalStateMgr {
         createBuiltinStorageVolume();
         resourceGroupMgr.createBuiltinResourceGroupsIfNotExist();
         keyMgr.initDefaultMasterKey();
-
-        // if leader change and the last cluster snapshot job has not been finished/error
-        // make the state as error, becase the job can not be continued in new leader.
-        if (clusterSnapshotMgr != null) {
-            clusterSnapshotMgr.resetLastUnFinishedAutomatedSnapshotJob();
-        }
     }
 
     public void setFrontendNodeType(FrontendNodeType newType) {
@@ -1360,10 +1351,6 @@ public class GlobalStateMgr {
         // start checkpoint thread
         checkpointController = new CheckpointController("global_state_checkpoint_controller", journal, "");
         checkpointController.start();
-
-        clusterSnapshotCheckpointScheduler = new ClusterSnapshotCheckpointScheduler(checkpointController,
-                StarMgrServer.getCurrentState().getCheckpointController());
-        clusterSnapshotCheckpointScheduler.start();
 
         keyRotationDaemon.start();
 
@@ -1442,6 +1429,9 @@ public class GlobalStateMgr {
         temporaryTableCleaner.start();
 
         connectorTableTriggerAnalyzeMgr.start();
+
+        clusterSnapshotMgr.startCheckpointScheduler(checkpointController,
+                                                    StarMgrServer.getCurrentState().getCheckpointController());
     }
 
     // start threads that should run on all FE
@@ -1800,6 +1790,7 @@ public class GlobalStateMgr {
                 keyMgr.save(imageWriter);
                 pipeManager.getRepo().save(imageWriter);
                 warehouseMgr.save(imageWriter);
+                clusterSnapshotMgr.save(imageWriter);
                 sqlBlackList.save(imageWriter);
             } catch (SRMetaBlockException e) {
                 LOG.error("Save meta block failed ", e);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1792,8 +1792,8 @@ public class GlobalStateMgr {
                 keyMgr.save(imageWriter);
                 pipeManager.getRepo().save(imageWriter);
                 warehouseMgr.save(imageWriter);
-                clusterSnapshotMgr.save(imageWriter);
                 sqlBlackList.save(imageWriter);
+                clusterSnapshotMgr.save(imageWriter);
             } catch (SRMetaBlockException e) {
                 LOG.error("Save meta block failed ", e);
                 throw new IOException("Save meta block failed ", e);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
@@ -225,13 +225,13 @@ public class ClusterSnapshotTest {
     public void testReplayClusterSnapshotLog() {
         // create atuomated snapshot request log
         ClusterSnapshotLog logCreate = new ClusterSnapshotLog();
-        logCreate.setAutomatedON(storageVolumeName);
+        logCreate.setAutomatedSnapshotOn(storageVolumeName);
         GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().replayLog(logCreate);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isAutomatedSnapshotOn());
 
         // drop automated snapshot request log
         ClusterSnapshotLog logDrop = new ClusterSnapshotLog();
-        logDrop.setAutomatedOFF();
+        logDrop.setAutomatedSnapshotOff();
         GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().replayLog(logDrop);
         Assert.assertTrue(!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isAutomatedSnapshotOn());
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
@@ -269,8 +269,8 @@ public class ClusterSnapshotTest {
     public void testCheckpointScheduler() {
         new MockUp<CheckpointController>() {
             @Mock
-            public Pair<Long, Long> getCheckpointJournalIds() {
-                return Pair.create(1L, 2L);
+            public long getImageJournalId() {
+                return 1L;
             }
 
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
@@ -334,7 +334,7 @@ public class ClusterSnapshotTest {
         localClusterSnapshotMgr.setAutomatedSnapshotOff();
 
         localClusterSnapshotMgr = new ClusterSnapshotMgr();
-        Assert.assertTrue(localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(10));
+        Assert.assertTrue(localClusterSnapshotMgr.isTableSafeToDeleteTablet(10));
         AlterJobV2 alterjob1 = new SchemaChangeJobV2(1, 2, 10, "table1", 100000);
         AlterJobV2 alterjob2 = new SchemaChangeJobV2(2, 2, 11, "table2", 100000);
         alterjob1.setJobState(AlterJobV2.JobState.FINISHED);
@@ -361,19 +361,19 @@ public class ClusterSnapshotTest {
         };
 
         localClusterSnapshotMgr.setAutomatedSnapshotOn(storageVolumeName);
-        Assert.assertTrue(!localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(10));
-        Assert.assertTrue(!localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(11));
+        Assert.assertTrue(!localClusterSnapshotMgr.isTableSafeToDeleteTablet(10));
+        Assert.assertTrue(!localClusterSnapshotMgr.isTableSafeToDeleteTablet(11));
         ClusterSnapshotJob j1 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
         j1.setState(ClusterSnapshotJobState.FINISHED);
 
-        Assert.assertTrue(!localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(10));
-        Assert.assertTrue(!localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(11));
+        Assert.assertTrue(!localClusterSnapshotMgr.isTableSafeToDeleteTablet(10));
+        Assert.assertTrue(!localClusterSnapshotMgr.isTableSafeToDeleteTablet(11));
 
         ClusterSnapshotJob j2 = localClusterSnapshotMgr.createAutomatedSnapshotJob();
         j2.setState(ClusterSnapshotJobState.FINISHED);
 
-        Assert.assertTrue(localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(10));
-        Assert.assertTrue(localClusterSnapshotMgr.checkValidDeletionForTableFromAlterJob(11));
+        Assert.assertTrue(localClusterSnapshotMgr.isTableSafeToDeleteTablet(10));
+        Assert.assertTrue(localClusterSnapshotMgr.isTableSafeToDeleteTablet(11));
         localClusterSnapshotMgr.setAutomatedSnapshotOff();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
@@ -208,7 +208,6 @@ public class ClusterSnapshotTest {
         setAutomatedSnapshotOn(false);
         ClusterSnapshotJob job = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().createAutomatedSnapshotJob();
         job.setState(ClusterSnapshotJobState.FINISHED);
-        job.addAutomatedClusterSnapshot();
         ClusterSnapshot snapshot = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getAutomatedSnapshot();
         Assert.assertTrue(job.getInfo() != null);
         Assert.assertTrue(snapshot.getInfo() != null);
@@ -264,12 +263,6 @@ public class ClusterSnapshotTest {
         GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().replayLog(logSnapshotJob);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getAllJobsInfo()
                                                                                   .getItems().get(0).state == "ERROR");
-
-        Assert.assertTrue(GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getAutomatedSnapshot() == null);
-        ClusterSnapshotLog logSnapshot = new ClusterSnapshotLog();
-        logSnapshot.setCreateSnapshot(new ClusterSnapshot(0, "my_name", "my_sv", 12345, -1, 0, 0));
-        GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().replayLog(logSnapshot);
-        Assert.assertTrue(GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getAutomatedSnapshot() != null);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ClusterSnapshotTest.java
@@ -225,13 +225,13 @@ public class ClusterSnapshotTest {
     public void testReplayClusterSnapshotLog() {
         // create atuomated snapshot request log
         ClusterSnapshotLog logCreate = new ClusterSnapshotLog();
-        logCreate.setCreateSnapshotNamePrefix(ClusterSnapshotMgr.AUTOMATED_NAME_PREFIX, storageVolumeName);
+        logCreate.setAutomatedON(storageVolumeName);
         GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().replayLog(logCreate);
         Assert.assertTrue(GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isAutomatedSnapshotOn());
 
         // drop automated snapshot request log
         ClusterSnapshotLog logDrop = new ClusterSnapshotLog();
-        logDrop.setDropSnapshot(ClusterSnapshotMgr.AUTOMATED_NAME_PREFIX);
+        logDrop.setAutomatedOFF();
         GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().replayLog(logDrop);
         Assert.assertTrue(!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isAutomatedSnapshotOn());
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1955,12 +1955,11 @@ struct TClusterSnapshotsItem {
     1: optional string snapshot_name;
     2: optional string snapshot_type;
     3: optional i64 created_time;
-    4: optional i64 finished_time;
-    5: optional i64 fe_jouranl_id;
-    6: optional i64 starmgr_jouranl_id;
-    7: optional string properties;
-    8: optional string storage_volume;
-    9: optional string storage_path;
+    4: optional i64 fe_jouranl_id;
+    5: optional i64 starmgr_jouranl_id;
+    6: optional string properties;
+    7: optional string storage_volume;
+    8: optional string storage_path;
 }
 
 struct TClusterSnapshotsRequest {


### PR DESCRIPTION
## What I'm doing:
Fix several problem for cluster snapshot backup:
1. remove finished_time column in `cluster_snapshots` sys table
2. make finished_time is NULL when the job does not finish for `cluster_snapshot_jobs` sys table
3. remove meta sync in lake schema change, make it executed in starMgrMetaSyncer
4. Use `isDeletionSafeToExecution` instead of direct comparation for timestamp
5. Fix bug for deletion control in alter table which is should check timestamp in `syncTableMetaAndColocationInfo`
6. skip first run of `ClusterSnapshotCheckpointScheduler` and reset the last unfinished job state
7. Make sure checkpoint id is greater than cur image version when `ClusterSnapshotCheckpointScheduler` begin a checkpoint
8. Introduce EXPIRED and DELETED state for clusterSnapshotJob
9. Fix persistent bug `ClusterSnapshotMgr`
10. refactor cluster snapshot relative editlog

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0