### PR TITLE
[Enhancement] run auto analyze job with priority

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeJob.java
@@ -195,6 +195,9 @@ public class ExternalAnalyzeJob implements AnalyzeJob, Writable {
 
         boolean hasFailedCollectJob = false;
         for (StatisticsCollectJob statsJob : jobs) {
+            if (!StatisticAutoCollector.checkoutAnalyzeTime()) {
+                break;
+            }
             AnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
                     statsJob.getCatalogName(), statsJob.getDb().getFullName(), statsJob.getTable().getName(),
                     statsJob.getTable().getUUID(), statsJob.getColumnNames(), statsJob.getType(), statsJob.getScheduleType(),

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeJob.java
@@ -223,6 +223,9 @@ public class NativeAnalyzeJob implements AnalyzeJob, Writable {
 
         boolean hasFailedCollectJob = false;
         for (StatisticsCollectJob statsJob : jobs) {
+            if (!StatisticAutoCollector.checkoutAnalyzeTime()) {
+                break;
+            }
             AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
                     statsJob.getDb().getId(), statsJob.getTable().getId(), statsJob.getColumnNames(),
                     statsJob.getType(), statsJob.getScheduleType(), statsJob.getProperties(), LocalDateTime.now());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -59,7 +59,7 @@ public class StatisticAutoCollector extends FrontendDaemon {
             return;
         }
 
-        if (!checkoutAnalyzeTime(LocalTime.now(TimeUtils.getTimeZone().toZoneId()))) {
+        if (!checkoutAnalyzeTime()) {
             return;
         }
 
@@ -106,6 +106,9 @@ public class StatisticAutoCollector extends FrontendDaemon {
             List<StatisticsCollectJob> allJobs =
                     StatisticsCollectJobFactory.buildStatisticsCollectJob(createDefaultJobAnalyzeAll());
             for (StatisticsCollectJob statsJob : allJobs) {
+                if (!checkoutAnalyzeTime()) {
+                    break;
+                }
                 // user-created analyze job has a higher priority
                 if (statsJob.isAnalyzeTable() && analyzeTableSet.contains(statsJob.getTable().getId())) {
                     continue;
@@ -170,7 +173,17 @@ public class StatisticAutoCollector extends FrontendDaemon {
                 Maps.newHashMap(), ScheduleStatus.PENDING, LocalDateTime.MIN);
     }
 
-    private boolean checkoutAnalyzeTime(LocalTime now) {
+    /**
+     * Check if it's a proper time to run auto analyze
+     *
+     * @return true if it's a good time
+     */
+    public static boolean checkoutAnalyzeTime() {
+        LocalTime now = LocalTime.now(TimeUtils.getTimeZone().toZoneId());
+        return checkoutAnalyzeTime(now);
+    }
+
+    private static boolean checkoutAnalyzeTime(LocalTime now) {
         try {
             LocalTime start = LocalTime.parse(Config.statistic_auto_analyze_start_time, DateUtils.TIME_FORMATTER);
             LocalTime end = LocalTime.parse(Config.statistic_auto_analyze_end_time, DateUtils.TIME_FORMATTER);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -294,7 +294,10 @@ public abstract class StatisticsCollectJob {
 
         @Override
         public int compare(StatisticsCollectJob o1, StatisticsCollectJob o2) {
-            return o1.getPriority().compareTo(o2.getPriority());
+            if (o1.getPriority() != null && o2.getPriority() != null) {
+                return o1.getPriority().compareTo(o2.getPriority());
+            }
+            return 0;
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -1583,4 +1583,30 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         Assert.assertTrue(cols.size() == 2);
         starRocksAssert.dropTable("test.t_gen_col");
     }
+
+    @Test
+    public void testPriorityComparison() {
+        // Test case with different health values
+        StatisticsCollectJob.Priority priority1 =
+                new StatisticsCollectJob.Priority(LocalDateTime.now(), LocalDateTime.now(), 0.5);
+        StatisticsCollectJob.Priority priority2 =
+                new StatisticsCollectJob.Priority(LocalDateTime.now(), LocalDateTime.now(), 0.6);
+        Assert.assertTrue(priority1.compareTo(priority2) < 0);
+
+        // Test case with different staleness values
+        LocalDateTime now = LocalDateTime.now();
+        StatisticsCollectJob.Priority priority3 = new StatisticsCollectJob.Priority(now, now.minusSeconds(100), 0.5);
+        StatisticsCollectJob.Priority priority4 = new StatisticsCollectJob.Priority(now, now.minusSeconds(50), 0.5);
+        Assert.assertTrue(priority3.compareTo(priority4) < 0);
+
+        // Test case with both different health and staleness values
+        StatisticsCollectJob.Priority priority5 = new StatisticsCollectJob.Priority(now, now.minusSeconds(100), 0.5);
+        StatisticsCollectJob.Priority priority6 = new StatisticsCollectJob.Priority(now, now.minusSeconds(50), 0.6);
+        Assert.assertTrue(priority5.compareTo(priority6) < 0);
+
+        // Test case with statsUpdateTime set to LocalDateTime.MIN
+        StatisticsCollectJob.Priority priority7 = new StatisticsCollectJob.Priority(now, LocalDateTime.MIN, 0.5);
+        StatisticsCollectJob.Priority priority8 = new StatisticsCollectJob.Priority(now, now.minusSeconds(10), 0.5);
+        Assert.assertTrue(priority7.compareTo(priority8) < 0);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

In case of a database with 10K+ tables, the auto analyze job can sustain for a few hours, so the job will not stop even if out of the running window.

## What I'm doing:

To address this issue, we introduce two optimizations:
1. Check the running window before analyze each table
2. Sort jobs with priority, considering the stats healthy and stats staleness

Out of scope:
1. Analyzing external tables do not support priority 
2. If analyze a single table can take a long time, it cannot be interrupted immediately

Fixes #55447

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0