### PR TITLE
[BugFix] PushDownSubfieldRule shouldn't pushdown expr with lambda

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
@@ -91,6 +92,11 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
             return null;
         }
         complexExpressions.add(subfieldOperator);
+        return null;
+    }
+
+    @Override
+    public Void visitLambdaFunctionOperator(LambdaFunctionOperator operator, Void context) {
         return null;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -746,4 +746,14 @@ public class ArrayTypeTest extends PlanTestBase {
                 "  |  \n" +
                 "  0:OlapScanNode");
     }
+
+    @Test
+    public void testLambdaFunction() throws Exception {
+        String sql = "select dense_rank() over(partition by v1 order by v2), " +
+                "array_filter(v3, x -> array_contains(v3, x)) from tarray";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "3:Project\n" +
+                "  |  <slot 4> : 4: dense_rank()\n" +
+                "  |  <slot 6> : array_filter(3: v3, array_map(<slot 5> -> array_contains(3: v3, <slot 5>), 3: v3))");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
before pushdown subfield rule:

```
LOGICAL
->  LogicalProjectOperator {projection=[18: dense_rank(), array_filter(13: col_date, array_map(([19: x]->array_contains(14: col_datetime, cast(19: x as datetime))), 13: col_date))]}
    ->  LogicalWindowOperator {window={18: dense_rank()=dense_rank()}, partitions=[1: case_key], orderBy=[17: expr ASC NULLS FIRST], enforceSort[1: case_key ASC NULLS FIRST, 17: expr ASC NULLS FIRST]}
        ->  LogicalProjectOperator {projection=[1: case_key, 4: col_bigint,1, 5: col_date, 6: col_datetime]}
            ->  LogicalOlapScanOperator {table=10429, selectedPartitionId=null, selectedIndexId=10430, outputColumns=[1: case_key, 4: col_bigint, 5: col_date, 6: col_datetime], predicate=null, prunedPartitionPredicates=[], limit=-1}
```

after rule:
```
LOGICAL
->  LogicalProjectOperator {projection=[18: dense_rank(), array_filter(13: col_date, array_map(([19: x]->22: array_contains), 13: col_date))]}
    ->  LogicalWindowOperator {window={18: dense_rank()=dense_rank()}, partitions=[1: case_key], orderBy=[17: expr ASC NULLS FIRST], enforceSort[1: case_key ASC NULLS FIRST, 17: expr ASC NULLS FIRST]}
        ->  LogicalProjectOperator {projection=[1: case_key, 23: expr, 24: array_contains, 5: col_date]}
            ->  LogicalProjectOperator {projection=[1: case_key, 5: col_date, 4: col_bigint,1, array_contains(6: col_datetime, cast(19: x as datetime))]}
                ->  LogicalOlapScanOperator {table=10429, selectedPartitionId=null, selectedIndexId=10430, outputColumns=[1: case_key, 4: col_bigint, 5: col_date, 6: col_datetime], predicate=null, prunedPartitionPredicates=[], limit=-1}
```

we shouldn't pushdown expr with lambda

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/8915

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0