### PR TITLE
[Enhancement] support lake table cache select in physical way

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1055,6 +1055,9 @@ CONF_mBool(lake_clear_corrupted_cache, "true");
 // The maximum number of files which need to rebuilt in cloud native pk index.
 // If files which need to rebuilt larger than this, we will flush memtable immediately.
 CONF_mInt32(cloud_native_pk_index_rebuild_files_threshold, "50");
+// if set to true, CACHE SELECT will only read file, save CPU time
+// if set to false, CACHE SELECT will behave like SELECT
+CONF_mBool(lake_cache_select_in_physical_way, "true");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -254,6 +254,9 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     _params.lake_io_opts.fill_data_cache = _scan_range.fill_data_cache;
     _params.lake_io_opts.skip_disk_cache = _scan_range.skip_disk_cache;
     _params.runtime_range_pruner = OlapRuntimeScanRangePruner(parser, _conjuncts_manager.unarrived_runtime_filters());
+    _params.lake_io_opts.cache_file_only = _runtime_state->query_options().__isset.enable_cache_select &&
+                                           _runtime_state->query_options().enable_cache_select &&
+                                           config::lake_cache_select_in_physical_way;
     _params.splitted_scan_rows = _provider->get_splitted_scan_rows();
     _params.scan_dop = _provider->get_scan_dop();
 

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -176,6 +176,15 @@ public:
         }
     }
 
+    Status touch_cache(int64_t offset, size_t length) override {
+        auto stream_st = _file_ptr->stream();
+        if (!stream_st.ok()) {
+            return to_status(stream_st.status());
+        }
+        auto res = (*stream_st)->touch_cache(offset, length);
+        return to_status(res);
+    }
+
     StatusOr<std::unique_ptr<io::NumericStatistics>> get_numeric_statistics() override {
         auto stream_st = _file_ptr->stream();
         if (!stream_st.ok()) {

--- a/be/src/io/seekable_input_stream.h
+++ b/be/src/io/seekable_input_stream.h
@@ -78,6 +78,11 @@ public:
     // to first send a HEAD OBJECT request to get the object size.
     virtual StatusOr<std::string> read_all();
 
+    // if cache in [offset, offset+length] exists, refresh it
+    // if not, read from remote and write to cache system
+    // stream offset will not change
+    virtual Status touch_cache(int64_t offset, size_t length) { return Status::OK(); }
+
     virtual const std::string& filename() const { return _filename; };
 
     virtual bool is_cache_hit() const { return false; };

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -79,6 +79,7 @@ struct LakeIOOptions {
     bool skip_disk_cache = false;
     // Specify different buffer size for different read scenarios
     int64_t buffer_size = -1;
+    bool cache_file_only = false; // only used for CACHE SELECT
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -107,20 +107,14 @@ public:
 
     virtual Status next_batch(const SparseRange<>& range, Column* dst);
 
-    Status convert_sparse_range_to_io_range(const SparseRange<>& range) {
-        if (auto sharedBufferStream = dynamic_cast<io::SharedBufferedInputStream*>(_opts.read_file);
-            sharedBufferStream == nullptr) {
-            return Status::OK();
-        }
-
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range) {
+        std::vector<std::pair<int64_t, int64_t>> res;
         auto reader = get_column_reader();
         if (reader == nullptr) {
             // should't happen
-            LOG(INFO) << "column reader nullptr, filename: " << _opts.read_file->filename();
-            return Status::OK();
+            return Status::InvalidArgument(fmt::format("column reader for {} is nullptr", _opts.read_file->filename()));
         }
 
-        std::vector<io::SharedBufferedInputStream::IORange> result;
         std::vector<std::pair<int, int>> page_index;
         int prev_page_index = -1;
         for (auto index = 0; index < range.size(); index++) {
@@ -148,7 +142,25 @@ public:
             RETURN_IF_ERROR(reader->seek_by_page_index(pair.second, &iter_end));
             auto offset = iter_start.page().offset;
             auto size = iter_end.page().offset - offset + iter_end.page().size;
-            io::SharedBufferedInputStream::IORange io_range(offset, size);
+            res.push_back({offset, size});
+        }
+
+        return res;
+    }
+
+    Status convert_sparse_range_to_io_range(const SparseRange<>& range) {
+        if (auto sharedBufferStream = dynamic_cast<io::SharedBufferedInputStream*>(_opts.read_file);
+            sharedBufferStream == nullptr) {
+            return Status::OK();
+        }
+
+        std::vector<io::SharedBufferedInputStream::IORange> result;
+        auto vec_or = get_io_range_vec(range);
+        if (!vec_or.ok()) {
+            return vec_or.status();
+        }
+        for (auto e : *vec_or) {
+            io::SharedBufferedInputStream::IORange io_range(e.first, e.second);
             result.emplace_back(io_range);
         }
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1118,6 +1118,39 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     MonotonicStopWatch sw;
     sw.start();
 
+    // only used for CACHE SELECT, do not form any chunk to save CPU time,
+    // just read file content in `_scan_range`
+    if (_opts.lake_io_opts.cache_file_only) {
+        // read every column in this segment at once, maybe optimize this later
+        size_t buf_size = config::starlet_fs_stream_buffer_size_bytes;
+        if (buf_size <= 0) {
+            buf_size = 1048576; // 1MB
+        }
+        for (auto& [cid, stream] : _column_files) {
+            auto vec_or = _column_iterators[cid]->get_io_range_vec(_scan_range);
+            if (!vec_or.ok()) {
+                return vec_or.status();
+            }
+            std::unique_ptr<char[]> buf(new char[buf_size]);
+            for (auto e : *vec_or) {
+                // if buf_size is 1MB, offset is 123, and size is 2MB
+                // after calculation, offset will be 0, and size will be 2MB+123
+                size_t offset = (e.first / buf_size) * buf_size;
+                size_t size = e.second + (e.first % buf_size);
+                while (size > 0) {
+                    size_t cur_size = std::min(buf_size, size);
+                    RETURN_IF_ERROR(stream->read_at_fully(offset, buf.get(), cur_size));
+                    offset += cur_size;
+                    size -= cur_size;
+                }
+            }
+        }
+
+        _opts.stats->block_load_ns += sw.elapsed_time();
+
+        return Status::EndOfFile("no more data in segment");
+    }
+
     const uint32_t chunk_capacity = _reserve_chunk_size;
     const uint32_t return_chunk_threshold = std::max<uint32_t>(chunk_capacity - chunk_capacity / 4, 1);
     const bool has_predicate = !_cid_to_predicates.empty();

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1131,7 +1131,6 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
             if (!vec_or.ok()) {
                 return vec_or.status();
             }
-            std::unique_ptr<char[]> buf(new char[buf_size]);
             for (auto e : *vec_or) {
                 // if buf_size is 1MB, offset is 123, and size is 2MB
                 // after calculation, offset will be 0, and size will be 2MB+123
@@ -1139,7 +1138,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
                 size_t size = e.second + (e.first % buf_size);
                 while (size > 0) {
                     size_t cur_size = std::min(buf_size, size);
-                    RETURN_IF_ERROR(stream->read_at_fully(offset, buf.get(), cur_size));
+                    RETURN_IF_ERROR(stream->touch_cache(offset, cur_size));
                     offset += cur_size;
                     size -= cur_size;
                 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

part of the cache select process is CPU heavy, which is unnecessary and can be removed.

100G SSB, everything is cached already, run `cache select * from lineorder;`.
 -| Previous Implementataion | New Implemention
-- | -- | --
Total | 2s373ms | 418ms
IOTime (IO heavy) | 272.922ms | 281.019ms
Decompress Page (CPU heavy) + Checksum Check (CPU heavy) + Form Chunk (CPU heavy)| 1.336s | 0s

100G TPCH, everything is cached already, run `cache select * from lineitem;`.
 -| Previous Implementataion | New Implemention
-- | -- | --
Total |  9s254ms | 1s190ms
IOTime (IO heavy) |  348.076ms | 274.867ms
Decompress Page (CPU heavy) + Checksum Check (CPU heavy) + Form Chunk (CPU heavy)| 5.402s | 0s


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
