### PR TITLE
[Feature] support SQL Plan Manager

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3539,4 +3539,7 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int max_get_partitions_meta_result_count = 100000;
+
+    @ConfField(mutable = false)
+    public static int max_spm_cache_baseline_size = 200;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -21,7 +21,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.FrontendDaemon;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.history.TableKeeper;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
@@ -103,7 +103,7 @@ public class LoadsHistorySyncer extends FrontendDaemon {
         }
 
         try {
-            RepoExecutor.getInstance().executeDML(SQLBuilder.buildSyncSql());
+            SimpleExecutor.getRepoExecutor().executeDML(SQLBuilder.buildSyncSql());
         } catch (Exception e) {
             LOG.error("Failed to sync loads history", e); 
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoAccessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoAccessor.java
@@ -16,6 +16,7 @@ package com.starrocks.load.pipe.filelist;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.load.pipe.PipeFileRecord;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.thrift.TResultBatch;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -41,7 +42,7 @@ public class RepoAccessor {
 
     public List<PipeFileRecord> listAllFiles() {
         try {
-            List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(
+            List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(
                     FileListTableRepo.SELECT_FILES);
             return PipeFileRecord.fromResultBatch(batch);
         } catch (Exception e) {
@@ -54,7 +55,7 @@ public class RepoAccessor {
         List<PipeFileRecord> res = null;
         try {
             String sql = buildListFileByState(pipeId, state, limit);
-            List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+            List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
             res = PipeFileRecord.fromResultBatch(batch);
         } catch (Exception e) {
             LOG.error("listUnloadedFiles failed", e);
@@ -67,7 +68,7 @@ public class RepoAccessor {
         PipeFileRecord res = null;
         try {
             String sql = buildListFileByPath(pipeId, path);
-            List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+            List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
             if (CollectionUtils.isEmpty(batch)) {
                 throw new IllegalArgumentException("file not found: " + path);
             } else if (batch.size() > 1) {
@@ -84,7 +85,7 @@ public class RepoAccessor {
     public List<PipeFileRecord> selectStagedFiles(List<PipeFileRecord> records) {
         try {
             String sql = buildSelectStagedFiles(records);
-            List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+            List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
             return PipeFileRecord.fromResultBatch(batch);
         } catch (Exception e) {
             LOG.error("selectStagedFiles failed", e);
@@ -95,7 +96,7 @@ public class RepoAccessor {
     public void addFiles(List<PipeFileRecord> records) {
         try {
             String sql = buildSqlAddFiles(records);
-            RepoExecutor.getInstance().executeDML(sql);
+            SimpleExecutor.getRepoExecutor().executeDML(sql);
             LOG.info("addFiles into repo: {}", records);
             return;
         } catch (Exception e) {
@@ -126,7 +127,7 @@ public class RepoAccessor {
                     Preconditions.checkState(false, "not supported");
                     break;
             }
-            RepoExecutor.getInstance().executeDML(sql);
+            SimpleExecutor.getRepoExecutor().executeDML(sql);
             LOG.info("update files state to {}: {}", state, records);
         } catch (Exception e) {
             LOG.error("update files state failed: {}", records, e);
@@ -137,7 +138,7 @@ public class RepoAccessor {
     public void deleteByPipe(long pipeId) {
         try {
             String sql = String.format(FileListTableRepo.DELETE_BY_PIPE, pipeId);
-            RepoExecutor.getInstance().executeDML(sql);
+            SimpleExecutor.getRepoExecutor().executeDML(sql);
             LOG.info("delete pipe files {}", pipeId);
         } catch (Exception e) {
             LOG.error("delete file of pipe {} failed", pipeId, e);

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
@@ -15,6 +15,7 @@
 package com.starrocks.load.pipe.filelist;
 
 import com.starrocks.common.StarRocksException;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatisticUtils;
 import org.apache.logging.log4j.LogManager;
@@ -63,7 +64,7 @@ public class RepoCreator {
         int expectedReplicationNum =
                 GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getSystemTableExpectedReplicationNum();
         String sql = FileListTableRepo.SQLBuilder.buildCreateTableSql(expectedReplicationNum);
-        RepoExecutor.getInstance().executeDDL(sql);
+        SimpleExecutor.getRepoExecutor().executeDDL(sql);
     }
 
     public static boolean correctTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -95,6 +95,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.spm.BaselinePlan;
 import com.starrocks.staros.StarMgrJournal;
 import com.starrocks.staros.StarMgrServer;
 import com.starrocks.statistic.AnalyzeJob;
@@ -1158,6 +1159,16 @@ public class EditLog {
                     GlobalStateMgr.getCurrentState().getAuthenticationMgr().replayDropGroupProvider(groupProviderLog.getName());
                     break;
                 }
+                case OperationType.OP_CREATE_SPM_BASELINE_LOG: {
+                    BaselinePlan bp = (BaselinePlan) journal.data();
+                    globalStateMgr.getSqlPlanStorage().replayBaselinePlan(bp, true);
+                    break;
+                }
+                case OperationType.OP_DROP_SPM_BASELINE_LOG: {
+                    BaselinePlan bp = (BaselinePlan) journal.data();
+                    globalStateMgr.getSqlPlanStorage().replayBaselinePlan(bp, false);
+                    break;
+                }
                 default: {
                     if (Config.metadata_ignore_unknown_operation_type) {
                         LOG.warn("UNKNOWN Operation Type {}", opCode);
@@ -2031,5 +2042,13 @@ public class EditLog {
 
     public void logClusterSnapshotLog(ClusterSnapshotLog info) {
         logEdit(OperationType.OP_CLUSTER_SNAPSHOT_LOG, info);
+    }
+
+    public void logCreateSPMBaseline(BaselinePlan info) {
+        logEdit(OperationType.OP_CREATE_SPM_BASELINE_LOG, info);
+    }
+
+    public void logDropSPMBaseline(BaselinePlan info) {
+        logEdit(OperationType.OP_DROP_SPM_BASELINE_LOG, info);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
@@ -50,6 +50,7 @@ import com.starrocks.scheduler.persist.TaskRunPeriodStatusChange;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.spm.BaselinePlan;
 import com.starrocks.staros.StarMgrJournal;
 import com.starrocks.statistic.BasicStatsMeta;
 import com.starrocks.statistic.ExternalAnalyzeJob;
@@ -250,6 +251,8 @@ public class EditLogDeserializer {
             .put(OperationType.OP_DROP_SECURITY_INTEGRATION, SecurityIntegrationPersistInfo.class)
             .put(OperationType.OP_CREATE_GROUP_PROVIDER, GroupProviderLog.class)
             .put(OperationType.OP_DROP_GROUP_PROVIDER, GroupProviderLog.class)
+            .put(OperationType.OP_CREATE_SPM_BASELINE_LOG, BaselinePlan.class)
+            .put(OperationType.OP_DROP_SPM_BASELINE_LOG, BaselinePlan.class)
             .build();
 
     public static Writable deserialize(Short opCode, DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -599,6 +599,12 @@ public class OperationType {
     @IgnorableOnReplayFailed
     public static final short OP_DROP_GROUP_PROVIDER = 13531;
 
+    @IgnorableOnReplayFailed
+    public static final short OP_CREATE_SPM_BASELINE_LOG = 13540;
+
+    @IgnorableOnReplayFailed
+    public static final short OP_DROP_SPM_BASELINE_LOG = 13541;
+
     /**
      * NOTICE: OperationType cannot use a value exceeding 20000, please follow the above sequence number
      */

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -82,6 +82,7 @@ import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.dump.DumpInfo;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.spm.SQLPlanStorage;
 import com.starrocks.thrift.TPipelineProfileLevel;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWorkGroup;
@@ -260,6 +261,9 @@ public class ConnectContext {
     // ExplicitTxnStateItem, and the transaction state is recorded in TransactionState.
     private ExplicitTxnState explicitTxnState;
 
+    // session level SPM storage
+    private SQLPlanStorage sqlPlanStorage = SQLPlanStorage.create(false);
+
     public void setExplicitTxnState(ExplicitTxnState explicitTxnState) {
         this.explicitTxnState = explicitTxnState;
     }
@@ -347,6 +351,9 @@ public class ConnectContext {
         return connectContext;
     }
 
+    public SQLPlanStorage getSqlPlanStorage() {
+        return sqlPlanStorage;
+    }
     public void putPreparedStmt(String stmtName, PrepareStmtContext ctx) {
         this.preparedStmtCtxs.put(stmtName, ctx);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -153,6 +153,7 @@ import com.starrocks.sql.ast.warehouse.CreateWarehouseStmt;
 import com.starrocks.sql.ast.warehouse.DropWarehouseStmt;
 import com.starrocks.sql.ast.warehouse.ResumeWarehouseStmt;
 import com.starrocks.sql.ast.warehouse.SuspendWarehouseStmt;
+import com.starrocks.sql.spm.SPMStmtExecutor;
 import com.starrocks.statistic.AnalyzeJob;
 import com.starrocks.statistic.ExternalAnalyzeJob;
 import com.starrocks.statistic.NativeAnalyzeJob;
@@ -1267,11 +1268,17 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitCreateBaselinePlanStatement(CreateBaselinePlanStmt statement,
                                                               ConnectContext context) {
+            ErrorReport.wrapWithRuntimeException(() -> {
+                SPMStmtExecutor.execute(context, statement);
+            });
             return null;
         }
 
         @Override
         public ShowResultSet visitDropBaselinePlanStatement(DropBaselinePlanStmt statement, ConnectContext context) {
+            ErrorReport.wrapWithRuntimeException(() -> {
+                SPMStmtExecutor.execute(context, statement);
+            });
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -1268,17 +1268,13 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitCreateBaselinePlanStatement(CreateBaselinePlanStmt statement,
                                                               ConnectContext context) {
-            ErrorReport.wrapWithRuntimeException(() -> {
-                SPMStmtExecutor.execute(context, statement);
-            });
+            ErrorReport.wrapWithRuntimeException(() -> SPMStmtExecutor.execute(context, statement));
             return null;
         }
 
         @Override
         public ShowResultSet visitDropBaselinePlanStatement(DropBaselinePlanStmt statement, ConnectContext context) {
-            ErrorReport.wrapWithRuntimeException(() -> {
-                SPMStmtExecutor.execute(context, statement);
-            });
+            ErrorReport.wrapWithRuntimeException(() -> SPMStmtExecutor.execute(context, statement));
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -655,6 +655,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_CBO_VIEW_BASED_MV_REWRITE = "enable_cbo_view_based_mv_rewrite";
 
+    public static final String ENABLE_SPM_REWRITE = "enable_sql_plan_manager_rewrite";
+
     public static final String ENABLE_BIG_QUERY_LOG = "enable_big_query_log";
     public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = "big_query_log_cpu_second_threshold";
     public static final String BIG_QUERY_LOG_SCAN_BYTES_THRESHOLD = "big_query_log_scan_bytes_threshold";
@@ -2032,6 +2034,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_CBO_VIEW_BASED_MV_REWRITE)
     private boolean enableCBOViewBasedMvRewrite = false;
+
+    @VarAttr(name = ENABLE_SPM_REWRITE)
+    private boolean enableSPMRewrite = false;
 
     /**
      * Materialized view rewrite rule output limit: how many MVs would be chosen in a Rule for an OptExpr ?
@@ -4653,6 +4658,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setBackPressureThrottleTimeUpperBound(long value) {
         this.backPressureThrottleTimeUpperBound = value;
+    }
+
+    public boolean isEnableSPMRewrite() {
+        return enableSPMRewrite;
+    }
+
+    public void setEnableSPMRewrite(boolean enableSPMRewrite) {
+        this.enableSPMRewrite = enableSPMRewrite;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -237,10 +237,12 @@ import com.starrocks.sql.ast.integration.ShowSecurityIntegrationStatement;
 import com.starrocks.sql.ast.pipe.DescPipeStmt;
 import com.starrocks.sql.ast.pipe.PipeName;
 import com.starrocks.sql.ast.pipe.ShowPipeStmt;
+import com.starrocks.sql.ast.spm.ShowBaselinePlanStmt;
 import com.starrocks.sql.ast.warehouse.ShowNodesStmt;
 import com.starrocks.sql.ast.warehouse.ShowWarehousesStmt;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import com.starrocks.sql.spm.SPMStmtExecutor;
 import com.starrocks.statistic.AnalyzeJob;
 import com.starrocks.statistic.AnalyzeStatus;
 import com.starrocks.statistic.BasicStatsMeta;
@@ -2461,6 +2463,11 @@ public class ShowExecutor {
 
             rows = doPredicate(statement, statement.getMetaData(), rows);
             return new ShowResultSet(statement.getMetaData(), rows);
+        }
+
+        @Override
+        public ShowResultSet visitShowBaselinePlanStatement(ShowBaselinePlanStmt statement, ConnectContext context) {
+            return SPMStmtExecutor.execute(context, statement);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -20,7 +20,7 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.load.loadv2.LoadsHistorySyncer;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.columns.PredicateColumnsStorage;
 import jdk.jshell.spi.ExecutionControl;
@@ -93,7 +93,7 @@ public class TableKeeper {
     }
 
     public void createTable() throws ExecutionControl.UserException {
-        RepoExecutor.getInstance().executeDDL(createTableSql);
+        SimpleExecutor.getRepoExecutor().executeDDL(createTableSql);
     }
 
     public void correctTable() {
@@ -107,7 +107,7 @@ public class TableKeeper {
         if (replica != expectedReplicationNum) {
             String sql = alterTableReplicas(expectedReplicationNum);
             if (StringUtils.isNotEmpty(sql)) {
-                RepoExecutor.getInstance().executeDDL(sql);
+                SimpleExecutor.getRepoExecutor().executeDDL(sql);
             }
             LOG.info("changed replication_number of table {} from {} to {}",
                     tableName, replica, expectedReplicationNum);
@@ -130,7 +130,7 @@ public class TableKeeper {
         }
         String sql = alterTableTTL(expectedTTLDays);
         try {
-            RepoExecutor.getInstance().executeDDL(sql);
+            SimpleExecutor.getRepoExecutor().executeDDL(sql);
             LOG.info("change table {}.{} TTL from {} to {}",
                     databaseName, tableName, currentTTLNumber, expectedTTLDays);
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -20,7 +20,7 @@ import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.persist.TaskRunStatus;
@@ -152,7 +152,7 @@ public class TaskRunHistoryTable {
             }).collect(Collectors.joining(", "));
 
             String sql = insert + values;
-            RepoExecutor.getInstance().executeDML(sql);
+            SimpleExecutor.getRepoExecutor().executeDML(sql);
         }
     }
 
@@ -211,7 +211,7 @@ public class TaskRunHistoryTable {
         }
         sql += Joiner.on(" AND ").join(predicates);
 
-        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
         List<TaskRunStatus> result = TaskRunStatus.fromResultBatch(batch);
         // sort results by create time desc to make the result more stable.
         Collections.sort(result, TaskRunStatus.COMPARATOR_BY_CREATE_TIME_DESC);
@@ -230,7 +230,7 @@ public class TaskRunHistoryTable {
         }
 
         String sql = LOOKUP + Joiner.on(" AND ").join(predicates);
-        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
         List<TaskRunStatus> result = TaskRunStatus.fromResultBatch(batch);
         // sort results by create time desc to make the result more stable.
         Collections.sort(result, TaskRunStatus.COMPARATOR_BY_CREATE_TIME_DESC);
@@ -277,7 +277,7 @@ public class TaskRunHistoryTable {
         DEFAULT_VELOCITY_ENGINE.evaluate(context, sw, "", template);
         String sql = sw.toString();
 
-        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
         return TaskRunStatus.fromResultBatch(batch);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -218,7 +218,7 @@ import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
 import com.starrocks.sql.optimizer.statistics.StatisticStorage;
 import com.starrocks.sql.parser.AstBuilder;
 import com.starrocks.sql.parser.SqlParser;
-import com.starrocks.sql.spm.SQLPlanManager;
+import com.starrocks.sql.spm.SQLPlanStorage;
 import com.starrocks.staros.StarMgrServer;
 import com.starrocks.statistic.AnalyzeMgr;
 import com.starrocks.statistic.StatisticAutoCollector;
@@ -528,7 +528,7 @@ public class GlobalStateMgr {
     private final SqlBlackList sqlBlackList;
     private final ReportHandler reportHandler;
     private final TabletCollector tabletCollector;
-    private final SQLPlanManager sqlPlanManager;
+    private final SQLPlanStorage sqlPlanStorage;
 
     private JwkMgr jwkMgr;
 
@@ -675,7 +675,7 @@ public class GlobalStateMgr {
         this.statisticAutoCollector = new StatisticAutoCollector();
         this.safeModeChecker = new SafeModeChecker();
         this.statisticStorage = new CachedStatisticStorage();
-        this.sqlPlanManager = new SQLPlanManager();
+        this.sqlPlanStorage = SQLPlanStorage.create(true);
 
         this.replayedJournalId = new AtomicLong(0L);
         this.synchronizedTimeMs = 0;
@@ -962,8 +962,8 @@ public class GlobalStateMgr {
         this.statisticStorage = statisticStorage;
     }
 
-    public SQLPlanManager getSqlPlanManager() {
-        return sqlPlanManager;
+    public SQLPlanStorage getSqlPlanStorage() {
+        return sqlPlanStorage;
     }
 
     public StarOSAgent getStarOSAgent() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
@@ -37,6 +37,7 @@ public class AnalyzeState {
     /**
      * Structure used to build QueryBlock
      */
+    private List<String> outputAlias;
     private List<Expr> outputExpressions;
     private Scope outputScope;
     private boolean isDistinct = false;
@@ -239,5 +240,13 @@ public class AnalyzeState {
 
     public List<Expr> getColumnNotInGroupBy() {
         return columnNotInGroupBy;
+    }
+
+    public List<String> getOutputAlias() {
+        return outputAlias;
+    }
+
+    public void setOutputAlias(List<String> outputAlias) {
+        this.outputAlias = outputAlias;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
@@ -37,7 +37,6 @@ public class AnalyzeState {
     /**
      * Structure used to build QueryBlock
      */
-    private List<String> outputAlias;
     private List<Expr> outputExpressions;
     private Scope outputScope;
     private boolean isDistinct = false;
@@ -240,13 +239,5 @@ public class AnalyzeState {
 
     public List<Expr> getColumnNotInGroupBy() {
         return columnNotInGroupBy;
-    }
-
-    public List<String> getOutputAlias() {
-        return outputAlias;
-    }
-
-    public void setOutputAlias(List<String> outputAlias) {
-        this.outputAlias = outputAlias;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -55,6 +55,7 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorEvaluator;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.sql.spm.SPMFunctions;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -677,6 +678,10 @@ public class FunctionAnalyzer {
             return fn;
         }
 
+        fn = SPMFunctions.getSPMFunction(node.getFnName().getFunction());
+        if (fn != null) {
+            return fn;
+        }
         // get fn from builtin functions
         fn = getAnalyzedBuiltInFunction(session, fnName, params, argumentTypes, node.getPos());
         if (fn != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Scope.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Scope.java
@@ -92,8 +92,8 @@ public class Scope {
 
     public ResolvedField resolveField(SlotRef expression, RelationId outerRelationId) {
         Optional<ResolvedField> resolvedField = resolveField(expression, 0, outerRelationId);
-        if (!resolvedField.isPresent()) {
-            throw new SemanticException("Column '%s' cannot be resolved", expression.toSql());
+        if (resolvedField.isEmpty()) {
+            throw new SemanticException("Column '%s' cannot be resolved", expression.toMySql());
         }
         return resolvedField.get();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -203,6 +203,7 @@ public class SelectAnalyzer {
     private List<Expr> analyzeSelect(SelectList selectList, Relation fromRelation, AnalyzeState analyzeState, Scope scope) {
         ImmutableList.Builder<Expr> outputExpressionBuilder = ImmutableList.builder();
         ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
+        List<String> outputAlias = Lists.newArrayList();
         List<Integer> outputExprInOrderByScope = new ArrayList<>();
 
         for (SelectListItem item : selectList.getItems()) {
@@ -241,6 +242,7 @@ public class SelectAnalyzer {
                     FieldReference fieldReference = new FieldReference(fieldIndex, item.getTblName());
                     analyzeExpression(fieldReference, analyzeState, scope);
                     outputExpressionBuilder.add(fieldReference);
+                    outputAlias.add(null);
                 }
                 outputFields.addAll(fields);
 
@@ -253,6 +255,7 @@ public class SelectAnalyzer {
                             AstToStringBuilder.getAliasName(item.getExpr(), false, false) : item.getAlias();
                 }
 
+                outputAlias.add(item.getAlias());
                 analyzeExpression(item.getExpr(), analyzeState, scope);
                 outputExpressionBuilder.add(item.getExpr());
 
@@ -309,6 +312,7 @@ public class SelectAnalyzer {
         analyzeState.setOutputExpression(outputExpressions);
         analyzeState.setOutputExprInOrderByScope(outputExprInOrderByScope);
         analyzeState.setOutputScope(new Scope(RelationId.anonymous(), new RelationFields(outputFields.build())));
+        analyzeState.setOutputAlias(outputAlias);
         return outputExpressions;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -203,7 +203,6 @@ public class SelectAnalyzer {
     private List<Expr> analyzeSelect(SelectList selectList, Relation fromRelation, AnalyzeState analyzeState, Scope scope) {
         ImmutableList.Builder<Expr> outputExpressionBuilder = ImmutableList.builder();
         ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
-        List<String> outputAlias = Lists.newArrayList();
         List<Integer> outputExprInOrderByScope = new ArrayList<>();
 
         for (SelectListItem item : selectList.getItems()) {
@@ -242,7 +241,6 @@ public class SelectAnalyzer {
                     FieldReference fieldReference = new FieldReference(fieldIndex, item.getTblName());
                     analyzeExpression(fieldReference, analyzeState, scope);
                     outputExpressionBuilder.add(fieldReference);
-                    outputAlias.add(null);
                 }
                 outputFields.addAll(fields);
 
@@ -255,7 +253,6 @@ public class SelectAnalyzer {
                             AstToStringBuilder.getAliasName(item.getExpr(), false, false) : item.getAlias();
                 }
 
-                outputAlias.add(item.getAlias());
                 analyzeExpression(item.getExpr(), analyzeState, scope);
                 outputExpressionBuilder.add(item.getExpr());
 
@@ -312,7 +309,6 @@ public class SelectAnalyzer {
         analyzeState.setOutputExpression(outputExpressions);
         analyzeState.setOutputExprInOrderByScope(outputExprInOrderByScope);
         analyzeState.setOutputScope(new Scope(RelationId.anonymous(), new RelationFields(outputFields.build())));
-        analyzeState.setOutputAlias(outputAlias);
         return outputExpressions;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -1605,7 +1605,7 @@ public interface AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
-    // -------------------------------------------BaselinePlan -------------------------------------------------------
+    // ------------------------------------------- BaselinePlan -------------------------------------------------------
 
     default R visitCreateBaselinePlanStatement(CreateBaselinePlanStmt statement, C context) {
         return visitDDLStatement(statement, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectListItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectListItem.java
@@ -99,9 +99,4 @@ public class SelectListItem implements ParseNode {
     public void setAlias(String alias) {
         this.alias = alias;
     }
-
-    @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitSelectItem(this, context);
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectListItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectListItem.java
@@ -100,4 +100,8 @@ public class SelectListItem implements ParseNode {
         this.alias = alias;
     }
 
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitSelectItem(this, context);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
@@ -41,6 +41,12 @@ public class SelectRelation extends QueryRelation {
      */
     private List<Expr> outputExpr;
 
+    /**
+     * outputAlias is different with output field name, use for construct sql
+     * e.g. select k+1, k+1 is the output name, but the alias is null
+     */
+    private List<String> outputAlias;
+
     private Expr predicate;
 
     /**
@@ -151,6 +157,7 @@ public class SelectRelation extends QueryRelation {
         this.orderByAnalytic = analyzeState.getOrderByAnalytic();
 
         this.columnReferences = analyzeState.getColumnReferences();
+        this.outputAlias = analyzeState.getOutputAlias();
 
         this.setScope(analyzeState.getOutputScope());
     }
@@ -296,5 +303,9 @@ public class SelectRelation extends QueryRelation {
     @Override
     public List<Expr> getOutputExpression() {
         return outputExpr;
+    }
+
+    public List<String> getOutputAlias() {
+        return outputAlias;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SelectRelation.java
@@ -41,12 +41,6 @@ public class SelectRelation extends QueryRelation {
      */
     private List<Expr> outputExpr;
 
-    /**
-     * outputAlias is different with output field name, use for construct sql
-     * e.g. select k+1, k+1 is the output name, but the alias is null
-     */
-    private List<String> outputAlias;
-
     private Expr predicate;
 
     /**
@@ -157,7 +151,6 @@ public class SelectRelation extends QueryRelation {
         this.orderByAnalytic = analyzeState.getOrderByAnalytic();
 
         this.columnReferences = analyzeState.getColumnReferences();
-        this.outputAlias = analyzeState.getOutputAlias();
 
         this.setScope(analyzeState.getOutputScope());
     }
@@ -303,9 +296,5 @@ public class SelectRelation extends QueryRelation {
     @Override
     public List<Expr> getOutputExpression() {
         return outputExpr;
-    }
-
-    public List<String> getOutputAlias() {
-        return outputAlias;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerFactory.java
@@ -56,6 +56,8 @@ public class OptimizerFactory {
     public static Optimizer create(OptimizerContext context) {
         if (context.getOptimizerOptions().isShortCircuit()) {
             return new ShortCircuitOptimizer(context);
+        } else if (context.getOptimizerOptions().isBaselinePlan()) {
+            return new SPMOptimizer(context);
         }
         return new QueryOptimizer(context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerOptions.java
@@ -23,6 +23,7 @@ public class OptimizerOptions {
         RULE_BASED,
         COST_BASED,
         SHORT_CIRCUIT,
+        BASELINE_PLAN,
     }
 
     private final OptimizerStrategy optimizerStrategy;
@@ -45,6 +46,10 @@ public class OptimizerOptions {
 
     public boolean isShortCircuit() {
         return optimizerStrategy.equals(OptimizerStrategy.SHORT_CIRCUIT);
+    }
+
+    public boolean isBaselinePlan() {
+        return optimizerStrategy.equals(OptimizerStrategy.BASELINE_PLAN);
     }
 
     public void disableRule(RuleType ruleType) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -683,6 +683,13 @@ public class QueryOptimizer extends Optimizer {
 
         tree = SimplifyCaseWhenPredicateRule.INSTANCE.rewrite(tree, rootTaskContext);
         deriveLogicalProperty(tree);
+
+        // TODO(packy92)
+        //  The tree-based rewriting rules in RBO may modify the child node but not update the
+        //  parent node, resulting in the statistical cache calculated by the previous rules
+        //  not being refreshed, which may affect the calculation of statistical information in memo.
+        //  Just clear it before into memo.
+        tree.getInputs().get(0).clearStatsAndInitOutputInfo();
         return tree.getInputs().get(0);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SPMOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SPMOptimizer.java
@@ -1,0 +1,319 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.JoinOperator;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
+import com.starrocks.sql.optimizer.rule.RuleSet;
+import com.starrocks.sql.optimizer.rule.join.JoinReorderFactory;
+import com.starrocks.sql.optimizer.rule.join.ReorderJoinRule;
+import com.starrocks.sql.optimizer.rule.transformation.ApplyExceptionRule;
+import com.starrocks.sql.optimizer.rule.transformation.ConvertToEqualForNullRule;
+import com.starrocks.sql.optimizer.rule.transformation.EliminateAggRule;
+import com.starrocks.sql.optimizer.rule.transformation.EliminateConstantCTERule;
+import com.starrocks.sql.optimizer.rule.transformation.ForceCTEReuseRule;
+import com.starrocks.sql.optimizer.rule.transformation.JoinLeftAsscomRule;
+import com.starrocks.sql.optimizer.rule.transformation.MergeProjectWithChildRule;
+import com.starrocks.sql.optimizer.rule.transformation.MergeTwoAggRule;
+import com.starrocks.sql.optimizer.rule.transformation.MergeTwoProjectRule;
+import com.starrocks.sql.optimizer.rule.transformation.PruneEmptyWindowRule;
+import com.starrocks.sql.optimizer.rule.transformation.PushDownJoinOnExpressionToChildProject;
+import com.starrocks.sql.optimizer.rule.transformation.PushDownProjectLimitRule;
+import com.starrocks.sql.optimizer.rule.transformation.PushDownTopNBelowOuterJoinRule;
+import com.starrocks.sql.optimizer.rule.transformation.PushDownTopNBelowUnionRule;
+import com.starrocks.sql.optimizer.rule.transformation.PushLimitAndFilterToCTEProduceRule;
+import com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctRule;
+import com.starrocks.sql.optimizer.rule.transformation.SeparateProjectRule;
+import com.starrocks.sql.optimizer.rule.transformation.UnionToValuesRule;
+import com.starrocks.sql.optimizer.rule.transformation.pruner.CboTablePruneRule;
+import com.starrocks.sql.optimizer.rule.tree.PushDownAggregateRule;
+import com.starrocks.sql.optimizer.rule.tree.PushDownDistinctAggregateRule;
+import com.starrocks.sql.optimizer.task.OptimizeGroupTask;
+import com.starrocks.sql.optimizer.task.TaskContext;
+import com.starrocks.sql.optimizer.task.TaskScheduler;
+
+import java.util.List;
+
+public class SPMOptimizer extends Optimizer {
+    private final TaskScheduler scheduler = new TaskScheduler();
+    private final Memo memo = new Memo();
+    private ColumnRefSet requiredColumns;
+
+    SPMOptimizer(OptimizerContext context) {
+        super(context);
+    }
+
+    @Override
+    public OptExpression optimize(OptExpression tree, PhysicalPropertySet requiredProperty,
+                                  ColumnRefSet requiredColumns) {
+
+        context.setMemo(memo);
+        context.setTaskScheduler(scheduler);
+        this.requiredColumns = requiredColumns;
+
+        TaskContext taskContext = new TaskContext(context, requiredProperty, requiredColumns.clone(), Double.MAX_VALUE);
+        tree = optimizeByRule(tree, taskContext);
+
+        memo.init(tree);
+        memo.deriveAllGroupLogicalProperty();
+        memoOptimize(memo, taskContext);
+
+        return extractBestPlan(requiredProperty, memo.getRootGroup());
+    }
+
+    /*
+    Remove:
+    isEnableFineGrainedRangePredicate
+    isEnableRewriteGroupingsetsToUnionAll
+    isCboPushDownGroupingSet
+    isEnableStatsToOptimizeSkewJoin
+    MVRewrite
+    PruneTable
+    PRUNE_UKFK_JOIN_RULES
+     */
+    private OptExpression optimizeByRule(OptExpression tree,
+                                         TaskContext rootTaskContext) {
+        tree = OptExpression.create(new LogicalTreeAnchorOperator(), tree);
+        deriveLogicalProperty(tree);
+
+        CTEContext cteContext = context.getCteContext();
+        CTEUtils.collectCteOperators(tree, context);
+
+        // inline CTE if consume use once
+        while (cteContext.hasInlineCTE()) {
+            scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.INLINE_CTE_RULES);
+            CTEUtils.collectCteOperators(tree, context);
+        }
+
+        scheduler.rewriteIterative(tree, rootTaskContext, new EliminateConstantCTERule());
+        CTEUtils.collectCteOperators(tree, context);
+
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.AGGREGATE_REWRITE_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PUSH_DOWN_SUBQUERY_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.SUBQUERY_REWRITE_COMMON_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.SUBQUERY_REWRITE_TO_WINDOW_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.SUBQUERY_REWRITE_TO_JOIN_RULES);
+        scheduler.rewriteOnce(tree, rootTaskContext, new ApplyExceptionRule());
+        CTEUtils.collectCteOperators(tree, context);
+
+        // Note: PUSH_DOWN_PREDICATE tasks should be executed before MERGE_LIMIT tasks
+        // because of the Filter node needs to be merged first to avoid the Limit node
+        // cannot merge
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PUSH_DOWN_PREDICATE_RULES);
+
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.ELIMINATE_OP_WITH_CONSTANT_RULES);
+
+        scheduler.rewriteOnce(tree, rootTaskContext, new ConvertToEqualForNullRule());
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
+        // Put EliminateAggRule after PRUNE_COLUMNS to give a chance to prune group bys before eliminate aggregations.
+        scheduler.rewriteOnce(tree, rootTaskContext, EliminateAggRule.getInstance());
+        deriveLogicalProperty(tree);
+
+        scheduler.rewriteOnce(tree, rootTaskContext, new PushDownJoinOnExpressionToChildProject());
+
+        scheduler.rewriteIterative(tree, rootTaskContext, new PruneEmptyWindowRule());
+        // @todo: resolve recursive optimization question:
+        //  MergeAgg -> PruneColumn -> PruneEmptyWindow -> MergeAgg/Project -> PruneColumn...
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoAggRule());
+
+        rootTaskContext.setRequiredColumns(requiredColumns.clone());
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
+
+        scheduler.rewriteIterative(tree, rootTaskContext, new PruneEmptyWindowRule());
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
+
+        // Limit push must be after the column prune,
+        // otherwise the Node containing limit may be prune
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.MERGE_LIMIT_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, new PushDownProjectLimitRule());
+
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PRUNE_ASSERT_ROW_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PRUNE_PROJECT_RULES);
+
+        CTEUtils.collectCteOperators(tree, context);
+        if (cteContext.needOptimizeCTE()) {
+            cteContext.reset();
+            scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.COLLECT_CTE_RULES);
+            rootTaskContext.setRequiredColumns(requiredColumns.clone());
+            scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
+            if (cteContext.needPushLimit() || cteContext.needPushPredicate()) {
+                scheduler.rewriteOnce(tree, rootTaskContext, new PushLimitAndFilterToCTEProduceRule());
+            }
+
+            if (cteContext.needPushPredicate()) {
+                scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PUSH_DOWN_PREDICATE_RULES);
+            }
+
+            if (cteContext.needPushLimit()) {
+                scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.MERGE_LIMIT_RULES);
+            }
+
+            scheduler.rewriteOnce(tree, rootTaskContext, new ForceCTEReuseRule());
+        }
+
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PARTITION_PRUNE_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, new RewriteMultiDistinctRule());
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PUSH_DOWN_PREDICATE_RULES);
+        scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.PRUNE_PROJECT_RULES);
+
+        tree = pushDownAggregation(tree, rootTaskContext, requiredColumns);
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.MERGE_LIMIT_RULES);
+
+        CTEUtils.collectCteOperators(tree, context);
+        // inline CTE if consume use once
+        while (cteContext.hasInlineCTE()) {
+            scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.INLINE_CTE_RULES);
+            CTEUtils.collectCteOperators(tree, context);
+        }
+
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
+
+        // After this rule, we shouldn't generate logical project operator
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
+
+        scheduler.rewriteOnce(tree, rootTaskContext, new PushDownTopNBelowOuterJoinRule());
+        // intersect rewrite depend on statistics
+        Utils.calculateStatistics(tree, rootTaskContext.getOptimizerContext());
+        scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.INTERSECT_REWRITE_RULES);
+        scheduler.rewriteOnce(tree, rootTaskContext, new PushDownTopNBelowUnionRule());
+
+        scheduler.rewriteOnce(tree, rootTaskContext, UnionToValuesRule.getInstance());
+        deriveLogicalProperty(tree);
+        
+        tree.getInputs().get(0).clearStatsAndInitOutputInfo();
+        return tree.getInputs().get(0);
+    }
+
+    private OptExpression pushDownAggregation(OptExpression tree, TaskContext rootTaskContext,
+                                              ColumnRefSet requiredColumns) {
+        boolean pushDistinctFlag = false;
+        boolean pushAggFlag = false;
+        if (context.getSessionVariable().isCboPushDownDistinctBelowWindow()) {
+            // TODO(by satanson): in future, PushDownDistinctAggregateRule and PushDownAggregateRule should be
+            //  fused one rule to tackle with all scenarios of agg push-down.
+            PushDownDistinctAggregateRule rule = new PushDownDistinctAggregateRule(rootTaskContext);
+            tree = rule.rewrite(tree, rootTaskContext);
+            pushDistinctFlag = rule.getRewriter().hasRewrite();
+        }
+
+        if (context.getSessionVariable().getCboPushDownAggregateMode() != -1) {
+            if (context.getSessionVariable().isCboPushDownAggregateOnBroadcastJoin()) {
+                // Reorder joins before applying PushDownAggregateRule to better decide where to push down aggregator.
+                // For example, do not push down a not very efficient aggregator below a very small broadcast join.
+                scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PARTITION_PRUNE_RULES);
+                scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
+                scheduler.rewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
+                CTEUtils.collectForceCteStatisticsOutsideMemo(tree, context);
+                deriveLogicalProperty(tree);
+                tree = new ReorderJoinRule().rewrite(tree, JoinReorderFactory.createJoinReorderAdaptive(), context);
+                tree = new SeparateProjectRule().rewrite(tree, rootTaskContext);
+                deriveLogicalProperty(tree);
+                Utils.calculateStatistics(tree, context);
+            }
+
+            PushDownAggregateRule rule = new PushDownAggregateRule(rootTaskContext);
+            rule.getRewriter().collectRewriteContext(tree);
+            if (rule.getRewriter().isNeedRewrite()) {
+                pushAggFlag = true;
+                tree = rule.rewrite(tree, rootTaskContext);
+            }
+        }
+
+        if (pushDistinctFlag || pushAggFlag) {
+            deriveLogicalProperty(tree);
+            rootTaskContext.setRequiredColumns(requiredColumns.clone());
+            scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
+            scheduler.rewriteOnce(tree, rootTaskContext, EliminateAggRule.getInstance());
+        }
+
+        return tree;
+    }
+
+    private void memoOptimize(Memo memo, TaskContext rootTaskContext) {
+        context.setInMemoPhase(true);
+        OptExpression tree = memo.getRootGroup().extractLogicalTree();
+        SessionVariable sessionVariable = context.getSessionVariable();
+        // add CboTablePruneRule
+        if (Utils.countJoinNodeSize(tree, CboTablePruneRule.JOIN_TYPES) < 10 &&
+                sessionVariable.isEnableCboTablePrune()) {
+            context.getRuleSet().addCboTablePruneRule();
+        }
+        // Join reorder
+        int innerCrossJoinNode = Utils.countJoinNodeSize(tree, JoinOperator.innerCrossJoinSet());
+        if (!sessionVariable.isDisableJoinReorder() && innerCrossJoinNode < sessionVariable.getCboMaxReorderNode()) {
+            if (innerCrossJoinNode > sessionVariable.getCboMaxReorderNodeUseExhaustive()) {
+                CTEUtils.collectForceCteStatistics(memo, context);
+
+                OptimizerTraceUtil.logOptExpression("before ReorderJoinRule:\n%s", tree);
+                new ReorderJoinRule().transform(tree, context);
+                OptimizerTraceUtil.logOptExpression("after ReorderJoinRule:\n%s", tree);
+
+                context.getRuleSet().addJoinCommutativityWithoutInnerRule();
+            } else {
+                if (Utils.countJoinNodeSize(tree, JoinOperator.semiAntiJoinSet()) <
+                        sessionVariable.getCboMaxReorderNodeUseExhaustive()) {
+                    context.getRuleSet().getTransformRules().add(JoinLeftAsscomRule.INNER_JOIN_LEFT_ASSCOM_RULE);
+                }
+                context.getRuleSet().addJoinTransformationRules();
+            }
+        }
+
+        if (!sessionVariable.isDisableJoinReorder() && sessionVariable.isEnableOuterJoinReorder()
+                && Utils.capableOuterReorder(tree, sessionVariable.getCboReorderThresholdUseExhaustive())) {
+            context.getRuleSet().addOuterJoinTransformationRules();
+        }
+
+        // add join implementRule
+        String joinImplementationMode = context.getSessionVariable().getJoinImplementationMode();
+        if ("merge".equalsIgnoreCase(joinImplementationMode)) {
+            context.getRuleSet().addMergeJoinImplementationRule();
+        } else if ("hash".equalsIgnoreCase(joinImplementationMode)) {
+            context.getRuleSet().addHashJoinImplementationRule();
+        } else if ("nestloop".equalsIgnoreCase(joinImplementationMode)) {
+            context.getRuleSet().addNestLoopJoinImplementationRule();
+        } else {
+            context.getRuleSet().addAutoJoinImplementationRule();
+        }
+
+        scheduler.pushTask(new OptimizeGroupTask(rootTaskContext, memo.getRootGroup()));
+        scheduler.executeTasks(rootTaskContext);
+    }
+
+    private OptExpression extractBestPlan(PhysicalPropertySet requiredProperty,
+                                          Group rootGroup) {
+        GroupExpression groupExpression = rootGroup.getBestExpression(requiredProperty);
+        if (groupExpression == null) {
+            String msg = "no executable plan for this sql. group: %s. required property: %s";
+            throw new IllegalArgumentException(String.format(msg, rootGroup, requiredProperty));
+        }
+        List<PhysicalPropertySet> inputProperties = groupExpression.getInputProperties(requiredProperty);
+
+        List<OptExpression> childPlans = Lists.newArrayList();
+        for (int i = 0; i < groupExpression.arity(); ++i) {
+            OptExpression childPlan = extractBestPlan(inputProperties.get(i), groupExpression.inputAt(i));
+            childPlans.add(childPlan);
+        }
+
+        OptExpression expression = OptExpression.create(groupExpression.getOp(), childPlans);
+        expression.setCost(groupExpression.getCost(requiredProperty));
+        expression.setRequiredProperties(inputProperties);
+        return expression;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -39,12 +39,12 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.hive.Partition;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.monitor.unit.ByteSizeValue;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.TaskRunManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Authorizer;
@@ -443,7 +443,7 @@ public class MetaFunctions {
         String sql = String.format("select cast(`%s` as string) from %s where `%s` = '%s' limit 1",
                 returnColumn.getVarchar(), tableNameValue.toString(), keyColumn.getName(), lookupKey.getVarchar());
         try {
-            List<TResultBatch> result = RepoExecutor.getInstance().executeDQL(sql);
+            List<TResultBatch> result = SimpleExecutor.getRepoExecutor().executeDQL(sql);
             return deserializeLookupResult(result);
         } catch (Throwable e) {
             final String notFoundMessage = "query failed if record not exist in dict table";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -59,6 +59,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorEvaluator;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
+import com.starrocks.sql.spm.SPMFunctions;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -193,6 +194,10 @@ public class ColumnFilterConverter {
 
         if (!checkColumnRefCanPartition(predicate.getChild(0), table)) {
             return;
+        }
+
+        if (predicate.getChildren().stream().skip(1).anyMatch(SPMFunctions::isSPMFunctions)) {
+            predicate = SPMFunctions.revertSPMFunctions(predicate);
         }
 
         if (predicate.getChildren().stream().skip(1).anyMatch(d -> !OperatorType.CONSTANT.equals(d.getOpType()))) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalRepeatOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalRepeatOperator.java
@@ -27,22 +27,25 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class LogicalRepeatOperator extends LogicalOperator {
     private List<ColumnRefOperator> outputGrouping;
     private List<List<ColumnRefOperator>> repeatColumnRefList;
     private List<List<Long>> groupingIds;
+    private Map<ColumnRefOperator, List<ColumnRefOperator>> groupingsFnArgs; // SPM use
     private boolean hasPushDown;
 
     public LogicalRepeatOperator(List<ColumnRefOperator> outputGrouping,
-                                 List<List<ColumnRefOperator>> repeatColumnRefList,
-                                 List<List<Long>> groupingIds) {
+                                 List<List<ColumnRefOperator>> repeatColumnRefList, List<List<Long>> groupingIds,
+                                 Map<ColumnRefOperator, List<ColumnRefOperator>> groupingsFnArgs) {
         super(OperatorType.LOGICAL_REPEAT);
         this.outputGrouping = outputGrouping;
         this.repeatColumnRefList = repeatColumnRefList;
         this.groupingIds = groupingIds;
         this.hasPushDown = false;
+        this.groupingsFnArgs = groupingsFnArgs;
     }
 
     private LogicalRepeatOperator() {
@@ -63,6 +66,10 @@ public class LogicalRepeatOperator extends LogicalOperator {
 
     public boolean hasPushDown() {
         return hasPushDown;
+    }
+
+    public Map<ColumnRefOperator, List<ColumnRefOperator>> getGroupingsFnArgs() {
+        return groupingsFnArgs;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalRepeatOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalRepeatOperator.java
@@ -27,17 +27,19 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class PhysicalRepeatOperator extends PhysicalOperator {
     private final List<ColumnRefOperator> outputGrouping;
     private final List<List<ColumnRefOperator>> repeatColumnRef;
     private final List<List<Long>> groupingIds;
+    private final Map<ColumnRefOperator, List<ColumnRefOperator>> groupingsFnArgs; // SPM use
 
     public PhysicalRepeatOperator(List<ColumnRefOperator> outputGrouping, List<List<ColumnRefOperator>> repeatColumnRef,
-                                  List<List<Long>> groupingIds, long limit,
-                                  ScalarOperator predicate,
-                                  Projection projection) {
+                                  List<List<Long>> groupingIds,
+                                  Map<ColumnRefOperator, List<ColumnRefOperator>> groupingsFnArgs, long limit,
+                                  ScalarOperator predicate, Projection projection) {
         super(OperatorType.PHYSICAL_REPEAT);
         this.outputGrouping = outputGrouping;
         this.repeatColumnRef = repeatColumnRef;
@@ -45,6 +47,7 @@ public class PhysicalRepeatOperator extends PhysicalOperator {
         this.limit = limit;
         this.predicate = predicate;
         this.projection = projection;
+        this.groupingsFnArgs = groupingsFnArgs;
     }
 
     @Override
@@ -77,6 +80,10 @@ public class PhysicalRepeatOperator extends PhysicalOperator {
 
     public List<List<Long>> getGroupingIds() {
         return groupingIds;
+    }
+
+    public Map<ColumnRefOperator, List<ColumnRefOperator>> getGroupingsFnArgs() {
+        return groupingsFnArgs;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
@@ -151,7 +151,7 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
         Optional<ConstantOperator> result = child.castTo(operator.getType());
         if (!result.isPresent()) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Fold cast constant error: " + operator + ", " + child.toString());
+                LOG.debug("Fold cast constant error: " + operator + ", " + child);
             }
             return operator;
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.sql.spm.SPMFunctions;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -52,6 +53,9 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
 
     @Override
     public ScalarOperator visitCastOperator(CastOperator operator, ScalarOperatorRewriteContext context) {
+        if (SPMFunctions.isSPMFunctions(operator.getChild(0))) {
+            return SPMFunctions.castSPMFunctions(operator.getChild(0), operator.getType());
+        }
         // remove duplicate cast
         if (operator.getChild(0) instanceof CastOperator && checkCastTypeReduceAble(operator.getType(),
                 operator.getChild(0).getType(), operator.getChild(0).getChild(0).getType())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.SubqueryOperator;
 import com.starrocks.sql.optimizer.rewrite.EliminateNegationsRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+import com.starrocks.sql.spm.SPMFunctions;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.text.StrTokenizer;
 
@@ -333,6 +334,10 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
         }
 
         if (predicate.getChild(1) instanceof SubqueryOperator) {
+            return predicate;
+        }
+
+        if (SPMFunctions.isSPMFunctions(predicate.getChild(1))) {
             return predicate;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/RepeatImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/RepeatImplementationRule.java
@@ -35,7 +35,8 @@ public class RepeatImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalRepeatOperator repeatOperator = (LogicalRepeatOperator) input.getOp();
         PhysicalRepeatOperator physicalRepeat = new PhysicalRepeatOperator(repeatOperator.getOutputGrouping(),
-                repeatOperator.getRepeatColumnRef(), repeatOperator.getGroupingIds(), repeatOperator.getLimit(),
+                repeatOperator.getRepeatColumnRef(), repeatOperator.getGroupingIds(),
+                repeatOperator.getGroupingsFnArgs(), repeatOperator.getLimit(),
                 repeatOperator.getPredicate(), repeatOperator.getProjection());
         return Lists.newArrayList(OptExpression.create(physicalRepeat, input.getInputs()));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -38,11 +38,11 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.catalog.system.information.PartitionsMetaSystemTable;
 import com.starrocks.common.Pair;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.planner.PartitionColumnFilter;
 import com.starrocks.planner.PartitionPruner;
 import com.starrocks.planner.RangePartitionPruner;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
@@ -608,7 +608,7 @@ public class PartitionSelector {
         String newWhereSql = newExpr.toSql();
         String sql = String.format(PARTITIONS_META_TEMPLATE, dbName, olapTable.getName(), newWhereSql);
         LOG.info("Get partition ids by sql: {}", sql);
-        List<TResultBatch> batch = RepoExecutor.getInstance().executeDQL(sql);
+        List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
         List<String> partitionNames = deserializeLookupResult(batch);
         // multi items in the single partition is not supported yet since `JSON_QUERY_TEMPLATE` is constructed the first element.
         Set<Long> excludedPartitionIds = Sets.newHashSet();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.spm.SPMFunctions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -191,7 +192,9 @@ public class ExpressionStatisticCalculator {
                 return deriveBasicColStats(call);
             }
 
-            if (call.getChildren().size() == 0) {
+            if (SPMFunctions.isSPMFunctions(call)) {
+                return SPMFunctions.getSPMFunctionStatistics(call, childrenColumnStatistics).get(0);
+            } else if (call.getChildren().isEmpty()) {
                 return nullaryExpressionCalculate(call);
             } else if (call.getChildren().size() == 1) {
                 return unaryExpressionCalculate(call, childrenColumnStatistics.get(0));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.spm.SPMFunctions;
 import org.apache.commons.math3.util.Precision;
 
 import java.util.List;
@@ -102,13 +103,21 @@ public class PredicateStatisticsCalculator {
             double selectivity;
 
             ScalarOperator firstChild = getChildForCastOperator(predicate.getChild(0));
-            List<ScalarOperator> otherChildrenList =
-                    predicate.getChildren().stream().skip(1).map(this::getChildForCastOperator).distinct()
-                            .collect(Collectors.toList());
             // 1. compute the inPredicate children column statistics
             ColumnStatistic inColumnStatistic = getExpressionStatistic(firstChild);
+
+            List<ScalarOperator> children = predicate.getChildren();
+            List<ScalarOperator> otherChildrenList = predicate.getChildren().stream().skip(1).toList();
+            if (children.size() == 2 && SPMFunctions.isSPMFunctions(children.get(1))) {
+                otherChildrenList = children.get(1).getChildren().stream().skip(1).collect(Collectors.toList());
+                if (otherChildrenList.isEmpty()) {
+                    return statistics;
+                }
+            }
+            otherChildrenList = otherChildrenList.stream().map(this::getChildForCastOperator).distinct().collect(
+                    Collectors.toList());
             List<ColumnStatistic> otherChildrenColumnStatisticList =
-                    otherChildrenList.stream().distinct().map(this::getExpressionStatistic).collect(Collectors.toList());
+                    otherChildrenList.stream().distinct().map(this::getExpressionStatistic).toList();
 
             // using ndv to estimate string col inPredicate
             if (!predicate.isNotIn() && firstChild.getType().getPrimitiveType().isCharFamily()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
@@ -51,12 +51,6 @@ public class OptExpressionValidator extends OptExpressionVisitor<OptExpression, 
     }
 
     public void validate(OptExpression root) {
-        // TODO(packy92)
-        //  The tree-based rewriting rules in RBO may modify the child node but not update the
-        //  parent node, resulting in the statistical cache calculated by the previous rules
-        //  not being refreshed, which may affect the calculation of statistical information in memo.
-        //  Just clear it before into memo.
-        root.clearStatsAndInitOutputInfo();
         visit(root, null);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -69,6 +69,8 @@ public class ExecPlan {
 
     private final boolean isShortCircuit;
 
+    private long useBaseline = -1;
+
     @VisibleForTesting
     public ExecPlan() {
         connectContext = new ConnectContext();
@@ -166,6 +168,10 @@ public class ExecPlan {
         return this.execGroups;
     }
 
+    public void setUseBaseline(long useBaseline) {
+        this.useBaseline = useBaseline;
+    }
+
     public void recordPlanNodeId2OptExpression(int id, OptExpression optExpression) {
         optExpression.getOp().setPlanNodeId(id);
         optExpressions.put(id, optExpression);
@@ -214,6 +220,9 @@ public class ExecPlan {
         } else {
             if (planCount != 0) {
                 str.append("There are ").append(planCount).append(" plans in optimizer search space\n");
+            }
+            if (useBaseline > 0) {
+                str.append("Using baseline plan[").append(useBaseline).append("]\n\n");
             }
 
             for (int i = 0; i < fragments.size(); ++i) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/BaselinePlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/BaselinePlan.java
@@ -13,9 +13,14 @@
 // limitations under the License.
 package com.starrocks.sql.spm;
 
-import java.time.LocalDateTime;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Writable;
 
-public class BaselinePlan {
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class BaselinePlan implements Writable {
+    @SerializedName("id")
     private long id;
 
     private final boolean isGlobal;
@@ -24,6 +29,7 @@ public class BaselinePlan {
     private final String bindSql;
     // bind sql without spm function, for bind query
     private final String bindSqlDigest;
+    @SerializedName("bindSqlHash")
     // bind sql hash, for fast search
     private final long bindSqlHash;
     // plan sql with hints
@@ -33,16 +39,26 @@ public class BaselinePlan {
 
     private final LocalDateTime updateTime;
 
+    public BaselinePlan(long id, long bindSqlHash) {
+        this.id = id;
+        this.bindSqlHash = bindSqlHash;
+        this.isGlobal = false;
+        this.bindSql = "";
+        this.bindSqlDigest = "";
+        this.planSql = "";
+        this.costs = 0;
+        this.updateTime = null;
+    }
+
     public BaselinePlan(boolean isGlobal, String bindSql, String bindSqlDigest,
-                        long bindSqlHash,
-                        String planSql, double costs) {
+                        long bindSqlHash, String planSql, double costs, LocalDateTime updateTime) {
         this.isGlobal = isGlobal;
         this.bindSql = bindSql;
         this.bindSqlDigest = bindSqlDigest;
         this.bindSqlHash = bindSqlHash;
         this.planSql = planSql;
         this.costs = costs;
-        this.updateTime = LocalDateTime.now();
+        this.updateTime = updateTime;
     }
 
     public long getId() {
@@ -79,6 +95,20 @@ public class BaselinePlan {
 
     public LocalDateTime getUpdateTime() {
         return updateTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BaselinePlan that = (BaselinePlan) o;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(bindSqlHash);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAst2SQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAst2SQLBuilder.java
@@ -1,0 +1,181 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.HintNode;
+import com.starrocks.analysis.InPredicate;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectListItem;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.TableRelation;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Why not use SqlDigestBuilder?
+ * SPM need special spm function to serialize/deserialize digest
+ */
+public class SPMAst2SQLBuilder {
+    private final boolean enableHints;
+
+    private final boolean enableDigest;
+
+    private final Builder builder = new Builder();
+
+    // for SQLPlanHash
+    private final Set<Long> tables = Sets.newHashSet();
+
+    private int aggCount = 0;
+
+    private int joinCount = 0;
+
+    public SPMAst2SQLBuilder(boolean enableHints, boolean enableDigest) {
+        this.enableHints = enableHints;
+        this.enableDigest = enableDigest;
+    }
+
+    public String build(QueryRelation statement) {
+        return new QueryStatement(statement).accept(builder, null);
+    }
+
+    public String build(QueryStatement statement) {
+        return statement.accept(builder, null);
+    }
+
+    public long buildHash() {
+        // low 32 bits: 6bit(agg)-6bit(join)-6bit(tableSize)-14bit(tableId)
+        // high 32 bits: reserved
+        long hash = 0;
+        hash |= aggCount;
+        hash <<= 6;
+        hash |= joinCount;
+        hash <<= 6;
+        hash |= tables.size();
+        hash <<= 14;
+        long tableHash = tables.stream().sorted().reduce(1L, (a, b) -> 31 * a + b);
+        tableHash &= (1L << 15) - 1;
+        hash |= tableHash;
+        return hash;
+    }
+
+    // need deserialize to SQL, so extends from AstToSQLBuilder, not AstToStringBuilder/SqlDigestBuilder
+    private class Builder extends AstToSQLBuilder.AST2SQLBuilderVisitor {
+        protected Builder() {
+            super(false, false, true);
+        }
+
+        @Override
+        protected String printWithParentheses(ParseNode node) {
+            if (node instanceof SlotRef || node instanceof LiteralExpr || SPMFunctions.isSPMFunctions((Expr) node)) {
+                return visit(node);
+            } else {
+                return "(" + visit(node) + ")";
+            }
+        }
+
+        @Override
+        public String visitTable(TableRelation node, Void outerScope) {
+            if (node.getTable() != null) {
+                tables.add(node.getTable().getId());
+            }
+            return super.visitTable(node, outerScope);
+        }
+
+        @Override
+        public String visitJoin(JoinRelation relation, Void context) {
+            joinCount++;
+            String join;
+            if (enableHints) {
+                join = super.visitJoin(relation, context);
+            } else {
+                String hints = relation.getJoinHint();
+                relation.setJoinHint(null);
+                join = super.visitJoin(relation, context);
+                relation.setJoinHint(hints);
+            }
+            return join;
+        }
+
+        @Override
+        public String visitSelect(SelectRelation stmt, Void context) {
+            if (stmt.hasGroupByClause()) {
+                aggCount++;
+            }
+
+            List<HintNode> hints = stmt.getSelectList().getHintNodes();
+            if (!enableHints) {
+                stmt.getSelectList().setHintNodes(null);
+            }
+            String s = super.visitSelect(stmt, context);
+            stmt.getSelectList().setHintNodes(hints);
+            return s;
+        }
+
+        protected List<String> visitSelectItemList(SelectRelation stmt) {
+            if (stmt.getSelectList().getItems().stream().allMatch(SelectListItem::isStar)) {
+                return stmt.getSelectList().getItems().stream()
+                        .map(item -> item.getTblName() != null ? item.getTblName() + ".*" : "*")
+                        .toList();
+            }
+            Preconditions.checkState(CollectionUtils.isNotEmpty(stmt.getOutputExpression()));
+            return super.visitSelectItemList(stmt);
+        }
+
+        @Override
+        public String visitInPredicate(InPredicate node, Void context) {
+            if ((node.getChildren().stream().anyMatch(SPMFunctions::isSPMFunctions) || node.isConstantValues())
+                    && enableDigest) {
+                StringBuilder strBuilder = new StringBuilder();
+                String notStr = (node.isNotIn()) ? "NOT " : "";
+                strBuilder.append(printWithParentheses(node.getChild(0))).append(" ").append(notStr).append("IN ");
+                strBuilder.append("(?)");
+                return strBuilder.toString();
+            }
+            return super.visitInPredicate(node, context);
+        }
+
+        @Override
+        public String visitFunctionCall(FunctionCallExpr node, Void context) {
+            if (SPMFunctions.isSPMFunctions(node)) {
+                if (enableDigest) {
+                    return "?";
+                }
+                List<String> children = node.getChildren().stream().map(this::visit).toList();
+                return SPMFunctions.toSQL(node.getFnName().getFunction(), children);
+            }
+            return super.visitFunctionCall(node, context);
+        }
+
+        @Override
+        public String visitLiteral(LiteralExpr expr, Void context) {
+            if (enableDigest) {
+                return "?";
+            }
+            return super.visitLiteral(expr, context);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAstCheckVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAstCheckVisitor.java
@@ -1,0 +1,215 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.starrocks.analysis.AnalyticExpr;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.OrderByElement;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.Subquery;
+import com.starrocks.sql.ast.AstVisitor;
+import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.FieldReference;
+import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetOperationRelation;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.ast.TableRelation;
+
+import java.util.List;
+import java.util.Objects;
+
+/*
+ * This class is used to compare two ASTs
+ */
+public class SPMAstCheckVisitor implements AstVisitor<Boolean, ParseNode> {
+    protected static <T> T cast(ParseNode node) {
+        return (T) node;
+    }
+
+    public boolean check(List<? extends ParseNode> list1, List<? extends ParseNode> list2) {
+        if (list1 == list2) {
+            return true;
+        }
+        if (list1 == null || list2 == null) {
+            return false;
+        }
+        if (list1.size() != list2.size()) {
+            return false;
+        }
+        for (int i = 0; i < list1.size(); i++) {
+            if (!check(list1.get(i), list2.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean check(ParseNode node1, ParseNode node2) {
+        if (node1 == node2) {
+            return true;
+        }
+        if (node1 == null || node2 == null) {
+            return false;
+        }
+        return visit(node1, node2);
+    }
+
+    @Override
+    public Boolean visitQueryStatement(QueryStatement statement, ParseNode context) {
+        QueryStatement other = cast(context);
+        return check(statement.getQueryRelation(), other.getQueryRelation());
+    }
+
+    @Override
+    public Boolean visitSubqueryRelation(SubqueryRelation node, ParseNode context) {
+        SubqueryRelation other = cast(context);
+        return check(node.getQueryStatement(), other.getQueryStatement());
+    }
+
+    @Override
+    public Boolean visitOrderByElement(OrderByElement node, ParseNode context) {
+        OrderByElement other = cast(context);
+        boolean check = Objects.equals(node.getNullsFirstParam(), other.getNullsFirstParam());
+        check = check && Objects.equals(node.getIsAsc(), other.getIsAsc());
+        return check && check(node.getExpr(), other.getExpr());
+    }
+
+    @Override
+    public Boolean visitSelect(SelectRelation node, ParseNode node2) {
+        SelectRelation other = cast(node2);
+        if (!check(node.getCteRelations(), other.getCteRelations())) {
+            return false;
+        }
+
+        boolean check = check(node.getRelation(), other.getRelation());
+        //        if (node.getOutputExpression() == null) {
+        //            check = check && check(node.getSelectList().getItems(), other.getSelectList().getItems());
+        //        } else {
+        //        check = check && check(node.getOutputExpression(), other.getOutputExpression());
+        //        }
+        check = check && check(node.getOutputExpression(), other.getOutputExpression());
+        check = check && check(node.getWhereClause(), other.getWhereClause());
+        check = check && check(node.getGroupBy(), other.getGroupBy());
+        check = check && check(node.getHaving(), other.getHaving());
+        check = check && check(node.getOrderBy(), other.getOrderBy());
+        return check;
+    }
+
+    //    @Override
+    //    public Boolean visitSelectItem(SelectListItem node, ParseNode context) {
+    //        SelectListItem other = cast(context);
+    //        if (!Objects.equals(node.isStar(), other.isStar()) || !Objects.equals(node.getAlias(), other.getAlias())
+    //                || !Objects.equals(node.getTblName(), other.getTblName())) {
+    //            return false;
+    //        }
+    //        return check(node.getExpr(), other.getExpr());
+    //    }
+
+    @Override
+    public Boolean visitSlot(SlotRef node, ParseNode node2) {
+        if (node2 instanceof SlotRef other) {
+            return node.equalsWithoutChild(other);
+        } else if (node2 instanceof FieldReference other) {
+            // field reference has none index, we just compare type here
+            // and depend on the field reference to check the index
+            return node.getType().equals(other.getType());
+        }
+        return false;
+    }
+
+    @Override
+    public Boolean visitJoin(JoinRelation node, ParseNode context) {
+        JoinRelation other = cast(context);
+        if (!node.getJoinOp().equals(other.getJoinOp())) {
+            return false;
+        }
+        boolean check = check(node.getLeft(), other.getLeft());
+        check = check && check(node.getRight(), other.getRight());
+        check = check && check(node.getOnPredicate(), other.getOnPredicate());
+        return check;
+    }
+
+    @Override
+    public Boolean visitTable(TableRelation node, ParseNode node2) {
+        TableRelation other = cast(node2);
+        if (node.getTable() != null && other.getTable() != null) {
+            return node.getTable().getId() == other.getTable().getId();
+        } else if (node.getTable() == null && other.getTable() == null) {
+            return node.getName().equals(other.getName());
+        }
+        return false;
+    }
+
+    @Override
+    public Boolean visitCTE(CTERelation stmt, ParseNode context) {
+        CTERelation other = cast(context);
+        return check(stmt.getCteQueryStatement(), other.getCteQueryStatement());
+    }
+
+    @Override
+    public Boolean visitSetOp(SetOperationRelation node, ParseNode context) {
+        SetOperationRelation other = cast(context);
+        if (node.getQualifier() != other.getQualifier()) {
+            return false;
+        }
+        return check(node.getRelations(), other.getRelations());
+    }
+
+    @Override
+    public Boolean visitSubqueryExpr(Subquery node, ParseNode context) {
+        Subquery other = cast(context);
+
+        QueryStatement qs1 = skipEmptyRelation(node.getQueryStatement());
+        QueryStatement qs2 = skipEmptyRelation(other.getQueryStatement());
+        return check(qs1, qs2);
+    }
+
+    private QueryStatement skipEmptyRelation(QueryStatement query) {
+        while ((query.getQueryRelation() instanceof SubqueryRelation qs)) {
+            if (qs.hasOffset() || qs.hasLimit() || qs.hasWithClause()) {
+                break;
+            }
+            query = qs.getQueryStatement();
+        }
+        return query;
+    }
+
+    @Override
+    public Boolean visitAnalyticExpr(AnalyticExpr node, ParseNode node2) {
+        AnalyticExpr other = cast(node2);
+        boolean check = Objects.equals(node.getWindow(), other.getWindow());
+        check = check && Objects.equals(node.getPartitionHint(), other.getPartitionHint());
+        check = check && Objects.equals(node.getSkewHint(), other.getSkewHint());
+        check = check && Objects.equals(node.isUseHashBasedPartition(), other.isUseHashBasedPartition());
+        check = check && Objects.equals(node.isSkewed(), other.isSkewed());
+
+        check = check && check(node.getFnCall(), other.getFnCall());
+        check = check && check(node.getPartitionExprs(), other.getPartitionExprs());
+        check = check && check(node.getOrderByElements(), other.getOrderByElements());
+        check = check && check(node.getChildren(), ((Expr) node2).getChildren());
+        return check;
+    }
+
+    @Override
+    public Boolean visitExpression(Expr node, ParseNode node2) {
+        if (!node.equalsWithoutChild(node2)) {
+            return false;
+        }
+        return check(node.getChildren(), ((Expr) node2).getChildren());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMFunctions.java
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.FunctionName;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Set;
+
+// SPMFunction to mark the variables in plan
+public class SPMFunctions {
+    // spm function: NULL_TYPE _spm_xxx(placeholderID, actual parameters),
+    // the actual parameters used to compute statistics
+    // NULL_TYPE _spm_const_list(placeholderID)
+    static final String CONST_LIST_FUNC = "_spm_const_list";
+    // NULL_TYPE _spm_const_var(placeholderID)
+    static final String CONST_VAR_FUNC = "_spm_const_var";
+
+    // for ut test
+    public static boolean enableSPMParamsPrint = false;
+
+    private static final Set<String> SPM_FUNCTIONS = Set.of(CONST_LIST_FUNC, CONST_VAR_FUNC);
+
+    public static Function getSPMFunction(String fnName) {
+        return getSPMFunction(fnName, Type.NULL);
+    }
+
+    private static Function getSPMFunction(String fnName, Type type) {
+        if (!SPM_FUNCTIONS.contains(StringUtils.lowerCase(fnName))) {
+            return null;
+        }
+
+        return new ScalarFunction(new FunctionName(StringUtils.lowerCase(fnName)),
+                new Type[] {Type.BIGINT}, type, false);
+    }
+
+    public static FunctionCallExpr newFunc(String func, long placeholderID, List<Expr> children) {
+        FunctionCallExpr expr =
+                new FunctionCallExpr(func, Lists.newArrayList(new IntLiteral(placeholderID, Type.BIGINT)));
+        expr.setFn(getSPMFunction(func, Type.NULL));
+        expr.setType(Type.NULL);
+        expr.addChildren(children);
+        return expr;
+    }
+
+    public static boolean isSPMFunctions(Expr expr) {
+        if (!(expr instanceof FunctionCallExpr)) {
+            return false;
+        }
+
+        return SPM_FUNCTIONS.contains(((FunctionCallExpr) expr).getFnName()
+                .getFunction().toLowerCase());
+    }
+
+    public static boolean isSPMFunctions(ScalarOperator operator) {
+        if (!(operator.getOpType() == OperatorType.CALL)) {
+            return false;
+        }
+
+        return SPM_FUNCTIONS.contains(((CallOperator) operator).getFnName().toLowerCase());
+    }
+
+    public static ScalarOperator castSPMFunctions(ScalarOperator operator, Type type) {
+        CallOperator call = (CallOperator) operator;
+        call.setType(type);
+        call.setFunction(getSPMFunction(call.getFunction().functionName(), type));
+        for (int i = 1; i < call.getChildren().size(); i++) {
+            call.setChild(i, new CastOperator(type, call.getChild(i)));
+        }
+        return call;
+    }
+
+    // SPM operator revert to scalar operator
+    public static ScalarOperator revertSPMFunctions(ScalarOperator operator) {
+        ScalarOperator clone = operator.clone();
+        List<ScalarOperator> newChildren = Lists.newArrayList();
+        for (ScalarOperator child : clone.getChildren()) {
+            if (!isSPMFunctions(child)) {
+                newChildren.add(child);
+            } else {
+                CallOperator call = (CallOperator) child;
+                if (call.getChildren().size() <= 1) {
+                    return operator;
+                } else {
+                    call.getChildren().stream().skip(1).forEach(newChildren::add);
+                }
+            }
+        }
+        clone.getChildren().clear();
+        clone.getChildren().addAll(newChildren);
+        return clone;
+    }
+
+    public static String toSQL(String function, List<String> children) {
+        if (enableSPMParamsPrint) {
+            return function + "(" + String.join(", ", children) + ")";
+        }
+        return function + "(" + children.get(0) + ")";
+    }
+
+    public static List<ColumnStatistic> getSPMFunctionStatistics(CallOperator operator,
+                                                                 List<ColumnStatistic> children) {
+        Preconditions.checkState(CONST_VAR_FUNC.equals(operator.getFnName()));
+        if (children.size() <= 1) {
+            return List.of(ColumnStatistic.unknown());
+        }
+        return List.of(children.get(1));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlaceholderBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlaceholderBuilder.java
@@ -1,0 +1,286 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.CompoundPredicate;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.InPredicate;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.analysis.Subquery;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.QueryRelation;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+// replace variables to SPMFunctions
+public class SPMPlaceholderBuilder {
+    private record PlaceholderExpr(Expr originalExpr, Expr placeholderExpr, Expr parentExpr) {
+        public boolean equals(Expr originalExpr, Expr parentExpr) {
+            if (parentExpr == null) {
+                // root expr
+                return this.originalExpr.equals(originalExpr) && this.parentExpr == null;
+            } else {
+                return this.originalExpr.equals(originalExpr) && parentExpr.equals(this.parentExpr);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "PlaceholderExpr{" +
+                    "originalExpr=" + originalExpr.toMySql() +
+                    ", placeholderExpr=" + placeholderExpr.toMySql() +
+                    ", parentExpr=" + (parentExpr == null ? "null" : parentExpr.toMySql()) +
+                    '}';
+        }
+    }
+
+    private final PlaceholderInserter inserter = new PlaceholderInserter();
+
+    private final PlaceholderFinder finder = new PlaceholderFinder();
+
+    private final Set<Long> userSPMIds = Sets.newHashSet();
+
+    private long placeholderID = 0;
+
+    private final boolean isStrictCheck;
+
+    private final List<PlaceholderExpr> placeholderExprs = Lists.newArrayList();
+
+    public SPMPlaceholderBuilder(boolean isStrictCheck) {
+        this.isStrictCheck = isStrictCheck;
+    }
+
+    private Optional<Expr> findPlaceholderExpr(Expr expr, Expr parent) {
+        List<PlaceholderExpr> l = placeholderExprs.stream()
+                .filter(p -> p.equals(expr, parent)).toList();
+        return l.size() == 1 ? Optional.of(l.get(0).placeholderExpr.clone()) : Optional.empty();
+    }
+
+    // insert placeholder expression to replace expression in query stmt
+    public QueryRelation insertPlaceholder(QueryRelation query) {
+        return (QueryRelation) query.accept(inserter, null);
+    }
+
+    // find placeholder expression from query stmt
+    // e.g. user add a query with SPMFunctions manually, we need to find it
+    public void findPlaceholder(QueryRelation query) {
+        query.accept(finder, null);
+    }
+
+    // plan stmt bind placeholder expression, find same
+    public void bindPlaceholder(QueryRelation query) {
+        PlanASTPlaceholderBinder binder = new PlanASTPlaceholderBinder();
+        binder.bind(query);
+    }
+
+    private long nextId() {
+        do {
+            placeholderID++;
+        } while (userSPMIds.contains(placeholderID));
+        return placeholderID;
+    }
+
+    private class PlaceholderFinder extends SPMUpdateExprVisitor<Void> {
+        @Override
+        public ParseNode visitFunctionCall(FunctionCallExpr node, Void context) {
+            if (SPMFunctions.isSPMFunctions(node)) {
+                Preconditions.checkState(node.getChild(0).isLiteral());
+                long spmId = ((IntLiteral) node.getChild(0)).getValue();
+                if (userSPMIds.contains(spmId)) {
+                    throw new SemanticException("sql plan found conflict placeholder expression: " + node.toMySql());
+                }
+                userSPMIds.add(spmId);
+                return node;
+            }
+            return super.visitFunctionCall(node, context);
+        }
+    }
+
+    private class PlaceholderInserter extends SPMUpdateExprVisitor<Expr> {
+        @Override
+        public ParseNode visitInPredicate(InPredicate node, Expr root) {
+            if (node.getChildren().stream().anyMatch(SPMFunctions::isSPMFunctions)) {
+                return visitExpression(node, root);
+            }
+            if (!node.isConstantValues()) {
+                return visitExpression(node, root);
+            }
+            Optional<Expr> placeholder = findPlaceholderExpr(node, root);
+            if (placeholder.isPresent()) {
+                if (isStrictCheck) {
+                    throw new SemanticException("sql plan found conflict placeholder expression: "
+                            + (root == null ? node.toMySql() : root.toMySql()));
+                } else {
+                    return placeholder.get();
+                }
+            }
+            List<Expr> v = node.getChildren().stream().skip(1).collect(Collectors.toList());
+            Expr spm = SPMFunctions.newFunc(SPMFunctions.CONST_LIST_FUNC, nextId(), v);
+            Expr in = new InPredicate(node.getChild(0), List.of(spm), node.isNotIn(), node.getPos());
+            placeholderExprs.add(new PlaceholderExpr(node, in, node));
+            return in;
+        }
+
+        @Override
+        public ParseNode visitLiteral(LiteralExpr node, Expr root) {
+            Optional<Expr> placeholder = findPlaceholderExpr(node, root);
+            if (placeholder.isPresent()) {
+                if (isStrictCheck) {
+                    throw new SemanticException("sql plan found conflict placeholder expression: "
+                            + (root == null ? node.toMySql() : root.toMySql()));
+                } else {
+                    return placeholder.get();
+                }
+            }
+            Expr s = SPMFunctions.newFunc(SPMFunctions.CONST_VAR_FUNC, nextId(), List.of(node));
+            PlaceholderExpr p = new PlaceholderExpr(node, s, root);
+            placeholderExprs.add(p);
+            return s;
+        }
+
+        @Override
+        public ParseNode visitFunctionCall(FunctionCallExpr node, Expr root) {
+            if (SPMFunctions.isSPMFunctions(node)) {
+                PlaceholderExpr p = new PlaceholderExpr(node, node, root);
+                placeholderExprs.add(p);
+                return node;
+            }
+            return super.visitFunctionCall(node, root);
+        }
+
+        @Override
+        public ParseNode visitCompoundPredicate(CompoundPredicate node, Expr root) {
+            // when compound predicate is root, update root
+            // e.g. A AND B AND C, set root to be A/B/C
+            if (root == null) {
+                for (int i = 0; i < node.getChildren().size(); i++) {
+                    if (node.getChild(i) instanceof CompoundPredicate) {
+                        // update root by child
+                        node.setChild(i, visitExpr(node.getChild(i), null));
+                    } else {
+                        node.setChild(i, visitExpr(node.getChild(i), node.getChild(i).clone()));
+                    }
+                }
+            } else {
+                // when compound not root, keep root
+                // e.g. case when A AND B THEN C ELSE D END, root should be case when
+                for (int i = 0; i < node.getChildren().size(); i++) {
+                    node.setChild(i, visitExpr(node.getChild(i), root));
+                }
+            }
+            return node;
+        }
+
+        @Override
+        public ParseNode visitSubqueryExpr(Subquery node, Expr context) {
+            node.getQueryStatement().accept(this, null);
+            return node;
+        }
+
+        @Override
+        public ParseNode visitBinaryPredicate(BinaryPredicate node, Expr root) {
+            if (node.getChildren().stream().anyMatch(s -> s instanceof Subquery)) {
+                // subquery is hard to patten, we ignore handle it, can be supported some easy case
+                for (int i = 0; i < node.getChildren().size(); i++) {
+                    // must clone root node, because node will update
+                    node.setChild(i, visitExpr(node.getChild(i), null));
+                }
+            }
+            return super.visitBinaryPredicate(node, root);
+        }
+
+        @Override
+        public ParseNode visitExpression(Expr node, Expr root) {
+            if (CollectionUtils.isEmpty(node.getChildren())) {
+                return node;
+            }
+            if (node.getChildren() != null && !node.getChildren().isEmpty()) {
+                for (int i = 0; i < node.getChildren().size(); i++) {
+                    // must clone root node, because node will update
+                    node.setChild(i, visitExpr(node.getChild(i), root == null ? node.clone() : root));
+                }
+            }
+            return node;
+        }
+    }
+
+    private class PlanASTPlaceholderBinder extends PlaceholderInserter {
+        private final Set<Expr> usePlaceholders = Sets.newHashSet();
+
+        public void bind(QueryRelation query) {
+            query.accept(this, null);
+            for (PlaceholderExpr pe : placeholderExprs) {
+                if (!usePlaceholders.contains(pe.placeholderExpr)) {
+                    throw new SemanticException("can't found expression[" + pe.originalExpr + "] used in plan stmt");
+                }
+            }
+            for (Expr pe : usePlaceholders) {
+                if (placeholderExprs.stream().noneMatch(e -> e.placeholderExpr.equals(pe))) {
+                    throw new SemanticException("can't found expression[" + pe.toMySql() + "] used in bind stmt");
+                }
+            }
+        }
+
+        @Override
+        public ParseNode visitInPredicate(InPredicate node, Expr root) {
+            if (node.getChildren().stream().anyMatch(SPMFunctions::isSPMFunctions)) {
+                return visitExpression(node, root);
+            }
+            if (!node.isConstantValues()) {
+                return visitExpression(node, root);
+            }
+            Optional<Expr> spm = findPlaceholderExpr(node, node);
+            if (spm.isEmpty()) {
+                throw new SemanticException("can't find expression placeholder or placeholder conflict, "
+                        + "expression : " + node.toMySql());
+            }
+            usePlaceholders.add(spm.get());
+            return spm.get();
+        }
+
+        @Override
+        public ParseNode visitLiteral(LiteralExpr node, Expr root) {
+            Optional<Expr> spm = findPlaceholderExpr(node, root);
+
+            if (spm.isEmpty()) {
+                throw new SemanticException("can't find expression placeholder or placeholder conflict, "
+                        + "expression : " + node.toMySql());
+            }
+            usePlaceholders.add(spm.get());
+            return spm.get();
+        }
+
+        @Override
+        public ParseNode visitFunctionCall(FunctionCallExpr node, Expr root) {
+            if (SPMFunctions.isSPMFunctions(node)) {
+                usePlaceholders.add(node);
+                return node;
+            }
+            return visitExpression(node, root);
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlan2SQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlan2SQLBuilder.java
@@ -1,0 +1,711 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.AnalyticWindow;
+import com.starrocks.analysis.HintNode;
+import com.starrocks.analysis.JoinOperator;
+import com.starrocks.sql.ExpressionPrinter;
+import com.starrocks.sql.common.UnsupportedException;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.HashDistributionDesc;
+import com.starrocks.sql.optimizer.base.HashDistributionSpec;
+import com.starrocks.sql.optimizer.base.Ordering;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.SortPhase;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEAnchorOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalFilterOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalLimitOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalRepeatOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalSetOperation;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+// translate physical tree plan to SQL
+public class SPMPlan2SQLBuilder {
+    private long tableId = 0;
+
+    private final ExprSQLBuilder exprSQLBuilder = new ExprSQLBuilder();
+
+    private final SQLBuilder planSQLBuilder = new SQLBuilder();
+
+    public String toSQL(List<HintNode> hints, OptExpression plan, List<ColumnRefOperator> outputColumn) {
+        SQLRelation relation = plan.getOp().accept(planSQLBuilder, plan, null);
+        if (hints != null && !hints.isEmpty()) {
+            relation.hints = hints.stream().map(HintNode::toSql).collect(Collectors.joining(", "));
+        }
+        // keep select order
+        String f = relation.toSQL();
+        String select =
+                outputColumn.stream().map(c -> relation.columnNames.get(c.getId())).collect(Collectors.joining(", "));
+        return "SELECT " + select + " FROM (" + f + ") t" + (tableId++);
+    }
+
+    private class SQLRelation {
+        private final Map<Integer, String> columnNames = Maps.newHashMap();
+        private List<String> cte = null;
+        private String select = "";
+        private String hints = "";
+        private String from = "";
+        private String where = "";
+        private String groupBy = "";
+        private String having = "";
+        private String orderBy = "";
+        private String limit = "";
+        private String groupings = "";
+        private String relationName = null;
+        // record table unused column name, avoid conflict
+        private List<String> reserveNames = null;
+
+        private String registerRef(Integer cid, String alias) {
+            columnNames.put(cid, alias);
+            return alias;
+        }
+
+        private String registerRef(Integer cid) {
+            String ref = "c_" + cid;
+            columnNames.put(cid, ref);
+            return ref;
+        }
+
+        private String newAlias() {
+            relationName = "t_" + (tableId++);
+            return relationName;
+        }
+
+        private String getRelationAlias() {
+            return relationName == null ? from : relationName;
+        }
+
+        private String toRelationSQL() {
+            if (relationName == null) {
+                return from;
+            }
+            return "(" + toSQL() + ") " + relationName;
+        }
+
+        private String toSQL() {
+            StringBuilder sql = new StringBuilder();
+            if (!CollectionUtils.isEmpty(cte)) {
+                sql.append("WITH ");
+                sql.append(String.join(", ", cte));
+                sql.append(" ");
+            }
+            sql.append("SELECT ");
+            if (!StringUtils.isBlank(hints)) {
+                sql.append(hints);
+            }
+            sql.append(StringUtils.isBlank(select) ? "*" : select);
+            sql.append(" FROM ");
+            sql.append(from);
+            if (!StringUtils.isBlank(where)) {
+                sql.append(" WHERE ");
+                sql.append(where);
+            }
+            if (!StringUtils.isBlank(groupBy)) {
+                sql.append(" GROUP BY ");
+                sql.append(groupBy);
+            }
+            if (!StringUtils.isBlank(having)) {
+                sql.append(" HAVING ");
+                sql.append(having);
+            }
+            if (!StringUtils.isBlank(orderBy)) {
+                sql.append(" ORDER BY ");
+                sql.append(orderBy);
+            }
+            if (!StringUtils.isBlank(limit)) {
+                sql.append(" LIMIT ");
+                sql.append(limit);
+            }
+            return sql.toString();
+        }
+    }
+
+    private class SQLBuilder extends OptExpressionVisitor<SQLRelation, Void> {
+        private final Map<Integer, String> cteColumnNames = Maps.newHashMap();
+        private final Map<Integer, String> cteRelationNames = Maps.newHashMap();
+
+        @Override
+        public SQLRelation visit(OptExpression optExpression, Void context) {
+            UnsupportedException.unsupportedException(
+                    "SQLPlanManager doesn't support: " + optExpression.getOp().getOpType());
+            return null;
+        }
+
+        public SQLRelation process(OptExpression optExpression) {
+            return optExpression.getOp().accept(this, optExpression, null);
+        }
+
+        @Override
+        public SQLRelation visitPhysicalJoin(OptExpression optExpression, Void context) {
+            SQLRelation left = process(optExpression.getInputs().get(0));
+            SQLRelation right = process(optExpression.getInputs().get(1));
+
+            SQLRelation joinRelation = new SQLRelation();
+            PhysicalJoinOperator join = optExpression.getOp().cast();
+            String hints = StringUtils.isBlank(join.getJoinHint()) ? getJoinDistributionHints(optExpression) :
+                    join.getJoinHint();
+
+            // check column name conflicts
+            if (StringUtils.equalsIgnoreCase(left.getRelationAlias(), right.getRelationAlias())) {
+                left.newAlias();
+                right.newAlias();
+            }
+
+            boolean columnConflicts = !Collections.disjoint(left.columnNames.values(), right.columnNames.values());
+            if (!columnConflicts && left.reserveNames != null) {
+                columnConflicts = !Collections.disjoint(left.reserveNames, right.columnNames.values());
+            }
+            if (!columnConflicts && right.reserveNames != null) {
+                columnConflicts = !Collections.disjoint(right.reserveNames, left.columnNames.values());
+            }
+
+            if (columnConflicts) {
+                left.columnNames.forEach((k, v) -> {
+                    joinRelation.columnNames.put(k, left.getRelationAlias() + "." + v);
+                });
+                right.columnNames.forEach((k, v) -> {
+                    joinRelation.columnNames.put(k, right.getRelationAlias() + "." + v);
+                });
+            } else {
+                joinRelation.columnNames.putAll(left.columnNames);
+                joinRelation.columnNames.putAll(right.columnNames);
+            }
+
+            if (join.getJoinType() == JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN) {
+                UnsupportedException.unsupportedException("sql plan manager doesn't support not-in subquery");
+            }
+
+            joinRelation.from = left.toRelationSQL() + " " + join.getJoinType().toString() + "[" + hints + "] "
+                    + right.toRelationSQL();
+            if (join.getOnPredicate() != null) {
+                joinRelation.from += " ON " + exprSQLBuilder.print(join.getOnPredicate(), joinRelation);
+            }
+            joinRelation.where = exprSQLBuilder.print(join.getPredicate(), joinRelation);
+            if (join.getProjection() != null) {
+                List<Integer> forces = columnConflicts ? Lists.newArrayList(joinRelation.columnNames.keySet()) :
+                        Collections.emptyList();
+                visitProjection(join.getProjection(), joinRelation, forces);
+            } else if (columnConflicts) {
+                List<String> selects = Lists.newArrayList();
+                for (Integer key : joinRelation.columnNames.keySet()) {
+                    selects.add(joinRelation.columnNames.get(key) + " AS " + joinRelation.registerRef(key));
+                }
+                joinRelation.select = String.join(", ", selects);
+            }
+            joinRelation.newAlias();
+            return joinRelation;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalHashAggregate(OptExpression optExpression, Void context) {
+            PhysicalHashAggregateOperator agg = optExpression.getOp().cast();
+            SQLRelation childRelation = process(optExpression.inputAt(0));
+            if (agg.getType().isLocal() || agg.getType().isDistinctLocal()) {
+                // update aggregate outputs function name
+                for (var entry : agg.getAggregations().entrySet()) {
+                    ColumnRefOperator key = entry.getKey();
+                    CallOperator aggFn = entry.getValue();
+                    String aggFnStr = exprSQLBuilder.print(aggFn, childRelation);
+                    childRelation.registerRef(key.getId(), aggFnStr);
+                }
+                return childRelation;
+            }
+
+            // group by grouping sets
+            SQLRelation aggRelation;
+            List<String> selects = Lists.newArrayList();
+            List<Integer> aliasIds = Lists.newArrayList();
+
+            if (!StringUtils.isEmpty(childRelation.groupings)) {
+                aggRelation = childRelation;
+                for (ColumnRefOperator groupBy : agg.getGroupBys()) {
+                    aliasIds.add(groupBy.getId());
+                    if (childRelation.columnNames.containsKey(groupBy.getId())) {
+                        // grouping_id doesn't contains
+                        selects.add(exprSQLBuilder.print(groupBy, childRelation));
+                        aggRelation.registerRef(groupBy.getId(), childRelation.columnNames.get(groupBy.getId()));
+                    }
+                }
+                aggRelation.groupBy = aggRelation.groupings;
+            } else {
+                aggRelation = new SQLRelation();
+                aggRelation.from = childRelation.toRelationSQL();
+                for (ColumnRefOperator groupBy : agg.getGroupBys()) {
+                    Preconditions.checkState(childRelation.columnNames.containsKey(groupBy.getId()));
+                    selects.add(exprSQLBuilder.print(groupBy, childRelation));
+                    aggRelation.registerRef(groupBy.getId(), childRelation.columnNames.get(groupBy.getId()));
+                }
+                aggRelation.groupBy = String.join(", ", selects);
+            }
+
+            for (var entry : agg.getAggregations().entrySet()) {
+                ColumnRefOperator key = entry.getKey();
+                CallOperator aggFn = entry.getValue();
+                String fn;
+                if (childRelation.columnNames.containsKey(key.getId())) {
+                    fn = exprSQLBuilder.print(key, childRelation);
+                } else {
+                    fn = exprSQLBuilder.print(aggFn, childRelation);
+                }
+                aggRelation.registerRef(key.getId(), fn);
+                selects.add(fn);
+                aliasIds.add(key.getId());
+            }
+
+            aggRelation.having = exprSQLBuilder.print(agg.getPredicate(), aggRelation);
+            aggRelation.select = String.join(", ", selects);
+            visitProjection(agg.getProjection(), aggRelation, aliasIds);
+            aggRelation.newAlias();
+            return aggRelation;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalDistribution(OptExpression optExpression, Void context) {
+            return process(optExpression.inputAt(0));
+        }
+
+        @Override
+        public SQLRelation visitPhysicalValues(OptExpression optExpression, Void context) {
+            PhysicalValuesOperator values = optExpression.getOp().cast();
+            SQLRelation relation = new SQLRelation();
+            relation.from = values.getRows().stream()
+                    .map(l -> "(" + l.stream().map(v -> exprSQLBuilder.print(v, relation))
+                            .collect(Collectors.joining(", ")) + ")").collect(Collectors.joining(", "));
+            relation.from = "(VALUES " + relation.from + ") AS t";
+            relation.from += "(" + values.getColumnRefSet().stream().map(c -> relation.registerRef(c.getId()))
+                    .collect(Collectors.joining(", ")) + ")";
+            return relation;
+        }
+
+        private SQLRelation visitPhysicalSet(OptExpression optExpression, String op) {
+            PhysicalSetOperation set = optExpression.getOp().cast();
+            SQLRelation setRelation = new SQLRelation();
+
+            set.getOutputColumnRefOp().forEach(c -> setRelation.registerRef(c.getId()));
+            List<String> children = Lists.newArrayList();
+            for (int i = 0; i < optExpression.getInputs().size(); i++) {
+                OptExpression child = optExpression.inputAt(i);
+                SQLRelation relation = process(child);
+                String childSQL = "";
+
+                List<ColumnRefOperator> childOutputs = set.getChildOutputColumns().get(i);
+                List<String> childSelects = Lists.newArrayList();
+                for (int index = 0; index < childOutputs.size(); index++) {
+                    String alias = relation.columnNames.get(childOutputs.get(index).getId()) + " AS "
+                            + setRelation.columnNames.get(set.getOutputColumnRefOp().get(index).getId());
+                    childSelects.add(alias);
+                }
+
+                if (StringUtils.isEmpty(relation.select)) {
+                    relation.select = String.join(", ", childSelects);
+                    childSQL += relation.toSQL();
+                } else {
+                    childSQL = "SELECT " + String.join(", ", childSelects) + " FROM ";
+                    childSQL += relation.toRelationSQL(); // don't need new relation
+                }
+                children.add(childSQL);
+            }
+            setRelation.from = "(" + String.join(" " + op + " ", children) + ") " + setRelation.newAlias();
+            setRelation.newAlias();
+            return setRelation;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalUnion(OptExpression optExpression, Void context) {
+            return visitPhysicalSet(optExpression, "UNION ALL");
+        }
+
+        @Override
+        public SQLRelation visitPhysicalExcept(OptExpression optExpression, Void context) {
+            return visitPhysicalSet(optExpression, "EXCEPT");
+        }
+
+        @Override
+        public SQLRelation visitPhysicalIntersect(OptExpression optExpression, Void context) {
+            return visitPhysicalSet(optExpression, "INTERSECT");
+        }
+
+        @Override
+        public SQLRelation visitPhysicalLimit(OptExpression optExpression, Void context) {
+            SQLRelation child = process(optExpression.getInputs().get(0));
+            PhysicalLimitOperator limit = optExpression.getOp().cast();
+            SQLRelation limitRelation;
+            if (StringUtils.isEmpty(child.limit)) {
+                limitRelation = child;
+            } else {
+                limitRelation = new SQLRelation();
+                limitRelation.from = child.toRelationSQL();
+                limitRelation.columnNames.putAll(child.columnNames);
+                limitRelation.newAlias();
+            }
+
+            limitRelation.limit = limit.hasOffset() ? limit.getOffset() + ", " : "";
+            limitRelation.limit += limit.getLimit();
+            return limitRelation;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalTopN(OptExpression optExpression, Void context) {
+            SQLRelation child = process(optExpression.getInputs().get(0));
+            PhysicalTopNOperator topN = optExpression.getOp().cast();
+            if (!CollectionUtils.isEmpty(topN.getPartitionByColumns()) || !StringUtils.isEmpty(child.groupings)
+                    || topN.getSortPhase() == SortPhase.PARTIAL) {
+                return child;
+            }
+
+            SQLRelation relation;
+            if (StringUtils.isEmpty(child.limit) && StringUtils.isEmpty(child.orderBy)) {
+                relation = child;
+            } else {
+                relation = new SQLRelation();
+                relation.from = child.toRelationSQL();
+                relation.columnNames.putAll(child.columnNames);
+                relation.newAlias();
+            }
+
+            relation.limit = topN.getOffset() > 0 ? topN.getOffset() + ", " : "";
+            relation.limit += topN.hasLimit() ? topN.getLimit() : "";
+            List<String> orderBys = Lists.newArrayList();
+            for (Ordering orderDesc : topN.getOrderSpec().getOrderDescs()) {
+                orderBys.add(exprSQLBuilder.print(orderDesc.getColumnRef(), relation) + " " + (orderDesc.isAscending() ?
+                        "ASC" : "DESC"));
+            }
+            relation.orderBy = String.join(", ", orderBys);
+            return relation;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalFilter(OptExpression optExpression, Void context) {
+            SQLRelation child = process(optExpression.getInputs().get(0));
+            PhysicalFilterOperator filter = optExpression.getOp().cast();
+            SQLRelation relation = new SQLRelation();
+            relation.from = child.toRelationSQL();
+            relation.where = exprSQLBuilder.print(filter.getPredicate(), child);
+            relation.columnNames.putAll(child.columnNames);
+            relation.newAlias();
+            return relation;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalCTEAnchor(OptExpression optExpression, Void context) {
+            PhysicalCTEAnchorOperator anchor = optExpression.getOp().cast();
+
+            SQLRelation produce = process(optExpression.getInputs().get(0));
+            produce.newAlias();
+            cteRelationNames.put(anchor.getCteId(), produce.getRelationAlias());
+            cteColumnNames.putAll(produce.columnNames);
+
+            SQLRelation consume = process(optExpression.getInputs().get(1));
+            if (consume.cte == null) {
+                consume.cte = Lists.newArrayList();
+            }
+            consume.cte.add(produce.getRelationAlias() + " AS (" + produce.toSQL() + ")");
+            return consume;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalCTEConsume(OptExpression optExpression, Void context) {
+            PhysicalCTEConsumeOperator consume = optExpression.getOp().cast();
+            SQLRelation relation = new SQLRelation();
+            relation.from = cteRelationNames.get(consume.getCteId());
+            consume.getCteOutputColumnRefMap()
+                    .forEach((k, v) -> relation.registerRef(k.getId(), cteColumnNames.get(v.getId())));
+            relation.where = exprSQLBuilder.print(consume.getPredicate(), relation);
+            visitProjection(consume.getProjection(), relation, Collections.emptyList());
+            if (consume.getPredicate() != null || consume.getProjection() != null) {
+                relation.newAlias();
+            }
+            return relation;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalCTEProduce(OptExpression optExpression, Void context) {
+            return process(optExpression.getInputs().get(0));
+        }
+
+        @Override
+        public SQLRelation visitPhysicalNoCTE(OptExpression optExpression, Void context) {
+            return process(optExpression.getInputs().get(0));
+        }
+
+        private void visitProjection(Projection projection, SQLRelation relation, List<Integer> forceAlias) {
+            if (projection == null) {
+                if (CollectionUtils.isEmpty(forceAlias)) {
+                    return;
+                }
+                // 1. update force alias
+                List<String> selects = Lists.newArrayList();
+                for (Integer key : relation.columnNames.keySet()) {
+                    String v = relation.columnNames.get(key);
+                    if (forceAlias.contains(key)) {
+                        selects.add(v + " AS " + relation.registerRef(key));
+                    } else {
+                        selects.add(v);
+                    }
+                }
+                relation.select = String.join(", ", selects);
+                return;
+            }
+
+            Map<ColumnRefOperator, ScalarOperator> project = projection.getColumnRefMap();
+            List<Integer> saveColumnIds = Lists.newArrayList();
+
+            List<String> selects = Lists.newArrayList();
+            List<String> alias = Lists.newArrayList();
+            // 1. print first
+            project.forEach((k, v) -> {
+                saveColumnIds.add(k.getId());
+                selects.add(exprSQLBuilder.print(v, relation));
+            });
+
+            // 2. register & override alias
+            project.forEach((k, v) -> {
+                if (k.equals(v) && !forceAlias.contains(k.getId())) {
+                    alias.add("");
+                } else {
+                    alias.add(" AS " + relation.registerRef(k.getId()));
+                }
+            });
+
+            // 3. combine to select
+            Preconditions.checkState(selects.size() == alias.size());
+            for (int i = 0; i < selects.size(); i++) {
+                selects.set(i, selects.get(i) + alias.get(i));
+            }
+
+            relation.select = String.join(", ", selects);
+            relation.columnNames.entrySet().removeIf(e -> !saveColumnIds.contains(e.getKey()));
+        }
+
+        @Override
+        public SQLRelation visitPhysicalAnalytic(OptExpression optExpression, Void context) {
+            SQLRelation child = process(optExpression.inputAt(0));
+            PhysicalWindowOperator window = optExpression.getOp().cast();
+
+            //            Preconditions.checkState(!StringUtils.isEmpty(child.orderBy));
+            Preconditions.checkState(window.getPredicate() == null);
+            child.orderBy = "";
+
+            SQLRelation relation = new SQLRelation();
+            relation.from = child.toRelationSQL();
+
+            String frame = "";
+            if (!CollectionUtils.isEmpty(window.getPartitionExpressions())) {
+                frame += "PARTITION BY " + window.getPartitionExpressions().stream()
+                        .map(p -> exprSQLBuilder.print(p, child)).collect(Collectors.joining(", "));
+                frame += " ";
+            }
+            if (!CollectionUtils.isEmpty(window.getOrderByElements())) {
+                frame += "ORDER BY " + window.getOrderByElements().stream()
+                        .map(o -> exprSQLBuilder.print(o.getColumnRef(), child) + " " + (o.isAscending() ? "ASC" :
+                                "DESC")).collect(Collectors.joining(", "));
+                frame += " ";
+            }
+            if (window.getAnalyticWindow() != null && !AnalyticWindow.DEFAULT_WINDOW.equals(
+                    window.getAnalyticWindow())) {
+                frame += window.getAnalyticWindow().toSql();
+            }
+            frame = " OVER (" + frame + ")";
+
+            List<Integer> analytics = Lists.newArrayList();
+            relation.columnNames.putAll(child.columnNames);
+            for (var entry : window.getAnalyticCall().entrySet()) {
+                ColumnRefOperator key = entry.getKey();
+                CallOperator value = entry.getValue();
+                relation.registerRef(key.getId(), exprSQLBuilder.print(value, child) + frame);
+                analytics.add(key.getId());
+            }
+
+            visitProjection(window.getProjection(), relation, analytics);
+            relation.newAlias();
+            return relation;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalRepeat(OptExpression optExpression, Void context) {
+            SQLRelation relation = process(optExpression.getInputs().get(0));
+            PhysicalRepeatOperator repeat = optExpression.getOp().cast();
+
+            SQLRelation groupingRelation = new SQLRelation();
+            groupingRelation.from = relation.toRelationSQL();
+            groupingRelation.columnNames.putAll(relation.columnNames);
+            for (ColumnRefOperator grouping : repeat.getOutputGrouping()) {
+                if ("GROUPING_ID".equals(grouping.getName())) {
+                    continue;
+                }
+                Preconditions.checkState("GROUPING".equals(grouping.getName()));
+                Preconditions.checkState(repeat.getGroupingsFnArgs().containsKey(grouping));
+                String fn = "GROUPING(" + repeat.getGroupingsFnArgs().get(grouping).stream()
+                        .map(p -> exprSQLBuilder.print(p, relation)).collect(Collectors.joining(", ")) + ")";
+                groupingRelation.registerRef(grouping.getId(), fn);
+            }
+            List<String> groupings = Lists.newArrayList();
+            for (var group : repeat.getRepeatColumnRef()) {
+                groupings.add("(" + group.stream().map(c -> exprSQLBuilder.print(c, relation))
+                        .collect(Collectors.joining(", ")) + ")");
+            }
+            groupingRelation.groupings = "GROUPING SETS(" + String.join(", ", groupings) + ")";
+            return groupingRelation;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalScan(OptExpression optExpression, Void context) {
+            SQLRelation relation = new SQLRelation();
+            PhysicalScanOperator scan = optExpression.getOp().cast();
+            relation.from = scan.getTable().getName();
+            scan.getColRefToColumnMetaMap().forEach((k, v) -> relation.registerRef(k.getId(), v.getName()));
+            relation.where = exprSQLBuilder.print(scan.getPredicate(), relation);
+            visitProjection(scan.getProjection(), relation, Collections.emptyList());
+
+            if (scan.getPredicate() != null || scan.getProjection() != null) {
+                relation.newAlias();
+                return relation;
+            }
+            relation.reserveNames = Lists.newArrayList();
+            scan.getTable().getColumns().forEach(c -> relation.reserveNames.add(c.getName()));
+            return relation;
+        }
+
+        @Override
+        public SQLRelation visitPhysicalOlapScan(OptExpression optExpression, Void context) {
+            SQLRelation relation = visitPhysicalScan(optExpression, context);
+            PhysicalOlapScanOperator olap = optExpression.getOp().cast();
+            if (CollectionUtils.isEmpty(olap.getPrunedPartitionPredicates())) {
+                return relation;
+            }
+            // prune partition predicate
+            String predicate = olap.getPrunedPartitionPredicates().stream().map(p -> exprSQLBuilder.print(p, relation))
+                    .collect(Collectors.joining(" AND "));
+            if (StringUtils.isEmpty(relation.where)) {
+                relation.where = predicate;
+            } else {
+                relation.where = relation.where + " AND " + predicate;
+            }
+            return relation;
+        }
+
+        // 1. left: exchange, right: exchange
+        //  a. hash shuffle
+        // 2. left: exchange, right: local
+        //  a. shuffle bucket
+        // 3. left: local, right: exchange
+        //  a. broadcast
+        //  b. local bucket
+        // 4. left: local, right: local
+        //  a. colocate
+        //  b. shuffle bucket
+        public String getJoinDistributionHints(OptExpression optExpression) {
+            boolean leftExchange = optExpression.inputAt(0).getOp().getOpType() == OperatorType.PHYSICAL_DISTRIBUTION;
+            boolean rightExchange = optExpression.inputAt(1).getOp().getOpType() == OperatorType.PHYSICAL_DISTRIBUTION;
+            if (leftExchange && rightExchange) {
+                PhysicalDistributionOperator left = optExpression.inputAt(0).getOp().cast();
+                PhysicalDistributionOperator right = optExpression.inputAt(1).getOp().cast();
+                Preconditions.checkState(
+                        left.getDistributionSpec().getType() == DistributionSpec.DistributionType.SHUFFLE);
+                Preconditions.checkState(
+                        right.getDistributionSpec().getType() == DistributionSpec.DistributionType.SHUFFLE);
+                return JoinOperator.HINT_SHUFFLE;
+            } else if (leftExchange) {
+                return JoinOperator.HINT_SHUFFLE;
+            } else if (rightExchange) {
+                PhysicalDistributionOperator right = optExpression.inputAt(1).getOp().cast();
+                if (right.getDistributionSpec().getType() == DistributionSpec.DistributionType.BROADCAST) {
+                    return JoinOperator.HINT_BROADCAST;
+                } else {
+                    Preconditions.checkState(
+                            right.getDistributionSpec().getType() == DistributionSpec.DistributionType.SHUFFLE);
+                    return JoinOperator.HINT_BUCKET;
+                }
+            } else {
+                Preconditions.checkState(optExpression.getRequiredProperties().stream()
+                        .allMatch(p -> p.getDistributionProperty().isShuffle()));
+                if (optExpression.getRequiredProperties().stream().allMatch(p -> {
+                    HashDistributionSpec spec = p.getDistributionProperty().getSpec().cast();
+                    return HashDistributionDesc.SourceType.LOCAL.equals(spec.getHashDistributionDesc().getSourceType());
+                })) {
+                    return JoinOperator.HINT_COLOCATE;
+                } else {
+                    return JoinOperator.HINT_SHUFFLE;
+                }
+            }
+        }
+    }
+
+    private static class ExprSQLBuilder extends ExpressionPrinter<SQLRelation> {
+        @Override
+        public String print(ScalarOperator scalarOperator) {
+            UnsupportedException.unsupportedException("SQLPlanManager doesn't support: " + scalarOperator);
+            return null;
+        }
+
+        @Override
+        public String print(ScalarOperator scalarOperator, SQLRelation context) {
+            if (scalarOperator == null) {
+                return "";
+            }
+            return super.print(scalarOperator, context);
+        }
+
+        @Override
+        public String visitVariableReference(ColumnRefOperator variable, SQLRelation context) {
+            return context.columnNames.get(variable.getId());
+        }
+
+        @Override
+        public String visitConstant(ConstantOperator literal, SQLRelation context) {
+            String x = super.visitConstant(literal, context);
+            if (literal.getType().isDateType()) {
+                return "'" + x + "'";
+            }
+            return x;
+        }
+
+        @Override
+        public String visitCall(CallOperator call, SQLRelation context) {
+            if (SPMFunctions.isSPMFunctions(call)) {
+                List<String> children =
+                        call.getChildren().stream().map(c -> print(c, context)).collect(Collectors.toList());
+                return SPMFunctions.toSQL(call.getFnName(), children);
+            }
+            return super.visitCall(call, context);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanBuilder.java
@@ -1,0 +1,163 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.starrocks.analysis.HintNode;
+import com.starrocks.analysis.SetVarHint;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.common.DdlException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.PlannerMetaLocker;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SystemVariable;
+import com.starrocks.sql.ast.spm.CreateBaselinePlanStmt;
+import com.starrocks.sql.common.UnsupportedException;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.Optimizer;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.OptimizerOptions;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.transformer.LogicalPlan;
+import com.starrocks.sql.optimizer.transformer.RelationTransformer;
+import com.starrocks.sql.optimizer.transformer.TransformerContext;
+
+import java.util.List;
+
+// to build plan for bind sql
+public class SPMPlanBuilder {
+    private final ConnectContext session;
+    private final CreateBaselinePlanStmt stmt;
+
+    private String bindSqlDigest;
+    private long bindSqlHash;
+    private String bindSql;
+    private String planStmtSQL;
+    private double costs;
+
+    protected String getBindSqlDigest() {
+        return bindSqlDigest;
+    }
+
+    protected String getPlanStmtSQL() {
+        return planStmtSQL;
+    }
+
+    protected String getBindSql() {
+        return bindSql;
+    }
+
+    public SPMPlanBuilder(ConnectContext session, CreateBaselinePlanStmt stmt) {
+        this.session = session;
+        this.stmt = stmt;
+    }
+
+    public BaselinePlan execute() {
+        analyze();
+        parameterizedStmt();
+        generatePlan();
+        return new BaselinePlan(stmt.isGlobal(), bindSql, bindSqlDigest, bindSqlHash,
+                planStmtSQL, costs);
+    }
+
+    // don't need lock, because we don't need to modify table stats
+    public void generatePlan() {
+        List<HintNode> hints = this.stmt.getAllQueryScopeHints();
+        SessionVariable backupVariable = session.getSessionVariable();
+        SessionVariable cloneVariable = null;
+        if (hints != null && !hints.isEmpty()) {
+            cloneVariable = (SessionVariable) backupVariable.clone();
+            for (HintNode hint : hints) {
+                if (!(hint instanceof SetVarHint)) {
+                    UnsupportedException.unsupportedException(
+                            "sql pLan manager only supported session variables: " + hint.toSql());
+                }
+
+                try {
+                    for (var entry : hint.getValue().entrySet()) {
+                        session.getGlobalStateMgr().getVariableMgr()
+                                .setSystemVariable(cloneVariable, new SystemVariable(
+                                        entry.getKey(), new StringLiteral(entry.getValue())), true);
+                    }
+                } catch (DdlException e) {
+                    throw new SemanticException("set variable error", e);
+                }
+            }
+            session.setSessionVariable(cloneVariable);
+        }
+
+        QueryRelation query = this.stmt.getPlanStmt();
+        try {
+            ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+            TransformerContext transformerContext = new TransformerContext(columnRefFactory, session, null);
+            LogicalPlan logicalPlan = new RelationTransformer(transformerContext).transformWithSelectLimit(query);
+
+            OptimizerContext optimizerContext = OptimizerFactory.initContext(session, columnRefFactory);
+            optimizerContext.setOptimizerOptions(
+                    new OptimizerOptions(OptimizerOptions.OptimizerStrategy.BASELINE_PLAN));
+            Optimizer optimizer = OptimizerFactory.create(optimizerContext);
+
+            OptExpression optimizedPlan = optimizer.optimize(logicalPlan.getRoot(),
+                    new PhysicalPropertySet(),
+                    new ColumnRefSet(logicalPlan.getOutputColumn()));
+
+            SPMPlan2SQLBuilder sqlBuilder = new SPMPlan2SQLBuilder();
+            planStmtSQL = sqlBuilder.toSQL(hints, optimizedPlan, logicalPlan.getOutputColumn());
+            costs = optimizedPlan.getCost();
+        } finally {
+            if (cloneVariable != null) {
+                session.setSessionVariable(backupVariable);
+            }
+        }
+    }
+
+    protected void parameterizedStmt() {
+        QueryRelation bind;
+        SPMPlaceholderBuilder builder = new SPMPlaceholderBuilder(false);
+        if (this.stmt.getBindStmt() != null) {
+            // has bind and plan
+            builder.findPlaceholder(this.stmt.getBindStmt());
+            bind = builder.insertPlaceholder(this.stmt.getBindStmt());
+            builder.bindPlaceholder(this.stmt.getPlanStmt());
+        } else {
+            // only plan
+            bind = builder.insertPlaceholder(this.stmt.getPlanStmt());
+        }
+        SPMAst2SQLBuilder digestBuilder = new SPMAst2SQLBuilder(false, true);
+        SPMAst2SQLBuilder sqlBuilder = new SPMAst2SQLBuilder(false, false);
+        bindSqlDigest = digestBuilder.build(bind);
+        bindSqlHash = digestBuilder.buildHash();
+        bindSql = sqlBuilder.build(bind);
+    }
+
+    protected void analyze() {
+        PlannerMetaLocker locker = new PlannerMetaLocker(session, stmt);
+        try {
+            locker.lock();
+            Analyzer.analyze(new QueryStatement(stmt.getPlanStmt()), session);
+            if (stmt.getBindStmt() != null) {
+                Analyzer.analyze(new QueryStatement(stmt.getBindStmt()), session);
+            }
+        } finally {
+            locker.unlock();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanBuilder.java
@@ -40,6 +40,7 @@ import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.TransformerContext;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 // to build plan for bind sql
@@ -75,7 +76,7 @@ public class SPMPlanBuilder {
         parameterizedStmt();
         generatePlan();
         return new BaselinePlan(stmt.isGlobal(), bindSql, bindSqlDigest, bindSqlHash,
-                planStmtSQL, costs);
+                planStmtSQL, costs, LocalDateTime.now());
     }
 
     // don't need lock, because we don't need to modify table stats

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
@@ -1,0 +1,238 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.ArithmeticExpr;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.InPredicate;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.analysis.TimestampArithmeticExpr;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.PlannerMetaLocker;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class SPMPlanner {
+    private final ConnectContext session;
+
+    private final Map<Long, Expr> placeholderValues = Maps.newHashMap();
+
+    private final PlaceholderBinder binder = new PlaceholderBinder();
+
+    private final PlaceholderReplacer replacer = new PlaceholderReplacer();
+
+    private BaselinePlan baseline;
+
+    public SPMPlanner(ConnectContext session) {
+        this.session = session;
+    }
+
+    public BaselinePlan getBaseline() {
+        return baseline;
+    }
+
+    public StatementBase plan(StatementBase query) {
+        if (!(query instanceof QueryStatement)) {
+            return query;
+        }
+        if (!session.getSessionVariable().isEnableSPMRewrite()) {
+            return query;
+        }
+
+        if (query.isExistQueryScopeHint()) {
+            return query;
+        }
+
+        try (Timer ignored = Tracers.watchScope("SPMPlanner")) {
+            analyze(query);
+
+            SPMAst2SQLBuilder builder = new SPMAst2SQLBuilder(false, true);
+            String digest = builder.build((QueryStatement) query);
+            long hash = builder.buildHash();
+            SQLPlanManager spm = GlobalStateMgr.getCurrentState().getSqlPlanManager();
+            List<BaselinePlan> plans = spm.findBaselinePlan(digest, hash);
+
+            Optional<BaselinePlan> base;
+            try (Timer ignored2 = Tracers.watchScope("bindPlan")) {
+                base = plans.stream().min(Comparator.comparingDouble(BaselinePlan::getCosts));
+                if (base.isEmpty()) {
+                    return query;
+                }
+            }
+            try (Timer ignored3 = Tracers.watchScope("replacePlan")) {
+                if (!bind(base.get(), query)) {
+                    return query;
+                }
+                baseline = base.get();
+                return replacePlan(base.get());
+            }
+        } catch (Exception e) {
+            // fallback to original query
+            baseline = null; // clean baseline
+            return query;
+        }
+    }
+
+    private void analyze(StatementBase query) {
+        PlannerMetaLocker locker = new PlannerMetaLocker(session, query);
+        try {
+            locker.lock();
+            Analyzer.analyze(query, session);
+        } finally {
+            locker.unlock();
+        }
+    }
+
+    private boolean bind(BaselinePlan baseline, StatementBase query) {
+        List<StatementBase> binder = SqlParser.parse(baseline.getBindSql(), session.getSessionVariable());
+        Preconditions.checkState(binder.size() == 1);
+        // remove when support cache
+        analyze(binder.get(0));
+        return this.binder.bind(binder.get(0), query);
+    }
+
+    private StatementBase replacePlan(BaselinePlan baseline) {
+        List<StatementBase> plan = SqlParser.parse(baseline.getPlanSql(), session.getSessionVariable());
+        Preconditions.checkState(plan.size() == 1);
+        if (placeholderValues.isEmpty()) {
+            return plan.get(0);
+        }
+        return (StatementBase) replacer.visit(plan.get(0));
+    }
+
+    private class PlaceholderBinder extends SPMAstCheckVisitor {
+        public boolean bind(ParseNode one, ParseNode two) {
+            try {
+                return one.accept(this, two);
+            } catch (ClassCastException e) {
+                // ignore
+                return false;
+            }
+        }
+
+        // Expressions using functions need to be handled separately, because spm_function may lead to the selection
+        // of different types of functions, which can be ignored during binding
+        //
+        // this problem only occurs when binding the real plan, because the parameters at this time may be different
+        // ----------------- start -----------------
+        @Override
+        public Boolean visitFunctionCall(FunctionCallExpr node, ParseNode node2) {
+            if (SPMFunctions.isSPMFunctions(node) && ((Expr) node2).isConstant()) {
+                Preconditions.checkState(!node.getChildren().isEmpty());
+                Preconditions.checkState(node.getChild(0) instanceof IntLiteral);
+                long spmId = ((IntLiteral) node.getChild(0)).getValue();
+
+                if (placeholderValues.containsKey(spmId)) {
+                    // same placeholder check is same values
+                    return placeholderValues.get(spmId).equals(node2);
+                }
+                placeholderValues.put(spmId, (Expr) node2);
+                return true;
+            }
+            FunctionCallExpr other = cast(node2);
+            Preconditions.checkNotNull(node.getFn());
+            Preconditions.checkNotNull(other.getFn());
+            if (!StringUtils.equals(node.getFn().functionName(), other.getFn().functionName())) {
+                return false;
+            }
+            return check(node.getChildren(), ((Expr) node2).getChildren());
+        }
+
+        @Override
+        public Boolean visitArithmeticExpr(ArithmeticExpr node, ParseNode node2) {
+            ArithmeticExpr other = cast(node2);
+            if (node.getOp() != other.getOp()) {
+                return false;
+            }
+            return check(node.getChildren(), ((Expr) node2).getChildren());
+        }
+
+        @Override
+        public Boolean visitTimestampArithmeticExpr(TimestampArithmeticExpr node, ParseNode node2) {
+            TimestampArithmeticExpr other = cast(node2);
+            Preconditions.checkNotNull(node.getFn());
+            Preconditions.checkNotNull(other.getFn());
+            if (!StringUtils.equals(node.getFn().functionName(), other.getFn().functionName())) {
+                return false;
+            }
+            return check(node.getChildren(), ((Expr) node2).getChildren());
+        }
+        // ----------------- end -----------------
+
+        @Override
+        public Boolean visitInPredicate(InPredicate node, ParseNode context) {
+            if (node.getChildren().stream().noneMatch(SPMFunctions::isSPMFunctions)) {
+                return super.visitExpression(node, context);
+            }
+            InPredicate other = cast(context);
+            if (node.isNotIn() != other.isNotIn() || !check(node.getChild(0), other.getChild(0))) {
+                return false;
+            }
+            Preconditions.checkState(node.getChildren().size() == 2);
+            Preconditions.checkState(SPMFunctions.isSPMFunctions(node.getChild(1)));
+            Preconditions.checkState(!node.getChild(1).getChildren().isEmpty());
+            Preconditions.checkState(node.getChild(1).getChild(0) instanceof IntLiteral);
+            long spmId = ((IntLiteral) node.getChild(1).getChild(0)).getValue();
+            if (placeholderValues.containsKey(spmId)) {
+                // same placeholder check is same values
+                return placeholderValues.get(spmId).equals(other);
+            }
+            placeholderValues.put(spmId, other);
+            return true;
+        }
+    }
+
+    private class PlaceholderReplacer extends SPMUpdateExprVisitor<Void> {
+        @Override
+        public ParseNode visitFunctionCall(FunctionCallExpr node, Void context) {
+            if (SPMFunctions.isSPMFunctions(node)) {
+                Preconditions.checkState(!node.getChildren().isEmpty());
+                Preconditions.checkState(node.getChild(0) instanceof IntLiteral);
+                long id = ((IntLiteral) node.getChild(0)).getValue();
+                return placeholderValues.get(id);
+            }
+            return super.visitExpression(node, context);
+        }
+
+        @Override
+        public ParseNode visitInPredicate(InPredicate node, Void context) {
+            if (node.getChildren().stream().anyMatch(SPMFunctions::isSPMFunctions)) {
+                Preconditions.checkState(node.getChildren().size() == 2);
+                Preconditions.checkState(SPMFunctions.isSPMFunctions(node.getChild(1)));
+                Preconditions.checkState(!node.getChild(1).getChildren().isEmpty());
+                Preconditions.checkState(node.getChild(1).getChild(0) instanceof IntLiteral);
+                long spmId = ((IntLiteral) node.getChild(1).getChild(0)).getValue();
+                InPredicate value = placeholderValues.get(spmId).cast();
+                return new InPredicate(node.getChild(0), value.getListChildren(), node.isNotIn());
+            }
+            return super.visitExpression(node, context);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlanner.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.spm;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.ArithmeticExpr;
 import com.starrocks.analysis.Expr;
@@ -76,8 +77,9 @@ public class SPMPlanner {
             SPMAst2SQLBuilder builder = new SPMAst2SQLBuilder(false, true);
             String digest = builder.build((QueryStatement) query);
             long hash = builder.buildHash();
-            SQLPlanManager spm = GlobalStateMgr.getCurrentState().getSqlPlanManager();
-            List<BaselinePlan> plans = spm.findBaselinePlan(digest, hash);
+            List<BaselinePlan> plans = Lists.newArrayList();
+            plans.addAll(session.getSqlPlanStorage().findBaselinePlan(digest, hash));
+            plans.addAll(GlobalStateMgr.getCurrentState().getSqlPlanStorage().findBaselinePlan(digest, hash));
 
             Optional<BaselinePlan> base;
             try (Timer ignored2 = Tracers.watchScope("bindPlan")) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMStmtExecutor.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.collect.Lists;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.sql.ast.spm.CreateBaselinePlanStmt;
+import com.starrocks.sql.ast.spm.DropBaselinePlanStmt;
+import com.starrocks.sql.ast.spm.ShowBaselinePlanStmt;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class SPMStmtExecutor {
+    public static void execute(ConnectContext context, CreateBaselinePlanStmt stmt) {
+        SPMPlanBuilder builder = new SPMPlanBuilder(context, stmt);
+        BaselinePlan plan = builder.execute();
+        context.getGlobalStateMgr().getSqlPlanManager().storeBaselinePlan(plan);
+    }
+
+    public static void execute(ConnectContext context, DropBaselinePlanStmt stmt) {
+        context.getGlobalStateMgr().getSqlPlanManager().dropBaselinePlan(stmt.getBaseLineId());
+    }
+
+    public static ShowResultSet execute(ConnectContext context, ShowBaselinePlanStmt stmt) {
+        List<BaselinePlan> baselines = context.getGlobalStateMgr().getSqlPlanManager().getAllBaselines();
+        List<List<String>> rows = Lists.newArrayList();
+        for (BaselinePlan baseline : baselines) {
+            List<String> row = Lists.newArrayList();
+            row.add(String.valueOf(baseline.getId()));
+            row.add(baseline.isGlobal() ? "Y" : "N");
+            row.add(baseline.getBindSqlDigest());
+            row.add(String.valueOf(baseline.getBindSqlHash()));
+            row.add(baseline.getBindSql());
+            row.add(baseline.getPlanSql());
+            row.add(String.valueOf(baseline.getCosts()));
+            row.add(baseline.getUpdateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+            rows.add(row);
+        }
+        return new ShowResultSet(stmt.getMetaData(), rows);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMUpdateExprVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMUpdateExprVisitor.java
@@ -1,0 +1,121 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.OrderByElement;
+import com.starrocks.analysis.ParseNode;
+import com.starrocks.sql.ast.AstVisitor;
+import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetOperationRelation;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.ast.ValuesRelation;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SPMUpdateExprVisitor<C> implements AstVisitor<ParseNode, C> {
+    protected Expr visitExpr(Expr node, C context) {
+        if (node == null) {
+            return null;
+        }
+        Expr x = (Expr) node.accept(this, context);
+        Preconditions.checkNotNull(x);
+        return x;
+    }
+
+    protected List<Expr> visitExprList(List<Expr> nodes, C context) {
+        if (nodes != null && !nodes.isEmpty()) {
+            return nodes.stream().map(p -> visitExpr(p, context)).collect(Collectors.toList());
+        }
+        return nodes;
+    }
+
+    @Override
+    public ParseNode visitQueryStatement(QueryStatement statement, C context) {
+        statement.getQueryRelation().accept(this, context);
+        return statement;
+    }
+
+    @Override
+    public ParseNode visitSelect(SelectRelation stmt, C context) {
+        stmt.getCteRelations().forEach(this::visit);
+        visit(stmt.getRelation());
+        if (stmt.getOutputExpression() == null) {
+            stmt.getSelectList().getItems().forEach(item -> item.setExpr(visitExpr(item.getExpr(), context)));
+        } else {
+            stmt.setOutputExpr(visitExprList(stmt.getOutputExpression(), context));
+        }
+        stmt.setWhereClause(visitExpr(stmt.getWhereClause(), context));
+        stmt.setGroupBy(visitExprList(stmt.getGroupBy(), context));
+        stmt.setHaving(visitExpr(stmt.getHaving(), context));
+        if (stmt.getOrderBy() != null) {
+            for (OrderByElement element : stmt.getOrderBy()) {
+                element.setExpr(visitExpr(element.getExpr(), context));
+            }
+        }
+        return stmt;
+    }
+
+    public ParseNode visitJoin(JoinRelation stmt, C context) {
+        visit(stmt.getLeft());
+        visit(stmt.getRight());
+        visitExpr(stmt.getOnPredicate(), context);
+        return stmt;
+    }
+
+    @Override
+    public ParseNode visitSubqueryRelation(SubqueryRelation stmt, C context) {
+        return visit(stmt.getQueryStatement());
+    }
+
+    @Override
+    public ParseNode visitSetOp(SetOperationRelation stmt, C context) {
+        for (QueryRelation relation : stmt.getRelations()) {
+            visit(relation);
+        }
+        return stmt;
+    }
+
+    @Override
+    public ParseNode visitValues(ValuesRelation stmt, C context) {
+        for (int i = 0; i < stmt.getRows().size(); i++) {
+            List<Expr> row = stmt.getRow(i);
+            stmt.getRows().set(i, visitExprList(row, context));
+        }
+        return stmt;
+    }
+
+    @Override
+    public ParseNode visitCTE(CTERelation stmt, C context) {
+        visit(stmt.getCteQueryStatement());
+        return stmt;
+    }
+
+    @Override
+    public ParseNode visitExpression(Expr node, C context) {
+        if (node.getChildren() != null && !node.getChildren().isEmpty()) {
+            for (int i = 0; i < node.getChildren().size(); i++) {
+                node.setChild(i, visitExpr(node.getChild(i), context));
+            }
+        }
+        return node;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanGlobalStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanGlobalStorage.java
@@ -1,0 +1,224 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.spm;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.thrift.TResultBatch;
+import com.starrocks.thrift.TResultSinkType;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+class SQLPlanGlobalStorage implements SQLPlanStorage {
+    /*
+     * SPM baselines table
+     * id         | bigint
+     * bind_sql   | varchar(65530)
+     * bind_sql_digest | varchar(65530)
+     * bind_sql_hash | bigint
+     * plan_sql   | varchar(65530)
+     * costs      | double
+     * update_time| datetime
+     */
+    private static final Logger LOG = LogManager.getLogger(SQLPlanGlobalStorage.class);
+    private static final String QUERY_SQL = "SELECT * FROM " + StatsConstants.SPM_BASELINE_TABLE_NAME + " ";
+    private static final String INSERT_SQL = "INSERT INTO " + StatsConstants.SPM_BASELINE_TABLE_NAME + " VALUES ";
+    private static final String DELETE_SQL = "DELETE FROM " + StatsConstants.SPM_BASELINE_TABLE_NAME + " WHERE id = ";
+
+    // for lazy load baseline plan
+    private record BaselineId(long id, long bindSQLHash) {}
+
+    // thread safe
+    private final Set<BaselineId> allBaselineIds = Sets.newConcurrentHashSet();
+
+    private boolean hasInit = false;
+
+    // cache
+    private final BaselinePlanLoader loader = new BaselinePlanLoader();
+    private final LoadingCache<Long, BaselinePlan> cache = Caffeine.newBuilder()
+            .maximumSize(Config.max_spm_cache_baseline_size)
+            .executor(Executors.newFixedThreadPool(1,
+                    new ThreadFactoryBuilder().setDaemon(true).setNameFormat("baseline-cache-%d").build()))
+            .build(loader);
+    private final SimpleExecutor executor = new SimpleExecutor("SPMExecutor", TResultSinkType.HTTP_PROTOCAL);
+
+    public void init() {
+        if (hasInit) {
+            return;
+        }
+        List<BaselinePlan> bps = getAllBaselines();
+        bps.forEach(bp -> cache.put(bp.getId(), bp));
+        allBaselineIds.addAll(bps.stream().map(bp -> new BaselineId(bp.getId(), bp.getBindSqlHash())).toList());
+        hasInit = true;
+    }
+
+    // only show stmt used, query be directly
+    public List<BaselinePlan> getAllBaselines() {
+        try {
+            List<TResultBatch> datas = executor.executeDQL(QUERY_SQL);
+            List<BaselinePlan> bps = castToBaselinePlan(datas);
+            if (!hasInit) {
+                bps.forEach(bp -> cache.put(bp.getId(), bp));
+                allBaselineIds.addAll(bps.stream().map(bp -> new BaselineId(bp.getId(), bp.getBindSqlHash())).toList());
+            }
+            return bps;
+        } catch (Exception e) {
+            LOG.warn("sql plan baselines get all baseline fail", e);
+            return List.of();
+        }
+    }
+
+    public void storeBaselinePlan(BaselinePlan plan) {
+        try {
+            plan.setId(GlobalStateMgr.getCurrentState().getNextId());
+            List<String> values = Lists.newArrayList();
+            values.add(String.valueOf(plan.getId()));
+            values.add("'" + plan.getBindSql() + "'");
+            values.add("'" + plan.getBindSqlDigest() + "'");
+            values.add(String.valueOf(plan.getBindSqlHash()));
+            values.add("'" + plan.getPlanSql() + "'");
+            values.add(String.valueOf(plan.getCosts()));
+            values.add("'" + DateUtils.formatDateTimeUnix(plan.getUpdateTime()) + "'");
+            String sql = INSERT_SQL + "(" + String.join(", ", values) + ");";
+            executor.executeDML(sql);
+
+            GlobalStateMgr.getCurrentState().getEditLog().logCreateSPMBaseline(plan);
+            allBaselineIds.add(new BaselineId(plan.getId(), plan.getBindSqlHash()));
+        } catch (Exception e) {
+            LOG.warn("sql plan baselines store baseline fail", e);
+        }
+    }
+
+    public List<BaselinePlan> findBaselinePlan(String sqlDigest, long hash) {
+        init();
+        List<Long> ids = allBaselineIds.stream()
+                .filter(baselineId -> baselineId.bindSQLHash == hash).map(f -> f.id).toList();
+        Map<Long, BaselinePlan> plans = cache.getAll(ids);
+        return plans.values().stream().filter(plan -> plan.getBindSqlDigest().equals(sqlDigest)).toList();
+    }
+
+    public void dropBaselinePlan(long baseLineId) {
+        try {
+            List<BaselineId> ids = allBaselineIds.stream().filter(b -> b.id == baseLineId).toList();
+            Preconditions.checkState(ids.size() == 1);
+            for (BaselineId id : ids) {
+                executor.executeDML(DELETE_SQL + id.id + ";");
+                GlobalStateMgr.getCurrentState().getEditLog()
+                        .logDropSPMBaseline(new BaselinePlan(id.id, id.bindSQLHash));
+                allBaselineIds.remove(id);
+                cache.invalidate(id.id);
+            }
+        } catch (Exception e) {
+            LOG.warn("sql plan baselines drop baseline fail", e);
+        }
+    }
+
+    // for ut test use
+    public void dropAllBaselinePlans() {
+        allBaselineIds.clear();
+    }
+
+    private List<BaselinePlan> castToBaselinePlan(List<TResultBatch> datas) {
+        List<BaselinePlan> result = Lists.newArrayList();
+        for (TResultBatch batch : ListUtils.emptyIfNull(datas)) {
+            for (ByteBuffer buffer : batch.getRows()) {
+                ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                String jsonString = copied.toString(Charset.defaultCharset());
+                /*
+                 * SPM baselines table
+                 * 0.id         | bigint
+                 * 1.bind_sql   | varchar(65530)
+                 * 2.bind_sql_digest | varchar(65530)
+                 * 3.bind_sql_hash | bigint
+                 * 4.plan_sql   | varchar(65530)
+                 * 5.costs      | double
+                 * 6.update_time| datetime
+                 */
+                JsonElement obj = JsonParser.parseString(jsonString);
+                JsonArray data = obj.getAsJsonObject().get("data").getAsJsonArray();
+                BaselinePlan bp = new BaselinePlan(true, data.get(1).getAsString(), data.get(2).getAsString(),
+                        data.get(3).getAsLong(), data.get(4).getAsString(), data.get(5).getAsDouble(),
+                        DateUtils.parseUnixDateTime(data.get(6).getAsString()));
+                bp.setId(data.get(0).getAsLong());
+                result.add(bp);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void replayBaselinePlan(BaselinePlan plan, boolean isCreate) {
+        if (isCreate) {
+            allBaselineIds.add(new BaselineId(plan.getId(), plan.getBindSqlHash()));
+        } else {
+            allBaselineIds.removeIf(b -> b.id == plan.getId());
+        }
+    }
+
+    private class BaselinePlanLoader implements CacheLoader<Long, BaselinePlan> {
+        @Override
+        public BaselinePlan load(@NonNull Long key) {
+            try {
+                List<TResultBatch> datas = executor.executeDQL(QUERY_SQL + "WHERE id = " + key + ";");
+                if (!datas.isEmpty()) {
+                    return castToBaselinePlan(datas).get(0);
+                }
+            } catch (Exception e) {
+                LOG.warn("sql plan baselines load baseline fail", e);
+            }
+            return null;
+        }
+
+        @NonNull
+        @Override
+        public Map<Long, BaselinePlan> loadAll(Iterable<? extends Long> keys) {
+            List<String> ks = Lists.newArrayList();
+            keys.forEach(key -> ks.add(String.valueOf(key)));
+            try {
+                List<TResultBatch> datas =
+                        executor.executeDQL(QUERY_SQL + "WHERE id IN (" + String.join(", ", ks) + ");");
+                return castToBaselinePlan(datas).stream().collect(Collectors.toMap(BaselinePlan::getId, b -> b));
+            } catch (Exception e) {
+                LOG.warn("sql plan baselines load all baseline fail", e);
+            }
+            return Map.of();
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanSessionStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanSessionStorage.java
@@ -19,7 +19,7 @@ import com.starrocks.server.GlobalStateMgr;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class SQLPlanManager {
+class SQLPlanSessionStorage implements SQLPlanStorage {
     private final List<BaselinePlan> baselinePlans = Lists.newArrayList();
 
     public List<BaselinePlan> getAllBaselines() {
@@ -40,8 +40,8 @@ public class SQLPlanManager {
         baselinePlans.removeIf(p -> p.getId() == baseLineId);
     }
 
-    // for ut
     public void dropAllBaselinePlans() {
         baselinePlans.clear();
     }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanStorage.java
@@ -11,27 +11,25 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+package com.starrocks.sql.spm;
 
-package com.starrocks.sql.ast.spm;
+import java.util.List;
 
-import com.starrocks.sql.ast.AstVisitor;
-import com.starrocks.sql.ast.DdlStmt;
-import com.starrocks.sql.parser.NodePosition;
-
-public class DropBaselinePlanStmt extends DdlStmt {
-    private final long baseLineId;
-
-    public DropBaselinePlanStmt(long baseLineId, NodePosition pos) {
-        super(pos);
-        this.baseLineId = baseLineId;
+public interface SQLPlanStorage {
+    static SQLPlanStorage create(boolean isGlobal) {
+        return isGlobal ? new SQLPlanGlobalStorage() : new SQLPlanSessionStorage();
     }
 
-    public long getBaseLineId() {
-        return baseLineId;
-    }
+    List<BaselinePlan> getAllBaselines();
 
-    @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitDropBaselinePlanStatement(this, context);
-    }
+    void storeBaselinePlan(BaselinePlan plan);
+
+    List<BaselinePlan> findBaselinePlan(String sqlDigest, long hash);
+
+    void dropBaselinePlan(long baseLineId);
+
+    // for ut test use
+    void dropAllBaselinePlans();
+
+    default void replayBaselinePlan(BaselinePlan plan, boolean isCreate) {}
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -48,8 +48,8 @@ import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.http.HttpConnectContext;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectContext;
@@ -551,7 +551,7 @@ public class StatisticUtils {
             String sql = String.format("ALTER TABLE %s.%s SET ('replication_num'='%d')",
                     StatsConstants.STATISTICS_DB_NAME, tableName, expectedReplicationNum);
             if (StringUtils.isNotEmpty(sql)) {
-                RepoExecutor.getInstance().executeDDL(sql);
+                SimpleExecutor.getRepoExecutor().executeDDL(sql);
             }
             LOG.info("changed replication_number of table {} from {} to {}",
                     tableName, replica, expectedReplicationNum);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -86,6 +86,9 @@ public class StatsConstants {
     public static final String HISTOGRAM_MCV_SIZE = "histogram_mcv_size";
     public static final String HISTOGRAM_SAMPLE_RATIO = "histogram_sample_ratio";
 
+    // SQL plan manager table
+    public static final String SPM_BASELINE_TABLE_NAME = "spm_baselines";
+
     /**
      * Deprecated stats properties
      */

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsStorage.java
@@ -26,7 +26,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.history.TableKeeper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
@@ -121,7 +121,7 @@ public class PredicateColumnsStorage {
     private final LocalDateTime systemStartTime = TimeUtils.getSystemNow();
     private volatile LocalDateTime lastPersist = LocalDateTime.MIN;
 
-    private final RepoExecutor executor;
+    private final SimpleExecutor executor;
 
     public static TableKeeper createKeeper() {
         return KEEPER;
@@ -132,10 +132,10 @@ public class PredicateColumnsStorage {
     }
 
     public PredicateColumnsStorage() {
-        this.executor = RepoExecutor.getInstance();
+        this.executor = SimpleExecutor.getRepoExecutor();
     }
 
-    public PredicateColumnsStorage(RepoExecutor executor) {
+    public PredicateColumnsStorage(SimpleExecutor executor) {
         this.executor = executor;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
@@ -26,7 +26,6 @@ import com.starrocks.fs.HdfsUtil;
 import com.starrocks.load.pipe.filelist.FileListRepo;
 import com.starrocks.load.pipe.filelist.FileListTableRepo;
 import com.starrocks.load.pipe.filelist.RepoAccessor;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.persist.OperationType;
 import com.starrocks.persist.PipeOpEntry;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
@@ -35,6 +34,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.SubmitResult;
@@ -354,7 +354,7 @@ public class PipeManagerTest {
     }
 
     public static void mockRepoExecutorDML() {
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public void executeDML(String sql) {
             }
@@ -371,7 +371,7 @@ public class PipeManagerTest {
     }
 
     private void mockRepoExecutor() {
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public void executeDML(String sql) {
             }

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
@@ -23,6 +23,7 @@ import com.starrocks.common.util.DateUtils;
 import com.starrocks.load.pipe.PipeFileRecord;
 import com.starrocks.load.pipe.PipeId;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.plan.ExecPlan;
@@ -182,7 +183,7 @@ public class FileListRepoTest {
     }
 
     private void mockExecutor() {
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             private boolean ddlExecuted = false;
 
             @Mock
@@ -213,11 +214,11 @@ public class FileListRepoTest {
                 return true;
             }
         };
-        RepoExecutor executor = RepoExecutor.getInstance();
+        SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
         RepoCreator creator = RepoCreator.getInstance();
 
         // failed for the first time
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public void executeDDL(String sql) {
                 throw new RuntimeException("ddl failed");
@@ -235,7 +236,7 @@ public class FileListRepoTest {
             }
         };
         AtomicInteger changed = new AtomicInteger(0);
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public void executeDDL(String sql) {
                 changed.addAndGet(1);
@@ -264,7 +265,7 @@ public class FileListRepoTest {
         FileListTableRepo repo = new FileListTableRepo();
         repo.setPipeId(new PipeId(1, 1));
         RepoAccessor accessor = RepoAccessor.getInstance();
-        RepoExecutor executor = RepoExecutor.getInstance();
+        SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
         new Expectations(executor) {
             {
                 executor.executeDQL(anyString);
@@ -381,7 +382,7 @@ public class FileListRepoTest {
             }
         };
 
-        RepoExecutor executor = RepoExecutor.getInstance();
+        SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
         new Expectations(executor) {
             {
                 executor.executeDML(
@@ -409,7 +410,7 @@ public class FileListRepoTest {
             }
         };
 
-        RepoExecutor executor = RepoExecutor.getInstance();
+        SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
 
         Assert.assertTrue(executor.executeDQL("select now()").isEmpty());
 
@@ -422,7 +423,7 @@ public class FileListRepoTest {
         FileListTableRepo repo = new FileListTableRepo();
         repo.setPipeId(new PipeId(1, 1));
         RepoAccessor accessor = RepoAccessor.getInstance();
-        RepoExecutor executor = RepoExecutor.getInstance();
+        SimpleExecutor executor = SimpleExecutor.getRepoExecutor();
 
         new Expectations(executor) {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -17,8 +17,8 @@ package com.starrocks.scheduler.history;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.statistic.StatisticsMetaManager;
@@ -71,7 +71,7 @@ public class TaskRunHistoryTest {
     }
 
     @Test
-    public void testCRUD(@Mocked RepoExecutor repo) {
+    public void testCRUD(@Mocked SimpleExecutor repo) {
         TaskRunStatus status = new TaskRunStatus();
         status.setQueryId("aaa");
         status.setTaskName("t1");
@@ -153,7 +153,7 @@ public class TaskRunHistoryTest {
     }
 
     @Test
-    public void testKeeper(@Mocked RepoExecutor repo) {
+    public void testKeeper(@Mocked SimpleExecutor repo) {
         TableKeeper keeper = TaskRunHistoryTable.createKeeper();
         assertEquals(StatsConstants.STATISTICS_DB_NAME, keeper.getDatabaseName());
         assertEquals(TaskRunHistoryTable.TABLE_NAME, keeper.getTableName());
@@ -196,7 +196,7 @@ public class TaskRunHistoryTest {
     }
 
     @Test
-    public void testHistoryVacuum(@Mocked RepoExecutor repo) {
+    public void testHistoryVacuum(@Mocked SimpleExecutor repo) {
         new MockUp<TableKeeper>() {
             @Mock
             public boolean isReady() {
@@ -337,7 +337,7 @@ public class TaskRunHistoryTest {
     }
 
     @Test
-    public void testLookByTaskNamesOrder(@Mocked RepoExecutor repo) {
+    public void testLookByTaskNamesOrder(@Mocked SimpleExecutor repo) {
         new MockUp<TableKeeper>() {
             @Mock
             public boolean isReady() {
@@ -353,7 +353,7 @@ public class TaskRunHistoryTest {
         }
         // shuffle the taskRuns' order
         Collections.shuffle(taskRuns);
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public List<TResultBatch> executeDQL(String sql) {
                 TaskRunStatus.TaskRunStatusJSONRecord record = new TaskRunStatus.TaskRunStatusJSONRecord();
@@ -378,7 +378,7 @@ public class TaskRunHistoryTest {
     }
 
     @Test
-    public void testLookOrder(@Mocked RepoExecutor repo) {
+    public void testLookOrder(@Mocked SimpleExecutor repo) {
         new MockUp<TableKeeper>() {
             @Mock
             public boolean isReady() {
@@ -396,7 +396,7 @@ public class TaskRunHistoryTest {
         // shuffle the taskRuns' order
         Collections.shuffle(taskRuns);
 
-        new MockUp<RepoExecutor>() {
+        new MockUp<SimpleExecutor>() {
             @Mock
             public List<TResultBatch> executeDQL(String sql) {
                 TaskRunStatus.TaskRunStatusJSONRecord record = new TaskRunStatus.TaskRunStatusJSONRecord();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -21,10 +21,10 @@ import com.starrocks.common.Config;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.leader.ReportHandler;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.optimizer.function.MetaFunctions;
@@ -197,7 +197,7 @@ public class MetaFunctionsTest {
             Assert.assertNull(lookupString("t1", "v1", "c1"));
 
             // normal
-            new MockUp<RepoExecutor>() {
+            new MockUp<SimpleExecutor>() {
                 @Mock
                 public List<TResultBatch> executeDQL(String sql) {
                     MetaFunctions.LookupRecord record = new MetaFunctions.LookupRecord();
@@ -213,7 +213,7 @@ public class MetaFunctionsTest {
             Assert.assertEquals("v1", lookupString("t1", "v1", "c1"));
 
             // record not found
-            new MockUp<RepoExecutor>() {
+            new MockUp<SimpleExecutor>() {
                 @Mock
                 public List<TResultBatch> executeDQL(String sql) {
                     throw new RuntimeException("query failed if record not exist in dict table");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMPlanTest.java
@@ -1,0 +1,576 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.spm.CreateBaselinePlanStmt;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class SPMPlanTest extends PlanTestBase {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        PlanTestBase.beforeAll();
+        connectContext.getSessionVariable().setEnableSPMRewrite(true);
+    }
+
+    @BeforeEach
+    public void before() {
+        SPMFunctions.enableSPMParamsPrint = true;
+    }
+
+    public CreateBaselinePlanStmt createBaselinePlanStmt(String sql) {
+        String createSql = "create baseline using " + sql;
+        List<StatementBase> statements = SqlParser.parse(createSql, connectContext.getSessionVariable());
+        Preconditions.checkState(statements.size() == 1);
+        Preconditions.checkState(statements.get(0) instanceof CreateBaselinePlanStmt);
+        return (CreateBaselinePlanStmt) statements.get(0);
+    }
+
+    public CreateBaselinePlanStmt createBaselinePlanStmt(String bind, String sql) {
+        String createSql = "create baseline on " + bind + " using " + sql;
+        List<StatementBase> statements = SqlParser.parse(createSql, connectContext.getSessionVariable());
+        Preconditions.checkState(statements.size() == 1);
+        Preconditions.checkState(statements.get(0) instanceof CreateBaselinePlanStmt);
+        return (CreateBaselinePlanStmt) statements.get(0);
+    }
+
+    @Test
+    public void testBindScan() {
+        SPMFunctions.enableSPMParamsPrint = false;
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt("select * from t0 where v2 = 1");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+
+        generator.execute();
+        assertContains(generator.getBindSqlDigest(), """
+                SELECT *
+                FROM `test`.`t0`
+                WHERE `test`.`t0`.`v2` = ?""");
+        assertContains(generator.getPlanStmtSQL(), "SELECT * FROM t0 WHERE v2 = _spm_const_var(1)");
+    }
+
+    @Test
+    public void testSPMReplaceScanPlan() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt("select * from t0 where v2 = 1");
+        SPMStmtExecutor.execute(connectContext, stmt);
+        SPMPlanner planner = new SPMPlanner(connectContext);
+
+        List<StatementBase> statements =
+                SqlParser.parse("select * from t0 where v2 = 20", connectContext.getSessionVariable());
+
+        StatementBase query = planner.plan(statements.get(0));
+        Assertions.assertTrue(planner.getBaseline().getId() > 1);
+        Assertions.assertNotEquals(query, statements.get(0));
+    }
+
+    @Test
+    public void testBindJoin() {
+        SPMFunctions.enableSPMParamsPrint = false;
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select * from t0 join t1 on t0.v3 = t1.v6 where t0.v2 = 1");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+
+        generator.execute();
+        assertContains(generator.getBindSqlDigest(), """
+                SELECT *
+                FROM `test`.`t0` INNER JOIN `test`.`t1` ON `test`.`t0`.`v3` = `test`.`t1`.`v6`
+                WHERE `test`.`t0`.`v2` = ?""");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT * FROM " + "(SELECT * FROM t0 WHERE v2 = _spm_const_var(1)) t_0 INNER JOIN[BROADCAST] " +
+                        "(SELECT * FROM t1 WHERE v6 IS NOT NULL) t_1 ON v3 = v6");
+    }
+
+    @Test
+    public void testBindJoin2() {
+        SPMFunctions.enableSPMParamsPrint = false;
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select t1.v4, t0.v2 from t0 join t1 on t0.v3 = t1.v6 where t0.v2 = 1");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+
+        generator.execute();
+        assertContains(generator.getBindSqlDigest(), "SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`\n" +
+                "FROM `test`.`t0` INNER JOIN `test`.`t1` ON `test`.`t0`.`v3` = `test`.`t1`.`v6`\n" +
+                "WHERE `test`.`t0`.`v2` = ?");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT v2, v4 FROM " + "(SELECT * FROM t0 WHERE v2 = _spm_const_var(1)) t_0 INNER JOIN[BROADCAST] " +
+                        "(SELECT * FROM t1 WHERE v6 IS NOT NULL) t_1 ON v3 = v6");
+    }
+
+    @Test
+    public void testBindJoin3() {
+        SPMFunctions.enableSPMParamsPrint = false;
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select t1.v4, t0.v2 from t0 join[SHUFFLE] t1 on t0.v3 = t1.v6 where t0.v2 = 1");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+
+        generator.execute();
+        assertContains(generator.getBindSqlDigest(), "SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`\n" +
+                "FROM `test`.`t0` INNER JOIN `test`.`t1` ON `test`.`t0`.`v3` = `test`.`t1`.`v6`\n" +
+                "WHERE `test`.`t0`.`v2` = ?");
+
+        assertContains(generator.getBindSql(), "SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`\n"
+                + "FROM `test`.`t0` INNER JOIN `test`.`t1` ON `test`.`t0`.`v3` = `test`.`t1`.`v6`\n"
+                + "WHERE `test`.`t0`.`v2` = _spm_const_var(1)");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT v2, v4 FROM " + "(SELECT * FROM t0 WHERE v2 = _spm_const_var(1)) t_0 INNER JOIN[SHUFFLE] " +
+                        "(SELECT * FROM t1 WHERE v6 IS NOT NULL) t_1 ON v3 = v6");
+    }
+
+    @Test
+    public void testSPMReplaceJoinPlan() {
+        SPMFunctions.enableSPMParamsPrint = false;
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select t1.v4, t0.v2 from t0 join[SHUFFLE] t1 on t0.v3 = t1.v6 where t0.v2 = 1000");
+        SPMStmtExecutor.execute(connectContext, stmt);
+        SPMPlanner planner = new SPMPlanner(connectContext);
+
+        List<StatementBase> statements =
+                SqlParser.parse("select t1.v4, t0.v2 from t0 join t1 on t0.v3 = t1.v6 where t0.v2 = 2",
+                        connectContext.getSessionVariable());
+
+        StatementBase query = planner.plan(statements.get(0));
+        Assertions.assertTrue(planner.getBaseline().getId() > 1);
+        Assertions.assertNotEquals(query, statements.get(0));
+        assertContains(planner.getBaseline().getPlanSql(),
+                "SELECT v2, v4 FROM " + "(SELECT * FROM t0 WHERE v2 = _spm_const_var(1)) t_0 INNER JOIN[SHUFFLE] " +
+                        "(SELECT * FROM t1 WHERE v6 IS NOT NULL) t_1 ON v3 = v6");
+        assertContains(AstToSQLBuilder.toSQL(query), "SELECT `v2`, `v4`\n" +
+                "FROM (SELECT *\n" +
+                "FROM `t0`\n" +
+                "WHERE `v2` = 2) `t_0` INNER JOIN [SHUFFLE] (SELECT *\n" +
+                "FROM `t1`\n" +
+                "WHERE `v6` IS NOT NULL) `t_1` ON `v3` = `v6`");
+    }
+
+    @Test
+    public void testBindInPredicate() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select t1.v4, t0.v2 from t0 join[SHUFFLE] t1 on t0.v3 = t1.v6 where t0.v2 in (1,2,3,4)");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+
+        generator.execute();
+        assertContains(generator.getBindSqlDigest(), "SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`\n" +
+                "FROM `test`.`t0` INNER JOIN `test`.`t1` ON `test`.`t0`.`v3` = `test`.`t1`.`v6`\n" +
+                "WHERE `test`.`t0`.`v2` IN (?)");
+
+        assertContains(generator.getBindSql(), "SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`\n"
+                + "FROM `test`.`t0` INNER JOIN `test`.`t1` ON `test`.`t0`.`v3` = `test`.`t1`.`v6`\n"
+                + "WHERE `test`.`t0`.`v2` IN (_spm_const_list(1, 1, 2, 3, 4))");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT v2, v4 FROM " + "(SELECT * FROM t0 WHERE v2 IN (_spm_const_list(1, 1, 2, 3, 4))) t_0 " +
+                        "INNER JOIN[SHUFFLE] " +
+                        "(SELECT * FROM t1 WHERE v6 IS NOT NULL) t_1 ON v3 = v6");
+    }
+
+    @Test
+    public void testPlanHints() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select /*+SET_VAR(cbo_cte_reuse=false,cbo_push_down_aggregate=false)*/ * from t0");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+        assertContains(generator.getBindSqlDigest(), "SELECT *\n"
+                + "FROM `test`.`t0`");
+
+        assertContains(generator.getBindSql(), "SELECT *\n"
+                + "FROM `test`.`t0`");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT /*+SET_VAR(cbo_cte_reuse=false,cbo_push_down_aggregate=false)*/* FROM t0");
+    }
+
+    @Test
+    public void testBindPlan() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select t1.v4, t0.v2 from t0, t1 where t0.v3 = t1.v6 and t0.v2 in (1,2,3,4)",
+                "SELECT v2, v4 FROM " +
+                        "(SELECT * FROM t0 WHERE v2 IN (1, 2, 3, 4)) t_0 " +
+                        " INNER JOIN[SHUFFLE] " +
+                        " t1 ON v3 = v6");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+        assertContains(generator.getBindSqlDigest(), "SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`\n" +
+                "FROM `test`.`t0` , `test`.`t1` \n" +
+                "WHERE (`test`.`t0`.`v3` = `test`.`t1`.`v6`) AND (`test`.`t0`.`v2` IN (?))");
+
+        assertContains(generator.getBindSql(), "SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`\n" +
+                "FROM `test`.`t0` , `test`.`t1` \n" +
+                "WHERE (`test`.`t0`.`v3` = `test`.`t1`.`v6`) AND (`test`.`t0`.`v2` IN (_spm_const_list(1, 1, 2, 3, 4)"
+                + "))");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT v2, v4 " +
+                        "FROM (SELECT * FROM t0 WHERE v3 IS NOT NULL AND v2 IN (_spm_const_list(1, 1, 2, 3, 4))) t_0 " +
+                        "INNER JOIN[SHUFFLE] (SELECT * FROM t1 WHERE v6 IS NOT NULL) t_1 ON v3 = v6");
+    }
+
+    @Test
+    public void testUserBindPlan() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select t1.v4, t0.v2 from t0, t1 where t0.v3 = t1.v6 and " +
+                        "t0.v2 in (_spm_const_list(1, 10, 11)) and t1.v5 = _spm_const_var(2, 5)",
+                "SELECT v2, v4 FROM " +
+                        "(SELECT * FROM t0 WHERE t0.v2 in (_spm_const_list(1, 10, 11)) ) t_0 " +
+                        " INNER JOIN[SHUFFLE] " +
+                        " (SELECT * FROM t1 WHERE v5 = _spm_const_var(2, 5)) t_1 ON v3 = v6");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+        assertContains(generator.getBindSqlDigest(), """
+                SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`
+                FROM `test`.`t0` , `test`.`t1`\s
+                WHERE ((`test`.`t0`.`v3` = `test`.`t1`.`v6`) AND (`test`.`t0`.`v2` IN (?))) AND (`test`.`t1`.`v5` = ?)""");
+
+        assertContains(generator.getBindSql(), """
+                SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`
+                FROM `test`.`t0` , `test`.`t1`\s
+                WHERE ((`test`.`t0`.`v3` = `test`.`t1`.`v6`) \
+                AND (`test`.`t0`.`v2` IN (_spm_const_list(1, 10, 11)))) \
+                AND (`test`.`t1`.`v5` = _spm_const_var(2, 5))""");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT v2, v4 FROM (SELECT * FROM t0 WHERE v3 IS NOT NULL AND v2 IN (_spm_const_list(1, 10, 11))) "
+                        + "t_0 INNER JOIN[SHUFFLE] (SELECT v4, v6 FROM t1 WHERE v6 IS NOT NULL AND v5 = "
+                        + "_spm_const_var(2, 5)) t_1 ON v3 = v6");
+    }
+
+    @Test
+    public void testUserBindPlan2() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select t1.v4, t0.v2 from t0, t1 where t0.v3 = t1.v6 and " +
+                        "t0.v2 in (_spm_const_list(1, 10, 11)) and t1.v5 = 1",
+                "SELECT v2, v4 FROM " +
+                        "(SELECT * FROM t0 WHERE t0.v2 in (_spm_const_list(1, 10, 11)) ) t_0 " +
+                        " INNER JOIN[SHUFFLE] " +
+                        " (SELECT * FROM t1 WHERE v5 = 1) t_1 ON v3 = v6");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+        assertContains(generator.getBindSqlDigest(), """
+                SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`
+                FROM `test`.`t0` , `test`.`t1`\s
+                WHERE ((`test`.`t0`.`v3` = `test`.`t1`.`v6`) AND (`test`.`t0`.`v2` IN (?))) AND (`test`.`t1`.`v5` = ?)""");
+
+        assertContains(generator.getBindSql(), """
+                SELECT `test`.`t1`.`v4`, `test`.`t0`.`v2`
+                FROM `test`.`t0` , `test`.`t1`\s
+                WHERE ((`test`.`t0`.`v3` = `test`.`t1`.`v6`) AND \
+                (`test`.`t0`.`v2` IN (_spm_const_list(1, 10, 11)))) AND \
+                (`test`.`t1`.`v5` = _spm_const_var(2, 1))""");
+
+        assertContains(generator.getPlanStmtSQL(), "SELECT v2, v4 FROM "
+                + "(SELECT * FROM t0 WHERE v3 IS NOT NULL AND v2 IN (_spm_const_list(1, 10, 11))) t_0 "
+                + "INNER JOIN[SHUFFLE] (SELECT v4, v6 FROM t1 WHERE v6 IS NOT NULL AND v5 = _spm_const_var(2, 1)) t_1 "
+                + "ON v3 = v6");
+    }
+
+    @Test
+    public void testUserBindPlanInvalid1() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select t1.v4, t0.v2 from t0, t1 where t0.v3 = t1.v6 and " +
+                        "t0.v2 in (_spm_const_list(1, 10, 11)) and t1.v5 = 1",
+                "SELECT v2, v4 FROM " +
+                        "(SELECT * FROM t0 WHERE t0.v2 in (_spm_const_list(1, 10, 11)) ) t_0 " +
+                        " INNER JOIN[SHUFFLE] " +
+                        " (SELECT * FROM t1 WHERE v5 = 234) t_1 ON v3 = v6");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.analyze();
+        Assertions.assertThrows(SemanticException.class, generator::parameterizedStmt);
+    }
+
+    @Test
+    public void testUserBindPlanInvalid2() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select t1.v4, t0.v2 from t0, t1 where t0.v3 = t1.v6 and " +
+                        "t0.v2 in (_spm_const_list(1, 10, 11)) and t1.v5 = 1",
+                "SELECT v2, v4 FROM " +
+                        "(SELECT * FROM t0 WHERE t0.v2 in (1,2,3) ) t_0 " +
+                        " INNER JOIN[SHUFFLE] " +
+                        " (SELECT * FROM t1 WHERE v5 = 234) t_1 ON v3 = v6");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.analyze();
+        Assertions.assertThrows(SemanticException.class, generator::parameterizedStmt);
+    }
+
+    @Test
+    public void testBindAggregate() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt("SELECT v2, sum(v3) FROM t0 WHERE v1 = 1 GROUP BY v2");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        assertContains(generator.getBindSqlDigest(), """
+                SELECT `test`.`t0`.`v2`, sum(`test`.`t0`.`v3`)
+                FROM `test`.`t0`
+                WHERE `test`.`t0`.`v1` = ?
+                GROUP BY `test`.`t0`.`v2`""");
+
+        assertContains(generator.getBindSql(), "SELECT `test`.`t0`.`v2`, sum(`test`.`t0`.`v3`)\n" + "FROM `test`.`t0`\n"
+                + "WHERE `test`.`t0`.`v1` = _spm_const_var(1, 1)\n" + "GROUP BY `test`.`t0`.`v2`");
+
+        assertContains(generator.getPlanStmtSQL(), "SELECT v2, sum(v3) AS c_4 "
+                + "FROM (SELECT v2, v3 FROM t0 WHERE v1 = _spm_const_var(1, 1)) t_0 "
+                + "GROUP BY v2");
+    }
+
+    @Test
+    public void testBindAggregateHaving() {
+        CreateBaselinePlanStmt stmt =
+                createBaselinePlanStmt("SELECT v2, sum(v3) FROM t0 WHERE v1 = 1 GROUP BY v2 HAVING sum(v3) > 100");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        assertContains(generator.getBindSqlDigest(),
+                "SELECT `test`.`t0`.`v2`, sum(`test`.`t0`.`v3`)\n" + "FROM `test`.`t0`\n"
+                        + "WHERE `test`.`t0`.`v1` = ?\n" + "GROUP BY `test`.`t0`.`v2`");
+
+        assertContains(generator.getBindSql(), "SELECT `test`.`t0`.`v2`, sum(`test`.`t0`.`v3`)\n" + "FROM `test`.`t0`\n"
+                + "WHERE `test`.`t0`.`v1` = _spm_const_var(1, 1)\n" + "GROUP BY `test`.`t0`.`v2`");
+
+        assertContains(generator.getPlanStmtSQL(), "SELECT v2, sum(v3) AS c_4 "
+                + "FROM (SELECT v2, v3 FROM t0 WHERE v1 = _spm_const_var(1, 1)) t_0 "
+                + "GROUP BY v2 HAVING sum(v3) > _spm_const_var(2, 100)");
+    }
+
+    @Test
+    public void testBindAggregateHavingProjection() {
+        CreateBaselinePlanStmt stmt =
+                createBaselinePlanStmt("SELECT v2 + 2, sum(v3) FROM t0 WHERE v1 = 1 GROUP BY v2 HAVING sum(v3) > 100");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+        assertContains(generator.getPlanStmtSQL(), "SELECT sum(v3) AS c_4, v2 + _spm_const_var(1, 2) AS c_5 "
+                + "FROM (SELECT v2, v3 FROM t0 WHERE v1 = _spm_const_var(2, 1)) t_0 "
+                + "GROUP BY v2 HAVING sum(v3) > _spm_const_var(3, 100)");
+    }
+
+    @Test
+    public void testValuesSQL() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt("SELECT * from (values(1,2,3), (4,5,6))");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        assertContains(generator.getBindSqlDigest(), "SELECT *\n"
+                + "FROM (VALUES(?, ?, ?), (?, ?, ?))");
+
+        assertContains(generator.getBindSql(), "SELECT *\n"
+                + "FROM (VALUES(_spm_const_var(1, 1), _spm_const_var(2, 2), _spm_const_var(3, 3)), "
+                + "(_spm_const_var(4, 4), _spm_const_var(5, 5), _spm_const_var(6, 6)))");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT * FROM (VALUES (_spm_const_var(1, 1), _spm_const_var(2, 2), _spm_const_var(3, 3)), "
+                        + "(_spm_const_var(4, 4), _spm_const_var(5, 5), _spm_const_var(6, 6))) AS t(c_1, c_2, c_3)");
+    }
+
+    @Test
+    public void testJoinValuesSQL() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt("SELECT * from (values(1,2,3), (4,5,6)) x(v1, v2, v3) "
+                + "join (values(9,7,8), (11,22,33)) y(v4, v5, v6) on x.v1 = y.v4");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        assertContains(generator.getBindSqlDigest(), "SELECT *\n"
+                + "FROM (VALUES(?, ?, ?), (?, ?, ?)) x(v1,v2,v3) INNER JOIN"
+                + " (VALUES(?, ?, ?), (?, ?, ?)) y(v4,v5,v6) ON `x`.`v1` = `y`.`v4`");
+
+        assertContains(generator.getBindSql(), "SELECT *\n"
+                + "FROM (VALUES(_spm_const_var(1, 1), _spm_const_var(2, 2), _spm_const_var(3, 3)), "
+                + "(_spm_const_var(4, 4), _spm_const_var(5, 5), _spm_const_var(6, 6))) "
+                + "x(v1,v2,v3) "
+                + "INNER JOIN "
+                + "(VALUES(_spm_const_var(7, 9), _spm_const_var(8, 7), _spm_const_var(9, 8)), "
+                + "(_spm_const_var(10, 11), _spm_const_var(11, 22), _spm_const_var(12, 33))) "
+                + "y(v4,v5,v6) ON `x`.`v1` = `y`.`v4`");
+
+        assertContains(generator.getPlanStmtSQL(), "SELECT * FROM "
+                + "(SELECT * FROM "
+                + "(VALUES (_spm_const_var(1, 1), _spm_const_var(2, 2), _spm_const_var(3, 3)), "
+                + "(_spm_const_var(4, 4), _spm_const_var(5, 5), _spm_const_var(6, 6))) AS t(c_1, c_2, c_3) "
+                + "WHERE c_1 IS NOT NULL) t_0 INNER JOIN[BROADCAST] "
+                + "(SELECT * FROM (VALUES (_spm_const_var(7, 9), _spm_const_var(8, 7), _spm_const_var(9, 8)), "
+                + "(_spm_const_var(10, 11), _spm_const_var(11, 22), _spm_const_var(12, 33))) AS t(c_4, c_5, c_6) "
+                + "WHERE c_4 IS NOT NULL) t_1 ON c_1 = c_4");
+    }
+
+    @Test
+    public void testUnion() {
+        CreateBaselinePlanStmt stmt =
+                createBaselinePlanStmt("SELECT * from t0 where v1 = 1 union all select * from t0 where v1 = 2");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        assertContains(generator.getBindSqlDigest(), """
+                SELECT *
+                FROM `test`.`t0`
+                WHERE `test`.`t0`.`v1` = ? UNION ALL SELECT *
+                FROM `test`.`t0`
+                WHERE `test`.`t0`.`v1` = ?""");
+
+        assertContains(generator.getBindSql(), """
+                SELECT *
+                FROM `test`.`t0`
+                WHERE `test`.`t0`.`v1` = _spm_const_var(1, 1) UNION ALL SELECT *
+                FROM `test`.`t0`
+                WHERE `test`.`t0`.`v1` = _spm_const_var(2, 2)""");
+
+        assertContains(generator.getPlanStmtSQL(), "SELECT * FROM ("
+                + "SELECT v1 AS c_7, v2 AS c_8, v3 AS c_9 FROM t0 WHERE v1 = _spm_const_var(1, 1) "
+                + "UNION ALL "
+                + "SELECT v1 AS c_7, v2 AS c_8, v3 AS c_9 FROM t0 WHERE v1 = _spm_const_var(2, 2)"
+                + ") t_2");
+    }
+
+    @Test
+    public void testOrderBy() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt("SELECT * from t0 where v1 = 1 order by v2 limit 10, 20");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        assertContains(generator.getBindSqlDigest(), """
+                SELECT *
+                FROM `test`.`t0`
+                WHERE `test`.`t0`.`v1` = ? ORDER BY `test`.`t0`.`v2` ASC  LIMIT 10, 20""");
+
+        assertContains(generator.getBindSql(), """
+                SELECT *
+                FROM `test`.`t0`
+                WHERE `test`.`t0`.`v1` = _spm_const_var(1, 1) ORDER BY `test`.`t0`.`v2` ASC  LIMIT 10, 20""");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT * FROM t0 WHERE v1 = _spm_const_var(1, 1) ORDER BY v2 ASC LIMIT 10, 20");
+    }
+
+    @Test
+    public void testCte() {
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "with x as (select * from t0), y as (select * from x) SELECT x.* from x, y where x.v1 = 1");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        assertContains(generator.getBindSqlDigest(), """
+                WITH `x` (`v1`, `v2`, `v3`) AS (SELECT *
+                FROM `test`.`t0`) , `y` (`v1`, `v2`, `v3`) AS (SELECT *
+                FROM `x`) SELECT x.*
+                FROM `x` , `y`\s
+                WHERE `x`.`v1` = ?""");
+
+        assertContains(generator.getBindSql(), """
+                WITH `x` (`v1`, `v2`, `v3`) AS (SELECT *
+                FROM `test`.`t0`) , `y` (`v1`, `v2`, `v3`) AS (SELECT *
+                FROM `x`) SELECT x.*
+                FROM `x` , `y`\s
+                WHERE `x`.`v1` = _spm_const_var(1, 1)""");
+
+        assertContains(generator.getPlanStmtSQL(), "WITH t_0 AS (SELECT * FROM t0) "
+                + "SELECT v1, v2, v3 FROM "
+                + "(SELECT * FROM t_0 WHERE v1 = _spm_const_var(1, 1)) t_1 "
+                + "CROSS JOIN[BROADCAST] (SELECT 1 AS c_12 FROM t_0) t_2");
+    }
+
+    @Test
+    public void testWindow() {
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select v3, avg(v2) over (partition by v2, v3 order by v2 desc), "
+                        + "sum(v2) over (partition by v2, v3 order by v2 desc) as sum1 from t0");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        assertContains(generator.getBindSqlDigest(), """
+                SELECT `test`.`t0`.`v3`, \
+                avg(`test`.`t0`.`v2`) OVER \
+                (PARTITION BY `test`.`t0`.`v2`, `test`.`t0`.`v3` ORDER BY `test`.`t0`.`v2` DESC ), \
+                sum(`test`.`t0`.`v2`) OVER \
+                (PARTITION BY `test`.`t0`.`v2`, `test`.`t0`.`v3` ORDER BY `test`.`t0`.`v2` DESC ) AS `sum1`
+                FROM `test`.`t0`""");
+
+        assertContains(generator.getBindSql(), "SELECT `test`.`t0`.`v3`, "
+                + "avg(`test`.`t0`.`v2`) OVER (PARTITION BY `test`.`t0`.`v2`, `test`.`t0`.`v3` ORDER BY `test`.`t0`"
+                + ".`v2` DESC ), "
+                + "sum(`test`.`t0`.`v2`) OVER (PARTITION BY `test`.`t0`.`v2`, `test`.`t0`.`v3` ORDER BY `test`.`t0`"
+                + ".`v2` DESC ) AS `sum1`\n"
+                + "FROM `test`.`t0`");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT v3, avg(v2) OVER (PARTITION BY v2, v3 ORDER BY v2 DESC ) AS c_4, "
+                        + "sum(v2) OVER (PARTITION BY v2, v3 ORDER BY v2 DESC ) AS c_5 FROM t0");
+    }
+
+    @Test
+    public void testWindow2() {
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select v3, sum(v2), avg(v2) over (partition by v2, v3 order by v2 desc), "
+                        + "sum(v2) over (partition by v2, v3 order by v2 desc) as sum1 from t0 "
+                        + "group by v2,v3 having sum(v2) > 100");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        assertContains(generator.getBindSqlDigest(), """
+                SELECT `test`.`t0`.`v3`, sum(`test`.`t0`.`v2`), \
+                avg(`test`.`t0`.`v2`) OVER (PARTITION BY `test`.`t0`.`v2`, `test`.`t0`.`v3` ORDER BY `test`.`t0`.`v2` DESC ), \
+                sum(`test`.`t0`.`v2`) OVER (PARTITION BY `test`.`t0`.`v2`, `test`.`t0`.`v3` ORDER BY `test`.`t0`.`v2` DESC ) AS `sum1`
+                FROM `test`.`t0`
+                GROUP BY `test`.`t0`.`v2`, `test`.`t0`.`v3`
+                HAVING (sum(`test`.`t0`.`v2`)) > ?""");
+
+        assertContains(generator.getBindSql(), "SELECT `test`.`t0`.`v3`, sum(`test`.`t0`.`v2`), "
+                + "avg(`test`.`t0`.`v2`) OVER (PARTITION BY `test`.`t0`.`v2`, `test`.`t0`.`v3` "
+                + "ORDER BY `test`.`t0`.`v2` DESC ), "
+                + "sum(`test`.`t0`.`v2`) OVER (PARTITION BY `test`.`t0`.`v2`, `test`.`t0`.`v3` "
+                + "ORDER BY `test`.`t0`.`v2` DESC ) AS `sum1`\n"
+                + "FROM `test`.`t0`\n"
+                + "GROUP BY `test`.`t0`.`v2`, `test`.`t0`.`v3`\n"
+                + "HAVING (sum(`test`.`t0`.`v2`)) > _spm_const_var(1, 100)");
+
+        assertContains(generator.getPlanStmtSQL(),
+                "SELECT v3, c_4, avg(v2) OVER (PARTITION BY v2, v3 ORDER BY v2 DESC ) AS c_5, "
+                        + "sum(v2) OVER (PARTITION BY v2, v3 ORDER BY v2 DESC ) AS c_6 "
+                        + "FROM (SELECT v2, v3, sum(v2) AS c_4 FROM t0 "
+                        + "GROUP BY v2, v3 HAVING sum(v2) > _spm_const_var(1, 100)) t_0");
+    }
+
+    @Test
+    public void testGroupingSets() {
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(
+                "select v1, v2, grouping_id(v1, v2) as b, sum(v3) from t0 group by grouping sets((), (v1, v2))");
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        assertContains(generator.getBindSqlDigest(),
+                "SELECT `test`.`t0`.`v1`, `test`.`t0`.`v2`, grouping(`test`.`t0`.`v1`, `test`.`t0`.`v2`) AS `b`, sum"
+                        + "(`test`.`t0`.`v3`)\n" + "FROM `test`.`t0`\n"
+                        + "GROUP BY GROUPING SETS ((), (`test`.`t0`.`v1`, `test`.`t0`.`v2`))");
+
+        assertContains(generator.getBindSql(),
+                "SELECT `test`.`t0`.`v1`, `test`.`t0`.`v2`, grouping(`test`.`t0`.`v1`, `test`.`t0`.`v2`) AS `b`, sum"
+                        + "(`test`.`t0`.`v3`)\n" + "FROM `test`.`t0`\n"
+                        + "GROUP BY GROUPING SETS ((), (`test`.`t0`.`v1`, `test`.`t0`.`v2`))");
+
+        assertContains(generator.getPlanStmtSQL(), "SELECT c_1, c_2, c_6, c_4 FROM "
+                + "(SELECT v1 AS c_1, v2 AS c_2, sum(v3) AS c_4, GROUPING(v1, v2) AS c_6 "
+                + "FROM t0 GROUP BY GROUPING SETS((), (v1, v2))) t1");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCDSBindTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCDSBindTest.java
@@ -1,0 +1,144 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.spm.CreateBaselinePlanStmt;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.TPCDSPlanTestBase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+
+public class SPMTPCDSBindTest extends TPCDSPlanTestBase {
+    private static final Logger LOG = LogManager.getLogger(SPMTPCDSBindTest.class);
+
+    private static final List<String> UNSUPPORTED = Lists.newArrayList(
+            "query04", "query06", "query09", "query14-1", "query14-2",
+            "query23-1", "query23-2", "query24-1", "query24-2", "query44", "query54", "query58");
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        beforeClass();
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
+        SPMFunctions.enableSPMParamsPrint = true;
+    }
+
+    public CreateBaselinePlanStmt createBaselinePlanStmt(String sql) {
+        String createSql = "create baseline using " + sql;
+        List<StatementBase> statements = SqlParser.parse(createSql, connectContext.getSessionVariable());
+        Preconditions.checkState(statements.size() == 1);
+        Preconditions.checkState(statements.get(0) instanceof CreateBaselinePlanStmt);
+        return (CreateBaselinePlanStmt) statements.get(0);
+    }
+
+    public CreateBaselinePlanStmt createBaselinePlanStmt(String bind, String sql) {
+        bind = bind.replace(";", "");
+        sql = sql.replace(";", "");
+        String createSql = "create baseline on " + bind + " using " + sql;
+        List<StatementBase> statements = SqlParser.parse(createSql, connectContext.getSessionVariable());
+        Preconditions.checkState(statements.size() == 1);
+        Preconditions.checkState(statements.get(0) instanceof CreateBaselinePlanStmt);
+        return (CreateBaselinePlanStmt) statements.get(0);
+    }
+
+    public static StatementBase analyzeSuccess(String originStmt) {
+        try {
+            StatementBase statementBase =
+                    com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable()).get(0);
+            Analyzer.analyze(statementBase, connectContext);
+            Preconditions.checkState(statementBase instanceof QueryStatement);
+            return statementBase;
+        } catch (Exception ex) {
+            LOG.error(originStmt, ex);
+            Assert.fail();
+            throw ex;
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("testCases")
+    public void validatePlan(String name, String sql) {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(sql);
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        String bindSQL = generator.getBindSql();
+        String planSQL = generator.getPlanStmtSQL();
+
+        analyzeSuccess(bindSQL);
+        analyzeSuccess(planSQL);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("testCases2")
+    public void validatePlan2(String name, String bind, String plan) {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(bind, plan);
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        String bindSQL = generator.getBindSql();
+        String planSQL = generator.getPlanStmtSQL();
+
+        analyzeSuccess(bindSQL);
+        analyzeSuccess(planSQL);
+    }
+
+    @Test
+    public void validateCase() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(Q69);
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        String bindSQL = generator.getBindSql();
+        String planSQL = generator.getPlanStmtSQL();
+
+        System.out.println(bindSQL);
+        System.out.println("\n\n====================================\n\n");
+        System.out.println(planSQL);
+    }
+
+    public static List<Arguments> testCases() {
+        List<Arguments> list = Lists.newArrayList();
+        getSqlMap().forEach((k, v) -> {
+            if (!UNSUPPORTED.contains(k)) {
+                list.add(Arguments.of(k, v));
+            }
+        });
+        return list;
+    }
+
+    public static List<Arguments> testCases2() {
+        List<Arguments> list = Lists.newArrayList();
+        List<String> conflict = Lists.newArrayList("query33", "query56", "query60", "query83");
+        getSqlMap().forEach((k, v) -> {
+            if (!UNSUPPORTED.contains(k) && !conflict.contains(k)) {
+                list.add(Arguments.of(k, v, v));
+            }
+        });
+        return list;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCDSUseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCDSUseTest.java
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.spm.CreateBaselinePlanStmt;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.TPCDSPlanTestBase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+
+public class SPMTPCDSUseTest extends TPCDSPlanTestBase {
+    private static final Logger LOG = LogManager.getLogger(SPMTPCDSUseTest.class);
+
+    private static final List<String> UNSUPPORTED = Lists.newArrayList(
+            "query04", "query06", "query09", "query14-1", "query14-2",
+            "query23-1", "query23-2", "query24-1", "query24-2", "query44", "query54", "query58");
+
+    public static CreateBaselinePlanStmt createBaselinePlanStmt(String sql) {
+        String createSql = "create baseline using " + sql;
+        List<StatementBase> statements = SqlParser.parse(createSql, connectContext.getSessionVariable());
+        Preconditions.checkState(statements.size() == 1);
+        Preconditions.checkState(statements.get(0) instanceof CreateBaselinePlanStmt);
+        return (CreateBaselinePlanStmt) statements.get(0);
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        beforeClass();
+        for (var entry : getSqlMap().entrySet()) {
+            if (UNSUPPORTED.contains(entry.getKey())) {
+                continue;
+            }
+            CreateBaselinePlanStmt stmt = createBaselinePlanStmt(entry.getValue());
+            SPMStmtExecutor.execute(connectContext, stmt);
+        }
+        connectContext.getSessionVariable().setEnableSPMRewrite(true);
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        afterClass();
+        connectContext.getGlobalStateMgr().getSqlPlanManager().dropAllBaselinePlans();
+        connectContext.getSessionVariable().setEnableSPMRewrite(false);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("testCases")
+    public void validate(String name, String sql) throws Exception {
+        String s = getFragmentPlan(sql);
+        if (UNSUPPORTED.contains(name)) {
+            assertNotContains(s, "Using baseline plan");
+        } else {
+            assertContains(s, "Using baseline plan");
+            assertNotContains(s, "spm_");
+        }
+    }
+
+    @Test
+    public void validate2() throws Exception {
+        String s = getFragmentPlan(Q69);
+        assertContains(s, "Using baseline plan");
+        assertNotContains(s, "spm_");
+    }
+
+    public static List<Arguments> testCases() {
+        List<Arguments> list = Lists.newArrayList();
+        getSqlMap().forEach((k, v) -> list.add(Arguments.of(k, v)));
+        return list;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCDSUseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCDSUseTest.java
@@ -62,7 +62,7 @@ public class SPMTPCDSUseTest extends TPCDSPlanTestBase {
     @AfterAll
     public static void afterAll() {
         afterClass();
-        connectContext.getGlobalStateMgr().getSqlPlanManager().dropAllBaselinePlans();
+        connectContext.getSqlPlanStorage().dropAllBaselinePlans();
         connectContext.getSessionVariable().setEnableSPMRewrite(false);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCHBindTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCHBindTest.java
@@ -1,0 +1,187 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.planner.TpchSQL;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.spm.CreateBaselinePlanStmt;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+
+public class SPMTPCHBindTest extends PlanTestBase {
+    private static final Logger LOG = LogManager.getLogger(SPMTPCHBindTest.class);
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        beforeClass();
+        SPMFunctions.enableSPMParamsPrint = true;
+    }
+
+    public CreateBaselinePlanStmt createBaselinePlanStmt(String sql) {
+        String createSql = "create baseline using " + sql;
+        List<StatementBase> statements = SqlParser.parse(createSql, connectContext.getSessionVariable());
+        Preconditions.checkState(statements.size() == 1);
+        Preconditions.checkState(statements.get(0) instanceof CreateBaselinePlanStmt);
+        return (CreateBaselinePlanStmt) statements.get(0);
+    }
+
+    public CreateBaselinePlanStmt createBaselinePlanStmt(String bind, String sql) {
+        bind = bind.replace(";", "");
+        sql = sql.replace(";", "");
+        String createSql = "create baseline on " + bind + " using " + sql;
+        List<StatementBase> statements = SqlParser.parse(createSql, connectContext.getSessionVariable());
+        Preconditions.checkState(statements.size() == 1);
+        Preconditions.checkState(statements.get(0) instanceof CreateBaselinePlanStmt);
+        return (CreateBaselinePlanStmt) statements.get(0);
+    }
+
+    public static StatementBase analyzeSuccess(String originStmt) {
+        try {
+            StatementBase statementBase =
+                    SqlParser.parse(originStmt, connectContext.getSessionVariable()).get(0);
+            Analyzer.analyze(statementBase, connectContext);
+            Preconditions.checkState(statementBase instanceof QueryStatement);
+            return statementBase;
+        } catch (Exception ex) {
+            LOG.error(originStmt, ex);
+            Assert.fail();
+            throw ex;
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("testCases")
+    public void validatePlanSQL(String name, String sql) {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(sql);
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        String bindSQL = generator.getBindSql();
+        String planSQL = generator.getPlanStmtSQL();
+
+        analyzeSuccess(bindSQL);
+        analyzeSuccess(planSQL);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("testCases2")
+    public void validateBindSQL(String name, String bindSQL, String planSQL) {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(bindSQL, planSQL);
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        String b = generator.getBindSql();
+        String p = generator.getPlanStmtSQL();
+
+        analyzeSuccess(b);
+        analyzeSuccess(p);
+    }
+
+    @Test
+    public void testConflict() {
+        CreateBaselinePlanStmt stmt = createBaselinePlanStmt(TpchSQL.Q19, TpchSQL.Q19);
+        SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+        generator.execute();
+
+        String p = generator.getPlanStmtSQL();
+        assertContains(p, "L_SHIPMODE IN (_spm_const_list(9, 'AIR', 'AIR REG')");
+    }
+
+    @Test
+    public void testConflict2() {
+        String plan = "select sum(l_extendedprice* (1 - l_discount)) as revenue\n"
+                + "from lineitem, part\n"
+                + "where (p_partkey = l_partkey\n"
+                + "            and p_brand = 'Brand#45'\n"
+                + "            and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')\n"
+                + "            and l_quantity >= 5 and l_quantity <= 5 + 10\n"
+                + "            and p_size between 1 and 5\n"
+                + "            and l_shipmode in ('AIR', 'AIR REG')\n"
+                + "            and l_shipinstruct = 'DELIVER IN PERSON'\n"
+                + "        ) or ( p_partkey = l_partkey\n"
+                + "            and p_brand = 'Brand#11'\n"
+                + "            and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')\n"
+                + "            and l_quantity >= 15 and l_quantity <= 15 + 10\n"
+                + "            and p_size between 1 and 10\n"
+                + "            and l_shipmode in ('XXXX', 'XXXXXX')\n"
+                + "            and l_shipinstruct = 'DELIVER IN PERSON');";
+        String bind = "select sum(l_extendedprice* (1 - l_discount)) as revenue\n"
+                + "from lineitem, part\n"
+                + "where (p_partkey = l_partkey\n"
+                + "            and p_brand = 'Brand#45'\n"
+                + "            and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')\n"
+                + "            and l_quantity >= 5 and l_quantity <= 5 + 10\n"
+                + "            and p_size between 1 and 5\n"
+                + "            and l_shipmode in ('AIR', 'AIR REG')\n"
+                + "            and l_shipinstruct = 'DELIVER IN PERSON'\n"
+                + "        ) or ( p_partkey = l_partkey\n"
+                + "            and p_brand = 'Brand#11'\n"
+                + "            and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')\n"
+                + "            and l_quantity >= 15 and l_quantity <= 15 + 10\n"
+                + "            and p_size between 1 and 10\n"
+                + "            and l_shipmode in ('AIR', 'AIR REG')\n"
+                + "            and l_shipinstruct = 'DELIVER IN PERSON');";
+        {
+            CreateBaselinePlanStmt stmt = createBaselinePlanStmt(bind, plan);
+            SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+            Assertions.assertThrows(SemanticException.class, generator::execute);
+        }
+
+        {
+            CreateBaselinePlanStmt stmt = createBaselinePlanStmt(plan, bind);
+            SPMPlanBuilder generator = new SPMPlanBuilder(connectContext, stmt);
+            Assertions.assertThrows(SemanticException.class, generator::execute);
+        }
+    }
+    public static List<Arguments> testCases() {
+        List<String> unsupported = Lists.newArrayList("q11", "q15", "q16", "q22");
+        List<Arguments> list = Lists.newArrayList();
+        TpchSQL.getAllSQL().forEach((k, v) -> {
+            if (!unsupported.contains(k)) {
+                list.add(Arguments.of("tpch." + k, v));
+            }
+        });
+        return list;
+    }
+
+    public static List<Arguments> testCases2() {
+        List<String> unsupported = Lists.newArrayList("q11", "q15", "q16", "q22");
+        List<String> conflict = Lists.newArrayList();
+        List<Arguments> list = Lists.newArrayList();
+        TpchSQL.getAllSQL().forEach((k, v) -> {
+            if (!unsupported.contains(k) && !conflict.contains(k)) {
+                list.add(Arguments.of("tpch." + k, v, v));
+            }
+        });
+        return list;
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCHUseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCHUseTest.java
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.planner.TpchSQL;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.spm.CreateBaselinePlanStmt;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+
+public class SPMTPCHUseTest extends PlanTestBase {
+    private static final Logger LOG = LogManager.getLogger(SPMTPCHUseTest.class);
+    private static final List<String> UNSUPPORTED = Lists.newArrayList("q11", "q15", "q16", "q22");
+
+    public static CreateBaselinePlanStmt createBaselinePlanStmt(String sql) {
+        String createSql = "create baseline using " + sql;
+        List<StatementBase> statements = SqlParser.parse(createSql, connectContext.getSessionVariable());
+        Preconditions.checkState(statements.size() == 1);
+        Preconditions.checkState(statements.get(0) instanceof CreateBaselinePlanStmt);
+        return (CreateBaselinePlanStmt) statements.get(0);
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        beforeClass();
+        for (var entry : TpchSQL.getAllSQL().entrySet()) {
+            if (UNSUPPORTED.contains(entry.getKey())) {
+                continue;
+            }
+            CreateBaselinePlanStmt stmt = createBaselinePlanStmt(entry.getValue());
+            SPMStmtExecutor.execute(connectContext, stmt);
+        }
+        connectContext.getSessionVariable().setEnableSPMRewrite(true);
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        afterClass();
+        connectContext.getGlobalStateMgr().getSqlPlanManager().dropAllBaselinePlans();
+        connectContext.getSessionVariable().setEnableSPMRewrite(false);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("testCases")
+    public void validate(String name, String sql) throws Exception {
+        String s = getFragmentPlan(sql);
+        if (UNSUPPORTED.contains(name)) {
+            assertNotContains(s, "Using baseline plan");
+        } else {
+            assertContains(s, "Using baseline plan");
+            assertNotContains(s, "spm_");
+        }
+    }
+
+    public static List<Arguments> testCases() {
+        List<Arguments> list = Lists.newArrayList();
+        TpchSQL.getAllSQL().forEach((k, v) -> list.add(Arguments.of(k, v)));
+        return list;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCHUseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SPMTPCHUseTest.java
@@ -59,7 +59,7 @@ public class SPMTPCHUseTest extends PlanTestBase {
     @AfterAll
     public static void afterAll() {
         afterClass();
-        connectContext.getGlobalStateMgr().getSqlPlanManager().dropAllBaselinePlans();
+        connectContext.getSqlPlanStorage().dropAllBaselinePlans();
         connectContext.getSessionVariable().setEnableSPMRewrite(false);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsStorageTest.java
@@ -19,8 +19,8 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.util.DateUtils;
-import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.history.TableKeeper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -59,7 +59,7 @@ class PredicateColumnsStorageTest extends PlanTestBase {
                 PredicateColumnsStorage.TABLE_NAME));
         ConnectContext.ScopeGuard guard = connectContext.bindScope();
 
-        RepoExecutor repo = Mockito.mock(RepoExecutor.class);
+        SimpleExecutor repo = Mockito.mock(SimpleExecutor.class);
         PredicateColumnsStorage instance = new PredicateColumnsStorage(repo);
 
         // restore


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

### Syntax
```
CREATE (GLOBAL)? BASELINE (ON querySQL)? USING planSQL (properties(....))?
-- CREATE BASELINE SELECT * FROM t0 USING SELECT * FROM t0;

DROP BASELINE id;
-- DROP BASELINE 123；

SHOW BASELINE; 
```

### Code
![image](https://github.com/user-attachments/assets/00e1d583-d72e-42a2-9941-45f83a227b28)

### Process

#### Create 

1. execute SQL: create baseline on BindSQL using PlanSQL. 
In this step, BindSQL & PlanSQL:
```
-- BindSQL
select * 
from t0, t1, t2 
where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > 200;

-- PlanSQL
select * 
from t0 join[SHUFFLE] t2 on t0.v1 = t2.v1
        join t1 on t0.v1 = t1.v1         
where t0.v2 > 200;
```

2. Parameterized BindSQL: replace Literal/Expression to SPMFunctions, e.g. id > 200 -> id > _spm_const_var(0), the argument is placeholdeID
In this step, BindSQL & PlanSQL:
```
-- BindSQL
select * 
from t0, t1, t2 
where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > _spm_const_var(0);

-- PlanSQL
select * 
from t0 join[SHUFFLE] t2 on t0.v1 = t2.v1
        join t1 on t0.v1 = t1.v1         
where t0.v2 > 200;
```

3. Bind placeholder in PlanSQL: find the position where the placeholder should be in PlanSQL, and also replace the original expression. 
In this step, BindSQL & PlanSQL:
```
-- BindSQL
select * 
from t0, t1, t2 
where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > _spm_const_var(0);

-- PlanSQL
select * 
from t0 join[SHUFFLE] t2 on t0.v1 = t2.v1
        join t1 on t0.v1 = t1.v1         
where t0.v2 > _spm_const_var(0);
```

4. Optimize the PlanSQL by optimizer, and get the phsyical tree
In this step, BindSQL & PlanSQL:
```
-- BindSQL
select * 
from t0, t1, t2 
where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > _spm_const_var(0);

-- PlanSQL to Plan, should be a physical tree
       Bucket Join
       /          \
 Shuffle Join       t1
   /    \
  t0     t2
```

6. Serialized physical tree to baseline SQL
In this step, BindSQL & PlanSQL:
```
-- BindSQL
select * 
from t0, t1, t2 
where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > _spm_const_var(0);

-- Plan to SQL(baseline)
select * 
from t0 join[SHUFFLE] t2 on t0.v1 = t2.v1
        join[BUCKET] t1 on t0.v1 = t1.v1         
where t0.v2 > _spm_const_var(0);
```

7. Save baseline


#### Query
1. Input query. e.g.
```
-- Query
select * from t0, t1, t2 where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > 10000;
```
3. Normalized query to SQLDigest
```
-- Query
select * from t0, t1, t2 where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > 10000;
-- Query Digest
select * from t0, t1, t2 where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > ?;
-- Query Hash: 123675
``` 

4. Find baseline by query's SQLDigest & Hash (match with baseline's bindSQL)
```
-- Query
select * from t0, t1, t2 where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > 10000;
-- Query Digest
select * from t0, t1, t2 where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > ?;
-- Query Hash: 123675

-- find Baseline
-- BindSQL
select * 
from t0, t1, t2 
where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > _spm_const_var(0);

-- PlanSQL
select * 
from t0 join[SHUFFLE] t2 on t0.v1 = t2.v1
        join[BUCKET] t1 on t0.v1 = t1.v1         
where t0.v2 > _spm_const_var(0);
```

5. Bind query with baseline，check Query is same as BindSQL && Bind SPM arguments. e.g.
```
-- Query
select * from t0, t1, t2 where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > 10000;
-- Query Digest
select * from t0, t1, t2 where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > ?;
-- Query Hash: 123675

-- Baseline
-- BindSQL
select * 
from t0, t1, t2 
where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > _spm_const_var(0);

-- Bind SPM arguments:
_spm_const_var(0) = 10000

-- PlanSQL
select * 
from t0 join[SHUFFLE] t2 on t0.v1 = t2.v1
        join[BUCKET] t1 on t0.v1 = t1.v1         
where t0.v2 > _spm_const_var(0);
```

6. Replace SPM arguments in PlanSQL
```
-- Query
select * from t0, t1, t2 where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > 10000;
-- Query Digest
select * from t0, t1, t2 where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > ?;
-- Query Hash: 123675

-- Baseline
-- BindSQL
select * 
from t0, t1, t2 
where t0.v1 = t1.v1 and t0.v1 = t2.v1 and t0.v2 > _spm_const_var(0);

-- Bind SPM arguments:
_spm_const_var(0) = 10000

-- PlanSQL
select * 
from t0 join[SHUFFLE] t2 on t0.v1 = t2.v1
        join[BUCKET] t1 on t0.v1 = t1.v1         
where t0.v2 > 10000;
```
7. return the PlanSQL to replace origin Query


#### Store
Now save Baseline in FE memory only, will support save on BE later


Fixes https://github.com/StarRocks/starrocks/issues/56310

sub-prs:
- [x] https://github.com/StarRocks/starrocks/pull/54951
- [x] https://github.com/StarRocks/starrocks/pull/55048
- [x] https://github.com/StarRocks/starrocks/pull/54951
- [x] https://github.com/StarRocks/starrocks/pull/55492
- [x] https://github.com/StarRocks/starrocks/pull/56505
- [x] https://github.com/StarRocks/starrocks/pull/56598
- [x] https://github.com/StarRocks/starrocks/pull/56652
- [x] https://github.com/StarRocks/starrocks/pull/56706
- [x] https://github.com/StarRocks/starrocks/pull/56750

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0