### PR TITLE
[Enhancement] Support materialized view for Oracle Dialect JDBC Catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/JDBCPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/JDBCPartitionTraits.java
@@ -15,9 +15,11 @@ package com.starrocks.connector.partitiontraits;
 
 import com.google.common.collect.Range;
 import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.JDBCPartitionKey;
 import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.PartitionInfo;
@@ -27,6 +29,7 @@ import com.starrocks.server.GlobalStateMgr;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class JDBCPartitionTraits extends DefaultTraits {
     @Override
@@ -65,6 +68,19 @@ public class JDBCPartitionTraits extends DefaultTraits {
         return partitionNameWithPartition.values().stream()
                 .map(com.starrocks.connector.PartitionInfo::getModifiedTime)
                 .max(Long::compareTo);
+    }
+
+    @Override
+    public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
+                                                MaterializedView.AsyncRefreshContext context) {
+
+        try {
+            return super.getUpdatedPartitionNames(baseTables, context);
+        } catch (Exception e) {
+            // some external table traits do not support getPartitionNameWithPartitionInfo, will throw exception,
+            // just return null
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

Refresh mv with oracle jdbc dialect will fail as:
```
2025-01-14 11:02:37.073+08:00 INFO (starrocks-taskrun-pool-0|267) [PartitionBasedMvRefreshProcessor.syncAndCheckPartitions():267] Sync and check materialized view mv_oracle01 partition changing after 1 times: true, costs: 121 ms
2025-01-14 11:02:37.079+08:00 WARN (starrocks-taskrun-pool-0|267) [PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry():377] Refresh materialized view mv_oracle01 failed at 1th time: java.lang.IllegalStateException: corrupted partition meta
	at com.google.common.base.Preconditions.checkState(Preconditions.java:512)
	at com.starrocks.connector.partitiontraits.DefaultTraits.getPartitionNameWithPartitionInfo(DefaultTraits.java:117)
	at com.starrocks.connector.partitiontraits.DefaultTraits.getUpdatedPartitionNames(DefaultTraits.java:134)
	at com.starrocks.catalog.MaterializedView.getUpdatedPartitionNamesOfExternalTable(MaterializedView.java:828)
	at com.starrocks.catalog.MvRefreshArbiter.needsToRefreshTable(MvRefreshArbiter.java:145)
	at com.starrocks.catalog.MvRefreshArbiter.needsToRefreshTable(MvRefreshArbiter.java:47)
	at com.starrocks.scheduler.mv.MVPCTRefreshPartitioner.isNonPartitionedMVNeedToRefresh(MVPCTRefreshPartitioner.java:246)
	at com.starrocks.scheduler.mv.MVPCTRefreshNonPartitioner.getMVPartitionsToRefresh(MVPCTRefreshNonPartitioner.java:66)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.getPartitionsToRefreshForMaterializedView(PartitionBasedMvRefreshProcessor.java:972)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.getPartitionsToRefreshForMaterializedView(PartitionBasedMvRefreshProcessor.java:930)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.checkMvToRefreshedPartitions(PartitionBasedMvRefreshProcessor.java:289)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:439)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:368)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:327)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:199)
	at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:270)
	at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:59)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:842)
2025-01-14 11:02:38.084+08:00 INFO (starrocks-taskrun-pool-0|267) [PartitionBasedMvRefreshProcessor.processTaskRun():219] Refresh mv mv_oracle01 trace logs:    0ms|-- MVRefreshPrepare[1] 7ms
   8ms|-- MVRefreshDoWholeRefresh[1] 1s195ms
  21ms|    -- MVRefreshComputeCandidatePartitions[1] 54ms
  75ms|    -- MVRefreshSyncAndCheckPartitions[1] 121ms
  75ms|        -- MVRefreshExternalTable[1] 58ms
 134ms|        -- MVRefreshCheckBaseTableChange[1] 62ms
 197ms|    -- MVRefreshCheckMVToRefreshPartitions[1] 3ms
Tracer Cost: 156us
```


## What I'm doing:

- Support more JDBC dialects for materialized view by using Orcalce metadata tables:
```
       /**
     *  desc ALL_TAB_PARTITIONS;
     *  Name                       Null?    Type
     *  ----------------------------------------- -------- ----------------------------
     *  TABLE_OWNER                        VARCHAR2(128)
     *  TABLE_NAME                        VARCHAR2(128)
     *  COMPOSITE                        VARCHAR2(3)
     *  PARTITION_NAME                     VARCHAR2(128)
     *  SUBPARTITION_COUNT                    NUMBER
     *  HIGH_VALUE                        LONG
     *  HIGH_VALUE_LENGTH                    NUMBER
     *  PARTITION_POSITION                    NUMBER
     *  TABLESPACE_NAME                    VARCHAR2(30)
     *  PCT_FREE                        NUMBER
     *  PCT_USED                        NUMBER
     *  INI_TRANS                        NUMBER
     *  MAX_TRANS                        NUMBER
     *  INITIAL_EXTENT                     NUMBER
     *  NEXT_EXTENT                        NUMBER
     *  MIN_EXTENT                        NUMBER
     *  MAX_EXTENT                        NUMBER
     *  MAX_SIZE                        NUMBER
     *  PCT_INCREASE                        NUMBER
     *  FREELISTS                        NUMBER
     *  FREELIST_GROUPS                    NUMBER
     *  LOGGING                        VARCHAR2(7)
     *  COMPRESSION                        VARCHAR2(8)
     *  COMPRESS_FOR                        VARCHAR2(30)
     *  NUM_ROWS                        NUMBER
     *  BLOCKS                         NUMBER
     *  EMPTY_BLOCKS                        NUMBER
     *  AVG_SPACE                        NUMBER
     *  CHAIN_CNT                        NUMBER
     *  AVG_ROW_LEN                        NUMBER
     *  SAMPLE_SIZE                        NUMBER
     *  LAST_ANALYZED                        DATE
     *  BUFFER_POOL                        VARCHAR2(7)
     *  FLASH_CACHE                        VARCHAR2(7)
     *  CELL_FLASH_CACHE                    VARCHAR2(7)
     *  GLOBAL_STATS                        VARCHAR2(3)
     *  USER_STATS                        VARCHAR2(3)
     *  IS_NESTED                        VARCHAR2(3)
     *  PARENT_TABLE_PARTITION                 VARCHAR2(128)
     *  INTERVAL                        VARCHAR2(3)
     *  SEGMENT_CREATED                    VARCHAR2(4)
     *  INDEXING                        VARCHAR2(4)
     *  READ_ONLY                        VARCHAR2(4)
     *  INMEMORY                        VARCHAR2(8)
     *  INMEMORY_PRIORITY                    VARCHAR2(8)
     *  INMEMORY_DISTRIBUTE                    VARCHAR2(15)
     *  INMEMORY_COMPRESSION                    VARCHAR2(17)
     *  INMEMORY_DUPLICATE                    VARCHAR2(13)
     *  CELLMEMORY                        VARCHAR2(24)
     *  INMEMORY_SERVICE                    VARCHAR2(12)
     *  INMEMORY_SERVICE_NAME                    VARCHAR2(1000)
     *  MEMOPTIMIZE_READ                    VARCHAR2(8)
     *  MEMOPTIMIZE_WRITE                    VARCHAR2(8)
     *  HIGH_VALUE_CLOB                    CLOB
     *  HIGH_VALUE_JSON                    JSON
     *
     *  desc ALL_TABLES;
     *  Name                       Null?    Type
     *  ----------------------------------------- -------- ----------------------------
     *  OWNER                       NOT NULL VARCHAR2(128)
     *  TABLE_NAME                   NOT NULL VARCHAR2(128)
     *  TABLESPACE_NAME                    VARCHAR2(30)
     *  CLUSTER_NAME                        VARCHAR2(128)
     *  IOT_NAME                        VARCHAR2(128)
     *  STATUS                         VARCHAR2(8)
     *  PCT_FREE                        NUMBER
     *  PCT_USED                        NUMBER
     *  INI_TRANS                        NUMBER
     *  MAX_TRANS                        NUMBER
     *  INITIAL_EXTENT                     NUMBER
     *  NEXT_EXTENT                        NUMBER
     *  MIN_EXTENTS                        NUMBER
     *  MAX_EXTENTS                        NUMBER
     *  PCT_INCREASE                        NUMBER
     *  FREELISTS                        NUMBER
     *  FREELIST_GROUPS                    NUMBER
     *  LOGGING                        VARCHAR2(3)
     *  BACKED_UP                        VARCHAR2(1)
     *  NUM_ROWS                        NUMBER
     *  BLOCKS                         NUMBER
     *  EMPTY_BLOCKS                        NUMBER
     *  AVG_SPACE                        NUMBER
     *  CHAIN_CNT                        NUMBER
     *  AVG_ROW_LEN                        NUMBER
     *  AVG_SPACE_FREELIST_BLOCKS                NUMBER
     *  NUM_FREELIST_BLOCKS                    NUMBER
     *  DEGREE                         VARCHAR2(10)
     *  INSTANCES                        VARCHAR2(10)
     *  CACHE                            VARCHAR2(5)
     *  TABLE_LOCK                        VARCHAR2(8)
     *  SAMPLE_SIZE                        NUMBER
     *  LAST_ANALYZED                        DATE
     *  PARTITIONED                        VARCHAR2(3)
     *  IOT_TYPE                        VARCHAR2(12)
     *  TEMPORARY                        VARCHAR2(1)
     *  SECONDARY                        VARCHAR2(1)
     *  NESTED                         VARCHAR2(3)
     *  BUFFER_POOL                        VARCHAR2(7)
     *  FLASH_CACHE                        VARCHAR2(7)
     *  CELL_FLASH_CACHE                    VARCHAR2(7)
     *  ROW_MOVEMENT                        VARCHAR2(8)
     *  GLOBAL_STATS                        VARCHAR2(3)
     *  USER_STATS                        VARCHAR2(3)
     *  DURATION                        VARCHAR2(15)
     *  SKIP_CORRUPT                        VARCHAR2(8)
     *  MONITORING                        VARCHAR2(3)
     *  CLUSTER_OWNER                        VARCHAR2(128)
     *  DEPENDENCIES                        VARCHAR2(8)
     *  COMPRESSION                        VARCHAR2(8)
     *  COMPRESS_FOR                        VARCHAR2(30)
     *  DROPPED                        VARCHAR2(3)
     *  READ_ONLY                        VARCHAR2(3)
     *  SEGMENT_CREATED                    VARCHAR2(3)
     *  RESULT_CACHE                        VARCHAR2(7)
     *  CLUSTERING                        VARCHAR2(3)
     *  ACTIVITY_TRACKING                    VARCHAR2(23)
     *  DML_TIMESTAMP                        VARCHAR2(25)
     *  HAS_IDENTITY                        VARCHAR2(3)
     *  CONTAINER_DATA                     VARCHAR2(3)
     *  INMEMORY                        VARCHAR2(8)
     *  INMEMORY_PRIORITY                    VARCHAR2(8)
     *  INMEMORY_DISTRIBUTE                    VARCHAR2(15)
     *  INMEMORY_COMPRESSION                    VARCHAR2(17)
     *  INMEMORY_DUPLICATE                    VARCHAR2(13)
     *  DEFAULT_COLLATION                    VARCHAR2(100)
     *  DUPLICATED                        VARCHAR2(1)
     *  SYNCHRONOUS_DUPLICATED                 VARCHAR2(1)
     *  SHARDED                        VARCHAR2(1)
     *  EXTERNALLY_SHARDED                    VARCHAR2(1)
     *  EXTERNALLY_DUPLICATED                    VARCHAR2(1)
     *  EXTERNAL                        VARCHAR2(3)
     *  HYBRID                         VARCHAR2(3)
     *  CELLMEMORY                        VARCHAR2(24)
     *  CONTAINERS_DEFAULT                    VARCHAR2(3)
     *  CONTAINER_MAP                        VARCHAR2(3)
     *  EXTENDED_DATA_LINK                    VARCHAR2(3)
     *  EXTENDED_DATA_LINK_MAP                 VARCHAR2(3)
     *  INMEMORY_SERVICE                    VARCHAR2(12)
     *  INMEMORY_SERVICE_NAME                    VARCHAR2(1000)
     *  CONTAINER_MAP_OBJECT                    VARCHAR2(3)
     *  MEMOPTIMIZE_READ                    VARCHAR2(8)
     *  MEMOPTIMIZE_WRITE                    VARCHAR2(8)
     *  HAS_SENSITIVE_COLUMN                    VARCHAR2(3)
     *  ADMIT_NULL                        VARCHAR2(3)
     *  DATA_LINK_DML_ENABLED                    VARCHAR2(3)
     *  LOGICAL_REPLICATION                ...
     */
```

Fixes https://github.com/StarRocks/starrocks/issues/55366

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0