### PR TITLE
[UT]make some case sequential

### DIFF
--- a/test/sql/test_analyze_statistics/R/test_analyze_column
+++ b/test/sql/test_analyze_statistics/R/test_analyze_column
@@ -1,4 +1,4 @@
--- name: test_analyze_columnn
+-- name: test_analyze_columnn @sequential
 create database analyze_test_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_analyze_statistics/R/test_predicate_columns
+++ b/test/sql/test_analyze_statistics/R/test_predicate_columns
@@ -1,4 +1,4 @@
--- name: test_predicate_columns
+-- name: test_predicate_columns @sequential
 admin set frontend config ('enable_statistic_collect_on_first_load'='false');
 -- result:
 -- !result

--- a/test/sql/test_analyze_statistics/T/test_analyze_column
+++ b/test/sql/test_analyze_statistics/T/test_analyze_column
@@ -1,4 +1,4 @@
--- name: test_analyze_columnn
+-- name: test_analyze_columnn @sequential
 create database analyze_test_${uuid0};
 use analyze_test_${uuid0};
 

--- a/test/sql/test_analyze_statistics/T/test_predicate_columns
+++ b/test/sql/test_analyze_statistics/T/test_predicate_columns
@@ -1,4 +1,4 @@
--- name: test_predicate_columns
+-- name: test_predicate_columns @sequential
 
 
 admin set frontend config ('enable_statistic_collect_on_first_load'='false');

--- a/test/sql/test_sort/R/test_topn
+++ b/test/sql/test_sort/R/test_topn
@@ -514,10 +514,6 @@ set group_execution_min_scan_rows=1;
 insert into tlow SELECT generate_series, if (generate_series<10, null, generate_series%10), generate_series, generate_series FROM TABLE(generate_series(1,  40960));
 -- result:
 -- !result
-analyze full table tl;
--- result:
-E: (1064, 'Getting analyzing error. Detail message: Table tl is not found.')
--- !result
 select count(distinct c1) from tlow;
 -- result:
 10

--- a/test/sql/test_sort/T/test_topn
+++ b/test/sql/test_sort/T/test_topn
@@ -126,7 +126,6 @@ set io_tasks_per_scan_operator=1;
 set group_execution_min_scan_rows=1;
 
 insert into tlow SELECT generate_series, if (generate_series<10, null, generate_series%10), generate_series, generate_series FROM TABLE(generate_series(1,  40960));
-analyze full table tl;
 select count(distinct c1) from tlow;
 function: wait_global_dict_ready('c1', 'tlow')
 


### PR DESCRIPTION
## Why I'm doing:
some case changed the default behavior of statistics collection, 
but some case need statistics, if they run at the same time, some
case will fail. In my opinion, the case changed global default 
behavior should run sequentially.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0