### PR TITLE
[Enhancement] Optimize serialize_batch for nullable/const column

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -532,18 +532,6 @@ uint32_t BinaryColumnBase<T>::max_one_element_serialize_size() const {
 }
 
 template <typename T>
-uint32_t BinaryColumnBase<T>::serialize(size_t idx, uint8_t* pos) {
-    // max size of one string is 2^32, so use uint32_t not T
-    auto binary_size = static_cast<uint32_t>(_offsets[idx + 1] - _offsets[idx]);
-    T offset = _offsets[idx];
-
-    strings::memcpy_inlined(pos, &binary_size, sizeof(uint32_t));
-    strings::memcpy_inlined(pos + sizeof(uint32_t), &_bytes[offset], binary_size);
-
-    return sizeof(uint32_t) + binary_size;
-}
-
-template <typename T>
 uint32_t BinaryColumnBase<T>::serialize_default(uint8_t* pos) {
     // max size of one string is 2^32, so use uint32_t not T
     uint32_t binary_size = 0;
@@ -581,6 +569,41 @@ void BinaryColumnBase<T>::deserialize_and_append_batch(Buffer<Slice>& srcs, size
     for (size_t i = 0; i < chunk_size; ++i) {
         srcs[i].data = (char*)deserialize_and_append((uint8_t*)srcs[i].data);
     }
+}
+
+template <typename T>
+void BinaryColumnBase<T>::serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes,
+                                                          size_t chunk_size, uint32_t max_one_row_size,
+                                                          uint8_t* null_masks, bool has_null) {
+    uint32_t* sizes = slice_sizes.data();
+
+    if (!has_null) {
+        for (size_t i = 0; i < chunk_size; ++i) {
+            memcpy(dst + i * max_one_row_size + sizes[i], &has_null, sizeof(bool));
+            sizes[i] += static_cast<uint32_t>(sizeof(bool)) +
+                        serialize(i, dst + i * max_one_row_size + sizes[i] + sizeof(bool));
+        }
+    } else {
+        for (size_t i = 0; i < chunk_size; ++i) {
+            memcpy(dst + i * max_one_row_size + sizes[i], null_masks + i, sizeof(bool));
+            sizes[i] += sizeof(bool);
+
+            if (!null_masks[i]) {
+                sizes[i] += serialize(i, dst + i * max_one_row_size + sizes[i]);
+            }
+        }
+    }
+}
+
+template <typename T>
+void BinaryColumnBase<T>::deserialize_and_append_batch_nullable(Buffer<Slice>& srcs, size_t chunk_size,
+                                                                Buffer<uint8_t>& is_nulls, bool& has_null) {
+    const uint32_t string_size = *((bool*)srcs[0].data) // is null
+                                         ? 4
+                                         : *((uint32_t*)(srcs[0].data + sizeof(bool))); // first string size
+    _bytes.reserve(chunk_size * string_size * 2);
+    ColumnFactory<Column, BinaryColumnBase<T>>::deserialize_and_append_batch_nullable(srcs, chunk_size, is_nulls,
+                                                                                      has_null);
 }
 
 template <typename T>

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -25,6 +25,7 @@
 #include "common/statusor.h"
 #include "gutil/casts.h"
 #include "storage/delete_condition.h" // for DelCondSatisfied
+#include "util/slice.h"
 
 namespace starrocks {
 
@@ -316,6 +317,9 @@ public:
     virtual void serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
                                                  uint32_t max_one_row_size, uint8_t* null_masks, bool has_null);
 
+    virtual void deserialize_and_append_batch_nullable(Buffer<Slice>& srcs, size_t chunk_size,
+                                                       Buffer<uint8_t>& is_nulls, bool& has_null) = 0;
+
     // deserialize one data and append to this column
     virtual const uint8_t* deserialize_and_append(const uint8_t* pos) = 0;
 
@@ -496,6 +500,24 @@ public:
 
     Status accept_mutable(ColumnVisitorMutable* visitor) override {
         return visitor->visit(static_cast<Derived*>(this));
+    }
+
+    void deserialize_and_append_batch_nullable(Buffer<Slice>& srcs, size_t chunk_size, Buffer<uint8_t>& is_nulls,
+                                               bool& has_null) override {
+        is_nulls.reserve(is_nulls.size() + chunk_size);
+        for (size_t i = 0; i < chunk_size; ++i) {
+            bool null;
+            memcpy(&null, srcs[i].data, sizeof(bool));
+            srcs[i].data += sizeof(bool);
+            is_nulls.emplace_back(null);
+
+            if (null == 0) {
+                srcs[i].data = (char*)mutable_derived()->deserialize_and_append((uint8_t*)srcs[i].data);
+            } else {
+                has_null = true;
+                mutable_derived()->append_default();
+            }
+        }
     }
 };
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -334,9 +334,7 @@ const uint8_t* NullableColumn::deserialize_and_append(const uint8_t* pos) {
 }
 
 void NullableColumn::deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) {
-    for (size_t i = 0; i < chunk_size; ++i) {
-        srcs[i].data = (char*)deserialize_and_append((uint8_t*)srcs[i].data);
-    }
+    _data_column->deserialize_and_append_batch_nullable(srcs, chunk_size, null_column_data(), _has_null);
 }
 
 // Note: the hash function should be same with RawValue::get_hash_value_fvn


### PR DESCRIPTION
## Why I'm doing:



## What I'm doing:

- Eliminate the virtual function `NullableColumn(BinaryColumn)::serialize` by overriding `BinaryColumnBase::serialize_batch_with_null_masks`.
- Eliminate the virtual function `NullableColumn::deserialize_and_append_batch`, similar to `NullableColumn::serialize_batch`.
- Optimize the copy logic of `ConstColumn::serialize_batch`.
- Force inline `BinaryColumn::serialize` to ensure that `BinaryColumnBase`'s `serialize_batch` and `serialize_batch_with_null_masks` can be inlined for serialization.

## Test

- Dataset: SSB 100G external table. (All the columns are nullable)
- Latency
    - Before: 6.140s
    - After: 5.671s


```sql
with w1 as (
  select count(1) as cnt
  from hive_qa.ssb_100g_parquet_zlib.lineorder_flat_lo
  group by rollup(lo_shipmode, lo_partkey%100, lo_quantity%30)
)
select count(cnt) from w1;
```

CPU perf
Before:
![img_v3_02ir_8c74f2ca-d3cf-4ecf-a62c-aa6a0891674g](https://github.com/user-attachments/assets/a2a60327-4342-43c2-b9b4-9f5a51edbe26)

After:
![img_v3_02ir_0dd5ad08-01e0-4c09-8c55-d627df4aaddg](https://github.com/user-attachments/assets/4fdce340-c3f7-45dc-a915-ffaf719988a4)



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0