### PR TITLE
[BugFix] CTE pushdown limit&predicate error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushLimitAndFilterToCTEProduceRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushLimitAndFilterToCTEProduceRule.java
@@ -82,7 +82,8 @@ public class PushLimitAndFilterToCTEProduceRule extends TransformationRule {
             child = OptExpression.create(new LogicalFilterOperator(extractor.rewriteAll(orPredicate)), child);
         }
 
-        if (consumeNums == limits.size()) {
+        if (consumeNums == limits.size() && predicates.isEmpty()) {
+            // only push down limit when no predicate
             Long maxLimit = limits.stream().reduce(Long::max).orElse(Operator.DEFAULT_LIMIT);
             child = OptExpression.create(LogicalLimitOperator.local(maxLimit), child);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -229,8 +229,7 @@ public class CTEPlanTest extends PlanTestBase {
                 "     tabletRatio=0/0\n" +
                 "     tabletList=\n" +
                 "     cardinality=1\n" +
-                "     avgRowSize=24.0\n" +
-                "     limit: 3");
+                "     avgRowSize=24.0\n");
     }
 
     @Test
@@ -916,5 +915,18 @@ public class CTEPlanTest extends PlanTestBase {
         assertContains(plan,
                 "1:Project\n" +
                         "  |  <slot 4> : 444");
+    }
+
+    @Test
+    public void testCTELimitSelect() throws Exception {
+        alwaysCTEReuse();
+        String sql = "with cte as (select * from t0)" +
+                " select case when not exists (select 1 from cte where v2 = 1) then 'A' else 'B' end," +
+                "        case when not exists (select 1 from cte where v3 = 1) then 'C' else 'D' end " +
+                " from t2;";
+        String plan = getFragmentPlan(sql);
+        defaultCTEReuse();
+        assertNotContains(plan, "1:EXCHANGE\n" +
+                "     limit: 1");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
SQL：
```
explain with t as (select * from t1) 
select 
not exists(select v1 from t where v1 = 1), 
not exists (select v2 from t where v2 = 1) 
from t2;
```

plan：
![image](https://github.com/user-attachments/assets/797fc600-dab0-4cfd-9167-6bc0ebfa291f)
execute limit first will take result error

can't push down limit & predicate at sametimes


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0