### PR TITLE
[BugFix] Ensure transparent mv's output columns with order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -2172,4 +2172,21 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
         return this.defineQueryParseNode;
     }
+
+    /**
+     * Get mv's ordered columns if the mv has defined its output columns order.
+     * @return: mv's defined output columns in the defined order
+     */
+    public List<Column> getOrderedOutputColumns() {
+        if (CollectionUtils.isEmpty(this.queryOutputIndices)) {
+            return this.getBaseSchemaWithoutGeneratedColumn();
+        } else {
+            List<Column> schema = this.getBaseSchemaWithoutGeneratedColumn();
+            List<Column> outputColumns = Lists.newArrayList();
+            for (Integer index : this.queryOutputIndices) {
+                outputColumns.add(schema.get(index));
+            }
+            return outputColumns;
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -879,7 +879,7 @@ public class MvRewritePreprocessor {
         materializationContext.setScanMvOperator(scanMvOp);
         // should keep the sequence of schema
         List<ColumnRefOperator> scanMvOutputColumns = Lists.newArrayList();
-        for (Column column : getMvOutputColumns(copiedMV)) {
+        for (Column column : copiedMV.getOrderedOutputColumns()) {
             scanMvOutputColumns.add(scanMvOp.getColumnReference(column));
         }
         Preconditions.checkState(mvOutputColumns.size() == scanMvOutputColumns.size());
@@ -897,24 +897,6 @@ public class MvRewritePreprocessor {
         materializationContext.setOutputMapping(outputMapping);
 
         return materializationContext;
-    }
-
-    /**
-     * Get mv's ordered columns by defined output columns order.
-     * @param mv: mv to check
-     * @return: mv's defined output columns in the defined order
-     */
-    public static List<Column> getMvOutputColumns(MaterializedView mv) {
-        if (mv.getQueryOutputIndices() == null || mv.getQueryOutputIndices().isEmpty()) {
-            return mv.getBaseSchemaWithoutGeneratedColumn();
-        } else {
-            List<Column> schema = mv.getBaseSchemaWithoutGeneratedColumn();
-            List<Column> outputColumns = Lists.newArrayList();
-            for (Integer index : mv.getQueryOutputIndices()) {
-                outputColumns.add(schema.get(index));
-            }
-            return outputColumns;
-        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -161,7 +161,8 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
                 mv, mvPlanContext, mvUpdateInfo, queryTables);
 
         Map<Column, ColumnRefOperator> columnToColumnRefMap = olapScanOperator.getColumnMetaToColRefMap();
-        List<Column> mvColumns = mv.getBaseSchemaWithoutGeneratedColumn();
+        // use ordered output columns to ensure the order of output columns if the mv contains order-by clause.
+        List<Column> mvColumns = mv.getOrderedOutputColumns();
         List<ColumnRefOperator> expectOutputColumns = mvColumns.stream()
                 .map(c -> columnToColumnRefMap.get(c))
                 .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -67,7 +67,6 @@ import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MaterializedViewOptimizer;
-import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.Optimizer;
@@ -1275,7 +1274,7 @@ public class MvUtils {
     public static List<ColumnRefOperator> getMvScanOutputColumnRefs(MaterializedView mv,
                                                                     LogicalOlapScanOperator scanMvOp) {
         List<ColumnRefOperator> scanMvOutputColumns = Lists.newArrayList();
-        for (Column column : MvRewritePreprocessor.getMvOutputColumns(mv)) {
+        for (Column column : mv.getOrderedOutputColumns()) {
             scanMvOutputColumns.add(scanMvOp.getColumnReference(column));
         }
         return scanMvOutputColumns;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -299,7 +299,7 @@ public class TextMatchBasedRewriteRule extends Rule {
         //  - support different output orders
         //  - support different aliases
         //  - support query is subset of mv's output
-        List<Column> mvColumns = MvRewritePreprocessor.getMvOutputColumns(mv);
+        List<Column> mvColumns = mv.getOrderedOutputColumns();
         Map<String, ColumnRefOperator> mvColRefNameColRefMapping = Maps.newHashMap();
         mvScanOperator.getOutputColumns().stream().forEach(colRef ->
                 mvColRefNameColRefMapping.put(colRef.getName(), colRef));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
@@ -1292,4 +1292,62 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                     });
         });
     }
+
+    @Test
+    public void testTransparentRewriteWithOrderBy() {
+        starRocksAssert.withTable(m1, () -> {
+            cluster.runSql("test", "insert into m1 values (1,1,1,1,1), (4,2,1,1,1);");
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0 " +
+                            " PARTITION BY (k1) " +
+                            " DISTRIBUTED BY HASH(k1) " +
+                            " ORDER BY (v11, k2, k1) " +
+                            " REFRESH DEFERRED MANUAL " +
+                            " PROPERTIES (\n" +
+                            " 'transparent_mv_rewrite_mode' = 'true'" +
+                            " ) " +
+                            " AS SELECT k1, k2, sum(v1) as v11 from m1 group by k1, k2;",
+                    () -> {
+                        starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n" +
+                                "PARTITION START ('%s') END ('%s')", "1", "3"));
+                        MaterializedView mv1 = getMv("test", "mv0");
+                        Set<String> mvNames = mv1.getPartitionNames();
+                        Assert.assertEquals("[p1]", mvNames.toString());
+                        // test: query rewrite
+                        {
+                            final String query = "SELECT k1, k2, sum(v1) as v11 from m1 group by k1, k2;";
+                            final String plan = getFragmentPlan(query);
+                            PlanTestBase.assertContains(plan, ":UNION");
+                            PlanTestBase.assertContains(plan, "mv0");
+                        }
+
+                        // test: query mv directly
+                        {
+                            final String query = "SELECT k1, k2, v11 from mv0 where k1=1";
+                            final String plan = getFragmentPlan(query);
+                            PlanTestBase.assertContains(plan, ":UNION");
+                            PlanTestBase.assertContains(plan, "mv0");
+                            PlanTestBase.assertContains(plan, " OUTPUT EXPRS:3: k1 | 2: k2 | 1: v11\n" +
+                                    "  PARTITION: RANDOM");
+                        }
+
+                        // test: query mv directly
+                        {
+                            final String query = "SELECT k2, v11, k2 from mv0 where k1=1";
+                            final String plan = getFragmentPlan(query);
+                            PlanTestBase.assertContains(plan, ":UNION");
+                            PlanTestBase.assertContains(plan, "mv0");
+                            PlanTestBase.assertContains(plan, "OUTPUT EXPRS:2: k2 | 1: v11 | 2: k2");
+                        }
+
+                        // test: query mv directly
+                        {
+                            final String query = "SELECT * from mv0 where k1=1";
+                            final String plan = getFragmentPlan(query);
+                            PlanTestBase.assertContains(plan, ":UNION");
+                            PlanTestBase.assertContains(plan, "mv0");
+                            PlanTestBase.assertContains(plan, " OUTPUT EXPRS:1: v11 | 2: k2 | 3: k1");
+                        }
+                    });
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -65,6 +65,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.load.routineload.RoutineLoadMgr;
@@ -894,7 +895,7 @@ public class StarRocksAssert {
             withMaterializedView(sql);
             action.run();
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
+            Assert.fail(DebugUtil.getStackTrace(e));
         } finally {
             // Create mv may fail.
             if (!Strings.isNullOrEmpty(mvName)) {


### PR DESCRIPTION
## Why I'm doing:
- Transparent MV: use ordered output columns to ensure the order of output columns if the mv contains order-by clause

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/55301

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0