### PR TITLE
[BugFix] correct repeatnode's output property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -350,27 +350,38 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
     public PhysicalPropertySet visitPhysicalRepeat(PhysicalRepeatOperator node, ExpressionContext context) {
         checkState(childrenOutputProperties.size() == 1);
         PhysicalPropertySet childPropertySet = childrenOutputProperties.get(0);
+
+        // calculate the Intersection of RepeatColumnRef
         List<ColumnRefOperator> subRefs = Lists.newArrayList(node.getRepeatColumnRef().get(0));
         node.getRepeatColumnRef().forEach(subRefs::retainAll);
-        Set<ColumnRefOperator> allGroupingRefs = Sets.newHashSet();
-
-        node.getRepeatColumnRef().forEach(allGroupingRefs::addAll);
-        subRefs.forEach(allGroupingRefs::remove);
 
         DistributionProperty childDistribution = childPropertySet.getDistributionProperty();
-        // update null distribution info to null relax for allGroupingRefs
-        if (!allGroupingRefs.isEmpty() && childDistribution.isShuffle()) {
-            HashDistributionSpec distributionSpec = (HashDistributionSpec) childDistribution.getSpec();
-            EquivalentDescriptor newEquivDesc = distributionSpec.getEquivDesc().copy();
-            newEquivDesc.clearNullStrictUnionFind();
-            HashDistributionSpec newDistributionSpec = distributionSpec.getNullRelaxSpec(newEquivDesc);
-            DistributionProperty newDistributionProperty = DistributionProperty.createProperty(
-                    newDistributionSpec,
-                    childPropertySet.getDistributionProperty().isCTERequired());
-            return new PhysicalPropertySet(newDistributionProperty, childPropertySet.getSortProperty(),
-                    childPropertySet.getCteProperty());
+        // only if the Intersection of RepeatColumnRef is the superset of the childrenOutputProperties
+        // we can use childrenOutputProperties as RepeatNode's output property
+        // such as RepeatColumnRef is (cola,colb),(cola), and childrenOutputProperties is hash(cola)
+        // since cola won't be inserted with null value, it's safe to use childrenOutputProperties
+        // if RepeatColumnRef is (cola,colb),(cola), and childrenOutputProperties is hash(cola,colb)
+        // since cola will be inserted with null value, it's unsafe to use hash(cola,colb)
+        DistributionProperty outputDistribution = EmptyDistributionProperty.INSTANCE;
+        if (childDistribution.isShuffle()) {
+            boolean canFollowChild = true;
+            HashDistributionSpec childDistributionSpec = (HashDistributionSpec) childDistribution.getSpec();
+            Set<Integer> commonRefs = subRefs.stream().map(ColumnRefOperator::getId).collect(Collectors.toSet());
+
+            for (DistributionCol col : childDistributionSpec.getHashDistributionDesc().getDistributionCols()) {
+                if (!commonRefs.contains(col.getColId())) {
+                    canFollowChild = false;
+                    break;
+                }
+            }
+
+            if (canFollowChild) {
+                outputDistribution = childDistribution;
+            }
         }
-        return childPropertySet;
+
+        return new PhysicalPropertySet(outputDistribution, childPropertySet.getSortProperty(),
+                childPropertySet.getCteProperty());
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:
only if the Intersection of RepeatColumnRef is the superset of the childrenOutputProperties, then we can use childrenOutputProperties as RepeatNode's output property.  Otherwise only output empty property

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/54483

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0