### PR TITLE
[Enhancement] Hoist heavy-cost(decimal divide) upon top-n

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -50,6 +50,7 @@ import com.starrocks.sql.optimizer.rule.transformation.EliminateConstantCTERule;
 import com.starrocks.sql.optimizer.rule.transformation.EliminateSortColumnWithEqualityPredicateRule;
 import com.starrocks.sql.optimizer.rule.transformation.ForceCTEReuseRule;
 import com.starrocks.sql.optimizer.rule.transformation.GroupByCountDistinctRewriteRule;
+import com.starrocks.sql.optimizer.rule.transformation.HoistHeavyCostExprsUponTopnRule;
 import com.starrocks.sql.optimizer.rule.transformation.IcebergEqualityDeleteRewriteRule;
 import com.starrocks.sql.optimizer.rule.transformation.IcebergPartitionsTableRewriteRule;
 import com.starrocks.sql.optimizer.rule.transformation.JoinLeftAsscomRule;
@@ -533,6 +534,7 @@ public class QueryOptimizer extends Optimizer {
         // otherwise the Node containing limit may be prune
         scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.MERGE_LIMIT_RULES);
         scheduler.rewriteIterative(tree, rootTaskContext, new PushDownProjectLimitRule());
+        scheduler.rewriteIterative(tree, rootTaskContext, new HoistHeavyCostExprsUponTopnRule());
 
         scheduler.rewriteOnce(tree, rootTaskContext, new PushDownLimitRankingWindowRule());
         rewriteGroupingSets(tree, rootTaskContext, sessionVariable);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
@@ -210,6 +210,7 @@ public enum RuleType {
     TF_PREDICATE_PROPAGATE,
 
     TF_VECTOR_REWRITE_RULE,
+    TF_HOIST_HEAVY_COST_UPON_TOPN,
 
     // The following are implementation rules:
     IMPLEMENTATION_RULES,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/HoistHeavyCostExprsUponTopnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/HoistHeavyCostExprsUponTopnRule.java
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.ArithmeticExpr;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.Ordering;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class HoistHeavyCostExprsUponTopnRule extends TransformationRule {
+    public HoistHeavyCostExprsUponTopnRule() {
+        super(RuleType.TF_HOIST_HEAVY_COST_UPON_TOPN,
+                Pattern.create(OperatorType.LOGICAL_TOPN, OperatorType.LOGICAL_PROJECT));
+    }
+
+    private boolean isHeavyCost(ScalarOperator op) {
+        if (op instanceof CallOperator) {
+            CallOperator call = op.cast();
+            if (call.getFnName().equals(ArithmeticExpr.Operator.DIVIDE.getName()) && (
+                    call.getType().getPrimitiveType().equals(PrimitiveType.LARGEINT) ||
+                            call.getType().getPrimitiveType().equals(PrimitiveType.DECIMAL128))) {
+                return true;
+            }
+        }
+        return op.getChildren().stream().anyMatch(this::isHeavyCost);
+    }
+
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        LogicalTopNOperator topnOp = input.getOp().cast();
+        if (topnOp.getPartitionByColumns() != null && !topnOp.getPartitionByColumns().isEmpty()) {
+            return false;
+        }
+        if (topnOp.getPredicate() != null || topnOp.getLimit() < 0) {
+            return false;
+        }
+        OptExpression child = input.inputAt(0);
+        Set<ColumnRefOperator> heavyCostColumnRefs = child.getRowOutputInfo().getColumnRefMap().entrySet()
+                .stream()
+                .filter(e -> isHeavyCost(e.getValue()))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+
+        if (heavyCostColumnRefs.isEmpty()) {
+            return false;
+        }
+
+        boolean isUsedByPredicate = Optional.ofNullable(child.getOp().getPredicate())
+                .map(pred -> pred.getUsedColumns().containsAny(heavyCostColumnRefs))
+                .orElse(false);
+
+        if (isUsedByPredicate) {
+            return false;
+        }
+
+        Set<ColumnRefOperator> orderByColumnRefs = topnOp.getOrderByElements().stream()
+                .map(Ordering::getColumnRef)
+                .collect(Collectors.toSet());
+
+        ColumnRefSet heavyColumnUsedAsOrderBy = ColumnRefSet.of();
+        heavyColumnUsedAsOrderBy.union(orderByColumnRefs);
+        ColumnRefSet heavyCostColumnRefSet = ColumnRefSet.of();
+        heavyCostColumnRefSet.union(heavyCostColumnRefs);
+        heavyColumnUsedAsOrderBy.intersect(heavyCostColumnRefSet);
+        return heavyColumnUsedAsOrderBy.isEmpty();
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalTopNOperator topnOp = input.getOp().cast();
+        OptExpression child = input.inputAt(0);
+        Map<Boolean, Map<ColumnRefOperator, ScalarOperator>> columnRefMaps =
+                child.getRowOutputInfo().getColumnRefMap().entrySet()
+                        .stream()
+                        .collect(Collectors.partitioningBy(e -> isHeavyCost(e.getValue()),
+                                Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+        Map<ColumnRefOperator, ScalarOperator> heavyCostColumnRefMap = columnRefMaps.get(true);
+        Map<ColumnRefOperator, ScalarOperator> childColumnRefMap = columnRefMaps.get(false);
+
+        Set<ColumnRefOperator> usedColumnRefs = heavyCostColumnRefMap.values().stream()
+                .map(ScalarOperator::getColumnRefs)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
+        if (!childColumnRefMap.keySet().containsAll(usedColumnRefs)) {
+            return Collections.emptyList();
+        }
+
+        Map<ColumnRefOperator, ScalarOperator> topnColumnRefMap = input.getRowOutputInfo().getColumnRefMap();
+        topnColumnRefMap.putAll(columnRefMaps.get(true));
+        LogicalProjectOperator projectOp = child.getOp().cast();
+
+        Operator newProjectOp = LogicalProjectOperator.builder().withOperator(projectOp)
+                .setColumnRefMap(childColumnRefMap)
+                .build();
+
+        OptExpression newChild = OptExpression.builder().setOp(newProjectOp).setInputs(child.getInputs()).build();
+        Operator upperProjectOp = LogicalProjectOperator.builder()
+                .setColumnRefMap(topnColumnRefMap).build();
+
+        OptExpression newTopn =
+                OptExpression.builder().setOp(topnOp).setInputs(Lists.newArrayList(newChild)).build();
+
+        return Collections.singletonList(OptExpression.create(upperProjectOp, newTopn));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HoistHeavyCostExprsUponTopnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HoistHeavyCostExprsUponTopnTest.java
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.sql.plan.PlanTestNoneDBBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class HoistHeavyCostExprsUponTopnTest extends PlanTestNoneDBBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestNoneDBBase.beforeClass();
+        starRocksAssert.withDatabase("test_db0").useDatabase("test_db0");
+        String createTableSql = "CREATE TABLE t0 (\n" +
+                "    EventDate DATE NOT NULL,\n" +
+                "    UserID STRING NOT NULL,\n" +
+                "    M0 DECIMAL(20,2),\n" +
+                "    M1 DECIMAL(20,2),\n" +
+                "    M2 LARGEINT,\n" +
+                "    M3 LARGEINT\n" +
+                ")  \n" +
+                "DUPLICATE KEY (EventDate)\n" +
+                "DISTRIBUTED BY HASH(UserID) BUCKETS 1\n" +
+                "PROPERTIES ( \"replication_num\"=\"1\");";
+        starRocksAssert.withTable(createTableSql);
+    }
+
+    @Test
+    public void testDecimalDivExprHoisted() throws Exception {
+        String sql = "select M1, M0, M0/M1\n" +
+                "from t0\n" +
+                "order by EventDate\n" +
+                "limit 10 offset 20";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(connectContext, sql);
+        assertCContains(plan, "  3:Project\n" +
+                "  |  output columns:\n" +
+                "  |  3 <-> [3: M0, DECIMAL128(20,2), true]\n" +
+                "  |  4 <-> [4: M1, DECIMAL128(20,2), true]\n" +
+                "  |  7 <-> [3: M0, DECIMAL128(20,2), true] / [4: M1, DECIMAL128(20,2), true]\n" +
+                "  |  limit: 10\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  2:MERGING-EXCHANGE");
+    }
+
+    @Test
+    public void testDecimalDivExprNotHoisted() throws Exception {
+        String sql = "select M1, M0/M1\n" +
+                "from t0\n" +
+                "order by EventDate\n" +
+                "limit 10 offset 20";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(connectContext, sql);
+        assertCContains(plan, "  1:Project\n" +
+                "  |  output columns:\n" +
+                "  |  1 <-> [1: EventDate, DATE, false]\n" +
+                "  |  4 <-> [4: M1, DECIMAL128(20,2), true]\n" +
+                "  |  7 <-> [3: M0, DECIMAL128(20,2), true] / [4: M1, DECIMAL128(20,2), true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+    }
+
+    @Test
+    public void testLargeInt128DivHoisted() throws Exception {
+        String sql = "select M2, M3, M2/M3\n" +
+                "from t0\n" +
+                "order by EventDate\n" +
+                "limit 10 offset 20";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(connectContext, sql);
+        assertCContains(plan, "  1:Project\n" +
+                "  |  output columns:\n" +
+                "  |  1 <-> [1: EventDate, DATE, false]\n" +
+                "  |  5 <-> [5: M2, LARGEINT, true]\n" +
+                "  |  6 <-> [6: M3, LARGEINT, true]\n" +
+                "  |  7 <-> cast([5: M2, LARGEINT, true] as DOUBLE) / cast([6: M3, LARGEINT, true] as DOUBLE)\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPushAggTest.java
@@ -81,11 +81,11 @@ public class TPCDSPushAggTest extends TPCDS1TTestBase {
         connectContext.getSessionVariable().setCboPushDownAggregateMode(1);
         String sql = getTPCDS("Q58");
         String plan = getCostExplain(sql);
-        assertContains(plan, "|----5:EXCHANGE\n" +
+        assertContains(plan, "  |----5:EXCHANGE\n" +
                 "  |       distribution type: BROADCAST\n" +
                 "  |       cardinality: 73049\n" +
                 "  |       probe runtime filters:\n" +
-                "  |       - filter_id = 3, probe_expr = (48: d_date)");
+                "  |       - filter_id = 3, probe_expr = (191: d_date)");
     }
 
     //    @ParameterizedTest(name = "{0}")


### PR DESCRIPTION
## Why I'm doing:
decimal divide is time-consuming, so if it is below top-n operator,  it is evaluated on too many rows, we can hoist it upon
top-n to make decimal divide evaluate on several rows.

1. we create a lineorder2 from ssb_100g.lineorder

```
CREATE TABLE `lineorder2` (
  `lo_orderkey` int(11) NOT NULL COMMENT "",
  `lo_linenumber` int(11) NOT NULL COMMENT "",
  `lo_custkey` int(11) NOT NULL COMMENT "",
  `lo_partkey` int(11) NOT NULL COMMENT "",
  `lo_suppkey` int(11) NOT NULL COMMENT "",
  `lo_orderdate` int(11) NOT NULL COMMENT "",
  `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
  `lo_shippriority` int(11) NOT NULL COMMENT "",
  `lo_quantity` int(11) NOT NULL COMMENT "",
  `lo_extendedprice` decimal(19,0) NOT NULL COMMENT "",
  `lo_ordtotalprice` decimal(19,0) NOT NULL COMMENT "",
  `lo_discount` decimal(19,0) NOT NULL COMMENT "",
  `lo_revenue` decimal(19,0) NOT NULL COMMENT "",
  `lo_supplycost` int(11) NOT NULL COMMENT "",
  `lo_tax` int(11) NOT NULL COMMENT "",
  `lo_commitdate` int(11) NOT NULL COMMENT "",
  `lo_shipmode` varchar(11) NOT NULL COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`lo_orderkey`)
COMMENT "OLAP"
PARTITION BY RANGE(`lo_orderdate`)
(PARTITION p1 VALUES [("-2147483648"), ("19930101")),
PARTITION p2 VALUES [("19930101"), ("19940101")),
PARTITION p3 VALUES [("19940101"), ("19950101")),
PARTITION p4 VALUES [("19950101"), ("19960101")),
PARTITION p5 VALUES [("19960101"), ("19970101")),
PARTITION p6 VALUES [("19970101"), ("19980101")),
PARTITION p7 VALUES [("19980101"), ("19990101")))
DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48 
PROPERTIES (
"colocate_with" = "groupa1",
"compression" = "LZ4",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
);

insert into lineorder2 select * from lineorder;
```

2. test q0(hoisted) and q1(non-hosited), the former(0.077s) speed up 3.3X contrasting with the latter(0.256)

```
-- q0  hosited
select lo_custkey,lo_extendedprice,lo_ordtotalprice,lo_extendedprice/lo_ordtotalprice from lineorder2 order by lo_custkey limit 100;

-- q1 non-hoisted
select lo_custkey,lo_extendedprice+1,lo_ordtotalprice,lo_extendedprice/lo_ordtotalprice from lineorder2 order by lo_custkey limit 100;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0