### PR TITLE
[BugFix] fix incorrect statistics of spill dir capacity

### DIFF
--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -70,12 +70,15 @@ public:
     Status flush();
 
     bool pre_allocate(size_t allocate_size) {
-        if (_dir->inc_size(allocate_size)) {
-            _acquired_data_size += allocate_size;
+        if (_data_size + allocate_size <= _acquired_data_size) {
             return true;
-        } else {
-            return false;
         }
+        size_t extra_size = _data_size + allocate_size - _acquired_data_size;
+        if (_dir->inc_size(extra_size)) {
+            _acquired_data_size += extra_size;
+            return true;
+        }
+        return false;
     }
 
     StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable();

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -83,12 +83,15 @@ public:
     uint64_t id() const { return _id; }
 
     bool pre_allocate(size_t allocate_size) {
-        if (_dir->inc_size(allocate_size)) {
-            _acquired_data_size += allocate_size;
+        if (_data_size + allocate_size <= _acquired_data_size) {
             return true;
-        } else {
-            return false;
         }
+        size_t extra_size = _data_size + allocate_size - _acquired_data_size;
+        if (_dir->inc_size(extra_size)) {
+            _acquired_data_size += extra_size;
+            return true;
+        }
+        return false;
     }
 
     Status append_data(const std::vector<Slice>& data, size_t total_size);
@@ -334,5 +337,4 @@ StatusOr<LogBlockContainerPtr> LogBlockManager::get_or_create_container(
     RETURN_IF_ERROR(block_container->open());
     return block_container;
 }
-
 } // namespace starrocks::spill


### PR DESCRIPTION
## Why I'm doing:

There are some problems with the current capacity management of spill dir.
We use `Dir::inc_size` and `Dir::dec_size` to apply for and release capacity.

`Dir::inc_size` is called in two places: `DirManager::acquire_writable_dir` and `BlockContainer::pre_allocate`
`Dir::dec_size` is called in one place: the destrcutor of `BlockContainer`

Assume that we allocate Block from an **existing** Container,
when applying for Block, the capacity of Dir will be updated (which we record as A), 
![image](https://github.com/user-attachments/assets/725fd351-c4b6-4570-95ef-43515e11e554)

and when appending data into Block, `pre_allocate` will also update the capacity of Dir (which we record as B),
![image](https://github.com/user-attachments/assets/86ade7bb-bf80-4437-8f27-2ee90e2255da)


 but when BlockContainer is destructed, A is not counted, which will **cause a leak**.

![image](https://github.com/user-attachments/assets/3666062f-d536-4cb8-bea3-0d10050c112e)


## What I'm doing:

Fix the implementation of `Block::pre_allocate`. When the remaining capacity is sufficient, new space will no longer be requested from Dir, thus ensuring that inc_size and dec_size always match.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0