### PR TITLE
[Enhancement] Convert Trino function from_iso8601_timestamp -> timestamp

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -257,6 +257,10 @@ public class Trino2SRFunctionCallTransformer {
                                 new IntLiteral(100))
                         )
                 )));
+
+        // from_iso8601_timestamp -> timestamp
+        registerFunctionTransformer("from_iso8601_timestamp", 1, "timestamp",
+                List.of(Expr.class));
     }
 
     private static void registerStringFunctionTransformer() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -217,6 +217,12 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
         sql = "select yow('2022-02-02')";
         assertPlanContains(sql, "<slot 2> : 2022");
+
+        sql = "select from_iso8601_timestamp('2025-02-02 14:37:02')";
+        assertPlanContains(sql, "timestamp('2025-02-02 14:37:02')");
+
+        sql = "select from_iso8601_timestamp('2025-02-02')";
+        assertPlanContains(sql, "timestamp('2025-02-02')");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -218,11 +218,11 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select yow('2022-02-02')";
         assertPlanContains(sql, "<slot 2> : 2022");
 
-        sql = "select from_iso8601_timestamp(timestamp '2025-02-02 14:37:02')";
-        assertPlanContains(sql, "timestamp('2025-02-02 14:37:02')");
+        sql = "select from_iso8601_timestamp('2025-02-02 14:37:02')";
+        assertPlanContains(sql, "'2025-02-02 14:37:02'");
 
-        sql = "select from_iso8601_timestamp(timestamp '2025-02-02')";
-        assertPlanContains(sql, "timestamp('2025-02-02')");
+        sql = "select from_iso8601_timestamp('2025-02-02')";
+        assertPlanContains(sql, "'2025-02-02 00:00:00'");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -218,10 +218,10 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select yow('2022-02-02')";
         assertPlanContains(sql, "<slot 2> : 2022");
 
-        sql = "select from_iso8601_timestamp('2025-02-02 14:37:02')";
+        sql = "select from_iso8601_timestamp(timestamp '2025-02-02 14:37:02')";
         assertPlanContains(sql, "timestamp('2025-02-02 14:37:02')");
 
-        sql = "select from_iso8601_timestamp('2025-02-02')";
+        sql = "select from_iso8601_timestamp(timestamp '2025-02-02')";
         assertPlanContains(sql, "timestamp('2025-02-02')");
     }
 


### PR DESCRIPTION
## Why I'm doing:
When sql_dialect=trino, it doesn't convert Trino function from_iso8601_timestamp -> timestamp

## What I'm doing:
Convert Trino function from_iso8601_timestamp -> timestamp
![image](https://github.com/user-attachments/assets/beb7b6bf-3db4-4e80-a6ba-2217191e94a5)

Trino doc for from_iso8601_timestamp function - https://trino.io/docs/current/functions/datetime.html

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0