### PR TITLE
[Enhancement] Compatible with mariadb client for ldap user login

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1830,6 +1830,24 @@ public class Config extends ConfigBase {
     public static boolean enable_starrocks_external_table_auth_check = true;
 
     /**
+     * The authentication_chain configuration specifies the sequence of security integrations
+     * that will be used to authenticate a user. Each security integration in the chain will be
+     * tried in the order they are defined until one of them successfully authenticates the user.
+     * The configuration should specify a list of names of the security integrations
+     * that will be used in the chain.
+     * <p>
+     * For example, if user specifies the value with {"ldap", "native"}, SR will first try to authenticate
+     * a user whose authentication info may exist in a ldap server, if failed, SR will continue trying to
+     * authenticate the user to check whether it's a native user in SR,  i.e. it's created by SR and
+     * its authentication info is stored in SR metadata.
+     * <p>
+     * For more information about security integration, you can refer to
+     * {@link SecurityIntegration}
+     */
+    @ConfField(mutable = true)
+    public static String[] authentication_chain = {AUTHENTICATION_CHAIN_MECHANISM_NATIVE};
+
+    /**
      * If set to true, the granularity of auth check extends to the column level
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlHandshakePacket.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlHandshakePacket.java
@@ -124,15 +124,15 @@ public class MysqlHandshakePacket extends MysqlPacket {
         }
     }
 
-    public boolean checkAuthPluginSameAsStarRocks(String pluginName) {
+    public static boolean checkAuthPluginSameAsStarRocks(String pluginName) {
         return SUPPORTED_PLUGINS.containsKey(pluginName) && SUPPORTED_PLUGINS.get(pluginName);
     }
 
     // If the auth default plugin in client is different from StarRocks
     // it will create a AuthSwitchRequest
-    public void buildAuthSwitchRequest(MysqlSerializer serializer) {
+    public void buildAuthSwitchRequest(MysqlSerializer serializer, String authPluginName) {
         serializer.writeInt1((byte) 0xfe);
-        serializer.writeNulTerminateString(NATIVE_AUTH_PLUGIN_NAME);
+        serializer.writeNulTerminateString(authPluginName);
         serializer.writeBytes(authPluginData);
         serializer.writeInt1(0);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -268,7 +268,7 @@ public class MysqlProto {
     private static boolean isLDAPUser(String user, ConnectContext context) {
         Map.Entry<UserIdentity, UserAuthenticationInfo> localUser = context.getGlobalStateMgr().getAuthenticationMgr()
                 .getBestMatchedUserIdentity(user, context.getMysqlChannel().getRemoteIp());
-        // If the user can not be find in local, and there is more than 1 auth type in authentication_chain.
+        // If the user can not be found in local, and there is more than 1 auth type in authentication_chain.
         // It is speculated that the user may be a ldap user.
         return localUser == null && Config.authentication_chain.length > 1;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -41,6 +41,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.Pair;
 import com.starrocks.mysql.ssl.SSLContextLoader;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -53,8 +54,6 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-
-import static com.starrocks.mysql.MysqlHandshakePacket.AUTHENTICATION_KERBEROS_CLIENT;
 
 // MySQL protocol util
 public class MysqlProto {
@@ -167,22 +166,17 @@ public class MysqlProto {
             return new NegotiateResult(authPacket, NegotiateState.NOT_SUPPORTED_AUTH_MODE);
         }
 
-        // Starting with MySQL 8.0.4, MySQL changed the default authentication plugin for MySQL client
-        // from mysql_native_password to caching_sha2_password.
-        // ref: https://mysqlserverteam.com/mysql-8-0-4-new-default-authentication-plugin-caching_sha2_password/
         // So, User use mysql client or ODBC Driver after 8.0.4 have problem to connect to StarRocks
         // with password.
         // So StarRocks support the Protocol::AuthSwitchRequest to tell client to keep the default password plugin
         // which StarRocks is using now.
-        //
-        // Older version mysql client does not send auth plugin info, like 5.1 version.
-        // So we check if auth plugin name is null and treat as mysql_native_password if is null.
+        Pair<Boolean, String> switchPair = shouldSwitchAuthPlugin(authPacket, context);
         String authPluginName = authPacket.getPluginName();
-        if (authPluginName != null && !handshakePacket.checkAuthPluginSameAsStarRocks(authPluginName)) {
+        if (switchPair.first) {
             // 1. clear the serializer
             serializer.reset();
             // 2. build the auth switch request and send to the client
-            if (authPluginName.equals(AUTHENTICATION_KERBEROS_CLIENT)) {
+            if (switchPair.second.equals(MysqlHandshakePacket.AUTHENTICATION_KERBEROS_CLIENT)) {
                 if (GlobalStateMgr.getCurrentState().getAuthenticationMgr().isSupportKerberosAuth()) {
                     try {
                         handshakePacket.buildKrb5AuthRequest(serializer, context.getRemoteIP(), authPacket.getUser());
@@ -197,16 +191,16 @@ public class MysqlProto {
                     return new NegotiateResult(authPacket, NegotiateState.KERBEROS_PLUGIN_NOT_LOADED);
                 }
             } else {
-                handshakePacket.buildAuthSwitchRequest(serializer);
+                handshakePacket.buildAuthSwitchRequest(serializer, switchPair.second);
             }
+            authPluginName = switchPair.second;
             channel.sendAndFlush(serializer.toByteBuffer());
             // Server receive auth switch response packet from client.
             ByteBuffer authSwitchResponse = channel.fetchOnePacket();
             if (authSwitchResponse == null) {
                 // receive response failed.
-                LOG.error("Building handshake with kerberos error, msg: Failed to get a valid service ticket for" +
-                        " {} from the client", authPacket.getUser());
-                return new NegotiateResult(authPacket, NegotiateState.KERBEROS_HANDSHAKE_FAILED);
+                LOG.warn("read auth switch response failed for user {}", authPacket.getUser());
+                return new NegotiateResult(authPacket, NegotiateState.READ_AUTH_SWITCH_PKG_FAILED);
             }
             // 3. the client use default password plugin of StarRocks to dispose
             // password
@@ -238,6 +232,45 @@ public class MysqlProto {
             }
         }
         return new NegotiateResult(authPacket, NegotiateState.OK);
+    }
+
+    private static Pair<Boolean, String> shouldSwitchAuthPlugin(MysqlAuthPacket authPacket, ConnectContext context) {
+        // Older version mysql client does not send auth plugin info, like 5.1 version.
+        // So we check if auth plugin name is null and treat as mysql_native_password if is null.
+        String authPluginName = authPacket.getPluginName();
+        if (authPluginName == null) {
+            return Pair.create(false, null);
+        }
+
+        // kerberos
+        if (authPluginName.equals(MysqlHandshakePacket.AUTHENTICATION_KERBEROS_CLIENT)) {
+            return Pair.create(true, MysqlHandshakePacket.AUTHENTICATION_KERBEROS_CLIENT);
+        }
+
+        // To compatible for mariadb client.
+        // mysql_clear_password cannot be specified in mariadb client, so if the user is a ldap user, switch to mysql_clear_password plugin.
+        if (!authPluginName.equals(MysqlHandshakePacket.CLEAR_PASSWORD_PLUGIN_NAME)
+                && isLDAPUser(authPacket.getUser(), context)) {
+            return Pair.create(true, MysqlHandshakePacket.CLEAR_PASSWORD_PLUGIN_NAME);
+        }
+
+        // Starting with MySQL 8.0.4, MySQL changed the default authentication plugin for MySQL client
+        // from mysql_native_password to caching_sha2_password.
+        // ref: https://mysqlserverteam.com/mysql-8-0-4-new-default-authentication-plugin-caching_sha2_password/
+        // But caching_sha2_password is not supported in starrocks. So switch to mysql_native_password.
+        if (!MysqlHandshakePacket.checkAuthPluginSameAsStarRocks(authPluginName)) {
+            return Pair.create(true, MysqlHandshakePacket.NATIVE_AUTH_PLUGIN_NAME);
+        }
+
+        return Pair.create(false, null);
+    }
+
+    private static boolean isLDAPUser(String user, ConnectContext context) {
+        Map.Entry<UserIdentity, UserAuthenticationInfo> localUser = context.getGlobalStateMgr().getAuthenticationMgr()
+                .getBestMatchedUserIdentity(user, context.getMysqlChannel().getRemoteIp());
+        // If the user can not be find in local, and there is more than 1 auth type in authentication_chain.
+        // It is speculated that the user may be a ldap user.
+        return localUser == null && Config.authentication_chain.length > 1;
     }
 
     private static MysqlAuthPacket readAuthPacket(ConnectContext context) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/NegotiateState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/NegotiateState.java
@@ -17,6 +17,7 @@ package com.starrocks.mysql;
 public enum NegotiateState {
     OK("ok"),
     READ_FIRST_AUTH_PKG_FAILED("read first auth package failed"),
+    READ_AUTH_SWITCH_PKG_FAILED("read auth switch package failed"),
     ENABLE_SSL_FAILED("enable ssl failed"),
     READ_SSL_AUTH_PKG_FAILED("read ssl auth package failed"),
     NOT_SUPPORTED_AUTH_MODE("not supported auth mode"),


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
To compatible for mariadb client.
mysql_clear_password cannot be specified in mariadb client, so if the user is a ldap user, switch to mysql_clear_password plugin.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0