### PR TITLE
[Enhancement] Update limitation of M_IVFPQ and is_input_normalized for vector index

### DIFF
--- a/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
@@ -101,7 +101,7 @@ static Status valid_input_vector(const ArrayColumn& input_column, const size_t i
             for (int j = 0; j < input_dim; j++) {
                 sum += nums[offsets[i] + j] * nums[offsets[i] + j];
             }
-            if (std::abs(sum - 1) > 1e-6) {
+            if (std::abs(sum - 1) > 1e-3) {
                 return Status::InvalidArgument(
                         "The input vector is not normalized but `metric_type` is cosine_similarity and "
                         "`is_vector_normed` is true");

--- a/be/test/storage/index/vector_index_test.cpp
+++ b/be/test/storage/index/vector_index_test.cpp
@@ -64,7 +64,7 @@ protected:
         DeferOp op([&] { ASSERT_TRUE(fs::path_exist(path)); });
 
         std::unique_ptr<VectorIndexWriter> vector_index_writer;
-        VectorIndexWriter::create(tablet_index, path, false, &vector_index_writer);
+        VectorIndexWriter::create(tablet_index, path, true, &vector_index_writer);
         CHECK_OK(vector_index_writer->init());
 
         // construct columns

--- a/be/test/storage/index/vector_search_test.cpp
+++ b/be/test/storage/index/vector_search_test.cpp
@@ -65,7 +65,7 @@ protected:
         DeferOp op([&] { ASSERT_TRUE(fs::path_exist(path)); });
 
         std::unique_ptr<VectorIndexWriter> vector_index_writer;
-        VectorIndexWriter::create(tablet_index, path, false, &vector_index_writer);
+        VectorIndexWriter::create(tablet_index, path, true, &vector_index_writer);
         CHECK_OK(vector_index_writer->init());
 
         // construct columns

--- a/fe/fe-core/src/main/java/com/starrocks/common/VectorIndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/VectorIndexParams.java
@@ -140,7 +140,7 @@ public class VectorIndexParams {
         M_IVFPQ(VectorIndexType.IVFPQ) {
             @Override
             public void check(String value) {
-                validateInteger(value, "M_IVFPQ", 2);
+                validateInteger(value, "M_IVFPQ", 1);
             }
         };
 


### PR DESCRIPTION
## Why I'm doing:
Limit `M_IVFPQ` to be >= 1, and reduce the check precision of `is_input_normalized` to 1e-3.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0