### PR TITLE
[BugFix] fix samples rows calculation error when sampling to collect table statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/TabletSampler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/TabletSampler.java
@@ -57,10 +57,6 @@ public class TabletSampler {
         return totalRows;
     }
 
-    public long getSampleRows() {
-        return (long) Math.min(sampleRowsLimit, Math.max(totalRows * tabletReadRatio, 1L));
-    }
-
     public long getTotalTablets() {
         return tablets.size();
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
we should use sampled tablets to calculate sample rows. currenty we use all tablets to calculate it.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0