### PR TITLE
[BugFix] Support non deterministic functions in transparent mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvPlanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvPlanContext.java
@@ -41,9 +41,10 @@ public class MvPlanContext {
     // indicate whether this mv is a SPJG plan
     // if not, we do not store other fields to save memory,
     // because we will not use other fields
-    private boolean isValidMvPlan;
-    private String invalidReason;
+    private final boolean isValidMvPlan;
+    private final String invalidReason;
     private final int mvScanOpNum;
+    private final boolean containsNDFunctions;
 
     public MvPlanContext(boolean valid, String invalidReason) {
         this.logicalPlan = null;
@@ -52,12 +53,14 @@ public class MvPlanContext {
         this.isValidMvPlan = valid;
         this.invalidReason = invalidReason;
         this.mvScanOpNum = 0;
+        this.containsNDFunctions = false;
     }
 
     public MvPlanContext(OptExpression logicalPlan,
                          List<ColumnRefOperator> outputColumns,
                          ColumnRefFactory refFactory,
                          boolean isValidMvPlan,
+                         boolean isContainsNonDeterministicFunctions,
                          String invalidReason) {
         Preconditions.checkState(logicalPlan != null);
         this.logicalPlan = logicalPlan;
@@ -66,6 +69,7 @@ public class MvPlanContext {
         this.isValidMvPlan = isValidMvPlan;
         this.mvScanOpNum = MvUtils.getOlapScanNode(logicalPlan).size();
         this.invalidReason = invalidReason;
+        this.containsNDFunctions = isContainsNonDeterministicFunctions;
     }
 
     public OptExpression getLogicalPlan() {
@@ -80,8 +84,11 @@ public class MvPlanContext {
         return refFactory;
     }
 
+    /**
+     * TODO: Support mv rewrite even mv contains non-deterministic functions
+     */
     public boolean isValidMvPlan() {
-        return isValidMvPlan;
+        return isValidMvPlan && !containsNDFunctions;
     }
 
     public String getInvalidReason() {
@@ -90,5 +97,9 @@ public class MvPlanContext {
 
     public int getMvScanOpNum() {
         return mvScanOpNum;
+    }
+
+    public boolean isContainsNDFunctions() {
+        return containsNDFunctions;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1723,7 +1723,7 @@ public class AnalyzerUtils {
         @Override
         public Void visitFunctionCall(FunctionCallExpr expr, Void context) {
             if (containsNonDeterministicFunction(expr)) {
-                nonDeterministicFunctionOpt = Optional.of(expr.getFn().functionName());
+                nonDeterministicFunctionOpt = Optional.ofNullable(expr.getFnName()).map(FunctionName::getFunction);
                 return null;
             }
             for (Expr param : expr.getChildren()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
@@ -38,7 +38,7 @@ public class MvPlanContextBuilder {
 
             // TODO: Only add context with view when view rewrite is set on.
             if (mv.getBaseTableTypes().stream().anyMatch(type -> type == TableType.VIEW)) {
-                MvPlanContext contextWithView = mvOptimizer.optimize(mv, connectContext, false);
+                MvPlanContext contextWithView = mvOptimizer.optimize(mv, connectContext, false, true);
                 results.add(contextWithView);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptConstFoldRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptConstFoldRewriter.java
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.apache.commons.math3.util.Pair;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class OptConstFoldRewriter extends OptExpressionVisitor<OptExpression, Void> {
+    private final ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
+    public OptConstFoldRewriter() {
+    }
+
+    public static OptExpression rewrite(OptExpression root) {
+        if (root == null) {
+            return null;
+        }
+        return root.getOp().accept(new OptConstFoldRewriter(), root, null);
+    }
+
+    private ScalarOperator rewrite(ScalarOperator scalarOperator) {
+        if (scalarOperator == null) {
+            return null;
+        }
+        return rewriter.rewrite(scalarOperator, ScalarOperatorRewriter.FOLD_CONSTANT_RULES);
+    }
+
+    private Projection rewrite(Projection projection) {
+        if (projection == null) {
+            return null;
+        }
+        Map<ColumnRefOperator, ScalarOperator> columnRefMap =
+                projection.getColumnRefMap();
+        if (columnRefMap == null) {
+            return projection;
+        }
+        Map<ColumnRefOperator, ScalarOperator> newColumnRefMap = columnRefMap.entrySet()
+                .stream()
+                .map(e -> Pair.create(e.getKey(), rewrite(e.getValue())))
+                .collect(Collectors.toMap(Pair::getFirst, Pair::getSecond));
+        return new Projection(newColumnRefMap);
+    }
+
+    private Operator rewriteOp(Operator operator) {
+        return withCommon(operator).build();
+    }
+
+    private Operator.Builder withCommon(Operator operator) {
+        final Operator.Builder builder = OperatorBuilderFactory.build(operator);
+        builder.withOperator(operator);
+        // projections
+        builder.setProjection(rewrite(operator.getProjection()));
+        // predicates
+        builder.setPredicate(rewrite(operator.getPredicate()));
+        return builder;
+    }
+
+    private List<OptExpression> visitChildren(OptExpression optExpression) {
+        return optExpression.getInputs().stream().map(child -> {
+            return child.getOp().accept(this, child, null);
+        }).collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public OptExpression visit(OptExpression optExpression, Void context) {
+        return OptExpression.create(rewriteOp(optExpression.getOp()), visitChildren(optExpression));
+    }
+
+    @Override
+    public OptExpression visitLogicalJoin(OptExpression optExpression, Void context) {
+        final LogicalJoinOperator joinOperator = (LogicalJoinOperator) optExpression.getOp();
+        final LogicalJoinOperator.Builder builder = (LogicalJoinOperator.Builder) withCommon(joinOperator);
+        builder.setOnPredicate(rewrite(joinOperator.getOnPredicate()));
+        return OptExpression.create(builder.build(), visitChildren(optExpression));
+    }
+
+    @Override
+    public OptExpression visitLogicalAggregate(OptExpression optExpression, Void context) {
+        final LogicalAggregationOperator operator = (LogicalAggregationOperator) optExpression.getOp();
+        final LogicalAggregationOperator.Builder builder = (LogicalAggregationOperator.Builder) withCommon(operator);
+        builder.setAggregations(operator.getAggregations()
+                .entrySet().stream().map(e -> Pair.create(e.getKey(), (CallOperator) rewrite(e.getValue())))
+                .collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)));
+        return OptExpression.create(builder.build(), visitChildren(optExpression));
+    }
+
+    @Override
+    public OptExpression visitLogicalWindow(OptExpression optExpression, Void context) {
+        final LogicalWindowOperator operator = (LogicalWindowOperator) optExpression.getOp();
+        final LogicalWindowOperator.Builder builder = (LogicalWindowOperator.Builder) withCommon(operator);
+        builder.setPartitionExpressions(operator.getPartitionExpressions()
+                .stream().map(this::rewrite).collect(Collectors.toList()));
+        builder.setWindowCall(operator.getWindowCall().entrySet()
+                .stream().map(e -> Pair.create(e.getKey(), (CallOperator) rewrite(e.getValue())))
+                .collect(Collectors.toMap(Pair::getFirst, Pair::getSecond)));
+        return OptExpression.create(builder.build(), visitChildren(optExpression));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -39,6 +39,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.OptConstFoldRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
@@ -104,8 +105,9 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
                                       OptExpression input,
                                       MvId mvId) {
         OptExpression mvTransparentPlan = doGetMvTransparentPlan(connectContext, context, mvId, olapScanOperator, input);
-        Preconditions.checkState(mvTransparentPlan != null,
-                "Build mv transparent plan failed: %s", mvId);
+        if (mvTransparentPlan == null) {
+            throw new RuntimeException("Build mv transparent plan failed: " + mvId);
+        }
         // merge projection
         Map<ColumnRefOperator, ScalarOperator> originalProjectionMap =
                 olapScanOperator.getProjection() == null ? null : olapScanOperator.getProjection().getColumnRefMap();
@@ -142,10 +144,19 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), mvId.getId());
         Preconditions.checkState(table instanceof MaterializedView);
         MaterializedView mv = (MaterializedView) table;
-        MvPlanContext mvPlanContext = MvUtils.getMVPlanContext(connectContext, mv, true);
-        Preconditions.checkState(mvPlanContext != null, "MV plan context not found: %s", mv.getName());
-
+        final MvPlanContext mvPlanContext = MvUtils.getMVPlanContext(connectContext, mv, true, false);
+        if (mvPlanContext == null) {
+            throw new RuntimeException("Cannot get mv plan context: " + mv.getName());
+        }
         OptExpression mvPlan = mvPlanContext.getLogicalPlan();
+        if (mvPlan == null) {
+            throw new RuntimeException("Cannot get mv plan: " + mv.getName());
+        }
+        // do const fold if mv contains non-deterministic functions
+        if (mvPlanContext.isContainsNDFunctions()) {
+            mvPlan = OptConstFoldRewriter.rewrite(mvPlan);
+        }
+
         Set<Table> queryTables = MvUtils.getAllTables(mvPlan).stream().collect(Collectors.toSet());
 
         // mv's to refresh partition info

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1252,7 +1252,8 @@ public class MvUtils {
      */
     public static MvPlanContext getMVPlanContext(ConnectContext connectContext,
                                                  MaterializedView mv,
-                                                 boolean isInlineView) {
+                                                 boolean isInlineView,
+                                                 boolean isCheckNonDeterministicFunction) {
         // step1: get from mv plan cache
         List<MvPlanContext> mvPlanContexts = CachingMvPlanContextBuilder.getInstance()
                 .getPlanContext(connectContext.getSessionVariable(), mv);
@@ -1261,7 +1262,7 @@ public class MvUtils {
             return mvPlanContexts.get(0);
         }
         // step2: get from optimize
-        return new MaterializedViewOptimizer().optimize(mv, connectContext, isInlineView);
+        return new MaterializedViewOptimizer().optimize(mv, connectContext, isInlineView, isCheckNonDeterministicFunction);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -241,7 +241,7 @@ public class TextMatchBasedRewriteRule extends Rule {
                 OptimizerTraceUtil.logMVRewrite(context, this, "TEXT_BASED_REWRITE: text matched with {}",
                         mv.getName());
 
-                MvPlanContext mvPlanContext = MvUtils.getMVPlanContext(connectContext, mv, true);
+                MvPlanContext mvPlanContext = MvUtils.getMVPlanContext(connectContext, mv, true, true);
                 if (mvPlanContext == null) {
                     logMVRewrite(context, this, "MV {} plan context is invalid", mv.getName());
                     continue;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -252,6 +252,8 @@ public class AlterMaterializedViewTest {
         // create the table and refresh
         starRocksAssert.dropTable("treload_1");
         starRocksAssert.withTable(createBaseTable);
+        checker.runForTest(true);
+        checker.runForTest(true);
         starRocksAssert.refreshMV("refresh materialized view mvreload_1");
         starRocksAssert.refreshMV("refresh materialized view mvreload_2");
         starRocksAssert.refreshMV("refresh materialized view mvreload_3");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DropPartitionWithExprListTest.java
@@ -16,13 +16,10 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.starrocks.clone.DynamicPartitionScheduler;
-import com.starrocks.common.util.UUIDUtil;
-import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
-import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.statistic.StatisticsMetaManager;
@@ -132,39 +129,6 @@ public class DropPartitionWithExprListTest extends MVTestBase {
 
     @AfterClass
     public static void afterClass() throws Exception {
-    }
-
-    public static void executeInsertSql(String sql) throws Exception {
-        connectContext.setQueryId(UUIDUtil.genUUID());
-        StatementBase statement = SqlParser.parseSingleStatement(sql, connectContext.getSessionVariable().getSqlMode());
-        new StmtExecutor(connectContext, statement).execute();
-    }
-
-    private String toPartitionVal(String val) {
-        return val == null ? "NULL" : String.format("'%s'", val);
-    }
-
-    private void addListPartition(String tbl, String pName, String pVal1, String pVal2) {
-        addListPartition(tbl, pName, pVal1, pVal2, false);
-    }
-
-    private void addListPartition(String tbl, String pName, String pVal1, String pVal2, boolean isInsertValues) {
-        String addPartitionSql = String.format("ALTER TABLE %s ADD PARTITION IF NOT EXISTS %s VALUES IN ((%s, %s))",
-                tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
-        StatementBase stmt = SqlParser.parseSingleStatement(addPartitionSql, connectContext.getSessionVariable().getSqlMode());
-        try {
-            // add a new partition
-            new StmtExecutor(connectContext, stmt).execute();
-
-            // insert values
-            if (isInsertValues) {
-                String insertSql = String.format("insert into %s partition(%s) values(1, 1, '%s', '%s');",
-                        tbl, pName, pVal1, pVal2);
-                executeInsertSql(insertSql);
-            }
-        } catch (Exception e) {
-            Assert.fail("add partition failed:" + e);
-        }
     }
 
     private void withTablePartitions(String tableName) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -15,8 +15,6 @@
 package com.starrocks.scheduler;
 
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.ExpressionRangePartitionInfo;
-import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.OlapTable;
@@ -38,8 +36,6 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
@@ -519,46 +515,6 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVTestBase {
                             });
                 }
         );
-    }
-
-
-    private String toPartitionVal(String val) {
-        return val == null ? "NULL" : String.format("'%s'", val);
-    }
-
-    private void addRangePartition(String tbl, String pName, String pVal1, String pVal2, boolean isInsertValue) {
-        // mock the check to ensure test can run
-        new MockUp<ExpressionRangePartitionInfo>() {
-            @Mock
-            public boolean isAutomaticPartition() {
-                return false;
-            }
-        };
-        new MockUp<ExpressionRangePartitionInfoV2>() {
-            @Mock
-            public boolean isAutomaticPartition() {
-                return false;
-            }
-        };
-        try {
-            String addPartitionSql = String.format("ALTER TABLE %s ADD " +
-                    "PARTITION %s VALUES [(%s),(%s))", tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
-            System.out.println(addPartitionSql);
-            starRocksAssert.alterTable(addPartitionSql);
-
-            // insert values
-            if (isInsertValue) {
-                String insertSql = String.format("insert into %s partition(%s) values('%s', 1, 1);",
-                        tbl, pName, pVal1);
-                executeInsertSql(insertSql);
-            }
-        } catch (Exception e) {
-            LOG.error("Failed to add partition", e);
-        }
-    }
-
-    private void addRangePartition(String tbl, String pName, String pVal1, String pVal2) {
-        addRangePartition(tbl, pName, pVal1, pVal2, false);
     }
 
     private void withTablePartitions(String tableName) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/OptConstFoldRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/OptConstFoldRewriterTest.java
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class OptConstFoldRewriterTest extends MVTestBase {
+    private static String R2;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MVTestBase.beforeClass();
+        // partition table by partition expression
+        R2 = "CREATE TABLE r2 \n" +
+                "(\n" +
+                "    dt datetime,\n" +
+                "    k1 int,\n" +
+                "    k2 int,\n" +
+                "    v1 int \n" +
+                ")\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');";
+    }
+
+    @Test
+    public void testRewrite() throws Exception {
+        starRocksAssert.withTable(R2);
+        String[] queries = {
+                "SELECT curdate(), dt, k2 from r2",
+                "SELECT dt, k2 from r2 where date_trunc('day', dt) < curdate()",
+                "SELECT a.dt, b.k2 from r2 a join r2 b on a.k2 = curdate()",
+                "SELECT curdate()  from r2 a join r2 b",
+                "SELECT dt, k2, sum(v1) as agg1 from r2 where date_trunc('day', dt) < timestamp(curdate()) group by dt, k2",
+                "SELECT dt, k2, sum(v1) as agg1 from r2 where date_trunc('day', dt) < curdate() group by dt, k2",
+                "SELECT curdate(), dt, k2, sum(v1) as agg1 from r2 group by dt, k2 ",
+                "SELECT dt, sum(v1) over(partition by k1 order by k2) as agg1 from r2 where dt < curdate()",
+                "SELECT curdate(), dt, k2, sum(v1) as agg1 from r2 group by dt, k2 union all " +
+                        "SELECT curdate(), dt, k2, sum(v1) as agg1 from r2 group by dt, k2",
+                "SELECT curdate(), dt, k2, sum(v1) as agg1 from r2 group by dt, k2 union " +
+                        "SELECT curdate(), dt, k2, sum(v1) as agg1 from r2 group by dt, k2",
+                "with cte as (SELECT curdate(), dt, k2, sum(v1) as agg1 from r2 group by dt, k2) select * from cte",
+                "with cte as (SELECT curdate(), dt, k2 from r2) select * from cte",
+                "with cte as (SELECT dt, k2 from r2 where dt < curdate()) select * from cte",
+        };
+        for (String sql : queries) {
+            connectContext.getSessionVariable().setDisableFunctionFoldConstants(true);
+            OptExpression optExpression = getLogicalOptimizedPlan(sql);
+            Assert.assertTrue(hasNonDeterministicFunction(optExpression));
+
+            connectContext.getSessionVariable().setDisableFunctionFoldConstants(false);
+            OptExpression newOptExpression = OptConstFoldRewriter.rewrite(optExpression);
+            Assert.assertFalse(hasNonDeterministicFunction(newOptExpression));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -21,8 +21,11 @@ import com.google.common.collect.Sets;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.MvRefreshArbiter;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
@@ -49,23 +52,28 @@ import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
+import com.starrocks.sql.optimizer.MaterializedViewOptimizer;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.OptimizerOptions;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
+import com.starrocks.sql.optimizer.rule.NonDeterministicVisitor;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
-import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -217,14 +225,23 @@ public class MVTestBase extends StarRocksTestBase {
         return getOptimizedPlan(sql, connectContext);
     }
 
+    public static OptExpression getLogicalOptimizedPlan(String sql) {
+        return getOptimizedPlan(sql, connectContext, OptimizerOptions.newRuleBaseOpt());
+    }
+
     public static OptExpression getOptimizedPlan(String sql, ConnectContext connectContext) {
+        return getOptimizedPlan(sql, connectContext, OptimizerOptions.defaultOpt());
+    }
+
+    public static OptExpression getOptimizedPlan(String sql, ConnectContext connectContext,
+                                                 OptimizerOptions optimizerOptions) {
         StatementBase mvStmt;
         try {
             List<StatementBase> statementBases =
                     com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable());
             Preconditions.checkState(statementBases.size() == 1);
             mvStmt = statementBases.get(0);
-        } catch (ParsingException parsingException) {
+        } catch (Exception e) {
             return null;
         }
         Preconditions.checkState(mvStmt instanceof QueryStatement);
@@ -233,7 +250,9 @@ public class MVTestBase extends StarRocksTestBase {
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         LogicalPlan logicalPlan =
                 new RelationTransformer(columnRefFactory, connectContext).transformWithSelectLimit(query);
-        Optimizer optimizer = OptimizerFactory.create(OptimizerFactory.mockContext(connectContext, columnRefFactory));
+        OptimizerContext optimizerContext =
+                OptimizerFactory.initContext(connectContext, columnRefFactory, optimizerOptions);
+        Optimizer optimizer = OptimizerFactory.create(optimizerContext);
         return optimizer.optimize(
                 logicalPlan.getRoot(),
                 new PhysicalPropertySet(),
@@ -387,5 +406,81 @@ public class MVTestBase extends StarRocksTestBase {
     protected static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
+    }
+
+    protected String toPartitionVal(String val) {
+        return val == null ? "NULL" : String.format("'%s'", val);
+    }
+
+    protected void addRangePartition(String tbl, String pName, String pVal1, String pVal2) {
+        addRangePartition(tbl, pName, pVal1, pVal2, false);
+    }
+
+    protected void addRangePartition(String tbl, String pName, String pVal1, String pVal2, boolean isInsertValue) {
+        // mock the check to ensure test can run
+        new MockUp<ExpressionRangePartitionInfo>() {
+            @Mock
+            public boolean isAutomaticPartition() {
+                return false;
+            }
+        };
+        new MockUp<ExpressionRangePartitionInfoV2>() {
+            @Mock
+            public boolean isAutomaticPartition() {
+                return false;
+            }
+        };
+        try {
+            String addPartitionSql = String.format("ALTER TABLE %s ADD " +
+                    "PARTITION %s VALUES [(%s),(%s))", tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
+            System.out.println(addPartitionSql);
+            starRocksAssert.alterTable(addPartitionSql);
+
+            // insert values
+            if (isInsertValue) {
+                String insertSql = String.format("insert into %s partition(%s) values('%s', 1, 1);",
+                        tbl, pName, pVal1);
+                executeInsertSql(insertSql);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            LOG.error("Failed to add partition", e);
+        }
+    }
+
+    protected void addListPartition(String tbl, String pName, String pVal1, String pVal2) {
+        addListPartition(tbl, pName, pVal1, pVal2, false);
+    }
+
+    protected void addListPartition(String tbl, String pName, String pVal1, String pVal2, boolean isInsertValues) {
+        String addPartitionSql = String.format("ALTER TABLE %s ADD PARTITION IF NOT EXISTS %s VALUES IN ((%s, %s))",
+                tbl, pName, toPartitionVal(pVal1), toPartitionVal(pVal2));
+        StatementBase stmt = SqlParser.parseSingleStatement(addPartitionSql, connectContext.getSessionVariable().getSqlMode());
+        try {
+            // add a new partition
+            new StmtExecutor(connectContext, stmt).execute();
+
+            // insert values
+            if (isInsertValues) {
+                String insertSql = String.format("insert into %s partition(%s) values(1, 1, '%s', '%s');",
+                        tbl, pName, pVal1, pVal2);
+                executeInsertSql(insertSql);
+            }
+        } catch (Exception e) {
+            Assert.fail("add partition failed:" + e);
+        }
+    }
+
+    protected MvPlanContext getOptimizedPlan(MaterializedView mv, boolean isInlineView, boolean isCheckNonDeterministicFunction) {
+        return new MaterializedViewOptimizer().optimize(mv, connectContext, isInlineView, isCheckNonDeterministicFunction);
+
+    }
+
+    protected MvPlanContext getOptimizedPlan(MaterializedView mv, boolean isInlineView) {
+        return new MaterializedViewOptimizer().optimize(mv, connectContext, isInlineView, true);
+    }
+
+    protected boolean hasNonDeterministicFunction(OptExpression root) {
+        return root.getOp().accept(new NonDeterministicVisitor(), root, null);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -25,7 +25,6 @@ import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.MaterializationContext;
-import com.starrocks.sql.optimizer.MaterializedViewOptimizer;
 import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
@@ -656,7 +655,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
         starRocksAssert.withMaterializedView(sql, (obj) -> {
             String mvName = (String) obj;
             MaterializedView mv = getMv(DB_NAME, mvName);
-            MvPlanContext mvPlanContext = new MaterializedViewOptimizer().optimize(mv, connectContext, true);
+            MvPlanContext mvPlanContext = getOptimizedPlan(mv, true);
             Assert.assertTrue(!mvPlanContext.isValidMvPlan());
         });
     }
@@ -674,9 +673,9 @@ public class MvRewritePreprocessorTest extends MVTestBase {
         starRocksAssert.withMaterializedView(sql, (obj) -> {
             String mvName = (String) obj;
             MaterializedView mv = getMv(DB_NAME, mvName);
-            MvPlanContext mvPlanContext = new MaterializedViewOptimizer().optimize(mv, connectContext, true);
+            MvPlanContext mvPlanContext = getOptimizedPlan(mv, true);
             Assert.assertTrue(!mvPlanContext.isValidMvPlan());
-            mvPlanContext = new MaterializedViewOptimizer().optimize(mv, connectContext, false);
+            mvPlanContext = getOptimizedPlan(mv, false);
             Assert.assertTrue(mvPlanContext.isValidMvPlan());
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithOlapTableTest.java
@@ -17,6 +17,9 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.FeConstants;
 import com.starrocks.schema.MTable;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TExplainLevel;
@@ -25,6 +28,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Set;
 
 public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
@@ -34,6 +39,7 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
     private static String t1;
     private static String t2;
     private static String t3;
+    private static String R2;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -128,6 +134,24 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                 "     PARTITION p4 VALUES IN ((\"guangdong\", \"2024-01-02\")) \n" +
                 ")\n" +
                 "DISTRIBUTED BY RANDOM\n";
+
+        // partition table by partition expression
+        R2 = "CREATE TABLE r2 \n" +
+                "(\n" +
+                "    dt datetime,\n" +
+                "    k2 int,\n" +
+                "    v1 int \n" +
+                ")\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                "PROPERTIES('replication_num' = '1');";
+    }
+
+    private void withTablePartitionsV2(String tableName) {
+        addRangePartition(tableName, "p1", "2024-01-29", "2024-01-30");
+        addRangePartition(tableName, "p2", "2024-01-30", "2024-01-31");
+        addRangePartition(tableName, "p3", "2024-01-31", "2024-02-01");
+        addRangePartition(tableName, "p4", "2024-02-01", "2024-02-02");
     }
 
     private void withPartialScanMv(StarRocksAssert.ExceptionRunnable runner) {
@@ -1346,6 +1370,84 @@ public class MvTransparentRewriteWithOlapTableTest extends MVTestBase {
                             PlanTestBase.assertContains(plan, ":UNION");
                             PlanTestBase.assertContains(plan, "mv0");
                             PlanTestBase.assertContains(plan, " OUTPUT EXPRS:1: v11 | 2: k2 | 3: k1");
+                        }
+                    });
+        });
+    }
+
+    @Test
+    public void testTransparentRewriteWithNonDeterministicFunctions() {
+        starRocksAssert.withTable(R2, (obj) -> {
+            String tableName = (String) obj;
+            withTablePartitionsV2(tableName);
+            OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test", tableName);
+            Assert.assertEquals(4, olapTable.getVisiblePartitions().size());
+            cluster.runSql("test", String.format("insert into %s values ('2024-02-01', 1, 1);", tableName));
+
+            starRocksAssert.withMaterializedView(String.format("CREATE MATERIALIZED VIEW mv0 " +
+                            " PARTITION BY (dt) " +
+                            " REFRESH DEFERRED MANUAL " +
+                            " PROPERTIES (\n" +
+                            " 'transparent_mv_rewrite_mode' = 'true'" +
+                            " ) " +
+                            " AS SELECT dt, k2, sum(v1) as agg1 from %s where date_trunc('day', dt) < timestamp(curdate()) " +
+                            " group by dt, k2;", tableName),
+                    () -> {
+                        starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n"));
+                        MaterializedView mv = getMv("test", "mv0");
+                        Set<String> mvNames = mv.getPartitionNames();
+                        Assert.assertEquals(4, mvNames.size());
+
+                        // test mv get plan context
+                        {
+                            MvPlanContext mvPlanContext = getOptimizedPlan(mv, true, true);
+                            Assert.assertTrue(mvPlanContext != null);
+                            Assert.assertTrue(!mvPlanContext.isValidMvPlan());
+                            Assert.assertTrue(mvPlanContext.getLogicalPlan() == null);
+                            Assert.assertTrue(mvPlanContext.getInvalidReason().contains("non-deterministic function"));
+                        }
+                        {
+                            MvPlanContext mvPlanContext = getOptimizedPlan(mv, true, false);
+                            Assert.assertTrue(mvPlanContext != null);
+                            Assert.assertFalse(mvPlanContext.isValidMvPlan());
+                            Assert.assertTrue(mvPlanContext.getLogicalPlan() != null);
+                            // For transparent mv we cannot const fold non-deterministic function because it should be changed
+                            // for each time.
+                            Assert.assertTrue(hasNonDeterministicFunction(mvPlanContext.getLogicalPlan()));
+                        }
+
+                        {
+                            String query = "SELECT * from mv0;";
+                            String plan = getFragmentPlan(query);
+                            PlanTestBase.assertContains(plan, "mv0");
+                            PlanTestBase.assertNotContains(plan, tableName);
+                        }
+
+                        {
+                            // add new partitions
+                            LocalDateTime now = LocalDateTime.now();
+                            addRangePartition(tableName, "p5",
+                                    now.plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                    now.plusDays(2).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                    true);
+                            String query = "SELECT * from mv0;";
+                            FeConstants.enablePruneEmptyOutputScan = true;
+                            String plan = getFragmentPlan(query);
+                            FeConstants.enablePruneEmptyOutputScan = false;
+                            PlanTestBase.assertContains(plan, "mv0");
+                            PlanTestBase.assertNotContains(plan, "UNION", tableName);
+                        }
+                        {
+                            // add new partitions
+                            LocalDateTime now = LocalDateTime.now();
+                            addRangePartition(tableName, "p6",
+                                    now.minusDays(2).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                    now.minusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                                    true);
+                            String query = "SELECT * from mv0;";
+                            String plan = getFragmentPlan(query);
+                            PlanTestBase.assertContains(plan, "mv0");
+                            PlanTestBase.assertContains(plan, "UNION", tableName);
                         }
                     });
         });

--- a/test/sql/test_transparent_mv/R/test_transparent_mv_olap_part3
+++ b/test/sql/test_transparent_mv/R/test_transparent_mv_olap_part3
@@ -436,6 +436,119 @@ SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-06-01' GRO
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by 1, 2 limit 3;
 -- result:
 -- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY dt
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("transparent_mv_rewrite_mode" = "true")
+AS select dt, sum(num) as num from t3 where date_trunc('day', dt) < timestamp(curdate()) GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt,sum(num) FROM test_mv1 where dt='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt !='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt>='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-15 00:00:00	3
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-15 00:00:00	3
+-- !result
+INSERT INTO t3 VALUES (3, "2020-06-15");
+-- result:
+-- !result
+INSERT INTO t3 select 1, curdate();
+-- result:
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt !='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt>='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-15 00:00:00	6
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-06-24 00:00:00	9
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-18 00:00:00	5
+2020-06-21 00:00:00	7
+2020-07-02 00:00:00	3
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
+SELECT dt,sum(num) FROM test_mv1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+-- result:
+2020-06-15 00:00:00	6
+-- !result
 drop table t1 force;
 -- result:
 -- !result

--- a/test/sql/test_transparent_mv/T/test_transparent_mv_olap_part3
+++ b/test/sql/test_transparent_mv/T/test_transparent_mv_olap_part3
@@ -174,6 +174,38 @@ SELECT dt,sum(num) FROM test_mv1 where date_trunc('day', dt) ='2020-06-15' GROUP
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-06-01' GROUP BY dt order by 1, 2 limit 3;
 SELECT dt,sum(num) FROM test_mv1 where date_trunc('month', dt) ='2020-07-01' GROUP BY dt order by 1, 2 limit 3;
 
+DROP MATERIALIZED VIEW test_mv1;
+
+-- test mv with non-deteriminstic functions
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY dt
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("transparent_mv_rewrite_mode" = "true")
+AS select dt, sum(num) as num from t3 where date_trunc('day', dt) < timestamp(curdate()) GROUP BY dt;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT dt,sum(num) FROM test_mv1 where dt='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt !='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt>='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+
+INSERT INTO t3 VALUES (3, "2020-06-15");
+INSERT INTO t3 select 1, curdate();
+SELECT dt,sum(num) FROM test_mv1 where dt='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt !='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt>='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt < '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt>'2020-06-15' and dt <= '2020-07-22' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where (dt>'2020-06-15' and dt <= '2020-06-22') or dt>'2020-07-01' GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where dt in ('2020-06-15', '2020-06-22', '2020-07-01') GROUP BY dt order by 1, 2 limit 3;
+SELECT dt,sum(num) FROM test_mv1 where date_trunc('day', dt) ='2020-06-15' GROUP BY dt order by 1, 2 limit 3;
+
 drop table t1 force;
 drop table t2 force;
 drop table t3 force;


### PR DESCRIPTION
## Why I'm doing:
A `transparent mv`  is defined when mv's 'transparent_mv_rewrite_mode' property is true. when user querys a transparent mv, optimizer will redirect query into refreshed mv partitions from mv and unrefreshed partitions from query by `union all`.

Since `transparent mv`  no needs to query rewrite, so it's fine to support non deterministic functions in transparent mv.

## What I'm doing:

To support non-deterministic functions in transparent mv:
1. Disable checking deterministic functions in transparent mv's getting plan(eg: `current_date`).
2. Eval non-deterministic functions after mv rewrite(eg: `current_date`).


NOTE: This only affects from `transparent mv`'s syntax and does not change mv rewrite (rewrite user's query rather than quering mv).


Fixes https://github.com/StarRocks/starrocks/issues/55509

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0