### PR TITLE
[BugFix] Fix reserve error with a large limit

### DIFF
--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -472,11 +472,11 @@ Status ChunksSorterTopn::_hybrid_sort_common(RuntimeState* state, std::pair<Perm
     // case2: rows_to_keep > 0, which means `SMALLER_THAN_MIN_OF_SEGMENT` part itself not suffice, we need to get more elements
     // from both `INCLUDE_IN_SEGMENT` part and _merged_segment. And notice that `INCLUDE_IN_SEGMENT` part may be empty
     if (rows_to_keep > 0) {
+        const size_t sorted_size = _merged_segment.chunk->num_rows();
+        rows_to_keep = std::min(rows_to_keep, sorted_size + second_size);
         if (big_chunk == nullptr) {
             big_chunk.reset(segments[new_permutation.second[0].chunk_index].chunk->clone_empty(rows_to_keep).release());
         }
-        const size_t sorted_size = _merged_segment.chunk->num_rows();
-        rows_to_keep = std::min(rows_to_keep, sorted_size + second_size);
         if (_topn_type == TTopNType::RANK && sorted_size + second_size > rows_to_keep) {
             // For rank type, there may exist a wide equal range, so we need to keep all elements of part2 and part3
             rows_to_keep = sorted_size + second_size;

--- a/test/sql/test_sort/R/test_topn_with_large_limit
+++ b/test/sql/test_sort/R/test_topn_with_large_limit
@@ -1,0 +1,20 @@
+-- name: test_topn_with_large_limit
+set pipeline_dop=1;
+-- result:
+-- !result
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT null, null FROM TABLE(generate_series(1,  65536));
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  257* 4096));
+-- result:
+-- !result
+select count(c0) from ( select c0 from t0 order by 1 asc nulls first limit 9223372036854775807 )t;
+-- result:
+1052672
+-- !result

--- a/test/sql/test_sort/T/test_topn_with_large_limit
+++ b/test/sql/test_sort/T/test_topn_with_large_limit
@@ -1,0 +1,12 @@
+-- name: test_topn_with_large_limit
+
+set pipeline_dop=1;
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT null, null FROM TABLE(generate_series(1,  65536));
+-- see ChunksSorterTopn::tunning_buffered_chunks
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  257* 4096));
+
+select count(c0) from ( select c0 from t0 order by 1 asc nulls first limit 9223372036854775807 )t;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
```
*** SIGABRT (@0x3eb000b1c24) received by PID 728100 (TID 0x7f0a15882640) LWP(728806) from PID 728100; stack trace: ***
    @         0x21c457b6 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f0b31c70ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x21c44ff9 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f0b31c19520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f0b31c6d9fc pthread_kill
    @     0x7f0b31c19476 raise
    @     0x7f0b31bff7f3 abort
    @         0x256c0603 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @         0x256bedbc __cxxabiv1::__terminate(void (*)())
    @         0x256bee27 std::terminate()
    @         0x256bef89 __cxa_throw
    @         0x1f42df57 __wrap___cxa_throw
    @         0x257160d1 std::__throw_length_error(char const*)
    @         0x125dddc1 std::vector<int, starrocks::ColumnAllocator<int> >::reserve(unsigned long)
    @         0x125c78b5 starrocks::FixedLengthColumnBase<int>::reserve(unsigned long)
    @         0x124e9592 starrocks::NullableColumn::reserve(unsigned long)
    @         0x12504180 starrocks::Chunk::clone_empty_with_slot(unsigned long) const
    @         0x12503b5d starrocks::Chunk::clone_empty(unsigned long) const
    @         0x14012135 starrocks::ChunksSorterTopn::_hybrid_sort_common(starrocks::RuntimeState*, std::pair<std::vector<starrocks::PermutationItem, std::allocator<starrocks::PermutationItem> >, std::vector<starrocks::PermutationItem, std::allocator<starrocks::PermutationItem> > <8B>^A
    @         0x1400fc8b starrocks::ChunksSorterTopn::_merge_sort_data_as_merged_segment(starrocks::RuntimeState*, std::pair<std::vector<starrocks::PermutationItem, std::allocator<starrocks::PermutationItem> >, std::vector<starrocks::PermutationItem, std::allocator<starrocks::Perm<8B>^A
    @         0x1400cc70 starrocks::ChunksSorterTopn::_sort_chunks(starrocks::RuntimeState*)
    @         0x1400b5f6 starrocks::ChunksSorterTopn::do_done(starrocks::RuntimeState*)
    @         0x13f4b9d3 starrocks::ChunksSorter::done(starrocks::RuntimeState*)
    @         0x1515e146 starrocks::pipeline::PartitionSortSinkOperator::set_finishing(starrocks::RuntimeState*)
    @         0x1533de66 starrocks::pipeline::PipelineDriver::_mark_operator_finishing(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @         0x15333570 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x152e6850 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x152e4bc8 starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x152f0d70 void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x152f0149 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver<8B>^A
    @         0x152efacb std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
````

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0