### PR TITLE
[BugFix] Fix crash in RowsetUpdateStateTest.with_deletes

### DIFF
--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -684,8 +684,8 @@ Status HorizontalRowsetWriter::flush_chunk_with_deletes(const Chunk& upserts, co
             wopts.encryption_info = pair.info;
             encryption_meta = std::move(pair.encryption_meta);
         }
-        ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(Rowset::segment_del_file_path(
-                                             _context.rowset_path_prefix, _context.rowset_id, _num_delfile)));
+        auto file_path = Rowset::segment_del_file_path(_context.rowset_path_prefix, _context.rowset_id, _num_delfile);
+        ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(wopts, file_path));
         size_t sz = serde::ColumnArraySerde::max_serialized_size(deletes);
         std::vector<uint8_t> content(sz);
         if (serde::ColumnArraySerde::serialize(deletes, content.data()) == nullptr) {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -622,7 +622,7 @@ Status TabletUpdates::get_apply_version_and_rowsets(int64_t* version, std::vecto
     return Status::OK();
 }
 
-Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time,
+Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time_ms,
                                     bool is_version_overwrite, bool is_double_write) {
     auto span = Tracer::Instance().start_trace("rowset_commit");
     auto scope_span = trace::Scope(span);
@@ -699,8 +699,8 @@ Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rows
             }
             _try_commit_pendings_unlocked();
             _check_for_apply();
-            if (wait_time > 0) {
-                st = _wait_for_version(EditVersion(version, 0), wait_time, ul);
+            if (wait_time_ms > 0) {
+                st = _wait_for_version(EditVersion(version, 0), wait_time_ms, ul);
             }
         }
     }

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -153,7 +153,7 @@ public:
 
     Status get_rowsets_total_stats(const std::vector<uint32_t>& rowsets, size_t* total_rows, size_t* total_dels);
 
-    Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time,
+    Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time_ms,
                          bool is_version_overwrite = false, bool is_double_write = false);
 
     // should only called by UpdateManager's apply thread

--- a/be/test/storage/rowset_update_state_test.cpp
+++ b/be/test/storage/rowset_update_state_test.cpp
@@ -239,7 +239,7 @@ TEST_F(RowsetUpdateStateTest, with_deletes) {
     Int64Column deletes;
     deletes.append_numbers(delete_keys.data(), sizeof(int64_t) * delete_keys.size());
     RowsetSharedPtr rowset = create_rowset(_tablet, keys, &deletes);
-    auto st = _tablet->rowset_commit(2, rowset, 0);
+    auto st = _tablet->rowset_commit(2, rowset, 2000);
     ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_EQ(2, _tablet->updates()->max_version());
 }


### PR DESCRIPTION
## Why I'm doing:
```
  [ RUN      ] RowsetUpdateStateTest.with_deletes
  I20250205 03:09:59.784710 139681926142080 key_cache.cpp:327] setup root key
  I20250205 03:09:59.784723 139681926142080 key_cache.cpp:322] KEK rotated from 0 to 2
  I20250205 03:09:59.784817 139681926142080 tablet_manager.cpp:169] Creating tablet 846930886
  I20250205 03:09:59.784860 139681926142080 tablet_manager.cpp:1427] creating tablet meta. next_unique_id:3
  I20250205 03:09:59.786174 139681926142080 tablet_manager.cpp:238] Created tablet 846930886
  I20250205 03:09:59.795201 139681926142080 tablet_manager.cpp:395] Start to drop tablet 846930886
  W20250205 03:09:59.795562 139679879915072 mem_hook.cpp:103] large memory alloc, query_id:00000000-0000-0000-0000-000000000000 instance: 00000000-0000-0000-0000-000000000000 acquire:1251614328 bytes, stack:
      @         0x105f472e  starrocks::get_stack_trace[abi:cxx11]()
      @         0x1045482d  report_large_memory_alloc(unsigned long)
      @         0x10453ccc  malloc
      @          0x7509245  starrocks::AllocatorFactory<starrocks::Allocator, starrocks::MemHookAllocator>::checked_alloc(unsigned long)
      @          0x6faaddf  std::vector<long, starrocks::raw::RawAllocator<long, 0ul, starrocks::ColumnAllocator<long> > >::_M_default_append(unsigned long)
      @          0xeec4592  starrocks::ColumnVisitorMutableAdapter<starrocks::serde::(anonymous namespace)::ColumnDeserializingVisitor>::visit(starrocks::FixedLengthColumn<long>*)
      @          0x6f9f198  starrocks::ColumnFactory<starrocks::FixedLengthColumnBase<long>, starrocks::FixedLengthColumn<long>, starrocks::Column>::accept_mutable(starrocks::ColumnVisitorMutable*)
      @          0xeec0bd1  starrocks::serde::ColumnArraySerde::deserialize(unsigned char const*, starrocks::Column*, bool, int)
      @          0xf593ee8  starrocks::RowsetUpdateState::_load_deletes(starrocks::Rowset*, unsigned int, starrocks::Column*)
      @          0xf5959c0  starrocks::RowsetUpdateState::_do_load(starrocks::Tablet*, starrocks::Rowset*)
      @          0xf5962df  starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)::{lambda()#1}::operator()() const
      @          0xf5967f4  std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)::{lambda()#1}>(std::once_flag&, starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)::{la
      @     0x7f0a3b699ee8  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
      @          0xf587e1c  starrocks::RowsetUpdateState::load(starrocks::Tablet*, starrocks::Rowset*)
      @          0xf74ac9a  starrocks::TabletUpdates::_apply_normal_rowset_commit(starrocks::EditVersionInfo const&, std::shared_ptr<starrocks::Rowset> const&)
      @          0xf752cae  starrocks::TabletUpdates::_apply_rowset_commit(starrocks::EditVersionInfo const&)
      @          0xf753218  starrocks::TabletUpdates::do_apply()
      @          0xf7a2c81  starrocks::ApplyCommitTask::run()
      @         0x1064c993  starrocks::ThreadPool::dispatch_thread()
      @          0xaa13305  std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
      @         0x10640eeb  starrocks::Thread::supervise_thread(void*)
      @     0x7f0a3b694ac3  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
      @     0x7f0a3b726850  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```
## What I'm doing:

When writing del file with encryption enabled, actual key is not passed to writer, so when reading the file, corruption occours. This PR fixes this issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0