### PR TITLE
[BugFix] fix array_map crash (backport #55383)

### DIFF
--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -525,7 +525,7 @@ public:
         }
     }
 
-    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override {
+    StatusOr<ColumnPtr> replicate(const Buffer<uint32_t>& offsets) override {
         materialized_nullable();
         return NullableColumn::replicate(offsets);
     }

--- a/be/src/column/array_view_column.cpp
+++ b/be/src/column/array_view_column.cpp
@@ -25,7 +25,7 @@
 
 namespace starrocks {
 
-ColumnPtr ArrayViewColumn::replicate(const Buffer<uint32_t>& offsets) {
+StatusOr<ColumnPtr> ArrayViewColumn::replicate(const Buffer<uint32_t>& offsets) {
     auto dest_size = offsets.size() - 1;
     auto new_offsets = UInt32Column::create();
     auto new_lengths = UInt32Column::create();

--- a/be/src/column/array_view_column.h
+++ b/be/src/column/array_view_column.h
@@ -162,7 +162,7 @@ public:
 
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
 
-    ColumnPtr replicate(const Buffer<uint32_t>& offsets) override;
+    StatusOr<ColumnPtr> replicate(const Buffer<uint32_t>& offsets) override;
 
     std::string get_name() const override { return "array-view-" + _elements->get_name(); }
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -120,7 +120,7 @@ void BinaryColumnBase<T>::append_value_multiple_times(const Column& src, uint32_
 
 //TODO(fzh): optimize copy using SIMD
 template <typename T>
-ColumnPtr BinaryColumnBase<T>::replicate(const std::vector<uint32_t>& offsets) {
+StatusOr<ColumnPtr> BinaryColumnBase<T>::replicate(const Buffer<uint32_t>& offsets) {
     auto dest = std::dynamic_pointer_cast<BinaryColumnBase<T>>(BinaryColumnBase<T>::create());
     auto& dest_offsets = dest->get_offset();
     auto& dest_bytes = dest->get_bytes();
@@ -142,6 +142,14 @@ ColumnPtr BinaryColumnBase<T>::replicate(const std::vector<uint32_t>& offsets) {
             dest_offsets[j + 1] = pos;
         }
     }
+
+    auto ret = dest->upgrade_if_overflow();
+    if (!ret.ok()) {
+        return ret.status();
+    } else if (ret.value() != nullptr) {
+        return ret.value();
+    }
+
     return dest;
 }
 

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -220,7 +220,7 @@ public:
         _slices_cache = false;
     }
 
-    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+    StatusOr<ColumnPtr> replicate(const Buffer<uint32_t>& offsets) override;
 
     void fill_default(const Filter& filter) override;
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -169,7 +169,7 @@ public:
     // for example: column(1,2)->replicate({0,2,5}) = column(1,1,2,2,2)
     // FixedLengthColumn, BinaryColumn and ConstColumn override this function for better performance.
     // TODO(fzh): optimize replicate() for ArrayColumn, ObjectColumn and others.
-    virtual ColumnPtr replicate(const std::vector<uint32_t>& offsets) {
+    virtual StatusOr<ColumnPtr> replicate(const Buffer<uint32_t>& offsets) {
         auto dest = this->clone_empty();
         auto dest_size = offsets.size() - 1;
         DCHECK(this->size() >= dest_size) << "The size of the source column is less when duplicating it.";

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -52,7 +52,7 @@ void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index,
     append(src, index, size);
 }
 
-ColumnPtr ConstColumn::replicate(const std::vector<uint32_t>& offsets) {
+StatusOr<ColumnPtr> ConstColumn::replicate(const Buffer<uint32_t>& offsets) {
     return ConstColumn::create(this->_data->clone_shared(), offsets.back());
 }
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -110,7 +110,7 @@ public:
 
     void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
-    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+    StatusOr<ColumnPtr> replicate(const Buffer<uint32_t>& offsets) override;
 
     bool append_nulls(size_t count) override {
         DCHECK_GT(count, 0);

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -65,7 +65,7 @@ void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, ui
 
 //TODO(fzh): optimize copy using SIMD
 template <typename T>
-ColumnPtr FixedLengthColumnBase<T>::replicate(const std::vector<uint32_t>& offsets) {
+StatusOr<ColumnPtr> FixedLengthColumnBase<T>::replicate(const Buffer<uint32_t>& offsets) {
     auto dest = this->clone_empty();
     auto& dest_data = down_cast<FixedLengthColumnBase<T>&>(*dest);
     dest_data._data.resize(offsets.back());

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -157,7 +157,7 @@ public:
         _data.resize(_data.size() + count, DefaultValueGenerator<ValueType>::next_value());
     }
 
-    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+    StatusOr<ColumnPtr> replicate(const Buffer<uint32_t>& offsets) override;
 
     void fill_default(const Filter& filter) override;
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -136,9 +136,12 @@ void NullableColumn::append_value_multiple_times(const Column& src, uint32_t ind
     DCHECK_EQ(_null_column->size(), _data_column->size());
 }
 
-ColumnPtr NullableColumn::replicate(const std::vector<uint32_t>& offsets) {
-    return NullableColumn::create(this->_data_column->replicate(offsets),
-                                  std::dynamic_pointer_cast<NullColumn>(this->_null_column->replicate(offsets)));
+StatusOr<ColumnPtr> NullableColumn::replicate(const Buffer<uint32_t>& offsets) {
+    ASSIGN_OR_RETURN(auto data_col, this->_data_column->replicate(offsets));
+
+    ASSIGN_OR_RETURN(auto null_col, this->_null_column->replicate(offsets));
+
+    return NullableColumn::create(data_col, std::dynamic_pointer_cast<NullColumn>(null_col));
 }
 
 bool NullableColumn::append_nulls(size_t count) {

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -252,7 +252,7 @@ public:
         _has_null = true;
         return true;
     }
-    ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
+    StatusOr<ColumnPtr> replicate(const Buffer<uint32_t>& offsets) override;
 
     size_t memory_usage() const override {
         return _data_column->memory_usage() + _null_column->memory_usage() + sizeof(bool);

--- a/be/src/exec/stream/aggregate/agg_group_state.cpp
+++ b/be/src/exec/stream/aggregate/agg_group_state.cpp
@@ -265,7 +265,7 @@ Status AggGroupState::output_changes(size_t chunk_size, const Columns& group_by_
             auto detail_result_chunk = std::make_shared<Chunk>();
             SlotId slot_id = 0;
             for (size_t j = 0; j < group_by_columns.size(); j++) {
-                auto replicated_col = group_by_columns[j]->replicate(replicate_offsets);
+                ASSIGN_OR_RETURN(auto replicated_col, group_by_columns[j]->replicate(replicate_offsets))
                 detail_result_chunk->append_column(replicated_col, slot_id++);
             }
             // TODO: take care slot_ids.

--- a/be/src/exprs/map_apply_expr.cpp
+++ b/be/src/exprs/map_apply_expr.cpp
@@ -122,7 +122,9 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
                 return Status::InternalError(fmt::format("The size of the captured column {} is less than map's size.",
                                                          captured->get_name()));
             }
-            cur_chunk->append_column(captured->replicate(input_map->offsets_column()->get_data()), id);
+
+            ASSIGN_OR_RETURN(auto replicated_col, captured->replicate(input_map->offsets_column()->get_data()));
+            cur_chunk->append_column(replicated_col, id);
         }
         // evaluate the lambda expression
         if (cur_chunk->num_rows() <= chunk->num_rows() * 8) {

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -1144,7 +1144,7 @@ PARALLEL_TEST(ArrayColumnTest, test_replicate) {
     off.push_back(5);
     off.push_back(7);
 
-    auto res = column->replicate(off);
+    auto res = column->replicate(off).value();
 
     ASSERT_EQ("[1,2,3]", res->debug_item(0));
     ASSERT_EQ("[1,2,3]", res->debug_item(1));

--- a/be/test/column/array_view_column_test.cpp
+++ b/be/test/column/array_view_column_test.cpp
@@ -176,7 +176,7 @@ PARALLEL_TEST(ArrayViewColumnTest, test_other_manipulations) {
         auto array_view_column =
                 std::dynamic_pointer_cast<ArrayViewColumn>(ArrayViewColumn::from_array_column(array_column));
         Buffer<uint32_t> offsets{0, 2, 3, 6};
-        auto column = array_view_column->replicate(offsets);
+        auto column = array_view_column->replicate(offsets).value();
         ASSERT_TRUE(column->is_array_view());
         auto result = std::dynamic_pointer_cast<ArrayViewColumn>(column);
         ASSERT_EQ(result->size(), 6);

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -638,7 +638,7 @@ PARALLEL_TEST(BinaryColumnTest, test_replicate) {
     offsets.push_back(3);
     offsets.push_back(5);
 
-    auto c2 = c1->replicate(offsets);
+    auto c2 = c1->replicate(offsets).value();
 
     auto slices = down_cast<BinaryColumn*>(c2.get())->get_data();
     ASSERT_EQ(5, c2->size());

--- a/be/test/column/const_column_test.cpp
+++ b/be/test/column/const_column_test.cpp
@@ -349,7 +349,7 @@ PARALLEL_TEST(ConstColumnTest, test_replicate) {
     offsets.push_back(5);
     offsets.push_back(7);
 
-    auto c2 = c1->replicate(offsets);
+    auto c2 = c1->replicate(offsets).value();
 
     ASSERT_EQ(7, c2->size());
     ASSERT_EQ(1, c2->get(6).get_int32());

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -613,7 +613,7 @@ TEST(FixedLengthColumnTest, test_replicate) {
     offsets.push_back(3);
     offsets.push_back(5);
 
-    auto c2 = column->replicate(offsets);
+    auto c2 = column->replicate(offsets).value();
     ASSERT_EQ(5, c2->size());
     ASSERT_EQ(c2->get(0).get_int32(), 7);
     ASSERT_EQ(c2->get(1).get_int32(), 7);

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -373,7 +373,7 @@ PARALLEL_TEST(NullableColumnTest, test_replicate) {
     offsets.push_back(2);
     offsets.push_back(4);
     offsets.push_back(7);
-    auto c2 = column->replicate(offsets);
+    auto c2 = column->replicate(offsets).value();
 
     ASSERT_EQ(1, c2->get(0).get_int32());
     ASSERT_EQ(1, c2->get(1).get_int32());


### PR DESCRIPTION
## Why I'm doing:
cp from https://github.com/StarRocks/starrocks/pull/55383

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
