### PR TITLE
[Enhancement] Add get_cluster_snapshot_restore_state rest api

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -64,6 +64,7 @@ import com.starrocks.http.rest.CheckDecommissionAction;
 import com.starrocks.http.rest.ConnectionAction;
 import com.starrocks.http.rest.ExecuteSqlAction;
 import com.starrocks.http.rest.FeatureAction;
+import com.starrocks.http.rest.GetClusterSnapshotRestoreStateAction;
 import com.starrocks.http.rest.GetDdlStmtAction;
 import com.starrocks.http.rest.GetLoadInfoAction;
 import com.starrocks.http.rest.GetLogFileAction;
@@ -176,6 +177,7 @@ public class HttpServer {
         // rest action
         HealthAction.registerAction(controller);
         FeatureAction.registerAction(controller);
+        GetClusterSnapshotRestoreStateAction.registerAction(controller);
         MetricsAction.registerAction(controller);
         ShowMetaInfoAction.registerAction(controller);
         ShowProcAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/GetClusterSnapshotRestoreStateAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/GetClusterSnapshotRestoreStateAction.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.lake.snapshot.RestoreClusterSnapshotMgr;
+import io.netty.handler.codec.http.HttpMethod;
+
+public class GetClusterSnapshotRestoreStateAction extends RestBaseAction {
+    public GetClusterSnapshotRestoreStateAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller)
+            throws IllegalArgException {
+        controller.registerHandler(HttpMethod.GET, "/api/v2/get_cluster_snapshot_restore_state",
+                new GetClusterSnapshotRestoreStateAction(controller));
+    }
+
+    @Override
+    public void execute(BaseRequest request, BaseResponse response) {
+        response.setContentType("application/json");
+
+        RestResult result = new RestResult();
+        result.addResultEntry("cluster_snapshot_restore_state",
+                RestoreClusterSnapshotMgr.isRestoring() ? "restoring" : "finished");
+        sendResult(request, response, result);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/GetClusterSnapshotRestoreStateActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/GetClusterSnapshotRestoreStateActionTest.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class GetClusterSnapshotRestoreStateActionTest extends StarRocksHttpTestCase {
+
+    private String sendHttp() throws IOException {
+        Request request = new Request.Builder()
+                .get()
+                .url("http://localhost:" + HTTP_PORT + "/api/v2/get_cluster_snapshot_restore_state")
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        assertTrue(response.isSuccessful());
+        String respStr = response.body().string();
+        Assert.assertNotNull(respStr);
+        return respStr;
+    }
+
+    @Test
+    public void testGetFeatures() throws IOException {
+        String resp = sendHttp();
+        Assert.assertTrue(resp.contains("finished"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
K8s needs this api to check if a cluster snapshot finished restoring.

## What I'm doing:
Add get_cluster_snapshot_restore_state rest api.

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0