### PR TITLE
[Enhancement] Add exception safe interface for AggregateFunction

### DIFF
--- a/be/src/exprs/agg/bitmap_agg.h
+++ b/be/src/exprs/agg/bitmap_agg.h
@@ -30,6 +30,8 @@ public:
     using InputColumnType = RunTimeColumnType<LT>;
     using InputCppType = RunTimeCppType<LT>;
 
+    bool is_exception_safe() const override { return false; }
+
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
         const auto* col = down_cast<const InputColumnType*>(columns[0]);
         auto value = col->get_data()[row_num];

--- a/be/src/exprs/agg/bitmap_intersect.h
+++ b/be/src/exprs/agg/bitmap_intersect.h
@@ -31,6 +31,8 @@ struct BitmapValuePacked {
 class BitmapIntersectAggregateFunction final
         : public AggregateFunctionBatchHelper<BitmapValuePacked, BitmapIntersectAggregateFunction> {
 public:
+    bool is_exception_safe() const override { return false; }
+
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
         const auto* col = down_cast<const BitmapColumn*>(columns[0]);
         if (!this->data(state).initial) {

--- a/be/src/exprs/agg/bitmap_union.h
+++ b/be/src/exprs/agg/bitmap_union.h
@@ -25,6 +25,8 @@ namespace starrocks {
 class BitmapUnionAggregateFunction final
         : public AggregateFunctionBatchHelper<BitmapValue, BitmapUnionAggregateFunction> {
 public:
+    bool is_exception_safe() const override { return false; }
+
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
         const auto* col = down_cast<const BitmapColumn*>(columns[0]);
         this->data(state) |= *(col->get_object(row_num));

--- a/be/src/exprs/agg/bitmap_union_count.h
+++ b/be/src/exprs/agg/bitmap_union_count.h
@@ -25,6 +25,8 @@ namespace starrocks {
 class BitmapUnionCountAggregateFunction final
         : public AggregateFunctionBatchHelper<BitmapValue, BitmapUnionCountAggregateFunction> {
 public:
+    bool is_exception_safe() const override { return false; }
+
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         this->data(state).clear();
     }

--- a/be/src/exprs/agg/bitmap_union_int.h
+++ b/be/src/exprs/agg/bitmap_union_int.h
@@ -28,6 +28,9 @@ class BitmapUnionIntAggregateFunction final
         : public AggregateFunctionBatchHelper<BitmapValue, BitmapUnionIntAggregateFunction<LT, T>> {
 public:
     using InputColumnType = RunTimeColumnType<LT>;
+
+    bool is_exception_safe() const override { return false; }
+
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
         DCHECK((*columns[0]).is_numeric());
         if constexpr (std::is_integral_v<T>) {

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -41,6 +41,8 @@ class JavaUDAFAggregateFunction : public AggregateFunction {
 public:
     using State = JavaUDAFState;
 
+    bool is_exception_safe() const override { return false; }
+
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state, size_t row_num) const final {
         CHECK(false) << "unreadable path";
     }

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -101,6 +101,8 @@ class NullableAggregateFunctionBase : public AggregateFunctionStateHelper<State>
     static constexpr bool is_result_always_nullable = !std::is_same_v<AggNullPred, AggNonNullPred<NestedState>>;
 
 public:
+    bool is_exception_safe() const override { return nested_function->is_exception_safe(); }
+
     explicit NullableAggregateFunctionBase(NestedAggregateFunctionPtr nested_function_,
                                            AggNullPred null_pred = AggNullPred())
             : nested_function(std::move(nested_function_)), null_pred(std::move(null_pred)) {}


### PR DESCRIPTION
## Why I'm doing:

Some aggregate function will allocate a large of memory at once when update or merge, so we should first check memory limit and then allocate, But this requires aggregate function to be exception, so a new interface needs to be added to handle this scenario.

## What I'm doing:

Add exception safe interface for AggregateFunction

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0