### PR TITLE
[Enhancement] Try catch the memory alloc of Aggregator::compute_batch_agg_states

### DIFF
--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -85,12 +85,11 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
         size_t chunk_size = chunk->num_rows();
         {
             SCOPED_TIMER(_aggregator->agg_compute_timer());
+            TRY_CATCH_ALLOC_SCOPE_START()
             if (!_aggregator->is_none_group_by_exprs()) {
-                TRY_CATCH_ALLOC_SCOPE_START()
                 _aggregator->build_hash_map(chunk_size, agg_group_by_with_limit);
 
                 _aggregator->try_convert_to_two_level_map();
-                TRY_CATCH_ALLOC_SCOPE_END()
             }
             if (_aggregator->is_none_group_by_exprs()) {
                 RETURN_IF_ERROR(_aggregator->compute_single_agg_state(chunk.get(), chunk_size));
@@ -108,6 +107,7 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
                     RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk.get(), chunk_size));
                 }
             }
+            TRY_CATCH_ALLOC_SCOPE_END()
 
             _aggregator->update_num_input_rows(chunk_size);
         }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -105,14 +105,16 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_force_streaming(const Chun
 Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(const ChunkPtr& chunk,
                                                                            const size_t chunk_size) {
     SCOPED_TIMER(_aggregator->agg_compute_timer());
-    TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
+    TRY_CATCH_ALLOC_SCOPE_START();
+    _aggregator->build_hash_map(chunk_size);
     if (_aggregator->is_none_group_by_exprs()) {
         RETURN_IF_ERROR(_aggregator->compute_single_agg_state(chunk.get(), chunk_size));
     } else {
         RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk.get(), chunk_size));
     }
 
-    TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
+    _aggregator->try_convert_to_two_level_map();
+    TRY_CATCH_ALLOC_SCOPE_END();
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
     return Status::OK();
@@ -121,9 +123,10 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(const
 Status AggregateStreamingSinkOperator::_push_chunk_by_selective_preaggregation(const ChunkPtr& chunk,
                                                                                const size_t chunk_size,
                                                                                bool need_build) {
+    TRY_CATCH_ALLOC_SCOPE_START();
     if (need_build) {
         SCOPED_TIMER(_aggregator->agg_compute_timer());
-        TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map_with_selection(chunk_size));
+        _aggregator->build_hash_map_with_selection(chunk_size);
     }
 
     size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection());
@@ -151,6 +154,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_selective_preaggregation(c
             _aggregator->offer_chunk_to_buffer(res);
         }
     }
+    TRY_CATCH_ALLOC_SCOPE_END();
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
     return Status::OK();
 }
@@ -182,14 +186,16 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const ChunkPtr& chunk
                                                           _aggregator->hash_map_variant().size())) {
             // hash table is not full or allow to expand the hash table according reduction rate
             SCOPED_TIMER(_aggregator->agg_compute_timer());
-            TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_map(chunk_size));
+            TRY_CATCH_ALLOC_SCOPE_START()
+            _aggregator->build_hash_map(chunk_size);
             if (_aggregator->is_none_group_by_exprs()) {
                 RETURN_IF_ERROR(_aggregator->compute_single_agg_state(chunk.get(), chunk_size));
             } else {
                 RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk.get(), chunk_size));
             }
 
-            TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
+            _aggregator->try_convert_to_two_level_map();
+            TRY_CATCH_ALLOC_SCOPE_END()
 
             COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
             break;

--- a/be/src/exprs/agg/aggregate_state_allocator.h
+++ b/be/src/exprs/agg/aggregate_state_allocator.h
@@ -88,8 +88,9 @@ template <typename T>
 using HashSetWithAggStateAllocator =
         phmap::flat_hash_set<T, StdHash<T>, phmap::priv::hash_default_eq<T>, AggregateStateAllocator<T>>;
 
-using SliceHashSetWithAggStateAllocator = phmap::flat_hash_set<SliceWithHash, HashOnSliceWithHash, EqualOnSliceWithHash,
-                                                               AggregateStateAllocator<SliceWithHash>>;
+using SliceHashSetWithAggStateAllocator =
+        phmap::parallel_flat_hash_set<SliceWithHash, HashOnSliceWithHash, EqualOnSliceWithHash,
+                                      AggregateStateAllocator<SliceWithHash>>;
 
 template <typename T>
 using VectorWithAggStateAllocator = std::vector<T, AggregateStateAllocator<T>>;

--- a/be/src/exprs/agg/aggregate_state_allocator.h
+++ b/be/src/exprs/agg/aggregate_state_allocator.h
@@ -88,9 +88,8 @@ template <typename T>
 using HashSetWithAggStateAllocator =
         phmap::flat_hash_set<T, StdHash<T>, phmap::priv::hash_default_eq<T>, AggregateStateAllocator<T>>;
 
-using SliceHashSetWithAggStateAllocator =
-        phmap::parallel_flat_hash_set<SliceWithHash, HashOnSliceWithHash, EqualOnSliceWithHash,
-                                      AggregateStateAllocator<SliceWithHash>>;
+using SliceHashSetWithAggStateAllocator = phmap::flat_hash_set<SliceWithHash, HashOnSliceWithHash, EqualOnSliceWithHash,
+                                                               AggregateStateAllocator<SliceWithHash>>;
 
 template <typename T>
 using VectorWithAggStateAllocator = std::vector<T, AggregateStateAllocator<T>>;


### PR DESCRIPTION
## Why I'm doing:

For `multi_distinct_count` or some other array aggr function, `deserialize_and_merge` may allocate a large amount of memory at once, sometimes it causes BE oom, so we better use the`TRY_CATCH_BAD_ALLOC` to ensure that memory is checked first and then allocate.

```
W0819 19:43:47.005649 51862 mem_hook.cpp:253] large memory alloc, is_catched: 0 query_id:3922a21c-5e20-11ef-950b-00163e3e1da6 instance: 3922a21c-5e20-11ef-950b-00163e3e1dd8 acquire:1677721592 bytes, stack:
    @          0x2b45f1b  malloc
    @          0x831a1e5  operator new()
    @          0x39869cd  phmap::priv::raw_hash_set<>::resize()
    @          0x3986ed3  phmap::priv::raw_hash_set<>::prepare_insert()
    @          0x41539e6  starrocks::DistinctAggregateState<>::deserialize_and_merge()
    @          0x4153c01  starrocks::TDistinctAggregateFunction<>::merge()
    @          0x4092814  starrocks::NullableAggregateFunctionUnary<>::merge_batch()
    @          0x372e50c  starrocks::Aggregator::compute_batch_agg_states()
    @          0x36367a5  starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk()
    @          0x3602123  starrocks::pipeline::PipelineDriver::process()
    @          0x35f3cee  starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x2c1488c  starrocks::ThreadPool::dispatch_thread()
    @          0x2c0e50a  starrocks::Thread::supervise_thread()
    @     0x7fcf28782ea5  start_thread
    @     0x7fcf284abb0d  __clone
    @              (nil)  (unknown)
```

## What I'm doing:

Try catch the memory alloc of `Aggregator::compute_batch_agg_states`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0