### PR TITLE
[Enhancement] add spill info in metrics of multi_cast_local_exchange operator

### DIFF
--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
@@ -95,14 +95,16 @@ Status InMemoryMultiCastLocalExchanger::push_chunk(const ChunkPtr& chunk, int32_
     return Status::OK();
 }
 
-Status InMemoryMultiCastLocalExchanger::init_metrics(RuntimeProfile* profile) {
-    _peak_memory_usage_counter = profile->AddHighWaterMarkCounter(
-            "ExchangerPeakMemoryUsage", TUnit::BYTES,
-            RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
-    _peak_buffer_row_size_counter = profile->AddHighWaterMarkCounter(
-            "ExchangerPeakBufferRowSize", TUnit::UNIT,
-            RuntimeProfile::Counter::create_strategy(TUnit::UNIT, TCounterMergeType::SKIP_FIRST_MERGE));
-
+Status InMemoryMultiCastLocalExchanger::init_metrics(RuntimeProfile* profile, bool is_first_sink_driver) {
+    profile->add_info_string("IsSpill", "false");
+    if (is_first_sink_driver) {
+        _peak_memory_usage_counter = profile->AddHighWaterMarkCounter(
+                "ExchangerPeakMemoryUsage", TUnit::BYTES,
+                RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
+        _peak_buffer_row_size_counter = profile->AddHighWaterMarkCounter(
+                "ExchangerPeakBufferRowSize", TUnit::UNIT,
+                RuntimeProfile::Counter::create_strategy(TUnit::UNIT, TCounterMergeType::SKIP_FIRST_MERGE));
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
@@ -54,7 +54,7 @@ public:
     virtual ~MultiCastLocalExchanger() = default;
     virtual bool support_event_scheduler() const = 0;
 
-    virtual Status init_metrics(RuntimeProfile* profile) = 0;
+    virtual Status init_metrics(RuntimeProfile* profile, bool is_first_sink_driver) = 0;
 
     virtual bool can_pull_chunk(int32_t mcast_consumer_index) const = 0;
     virtual bool can_push_chunk() const = 0;
@@ -80,7 +80,7 @@ public:
     ~InMemoryMultiCastLocalExchanger() override;
     bool support_event_scheduler() const override { return true; }
 
-    Status init_metrics(RuntimeProfile* profile) override;
+    Status init_metrics(RuntimeProfile* profile, bool is_first_sink_driver) override;
     bool can_pull_chunk(int32_t mcast_consumer_index) const override;
     bool can_push_chunk() const override;
     Status push_chunk(const ChunkPtr& chunk, int32_t sink_driver_sequence) override;
@@ -130,7 +130,7 @@ public:
     ~SpillableMultiCastLocalExchanger() override = default;
     bool support_event_scheduler() const override { return false; }
 
-    Status init_metrics(RuntimeProfile* profile) override;
+    Status init_metrics(RuntimeProfile* profile, bool is_first_sink_driver) override;
     bool can_pull_chunk(int32_t mcast_consumer_index) const override;
     bool can_push_chunk() const override;
     Status push_chunk(const ChunkPtr& chunk, int32_t sink_driver_sequence) override;

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.cpp
@@ -18,9 +18,7 @@ namespace starrocks::pipeline {
 
 Status MultiCastLocalExchangeSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
-    if (_driver_sequence == 0) {
-        RETURN_IF_ERROR(_exchanger->init_metrics(_unique_metrics.get()));
-    }
+    RETURN_IF_ERROR(_exchanger->init_metrics(_unique_metrics.get(), _driver_sequence == 0));
     _exchanger->open_sink_operator();
     _exchanger->observable().attach_sink_observer(state, observer());
     return Status::OK();

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.cpp
@@ -18,6 +18,7 @@ namespace starrocks::pipeline {
 
 Status MultiCastLocalExchangeSourceOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
+    RETURN_IF_ERROR(_exchanger->init_metrics(_unique_metrics.get(), false));
     _exchanger->open_source_operator(_mcast_consumer_index);
     _exchanger->observable().attach_source_observer(state, observer());
     return Status::OK();

--- a/be/src/exec/pipeline/exchange/spillable_multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/spillable_multi_cast_local_exchange.cpp
@@ -54,8 +54,12 @@ SpillableMultiCastLocalExchanger::SpillableMultiCastLocalExchanger(RuntimeState*
     _queue = std::make_shared<MemLimitedChunkQueue>(runtime_state, consumer_number, opts);
 }
 
-Status SpillableMultiCastLocalExchanger::init_metrics(RuntimeProfile* profile) {
-    return _queue->init_metrics(profile);
+Status SpillableMultiCastLocalExchanger::init_metrics(RuntimeProfile* profile, bool is_first_sink_driver) {
+    profile->add_info_string("IsSpill", "true");
+    if (is_first_sink_driver) {
+        return _queue->init_metrics(profile);
+    }
+    return Status::OK();
 }
 
 bool SpillableMultiCastLocalExchanger::can_pull_chunk(int32_t mcast_consumer_index) const {


### PR DESCRIPTION
## Why I'm doing:
It has been hard to distinguish whether a MultiCastLocalExchange operator is a spillable operator in the profile since SpillableMultiCastLocalExchanger was implemented (#47982).

This commit aims to show spill info of the MultiCastLocalExchange operator in the profile.

## What I'm doing:
Add spill info into the UniqueMetrics of ```MultiCastLocalExchangeSinkOperator``` and ```MultiCastLocalExchangeSourceOperator```

Before:
```
// sink operator
MULTI_CAST_LOCAL_EXCHANGE_SINK
    UniqueMetrics:
         - ExchangerPeakBufferRowSize: 1.311M (1310720)
         - ExchangerPeakMemoryUsage: 91.520 MB
         - FlushIOBytes: 2.390 GB
         - FlushIOCount: 593
         - FlushIOTime: 1s967ms
         - ReadIOBytes: 21.408 GB
         - ReadIOCount: 5.268K (5268)
         - ReadIOTime: 4s871ms

// source operator
MULTI_CAST_LOCAL_EXCHANGE_SOURCE
    UniqueMetrics: 
```
Now:
```
// for sink operator
MULTI_CAST_LOCAL_EXCHANGE_SINK
    UniqueMetrics:
         - IsSpill: true
         - ExchangerPeakBufferRowSize: 1.305M (1305316)
         - ExchangerPeakMemoryUsage: 90.968 MB
         - FlushIOBytes: 750.902 MB
         - FlushIOCount: 185
         - FlushIOTime: 473.873ms
         - ReadIOBytes: 1.106 GB
         - ReadIOCount: 273
         - ReadIOTime: 195.835ms

// for source operator
MULTI_CAST_LOCAL_EXCHANGE_SOURCE
    UniqueMetrics:
         - IsSpill: true
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0