### PR TITLE
[BugFix] Fix wrong result when query cache work with select node

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/SelectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SelectNode.java
@@ -37,14 +37,18 @@ package com.starrocks.planner;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotId;
+import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TNormalPlanNode;
+import com.starrocks.thrift.TNormalSelectNode;
 import com.starrocks.thrift.TPlanNode;
 import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.thrift.TSelectNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -82,6 +86,19 @@ public class SelectNode extends PlanNode {
 
     @Override
     public void computeStats(Analyzer analyzer) {
+    }
+
+    @Override
+    protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
+        TNormalSelectNode selectNode = new TNormalSelectNode();
+        if (commonSlotMap != null) {
+            Pair<List<Integer>, List<ByteBuffer>> slotIdsAndExprs = normalizer.normalizeSlotIdsAndExprs(commonSlotMap);
+            selectNode.setCse_slot_ids(slotIdsAndExprs.first);
+            selectNode.setCse_exprs(slotIdsAndExprs.second);
+        }
+        planNode.setSelect_node(selectNode);
+        planNode.setNode_type(TPlanNodeType.SELECT_NODE);
+        normalizeConjuncts(normalizer, planNode, conjuncts);
     }
 
     @Override

--- a/gensrc/thrift/Normalization.thrift
+++ b/gensrc/thrift/Normalization.thrift
@@ -143,6 +143,11 @@ struct TNormalSetOperationNode {
   4: optional i64 first_materialized_child_idx
 }
 
+struct TNormalSelectNode {
+  1: optional list<Types.TSlotId> cse_slot_ids;
+  2: optional list<binary> cse_exprs;
+}
+
 struct TNormalPlanNode {
   1: optional Types.TPlanNodeId node_id
   2: optional PlanNodes.TPlanNodeType node_type
@@ -166,4 +171,5 @@ struct TNormalPlanNode {
   19: optional TNormalSortNode sort_node
   20: optional TNormalSortAggregationNode sort_aggregation_node
   22: optional TNormalSetOperationNode set_operation_node
+  23: optional TNormalSelectNode select_node
 }

--- a/test/sql/test_query_cache/R/test_query_cache_select_node
+++ b/test/sql/test_query_cache/R/test_query_cache_select_node
@@ -1,0 +1,32 @@
+-- name: test_query_cache_select_node
+CREATE TABLE `tarray` (
+  `id` int(4) NULL COMMENT "",
+  `val` array<int> NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id`) BUCKETS 2
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "false",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tarray SELECT generate_series, [generate_series % 4, generate_series%3] FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+set enable_query_cache = true;
+-- result:
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+SELECT rule_id,COUNT(*) AS cnt FROM ( SELECT  id,unnest AS rule_id FROM tarray, unnest(val) ) er WHERE rule_id IN (28,128,127) GROUP BY  rule_id;
+-- result:
+-- !result
+SELECT rule_id,COUNT(*) AS cnt FROM ( SELECT  id,unnest AS rule_id FROM tarray, unnest(val) ) er WHERE rule_id IN (1) GROUP BY  rule_id;
+-- result:
+1	2390
+-- !result

--- a/test/sql/test_query_cache/T/test_query_cache_select_node
+++ b/test/sql/test_query_cache/T/test_query_cache_select_node
@@ -1,0 +1,22 @@
+-- name: test_query_cache_select_node
+CREATE TABLE `tarray` (
+  `id` int(4) NULL COMMENT "",
+  `val` array<int> NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id`) BUCKETS 2
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "false",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into tarray SELECT generate_series, [generate_series % 4, generate_series%3] FROM TABLE(generate_series(1,  4096));
+
+set enable_query_cache = true;
+set pipeline_dop=1;
+
+SELECT rule_id,COUNT(*) AS cnt FROM ( SELECT  id,unnest AS rule_id FROM tarray, unnest(val) ) er WHERE rule_id IN (28,128,127) GROUP BY  rule_id;
+SELECT rule_id,COUNT(*) AS cnt FROM ( SELECT  id,unnest AS rule_id FROM tarray, unnest(val) ) er WHERE rule_id IN (1) GROUP BY  rule_id;


### PR DESCRIPTION
## Why I'm doing:

The query cache does not normalize the select node during the normalize stage, which can lead to incorrect results if different predicates use the same digest.

## What I'm doing:

mini reproduce see test case.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0