### PR TITLE
[BugFix] Fix stream load redirected to non-alive nodes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -174,7 +174,7 @@ public class LoadAction extends RestBaseAction {
             Collections.shuffle(nodeIds);
         } else {
             SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-            nodeIds = systemInfoService.getNodeSelector().seqChooseBackendIds(1, false, false, null);
+            nodeIds = systemInfoService.getNodeSelector().seqChooseBackendIds(1, true, false, null);
         }
 
         if (CollectionUtils.isEmpty(nodeIds)) {

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -20,13 +20,18 @@ import com.starrocks.load.batchwrite.BatchWriteMgr;
 import com.starrocks.load.batchwrite.RequestCoordinatorBackendResult;
 import com.starrocks.load.batchwrite.TableId;
 import com.starrocks.load.streamload.StreamLoadKvParams;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.NodeSelector;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import okhttp3.OkHttpClient;
@@ -54,7 +59,9 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE;
+import static com.starrocks.server.WarehouseManager.DEFAULT_WAREHOUSE_NAME;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class LoadActionTest extends StarRocksHttpTestCase {
@@ -266,5 +273,64 @@ public class LoadActionTest extends StarRocksHttpTestCase {
             }
         }
         client.close();
+    }
+
+    @Test
+    public void testStreamLoadSkipNonAliveNodesForSharedNothing() throws Exception {
+        new MockUp<NodeSelector>() {
+            @Mock
+            public List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable,
+                                                  boolean isCreate, Multimap<String, String> locReq) {
+                assertEquals(1, backendNum);
+                assertTrue(needAvailable);
+                assertFalse(isCreate);
+                return new ArrayList<>();
+            }
+        };
+
+        Map<String, String> map = new HashMap<>();
+        Request request = buildRequest(map);
+        try (Response response = noRedirectClient.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            Map<String, Object> result = parseResponseBody(response);
+            assertEquals("FAILED", result.get("Status"));
+            assertEquals("class com.starrocks.common.DdlException: No backend alive.", result.get("Message"));
+        }
+    }
+
+    @Test
+    public void testStreamLoadSkipNonAliveNodesForSharedData() throws Exception {
+        SystemInfoService service = new SystemInfoService();
+        Backend backend = new Backend(1, "127.0.0.1", 9050);
+        backend.setAlive(false);
+        service.addBackend(backend);
+
+        List<Long> nodeIds = new ArrayList<>();
+        nodeIds.add(1L);
+
+        new MockUp<RunMode>() {
+            @Mock
+            boolean isSharedDataMode() {
+                return true;
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getWarehouseMgr().getAllComputeNodeIds(DEFAULT_WAREHOUSE_NAME);
+                result = nodeIds;
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+                result = service;
+            }
+        };
+
+        Map<String, String> map = new HashMap<>();
+        Request request = buildRequest(map);
+        try (Response response = noRedirectClient.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            Map<String, Object> result = parseResponseBody(response);
+            assertEquals("FAILED", result.get("Status"));
+            assertEquals("class com.starrocks.common.DdlException: No backend alive.", result.get("Message"));
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Stream load is redirected to non-alive nodes. This problem is introduced by #38833 since 3.2

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0