### PR TITLE
[BugFix] Fix bugs for iceberg rest catalog

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -342,6 +342,13 @@ under the License.
             <version>${iceberg.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5 -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.4.1</version>
+        </dependency>
+
         <dependency>
             <groupId>io.delta</groupId>
             <artifactId>delta-kernel-api</artifactId>

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -192,6 +192,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return delegate.createView(connectorViewDefinition, replace);
     }
 
+    @Override
     public boolean dropView(String dbName, String viewName) {
         return delegate.dropView(dbName, viewName);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -183,7 +183,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public List<String> listTables(String dbName) {
         Namespace ns = convertDbNameToNamespace(dbName);
-        List<TableIdentifier> tableIdentifiers = delegate.listTables(ns);
+        List<TableIdentifier> tableIdentifiers = new ArrayList<>(delegate.listTables(ns));
         List<TableIdentifier> viewIdentifiers = new ArrayList<>();
         try {
             viewIdentifiers = delegate.listViews(ns);
@@ -246,8 +246,9 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         return true;
     }
 
-    public boolean dropView(Namespace ns, String viewName) {
-        return delegate.dropView(TableIdentifier.of(ns, viewName));
+    @Override
+    public boolean dropView(String dbName, String viewName) {
+        return delegate.dropView(TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -16,22 +16,75 @@
 package com.starrocks.connector.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergView;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.ast.ColWithComment;
+import com.starrocks.sql.ast.CreateViewStmt;
+import com.starrocks.sql.ast.DropTableStmt;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.BaseView;
+import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
+
+import static com.starrocks.catalog.Table.TableType.ICEBERG_VIEW;
+import static com.starrocks.catalog.Type.INT;
+import static com.starrocks.connector.iceberg.IcebergCatalogProperties.HIVE_METASTORE_URIS;
+import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CATALOG_TYPE;
 
 public class IcebergRESTCatalogTest {
+    private static final String CATALOG_NAME = "iceberg_rest_catalog";
+    public static final IcebergCatalogProperties DEFAULT_CATALOG_PROPERTIES;
+    public static final Map<String, String> DEFAULT_CONFIG = new HashMap<>();
+    public static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
+
+    static {
+        DEFAULT_CONFIG.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732"); // non-exist ip, prevent to connect local service
+        DEFAULT_CONFIG.put(ICEBERG_CATALOG_TYPE, "hive");
+        DEFAULT_CATALOG_PROPERTIES = new IcebergCatalogProperties(DEFAULT_CONFIG);
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+    }
+
+    public IcebergMetadata buildIcebergMetadata(RESTCatalog restCatalog) {
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(restCatalog, new Configuration());
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(
+                CATALOG_NAME, icebergRESTCatalog, DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+
+        return new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, cachingIcebergCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(),
+                new IcebergCatalogProperties(DEFAULT_CONFIG));
+    }
+
     @Test
     public void testListAllDatabases(@Mocked RESTCatalog restCatalog) {
         new Expectations() {
@@ -76,5 +129,108 @@ public class IcebergRESTCatalogTest {
         icebergRESTCatalog.renameTable("db", "tb1", "tb2");
         boolean exists = icebergRESTCatalog.tableExists("db", "tbl2");
         Assert.assertTrue(exists);
+    }
+
+    @Test
+    public void testShowTableVies(@Mocked RESTCatalog restCatalog) {
+        IcebergMetadata metadata = buildIcebergMetadata(restCatalog);
+
+        new Expectations() {
+            {
+                restCatalog.listTables((Namespace) any);
+                result = ImmutableList.of(TableIdentifier.of("db", "tbl1"));
+                minTimes = 1;
+
+                restCatalog.listViews((Namespace) any);
+                result = ImmutableList.of(TableIdentifier.of("db", "view1"));
+                minTimes = 1;
+            }
+        };
+
+        List<String> tables = metadata.listTableNames("db");
+        Assert.assertEquals(2, tables.size());
+        Assert.assertEquals(tables, Lists.newArrayList("tbl1", "view1"));
+    }
+
+    @Test
+    public void testDropView(@Mocked RESTCatalog restCatalog) {
+        IcebergMetadata metadata = buildIcebergMetadata(restCatalog);
+        new MockUp<IcebergMetadata>() {
+            @Mock
+            Table getTable(String dbName, String tblName) {
+                return new IcebergView(1, "iceberg_rest_catalog", "db", "view",
+                        Lists.newArrayList(), "mocked", "iceberg_rest_catalog", "db",
+                        "location");
+            }
+        };
+
+        new Expectations() {
+            {
+                restCatalog.dropView((TableIdentifier) any);
+                result = true;
+                minTimes = 1;
+            }
+        };
+
+        metadata.dropTable(new DropTableStmt(false, new TableName("catalog", "db", "view"), false));
+    }
+
+    @Test
+    public void testCreateView(@Mocked RESTCatalog restCatalog, @Mocked BaseView baseView,
+                               @Mocked ImmutableSQLViewRepresentation representation) throws Exception {
+        IcebergMetadata metadata = buildIcebergMetadata(restCatalog);
+
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata(Namespace.of("db"));
+                result = ImmutableMap.of("location", "xxxxx");
+                minTimes = 1;
+
+                restCatalog.name();
+                result = "rest_catalog";
+                minTimes = 1;
+            }
+        };
+
+        CreateViewStmt stmt = new CreateViewStmt(false, false, new TableName("catalog", "db", "table"),
+                Lists.newArrayList(new ColWithComment("k1", "", NodePosition.ZERO)), "", false, null, NodePosition.ZERO);
+        stmt.setColumns(Lists.newArrayList(new Column("k1", INT)));
+        metadata.createView(stmt);
+
+        new Expectations() {
+            {
+                representation.sql();
+                result = "select * from table";
+                minTimes = 1;
+
+                baseView.sqlFor("starrocks");
+                result = representation;
+                minTimes = 1;
+
+                baseView.properties();
+                result = ImmutableMap.of("comment", "mocked");
+                minTimes = 1;
+
+                baseView.schema();
+                result = new Schema(Types.NestedField.optional(1, "k1", Types.IntegerType.get()));
+                minTimes = 1;
+
+                baseView.name();
+                result = "view";
+                minTimes = 1;
+
+                baseView.location();
+                result = "xxx";
+                minTimes = 1;
+
+                restCatalog.loadView(TableIdentifier.of("db", "view"));
+                result = baseView;
+                minTimes = 1;
+            }
+        };
+
+        Table table = metadata.getView("db", "view");
+        Assert.assertEquals(ICEBERG_VIEW, table.getType());
+        Assert.assertEquals("xxx", table.getTableLocation());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
fix some bugs for iceberg rest catalog
### **1. can not query resy catalog and throw exceprion like this**
```
StarRocks>show databases from iceberg_rest;
ERROR 1064 (HY000): Could not initialize class org.apache.hc.client5.http.impl.io.ManagedHttpClientConnectionFactory
```
this is because starrocks upgrade iceberg to 1.7.1
### **2. can not show tables and drop view**
![image](https://github.com/user-attachments/assets/528a12cd-3799-4b67-b76f-69d52d374476)


## What I'm doing:
1. add dependency
2. use lmutable list
3. rest catalog drop view override the default exception

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0