### PR TITLE
[Enhancement] Add metrics to monitor unstable routine load jobs

### DIFF
--- a/docs/en/administration/management/monitoring/alert.md
+++ b/docs/en/administration/management/monitoring/alert.md
@@ -429,6 +429,7 @@ Check the logs of the Leader FE node to find information about the loading error
 (sum by (job_name)(starrocks_fe_routine_load_max_lag_of_partition{job="$job_name",instance="$fe_mater"})) > 300000
 starrocks_fe_routine_load_jobs{job="$job_name",host="$fe_mater",state="NEED_SCHEDULE"} > 3
 starrocks_fe_routine_load_jobs{job="$job_name",host="$fe_mater",state="PAUSED"} > 0
+starrocks_fe_routine_load_jobs{job="$job_name",host="$fe_mater",state="UNSTABLE"} > 0
 ```
 
 **Alert Description**
@@ -436,6 +437,7 @@ starrocks_fe_routine_load_jobs{job="$job_name",host="$fe_mater",state="PAUSED"} 
 - An alert is triggered when over 300,000 entries are delayed in consumption.
 - An alert is triggered when the number of pending Routine Load tasks exceeds 3.
 - An alert is triggered when there are tasks in the `PAUSED` state.
+- An alert is triggered when there are tasks in the `UNSTABLE` state.
 
 **Resolution**
 

--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -1646,6 +1646,7 @@ For more information on how to build a monitoring service for your StarRocks clu
   starrocks_fe_routine_load_jobs{state="PAUSED"} 0
   starrocks_fe_routine_load_jobs{state="STOPPED"} 0
   starrocks_fe_routine_load_jobs{state="CANCELLED"} 1
+  starrocks_fe_routine_load_jobs{state="UNSTABLE"} 0
   ```
 
 ### starrocks_fe_routine_load_paused

--- a/docs/zh/administration/management/monitoring/alert.md
+++ b/docs/zh/administration/management/monitoring/alert.md
@@ -428,6 +428,7 @@ rate(starrocks_fe_txn_failed{job="$job_name",instance="$fe_master"}[5m]) * 100 >
 (sum by (job_name)(starrocks_fe_routine_load_max_lag_of_partition{job="$job_name",instance="$fe_mater"})) > 300000
 starrocks_fe_routine_load_jobs{job="$job_name",host="$fe_mater",state="NEED_SCHEDULE"} > 3
 starrocks_fe_routine_load_jobs{job="$job_name",host="$fe_mater",state="PAUSED"} > 0
+starrocks_fe_routine_load_jobs{job="$job_name",host="$fe_mater",state="UNSTABLE"} > 0
 ```
 
 **报警描述**
@@ -435,6 +436,7 @@ starrocks_fe_routine_load_jobs{job="$job_name",host="$fe_mater",state="PAUSED"} 
 - 当消费延迟超过 300000 条时发送报警。
 - 当待调度的 Routine Load 任务个数超过 3 时发送报警。
 - 当有状态为 PAUSED 的任务时发送报警。
+- 当有状态为 UNSTABLE 的任务时发送报警。
 
 **处理办法**
 

--- a/docs/zh/administration/management/monitoring/metrics.md
+++ b/docs/zh/administration/management/monitoring/metrics.md
@@ -1645,6 +1645,7 @@ displayed_sidebar: docs
   starrocks_fe_routine_load_jobs{state="PAUSED"} 0
   starrocks_fe_routine_load_jobs{state="STOPPED"} 0
   starrocks_fe_routine_load_jobs{state="CANCELLED"} 1
+  starrocks_fe_routine_load_jobs{state="UNSTABLE"} 0
   ```
 
 ### starrocks_fe_routine_load_paused

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -556,6 +556,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         return state;
     }
 
+    public boolean isUnstable() {
+        return state == JobState.RUNNING && substate == JobSubstate.UNSTABLE;
+    }
+
     public long getAuthCode() {
         return authCode;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -602,6 +602,10 @@ public class RoutineLoadMgr implements Writable, MemoryTrackable {
                 .collect(Collectors.toList());
     }
 
+    public long numUnstableJobs() {
+        return idToRoutineLoadJob.values().stream().filter(RoutineLoadJob::isUnstable).count();
+    }
+
     // RoutineLoadScheduler will run this method at fixed interval, and renew the timeout tasks
     public void processTimeoutTasks() {
         readLock();

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -323,6 +323,19 @@ public final class MetricRepo {
             STARROCKS_METRIC_REGISTER.addMetric(gauge);
         }
 
+        GaugeMetric<Long> routineLoadUnstableJobsGauge = new GaugeMetric<Long>("routine_load_jobs",
+                MetricUnit.NOUNIT, "routine load jobs") {
+            @Override
+            public Long getValue() {
+                if (null == routineLoadManger) {
+                    return 0L;
+                }
+                return routineLoadManger.numUnstableJobs();
+            }
+        };
+        routineLoadUnstableJobsGauge.addLabel(new MetricLabel("state", "UNSTABLE"));
+        STARROCKS_METRIC_REGISTER.addMetric(routineLoadUnstableJobsGauge);
+
         // qps, rps, error rate and query latency
         // these metrics should be set an init value, in case that metric calculator is not running
         GAUGE_QUERY_PER_SECOND = new GaugeMetricImpl<>("qps", MetricUnit.NOUNIT, "query per second");

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -320,6 +320,7 @@ public class RoutineLoadJobTest {
             routineLoadJob.updateState(RoutineLoadJob.JobState.RUNNING, null, false);
             // The job is set unstable due to the progress is too slow.
             routineLoadJob.updateSubstate();
+            Assert.assertTrue(routineLoadJob.isUnstable());
 
             List<String> showInfo = routineLoadJob.getShowInfo();
             Assert.assertEquals("UNSTABLE", showInfo.get(7));


### PR DESCRIPTION
## Why I'm doing:
Add metric `starrocks_fe_routine_load_jobs{state="UNSTABLE"}` to monitor unstable routine load jobs

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/48636

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0