### PR TITLE
[BugFix] flatjson read notObject json crash

### DIFF
--- a/test/sql/test_json/R/test_string_json
+++ b/test/sql/test_json/R/test_string_json
@@ -1,0 +1,59 @@
+-- name: test_string_json
+CREATE DATABASE test_string_json;
+-- result:
+-- !result
+USE test_string_json;
+-- result:
+-- !result
+CREATE TABLE `js7` (
+  `v1` int(11) NOT NULL COMMENT "",
+  `js` json NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "olap"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into js7 values
+(1, parse_json('{\"job\": \"Designer, television/film set\", \"company1\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}')),
+(2, parse_json('{\"job\": \"Designer, television/film set\", \"company2\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}')),
+(3, parse_json('{\"job\": \"Designer, television/film set\", \"company3\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}')),
+(4, parse_json('{\"job\": \"Designer, television/film set\", \"company4\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}')),
+(5, parse_json('{\"job\": \"Designer, television/film set\", \"company5\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}')),
+(6, parse_json('{\"job\": \"Designer, television/film set\", \"company6\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}'));
+-- result:
+-- !result
+insert into js7 select * from js7;
+-- result:
+-- !result
+insert into js7 select * from js7;
+-- result:
+-- !result
+ALTER TABLE js7 COMPACT;
+-- result:
+-- !result
+select js from js7 where v1 = 1 limit 1;
+-- result:
+{"birthdate": "1914-03-20", "company1": "Rodriguez-Meadows1", "job": "Designer, television/film set", "mail": "zbarnes@gmail.com", "ssn": "192-89-6614"}
+-- !result
+insert into js7 values
+(11, parse_json('1985-07-10 01:35:29')),
+(21, parse_json('{}'));
+-- result:
+-- !result
+ALTER TABLE js7 COMPACT;
+-- result:
+-- !result
+select js from js7 where v1 = 11 limit 1;
+-- result:
+"1985-07-10 01:35:29"
+-- !result
+select js from js7 where v1 = 12 limit 1;
+-- result:
+-- !result

--- a/test/sql/test_json/T/test_string_json
+++ b/test/sql/test_json/T/test_string_json
@@ -1,0 +1,41 @@
+-- name: test_string_json
+CREATE DATABASE test_string_json;
+USE test_string_json;
+
+CREATE TABLE `js7` (
+  `v1` int(11) NOT NULL COMMENT "",
+  `js` json NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "olap"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+
+insert into js7 values
+(1, parse_json('{\"job\": \"Designer, television/film set\", \"company1\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}')),
+(2, parse_json('{\"job\": \"Designer, television/film set\", \"company2\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}')),
+(3, parse_json('{\"job\": \"Designer, television/film set\", \"company3\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}')),
+(4, parse_json('{\"job\": \"Designer, television/film set\", \"company4\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}')),
+(5, parse_json('{\"job\": \"Designer, television/film set\", \"company5\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}')),
+(6, parse_json('{\"job\": \"Designer, television/film set\", \"company6\": \"Rodriguez-Meadows1\", \"ssn\": \"192-89-6614\", \"mail\": \"zbarnes@gmail.com\", \"birthdate\": \"1914-03-20\"}'));
+
+insert into js7 select * from js7;
+insert into js7 select * from js7;
+
+ALTER TABLE js7 COMPACT;
+
+select js from js7 where v1 = 1 limit 1;
+
+insert into js7 values
+(11, parse_json('1985-07-10 01:35:29')),
+(21, parse_json('{}'));
+
+ALTER TABLE js7 COMPACT;
+select js from js7 where v1 = 11 limit 1;
+select js from js7 where v1 = 12 limit 1;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
like `insert into js8 values (11, parse_json('1985-07-10 01:35:29'));`
the remain json will be `'1985-07-10 01:35:29'`, not object, need special process

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0