### PR TITLE
[Enhancement] Reduce the size of data written to edit log when schema changes in shared-data clusters with fast schema evolution enabled.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -62,6 +62,11 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
     }
 
     @Override
+    protected LakeTableAlterMetaJob getShadowCopy() {
+        return this;
+    }
+
+    @Override
     protected void updateCatalog(Database db, LakeTable table) {
         if (metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX) {
             // re-use ENABLE_PERSISTENT_INDEX for both enable index and index's type.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -110,7 +110,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             this.watershedTxnId = globalStateMgr.getGlobalTransactionMgr().getTransactionIDGenerator()
                     .getNextTransactionId();
             this.watershedGtid = globalStateMgr.getGtidGenerator().nextGtid();
-            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this.getShadowCopy());
         }
 
         try {
@@ -166,7 +166,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             this.jobState = JobState.FINISHED_REWRITING;
             this.finishedTimeMs = System.currentTimeMillis();
 
-            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this.getShadowCopy());
 
             // NOTE: !!! below this point, this update meta job must success unless the database or table been dropped. !!!
             updateNextVersion(table);
@@ -209,7 +209,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             updateCatalog(db, table);
             this.jobState = JobState.FINISHED;
             this.finishedTimeMs = System.currentTimeMillis();
-            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this.getShadowCopy());
             // set visible version
             updateVisibleVersion(table);
             table.setState(OlapTable.OlapTableState.NORMAL);
@@ -419,6 +419,9 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         return watershedTxnId;
     }
 
+    // Only for reducing data writing after the first log, so we don't do deep copy
+    protected abstract LakeTableAlterMetaJobBase getShadowCopy();
+
     @Override
     protected boolean cancelImpl(String errMsg) {
         if (jobState == JobState.CANCELLED || jobState == JobState.FINISHED) {
@@ -515,6 +518,25 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         }
+    }
+
+    protected void copyOnlyForNonFirstLog(LakeTableAlterMetaJobBase copied) {
+        copied.watershedTxnId = this.watershedTxnId;
+        copied.watershedGtid = this.watershedGtid;
+        copied.physicalPartitionIndexMap = this.physicalPartitionIndexMap;
+        copied.commitVersionMap = this.commitVersionMap;
+
+        copied.type = this.type;
+        copied.jobId = this.jobId;
+        copied.jobState = this.jobState;
+        copied.dbId = this.dbId;
+        copied.tableId = this.tableId;
+        copied.tableName = this.tableName;
+        copied.errMsg = this.errMsg;
+        copied.createTimeMs = this.createTimeMs;
+        copied.finishedTimeMs = this.finishedTimeMs;
+        copied.timeoutMs = this.timeoutMs;
+        copied.warehouseId = this.warehouseId;
     }
 
     // for test

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -111,6 +111,13 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     }
 
     @Override
+    protected LakeTableAsyncFastSchemaChangeJob getShadowCopy() {
+        LakeTableAsyncFastSchemaChangeJob copied = new LakeTableAsyncFastSchemaChangeJob();
+        copyOnlyForNonFirstLog(copied);
+        return copied;
+    }
+
+    @Override
     protected void updateCatalog(Database db, LakeTable table) {
         updateCatalogUnprotected(db, table);
     }
@@ -152,10 +159,11 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
 
     @Override
     protected void restoreState(LakeTableAlterMetaJobBase job) {
-        this.schemaInfos = new ArrayList<>(((LakeTableAsyncFastSchemaChangeJob) job).schemaInfos);
+        List<IndexSchemaInfo> jobSchemaInfos = ((LakeTableAsyncFastSchemaChangeJob) job).schemaInfos;
+        if (jobSchemaInfos != null && !jobSchemaInfos.isEmpty()) {
+            this.schemaInfos = new ArrayList<>(jobSchemaInfos);
+        }
     }
-
-
 
     private static class IndexSchemaInfo {
         @SerializedName("indexId")


### PR DESCRIPTION
## Why I'm doing:
When columns are added or dropped, the schema change job in shared-data clusters with fast schema evolution enabled is written to the edit log. In total, there are four write operations, and each operation writes the same `schemaInfos`. This introduces additional overhead for wide tables with a large number of column comments.

## What I'm doing:
Write schemaInfos only once.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0