### PR TITLE
[Enhancement] avoid redundant directory creation when create file block

### DIFF
--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -234,7 +234,10 @@ StatusOr<FileBlockContainerPtr> FileBlockManager::get_or_create_container(const 
                     << plan_node_name;
     uint64_t id = _next_container_id++;
     std::string container_dir = dir->dir() + "/" + print_id(_query_id);
-    RETURN_IF_ERROR(dir->fs()->create_dir_if_missing(container_dir));
+    if (_last_created_container_dir != container_dir) {
+        RETURN_IF_ERROR(dir->fs()->create_dir_if_missing(container_dir));
+        _last_created_container_dir = container_dir;
+    }
     ASSIGN_OR_RETURN(auto block_container, FileBlockContainer::create(dir, _query_id, fragment_instance_id,
                                                                       plan_node_id, plan_node_name, id, block_size));
     RETURN_IF_ERROR(block_container->open());

--- a/be/src/exec/spill/file_block_manager.h
+++ b/be/src/exec/spill/file_block_manager.h
@@ -48,6 +48,7 @@ private:
 
     TUniqueId _query_id;
     std::atomic<uint64_t> _next_container_id = 0;
+    std::string _last_created_container_dir;
 
     DirManager* _dir_mgr = nullptr;
 };


### PR DESCRIPTION
## Why I'm doing:
After version 3.3, we support spilling operator intermediates to remote object storage. However, in the current implementation, every time a block is allocated, it checks whether the directory exists, resulting in unnecessary API calls and latency.

## What I'm doing:
This pull request includes changes to the `FileBlockManager` class to optimize the creation of directories in the file block manager. The most important changes involve adding a check to avoid redundant directory creation and introducing a new member variable to track the last created directory.

Optimization of directory creation:

* [`be/src/exec/spill/file_block_manager.cpp`](diffhunk://#diff-3bb4fc69ffe78e61658f4b5aa8ac78514b11550a0c87a1781c33d6a9d19a5e02R237-R240): Added a check to ensure that the directory is only created if it has not been created before, reducing unnecessary filesystem operations. (`[be/src/exec/spill/file_block_manager.cppR237-R240](diffhunk://#diff-3bb4fc69ffe78e61658f4b5aa8ac78514b11550a0c87a1781c33d6a9d19a5e02R237-R240)`)
* [`be/src/exec/spill/file_block_manager.h`](diffhunk://#diff-80a364cbfceb51fff006948ceed1b690236ad393f2fca768cf22032eb88b34e9R51): Introduced a new member variable `_last_created_container_dir` to store the path of the last created directory, which is used in the aforementioned check. (`[be/src/exec/spill/file_block_manager.hR51](diffhunk://#diff-80a364cbfceb51fff006948ceed1b690236ad393f2fca768cf22032eb88b34e9R51)`)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0