### PR TITLE
[BugFix] Support more patterns for mv union rewrite by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1660,6 +1660,30 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
                 });
     }
 
+    private boolean isPullPredicateRewrite(List<ScalarOperator> queryPredicates,
+                                           Set<ColumnRefOperator> mvPredicateUsedColRefs,
+                                           MVUnionRewriteMode unionRewriteMode) {
+        if (unionRewriteMode.isPullPredicateRewrite()) {
+            return true;
+        }
+        // if mv predicates are empty, try to union rewrite.
+        if (mvPredicateUsedColRefs == null || mvPredicateUsedColRefs.isEmpty()) {
+            return true;
+        }
+        // if query predicates and mv predicates have the same column, try to union rewrite.
+        if (queryPredicates.stream()
+                .anyMatch(pred -> pred.getColumnRefs().stream().anyMatch(col -> mvPredicateUsedColRefs.contains(col)))) {
+            return true;
+        }
+        // TODO: if query predicates are not contained in mv predicates, there maybe a chance to union rewrite
+        //  but the performance may not be good.
+        // eg:
+        //   query: select dt, k2 from tblA where date_trunc('day', dt) >= '2023-11-01'
+        //   mv : select dt, k2 from tblA where k2 > 10;
+        // whether to rewrite query by mv should be considered carefully later.
+        return false;
+    }
+
     private PredicateSplit getUnionRewriteQueryCompensation(RewriteContext rewriteContext,
                                                             ColumnRewriter columnRewriter) {
         final PredicateSplit mvCompensationToQuery = getCompensationPredicates(columnRewriter,
@@ -1674,12 +1698,7 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         SessionVariable sessionVariable = optimizerContext.getSessionVariable();
         MVUnionRewriteMode unionRewriteMode =
                 MVUnionRewriteMode.getInstance(sessionVariable.getMaterializedViewUnionRewriteMode());
-        if (!unionRewriteMode.isPullPredicateRewrite()) {
-            return null;
-        }
 
-        logMVRewrite(mvRewriteContext, "Try to pull up query's predicates to make possible for union rewrite, " +
-                "unionRewriteMode:{}", unionRewriteMode);
         // try to pull up query's predicates to make possible for rewrite from mv to query.
         PredicateSplit mvPredicateSplit = rewriteContext.getMvPredicateSplit();
         PredicateSplit queryPredicateSplit = rewriteContext.getQueryPredicateSplit();
@@ -1691,6 +1710,13 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         List<ScalarOperator> queryPredicates = Lists.newArrayList();
         queryPredicates.addAll(Utils.extractConjuncts(queryPredicateSplit.getRangePredicates()));
         queryPredicates.addAll(Utils.extractConjuncts(queryPredicateSplit.getResidualPredicates()));
+        
+        // if query and mv contains the same column, we can rewrite query by mv.
+        if (!isPullPredicateRewrite(queryPredicates, mvPredicateUsedColRefs, unionRewriteMode)) {
+            return null;
+        }
+        logMVRewrite(mvRewriteContext, "Try to pull up query's predicates to make possible for union rewrite, " +
+                "unionRewriteMode:{}", unionRewriteMode);
 
         Set<ScalarOperator> queryOnPredicates = MvUtils.getJoinOnPredicates(rewriteContext.getQueryExpression());
         ColumnRefSet queryOnPredicateUsedColRefs = Optional.ofNullable(Utils.compoundAnd(queryOnPredicates))

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1706,7 +1706,7 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         // filter redundant predicates since they are not used for rewrite.
         Set<ColumnRefOperator> mvPredicateUsedColRefs = mvPredicateSplit.getPredicates()
                 .stream()
-                .filter(pred -> !pred.isRedundant())
+                .filter(pred -> pred != null && !pred.isRedundant())
                 .map(pred -> pred.getColumnRefs()
                         .stream()
                         .map(colRef -> (ColumnRefOperator) columnRewriter.rewriteViewToQuery(colRef))
@@ -1717,11 +1717,11 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         List<ScalarOperator> queryPredicates = Lists.newArrayList();
         Utils.extractConjuncts(queryPredicateSplit.getRangePredicates())
                 .stream()
-                .filter(pred -> !pred.isRedundant())
+                .filter(pred -> pred != null && !pred.isRedundant())
                 .forEach(queryPredicates::add);
         Utils.extractConjuncts(queryPredicateSplit.getResidualPredicates())
                 .stream()
-                .filter(pred -> !pred.isRedundant())
+                .filter(pred -> pred != null && !pred.isRedundant())
                 .forEach(queryPredicates::add);
         
         // if query and mv contains the same column, we can rewrite query by mv.

--- a/test/sql/test_transparent_mv/R/test_transparent_mv_union_hive2
+++ b/test/sql/test_transparent_mv/R/test_transparent_mv_union_hive2
@@ -1,0 +1,470 @@
+-- name: test_transparent_mv_union_hive2
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+-- result:
+-- !result
+set new_planner_optimize_timeout=10000;
+-- result:
+-- !result
+set catalog mv_hive_${uuid0};
+-- result:
+-- !result
+create database mv_hive_db_${uuid0};
+-- result:
+-- !result
+use mv_hive_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES 
+  (1,"2024-11-15"),(2,"2024-11-18"),(3,"2024-11-21"),(4,"2024-11-24"),
+  (1,"2024-12-02"),(2,"2024-12-05"),(3,"2024-12-08"),(4,"2024-12-11"),
+  (1,"2024-12-16"),(2,"2024-12-19"),(3,"2024-12-22"),(4,"2024-12-25"),
+  (2,"2024-11-15"),(3,"2024-11-18"),(4,"2024-11-21"),(5,"2024-11-24"),
+  (2,"2024-12-02"),(3,"2024-12-05"),(4,"2024-12-08"),(5,"2024-12-11");
+-- result:
+-- !result
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 VALUES 
+  (1,"2024-11-15"),(2,"2024-11-18"),(3,"2024-11-21"),(4,"2024-11-24"),
+  (1,"2024-12-02"),(2,"2024-12-05"),(3,"2024-12-08"),(4,"2024-12-11"),
+  (1,"2024-12-16"),(2,"2024-12-19"),(3,"2024-12-22"),(4,"2024-12-25"),
+  (2,"2024-11-15"),(3,"2024-11-18"),(4,"2024-11-21"),(5,"2024-11-24"),
+  (2,"2024-12-02"),(3,"2024-12-05"),(4,"2024-12-08"),(5,"2024-12-11");
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+  "replication_num" = "1",
+  "query_rewrite_consistency" = "checked"
+  -- "partition_ttl"="60 day"
+)
+AS SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (1, "2024-11-15"), (1, "2024-11-18"), (1, "2024-11-23"), (4, "2024-12-25");
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3) t order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;
+-- result:
+1	2024-12-02
+1	2024-12-16
+2	2024-12-02
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;
+-- result:
+5	2024-12-11
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;
+-- result:
+1	2024-11-23
+1	2024-12-02
+1	2024-12-16
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;
+-- result:
+5	2024-11-24
+5	2024-12-11
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;
+-- result:
+1	2024-11-15
+1	2024-11-15
+1	2024-11-18
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;
+-- result:
+4	2024-11-21
+4	2024-11-24
+4	2024-12-08
+-- !result
+SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3)t order by 1, 2 limit 3;
+-- result:
+4	2024-11-21
+4	2024-11-21
+4	2024-11-24
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+  "replication_num" = "1",
+  "query_rewrite_consistency" = "loose"
+)
+AS SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (1, "2024-11-15"), (1, "2024-11-18"), (1, "2024-11-23"), (4, "2024-12-25");
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3) t order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;
+-- result:
+1	2024-12-02
+1	2024-12-16
+2	2024-12-02
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;
+-- result:
+5	2024-12-11
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;
+-- result:
+1	2024-11-23
+1	2024-12-02
+1	2024-12-16
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;
+-- result:
+5	2024-11-24
+5	2024-12-11
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;
+-- result:
+1	2024-11-15
+1	2024-11-15
+1	2024-11-18
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;
+-- result:
+4	2024-11-21
+4	2024-11-24
+4	2024-12-08
+-- !result
+SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3)t order by 1, 2 limit 3;
+-- result:
+4	2024-11-21
+4	2024-11-21
+4	2024-11-24
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+  "replication_num" = "1",
+  "query_rewrite_consistency" = "loose"
+)
+AS SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01';
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (1, "2024-11-15"), (1, "2024-11-18"), (1, "2024-11-23"), (4, "2024-12-25");
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+False
+-- !result
+function: print_hit_materialized_view("SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3) t order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;
+-- result:
+1	2024-12-02
+1	2024-12-16
+2	2024-12-02
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;
+-- result:
+5	2024-12-11
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;
+-- result:
+1	2024-11-23
+1	2024-11-23
+1	2024-11-23
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;
+-- result:
+5	2024-11-24
+5	2024-12-11
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;
+-- result:
+1	2024-11-15
+1	2024-11-15
+1	2024-11-15
+-- !result
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;
+-- result:
+4	2024-11-21
+4	2024-11-24
+4	2024-12-08
+-- !result
+SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3)t order by 1, 2 limit 3;
+-- result:
+4	2024-11-21
+4	2024-11-21
+4	2024-11-24
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+AS SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (1, "2024-11-15"), (4, "2024-12-25");
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  GROUP BY dt order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt >'2024-12-01' GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  GROUP BY dt order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt >'2024-11-20' GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM (SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt having sum(num) > 10 UNION ALL SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt) t order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2024-12-02	3
+2024-12-05	5
+2024-12-08	7
+-- !result
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt >'2024-12-01' GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;
+-- result:
+2024-12-25	20
+-- !result
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2024-11-21	7
+2024-11-23	3
+2024-11-24	9
+-- !result
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt >'2024-11-20' GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;
+-- result:
+2024-12-25	20
+-- !result
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2024-11-15	7
+2024-11-18	8
+2024-11-21	7
+-- !result
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;
+-- result:
+2024-12-25	20
+-- !result
+SELECT * FROM (SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt having sum(num) > 10 UNION ALL SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt) t order by 1, 2 limit 3;
+-- result:
+2024-11-15	7
+2024-11-18	8
+2024-11-21	7
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+AS SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt=t2.dt where t2.dt > '2024-12-01' GROUP BY t2.dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (1, "2024-11-15"), (4, "2024-12-25");
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-12-01' GROUP BY t2.dt order by 1, 2 limit 3;", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-12-01' GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;", "test_mv1")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+function: print_hit_materialized_view("SELECT * FROM (SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10 UNION ALL SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10) t order by 1, 2 limit 3", "test_mv1", "UNION")
+-- result:
+True
+-- !result
+SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-12-01' GROUP BY t2.dt order by 1, 2 limit 3;
+-- result:
+2024-12-02	6
+2024-12-05	10
+2024-12-08	14
+-- !result
+SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-12-01' GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;
+-- result:
+2024-12-08	14
+2024-12-11	18
+2024-12-25	24
+-- !result
+SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt order by 1, 2 limit 3;
+-- result:
+2024-11-21	14
+2024-11-24	18
+2024-12-02	6
+-- !result
+SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;
+-- result:
+2024-11-21	14
+2024-11-24	18
+2024-12-08	14
+-- !result
+SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;
+-- result:
+2024-11-15	21
+2024-11-18	25
+2024-11-21	14
+-- !result
+SELECT * FROM (SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10 UNION ALL SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10) t order by 1, 2 limit 3;
+-- result:
+2024-11-21	14
+2024-11-21	14
+2024-11-24	18
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;
+-- result:
+-- !result

--- a/test/sql/test_transparent_mv/T/test_transparent_mv_union_hive2
+++ b/test/sql/test_transparent_mv/T/test_transparent_mv_union_hive2
@@ -1,0 +1,175 @@
+-- name: test_transparent_mv_union_hive2
+create external catalog mv_hive_${uuid0}
+properties
+(
+    "type" = "hive",
+    "hive.catalog.type" = "hive",
+    "hive.metastore.uris" = "${hive_metastore_uris}"
+);
+
+set new_planner_optimize_timeout=10000;
+-- create hive table
+set catalog mv_hive_${uuid0};
+create database mv_hive_db_${uuid0};
+use mv_hive_db_${uuid0};
+
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES 
+  (1,"2024-11-15"),(2,"2024-11-18"),(3,"2024-11-21"),(4,"2024-11-24"),
+  (1,"2024-12-02"),(2,"2024-12-05"),(3,"2024-12-08"),(4,"2024-12-11"),
+  (1,"2024-12-16"),(2,"2024-12-19"),(3,"2024-12-22"),(4,"2024-12-25"),
+  (2,"2024-11-15"),(3,"2024-11-18"),(4,"2024-11-21"),(5,"2024-11-24"),
+  (2,"2024-12-02"),(3,"2024-12-05"),(4,"2024-12-08"),(5,"2024-12-11");
+
+CREATE TABLE mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 (
+  num int,
+  dt date
+)
+PARTITION BY (dt);
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 VALUES 
+  (1,"2024-11-15"),(2,"2024-11-18"),(3,"2024-11-21"),(4,"2024-11-24"),
+  (1,"2024-12-02"),(2,"2024-12-05"),(3,"2024-12-08"),(4,"2024-12-11"),
+  (1,"2024-12-16"),(2,"2024-12-19"),(3,"2024-12-22"),(4,"2024-12-25"),
+  (2,"2024-11-15"),(3,"2024-11-18"),(4,"2024-11-21"),(5,"2024-11-24"),
+  (2,"2024-12-02"),(3,"2024-12-05"),(4,"2024-12-08"),(5,"2024-12-11");
+
+-- create mv
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+-- set materialized_view_union_rewrite_mode=2;
+
+-- NOTE: test mv with the single table
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+  "replication_num" = "1",
+  "query_rewrite_consistency" = "checked"
+  -- "partition_ttl"="60 day"
+)
+AS SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (1, "2024-11-15"), (1, "2024-11-18"), (1, "2024-11-23"), (4, "2024-12-25");
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3) t order by 1, 2 limit 3;", "test_mv1", "UNION")
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;
+SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3)t order by 1, 2 limit 3;
+
+-- NOTE: test mv with the single table
+DROP MATERIALIZED VIEW test_mv1;
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+  "replication_num" = "1",
+  "query_rewrite_consistency" = "loose"
+)
+AS SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (1, "2024-11-15"), (1, "2024-11-18"), (1, "2024-11-23"), (4, "2024-12-25");
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3) t order by 1, 2 limit 3;", "test_mv1", "UNION")
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;
+SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3)t order by 1, 2 limit 3;
+
+-- NOTE: test mv with the single table
+DROP MATERIALIZED VIEW test_mv1;
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+  "replication_num" = "1",
+  "query_rewrite_consistency" = "loose"
+)
+AS SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01';
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (1, "2024-11-15"), (1, "2024-11-18"), (1, "2024-11-23"), (4, "2024-12-25");
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3) t order by 1, 2 limit 3;", "test_mv1", "UNION")
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' and num > 4 order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20' and num > 4 order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 order by 1, 2 limit 3;
+SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 order by 1, 2 limit 3;
+SELECT * FROM (SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3 UNION ALL SELECT * FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where num > 3)t order by 1, 2 limit 3;
+
+DROP MATERIALIZED VIEW test_mv1;
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+AS SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01' GROUP BY dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (1, "2024-11-15"), (4, "2024-12-25");
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  GROUP BY dt order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt >'2024-12-01' GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  GROUP BY dt order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt >'2024-11-20' GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM (SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt having sum(num) > 10 UNION ALL SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt) t order by 1, 2 limit 3;", "test_mv1", "UNION")
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-12-01'  GROUP BY dt order by 1, 2 limit 3;
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt >'2024-12-01' GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt > '2024-11-20'  GROUP BY dt order by 1, 2 limit 3;
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 where dt >'2024-11-20' GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt order by 1, 2 limit 3;
+SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt having sum(num) > 10 order by 1, 2 limit 3;
+SELECT * FROM (SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt having sum(num) > 10 UNION ALL SELECT dt, sum(num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 GROUP BY dt) t order by 1, 2 limit 3;
+
+DROP MATERIALIZED VIEW test_mv1;
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+AS SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt=t2.dt where t2.dt > '2024-12-01' GROUP BY t2.dt;
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+INSERT INTO mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 VALUES (1, "2024-11-15"), (4, "2024-12-25");
+
+function: print_hit_materialized_view("SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-12-01' GROUP BY t2.dt order by 1, 2 limit 3;", "test_mv1")
+function: print_hit_materialized_view("SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-12-01' GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;", "test_mv1")
+function: print_hit_materialized_view("SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;", "test_mv1", "UNION")
+function: print_hit_materialized_view("SELECT * FROM (SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10 UNION ALL SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10) t order by 1, 2 limit 3", "test_mv1", "UNION")
+SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-12-01' GROUP BY t2.dt order by 1, 2 limit 3;
+SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-12-01' GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;
+SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt order by 1, 2 limit 3;
+SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;
+SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt GROUP BY t2.dt having sum(t2.num) > 10 order by 1, 2 limit 3;
+SELECT * FROM (SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10 UNION ALL SELECT t2.dt, sum(t2.num) as num FROM mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 join mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 on t1.dt = t2.dt where t2.dt > '2024-11-20' GROUP BY t2.dt having sum(t2.num) > 10) t order by 1, 2 limit 3;
+
+DROP MATERIALIZED VIEW test_mv1;
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t1 force;
+drop table mv_hive_${uuid0}.mv_hive_db_${uuid0}.t2 force;


### PR DESCRIPTION
## Why I'm doing:

1. f query predicates and mv predicates have the same column, try to union rewrite.
2. if mv predicates are empty, try to union rewrite.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0