### PR TITLE
[Enhancement] support all tables using pk/fk optimization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.catalog;
 
 import com.google.common.base.Joiner;
@@ -21,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.server.CatalogMgr;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * BaseTableInfo is used for MaterializedView persisted as a base table's meta info which can be an olap
@@ -112,6 +112,7 @@ public class BaseTableInfo {
 
     /**
      * Called when a table is renamed.
+     *
      * @param newTable the new table with the new table name
      */
     public void onTableRename(Table newTable, String oldTableName) {
@@ -163,5 +164,16 @@ public class BaseTableInfo {
     @Override
     public int hashCode() {
         return Objects.hashCode(catalogName, dbId, tableId, dbName, tableIdentifier, tableName);
+    }
+
+    public boolean matchTable(Table t) {
+        if (isInternalCatalog()) {
+            return tableId == t.getId();
+        } else {
+            return StringUtils.equals(catalogName, t.getCatalogName()) &&
+                    StringUtils.equals(dbName, t.getCatalogDBName()) &&
+                    StringUtils.equals(tableName, t.getCatalogTableName()) &&
+                    StringUtils.equals(tableIdentifier, t.getTableIdentifier());
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -45,8 +45,6 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.DescriptorTable.ReferencedPartitionInfo;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
-import com.starrocks.catalog.constraint.ForeignKeyConstraint;
-import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -408,16 +406,6 @@ public class HiveTable extends Table {
         sb.append(", createTime=").append(createTime);
         sb.append('}');
         return sb.toString();
-    }
-
-    @Override
-    public List<UniqueConstraint> getUniqueConstraints() {
-        return uniqueConstraints;
-    }
-
-    @Override
-    public List<ForeignKeyConstraint> getForeignKeyConstraints() {
-        return foreignKeyConstraints;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -491,6 +492,10 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         return new ArrayList<>(nameToColumn.values());
     }
 
+    public List<Column> getKeyColumns() {
+        return null;
+    }
+
     public void addColumn(Column column) {
         fullSchema.add(column);
         nameToColumn.put(column.getName(), column);
@@ -511,8 +516,6 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     public TTableDescriptor toThrift(List<ReferencedPartitionInfo> partitions) {
         return null;
     }
-
-
 
     @Override
     public void gsonPostProcess() throws IOException {
@@ -827,5 +830,36 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
 
     public boolean isSupportBackupRestore() {
         return isOlapTableOrMaterializedView() || isOlapView();
+    }
+
+    // Sometimes when we prune a table but want to preserve a single column
+    // for olap table, we could use first key column
+    // for other tables, probably we could choose the most narrow column for performance.
+    // but theoretically we can choose any column.
+    public Column getPresentivateColumn() {
+        List<Column> keyColumns = getKeyColumns();
+        if (keyColumns != null && keyColumns.size() > 0) {
+            return keyColumns.get(0);
+        }
+        List<UniqueConstraint> uniqueConstraintList = getUniqueConstraints();
+        if (uniqueConstraintList != null) {
+            for (UniqueConstraint uc : uniqueConstraintList) {
+                for (ColumnId id : uc.getUniqueColumns()) {
+                    Column c = getColumn(id);
+                    if (c != null) {
+                        return c;
+                    }
+                }
+            }
+        }
+        return getColumns().stream().min((c1, c2) -> {
+            Function<Column, Integer> ff = c -> {
+                if (c.getType().isScalarType()) {
+                    return c.getType().getTypeSize();
+                }
+                return Integer.MAX_VALUE;
+            };
+            return ff.apply(c1) - ff.apply(c2);
+        }).get();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderCardinalityPreserving.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderCardinalityPreserving.java
@@ -19,7 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.BinaryType;
-import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -283,16 +283,13 @@ public class JoinReorderCardinalityPreserving extends JoinOrder {
             return;
         }
         // We only try to reorder atoms which are LogicalScanOperator, since at present,
-        // we can extract cardinality-preserving relation from a pair of OlapTable.
+        // we can extract cardinality-preserving relation from a pair of table.
         List<OptExpression> scanOps = atomOptExprs.stream().filter(opt -> {
             if (!(opt.getOp() instanceof LogicalScanOperator)) {
                 return false;
             }
             LogicalScanOperator scanOp = opt.getOp().cast();
-            if (!(scanOp.getTable() instanceof OlapTable)) {
-                return false;
-            }
-            OlapTable table = ((OlapTable) scanOp.getTable());
+            Table table = scanOp.getTable();
             return table.hasUniqueConstraints() || table.hasForeignKeyConstraints();
         }).collect(Collectors.toList());
 
@@ -302,7 +299,7 @@ public class JoinReorderCardinalityPreserving extends JoinOrder {
 
         // Construct a mapping from ColumnRefOperator to OptExpression, later we
         // only try matches equality predicate that references ColumnRefOperators backed
-        // by real columns of OlapTables to pairs of ColumnRefOperator of cardinality-preserving
+        // by real columns of tables to pairs of ColumnRefOperator of cardinality-preserving
         // relation of two OptExpression.
         Map<ColumnRefOperator, OptExpression> colRefToScanNodes = Maps.newHashMap();
         for (OptExpression scanOp : scanOps) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CboTablePruneRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CboTablePruneRule.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -34,7 +34,8 @@ import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -55,10 +56,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class CboTablePruneRule extends TransformationRule {
-    public CboTablePruneRule() {
+    private CboTablePruneRule() {
         super(RuleType.TF_CBO_TABLE_PRUNE_RULE,
-                Pattern.create(OperatorType.LOGICAL_JOIN, OperatorType.LOGICAL_OLAP_SCAN,
-                        OperatorType.LOGICAL_OLAP_SCAN));
+                Pattern.create(OperatorType.LOGICAL_JOIN, OperatorType.LOGICAL, OperatorType.LOGICAL));
     }
 
     // the count of joins of these types exceeds certain threshold, this Rule would be time-consuming
@@ -78,9 +78,22 @@ public class CboTablePruneRule extends TransformationRule {
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
         LogicalJoinOperator joinOp = input.getOp().cast();
-        return joinOp.getJoinType() == JoinOperator.INNER_JOIN ||
+        boolean supportedJoinType = (joinOp.getJoinType() == JoinOperator.INNER_JOIN ||
                 joinOp.getJoinType() == JoinOperator.LEFT_OUTER_JOIN ||
-                joinOp.getJoinType() == JoinOperator.RIGHT_OUTER_JOIN;
+                joinOp.getJoinType() == JoinOperator.RIGHT_OUTER_JOIN);
+        if (!supportedJoinType) {
+            return false;
+        }
+        if (input.getInputs().size() != 2) {
+            return false;
+        }
+        for (int i = 0; i < input.getInputs().size(); i++) {
+            LogicalOperator op = input.inputAt(i).getOp().cast();
+            if (!Pattern.isScanOperator(op.getOpType())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
@@ -89,8 +102,8 @@ public class CboTablePruneRule extends TransformationRule {
         JoinOperator joinType = joinOp.getJoinType();
         OptExpression lhs = input.inputAt(0);
         OptExpression rhs = input.inputAt(1);
-        LogicalOlapScanOperator lhsScanOp = input.inputAt(0).getOp().cast();
-        LogicalOlapScanOperator rhsScanOp = input.inputAt(1).getOp().cast();
+        LogicalScanOperator lhsScanOp = input.inputAt(0).getOp().cast();
+        LogicalScanOperator rhsScanOp = input.inputAt(1).getOp().cast();
         Pair<List<BinaryPredicateOperator>, List<ScalarOperator>> onPredicates =
                 JoinHelper.separateEqualPredicatesFromOthers(input);
         List<BinaryPredicateOperator> eqOnPredicates = onPredicates.first;
@@ -137,8 +150,8 @@ public class CboTablePruneRule extends TransformationRule {
         return Collections.emptyList();
     }
 
-    private boolean matchUniqueConstraints(LogicalOlapScanOperator scanOp, List<ColumnRefOperator> colRefs) {
-        OlapTable table = (OlapTable) scanOp.getTable();
+    private boolean matchUniqueConstraints(LogicalScanOperator scanOp, List<ColumnRefOperator> colRefs) {
+        Table table = scanOp.getTable();
         if (!table.hasUniqueConstraints()) {
             return false;
         }
@@ -219,8 +232,8 @@ public class CboTablePruneRule extends TransformationRule {
             Optional<ScalarOperator> optOtherJoinOnPredicate) {
         OptExpression lhs = joinOptExpression.inputAt(0);
         OptExpression rhs = joinOptExpression.inputAt(1);
-        LogicalOlapScanOperator lhsScanOp = lhs.getOp().cast();
-        LogicalOlapScanOperator rhsScanOp = rhs.getOp().cast();
+        LogicalScanOperator lhsScanOp = lhs.getOp().cast();
+        LogicalScanOperator rhsScanOp = rhs.getOp().cast();
         LogicalJoinOperator joinOp = joinOptExpression.getOp().cast();
         JoinOperator joinType = joinOp.getJoinType();
         // If there exist other predicates in on-clause except equality predicates, left/right join
@@ -230,7 +243,7 @@ public class CboTablePruneRule extends TransformationRule {
         }
 
         // must be the same table
-        if (lhsScanOp.getTable().getId() != rhsScanOp.getTable().getId()) {
+        if (lhsScanOp.getTable().equals(rhsScanOp.getTable())) {
             return Collections.emptyList();
         }
 
@@ -238,7 +251,7 @@ public class CboTablePruneRule extends TransformationRule {
         if (eqColRefPairs.stream().anyMatch(p -> p.first.isNullable() || p.second.isNullable())) {
             return Collections.emptyList();
         }
-        // rhs of LEFT JOIN or lhs of RIGHT JOIN must output all rows of the OlapTable
+        // rhs of LEFT JOIN or lhs of RIGHT JOIN must output all rows of the table
         if ((joinType.isLeftOuterJoin() && (rhsScanOp.getPredicate() != null || rhsScanOp.hasLimit())) ||
                 (joinType.isRightOuterJoin() && (lhsScanOp.getPredicate() != null || lhsScanOp.hasLimit()))) {
             return Collections.emptyList();
@@ -256,8 +269,8 @@ public class CboTablePruneRule extends TransformationRule {
                                                  Optional<ScalarOperator> optOtherJoinOnPredicate) {
         OptExpression lhs = joinOptExpression.inputAt(0);
         OptExpression rhs = joinOptExpression.inputAt(1);
-        LogicalOlapScanOperator lhsScanOp = lhs.getOp().cast();
-        LogicalOlapScanOperator rhsScanOp = rhs.getOp().cast();
+        LogicalScanOperator lhsScanOp = lhs.getOp().cast();
+        LogicalScanOperator rhsScanOp = rhs.getOp().cast();
         Map<Column, ColumnRefOperator> lhsColToColRef = lhsScanOp.getColumnMetaToColRefMap();
         Map<Column, ColumnRefOperator> rhsColToColRef = rhsScanOp.getColumnMetaToColRefMap();
         Map<ColumnRefOperator, ScalarOperator> rewriteMapping = Maps.newHashMap();
@@ -334,8 +347,8 @@ public class CboTablePruneRule extends TransformationRule {
 
         // create a new ScanOperator who unifies join operator, retain-side scan operator and
         // prune-side scan operators.
-        LogicalOlapScanOperator.Builder newOpBuilder =
-                (LogicalOlapScanOperator.Builder) OperatorBuilderFactory.build(retainOp.getOp())
+        LogicalScanOperator.Builder newOpBuilder =
+                (LogicalScanOperator.Builder) OperatorBuilderFactory.build(retainOp.getOp())
                         .withOperator(retainOp.getOp())
                         .setPredicate(newPredicate)
                         .setProjection(new Projection(newColRefMap));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CboTablePruneRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CboTablePruneRule.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.pattern.MultiOpPattern;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -89,7 +90,7 @@ public class CboTablePruneRule extends TransformationRule {
         }
         for (int i = 0; i < input.getInputs().size(); i++) {
             LogicalOperator op = input.inputAt(i).getOp().cast();
-            if (!Pattern.isScanOperator(op.getOpType())) {
+            if (MultiOpPattern.ALL_SCAN_TYPES.contains(op.getOpType())) {
                 return false;
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.iceberg.TableTestBase;
 import com.starrocks.server.IcebergTableFactory;
@@ -29,7 +30,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.starrocks.catalog.Type.ARRAY_BIGINT;
 import static com.starrocks.catalog.Type.INT;
+import static com.starrocks.catalog.Type.STRING;
 import static com.starrocks.server.ExternalTableFactory.RESOURCE;
 
 public class IcebergTableTest extends TableTestBase {
@@ -68,5 +71,36 @@ public class IcebergTableTest extends TableTestBase {
         IcebergTableFactory.copyFromCatalogTable(newBuilder, oTable, properties);
         IcebergTable table = newBuilder.build();
         Assert.assertEquals(table.getResourceName(), resourceName);
+    }
+
+    @Test
+    public void testIcebergTableRepresentativeColumn() {
+        List<Column> columns = Lists.newArrayList(
+                new Column("k1", INT),
+                new Column("k2", STRING),
+                new Column("k3", ARRAY_BIGINT));
+        IcebergTable.Builder tableBuilder = IcebergTable.builder()
+                .setId(1000)
+                .setSrTableName("supplier")
+                .setCatalogName("iceberg_catalog")
+                .setCatalogDBName("iceberg_oss_tpch_1g_parquet_gzip")
+                .setCatalogTableName("supplier")
+                .setFullSchema(columns)
+                .setNativeTable(null)
+                .setIcebergProperties(new HashMap<>());
+        // by default use k1 as column
+        IcebergTable table = tableBuilder.build();
+        {
+            Column c = table.getPresentivateColumn();
+            Assert.assertEquals(c.getName(), "k1");
+        }
+
+        // use k3 as unique column
+        List<ColumnId> uniqueColumns = Lists.newArrayList(columns.get(2).getColumnId());
+        table.setUniqueConstraints(Lists.newArrayList(new UniqueConstraint("cat", "db", "tbl", uniqueColumns)));
+        {
+            Column c = table.getPresentivateColumn();
+            Assert.assertEquals(c.getName(), "k3");
+        }
     }
 }

--- a/test/sql/test_iceberg/R/test_pkfk_property
+++ b/test/sql/test_iceberg/R/test_pkfk_property
@@ -1,0 +1,51 @@
+-- name: test_pkfk_property
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+create external table payment (id int, created_at date, status string);
+-- result:
+-- !result
+create external table txn (id int, created_at date, payment_id int);
+-- result:
+-- !result
+INSERT INTO payment (id, created_at, status) VALUES
+(1, '2025-01-01', 'COMPLETED'),
+(2, '2025-01-02', 'PENDING'),
+(3, '2025-01-03', 'FAILED'),
+(4, '2025-01-04', 'COMPLETED'),
+(5, '2025-01-05', 'REFUNDED');
+-- result:
+-- !result
+INSERT INTO txn (id, created_at, payment_id) VALUES
+(101, '2025-01-01', 1),
+(102, '2025-01-02', 2),
+(103, '2025-01-03', 3),
+(104, '2025-01-04', 4),
+(105, '2025-01-05', 5),
+(106, '2025-01-06', 1);
+-- result:
+-- !result
+SET enable_rbo_table_prune=true;
+-- result:
+-- !result
+SET enable_cbo_table_prune=true; 
+SET enable_table_prune_on_update = true;
+-- result:
+-- !result
+explain logical select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id;
+alter table payment set  ("unique_constraints" = "id");
+-- result:
+-- !result
+ALTER TABLE txn SET ("foreign_key_constraints" = "(payment_id) REFERENCES payment(id)");
+-- result:
+-- !result
+explain logical select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id;
+set catalog default_catalog;
+-- result:
+-- !result

--- a/test/sql/test_iceberg/R/test_pkfk_property
+++ b/test/sql/test_iceberg/R/test_pkfk_property
@@ -103,16 +103,14 @@ function: assert_explain_not_contains("select count(1) as cnt, payment.id from p
 -- result:
 None
 -- !result
+drop table txn force;
+-- result:
+-- !result
 drop table payment force;
 -- result:
 -- !result
-drop table txn force;
--- result:
-E: (5502, "Getting analyzing error. Detail message: Unknown table 'txn'.")
--- !result
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 -- result:
-E: (1064, 'Database iceberg_db_ad6df88aa3e146628e93381f4a4a9c04 not empty')
 -- !result
 drop catalog iceberg_sql_test_${uuid0};
 -- result:

--- a/test/sql/test_iceberg/R/test_pkfk_property
+++ b/test/sql/test_iceberg/R/test_pkfk_property
@@ -31,6 +31,15 @@ INSERT INTO txn (id, created_at, payment_id) VALUES
 (106, '2025-01-06', 1);
 -- result:
 -- !result
+alter table payment set  ("unique_constraints" = "id");
+-- result:
+-- !result
+ALTER TABLE txn SET ("foreign_key_constraints" = "(payment_id) REFERENCES payment(id)");
+-- result:
+-- !result
+set enable_ukfk_opt = false;
+-- result:
+-- !result
 SET enable_rbo_table_prune=true;
 -- result:
 -- !result
@@ -38,14 +47,76 @@ SET enable_cbo_table_prune=true;
 SET enable_table_prune_on_update = true;
 -- result:
 -- !result
-explain logical select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id;
-alter table payment set  ("unique_constraints" = "id");
+function: assert_explain_not_contains("select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.payment")
+-- result:
+None
+-- !result
+function: assert_explain_contains("select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.txn")
+-- result:
+None
+-- !result
+function: assert_explain_contains("select txn.id, txn.created_at, txn.payment_id from  txn inner join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.payment")
+-- result:
+None
+-- !result
+function: assert_explain_contains("select txn.id, txn.created_at, txn.payment_id from  txn inner join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.txn")
+-- result:
+None
+-- !result
+set enable_ukfk_opt = true;
 -- result:
 -- !result
-ALTER TABLE txn SET ("foreign_key_constraints" = "(payment_id) REFERENCES payment(id)");
+SET enable_rbo_table_prune=false;
 -- result:
 -- !result
-explain logical select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id;
+SET enable_cbo_table_prune=false; 
+SET enable_table_prune_on_update = false;
+-- result:
+-- !result
+function: assert_explain_not_contains("select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.payment")
+-- result:
+None
+-- !result
+function: assert_explain_contains("select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.txn")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains("select txn.id, txn.created_at, txn.payment_id from  txn inner join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.payment")
+-- result:
+None
+-- !result
+function: assert_explain_contains("select txn.id, txn.created_at, txn.payment_id from  txn inner join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.txn", "payment_id IS NOT NULL")
+-- result:
+None
+-- !result
+set enable_eliminate_agg = false;
+-- result:
+-- !result
+function: assert_explain_contains("select count(1) as cnt, payment.id from payment group by payment.id;", "AGGREGATE")
+-- result:
+None
+-- !result
+set enable_eliminate_agg = true;
+-- result:
+-- !result
+function: assert_explain_not_contains("select count(1) as cnt, payment.id from payment group by payment.id;", "AGGREGATE")
+-- result:
+None
+-- !result
+drop table payment force;
+-- result:
+-- !result
+drop table txn force;
+-- result:
+E: (5502, "Getting analyzing error. Detail message: Unknown table 'txn'.")
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+E: (1064, 'Database iceberg_db_ad6df88aa3e146628e93381f4a4a9c04 not empty')
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result
 set catalog default_catalog;
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_pkfk_property
+++ b/test/sql/test_iceberg/T/test_pkfk_property
@@ -1,0 +1,45 @@
+-- name: test_pkfk_property
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+
+create external table payment (id int, created_at date, status string);
+create external table txn (id int, created_at date, payment_id int);
+
+
+INSERT INTO payment (id, created_at, status) VALUES
+(1, '2025-01-01', 'COMPLETED'),
+(2, '2025-01-02', 'PENDING'),
+(3, '2025-01-03', 'FAILED'),
+(4, '2025-01-04', 'COMPLETED'),
+(5, '2025-01-05', 'REFUNDED');
+
+INSERT INTO txn (id, created_at, payment_id) VALUES
+(101, '2025-01-01', 1),
+(102, '2025-01-02', 2),
+(103, '2025-01-03', 3),
+(104, '2025-01-04', 4),
+(105, '2025-01-05', 5),
+(106, '2025-01-06', 1);
+
+SET enable_rbo_table_prune=true;
+SET enable_cbo_table_prune=true; 
+SET enable_table_prune_on_update = true;
+
+explain logical select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id;
+
+alter table payment set  ("unique_constraints" = "id");
+ALTER TABLE txn SET ("foreign_key_constraints" = "(payment_id) REFERENCES iceberg_sql_test_0b0212d10fe1436d8e346ee4e16c9877.iceberg_db_0b0212d10fe1436d8e346ee4e16c9877.payment(id)");
+
+explain logical select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id;
+
+
+-- drop table payment force;
+-- drop table txn force;
+
+-- drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- drop catalog iceberg_sql_test_${uuid0};
+
+set catalog default_catalog;

--- a/test/sql/test_iceberg/T/test_pkfk_property
+++ b/test/sql/test_iceberg/T/test_pkfk_property
@@ -66,8 +66,9 @@ set enable_eliminate_agg = true;
 function: assert_explain_not_contains("select count(1) as cnt, payment.id from payment group by payment.id;", "AGGREGATE")
 
 
-drop table payment force;
+-- order matters. if drop table payment first, when drop table txn, it will fail because payment is not found.
 drop table txn force;
+drop table payment force;
 
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 drop catalog iceberg_sql_test_${uuid0};

--- a/test/sql/test_iceberg/T/test_pkfk_property
+++ b/test/sql/test_iceberg/T/test_pkfk_property
@@ -24,22 +24,52 @@ INSERT INTO txn (id, created_at, payment_id) VALUES
 (105, '2025-01-05', 5),
 (106, '2025-01-06', 1);
 
+-- add table properties
+alter table payment set  ("unique_constraints" = "id");
+ALTER TABLE txn SET ("foreign_key_constraints" = "(payment_id) REFERENCES payment(id)");
+
+-- because two groups of session variables can both work. here we can test one group of session variables.
+set enable_ukfk_opt = false;
 SET enable_rbo_table_prune=true;
 SET enable_cbo_table_prune=true; 
 SET enable_table_prune_on_update = true;
 
-explain logical select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id;
+-- payment can be elimiated
+function: assert_explain_not_contains("select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.payment")
+function: assert_explain_contains("select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.txn")
 
-alter table payment set  ("unique_constraints" = "id");
-ALTER TABLE txn SET ("foreign_key_constraints" = "(payment_id) REFERENCES iceberg_sql_test_0b0212d10fe1436d8e346ee4e16c9877.iceberg_db_0b0212d10fe1436d8e346ee4e16c9877.payment(id)");
+-- payment can not be elimiated because txn.id is nullable.
+function: assert_explain_contains("select txn.id, txn.created_at, txn.payment_id from  txn inner join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.payment")
+function: assert_explain_contains("select txn.id, txn.created_at, txn.payment_id from  txn inner join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.txn")
 
-explain logical select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id;
+
+-- switch to another group of session variables
+set enable_ukfk_opt = true;
+SET enable_rbo_table_prune=false;
+SET enable_cbo_table_prune=false; 
+SET enable_table_prune_on_update = false;
+
+-- payment can be elimiated
+function: assert_explain_not_contains("select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.payment")
+function: assert_explain_contains("select txn.id, txn.created_at, txn.payment_id from  txn left join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.txn")
+
+-- payment can be elimiated with a extra predicate: payment_id is not null.
+function: assert_explain_not_contains("select txn.id, txn.created_at, txn.payment_id from  txn inner join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.payment")
+function: assert_explain_contains("select txn.id, txn.created_at, txn.payment_id from  txn inner join payment on payment.id = txn.payment_id", "TABLE: iceberg_db_${uuid0}.txn", "payment_id IS NOT NULL")
 
 
--- drop table payment force;
--- drop table txn force;
+-- test elimiate agg on primary key
+set enable_eliminate_agg = false;
+function: assert_explain_contains("select count(1) as cnt, payment.id from payment group by payment.id;", "AGGREGATE")
 
--- drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
--- drop catalog iceberg_sql_test_${uuid0};
+set enable_eliminate_agg = true;
+function: assert_explain_not_contains("select count(1) as cnt, payment.id from payment group by payment.id;", "AGGREGATE")
+
+
+drop table payment force;
+drop table txn force;
+
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};
 
 set catalog default_catalog;


### PR DESCRIPTION
## Why I'm doing:

We have features:
- cardinality preserving join: https://github.com/StarRocks/starrocks/pull/24843
- PK/FK pruning table: https://github.com/StarRocks/starrocks/pull/52201
- PK/FK group by elimination: https://github.com/StarRocks/starrocks/pull/52201

Unfortunately those features only work on native table. 

Since we can also specify properties on iceberg table: 
- https://github.com/StarRocks/starrocks/pull/54364

Maybe it's nice to apply all those features on all tables instead of only on native table.

## What I'm doing:

Change those optimization rules to make it all on all tables.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0