### PR TITLE
[BugFix] Remove the binary type constrain in HIVE_UNSUPPORTED_TYPES

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -102,7 +102,7 @@ public class ColumnTypeConverter {
     public static final String STRUCT_PATTERN = "^struct<" + COMPLEX_PATTERN + ">";
     public static final String CHAR_PATTERN = "^char\\(([0-9]+)\\)";
     public static final String VARCHAR_PATTERN = "^varchar\\(([0-9,-1]+)\\)";
-    protected static final List<String> HIVE_UNSUPPORTED_TYPES = Arrays.asList("BINARY", "UNIONTYPE");
+    protected static final List<String> HIVE_UNSUPPORTED_TYPES = Arrays.asList("UNIONTYPE");
 
     public static Type fromHiveType(String hiveType) {
         String typeUpperCase = getTypeKeyword(hiveType).toUpperCase();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
@@ -135,6 +135,10 @@ public class ColumnTypeConverterTest {
         itemType = ScalarType.createUnifiedDecimalType(4, 2);
         Assert.assertEquals(new ArrayType(new ArrayType(itemType)),
                 fromHiveTypeToArrayType("array<Array<decimal(4, 2)>>"));
+
+        itemType = ScalarType.createType(PrimitiveType.VARBINARY);
+        Assert.assertEquals(new ArrayType(itemType),
+                fromHiveTypeToArrayType("array<BINARY>"));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
1. Currently the SR already supported the binary type for Hive.
2. If we do not remove the binary type constrain in `HIVE_UNSUPPORTED_TYPES` we may have the following issue.
When we query some table that have the column like `user_attributes:array<struct<key:string,value:binary>>` the user_attributes will be regraded as `UNKNOWN_TYPE`.
And then as for the backend we will got the fatal log like the following:
![image](https://github.com/user-attachments/assets/bd2ffcd9-651c-4e6e-bd6b-afa3d94a60e4)
## What I'm doing:
Remove the he binary type constrain in `HIVE_UNSUPPORTED_TYPES`
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0