### PR TITLE
[Enhancement] support lake table cache select in physical way

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1084,6 +1084,9 @@ CONF_mBool(lake_clear_corrupted_cache, "true");
 // The maximum number of files which need to rebuilt in cloud native pk index.
 // If files which need to rebuilt larger than this, we will flush memtable immediately.
 CONF_mInt32(cloud_native_pk_index_rebuild_files_threshold, "50");
+// if set to true, CACHE SELECT will only read file, save CPU time
+// if set to false, CACHE SELECT will behave like SELECT
+CONF_mBool(lake_cache_select_in_physical_way, "true");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -261,6 +261,9 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     _params.lake_io_opts.fill_data_cache = _scan_range.fill_data_cache;
     _params.lake_io_opts.skip_disk_cache = _scan_range.skip_disk_cache;
     _params.runtime_range_pruner = RuntimeScanRangePruner(parser, _conjuncts_manager->unarrived_runtime_filters());
+    _params.lake_io_opts.cache_file_only = _runtime_state->query_options().__isset.enable_cache_select &&
+                                           _runtime_state->query_options().enable_cache_select &&
+                                           config::lake_cache_select_in_physical_way;
     _params.splitted_scan_rows = _provider->get_splitted_scan_rows();
     _params.scan_dop = _provider->get_scan_dop();
 

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -83,6 +83,7 @@ struct LakeIOOptions {
     int64_t buffer_size = -1;
     bool fill_metadata_cache = false;
     bool use_page_cache = false;
+    bool cache_file_only = false; // only used for CACHE SELECT
     std::shared_ptr<FileSystem> fs;
     std::shared_ptr<starrocks::lake::LocationProvider> location_provider;
 };

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -108,20 +108,14 @@ public:
 
     virtual Status next_batch(const SparseRange<>& range, Column* dst);
 
-    Status convert_sparse_range_to_io_range(const SparseRange<>& range) {
-        if (auto sharedBufferStream = dynamic_cast<io::SharedBufferedInputStream*>(_opts.read_file);
-            sharedBufferStream == nullptr) {
-            return Status::OK();
-        }
-
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range) {
+        std::vector<std::pair<int64_t, int64_t>> res;
         auto reader = get_column_reader();
         if (reader == nullptr) {
             // should't happen
-            LOG(INFO) << "column reader nullptr, filename: " << _opts.read_file->filename();
-            return Status::OK();
+            return Status::InvalidArgument(fmt::format("column reader for {} is nullptr", _opts.read_file->filename()));
         }
 
-        std::vector<io::SharedBufferedInputStream::IORange> result;
         std::vector<std::pair<int, int>> page_index;
         int prev_page_index = -1;
         for (auto index = 0; index < range.size(); index++) {
@@ -149,7 +143,22 @@ public:
             RETURN_IF_ERROR(reader->seek_by_page_index(pair.second, &iter_end));
             auto offset = iter_start.page().offset;
             auto size = iter_end.page().offset - offset + iter_end.page().size;
-            io::SharedBufferedInputStream::IORange io_range(offset, size);
+            res.push_back({offset, size});
+        }
+
+        return res;
+    }
+
+    Status convert_sparse_range_to_io_range(const SparseRange<>& range) {
+        if (auto sharedBufferStream = dynamic_cast<io::SharedBufferedInputStream*>(_opts.read_file);
+            sharedBufferStream == nullptr) {
+            return Status::OK();
+        }
+
+        std::vector<io::SharedBufferedInputStream::IORange> result;
+        ASSIGN_OR_RETURN(auto vec, get_io_range_vec(range));
+        for (auto e : vec) {
+            io::SharedBufferedInputStream::IORange io_range(e.first, e.second);
             result.emplace_back(io_range);
         }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

part of the cache select process is CPU heavy, which is unnecessary and can be removed.

100G SSB, everything is cached already, run `cache select * from lineorder;`.
 -| Previous Implementataion | New Implemention
-- | -- | --
Total | 2s373ms | 418ms
IOTime (IO heavy) | 272.922ms | 281.019ms
Decompress Page (CPU heavy) + Checksum Check (CPU heavy) + Form Chunk (CPU heavy)| 1.336s | 0s

100G TPCH, everything is cached already, run `cache select * from lineitem;`.
 -| Previous Implementataion | New Implemention
-- | -- | --
Total |  9s254ms | 1s190ms
IOTime (IO heavy) |  348.076ms | 274.867ms
Decompress Page (CPU heavy) + Checksum Check (CPU heavy) + Form Chunk (CPU heavy)| 5.402s | 0s


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0