### PR TITLE
[BugFix] fix resource leak when doing checkpoint

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -344,5 +344,8 @@ public interface ConnectorMetadata {
                                            ScalarOperator predicate, FileContent fileContent) {
         throw new StarRocksConnectorException("This connector doesn't support getting delete files");
     }
+
+    default void shutdown() {
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
@@ -133,4 +133,10 @@ public class ConnectorMgr {
         }
         return memoryTrackers;
     }
+
+    public void shutdown() {
+        for (CatalogConnector cc : connectors.values()) {
+            cc.shutdown();
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCConnector.java
@@ -103,4 +103,11 @@ public class JDBCConnector implements Connector {
         }
         return metadata;
     }
+
+    @Override
+    public void shutdown() {
+        if (metadata != null) {
+            metadata.shutdown();
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -302,4 +302,11 @@ public class JDBCMetadata implements ConnectorMetadata {
     public void refreshCache(Map<String, String> properties) {
         createMetaAsyncCacheInstances(properties);
     }
+
+    @Override
+    public void shutdown() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -834,7 +834,11 @@ public class GlobalStateMgr {
 
     public static void destroyCheckpoint() {
         if (CHECKPOINT != null) {
-            CHECKPOINT.shutdown();
+            try {
+                CHECKPOINT.shutdown();
+            } catch (Exception e) {
+                LOG.warn("exception when destroy checkpoint", e);
+            }
             CHECKPOINT = null;
         }
     }
@@ -1358,7 +1362,7 @@ public class GlobalStateMgr {
         checkpointController.start();
 
         clusterSnapshotCheckpointScheduler = new ClusterSnapshotCheckpointScheduler(checkpointController,
-                                                  StarMgrServer.getCurrentState().getCheckpointController());
+                StarMgrServer.getCurrentState().getCheckpointController());
         clusterSnapshotCheckpointScheduler.start();
 
         keyRotationDaemon.start();

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -834,6 +834,7 @@ public class GlobalStateMgr {
 
     public static void destroyCheckpoint() {
         if (CHECKPOINT != null) {
+            CHECKPOINT.shutdown();
             CHECKPOINT = null;
         }
     }
@@ -2707,5 +2708,10 @@ public class GlobalStateMgr {
 
     public WarehouseIdleChecker getWarehouseIdleChecker() {
         return warehouseIdleChecker;
+    }
+
+    public void shutdown() {
+        // in a single thread.
+        connectorMgr.shutdown();
     }
 }


### PR DESCRIPTION
## Why I'm doing:

I've observed that jdbc pool connection keep growing on doing checkpoint

```
2025-01-18 09:35:11.157+08:00 INFO (leaderCheckpointer|348) [JDBCMetadata.createHikariDataSource():136] create hikari data source
java.lang.Throwable: null
        at com.starrocks.connector.jdbc.JDBCMetadata.createHikariDataSource(JDBCMetadata.java:136) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.jdbc.JDBCMetadata.<init>(JDBCMetadata.java:94) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.jdbc.JDBCMetadata.<init>(JDBCMetadata.java:63) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.jdbc.JDBCConnector.getMetadata(JDBCConnector.java:98) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.LazyConnector.getMetadata(LazyConnector.java:33) ~[starrocks-fe.jar:?]
        at com.starrocks.connector.CatalogConnector.getMetadata(CatalogConnector.java:43) ~[starrocks-fe.jar:?]
        at com.starrocks.server.MetadataMgr.getOptionalMetadata(MetadataMgr.java:190) ~[starrocks-fe.jar:?]
        at com.starrocks.server.MetadataMgr.getOptionalMetadata(MetadataMgr.java:164) ~[starrocks-fe.jar:?]
        at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:496) ~[starrocks-fe.jar:?]
        at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:526) ~[starrocks-fe.jar:?]
        at com.starrocks.server.MetadataMgr.getTableWithIdentifier(MetadataMgr.java:531) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getTableWithIdentifier(MvUtils.java:1410) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.MaterializedView.onReloadImpl(MaterializedView.java:985) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.MaterializedView.onReload(MaterializedView.java:916) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.processMvRelatedMeta(GlobalStateMgr.java:1557) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.postLoadImage(GlobalStateMgr.java:1547) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.loadImage(GlobalStateMgr.java:1536) ~[starrocks-fe.jar:?]
        at com.starrocks.leader.Checkpoint.replayAndGenerateGlobalStateMgrImage(Checkpoint.java:208) ~[starrocks-fe.jar:?]
        at com.starrocks.leader.Checkpoint.createImage(Checkpoint.java:193) ~[starrocks-fe.jar:?]
        at com.starrocks.leader.Checkpoint.runAfterCatalogReady(Checkpoint.java:110) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:107) ~[starrocks-fe.jar:?]
```

And I checked the code, it's because we use a `CHECKPOINT` instance to do checkpoint. And after doing checkpoint,  we just set is null instead of freeing resources.

```
    public static void destroyCheckpoint() {
        if (CHECKPOINT != null) {
            CHECKPOINT = null;
        }
    }
```

## What I'm doing:

Add a `shutdown` method into `GlobalStateMgr` class, and call this method when `destroyCheckpoint`

Fixes #55269

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0