### PR TITLE
[BugFix] reset the start time before execution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeStatus.java
@@ -64,6 +64,8 @@ public interface AnalyzeStatus {
 
     LocalDateTime getEndTime();
 
+    void setStartTime(LocalDateTime endTime);
+
     void setEndTime(LocalDateTime endTime);
 
     void setStatus(StatsConstants.ScheduleStatus status);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeStatus.java
@@ -152,6 +152,11 @@ public class ExternalAnalyzeStatus implements AnalyzeStatus, Writable {
     }
 
     @Override
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    @Override
     public void setEndTime(LocalDateTime endTime) {
         this.endTime = endTime;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeStatus.java
@@ -165,6 +165,11 @@ public class NativeAnalyzeStatus implements AnalyzeStatus, Writable {
     }
 
     @Override
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    @Override
     public void setEndTime(LocalDateTime endTime) {
         this.endTime = endTime;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -180,6 +180,8 @@ public class StatisticsCollectionTrigger {
             future = GlobalStateMgr.getCurrentState().getAnalyzeMgr().getAnalyzeTaskThreadPool()
                     .submit(() -> {
                         isRunning.set(true);
+                        // reset the start time after pending, so [end-start] can represent execution period
+                        analyzeStatus.setStartTime(LocalDateTime.now());
                         StatisticExecutor statisticExecutor = new StatisticExecutor();
                         ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
                         // set session id for temporary table


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`AnalyzeStatus.StartTime` should count from the beginning of execution rather than pending. For certain cases it can pend in the queue for a long time.

Fixes #55447

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0