### PR TITLE
[BugFix] Fix show create table with fk error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/ForeignKeyConstraint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/ForeignKeyConstraint.java
@@ -259,6 +259,9 @@ public class ForeignKeyConstraint extends Constraint {
     }
 
     public static String getShowCreateTableConstraintDesc(OlapTable baseTable, List<ForeignKeyConstraint> constraints) {
+        if (CollectionUtils.isEmpty(constraints)) {
+            return "";
+        }
         List<String> constraintStrs = Lists.newArrayList();
         for (ForeignKeyConstraint constraint : constraints) {
             BaseTableInfo parentTableInfo = constraint.getParentTableInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/UniqueConstraint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/constraint/UniqueConstraint.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -112,6 +113,9 @@ public class UniqueConstraint extends Constraint {
     }
 
     public static String getShowCreateTableConstraintDesc(List<UniqueConstraint> constraints, Table selfTable) {
+        if (CollectionUtils.isEmpty(constraints)) {
+            return "";
+        }
         List<String> constraintStrs = Lists.newArrayList();
         for (UniqueConstraint constraint : constraints) {
             StringBuilder constraintSb = new StringBuilder();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ForeignKeyConstraintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ForeignKeyConstraintTest.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.api.client.util.Lists;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
+import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -309,5 +310,11 @@ public class ForeignKeyConstraintTest {
         Assert.assertEquals(1, foreignKeyConstraints1.get(0).getColumnRefPairs().size());
         Assert.assertEquals(ColumnId.create("lo_custkey"), foreignKeyConstraints1.get(0).getColumnRefPairs().get(0).first);
         Assert.assertEquals(ColumnId.create("c_custkey"), foreignKeyConstraints1.get(0).getColumnRefPairs().get(0).second);
+    }
+
+    @Test
+    public void testFKGetShowCreateTableConstraintDesc() {
+        Assert.assertEquals("", ForeignKeyConstraint.getShowCreateTableConstraintDesc(null, null));
+        Assert.assertEquals("", UniqueConstraint.getShowCreateTableConstraintDesc(null, null));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

```
2025-01-28 00:33:49.888Z ERROR (thrift-server-pool-2202|6623) [ProcessFunction.process():49] Internal error processing getTablesConfig
java.lang.NullPointerException: null
	at com.starrocks.catalog.constraint.ForeignKeyConstraint.getShowCreateTableConstraintDesc(ForeignKeyConstraint.java:239) ~[starrocks-fe.jar:?]
	at com.starrocks.catalog.OlapTable.getCommonProperties(OlapTable.java:3433) ~[starrocks-fe.jar:?]
	at com.starrocks.catalog.OlapTable.getProperties(OlapTable.java:3321) ~[starrocks-fe.jar:?]
	at com.starrocks.service.InformationSchemaDataSource.genProps(InformationSchemaDataSource.java:198) ~[starrocks-fe.jar:?]
	at com.starrocks.service.InformationSchemaDataSource.genNormalTableConfigInfo(InformationSchemaDataSource.java:247) ~[starrocks-fe.jar:?]
	at com.starrocks.service.InformationSchemaDataSource.generateTablesConfigResponse(InformationSchemaDataSource.java:179) ~[starrocks-fe.jar:?]
	at com.starrocks.service.FrontendServiceImpl.getTablesConfig(FrontendServiceImpl.java:2489) ~[starrocks-fe.jar:?]
	at com.starrocks.thrift.FrontendService$Processor$getTablesConfig.getResult(FrontendService.java:4661) ~[starrocks-fe.jar:?]
	at com.starrocks.thrift.FrontendService$Processor$getTablesConfig.getResult(FrontendService.java:4638) ~[starrocks-fe.jar:?]
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40) ~[libthrift-0.20.0.jar:0.20.0]
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40) ~[libthrift-0.20.0.jar:0.20.0]
	at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311) ~[starrocks-fe.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
```
## What I'm doing:
- `constraints` may be null if it parsed fail or not set, return empty string instead of npe.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0