### PR TITLE
[BugFix] fix using incorrect read ratio when sampling to collect table statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/PartitionSampler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/PartitionSampler.java
@@ -27,10 +27,10 @@ import java.util.List;
 import java.util.Map;
 
 public class PartitionSampler {
-    private static final double HIGH_WEIGHT_READ_RATIO = 0.001;
-    private static final double MEDIUM_HIGH_WEIGHT_READ_RATIO = 0.01;
-    private static final double MEDIUM_LOW_WEIGHT_READ_RATIO = 0.1;
-    private static final double LOW_WEIGHT_READ_RATIO = 0.8;
+    public static final double HIGH_WEIGHT_READ_RATIO = 0.001;
+    public static final double MEDIUM_HIGH_WEIGHT_READ_RATIO = 0.01;
+    public static final double MEDIUM_LOW_WEIGHT_READ_RATIO = 0.1;
+    public static final double LOW_WEIGHT_READ_RATIO = 0.8;
     private static final long HIGH_WEIGHT_ROWS_THRESHOLD = 10000000L;
     private static final long MEDIUM_HIGH_WEIGHT_ROWS_THRESHOLD = 1000000L;
     private static final long MEDIUM_LOW_WEIGHT_ROWS_THRESHOLD = 100000L;
@@ -54,26 +54,6 @@ public class PartitionSampler {
         this.maxSize = maxSize;
 
         this.sampleRowsLimit = sampleRowLimit;
-    }
-
-    public double getHighRatio() {
-        return highRatio;
-    }
-
-    public double getMediumHighRatio() {
-        return mediumHighRatio;
-    }
-
-    public double getMediumLowRatio() {
-        return mediumLowRatio;
-    }
-
-    public double getLowRatio() {
-        return lowRatio;
-    }
-
-    public int getMaxSize() {
-        return maxSize;
     }
 
     public long getSampleRowsLimit() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
@@ -32,6 +32,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static com.starrocks.statistic.base.PartitionSampler.HIGH_WEIGHT_READ_RATIO;
+import static com.starrocks.statistic.base.PartitionSampler.LOW_WEIGHT_READ_RATIO;
+import static com.starrocks.statistic.base.PartitionSampler.MEDIUM_HIGH_WEIGHT_READ_RATIO;
+import static com.starrocks.statistic.base.PartitionSampler.MEDIUM_LOW_WEIGHT_READ_RATIO;
+
 public class HyperStatisticSQLs {
     private static final VelocityEngine DEFAULT_VELOCITY_ENGINE;
 
@@ -131,13 +136,13 @@ public class HyperStatisticSQLs {
         List<String> groupSQLs = Lists.newArrayList();
         StringBuilder sqlBuilder = new StringBuilder();
         groupSQLs.add(generateRatioTable(tableName, sampler.getSampleRowsLimit(), info.getHighWeightTablets(),
-                sampler.getHighRatio(), "t_high"));
+                HIGH_WEIGHT_READ_RATIO, "t_high"));
         groupSQLs.add(generateRatioTable(tableName, sampler.getSampleRowsLimit(), info.getMediumHighWeightTablets(),
-                sampler.getMediumHighRatio(), "t_medium_high"));
+                MEDIUM_HIGH_WEIGHT_READ_RATIO, "t_medium_high"));
         groupSQLs.add(generateRatioTable(tableName, sampler.getSampleRowsLimit(), info.getMediumLowWeightTablets(),
-                sampler.getMediumLowRatio(), "t_medium_low"));
+                MEDIUM_LOW_WEIGHT_READ_RATIO, "t_medium_low"));
         groupSQLs.add(generateRatioTable(tableName, sampler.getSampleRowsLimit(), info.getLowWeightTablets(),
-                sampler.getLowRatio(), "t_low"));
+                LOW_WEIGHT_READ_RATIO, "t_low"));
         if (groupSQLs.stream().allMatch(Objects::isNull)) {
             groupSQLs.add("SELECT * FROM " + tableName + " LIMIT " + Config.statistic_sample_collect_rows);
         }


### PR DESCRIPTION
## Why I'm doing:
currently we use tablet sample ratio as tablet read ratio.  it should be mistake.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0