### PR TITLE
[BugFix] Fix the compile problem when using clang-19

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -522,7 +522,7 @@ public:
     CppType min_value(ObjectPool* pool) const {
         if constexpr (IsSlice<CppType>) {
             std::lock_guard<std::mutex> lk(_slice_mutex);
-            auto* str = pool->template add(new std::string(_min.get_data(), _min.get_size()));
+            auto* str = pool->template add<std::string>(new std::string(_min.get_data(), _min.get_size()));
             return Slice(*str);
         } else {
             return _min;
@@ -532,7 +532,7 @@ public:
     CppType max_value(ObjectPool* pool) const {
         if constexpr (IsSlice<CppType>) {
             std::lock_guard<std::mutex> lk(_slice_mutex);
-            auto* str = pool->template add(new std::string(_max.get_data(), _max.get_size()));
+            auto* str = pool->template add<std::string>(new std::string(_max.get_data(), _max.get_size()));
             return Slice(*str);
         } else {
             return _max;


### PR DESCRIPTION
## Why I'm doing:

When using clang-19, compile failed:

```
In file included from /root/starrocks/be/src/exprs/runtime_filter_bank.h:28:                                                            
/root/starrocks/be/src/exprs/runtime_filter.h:525:40: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  525 |             auto* str = pool->template add(new std::string(_min.get_data(), _min.get_size()));                                  
      |                                        ^                                                                                        
/root/starrocks/be/src/exprs/runtime_filter.h:535:40: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  535 |             auto* str = pool->template add(new std::string(_max.get_data(), _max.get_size()));                                  
      |                                        ^                                                                                        
2 errors generated. 
```

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0