### PR TITLE
[BugFix] Fix NPE due to old partition fields not being removed in IcebergScanNode.getPartitionKey after Iceberg table partition fields modification

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -216,6 +216,7 @@ public class IcebergScanNode extends ScanNode {
                 BiMap<Integer, PartitionField> indexToField = getIdentityPartitions(task.spec());
                 if (!indexToField.isEmpty()) {
                     List<Integer> partitionSlotIds = task.spec().fields().stream()
+                            .filter(x -> indexToField.inverse().get(x) != null)
                             .map(x -> desc.getColumnSlot(x.name()))
                             .filter(Objects::nonNull)
                             .map(SlotDescriptor::getId)
@@ -224,6 +225,7 @@ public class IcebergScanNode extends ScanNode {
                     List<Integer> indexes = task.spec().fields().stream()
                             .filter(x -> desc.getColumnSlot(x.name()) != null)
                             .map(x -> indexToField.inverse().get(x))
+                            .filter(Objects::nonNull)
                             .collect(Collectors.toList());
                     PartitionKey partitionKey = getPartitionKey(partition, task.spec(), indexes, indexToField);
 


### PR DESCRIPTION
## Why I'm doing:
A `NullPointerException` occurred because the `getPartitionKey` method in the `IcebergScanNode` class did not properly remove old partition fields after modifying the partition fields of an Iceberg table. 
```
2025-01-21 17:08:20.156+08:00 WARN (starrocks-mysql-nio-pool-685|45750) [StmtExecutor.execute():753] execute Exception, sql SELECT   * FROM   columbus_dx.fo
rmatted_risk_log_iceberg WHERE   dt = '2025-01-21' LIMIT   10
java.lang.NullPointerException: null
        at com.starrocks.planner.IcebergScanNode.lambda$getPartitionKey$0(IcebergScanNode.java:154) ~[starrocks-fe.jar:?]
        at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
        at com.starrocks.planner.IcebergScanNode.IcebergScanNode(IcebergScanNode.java:152) ~[starrocks-fe.jar:?]
        at com.starrocks.planner.IcebergScanNode.setupScanRangeLocations(IcebergScanNode.java:228) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalIcebergScan(PlanFragmentBuilder.java:1394) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalIcebergScan(PlanFragmentBuilder.java:412) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergScanOperator.accept(PhysicalIcebergScanOperator.java:50) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visit(PlanFragmentBuilder.java:460) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalDistribution(PlanFragmentBuilder.java:2306) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalDistribution(PlanFragmentBuilder.java:412) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator.accept(PhysicalDistributionOperator.java:75) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visit(PlanFragmentBuilder.java:460) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalLimit(PlanFragmentBuilder.java:3216) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalLimit(PlanFragmentBuilder.java:412) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.physical.PhysicalLimitOperator.accept(PhysicalLimitOperator.java:58) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visit(PlanFragmentBuilder.java:460) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.translate(PlanFragmentBuilder.java:425) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder.createPhysicalPlan(PlanFragmentBuilder.java:240) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:336) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:133) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:92) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:549) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:361) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:556) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:890) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
