### PR TITLE
[Enhancement]lazy convert for parquet

### DIFF
--- a/be/src/formats/parquet/scalar_column_reader.cpp
+++ b/be/src/formats/parquet/scalar_column_reader.cpp
@@ -16,7 +16,6 @@
 
 #include "formats/parquet/column_reader.h"
 #include "formats/parquet/stored_column_reader_with_index.h"
-#include "formats/parquet/utils.h"
 #include "formats/parquet/zone_map_filter_evaluator.h"
 #include "gutil/casts.h"
 #include "io/shared_buffered_input_stream.h"
@@ -351,26 +350,13 @@ Status ScalarColumnReader::read_range(const Range<uint64_t>& range, const Filter
             _dict_filter_ctx != nullptr || (_can_lazy_decode && filter != nullptr &&
                                             SIMD::count_nonzero(*filter) * 1.0 / filter->size() < FILTER_RATIO);
     ColumnContentType content_type = !_need_lazy_decode ? ColumnContentType::VALUE : ColumnContentType::DICT_CODE;
+    auto need_lazy_covert = _can_lazy_convert && _converter->need_convert;
     if (_need_lazy_decode) {
-        if (_dict_code == nullptr) {
-            _dict_code = ColumnHelper::create_column(
-                    TypeDescriptor::from_logical_type(ColumnDictFilterContext::kDictCodePrimitiveType), true);
-        }
-        _ori_column = dst;
-        dst = _dict_code;
-        dst->reserve(range.span_size());
-    }
-    if (!_converter->need_convert) {
-        SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
-        return _reader->read_range(range, filter, content_type, dst.get());
+        return _read_range_impl<true, false>(range, filter, content_type, dst);
+    } else if (need_lazy_covert) {
+        return _read_range_impl<false, true>(range, filter, content_type, dst);
     } else {
-        auto column = _converter->create_src_column();
-        {
-            SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
-            RETURN_IF_ERROR(_reader->read_range(range, filter, content_type, column.get()));
-        }
-        SCOPED_RAW_TIMER(&_opts.stats->column_convert_ns);
-        return _converter->convert(column, dst.get());
+        return _read_range_impl<false, false>(range, filter, content_type, dst);
     }
 }
 
@@ -399,32 +385,111 @@ bool ScalarColumnReader::try_to_use_dict_filter(ExprContext* ctx, bool is_decode
 }
 
 Status ScalarColumnReader::fill_dst_column(ColumnPtr& dst, ColumnPtr& src) {
-    if (!_need_lazy_decode) {
-        dst->swap_column(*src);
+    auto need_lazy_covert = _can_lazy_convert && _converter->need_convert;
+    if (_need_lazy_decode) {
+        return _fill_dst_column_impl<true, false>(dst, src);
+    } else if (need_lazy_covert) {
+        return _fill_dst_column_impl<false, true>(dst, src);
     } else {
-        if (_dict_filter_ctx == nullptr || _dict_filter_ctx->is_decode_needed) {
-            ColumnPtr& dict_values = dst;
-            dict_values->reserve(src->size());
+        return _fill_dst_column_impl<false, false>(dst, src);
+    }
+}
 
-            // decode dict code to dict values.
-            // note that in dict code, there could be null value.
-            const ColumnPtr& dict_codes = src;
-            auto* codes_nullable_column = ColumnHelper::as_raw_column<NullableColumn>(dict_codes);
-            auto* codes_column =
-                    ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(codes_nullable_column->data_column());
-            RETURN_IF_ERROR(
-                    _reader->get_dict_values(codes_column->get_data(), *codes_nullable_column, dict_values.get()));
-            DCHECK_EQ(dict_codes->size(), dict_values->size());
-            if (dict_values->is_nullable()) {
-                auto* nullable_values = down_cast<NullableColumn*>(dict_values.get());
-                nullable_values->swap_null_column(*codes_nullable_column);
-            }
-        } else {
-            dst->append_default(src->size());
+template <bool LAZY_DECODE, bool LAZY_CONVERT>
+Status ScalarColumnReader::_read_range_impl(const Range<uint64_t>& range, const Filter* filter,
+                                            ColumnContentType content_type, ColumnPtr& dst) {
+    if constexpr (LAZY_DECODE) {
+        if (_tmp_code_column == nullptr) {
+            _tmp_code_column = ColumnHelper::create_column(
+                    TypeDescriptor::from_logical_type(ColumnDictFilterContext::kDictCodePrimitiveType), true);
         }
+        _ori_column = dst;
+        dst = _tmp_code_column;
+        dst->reserve(range.span_size());
+        SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
+        return _reader->read_range(range, filter, content_type, dst.get());
+    } else {
+        if (!_converter->need_convert) {
+            SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
+            return _reader->read_range(range, filter, content_type, dst.get());
+        } else {
+            if (_tmp_intermediate_column == nullptr) {
+                _tmp_intermediate_column = _converter->create_src_column();
+            }
+            _tmp_intermediate_column->reserve(range.span_size());
+            {
+                SCOPED_RAW_TIMER(&_opts.stats->column_read_ns);
+                RETURN_IF_ERROR(_reader->read_range(range, filter, content_type, _tmp_intermediate_column.get()));
+            }
+            if constexpr (!LAZY_CONVERT) {
+                {
+                    SCOPED_RAW_TIMER(&_opts.stats->column_convert_ns);
+                    RETURN_IF_ERROR(_converter->convert(_tmp_intermediate_column, dst.get()));
+                }
+                _tmp_intermediate_column->reset_column();
+                return Status::OK();
+            } else {
+                _ori_column = dst;
+                dst = _tmp_intermediate_column;
+                return Status::OK();
+            }
+        }
+    }
+}
 
-        src->reset_column();
+Status ScalarColumnReader::_dict_decode(ColumnPtr& dst, ColumnPtr& src) {
+    Column* dict_values = ColumnHelper::get_data_column(dst.get());
+    dict_values->reserve(src->size());
+
+    // decode dict code to dict values.
+    // note that in dict code, there could be null value.
+    const ColumnPtr& dict_codes = src;
+    auto* codes_nullable_column = ColumnHelper::as_raw_column<NullableColumn>(dict_codes);
+    auto* codes_column = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(codes_nullable_column->data_column());
+    RETURN_IF_ERROR(_reader->get_dict_values(codes_column->get_data(), *codes_nullable_column, dict_values));
+    DCHECK_EQ(dict_codes->size(), dict_values->size());
+    if (dst->is_nullable()) {
+        auto* nullable_values = down_cast<NullableColumn*>(dst.get());
+        nullable_values->swap_null_column(*codes_nullable_column);
+    }
+    src->reset_column();
+    return Status::OK();
+}
+
+template <bool LAZY_DECODE, bool LAZY_CONVERT>
+Status ScalarColumnReader::_fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src) {
+    if constexpr (LAZY_DECODE) {
+        if (_dict_filter_ctx != nullptr && !_dict_filter_ctx->is_decode_needed) {
+            dst->append_default(src->size());
+            src->reset_column();
+        } else {
+            if constexpr (LAZY_CONVERT) {
+                if (_tmp_intermediate_column == nullptr) {
+                    _tmp_intermediate_column = _converter->create_src_column();
+                }
+                _tmp_intermediate_column->reserve(src->size());
+                RETURN_IF_ERROR(_dict_decode(_tmp_intermediate_column, src));
+                {
+                    SCOPED_RAW_TIMER(&_opts.stats->column_convert_ns);
+                    RETURN_IF_ERROR(_converter->convert(_tmp_intermediate_column, dst.get()));
+                }
+                _tmp_intermediate_column->reset_column();
+            } else {
+                RETURN_IF_ERROR(_dict_decode(dst, src));
+            }
+        }
         src = _ori_column;
+    } else {
+        if constexpr (LAZY_CONVERT) {
+            {
+                SCOPED_RAW_TIMER(&_opts.stats->column_convert_ns);
+                RETURN_IF_ERROR(_converter->convert(src, dst.get()));
+            }
+            src->reset_column();
+            src = _ori_column;
+        } else {
+            dst->swap_column(*src);
+        }
     }
     return Status::OK();
 }

--- a/be/src/formats/parquet/scalar_column_reader.h
+++ b/be/src/formats/parquet/scalar_column_reader.h
@@ -147,7 +147,7 @@ public:
 
     void set_can_lazy_decode(bool can_lazy_decode) override {
         _can_lazy_convert = can_lazy_decode;
-        _can_lazy_decode = can_lazy_decode && _col_type->is_string_type() && column_all_pages_dict_encoded();
+        _can_lazy_dict_decode = can_lazy_decode && _col_type->is_string_type() && column_all_pages_dict_encoded();
     }
 
     Status filter_dict_column(const ColumnPtr& column, Filter* filter, const std::vector<std::string>& sub_field_path,
@@ -172,11 +172,11 @@ public:
     }
 
 private:
-    template <bool LAZY_DECODE, bool LAZY_CONVERT>
+    template <bool LAZY_DICT_DECODE, bool LAZY_CONVERT>
     Status _read_range_impl(const Range<uint64_t>& range, const Filter* filter, ColumnContentType content_type,
                             ColumnPtr& dst);
 
-    template <bool LAZY_DECODE, bool LAZY_CONVERT>
+    template <bool LAZY_DICT_DECODE, bool LAZY_CONVERT>
     Status _fill_dst_column_impl(ColumnPtr& dst, ColumnPtr& src);
 
     Status _dict_decode(ColumnPtr& dst, ColumnPtr& src);
@@ -186,8 +186,8 @@ private:
     std::unique_ptr<ColumnDictFilterContext> _dict_filter_ctx;
     const TypeDescriptor* _col_type = nullptr;
 
-    // _can_lazy_decode means string type and all page dict code
-    bool _can_lazy_decode = false;
+    // _can_lazy_dict_decode means string type and all page dict code
+    bool _can_lazy_dict_decode = false;
     bool _can_lazy_convert = false;
     // we use lazy decode adaptively because of RLE && decoder may be better than filter && decoder
     static constexpr double FILTER_RATIO = 0.2;


### PR DESCRIPTION
## Why I'm doing:
converting for timestamp/decimal type costs lots of cpu, 
so we do these processes lazily.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0