### PR TITLE
[BugFix] fix ingestion hang because of alter job timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -223,9 +223,7 @@ public abstract class AlterJobV2 implements Writable {
      */
     public synchronized void run() {
         if (isTimeout()) {
-            boolean cancelled = cancelImpl("Timeout");
-            cancelHook(cancelled);
-            if (cancelled) {
+            if (cancelInternal("Timeout")) {
                 // If this job can't be cancelled, we should execute it.
                 return;
             }
@@ -259,15 +257,19 @@ public abstract class AlterJobV2 implements Writable {
                 } // else: handle the new state
             }
         } catch (AlterCancelException e) {
-            cancelHook(cancelImpl(e.getMessage()));
+            cancelInternal(e.getMessage());
         }
+    }
+
+    protected boolean cancelInternal(String errMsg) {
+        boolean cancelled = cancelImpl(errMsg);
+        cancelHook(cancelled);
+        return cancelled;
     }
 
     public boolean cancel(String errMsg) {
         synchronized (this) {
-            boolean cancelled = cancelImpl(errMsg);
-            cancelHook(cancelled);
-            return cancelled;
+            return cancelInternal(errMsg);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -223,8 +223,12 @@ public abstract class AlterJobV2 implements Writable {
      */
     public synchronized void run() {
         if (isTimeout()) {
-            cancelHook(cancelImpl("Timeout"));
-            return;
+            bool cancelled = cancelImpl("Timeout");
+            cancelHook(cancelled);
+            if (cancelled) {
+                // If this job can't be cancelled, we should execute it.
+                return;
+            }
         }
 
         // create connectcontext

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -223,7 +223,7 @@ public abstract class AlterJobV2 implements Writable {
      */
     public synchronized void run() {
         if (isTimeout()) {
-            bool cancelled = cancelImpl("Timeout");
+            boolean cancelled = cancelImpl("Timeout");
             cancelHook(cancelled);
             if (cancelled) {
                 // If this job can't be cancelled, we should execute it.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -1080,9 +1080,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                 createReplicaLatch.countDownToZero(new Status(TStatusCode.OK, ""));
             }
             synchronized (this) {
-                boolean cancelled = cancelImpl(errMsg);
-                cancelHook(cancelled);
-                return cancelled;
+                return cancelInternal(errMsg);
             }
         } finally {
             isCancelling.set(false);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -770,9 +770,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 createReplicaLatch.countDownToZero(new Status(TStatusCode.OK, ""));
             }
             synchronized (this) {
-                boolean cancelled = cancelImpl(errMsg);
-                cancelHook(cancelled);
-                return cancelled;
+                return cancelInternal(errMsg)
             }
         } finally {
             isCancelling.set(false);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -770,7 +770,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 createReplicaLatch.countDownToZero(new Status(TStatusCode.OK, ""));
             }
             synchronized (this) {
-                return cancelInternal(errMsg)
+                return cancelInternal(errMsg);
             }
         } finally {
             isCancelling.set(false);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2110,7 +2110,7 @@ public class SchemaChangeHandler extends AlterHandler {
             long timeoutSecond = PropertyAnalyzer.analyzeTimeout(properties, Config.alter_table_timeout_second);
             alterMetaJob = new LakeTableAlterMetaJob(GlobalStateMgr.getCurrentState().getNextId(),
                     db.getId(),
-                    olapTable.getId(), olapTable.getName(), timeoutSecond,
+                    olapTable.getId(), olapTable.getName(), timeoutSecond * 1000 /* should be ms*/,
                     TTabletMetaType.ENABLE_PERSISTENT_INDEX, enablePersistentIndex, persistentIndexType);
         } else {
             // shouldn't happen

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -946,9 +946,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                 createReplicaLatch.countDownToZero(new Status(TStatusCode.OK, ""));
             }
             synchronized (this) {
-                boolean cancelled = cancelImpl(errMsg);
-                cancelHook(cancelled);
-                return cancelled;
+                return cancelInternal(errMsg);
             }
         } finally {
             isCancelling.set(false);


### PR DESCRIPTION
## Why I'm doing:
In shared-data cluster, alter job will increase partition's next version and then change state to `FINISHED_REWRITING`. But if this alter job is timeout, it won't be executed and can't finish, it will lead to version gap and cause issue like:
```
2025-01-13 05:13:26.728Z ERROR (lake-publish-task-160840|200302) [PublishVersionDaemon.publishPartitionBatch():488] publish partition batch partition.getVisibleVersion() + 1 != version.get(0) 4473684 37071 37073
```

## What I'm doing:
Two changes in my PR:
1. Only skip the alter job which can be cancelled.
2. Fix timeout setting when create LakeTableAlterMetaJob.

This pull request includes changes to improve the handling of job cancellation and timeouts in the `AlterJobV2` class, as well as a minor adjustment to the timeout parameter in the `SchemaChangeHandler` class. The most important changes are summarized below:

Improvements to job cancellation handling:

* [`fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java`](diffhunk://#diff-419474f2e7da8320296dd4233f1afbbd333e5288bbece76f940ecd307daba508L226-R232): Modified the `run` method to handle job cancellation more effectively by checking if the job can be cancelled and executing it if not.

Adjustments to timeout parameter:

* [`fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java`](diffhunk://#diff-d751b4c625247dce88660ac5678891ba795e8b6e94ab55bb7aaed7204705664cL2113-R2113): Changed the timeout parameter for `LakeTableAlterMetaJob` from seconds to milliseconds to ensure accurate timeout handling.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0