### PR TITLE
[BugFix]only use global dict on lake when stmt is query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -109,6 +109,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             FunctionSet.CARDINALITY);
 
     private final SessionVariable sessionVariable;
+    private final boolean isQuery;
 
     // These fields are the same as the fields in the DecodeContext,
     // the difference: these fields store all string information, the
@@ -140,8 +141,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
     // check if there is a blocking node in plan
     private boolean canBlockingOutput = false;
 
-    public DecodeCollector(SessionVariable session) {
+    public DecodeCollector(SessionVariable session, boolean isQuery) {
         this.sessionVariable = session;
+        this.isQuery = isQuery;
     }
 
     public void collect(OptExpression root, DecodeContext context) {
@@ -607,7 +609,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     @Override
     public DecodeInfo visitPhysicalHiveScan(OptExpression optExpression, DecodeInfo context) {
-        if (!canBlockingOutput || !sessionVariable.isUseLowCardinalityOptimizeOnLake()) {
+        if (!canBlockingOutput || !sessionVariable.isUseLowCardinalityOptimizeOnLake() || !isQuery) {
             return DecodeInfo.EMPTY;
         }
         PhysicalHiveScanOperator scan = optExpression.getOp().cast();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/LowCardinalityRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/LowCardinalityRewriteRule.java
@@ -25,6 +25,7 @@ public class LowCardinalityRewriteRule implements TreeRewriteRule {
     @Override
     public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
         SessionVariable session = taskContext.getOptimizerContext().getSessionVariable();
+        boolean isQuery = taskContext.getOptimizerContext().getConnectContext().getState().isQuery();
         if (!session.isEnableLowCardinalityOptimize() || !session.isUseLowCardinalityOptimizeV2()) {
             return root;
         }
@@ -32,7 +33,7 @@ public class LowCardinalityRewriteRule implements TreeRewriteRule {
         ColumnRefFactory factory = taskContext.getOptimizerContext().getColumnRefFactory();
         DecodeContext context = new DecodeContext(factory);
         {
-            DecodeCollector collector = new DecodeCollector(session);
+            DecodeCollector collector = new DecodeCollector(session, isQuery);
             collector.collect(root, context);
             if (!collector.isValidMatchChildren()) {
                 return root;


### PR DESCRIPTION
## Why I'm doing:
Not all stmt support retry, but using global dict on lake needs retry,
so we only use it when stmt is query. 

## What I'm doing:

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/9198

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
    daily case
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0