### PR TITLE
[BugFix] fix nljoin with big array cause be oom

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
@@ -87,8 +87,8 @@ private:
     bool _skip_probe() const;
     void _check_post_probe() const;
     void _init_build_match() const;
-    void _permute_probe_row(const ChunkPtr& chunk);
-    ChunkPtr _permute_chunk_for_other_join(size_t chunk_size);
+    Status _permute_probe_row(const ChunkPtr& chunk);
+    StatusOr<ChunkPtr> _permute_chunk_for_other_join(size_t chunk_size);
     ChunkPtr _permute_chunk_for_inner_join(size_t chunk_size);
     void _permute_chunk_base_left(ChunkPtr* chunk);
     void _permute_chunk_base_right(ChunkPtr* chunk);


### PR DESCRIPTION
## Why I'm doing:
be oom
`Out of memory: Killed process 9053 (starrocks_be) total-vm:175313672kB, anon-rss:63211384kB, file-rss:0kB, shmem-rss:0kB, UID:1000 pgtables:197484kB oom_score_adj:0`

be.WARNING:
```
W20250206 13:59:54.425003 140042637096512 mem_hook.cpp:103] large memory alloc, query_id:95024d6e-e44f-11ef-9a27-00163e15ae91 instance: 95024d6e-e44f-11ef-9a27-00163e15ae94 acquire:1846501376 bytes, stack:
    @          0x9474835  starrocks::get_stack_trace[abi:cxx11]()
    @          0x92dca75  report_large_memory_alloc(unsigned long)
    @          0x92d8add  malloc
    @          0x5d2eef3  starrocks::AllocatorFactory<starrocks::Allocator, starrocks::MemHookAllocator>::checked_alloc(unsigned long)
    @          0x5b6985c  starrocks::FixedLengthColumnBase<int>::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x5b4b006  starrocks::NullableColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x5b8dbaf  starrocks::ArrayColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x5b4b006  starrocks::NullableColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x8170804  starrocks::pipeline::NLJoinProbeOperator::_permute_probe_row(std::shared_ptr<starrocks::Chunk> const&)
    @          0x8171c3e  starrocks::pipeline::NLJoinProbeOperator::_permute_chunk_for_other_join(unsigned long)
    @          0x8172998  starrocks::pipeline::NLJoinProbeOperator::_pull_chunk_for_other_join(unsigned long)
    @          0x8172df5  starrocks::pipeline::NLJoinProbeOperator::pull_chunk(starrocks::RuntimeState*)
    @          0x5a7dd19  starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x8fead53  starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x94b6be3  starrocks::ThreadPool::dispatch_thread()
    @          0x94ae229  starrocks::Thread::supervise_thread(void*)
    @     0x7f5ebabf1ac3  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f5ebac83850  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0