### PR TITLE
[BugFix] Prune aggregate non-required columns after mv transparent rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OpRuleBit.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OpRuleBit.java
@@ -30,4 +30,6 @@ public class OpRuleBit {
     public static final int OP_MV_TRANSPARENT_REWRITE = 2;
     // Operator has been partition pruned or not, if partition pruned, no need to prune again.
     public static final int OP_PARTITION_PRUNED = 3;
+    // Operator has been mv transparent union rewrite and needs to prune agg columns.
+    public static final int OP_MV_AGG_PRUNE_COLUMNS = 4;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
@@ -217,7 +218,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
     /**
      * Get transparent plan if possible.
      * What's the transparent plan?
-     * see {@link MvPartitionCompensator#getMvTransparentPlan(MaterializationContext, MVCompensation, List)
+     * see {@link MvPartitionCompensator#getMvTransparentPlan(MaterializationContext, MVCompensation, List, ColumnRefSet)}
      */
     private OptExpression getMvTransparentPlan(MaterializationContext mvContext,
                                                OptExpression input,
@@ -247,7 +248,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
             return null;
         }
         OptExpression transparentPlan = MvPartitionCompensator.getMvTransparentPlan(mvContext, mvCompensation,
-                expectOutputColumns);
+                expectOutputColumns, false);
         return transparentPlan;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -60,6 +60,12 @@ public class MVColumnPruner {
     }
 
     public OptExpression doPruneColumns(OptExpression optExpression) {
+        // TODO: remove this check after we support more operators.
+        Projection projection = optExpression.getOp().getProjection();
+        // OptExpression after mv rewrite must have projection.
+        if (projection == null) {
+            return optExpression;
+        }
         // OptExpression after mv rewrite must have projection.
         return optExpression.getOp().accept(new ColumnPruneVisitor(), optExpression, null);
     }
@@ -181,8 +187,6 @@ public class MVColumnPruner {
             if (unionOperator.getProjection() != null) {
                 Projection projection = optExpression.getOp().getProjection();
                 projection.getColumnRefMap().values().forEach(s -> requiredOutputColumns.union(s.getUsedColumns()));
-            } else {
-                requiredOutputColumns.union(unionOperator.getOutputColumnRefOp());
             }
             List<ColumnRefOperator> unionOutputColRefs = unionOperator.getOutputColumnRefOp();
             List<Integer> newUnionOutputIdxes = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -62,9 +61,7 @@ public class MVColumnPruner {
     }
 
     public OptExpression doPruneColumns(OptExpression optExpression) {
-        Projection projection = optExpression.getOp().getProjection();
         // OptExpression after mv rewrite must have projection.
-        Preconditions.checkState(projection != null);
         return optExpression.getOp().accept(new ColumnPruneVisitor(), optExpression, null);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -552,7 +552,8 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         if (candidate == null) {
             return null;
         }
-        candidate = new MVColumnPruner().pruneColumns(candidate);
+        final ColumnRefSet requiredOutputColumns = optimizerContext.getTaskContext().getRequiredColumns();
+        candidate = new MVColumnPruner().pruneColumns(candidate, requiredOutputColumns);
         candidate = new MVPartitionPruner(optimizerContext, mvRewriteContext).prunePartition(candidate);
         return candidate;
     }
@@ -1270,7 +1271,7 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
         final List<ColumnRefOperator>  originalOutputColumns = MvUtils.getMvScanOutputColumnRefs(mv, mvScanOperator);
         // build mv scan opt expression with or without compensate
         final OptExpression mvScanOptExpression = mvCompensation.isTransparentRewrite() ?
-                getMvTransparentPlan(materializationContext, mvCompensation, originalOutputColumns) :
+                getMvTransparentPlan(materializationContext, mvCompensation, originalOutputColumns, true) :
                 getMVScanPlanWithoutCompensate(rewriteContext, columnRewriter, mvColumnRefToScalarOp);
         return mvScanOptExpression;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -129,6 +129,10 @@ public class MVTestBase extends StarRocksTestBase {
         return getFragmentPlan(sql, TExplainLevel.NORMAL, traceModule);
     }
 
+    public String getFragmentPlan(String sql, TExplainLevel level) throws Exception {
+        return getFragmentPlan(sql, level, null);
+    }
+
     public String getFragmentPlan(String sql, TExplainLevel level, String traceModule) throws Exception {
         Pair<String, Pair<ExecPlan, String>> result =
                 UtFrameUtils.getFragmentPlanWithTrace(connectContext, sql, traceModule);


### PR DESCRIPTION
## Why I'm doing:

Since we treat mv as always-transparent(refresh timeliness is always fine) which we use mv transparent union rewrite internally. But after rewrite, mvScanPlan and mvCompensatePlan will output all columns of the mv's defined query, it may contain more columns than the requiredColumns.

- For simple non-blocking operators(scan/join), it can be pruned by normal rules, but for aggregate operators, it should be handled in MVColumnPruner.
## What I'm doing:
-  For mv rewrite, it's safe to prune aggregate columns in mv compensate plan, but it cannot determine required columns in the transparent rule.

Fixes https://github.com/StarRocks/starrocks/issues/55221

Further:
- https://github.com/StarRocks/starrocks/issues/55285

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0