### PR TITLE
[BugFix] Fix valid normalized null vector for vector index

### DIFF
--- a/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
@@ -77,7 +77,8 @@ Status TenAnnIndexBuilderProxy::init() {
 }
 
 template <bool is_input_normalized>
-static Status valid_input_vector(const ArrayColumn& input_column, const size_t index_dim) {
+static Status valid_input_vector(const ArrayColumn& input_column, const size_t index_dim,
+                                 const uint8_t* is_element_nulls) {
     if (input_column.empty()) {
         return Status::OK();
     }
@@ -96,10 +97,13 @@ static Status valid_input_vector(const ArrayColumn& input_column, const size_t i
                                         index_dim, input_dim));
         }
 
+        double sum = 0;
         if constexpr (is_input_normalized) {
-            double sum = 0;
             for (int j = 0; j < input_dim; j++) {
-                sum += nums[offsets[i] + j] * nums[offsets[i] + j];
+                const size_t offset = offsets[i] + j;
+                if (!is_element_nulls[offset]) {
+                    sum += nums[offset] * nums[offset];
+                }
             }
             if (std::abs(sum - 1) > 1e-3) {
                 return Status::InvalidArgument(
@@ -119,11 +123,12 @@ Status TenAnnIndexBuilderProxy::add(const Column& array_column, const size_t off
     DCHECK(array_col.elements_column()->is_nullable());
     const auto& nullable_elements = down_cast<const NullableColumn&>(array_col.elements());
     const auto& is_element_nulls = nullable_elements.null_column_ref();
+    const uint8_t* is_element_nulls_data = is_element_nulls.raw_data();
 
     if (_is_input_normalized) {
-        RETURN_IF_ERROR(valid_input_vector<true>(array_col, _dim));
+        RETURN_IF_ERROR(valid_input_vector<true>(array_col, _dim, is_element_nulls_data));
     } else {
-        RETURN_IF_ERROR(valid_input_vector<false>(array_col, _dim));
+        RETURN_IF_ERROR(valid_input_vector<false>(array_col, _dim, is_element_nulls_data));
     }
 
     try {
@@ -133,7 +138,7 @@ Status TenAnnIndexBuilderProxy::add(const Column& array_column, const size_t off
                                                 .elem_type = tenann::kFloatType};
         std::vector<int64_t> row_ids(array_col.size());
         std::iota(row_ids.begin(), row_ids.end(), offset);
-        _index_builder->Add({vector_view}, row_ids.data(), is_element_nulls.raw_data());
+        _index_builder->Add({vector_view}, row_ids.data(), is_element_nulls_data);
     } catch (tenann::Error& e) {
         LOG(WARNING) << e.what();
         return Status::InternalError(e.what());

--- a/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
@@ -97,8 +97,8 @@ static Status valid_input_vector(const ArrayColumn& input_column, const size_t i
                                         index_dim, input_dim));
         }
 
-        double sum = 0;
         if constexpr (is_input_normalized) {
+            double sum = 0;
             for (int j = 0; j < input_dim; j++) {
                 const size_t offset = offsets[i] + j;
                 if (!is_element_nulls[offset]) {


### PR DESCRIPTION
## Why I'm doing:

When `is_input_normalized` is required, each row must have a sum of squares equal to 1. 

The `ArrayColumn` elements are always `NullableColumn`. The previous implementation assumed that the data column of a `NullableColumn` is the default value (e.g., 0 for float) when this element is null. However, this assumption is incorrect, leading to rare cases where the sum of squares for `[null, null, null, null]` might equal 1.


## What I'm doing:

To address this, exclude null values when calculating the sum of squares for each row.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0