### PR TITLE
[BugFix] Fix AlterTable operator not protected by meta lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -918,7 +918,7 @@ public final class MetricRepo {
                     MetricUnit.BYTES, "total size of db in bytes") {
                 @Override
                 public Long getValue() {
-                    return db.getUsedDataQuotaWithLock();
+                    return globalStateMgr.getLocalMetastore().getUsedDataQuotaWithLock(db);
                 }
             };
             dbSizeBytesTotal.addLabel(new MetricLabel("db_name", dbName));

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -113,6 +113,7 @@ import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
@@ -806,16 +807,18 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 LOG.info("create table[{}] which already exists", tableName);
                 return false;
             }
+
+            // only internal table should check quota and cluster capacity
+            if (!stmt.isExternal()) {
+                // check cluster capacity
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkClusterCapacity();
+
+                // check db quota
+                checkDataSizeQuota(db);
+                checkReplicaQuota(db);
+            }
         } finally {
             locker.unLockDatabase(db.getId(), LockType.READ);
-        }
-
-        // only internal table should check quota and cluster capacity
-        if (!stmt.isExternal()) {
-            // check cluster capacity
-            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkClusterCapacity();
-            // check db quota
-            db.checkQuota();
         }
 
         AbstractTableFactory tableFactory = TableFactoryProvider.getFactory(stmt.getEngineName());
@@ -2751,10 +2754,16 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
         // check cluster capacity
         GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkClusterCapacity();
-        // check db quota
-        db.checkQuota();
-
         Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.READ);
+        try {
+            // check db quota
+            checkDataSizeQuota(db);
+            checkReplicaQuota(db);
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.READ);
+        }
+
         if (!locker.lockDatabaseAndCheckExist(db, LockType.WRITE)) {
             throw new DdlException("create materialized failed. database:" + db.getFullName() + " not exist");
         }
@@ -5024,6 +5033,81 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         Long oldId = tableIdToIncrementId.putIfAbsent(tableId, id);
         if (oldId != null) {
             tableIdToIncrementId.replace(tableId, id);
+        }
+    }
+
+    public void checkDataSizeQuota(Database database) throws DdlException {
+        long dataQuotaBytes = database.getDataQuota();
+        String fullQualifiedName = database.getFullName();
+
+        Pair<Double, String> quotaUnitPair = DebugUtil.getByteUint(dataQuotaBytes);
+        String readableQuota = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(quotaUnitPair.first) + " "
+                + quotaUnitPair.second;
+        long usedDataQuota = 0;
+        for (Table table : database.getTables()) {
+            if (!table.isOlapTableOrMaterializedView()) {
+                continue;
+            }
+
+            OlapTable olapTable = (OlapTable) table;
+            usedDataQuota = usedDataQuota + olapTable.getDataSize();
+        }
+
+        long leftDataQuota = Math.max(dataQuotaBytes - usedDataQuota, 0);
+
+        Pair<Double, String> leftQuotaUnitPair = DebugUtil.getByteUint(leftDataQuota);
+        String readableLeftQuota = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(leftQuotaUnitPair.first) + " "
+                + leftQuotaUnitPair.second;
+
+        LOG.info("database[{}] data quota: left bytes: {} / total: {}",
+                fullQualifiedName, readableLeftQuota, readableQuota);
+
+        if (leftDataQuota == 0L) {
+            throw new DdlException("Database[" + fullQualifiedName
+                    + "] data size exceeds quota[" + readableQuota + "]");
+        }
+    }
+
+    public long getUsedDataQuotaWithLock(Database database) {
+        long usedDataQuota = 0;
+        Locker locker = new Locker();
+        locker.lockDatabase(database.getId(), LockType.READ);
+        try {
+            for (Table table : database.getTables()) {
+                if (!table.isOlapTableOrMaterializedView()) {
+                    continue;
+                }
+
+                OlapTable olapTable = (OlapTable) table;
+                usedDataQuota = usedDataQuota + olapTable.getDataSize();
+            }
+            return usedDataQuota;
+        } finally {
+            locker.unLockDatabase(database.getId(), LockType.READ);
+        }
+    }
+
+    public void checkReplicaQuota(Database database) throws DdlException {
+        String fullQualifiedName = database.getFullName();
+        long replicaQuotaSize = database.getReplicaQuota();
+
+        long usedReplicaQuota = 0;
+        for (Table table : database.getTables()) {
+            if (!table.isOlapTableOrMaterializedView()) {
+                continue;
+            }
+
+            OlapTable olapTable = (OlapTable) table;
+            usedReplicaQuota = usedReplicaQuota + olapTable.getReplicaCount();
+        }
+
+        long leftReplicaQuota = Math.max(replicaQuotaSize - usedReplicaQuota, 0L);
+        LOG.info("database[{}] replica quota: left number: {} / total: {}",
+                fullQualifiedName, leftReplicaQuota, replicaQuotaSize);
+
+        if (leftReplicaQuota == 0L) {
+            throw new DdlException("Database[" + fullQualifiedName
+                    + "] replica number exceeds quota[" + replicaQuotaSize + "]");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -58,7 +58,8 @@ public class AlterTableStatementAnalyzer {
         if (alterClauseList.stream().map(AlterClause::getOpType).anyMatch(AlterOpType::needCheckCapacity)) {
             try {
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().checkClusterCapacity();
-                db.checkQuota();
+                GlobalStateMgr.getCurrentState().getLocalMetastore().checkDataSizeQuota(db);
+                GlobalStateMgr.getCurrentState().getLocalMetastore().checkReplicaQuota(db);
             } catch (DdlException e) {
                 throw new SemanticException(e.getMessage());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -26,6 +26,9 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.ast.AlterMaterializedViewStmt;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.AlterViewStmt;
 import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.InsertStmt;
@@ -199,6 +202,27 @@ public class PlannerMetaLocker {
             Pair<Database, Table> dbAndTable = resolveTable(session, node.getTableName());
             put(dbAndTable);
             return super.visitDeleteStatement(node, context);
+        }
+
+        @Override
+        public Void visitAlterTableStatement(AlterTableStmt statement, Void context) {
+            Pair<Database, Table> dbAndTable = resolveTable(session, statement.getTbl());
+            put(dbAndTable);
+            return super.visitAlterTableStatement(statement, context);
+        }
+
+        @Override
+        public Void visitAlterViewStatement(AlterViewStmt statement, Void context) {
+            Pair<Database, Table> dbAndTable = resolveTable(session, statement.getTableName());
+            put(dbAndTable);
+            return super.visitAlterViewStatement(statement, context);
+        }
+
+        @Override
+        public Void visitAlterMaterializedViewStatement(AlterMaterializedViewStmt statement, Void context) {
+            Pair<Database, Table> dbAndTable = resolveTable(session, statement.getMvName());
+            put(dbAndTable);
+            return super.visitAlterMaterializedViewStatement(statement, context);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterTableStmt.java
@@ -14,16 +14,14 @@
 
 package com.starrocks.sql.ast;
 
-import com.starrocks.alter.AlterOpType;
 import com.starrocks.analysis.TableName;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 // Alter table statement.
 public class AlterTableStmt extends DdlStmt {
-    private TableName tbl;
+    private final TableName tbl;
     private final List<AlterClause> alterClauseList;
 
     public AlterTableStmt(TableName tbl, List<AlterClause> ops) {
@@ -34,10 +32,6 @@ public class AlterTableStmt extends DdlStmt {
         super(pos);
         this.tbl = tbl;
         this.alterClauseList = ops;
-    }
-
-    public void setTableName(String newTableName) {
-        tbl = new TableName(tbl.getDb(), newTableName);
     }
 
     public TableName getTbl() {
@@ -58,30 +52,6 @@ public class AlterTableStmt extends DdlStmt {
 
     public String getTableName() {
         return tbl.getTbl();
-    }
-
-    public boolean contains(AlterOpType op) {
-        List<AlterOpType> currentOps = alterClauseList.stream().map(AlterClause::getOpType).collect(Collectors.toList());
-        return currentOps.contains(op);
-    }
-
-    public boolean hasPartitionOp() {
-        List<AlterOpType> currentOps = alterClauseList.stream().map(AlterClause::getOpType).collect(Collectors.toList());
-        return currentOps.contains(AlterOpType.ADD_PARTITION)
-                || currentOps.contains(AlterOpType.DROP_PARTITION)
-                || currentOps.contains(AlterOpType.REPLACE_PARTITION)
-                || currentOps.contains(AlterOpType.MODIFY_PARTITION)
-                || currentOps.contains(AlterOpType.TRUNCATE_PARTITION);
-    }
-
-    public boolean hasSchemaChangeOp() {
-        List<AlterOpType> currentOps = alterClauseList.stream().map(AlterClause::getOpType).collect(Collectors.toList());
-        return currentOps.contains(AlterOpType.SCHEMA_CHANGE) || currentOps.contains(AlterOpType.OPTIMIZE);
-    }
-
-    public boolean hasRollupOp() {
-        List<AlterOpType> currentOps = alterClauseList.stream().map(AlterClause::getOpType).collect(Collectors.toList());
-        return currentOps.contains(AlterOpType.ADD_ROLLUP) || currentOps.contains(AlterOpType.DROP_ROLLUP);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
@@ -87,7 +87,31 @@ public class AstTraverser<R, C> implements AstVisitor<R, C> {
         return null;
     }
 
-    // ------------------------------------------- Relation ----------------------------------==------------------------
+    // ------------------------------------------- DDL Statement -------------------------------------------------------
+
+    @Override
+    public R visitAlterTableStatement(AlterTableStmt statement, C context) {
+        statement.getAlterClauseList().forEach(x -> visit(x, context));
+        return null;
+    }
+
+    @Override
+    public R visitAlterViewStatement(AlterViewStmt statement, C context) {
+        if (statement.getAlterClause() != null) {
+            visit(statement.getAlterClause(), context);
+        }
+        return null;
+    }
+
+    @Override
+    public R visitAlterMaterializedViewStatement(AlterMaterializedViewStmt statement, C context) {
+        if (statement.getAlterTableClause() != null) {
+            visit(statement.getAlterTableClause(), context);
+        }
+        return null;
+    }
+
+    // ------------------------------------------- Relation ------------------------------------------------------------
 
     @Override
     public R visitSelect(SelectRelation node, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshTableStmt.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.RedirectStatus;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -2104,7 +2104,7 @@ public class DatabaseTransactionMgr {
         }
 
         if (usedQuotaDataBytes == -1) {
-            usedQuotaDataBytes = db.getUsedDataQuotaWithLock();
+            usedQuotaDataBytes = globalStateMgr.getLocalMetastore().getUsedDataQuotaWithLock(db);
         }
 
         long dataQuotaBytes = db.getDataQuota();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/UpdateDbUsedDataQuotaDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/UpdateDbUsedDataQuotaDaemon.java
@@ -70,7 +70,7 @@ public class UpdateDbUsedDataQuotaDaemon extends FrontendDaemon {
                 continue;
             }
             try {
-                long usedDataQuotaBytes = db.getUsedDataQuotaWithLock();
+                long usedDataQuotaBytes = globalStateMgr.getLocalMetastore().getUsedDataQuotaWithLock(db);
                 globalTransactionMgr.updateDatabaseUsedQuotaData(dbId, usedDataQuotaBytes);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Update database[{}] used data quota bytes : {}.", db.getOriginName(), usedDataQuotaBytes);


### PR DESCRIPTION
## Why I'm doing:
The Analyze process of the current AlterTableStatement is not protected by the meta lock, which may cause ConcurrentModificationException
## What I'm doing:

Fixes #issue
1、Add AlterTableStatement analyze protected by meta lock
2、Because locks cannot be nested, the code structure of checkDataSizeQuota is refactored, but the logic is not changed.
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0