### PR TITLE
[BugFix] should acquire db lock out of createLoadTask to avoid dead lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -894,7 +894,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
             planParams.query_options.setLoad_job_type(TLoadJobType.ROUTINE_LOAD);
             StreamLoadMgr streamLoadManager = GlobalStateMgr.getCurrentState().getStreamLoadMgr();
 
-            StreamLoadTask streamLoadTask = streamLoadManager.createLoadTaskWithoutLock(db, table.getName(), label, "", "",
+            StreamLoadTask streamLoadTask = streamLoadManager.createLoadTaskWithoutLock(db, table, label, "", "",
                     taskTimeoutSecond * 1000, true, warehouseId);
             streamLoadTask.setTxnId(txnId);
             streamLoadTask.setLabel(label);

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -145,7 +145,7 @@ public class StreamLoadMgr implements MemoryTrackable {
                 task.beginTxnFromFrontend(channelId, channelNum, resp);
                 return;
             }
-            task = createLoadTask(db, table, label, user, clientIp, timeoutMillis, channelNum, channelId, warehouseId);
+            task = createLoadTaskWithoutLock(db, table, label, user, clientIp, timeoutMillis, channelNum, channelId, warehouseId);
             LOG.info(new LogBuilder(LogKey.STREAM_LOAD_TASK, task.getId())
                     .add("msg", "create load task").build());
             addLoadTask(task);
@@ -192,9 +192,9 @@ public class StreamLoadMgr implements MemoryTrackable {
         return streamLoadTask;
     }
 
-    private StreamLoadTask createLoadTask(Database db, Table table, String label, String user, String clientIp,
-                                         long timeoutMillis, int channelNum,
-                                         int channelId, long warehouseId) {
+    private StreamLoadTask createLoadTaskWithoutLock(Database db, Table table, String label, String user,
+                                                     String clientIp, long timeoutMillis, int channelNum,
+                                                     int channelId, long warehouseId) {
         // init stream load task
         long id = GlobalStateMgr.getCurrentState().getNextId();
         StreamLoadTask streamLoadTask = new StreamLoadTask(id, db, (OlapTable) table,


### PR DESCRIPTION
## Why I'm doing:
A dead lock issue is found:

Slow lock:
![image](https://github.com/user-attachments/assets/b0466e81-539a-416d-8ce3-6a88f184fd2a)

Thread "pool-21-thread-406" **owns the database lock**.
`StreamLoadMgr.cleanSyncStreamLoadTasks()` tries to acquire `StreamLoadMgr.lock.writeLock()` _**0x00007fb9905311a8**_

Jstack:
![image](https://github.com/user-attachments/assets/f37b72a3-5f69-410a-8068-3dc3380bcce2)

Thread "thrift-server-pool-6208" owns the StreamLoadMgr.lock.writeLock(): _**0x00007fb9905311a8**_ in `StreamLoadMgr.beginLoadTask()`

`StreamLoadMgr.beginLoadTask()` call `StreamLoadMgr.createLoadTask()` who is trying to **acquire database lock**

## What I'm doing:
`StreamLoadMgr.createLoadTask()` don't acquire database lock.
`StreamLoadMgr.beginLoadTask()` first acquire database lock and unlock, then acquire `StreamLoadMgr.lock.writeLock()` 



Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0