### PR TITLE
[BugFix] fix the privilege issue DROP STATS command

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1129,7 +1129,7 @@ public class ConnectContext {
      * }
      */
     public ScopeGuard bindScope() {
-        return ScopeGuard.exchange(this);
+        return ScopeGuard.bind(this);
     }
 
     // Change current catalog of this session, and reset current database.
@@ -1285,7 +1285,7 @@ public class ConnectContext {
         private ScopeGuard() {
         }
 
-        private static ScopeGuard exchange(ConnectContext session) {
+        private static ScopeGuard bind(ConnectContext session) {
             ScopeGuard res = new ScopeGuard();
             res.prev = exchangeThreadLocalInfo(session);
             res.set = true;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1281,6 +1281,10 @@ public class ConnectContext {
             return res;
         }
 
+        public ConnectContext prev() {
+            return prev;
+        }
+
         @Override
         public void close() {
             if (set) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -221,6 +221,9 @@ public class ConnectContext {
     protected boolean isMetadataContext = false;
     protected boolean needQueued = true;
 
+    // Bypass the authorizer check for certain cases
+    protected boolean bypassAuthorizerCheck = false;
+
     protected DumpInfo dumpInfo;
 
     // The related db ids for current sql
@@ -921,6 +924,14 @@ public class ConnectContext {
 
     public void setNeedQueued(boolean needQueued) {
         this.needQueued = needQueued;
+    }
+
+    public boolean isBypassAuthorizerCheck() {
+        return bypassAuthorizerCheck;
+    }
+
+    public void setBypassAuthorizerCheck(boolean value) {
+        this.bypassAuthorizerCheck = value;
     }
 
     public ConnectContext getParent() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1528,12 +1528,9 @@ public class StmtExecutor {
         // from current session, may execute analyze stmt
         statsConnectCtx.getSessionVariable().setStatisticCollectParallelism(
                 context.getSessionVariable().getStatisticCollectParallelism());
-        statsConnectCtx.setThreadLocalInfo();
         statsConnectCtx.setStatisticsConnection(true);
-        try {
+        try (var guard = statsConnectCtx.bindScope()) {
             executeAnalyze(statsConnectCtx, analyzeStmt, analyzeStatus, db, table);
-        } finally {
-            ConnectContext.remove();
         }
 
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/PhasedExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/PhasedExecutionSchedule.java
@@ -249,7 +249,7 @@ public class PhasedExecutionSchedule implements ExecutionSchedule {
         if (countDowns.decrementAndGet() != 0) {
             return;
         }
-        try (var guard = ConnectContext.ScopeGuard.setIfNotExists(connectContext)) {
+        try (var guard = connectContext.bindScope()) {
             final int oldTaskCnt = inputScheduleTaskNums.getAndIncrement();
             if (oldTaskCnt == 0) {
                 int dec = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -122,7 +122,9 @@ public class StatementPlanner {
             analyzeStatement(stmt, session, plannerMetaLocker);
 
             // Authorization check
-            Authorizer.check(stmt, session);
+            if (!session.isBypassAuthorizerCheck()) {
+                Authorizer.check(stmt, session);
+            }
             if (stmt instanceof QueryStatement) {
                 OptimizerTraceUtil.logQueryStatement("after analyze:\n%s", (QueryStatement) stmt);
             }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Introduced by https://github.com/StarRocks/starrocks/pull/55400. 
- When executing `DELETE` sql, it will construct an `SELECT` sql to do partition pruning. But the user may have different privilege on `DELETE` and `SELECT`, which means that user may have privilege to `DELETE` but no privilege to perform `SELECT`
- One example is `DROP STATS xxx` command,  it will execute an `DELETE FROM table_statistics_v1` SQL, which should use the ROOT user, otherwise may lack the right privilege. But there's a bug with it, which doesn't bind the session to thread-local, so `DELETE` still uses the original user but not root

To address this, we need to do several fixes:
- Bypass the privilege check when planning `SELECT` in `DELETE`, to avoid the privilege issue
- Correctly bind the thread-local session for `DROP STATS` and other commands


Alternatives:
- Solution 1: invoke only necessary optimizer components to do partition pruning, rather than constructing a sql directly. Why don't we choose this approach? 
    - In theory we should have a DeletePlanner, which can do partition pruning for `DELETE` statement, so we don't have to do it in `DeleteMgr` which should be responsible for execution. But unfortunetely we don't have it, and the query plan of `DELETE` is pretty naive. 
    - Or can we invoke the optimizer components to do partition pruning in `DeleteMgr`, but partition pruning has pretty much dependency on other components like predicate simplification & pushdown, it needs to copy pretty much duplicate code like `StatementPlanner::plan`
    - So in result this approach will make the problem more complicated 


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0