### PR TITLE
[BugFix] fix memory usage calculation of pk column lazy load

### DIFF
--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -35,7 +35,9 @@
 namespace starrocks::lake {
 
 Status SegmentPKEncodeResult::_load() {
-    pk_column->reset_column();
+    // reset pk_column to empty
+    auto clone_pk_column = pk_column->clone_empty();
+    pk_column = std::move(clone_pk_column);
     ChunkUniquePtr chunk_shared_ptr;
     TRY_CATCH_BAD_ALLOC(chunk_shared_ptr = ChunkHelper::new_chunk(_pkey_schema, 4096));
     auto chunk = chunk_shared_ptr.get();


### PR DESCRIPTION
## Why I'm doing:
`reset_column` won't release column memory, and `pk_column->memory_usage()` will always larger than `pk_column_lazy_load_threshold_bytes` after first load.
```
if (_lazy_load && pk_column->memory_usage() >= config::pk_column_lazy_load_threshold_bytes) {
                    break;
}
```

## What I'm doing:
Fix #53954

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0