### PR TITLE
[Enhancement] Skip load primary index for empty rowset

### DIFF
--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -176,6 +176,12 @@ public:
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(true);
         SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(
                 config::enable_pk_strict_memcheck ? _tablet.update_mgr()->mem_tracker() : nullptr);
+        // local persistent index will update index version, so we need to load first
+        if (_index_entry == nullptr) {
+            if (_metadata->enable_persistent_index() && _metadata->persistent_index_type() == PersistentIndexTypePB::LOCAL) {
+                RETURN_IF_ERROR(prepare_primary_index());
+            }
+        }
         // still need prepre primary index even there is an empty compaction
         if (_index_entry == nullptr && _has_empty_compaction) {
             // get lock to avoid gc

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -178,7 +178,8 @@ public:
                 config::enable_pk_strict_memcheck ? _tablet.update_mgr()->mem_tracker() : nullptr);
         // local persistent index will update index version, so we need to load first
         if (_index_entry == nullptr) {
-            if (_metadata->enable_persistent_index() && _metadata->persistent_index_type() == PersistentIndexTypePB::LOCAL) {
+            if (_metadata->enable_persistent_index() &&
+                _metadata->persistent_index_type() == PersistentIndexTypePB::LOCAL) {
                 RETURN_IF_ERROR(prepare_primary_index());
             }
         }

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -177,14 +177,10 @@ public:
         SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(
                 config::enable_pk_strict_memcheck ? _tablet.update_mgr()->mem_tracker() : nullptr);
         // local persistent index will update index version, so we need to load first
-        if (_index_entry == nullptr) {
-            if (_metadata->enable_persistent_index() &&
-                _metadata->persistent_index_type() == PersistentIndexTypePB::LOCAL) {
-                RETURN_IF_ERROR(prepare_primary_index());
-            }
-        }
         // still need prepre primary index even there is an empty compaction
-        if (_index_entry == nullptr && _has_empty_compaction) {
+        if (_index_entry == nullptr &&
+            (_has_empty_compaction || (_metadata->enable_persistent_index() &&
+                                       _metadata->persistent_index_type() == PersistentIndexTypePB::LOCAL))) {
             // get lock to avoid gc
             _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
             DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1125,4 +1125,13 @@ Status UpdateManager::pk_index_major_compaction(int64_t tablet_id, DataDir* data
     return Status::OK();
 }
 
+bool UpdateManager::TEST_primary_index_refcnt(int64_t tablet_id, uint32_t expected_cnt) {
+    auto index_entry = _index_cache.get(tablet_id);
+    if (index_entry == nullptr) {
+        return expected_cnt == 0;
+    }
+    _index_cache.release(index_entry);
+    return index_entry->get_ref() == expected_cnt;
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -203,6 +203,8 @@ public:
 
     Status pk_index_major_compaction(int64_t tablet_id, DataDir* data_dir);
 
+    bool TEST_primary_index_refcnt(int64_t tablet_id, uint32_t expected_cnt);
+
 private:
     // print memory tracker state
     void _print_memory_stats();

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -565,4 +565,36 @@ TEST_F(AlterTabletMetaTest, test_alter_persistent_index_type) {
     ASSERT_TRUE(tablet_meta4->orphan_files_size() > 0);
 }
 
+TEST_F(AlterTabletMetaTest, test_skip_load_pindex) {
+    std::shared_ptr<TabletMetadata> tablet_metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*tablet_metadata));
+    // write empty rowset
+    {
+        TxnLogPB log;
+        auto op_write_meta = log.mutable_op_write();
+        auto rs_meta = op_write_meta->mutable_rowset();
+        rs_meta->set_id(next_id());
+        rs_meta->set_num_rows(0);
+
+        auto tablet_id = tablet_metadata->id();
+        auto version = tablet_metadata->version() + 1;
+        std::unique_ptr<TxnLogApplier> log_applier =
+                new_txn_log_applier(Tablet(_tablet_mgr.get(), tablet_id), tablet_metadata, version, false);
+        ASSERT_OK(log_applier->apply(log));
+        ASSERT_TRUE(_tablet_mgr->update_mgr()->TEST_primary_index_refcnt(tablet_metadata->id(), 0));
+    }
+
+    {
+        TxnLogPB log;
+        auto op_compaction_meta = log.mutable_op_compaction();
+        auto tablet_id = tablet_metadata->id();
+        auto version = tablet_metadata->version() + 1;
+        op_compaction_meta->set_compact_version(version);
+        std::unique_ptr<TxnLogApplier> log_applier =
+                new_txn_log_applier(Tablet(_tablet_mgr.get(), tablet_id), tablet_metadata, version, false);
+        ASSERT_OK(log_applier->apply(log));
+        ASSERT_TRUE(_tablet_mgr->update_mgr()->TEST_primary_index_refcnt(tablet_metadata->id(), 0));
+    }
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:
During the publish process, the primary index is loaded, which consumes additional memory. However, for empty rowsets, loading the primary index is unnecessary. Skipping the loading of the primary index can save memory and improve the efficiency of the publish operation.

## What I'm doing:
Skip load primary index for empty rowset.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0