### PR TITLE
[Enhancement] Optimize vacuum logic by adding vacuum version.

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -391,12 +391,12 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
         RETURN_IF_ERROR(collect_files_to_vacuum(tablet_mgr, root_dir, tablet_id, grace_timestamp, min_retain_version,
                                                 &datafile_deleter, &metafile_deleter, vacuumed_file_size,
                                                 &tablet_vacuumed_version));
+        RETURN_IF_ERROR(datafile_deleter.finish());
+        RETURN_IF_ERROR(metafile_deleter.finish());
         if (*vacuumed_version == 0 || *vacuumed_version > tablet_vacuumed_version) {
             // set partition vacuumed_version to min tablet vacuumed version
             *vacuumed_version = tablet_vacuumed_version;
         }
-        RETURN_IF_ERROR(datafile_deleter.finish());
-        RETURN_IF_ERROR(metafile_deleter.finish());
         (*vacuumed_files) += datafile_deleter.delete_count();
         (*vacuumed_files) += metafile_deleter.delete_count();
     }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -389,7 +389,8 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
         AsyncFileDeleter datafile_deleter(config::lake_vacuum_min_batch_delete_size);
         AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
         RETURN_IF_ERROR(collect_files_to_vacuum(tablet_mgr, root_dir, tablet_id, grace_timestamp, min_retain_version,
-                                                &datafile_deleter, &metafile_deleter, vacuumed_file_size, &tablet_vacuumed_version));
+                                                &datafile_deleter, &metafile_deleter, vacuumed_file_size,
+                                                &tablet_vacuumed_version));
         if (*vacuumed_version == 0 || *vacuumed_version > tablet_vacuumed_version) {
             // set partition vacuumed_version to min tablet vacuumed version
             *vacuumed_version = tablet_vacuumed_version;

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -277,7 +277,7 @@ static Status collect_garbage_files(const TabletMetadataPB& metadata, const std:
 static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_view root_dir, int64_t tablet_id,
                                       int64_t grace_timestamp, int64_t min_retain_version,
                                       AsyncFileDeleter* datafile_deleter, AsyncFileDeleter* metafile_deleter,
-                                      int64_t* total_datafile_size) {
+                                      int64_t* total_datafile_size, int64_t* vacuumed_version) {
     auto t0 = butil::gettimeofday_ms();
     auto meta_dir = join_path(root_dir, kMetadataDirectoryName);
     auto data_dir = join_path(root_dir, kSegmentDirectoryName);
@@ -348,6 +348,7 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
     auto t1 = butil::gettimeofday_ms();
     g_metadata_travel_latency << (t1 - t0);
 
+    *vacuumed_version = final_retain_version - 1;
     if (!skip_check_grace_timestamp) {
         // All tablet metadata files encountered were created after the grace timestamp, there were no files to delete
         return Status::OK();
@@ -371,7 +372,8 @@ static void erase_tablet_metadata_from_metacache(TabletManager* tablet_mgr, cons
 
 static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view root_dir,
                                      const std::vector<int64_t>& tablet_ids, int64_t min_retain_version,
-                                     int64_t grace_timestamp, int64_t* vacuumed_files, int64_t* vacuumed_file_size) {
+                                     int64_t grace_timestamp, int64_t* vacuumed_files, int64_t* vacuumed_file_size,
+                                     int64_t* vacuumed_version) {
     DCHECK(tablet_mgr != nullptr);
     DCHECK(std::is_sorted(tablet_ids.begin(), tablet_ids.end()));
     DCHECK(min_retain_version >= 0);
@@ -382,12 +384,16 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
     auto metafile_delete_cb = [=](const std::vector<std::string>& files) {
         erase_tablet_metadata_from_metacache(tablet_mgr, files);
     };
-
     for (auto tablet_id : tablet_ids) {
+        int64_t tablet_vacuumed_version = 0;
         AsyncFileDeleter datafile_deleter(config::lake_vacuum_min_batch_delete_size);
         AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
         RETURN_IF_ERROR(collect_files_to_vacuum(tablet_mgr, root_dir, tablet_id, grace_timestamp, min_retain_version,
-                                                &datafile_deleter, &metafile_deleter, vacuumed_file_size));
+                                                &datafile_deleter, &metafile_deleter, vacuumed_file_size, &tablet_vacuumed_version));
+        if (*vacuumed_version == 0 || *vacuumed_version > tablet_vacuumed_version) {
+            // set partition vacuumed_version to min tablet vacuumed version
+            *vacuumed_version = tablet_vacuumed_version;
+        }
         RETURN_IF_ERROR(datafile_deleter.finish());
         RETURN_IF_ERROR(metafile_deleter.finish());
         (*vacuumed_files) += datafile_deleter.delete_count();
@@ -466,16 +472,18 @@ Status vacuum_impl(TabletManager* tablet_mgr, const VacuumRequest& request, Vacu
 
     int64_t vacuumed_files = 0;
     int64_t vacuumed_file_size = 0;
+    int64_t vacuumed_version = 0;
 
     std::sort(tablet_ids.begin(), tablet_ids.end());
 
     RETURN_IF_ERROR(vacuum_tablet_metadata(tablet_mgr, root_loc, tablet_ids, min_retain_version, grace_timestamp,
-                                           &vacuumed_files, &vacuumed_file_size));
+                                           &vacuumed_files, &vacuumed_file_size, &vacuumed_version));
     if (request.delete_txn_log()) {
         RETURN_IF_ERROR(vacuum_txn_log(root_loc, min_active_txn_id, &vacuumed_files, &vacuumed_file_size));
     }
     response->set_vacuumed_files(vacuumed_files);
     response->set_vacuumed_file_size(vacuumed_file_size);
+    response->set_vacuumed_version(vacuumed_version);
     return Status::OK();
 }
 

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -348,7 +348,7 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
     auto t1 = butil::gettimeofday_ms();
     g_metadata_travel_latency << (t1 - t0);
 
-    *vacuumed_version = final_retain_version - 1;
+    *vacuumed_version = final_retain_version;
     if (!skip_check_grace_timestamp) {
         // All tablet metadata files encountered were created after the grace timestamp, there were no files to delete
         return Status::OK();

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -511,6 +511,7 @@ TEST_P(LakeVacuumTest, test_vacuum_3) {
         ASSERT_NE(0, response.status().status_code());
         EXPECT_EQ(0, response.vacuumed_files());
         EXPECT_EQ(0, response.vacuumed_file_size());
+        EXPECT_EQ(0, response.vacuumed_version());
 
         ensure_all_files_exist();
     }
@@ -529,6 +530,7 @@ TEST_P(LakeVacuumTest, test_vacuum_3) {
                 << response.status().error_msgs(0);
         EXPECT_EQ(0, response.vacuumed_files());
         EXPECT_EQ(0, response.vacuumed_file_size());
+        EXPECT_EQ(0, response.vacuumed_version());
 
         ensure_all_files_exist();
     }
@@ -548,6 +550,7 @@ TEST_P(LakeVacuumTest, test_vacuum_3) {
                 << response.status().error_msgs(0);
         EXPECT_EQ(0, response.vacuumed_files());
         EXPECT_EQ(0, response.vacuumed_file_size());
+        EXPECT_EQ(0, response.vacuumed_version());
 
         ensure_all_files_exist();
     }
@@ -568,6 +571,7 @@ TEST_P(LakeVacuumTest, test_vacuum_3) {
                 << response.status().error_msgs(0);
         EXPECT_EQ(0, response.vacuumed_files());
         EXPECT_EQ(0, response.vacuumed_file_size());
+        EXPECT_EQ(0, response.vacuumed_version());
 
         ensure_all_files_exist();
     }
@@ -586,6 +590,7 @@ TEST_P(LakeVacuumTest, test_vacuum_3) {
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
         EXPECT_EQ(0, response.vacuumed_files());
         EXPECT_EQ(0, response.vacuumed_file_size());
+        EXPECT_EQ(2, response.vacuumed_version());
 
         ensure_all_files_exist();
     }
@@ -609,6 +614,7 @@ TEST_P(LakeVacuumTest, test_vacuum_3) {
         // 1 txn slog file
         EXPECT_EQ(15, response.vacuumed_files());
         EXPECT_GT(response.vacuumed_file_size(), 0);
+        EXPECT_EQ(5, response.vacuumed_version());
 
         EXPECT_FALSE(file_exist(tablet_metadata_filename(100, 2)));
         EXPECT_FALSE(file_exist(tablet_metadata_filename(100, 3)));
@@ -1335,6 +1341,105 @@ TEST_P(LakeVacuumTest, test_vacuum_combined_txn_log) {
         ASSERT_TRUE(response.has_status());
         ASSERT_EQ(TStatusCode::OK, response.status().status_code());
         EXPECT_FALSE(file_exist(combined_txn_log_filename(1000)));
+    }
+}
+
+TEST_P(LakeVacuumTest, test_vacuumed_version) {
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 10001,
+        "version": 2,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000059e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "commit_time": 1687331159
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 10001,
+        "version": 3,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000059e5_5b3c5f4b-2675-4b7a-b5e0-4006cc285815.dat"
+                ],
+                "data_size": 100
+            }
+        ],
+        "prev_garbage_version": 2,
+        "commit_time": 1687331160
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 10001,
+        "version": 4,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000059e5_5b3c5f4b-2675-4b7a-b5e0-4006cc285815.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "prev_garbage_version": 3,
+        "commit_time": 1687331161
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 10002,
+        "version": 4,
+        "rowsets": [
+            {
+                "segments": [
+                    "00000000000059e5_5b3c5f4b-2675-4b7a-b5e0-4006cc285815.dat"
+                ],
+                "data_size": 4096
+            }
+        ],
+        "prev_garbage_version": 3,
+        "commit_time": 1687331162
+        }
+        )DEL")));
+
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(true);
+        request.add_tablet_ids(10001);
+        request.add_tablet_ids(10002);
+        request.set_min_retain_version(4);
+        request.set_grace_timestamp(1687331161);
+        request.set_min_active_txn_id(12344);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_EQ(3, response.vacuumed_version());
+    }
+
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(true);
+        request.add_tablet_ids(10001);
+        request.add_tablet_ids(10002);
+        request.set_min_retain_version(4);
+        request.set_grace_timestamp(1687331162);
+        request.set_min_active_txn_id(12344);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_EQ(4, response.vacuumed_version());
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -112,6 +112,8 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     private volatile long minRetainVersion = 0;
 
+    private volatile long lastSuccVacuumVersion = 0;
+
     private PhysicalPartition() {
 
     }
@@ -197,6 +199,14 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public void setMinRetainVersion(long minRetainVersion) {
         this.minRetainVersion = minRetainVersion;
+    }
+
+    public long getLastSuccVacuumVersion() {
+        return lastSuccVacuumVersion;
+    }
+
+    public void setLastSuccVacuumVersion(long lastSuccVacuumVersion) {
+        this.lastSuccVacuumVersion = lastSuccVacuumVersion;
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2906,7 +2906,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, comment = 
             "Determine whether a vacuum operation needs to be initiated based on the vacuum version.\n")
-    public static boolean lake_autovacuum_by_version = true;
+    public static boolean lake_autovacuum_detect_vaccumed_version = true;
 
     @ConfField(mutable = true, comment =
             "Whether enable throttling ingestion speed when compaction score exceeds the threshold.\n" +

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2904,6 +2904,10 @@ public class Config extends ConfigBase {
                     "Only takes effect for tables in clusters with run_mode=shared_data.\n")
     public static long lake_autovacuum_stale_partition_threshold = 12;
 
+    @ConfField(mutable = true, comment = 
+            "Determine whether a vacuum operation needs to be initiated based on the vacuum version.\n")
+    public static boolean lake_autovacuum_by_version = true;
+
     @ConfField(mutable = true, comment =
             "Whether enable throttling ingestion speed when compaction score exceeds the threshold.\n" +
                     "Only takes effect for tables in clusters with run_mode=shared_data.")

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -107,13 +107,15 @@ public class AutovacuumDaemon extends FrontendDaemon {
         if (current < partition.getLastVacuumTime() + Config.lake_autovacuum_partition_naptime_seconds * 1000) {
             return false;
         }
-        long minRetainVersion = partition.getMinRetainVersion();
-        if (minRetainVersion <= 0) {
-            minRetainVersion = Math.max(1, partition.getVisibleVersion() - Config.lake_autovacuum_max_previous_versions);
-        }
-        // the file before minRetainVersion vacuum success
-        if (Config.lake_autovacuum_by_version && partition.getLastSuccVacuumVersion() >= minRetainVersion) {
-            return false;
+        if (Config.lake_autovacuum_by_version) {
+            long minRetainVersion = partition.getMinRetainVersion();
+            if (minRetainVersion <= 0) {
+                minRetainVersion = Math.max(1, partition.getVisibleVersion() - Config.lake_autovacuum_max_previous_versions);
+            }
+            // the file before minRetainVersion vacuum success
+            if (partition.getLastSuccVacuumVersion() >= minRetainVersion) {
+                return false;
+            }
         }
         // TODO(zhangqiang)
         // add partition data size and storage size on S3 to decide vacuum or not

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -103,7 +103,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
         if (partition.getVisibleVersion() <= 1) {
             return false;
         }
-        // avoid parition too frequent
+        // prevent vacuum too frequent
         if (current < partition.getLastVacuumTime() + Config.lake_autovacuum_partition_naptime_seconds * 1000) {
             return false;
         }
@@ -111,7 +111,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
         if (minRetainVersion <= 0) {
             minRetainVersion = Math.max(1, partition.getVisibleVersion() - Config.lake_autovacuum_max_previous_versions);
         }
-        // the file before minVersion vacuum success
+        // the file before minRetainVersion vacuum success
         if (Config.lake_autovacuum_by_version && partition.getLastSuccVacuumVersion() >= minRetainVersion) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -240,7 +240,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
 
         partition.setLastVacuumTime(startTime);
         if (!hasError && vacuumedVersion > partition.getLastSuccVacuumVersion()) {
-            partition.setLastSuccVacuumVersion(minRetainVersion);
+            partition.setLastSuccVacuumVersion(vacuumedVersion);
         }
         LOG.info("Vacuumed {}.{}.{} hasError={} vacuumedFiles={} vacuumedFileSize={} " +
                         "visibleVersion={} minRetainVersion={} minActiveTxnId={} cost={}ms",

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -107,7 +107,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
         if (current < partition.getLastVacuumTime() + Config.lake_autovacuum_partition_naptime_seconds * 1000) {
             return false;
         }
-        if (Config.lake_autovacuum_by_version) {
+        if (Config.lake_autovacuum_detect_vaccumed_version) {
             long minRetainVersion = partition.getMinRetainVersion();
             if (minRetainVersion <= 0) {
                 minRetainVersion = Math.max(1, partition.getVisibleVersion() - Config.lake_autovacuum_max_previous_versions);
@@ -240,6 +240,9 @@ public class AutovacuumDaemon extends FrontendDaemon {
 
         partition.setLastVacuumTime(startTime);
         if (!hasError && vacuumedVersion > partition.getLastSuccVacuumVersion()) {
+            // hasError is false means that the vacuum operation on all tablets was successful.
+            // the vacuumedVersion isthe minimum success vacuum version among all tablets within the partition which
+            // means that all the garbage files before the vacuumVersion have been deleted.
             partition.setLastSuccVacuumVersion(vacuumedVersion);
         }
         LOG.info("Vacuumed {}.{}.{} hasError={} vacuumedFiles={} vacuumedFileSize={} " +

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -248,8 +248,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
         LOG.info("Vacuumed {}.{}.{} hasError={} vacuumedFiles={} vacuumedFileSize={} " +
                         "visibleVersion={} minRetainVersion={} minActiveTxnId={} vacuumVersion={} cost={}ms",
                 db.getFullName(), table.getName(), partition.getId(), hasError, vacuumedFiles, vacuumedFileSize,
-                visibleVersion, minRetainVersion, minActiveTxnId, , vacuumedVersion,
-                System.currentTimeMillis() - startTime);
+                visibleVersion, minRetainVersion, minActiveTxnId, vacuumedVersion, System.currentTimeMillis() - startTime);
     }
 
     private static long computeMinActiveTxnId(Database db, Table table) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -246,9 +246,10 @@ public class AutovacuumDaemon extends FrontendDaemon {
             partition.setLastSuccVacuumVersion(vacuumedVersion);
         }
         LOG.info("Vacuumed {}.{}.{} hasError={} vacuumedFiles={} vacuumedFileSize={} " +
-                        "visibleVersion={} minRetainVersion={} minActiveTxnId={} cost={}ms",
+                        "visibleVersion={} minRetainVersion={} minActiveTxnId={} vacuumVersion={} cost={}ms",
                 db.getFullName(), table.getName(), partition.getId(), hasError, vacuumedFiles, vacuumedFileSize,
-                visibleVersion, minRetainVersion, minActiveTxnId, System.currentTimeMillis() - startTime);
+                visibleVersion, minRetainVersion, minActiveTxnId, , vacuumedVersion,
+                System.currentTimeMillis() - startTime);
     }
 
     private static long computeMinActiveTxnId(Database db, Table table) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -1,0 +1,166 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.GlobalStateMgrTestUtil;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.common.FeConstants;
+import com.starrocks.lake.vacuum.AutovacuumDaemon;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.proto.VacuumRequest;
+import com.starrocks.proto.VacuumResponse;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.Warehouse;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Arrays;
+import java.util.concurrent.Future;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class VacuumTest {
+    private Database db;
+    private OlapTable olapTable;
+    private PhysicalPartition partition;
+    private WarehouseManager warehouseManager;
+    private ComputeNode computeNode;
+    private LakeService lakeService;
+    private ConnectContext connectContext;
+    protected StarRocksAssert starRocksAssert;
+
+
+    @Before
+    public void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase(GlobalStateMgrTestUtil.testDb1)
+                    .useDatabase(GlobalStateMgrTestUtil.testDb1);
+
+        starRocksAssert.withTable("CREATE TABLE testTable1\n" +
+                    "(\n" +
+                    "    v1 date,\n" +
+                    "    v2 int,\n" +
+                    "    v3 int\n" +
+                    ")\n" +
+                    "DUPLICATE KEY(`v1`)\n" +
+                    "DISTRIBUTED BY HASH(v1) BUCKETS 1\n" +
+                    "PROPERTIES('replication_num' = '1');");
+
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(GlobalStateMgrTestUtil.testDb1);
+        olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
+        partition = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
+        partition.setVisibleVersion(10L, System.currentTimeMillis());
+        partition.setMinRetainVersion(5L);
+        partition.setLastSuccVacuumVersion(4L);
+
+        warehouseManager = mock(WarehouseManager.class);
+        computeNode = mock(ComputeNode.class);
+        
+
+        when(warehouseManager.getBackgroundWarehouse()).thenReturn(mock(Warehouse.class));
+        when(warehouseManager.getComputeNodeAssignedToTablet(anyString(), any(LakeTablet.class))).thenReturn(computeNode);
+
+        when(computeNode.getHost()).thenReturn("localhost");
+        when(computeNode.getBrpcPort()).thenReturn(8080);
+
+        
+    }
+
+    @After
+    public void clear() {
+        db.dropTable(olapTable.getName());
+    }
+
+    @Test
+    public void testLastSuccVacuumVersionUpdate() throws Exception {
+        GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
+        AutovacuumDaemon autovacuumDaemon = new AutovacuumDaemon();
+
+        VacuumResponse mockResponse = new VacuumResponse();
+        mockResponse.status = new StatusPB();
+        mockResponse.status.statusCode = 0;
+        mockResponse.vacuumedFiles = 10L;
+        mockResponse.vacuumedFileSize = 1024L;
+        mockResponse.vacuumedVersion = 5L;
+
+        Future<VacuumResponse> mockFuture = mock(Future.class);
+        when(mockFuture.get()).thenReturn(mockResponse);
+
+        lakeService = mock(LakeService.class);
+        when(lakeService.vacuum(any(VacuumRequest.class))).thenReturn(mockFuture);
+        try (MockedStatic<BrpcProxy> mockBrpcProxyStatic = mockStatic(BrpcProxy.class)) {
+            mockBrpcProxyStatic.when(() -> BrpcProxy.getLakeService(anyString(), anyInt())).thenReturn(lakeService);
+            autovacuumDaemon.testVacuumPartitionImpl(db, olapTable, partition);
+        }
+        
+        Assert.assertEquals(5L, partition.getLastSuccVacuumVersion());
+
+        partition.setVisibleVersion(5L, System.currentTimeMillis());
+        try (MockedStatic<BrpcProxy> mockBrpcProxyStatic = mockStatic(BrpcProxy.class)) {
+            mockBrpcProxyStatic.when(() -> BrpcProxy.getLakeService(anyString(), anyInt())).thenReturn(lakeService);
+            autovacuumDaemon.testVacuumPartitionImpl(db, olapTable, partition);
+        }
+        Assert.assertEquals(5L, partition.getLastSuccVacuumVersion());
+    }
+
+    @Test
+    public void testLastSuccVacuumVersionUpdateFailed() throws Exception {
+        GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
+        AutovacuumDaemon autovacuumDaemon = new AutovacuumDaemon();
+
+        VacuumResponse mockResponse = new VacuumResponse();
+        mockResponse.status = new StatusPB();
+        mockResponse.status.statusCode = 1;
+        mockResponse.status.errorMsgs = Arrays.asList("internal failed");
+        mockResponse.vacuumedFiles = 10L;
+        mockResponse.vacuumedFileSize = 1024L;
+        mockResponse.vacuumedVersion = 5L;
+
+        Future<VacuumResponse> mockFuture = mock(Future.class);
+        when(mockFuture.get()).thenReturn(mockResponse);
+
+        lakeService = mock(LakeService.class);
+        when(lakeService.vacuum(any(VacuumRequest.class))).thenReturn(mockFuture);
+        try (MockedStatic<BrpcProxy> mockBrpcProxyStatic = mockStatic(BrpcProxy.class)) {
+            mockBrpcProxyStatic.when(() -> BrpcProxy.getLakeService(anyString(), anyInt())).thenReturn(lakeService);
+            autovacuumDaemon.testVacuumPartitionImpl(db, olapTable, partition);
+        }
+        
+        Assert.assertEquals(4L, partition.getLastSuccVacuumVersion());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -184,7 +184,7 @@ public class VacuumTest {
         partition.setLastSuccVacuumVersion(10L);
         Assert.assertFalse(autovacuumDaemon.shouldVacuum(partition));
         // disable
-        Config.lake_autovacuum_by_version = false;
+        Config.lake_autovacuum_detect_vaccumed_version = false;
         Assert.assertTrue(autovacuumDaemon.shouldVacuum(partition));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -86,7 +86,7 @@ public class VacuumTest {
                     .getTable(db.getFullName(), GlobalStateMgrTestUtil.testTable1);
         partition = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
         partition.setVisibleVersion(10L, System.currentTimeMillis());
-        partition.setMinRetainVersion(5L);
+        partition.setMinRetainVersion(10L);
         partition.setLastSuccVacuumVersion(4L);
 
         warehouseManager = mock(WarehouseManager.class);
@@ -131,12 +131,12 @@ public class VacuumTest {
         
         Assert.assertEquals(5L, partition.getLastSuccVacuumVersion());
 
-        partition.setVisibleVersion(5L, System.currentTimeMillis());
+        mockResponse.vacuumedVersion = 7L;
         try (MockedStatic<BrpcProxy> mockBrpcProxyStatic = mockStatic(BrpcProxy.class)) {
             mockBrpcProxyStatic.when(() -> BrpcProxy.getLakeService(anyString(), anyInt())).thenReturn(lakeService);
             autovacuumDaemon.testVacuumPartitionImpl(db, olapTable, partition);
         }
-        Assert.assertEquals(5L, partition.getLastSuccVacuumVersion());
+        Assert.assertEquals(7L, partition.getLastSuccVacuumVersion());
     }
 
     @Test

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -270,6 +270,8 @@ message VacuumResponse {
     optional int64 vacuumed_files = 2;
     // The total size of files vacuumed, value undefined if status is not ok.
     optional int64 vacuumed_file_size = 3;
+    // The versions before vacuumed_version are vacuumed
+    optional int64 vacuumed_version = 4;
 }
 
 message VacuumFullRequest {


### PR DESCRIPTION
## Why I'm doing:
The FE (Frontend) will continuously issue vacuum requests to the CN (Compute Node) without any intelligent control, until the `lake_autovacuum_stale_partition_threshold` is reached, which is set to 12 hours by default. This approach presents two issues:

1. **Incomplete Vacuuming**:  
   It is possible that after this time threshold has passed, the partition may not have completed the vacuum process. However, it will no longer be scheduled for vacuuming afterward, leaving some data unprocessed.

2. **Redundant Requests**:  
   It is also possible that the partition has already been vacuumed, but the FE continues to issue vacuum requests indiscriminately. This results in unnecessary requests being sent, which not only wastes resources but also increases S3 API costs. 

These issues highlight the need for a more intelligent scheduling mechanism to optimize vacuuming efficiency and reduce unnecessary costs.

## What I'm doing:
Add  `lastSuccVacuumVersion` as the last success vacuum version, which means all garbage files before this version have been vacuumed and FE does not need to resend vacuum request if the `lastSuccVacuumVersion` is catch up the latest version.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0