### PR TITLE
[Enhancement] translate sql use right position when throw exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2636,7 +2636,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitAdminSetAutomatedSnapshotOnStatement(
-                     StarRocksParser.AdminSetAutomatedSnapshotOnStatementContext context) {
+            StarRocksParser.AdminSetAutomatedSnapshotOnStatementContext context) {
         String svName = StorageVolumeMgr.BUILTIN_STORAGE_VOLUME;
         if (context.svName != null) {
             svName = getIdentifierName(context.svName);
@@ -2646,7 +2646,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitAdminSetAutomatedSnapshotOffStatement(
-                     StarRocksParser.AdminSetAutomatedSnapshotOffStatementContext context) {
+            StarRocksParser.AdminSetAutomatedSnapshotOffStatementContext context) {
         return new AdminSetAutomatedSnapshotOffStmt(createPos(context));
     }
 
@@ -5181,11 +5181,23 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitTranslateSQL(StarRocksParser.TranslateSQLContext context) {
         StringBuilder buf = new StringBuilder();
+        int lastLine = context.start.getLine();
+        int lastPosition = 0;
         for (int i = 0; i < context.getChildCount(); ++i) {
+            TerminalNode child = (TerminalNode) context.getChild(i);
             if (i > 0) {
-                buf.append(' ');
+                int currentLine = child.getSymbol().getLine();
+                if (lastLine != currentLine) {
+                    buf.append('\n');
+                    lastLine = currentLine;
+                    lastPosition = 0;
+                }
+
+                buf.append(" ".repeat(child.getSymbol().getCharPositionInLine() - lastPosition));
+                lastPosition = child.getSymbol().getCharPositionInLine();
             }
-            buf.append(context.getChild(i).getText());
+            buf.append(child.getText());
+            lastPosition += child.getText().length();
         }
         return new StringLiteral(buf.toString(), createPos(context));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTranslateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTranslateTest.java
@@ -127,7 +127,9 @@ public class AnalyzeTranslateTest {
     @Test
     public void testParsedTranslateSQL() {
         String sql = "translate trino select \nto_unixtime(\nTIMESTAMP '2023-04-22 00:00:00'\n)";
-        TranslateStmt parsedStmt = (TranslateStmt) SqlParser.parse(sql, AnalyzeTestUtil.getConnectContext().getSessionVariable()).get(0);
-        Assert.assertEquals("select\nto_unixtime(\nTIMESTAMP '2023-04-22 00:00:00'\n)", parsedStmt.getTranslateSQL());
+        TranslateStmt parsedStmt = (TranslateStmt) SqlParser.parse(sql,
+                AnalyzeTestUtil.getConnectContext().getSessionVariable()).get(0);
+        Assert.assertEquals("select\nto_unixtime(\nTIMESTAMP '2023-04-22 00:00:00'\n)",
+                parsedStmt.getTranslateSQL());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTranslateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTranslateTest.java
@@ -123,4 +123,11 @@ public class AnalyzeTranslateTest {
                 "GROUP BY `o_orderpriority` ORDER BY `o_orderpriority` ASC ");
 
     }
+
+    @Test
+    public void testParsedTranslateSQL() {
+        String sql = "translate trino select \nto_unixtime(\nTIMESTAMP '2023-04-22 00:00:00'\n)";
+        TranslateStmt parsedStmt = (TranslateStmt) SqlParser.parse(sql, AnalyzeTestUtil.getConnectContext().getSessionVariable()).get(0);
+        Assert.assertEquals("select\nto_unixtime(\nTIMESTAMP '2023-04-22 00:00:00'\n)", parsedStmt.getTranslateSQL());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
For SQL we can not translate, the parser would give the wrong position when throw exception, for example 
```
Trino parser parse sql error: [io.trino.sql.parser.ParsingException: line 1:3275: mismatched input '('. Expecting: '%', '*', '+', '-', '.', '/', 'AND', 'AT', 'EXCEPT', 'FETCH', 'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'OR', 'ORDER', 'UNION', 'WINDOW', '[', '||', <EOF>], and StarRocks parser also can not parse: [com.starrocks.sql.parser.ParsingException: Getting syntax error from line 1, column 1,224 to line 1, column 1,262. Detail message: Incorrect number of arguments in expr 'date_add'.]
```
This because starrocks treats the SQL statements to be translated as single line.
## What I'm doing:
When translating SQL, the original number of lines and positions of the SQL statements are preserved.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0