### PR TITLE
[Enhancement] Adjust sample table statistics strategy to reduce the estimation error rate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2115,6 +2115,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long statistic_sample_collect_rows = 200000;
 
+    @ConfField(mutable = true)
+    public static double statistics_min_sample_row_ratio = 0.01;
+
     /**
      * The partition size of sample collect, default 1k partitions
      */

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -498,8 +498,12 @@ public class StatisticsCollectJobFactory {
                         table.getName(), healthy, statisticAutoCollectRatio);
                 return;
             } else if (healthy < Config.statistic_auto_collect_sample_threshold) {
-                if (job.getAnalyzeType() != StatsConstants.AnalyzeType.HISTOGRAM &&
-                        sumDataSize > Config.statistic_auto_collect_small_table_size) {
+                long autoCollectSmallTableSize = Config.statistic_auto_collect_small_table_size;
+                if (table.isPartitioned() && Config.statistic_use_meta_statistics) {
+                    autoCollectSmallTableSize *= 10;
+                }
+
+                if (job.getAnalyzeType() != StatsConstants.AnalyzeType.HISTOGRAM && sumDataSize > autoCollectSmallTableSize) {
                     LOG.debug("statistics job choose sample on real-time update table: {}" +
                                     ", last collect time: {}, current healthy: {}, full collect healthy limit: {}, " +
                                     ", update data size: {}MB, full collect healthy data size limit: <{}MB",

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/TabletSampler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/TabletSampler.java
@@ -21,23 +21,18 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class TabletSampler {
-    private final double tabletsSampleRatio;
-
-    private final double tabletReadRatio;
+    private double tabletsSampleRatio;
 
     private final int maxSize;
 
     private final List<TabletStats> tablets = Lists.newArrayList();
 
-    private final long sampleRowsLimit;
 
     private long totalRows;
 
-    public TabletSampler(double tabletsSampleRatio, double tabletReadRatio, int maxSize, long sampleRowsLimit) {
+    public TabletSampler(double tabletsSampleRatio, int maxSize) {
         this.tabletsSampleRatio = tabletsSampleRatio;
-        this.tabletReadRatio = tabletReadRatio;
         this.maxSize = maxSize;
-        this.sampleRowsLimit = sampleRowsLimit;
     }
 
     public void addTabletStats(TabletStats tablet) {
@@ -51,6 +46,10 @@ public class TabletSampler {
         // sort by row count in descending order
         return tablets.stream().sorted((o1, o2) -> Long.compare(o2.getRowCount(), o1.getRowCount()))
                 .limit(number).collect(Collectors.toList());
+    }
+
+    public void adjustTabletSampleRatio() {
+        this.tabletsSampleRatio *= 2;
     }
 
     public long getTotalRows() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperStatisticSQLs.java
@@ -135,13 +135,13 @@ public class HyperStatisticSQLs {
         SampleInfo info = sampler.getSampleInfo(p.getId());
         List<String> groupSQLs = Lists.newArrayList();
         StringBuilder sqlBuilder = new StringBuilder();
-        groupSQLs.add(generateRatioTable(tableName, sampler.getSampleRowsLimit(), info.getHighWeightTablets(),
+        groupSQLs.add(generateRatioTable(tableName, info.getHighWeightTablets(),
                 HIGH_WEIGHT_READ_RATIO, "t_high"));
-        groupSQLs.add(generateRatioTable(tableName, sampler.getSampleRowsLimit(), info.getMediumHighWeightTablets(),
+        groupSQLs.add(generateRatioTable(tableName, info.getMediumHighWeightTablets(),
                 MEDIUM_HIGH_WEIGHT_READ_RATIO, "t_medium_high"));
-        groupSQLs.add(generateRatioTable(tableName, sampler.getSampleRowsLimit(), info.getMediumLowWeightTablets(),
+        groupSQLs.add(generateRatioTable(tableName, info.getMediumLowWeightTablets(),
                 MEDIUM_LOW_WEIGHT_READ_RATIO, "t_medium_low"));
-        groupSQLs.add(generateRatioTable(tableName, sampler.getSampleRowsLimit(), info.getLowWeightTablets(),
+        groupSQLs.add(generateRatioTable(tableName, info.getLowWeightTablets(),
                 LOW_WEIGHT_READ_RATIO, "t_low"));
         if (groupSQLs.stream().allMatch(Objects::isNull)) {
             groupSQLs.add("SELECT * FROM " + tableName + " LIMIT " + Config.statistic_sample_collect_rows);
@@ -167,8 +167,7 @@ public class HyperStatisticSQLs {
         return sqlBuilder.toString();
     }
 
-    private static String generateRatioTable(String table, long limit,
-                                             List<TabletStats> tablets, double ratio, String alias) {
+    private static String generateRatioTable(String table, List<TabletStats> tablets, double ratio, String alias) {
         if (tablets.isEmpty()) {
             return null;
         }
@@ -179,14 +178,12 @@ public class HyperStatisticSQLs {
             return String.format(" SELECT * FROM (SELECT * " +
                             " FROM %s tablet(%s) " +
                             " WHERE rand() <= %f " +
-                            " LIMIT %d) %s",
-                    table, tabletHint, ratio, limit, alias);
+                            " ) %s",
+                    table, tabletHint, ratio, alias);
         } else {
             int percent = (int) (ratio * 100);
-            return String.format(" SELECT * FROM (SELECT * " +
-                            " FROM %s TABLET(%s) SAMPLE('percent'='%d') " +
-                            " LIMIT %d) %s",
-                    table, tabletHint, percent, limit, alias);
+            return String.format(" SELECT * FROM (SELECT * FROM %s TABLET(%s) SAMPLE('percent'='%d')) %s",
+                    table, tabletHint, percent, alias);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleInfo.java
@@ -54,7 +54,7 @@ public class SampleInfo {
         this.lowWeightTablets = null;
     }
 
-    public SampleInfo(String dbName, String tableName, double tabletSampleRatio,
+    public SampleInfo(double tabletSampleRatio,
                       long sampleRowCount, long totalRowCount,
                       List<TabletStats> highWeightTablets,
                       List<TabletStats> mediumHighWeightTablets,

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/TabletSampleManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/TabletSampleManager.java
@@ -140,7 +140,6 @@ public class TabletSampleManager {
                 + mediumLowWeight.getRowCount() + lowWeight.getRowCount(), 1);
 
         return new SampleInfo(
-                dbName, tableName,
                 sampleTablets * 1.0 / totalTablets,
                 sampleRows, totalRows,
                 highWeightTablets,

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/hyper/HyperJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/hyper/HyperJobTest.java
@@ -211,8 +211,8 @@ public class HyperJobTest extends DistributedEnvPlanTestBase {
         List<String> sql = jobs.get(1).buildQuerySQL();
         Assert.assertEquals(1, sql.size());
 
-        assertContains(sql.get(0), "with base_cte_table as ( SELECT * FROM (SELECT *  FROM `test`.`t_struct` TABLET(1)" +
-                " SAMPLE('percent'='1')  LIMIT 200000)");
+        assertContains(sql.get(0), "with base_cte_table as ( SELECT * FROM (SELECT * FROM `test`.`t_struct` " +
+                "TABLET(1) SAMPLE('percent'='10')) t_medium_high)");
         assertContains(sql.get(0), "cast(IFNULL(SUM(CHAR_LENGTH(`c2`)) * 0/ COUNT(*), 0) as BIGINT), " +
                 "hex(hll_serialize(IFNULL(hll_raw(`c2`), hll_empty())))," +
                 " cast((COUNT(*) - COUNT(`c2`)) * 0 / COUNT(*) as BIGINT), " +
@@ -251,7 +251,7 @@ public class HyperJobTest extends DistributedEnvPlanTestBase {
 
         };
         PartitionSampler sampler = PartitionSampler.create(table, List.of(pid), Maps.newHashMap());
-        Assert.assertEquals(800000, sampler.getSampleInfo(pid).getSampleRowCount());
+        Assert.assertEquals(5550000, sampler.getSampleInfo(pid).getSampleRowCount());
     }
 
     @AfterClass


### PR DESCRIPTION
## Why I'm doing:
The current sample table statistics have a high error rate.

## What I'm doing:
Currently, we have written the results of both sample and full sampling type to the same partition table. our previous sample strategy was for full table. currently we are collecting against partitions level. so we need to adjust some strategy for sample table.
major changes:
- remove limit 
- alignment of tablet sample ratio for different sample groups
- increase the default tablet read ratio
- limit minimum sampling ratio
- Increase the threshold of hitting the sample when collecting periodically in the background

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0