### PR TITLE
[Enhancement] move time-consuming listMaterializedViewStatus out of db lock scope

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -374,18 +374,18 @@ public class ShowExecutor {
                         }
                     }
                 }
-
-                List<ShowMaterializedViewStatus> mvStatusList =
-                        listMaterializedViewStatus(dbName, materializedViews, singleTableMVs);
-                List<List<String>> rowSets = mvStatusList.stream().map(ShowMaterializedViewStatus::toResultSet)
-                        .collect(Collectors.toList());
-                return new ShowResultSet(statement.getMetaData(), rowSets);
             } catch (Exception e) {
                 LOG.warn("listMaterializedViews failed:", e);
                 throw e;
             } finally {
                 locker.unLockDatabase(db.getId(), LockType.READ);
             }
+
+            List<ShowMaterializedViewStatus> mvStatusList =
+                    listMaterializedViewStatus(dbName, materializedViews, singleTableMVs);
+            List<List<String>> rowSets = mvStatusList.stream().map(ShowMaterializedViewStatus::toResultSet)
+                    .collect(Collectors.toList());
+            return new ShowResultSet(statement.getMetaData(), rowSets);
         }
 
         @Override


### PR DESCRIPTION
## Why I'm doing:
![image](https://github.com/user-attachments/assets/261221eb-81b4-4120-98c5-a488338275fa)

`ShowExecutor.listMaterializedViewStatus()` is very time-consuming in deserializing json and is called in db lock scope in `ShowExecutor.visitShowMaterializedViewStatement()`, which will block other thread to acquire db write lock.

 `ShowExecutor.listMaterializedViewStatus()` is also called in `FrontendServiceImpl.listMaterializedViews()` and is out of db lock scope.
 
![image](https://github.com/user-attachments/assets/1f590ab3-5af3-41b9-885d-5db6904c2a58)

## What I'm doing:
Call `ShowExecutor.listMaterializedViewStatus()` out db lock scope in `ShowExecutor.visitShowMaterializedViewStatement()`
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0