### PR TITLE
[Enhancement] Support RESTORE_CLUSTER_SNAPSHOT env var to enter the restore cluster snapshot procedure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
@@ -53,10 +53,16 @@ public class RestoreClusterSnapshotMgr {
     public static void init(String clusterSnapshotYamlFile, String[] args) throws StarRocksException {
         for (String arg : args) {
             if (arg.equalsIgnoreCase("-cluster_snapshot")) {
-                LOG.info("FE start to restore from a cluster snapshot");
+                LOG.info("FE start to restore from a cluster snapshot (-cluster_snapshot)");
                 instance = new RestoreClusterSnapshotMgr(clusterSnapshotYamlFile);
                 return;
             }
+        }
+
+        String restoreClusterSnapshotEnv = System.getenv("RESTORE_CLUSTER_SNAPSHOT");
+        if (restoreClusterSnapshotEnv != null && restoreClusterSnapshotEnv.equalsIgnoreCase("true")) {
+            LOG.info("FE start to restore from a cluster snapshot (RESTORE_CLUSTER_SNAPSHOT=true)");
+            instance = new RestoreClusterSnapshotMgr(clusterSnapshotYamlFile);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
Injecting env var is much easier than modifying the command line options in k8s env.

## What I'm doing:
Support RESTORE_CLUSTER_SNAPSHOT env var to enter the restore cluster snapshot procedure.

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0