### PR TITLE
[Enhancement] add table names to explain analyze

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.planner.AggregateInfo;
 import com.starrocks.planner.AggregationNode;
@@ -407,6 +408,20 @@ public class ProfilingExecPlan {
             if (scanNode instanceof OlapScanNode) {
                 OlapScanNode olapScanNode = (OlapScanNode) scanNode;
                 element.addInfo("Table: ", olapScanNode.getOlapTable().getName());
+            } else {
+                Table table = scanNode.getTable();
+                // FILES() table-function scans and some load-task planners build tuple
+                // descriptors without attaching a table, so getTable() is null.
+                if (table != null) {
+                    String tableName;
+                    if (table.isExternalTableWithFileSystem() || table.isOdpsTable() || table.isJDBCTable()) {
+                        String dbName = table.getCatalogDBName();
+                        tableName = dbName == null ? table.getName() : dbName + "." + table.getName();
+                    } else {
+                        tableName = table.getName();
+                    }
+                    element.addInfo("Table: ", tableName);
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -152,7 +152,12 @@ public class DeltaLakeScanNode extends ScanNode {
     protected String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
         StringBuilder output = new StringBuilder();
 
-        output.append(prefix).append("TABLE: ").append(deltaLakeTable.getName()).append("\n");
+        output.append(prefix)
+            .append("TABLE: ")
+            .append(deltaLakeTable.getCatalogDBName())
+            .append(".")
+            .append(deltaLakeTable.getName())
+            .append("\n");
 
         if (null != sortColumn) {
             output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -126,7 +126,12 @@ public class HdfsScanNode extends ScanNode {
     protected String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
         StringBuilder output = new StringBuilder();
 
-        output.append(prefix).append("TABLE: ").append(hiveTable.getName()).append("\n");
+        output.append(prefix)
+            .append("TABLE: ")
+            .append(hiveTable.getCatalogDBName())
+            .append(".")
+            .append(hiveTable.getName())
+            .append("\n");
 
         if (null != sortColumn) {
             output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
@@ -90,7 +90,12 @@ public class HudiScanNode extends ScanNode {
     protected String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
         StringBuilder output = new StringBuilder();
 
-        output.append(prefix).append("TABLE: ").append(hudiTable.getName()).append("\n");
+        output.append(prefix)
+            .append("TABLE: ")
+            .append(hudiTable.getCatalogDBName())
+            .append(".")
+            .append(hudiTable.getName())
+            .append("\n");
 
         if (null != sortColumn) {
             output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/KuduScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/KuduScanNode.java
@@ -169,7 +169,12 @@ public class KuduScanNode extends ScanNode {
     protected String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
         StringBuilder output = new StringBuilder();
 
-        output.append(prefix).append("TABLE: ").append(kuduTable.getName()).append("\n");
+        output.append(prefix)
+            .append("TABLE: ")
+            .append(kuduTable.getCatalogDBName())
+            .append(".")
+            .append(kuduTable.getName())
+            .append("\n");
 
         if (null != sortColumn) {
             output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OdpsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OdpsScanNode.java
@@ -156,7 +156,7 @@ public class OdpsScanNode extends ScanNode {
     @Override
     protected String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
         StringBuilder output = new StringBuilder();
-        output.append(prefix).append("TABLE: ").append(table.getCatalogDBName()).append(".").append(table.getCatalogTableName())
+        output.append(prefix).append("TABLE: ").append(table.getCatalogDBName()).append(".").append(table.getName())
                 .append("\n");
         return output.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -348,7 +348,12 @@ public class PaimonScanNode extends ScanNode {
     protected String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
         StringBuilder output = new StringBuilder();
 
-        output.append(prefix).append("TABLE: ").append(paimonTable.getName()).append("\n");
+        output.append(prefix)
+            .append("TABLE: ")
+            .append(paimonTable.getCatalogDBName())
+            .append(".")
+            .append(paimonTable.getName())
+            .append("\n");
 
         if (null != sortColumn) {
             output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -137,6 +137,10 @@ public abstract class ScanNode extends PlanNode {
         return desc.getTable().getName();
     }
 
+    public Table getTable() {
+        return desc.getTable();
+    }
+
     public int getBucketNums() throws StarRocksException {
         throw new StarRocksException("Error when using bucket-aware execution");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
@@ -71,7 +71,7 @@ public class HiveViewTest extends PlanTestBase {
         String sql = "select * from hive0.tpch.customer_view";
         String sqlPlan = getFragmentPlan(sql);
         assertContains(sqlPlan, "0:HdfsScanNode\n" +
-                "     TABLE: customer");
+                "     TABLE: tpch.customer");
     }
 
     @Test
@@ -79,9 +79,9 @@ public class HiveViewTest extends PlanTestBase {
         String sql = "select * from hive0.tpch.customer_nation_view where c_custkey = 1";
         String sqlPlan = getFragmentPlan(sql);
         assertContains(sqlPlan, "1:HdfsScanNode\n" +
-                        "     TABLE: customer",
+                        "     TABLE: tpch.customer",
                 "0:HdfsScanNode\n" +
-                        "     TABLE: nation");
+                        "     TABLE: tpch.nation");
     }
 
     @Test
@@ -168,7 +168,7 @@ public class HiveViewTest extends PlanTestBase {
         connectContext.getSessionVariable().setSqlDialect("trino");
         String sqlPlan = getFragmentPlan(sql);
         assertContains(sqlPlan, "0:HdfsScanNode\n" +
-                "     TABLE: customer");
+                "     TABLE: tpch.customer");
     }
 
     @Test
@@ -177,14 +177,14 @@ public class HiveViewTest extends PlanTestBase {
         String sql = "select * from hive0.tpch.customer_view_without_db where c_custkey = 1";
         String sqlPlan = getFragmentPlan(sql);
         assertContains(sqlPlan, "0:HdfsScanNode\n" +
-                "     TABLE: customer");
+                "     TABLE: tpch.customer");
     }
 
     @Test
     public void testQueryHiveViewCaseInsensitive() throws Exception {
         String sql = "select * from hive0.tpch.customer_case_insensitive_view where c_custkey = 1";
         String sqlPlan = getFragmentPlan(sql);
-        assertContains(sqlPlan, "TABLE: customer");
+        assertContains(sqlPlan, "TABLE: tpch.customer");
 
         Throwable exception = assertThrows(SemanticException.class, () -> {
             getFragmentPlan("select * from hive0.tpch.customer_case_insensitive_view v1 join test.t0 T0 on v1.c_custkey = t0.v1");

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -817,11 +817,11 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            PlanTestBase.assertContains(plan, "TABLE: part_tbl1\n" +
+            PlanTestBase.assertContains(plan, "TABLE: partitioned_db.part_tbl1\n" +
                     "     PARTITION PREDICATES: 4: par_date IS NOT NULL, 4: par_date >= '2020-01-01', " +
                     "4: par_date < '2020-01-05'\n" +
                     "     partitions=4/4");
-            PlanTestBase.assertContains(plan, "TABLE: part_tbl2\n" +
+            PlanTestBase.assertContains(plan, "TABLE: partitioned_db.part_tbl2\n" +
                     "     PARTITION PREDICATES: 8: par_date IS NOT NULL, 8: par_date >= '2020-01-01', 8: par_date < " +
                     "'2020-01-05' \n" +
                     "     partitions=4/4");
@@ -859,11 +859,11 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            PlanTestBase.assertContains(plan, "     TABLE: part_tbl1\n" +
+            PlanTestBase.assertContains(plan, "     TABLE: partitioned_db.part_tbl1\n" +
                     "     PARTITION PREDICATES: 4: par_date IS NOT NULL, 4: par_date >= '2020-01-05', 4: par_date < " +
                     "'2020-01-06'\n" +
                     "     partitions=1/5");
-            PlanTestBase.assertContains(plan, "     TABLE: part_tbl2\n" +
+            PlanTestBase.assertContains(plan, "     TABLE: partitioned_db.part_tbl2\n" +
                     "     PARTITION PREDICATES: 8: par_date IS NOT NULL, 8: par_date >= '2020-01-05', 8: par_date < " +
                     "'2020-01-06'\n" +
                     "     partitions=1/5");
@@ -934,11 +934,11 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            PlanTestBase.assertContains(plan, "TABLE: t1_par\n" +
+            PlanTestBase.assertContains(plan, "TABLE: partitioned_db.t1_par\n" +
                     "     PARTITION PREDICATES: 10: par_date >= '2020-01-01', " +
                     "10: par_date < '2020-01-05'\n" +
                     "     partitions=6/6");
-            PlanTestBase.assertContains(plan, "TABLE: t2_par\n" +
+            PlanTestBase.assertContains(plan, "TABLE: partitioned_db.t2_par\n" +
                     "     PARTITION PREDICATES: 4: par_col IS NOT NULL\n" +
                     "     partitions=6/6");
         }
@@ -956,12 +956,12 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            PlanTestBase.assertContains(plan, "TABLE: t1_par\n" +
+            PlanTestBase.assertContains(plan, "TABLE: partitioned_db.t1_par\n" +
                     "     PARTITION PREDICATES: 10: par_date >= '2020-01-05', " +
                     "10: par_date < '2020-01-06'\n" +
                     "     partitions=1/7");
             // TODO: multi-column partitions cannot prune partitions.
-            PlanTestBase.assertContains(plan, "TABLE: t2_par\n" +
+            PlanTestBase.assertContains(plan, "TABLE: partitioned_db.t2_par\n" +
                     "     PARTITION PREDICATES: 4: par_col IS NOT NULL\n" +
                     "     partitions=6/6");
         }
@@ -980,12 +980,12 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
             // TODO: non-ref base table's update will refresh all the materialized views' partitions.
-            PlanTestBase.assertContains(plan, "TABLE: t1_par\n" +
+            PlanTestBase.assertContains(plan, "TABLE: partitioned_db.t1_par\n" +
                     "     PARTITION PREDICATES: 10: par_date >= '2020-01-01', 10: par_date < " +
                     "'2020-01-06'\n" +
                     "     partitions=7/7");
             // TODO: multi-column partitions cannot prune partitions.
-            PlanTestBase.assertContains(plan, "TABLE: t2_par\n" +
+            PlanTestBase.assertContains(plan, "TABLE: partitioned_db.t2_par\n" +
                     "     PARTITION PREDICATES: 4: par_col IS NOT NULL\n" +
                     "     partitions=7/7");
         }
@@ -1260,7 +1260,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            PlanTestBase.assertContains(plan, "     TABLE: t1_par\n");
+            PlanTestBase.assertContains(plan, "     TABLE: partitioned_db.t1_par\n");
             PlanTestBase.assertContains(plan, "     partitions=6/6");
         }
 
@@ -1276,7 +1276,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            PlanTestBase.assertContains(plan, "     TABLE: t1_par\n" +
+            PlanTestBase.assertContains(plan, "     TABLE: partitioned_db.t1_par\n" +
                     "     PARTITION PREDICATES: 5: par_date = '2020-01-05', 4: par_col = 4\n" +
                     "     partitions=1/7");
         }
@@ -1325,7 +1325,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            PlanTestBase.assertContains(plan, "     TABLE: t1_par\n");
+            PlanTestBase.assertContains(plan, "     TABLE: partitioned_db.t1_par\n");
             PlanTestBase.assertContains(plan, "     partitions=6/6");
         }
 
@@ -1339,7 +1339,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            PlanTestBase.assertContains(plan, "     TABLE: t1_par\n" +
+            PlanTestBase.assertContains(plan, "     TABLE: partitioned_db.t1_par\n" +
                     "     PARTITION PREDICATES: 4: par_col = 4, 5: par_date = '2020-01-05'\n" +
                     "     partitions=1/7");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -165,7 +165,7 @@ public class MvRewriteHiveTest extends MVTestBase {
         String plan1 = getFragmentPlan(query1);
         PlanTestBase.assertContains(plan1, "0:UNION");
         PlanTestBase.assertContains(plan1, "hive_union_mv_1");
-        PlanTestBase.assertContains(plan1, "     TABLE: supplier\n" +
+        PlanTestBase.assertContains(plan1, "     TABLE: tpch.supplier\n" +
                 "     NON-PARTITION PREDICATES: 12: s_suppkey < 10, (12: s_suppkey >= 5) OR (12: s_suppkey IS NULL)\n" +
                 "     MIN/MAX PREDICATES: 12: s_suppkey < 10");
         dropMv("test", "hive_union_mv_1");
@@ -188,7 +188,7 @@ public class MvRewriteHiveTest extends MVTestBase {
 
         String query1 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 10";
         String plan = getFragmentPlan(query1);
-        PlanTestBase.assertContains(plan, "     TABLE: supplier\n" +
+        PlanTestBase.assertContains(plan, "     TABLE: tpch.supplier\n" +
                 "     NON-PARTITION PREDICATES: 12: s_suppkey < 10, (12: s_suppkey >= 5) OR (12: s_suppkey IS NULL)\n" +
                 "     MIN/MAX PREDICATES: 12: s_suppkey < 10");
         connectContext.getSessionVariable().setUseNthExecPlan(0);
@@ -823,10 +823,10 @@ public class MvRewriteHiveTest extends MVTestBase {
                             "  |  equal join conjunct: 1: l_orderkey = 17: o_orderkey\n" +
                             "  |  other join predicates: 16: l_shipdate = '1998-01-01'");
                     PlanTestBase.assertContains(plan, "  2:HdfsScanNode\n" +
-                            "     TABLE: orders\n" +
+                            "     TABLE: partitioned_db.orders\n" +
                             "     partitions=1095/1095");
                     PlanTestBase.assertContains(plan, "  0:HdfsScanNode\n" +
-                            "     TABLE: lineitem_par\n" +
+                            "     TABLE: partitioned_db.lineitem_par\n" +
                             "     partitions=6/6");
                 }
                 {
@@ -836,10 +836,10 @@ public class MvRewriteHiveTest extends MVTestBase {
                             "and b.o_orderdate='1998-01-01';";
                     String plan = getFragmentPlan(query);
                     PlanTestBase.assertContains(plan, "  0:HdfsScanNode\n" +
-                            "     TABLE: lineitem_par\n" +
+                            "     TABLE: partitioned_db.lineitem_par\n" +
                             "     partitions=6/6");
                     PlanTestBase.assertContains(plan, "  1:HdfsScanNode\n" +
-                            "     TABLE: orders\n" +
+                            "     TABLE: partitioned_db.orders\n" +
                             "     PARTITION PREDICATES: 25: o_orderdate = '1998-01-01'\n" +
                             "     partitions=0/1095");
 
@@ -930,7 +930,7 @@ public class MvRewriteHiveTest extends MVTestBase {
                 "     PREAGGREGATION: ON\n" +
                 "     partitions=1/2");
         // non -refresh part cannot be rewritten
-        PlanTestBase.assertContains(plan, "     TABLE: lineitem_par\n" +
+        PlanTestBase.assertContains(plan, "     TABLE: partitioned_db.lineitem_par\n" +
                         "     PARTITION PREDICATES: 45: l_shipdate = '1998-01-05'," +
                 " (45: l_shipdate IN ('1998-01-01', '1998-01-04', '1998-01-05')) OR (45: l_shipdate IS NULL)\n" +
                         "     partitions=1/6");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -447,7 +447,7 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
                 "     PREAGGREGATION: ON\n" +
                 "     partitions=5/6\n" +
                 "     rollup: hive_parttbl_mv_2");
-        PlanTestBase.assertContains(plan, "     TABLE: lineitem_par\n" +
+        PlanTestBase.assertContains(plan, "     TABLE: partitioned_db.lineitem_par\n" +
                 "     PARTITION PREDICATES: 25: l_shipdate IN ('1998-01-02')\n" +
                 "     NON-PARTITION PREDICATES: 23: l_orderkey > 100\n" +
                 "     MIN/MAX PREDICATES: 23: l_orderkey > 100\n" +
@@ -481,7 +481,7 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
                         "where l_shipdate < '1998-01-02' and l_orderkey = 100;");
         String query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` ";
         String plan = getFragmentPlan(query);
-        PlanTestBase.assertContains(plan, "     TABLE: lineitem_par\n" +
+        PlanTestBase.assertContains(plan, "     TABLE: partitioned_db.lineitem_par\n" +
                         "     NON-PARTITION PREDICATES: (((22: l_shipdate < '1998-01-02') AND (20: l_orderkey = 100) IS NULL) " +
                         "OR (22: l_shipdate >= '1998-01-02')) OR ((22: l_shipdate IS NULL) OR (20: l_orderkey != 100))\n" +
                         "     partitions=6/6",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTimeSeriesRewriteWithHiveTest.java
@@ -46,7 +46,7 @@ public class MvTimeSeriesRewriteWithHiveTest extends MVTestBase {
                     "     PREAGGREGATION: ON\n" +
                     "     PREDICATES: 26: dt >= '1998-01-02'\n" +
                     "     partitions=1/2");
-            PlanTestBase.assertContains(plan, "     TABLE: lineitem_par\n" +
+            PlanTestBase.assertContains(plan, "     TABLE: partitioned_db.lineitem_par\n" +
                     "     PARTITION PREDICATES: ((date_trunc('month', 35: l_shipdate) < '1998-01-02') " +
                     "OR (date_trunc('month', 35: l_shipdate) IS NULL)) " +
                     "OR ((date_trunc('month', 35: l_shipdate) < '1998-01-02') " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithHiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentRewriteWithHiveTableTest.java
@@ -124,7 +124,7 @@ public class MvTransparentRewriteWithHiveTableTest extends MVTestBase {
                 for (String query : sqls) {
                     logSysInfo(query);
                     String plan = getFragmentPlan(query);
-                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": partitioned_db.lineitem_par");
                 }
             }
         });
@@ -160,7 +160,7 @@ public class MvTransparentRewriteWithHiveTableTest extends MVTestBase {
                 };
                 for (String query : sqls) {
                     String plan = getFragmentPlan(query);
-                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": partitioned_db.lineitem_par");
                 }
             }
         });
@@ -192,7 +192,7 @@ public class MvTransparentRewriteWithHiveTableTest extends MVTestBase {
                 };
                 for (String query : sqls) {
                     String plan = getFragmentPlan(query);
-                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": partitioned_db.lineitem_par");
                 }
             }
         });

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvTransparentUnionRewriteHiveTest.java
@@ -134,7 +134,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                                 " l_shipdate >= '1998-01-02' and l_suppkey > 1;",
                 };
                 String[] expects = {
-                        "     TABLE: lineitem_par\n" +
+                        "     TABLE: partitioned_db.lineitem_par\n" +
                                 "     PARTITION PREDICATES: 25: l_shipdate >= '1998-01-02', " +
                                 "(25: l_shipdate IN ('1998-01-02', '1998-01-05')) OR (25: l_shipdate IS NULL)\n" +
                                 "     partitions=2/6",
@@ -143,7 +143,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                                 "     partitions=2/4\n" +
                                 "     rollup: mv0\n" +
                                 "     tabletRatio=12/12", // case 1
-                        "     TABLE: lineitem_par\n" +
+                        "     TABLE: partitioned_db.lineitem_par\n" +
                                 "     PARTITION PREDICATES: 26: l_shipdate != '1998-01-01', " +
                                 "(26: l_shipdate IN ('1998-01-02', '1998-01-05')) OR (26: l_shipdate IS NULL)\n" +
                                 "     partitions=2/6",
@@ -151,7 +151,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                                 "     PREAGGREGATION: ON\n" +
                                 "     PREDICATES: 23: l_shipdate != '1998-01-01'\n" +
                                 "     partitions=3/4", // case 2
-                        "     TABLE: lineitem_par\n" +
+                        "     TABLE: partitioned_db.lineitem_par\n" +
                                 "     PARTITION PREDICATES: 26: l_shipdate >= '1998-01-02', " +
                                 "(26: l_shipdate IN ('1998-01-02', '1998-01-05')) OR (26: l_shipdate IS NULL)\n" +
                                 "     NON-PARTITION PREDICATES: 25: l_suppkey > 1\n" +
@@ -167,7 +167,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                     logSysInfo("start to test case " + i);
                     String query = sqls[i];
                     String plan = getFragmentPlan(query);
-                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": partitioned_db.lineitem_par");
                     PlanTestBase.assertContains(plan, expects[i * 2]);
                     PlanTestBase.assertContains(plan, expects[i * 2 + 1]);
                 }
@@ -191,7 +191,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                                 "     partitions=3/4\n" +
                                 "     rollup: mv0\n" +
                                 "     tabletRatio=18/18",
-                        "     TABLE: lineitem_par\n" +
+                        "     TABLE: partitioned_db.lineitem_par\n" +
                                 "     PARTITION PREDICATES: date_trunc('month', 25: l_shipdate) = '1998-01-01', " +
                                 "(25: l_shipdate IN ('1998-01-02', '1998-01-05')) OR (25: l_shipdate IS NULL)\n" +
                                 "     NO EVAL-PARTITION PREDICATES: date_trunc('month', 25: l_shipdate) = '1998-01-01'\n" +
@@ -237,7 +237,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                 };
                 for (String query : sqls) {
                     String plan = getFragmentPlan(query);
-                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": partitioned_db.lineitem_par");
                 }
             }
         });
@@ -271,7 +271,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                 };
                 for (String query : sqls) {
                     String plan = getFragmentPlan(query);
-                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                    PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": partitioned_db.lineitem_par");
                 }
             }
         });
@@ -331,7 +331,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                 for (String query : sqls) {
                     logSysInfo(query);
                     String plan = getFragmentPlan(query);
-                    PlanTestBase.assertContains(plan, ": lineitem_par");
+                    PlanTestBase.assertContains(plan, ": partitioned_db.lineitem_par");
                     PlanTestBase.assertContains(plan, ":UNION", ": mv0");
                 }
             }
@@ -366,14 +366,14 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                                         " l_shipdate >= '1998-01-01' and l_suppkey > 1;",
                         };
                         String[] expects = {
-                                "     TABLE: lineitem_par\n" +
+                                "     TABLE: partitioned_db.lineitem_par\n" +
                                         "     PARTITION PREDICATES: 25: l_shipdate >= '1998-01-02', " +
                                         "(25: l_shipdate IN ('1998-01-02', '1998-01-05')) OR (25: l_shipdate IS NULL)\n" +
                                         "     partitions=2/6",
                                 "     TABLE: mv0\n" +
                                         "     PREAGGREGATION: ON\n" +
                                         "     partitions=3/4", // case 1
-                                "     TABLE: lineitem_par\n" +
+                                "     TABLE: partitioned_db.lineitem_par\n" +
                                         "     PARTITION PREDICATES: 41: l_shipdate >= '1998-01-01', " +
                                         "(41: l_shipdate < '1998-01-02') OR (41: l_shipdate IS NULL)\n" +
                                         "     NON-PARTITION PREDICATES: 40: l_suppkey > 1\n" +
@@ -389,7 +389,7 @@ public class MvTransparentUnionRewriteHiveTest extends MVTestBase {
                             logSysInfo("start to test case " + i);
                             String query = sqls[i];
                             String plan = getFragmentPlan(query);
-                            PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": lineitem_par");
+                            PlanTestBase.assertContains(plan, ":UNION", ": mv0", ": partitioned_db.lineitem_par");
                             PlanTestBase.assertContains(plan, expects[i * 2]);
                             PlanTestBase.assertContains(plan, expects[i * 2 + 1]);
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneLimitTest.java
@@ -42,14 +42,14 @@ public class HivePartitionPruneLimitTest extends ConnectorPlanTestBase {
         String sql = "select * from t1 where par_col = 0;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "0:HdfsScanNode\n" +
-                "     TABLE: t1\n" +
+                "     TABLE: partitioned_db.t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = 0\n" +
                 "     partitions=1/3");
 
         sql = "select * from t1 where par_col = 1 and c1 = 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "0:HdfsScanNode\n" +
-                "     TABLE: t1\n" +
+                "     TABLE: partitioned_db.t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = 1\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
                 "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +
@@ -61,7 +61,7 @@ public class HivePartitionPruneLimitTest extends ConnectorPlanTestBase {
         sql = "select * from t1 where par_col = 1+1 and c1 = 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "0:HdfsScanNode\n" +
-                "     TABLE: t1\n" +
+                "     TABLE: partitioned_db.t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = 2\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
                 "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -39,14 +39,14 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
         String sql = "select * from t1 where par_col = 0;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "0:HdfsScanNode\n" +
-                "     TABLE: t1\n" +
+                "     TABLE: partitioned_db.t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = 0\n" +
                 "     partitions=1/3");
 
         sql = "select * from t1 where par_col = 1 and c1 = 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "0:HdfsScanNode\n" +
-                "     TABLE: t1\n" +
+                "     TABLE: partitioned_db.t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = 1\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
                 "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +
@@ -55,7 +55,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
         sql = "select * from t1 where par_col = abs(-1) and c1 = 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "0:HdfsScanNode\n" +
-                "     TABLE: t1\n" +
+                "     TABLE: partitioned_db.t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = CAST(abs(-1) AS INT)\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
                 "     NO EVAL-PARTITION PREDICATES: 4: par_col = CAST(abs(-1) AS INT)\n" +
@@ -65,7 +65,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
         sql = "select * from t1 where par_col = 1+1 and c1 = 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "0:HdfsScanNode\n" +
-                "     TABLE: t1\n" +
+                "     TABLE: partitioned_db.t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = 2\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
                 "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -262,7 +262,7 @@ public class StatisticsSQLTest extends PlanTestBase {
             starRocksAssert.useDatabase("_statistics_");
             String plan = getFragmentPlan(sql);
             assertCContains(plan, " 0:HdfsScanNode\n" +
-                    "     TABLE: subfield");
+                    "     TABLE: subfield_db.subfield");
         }
 
         for (String col : columnNames) {

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q1.sql
@@ -111,7 +111,7 @@ OutPut Exchange Id: 03
 |  * expr-->[810.9, 113345.46, 0.0, 16.0, 3736520.0] ESTIMATE
 |
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 11: l_shipdate <= '1998-12-01'
 MIN/MAX PREDICATES: 11: l_shipdate <= '1998-12-01'
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
@@ -187,7 +187,7 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 13
 
 12:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 34: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=29.0
@@ -244,7 +244,7 @@ OutPut Exchange Id: 09
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
 2:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 26: l_returnflag = 'R'
 MIN/MAX PREDICATES: 26: l_returnflag <= 'R', 26: l_returnflag >= 'R'
 partitions=1/1
@@ -275,7 +275,7 @@ OutPut Exchange Id: 06
 |  * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 5738045.738045738] ESTIMATE
 |
 4:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: 13: o_orderdate >= '1994-05-01', 13: o_orderdate < '1994-08-01'
 MIN/MAX PREDICATES: 13: o_orderdate >= '1994-05-01', 13: o_orderdate < '1994-08-01'
 partitions=1/1
@@ -294,7 +294,7 @@ OutPut Partition: HASH_PARTITIONED: 1: c_custkey
 OutPut Exchange Id: 01
 
 0:HdfsScanNode
-TABLE: customer
+TABLE: tpch.customer
 NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=217.0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q11.sql
@@ -126,7 +126,7 @@ OutPut Exchange Id: 24
 |       cardinality: 40000
 |
 13:HdfsScanNode
-TABLE: partsupp
+TABLE: tpch.partsupp
 NON-PARTITION PREDICATES: 20: ps_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=20.0
@@ -169,7 +169,7 @@ OutPut Exchange Id: 20
 |       cardinality: 1
 |
 14:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 NON-PARTITION PREDICATES: 24: s_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=8.0
@@ -195,7 +195,7 @@ OutPut Exchange Id: 17
 |  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
 |
 15:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 32: n_name = 'PERU'
 MIN/MAX PREDICATES: 32: n_name <= 'PERU', 32: n_name >= 'PERU'
 partitions=1/1
@@ -250,7 +250,7 @@ OutPut Exchange Id: 11
 |       cardinality: 40000
 |
 0:HdfsScanNode
-TABLE: partsupp
+TABLE: tpch.partsupp
 NON-PARTITION PREDICATES: 2: ps_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=28.0
@@ -294,7 +294,7 @@ OutPut Exchange Id: 07
 |       cardinality: 1
 |
 1:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 NON-PARTITION PREDICATES: 6: s_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=8.0
@@ -320,7 +320,7 @@ OutPut Exchange Id: 04
 |  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
 |
 2:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 14: n_name = 'PERU'
 MIN/MAX PREDICATES: 14: n_name <= 'PERU', 14: n_name >= 'PERU'
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q12.sql
@@ -88,7 +88,7 @@ OutPut Exchange Id: 07
 |       cardinality: 4661679
 |
 0:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: 1: o_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=23.0
@@ -116,7 +116,7 @@ OutPut Exchange Id: 03
 |  * l_shipmode-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
 |
 1:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 24: l_shipmode IN ('REG AIR', 'MAIL'), 21: l_commitdate < 22: l_receiptdate, 20: l_shipdate < 21: l_commitdate, 22: l_receiptdate >= '1997-01-01', 22: l_receiptdate < '1998-01-01', 21: l_commitdate < '1998-01-01', 20: l_shipdate < '1998-01-01'
 MIN/MAX PREDICATES: 24: l_shipmode >= 'MAIL', 24: l_shipmode <= 'REG AIR', 22: l_receiptdate >= '1997-01-01', 22: l_receiptdate < '1998-01-01', 21: l_commitdate < '1998-01-01', 20: l_shipdate < '1998-01-01'
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q13.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q13.sql
@@ -112,7 +112,7 @@ OutPut Partition: HASH_PARTITIONED: 1: c_custkey
 OutPut Exchange Id: 04
 
 3:HdfsScanNode
-TABLE: customer
+TABLE: tpch.customer
 partitions=1/1
 avgRowSize=8.0
 dataCacheOptions={populate: false}
@@ -136,7 +136,7 @@ OutPut Exchange Id: 02
 |  * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 1.0031873E7] ESTIMATE
 |
 0:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: NOT (17: o_comment LIKE '%unusual%deposits%')
 partitions=1/1
 avgRowSize=95.0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
@@ -96,7 +96,7 @@ OutPut Exchange Id: 04
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
 2:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 11: l_shipdate >= '1997-02-01', 11: l_shipdate < '1997-03-01'
 MIN/MAX PREDICATES: 11: l_shipdate >= '1997-02-01', 11: l_shipdate < '1997-03-01'
 partitions=1/1
@@ -116,7 +116,7 @@ OutPut Partition: HASH_PARTITIONED: 17: p_partkey
 OutPut Exchange Id: 01
 
 0:HdfsScanNode
-TABLE: part
+TABLE: tpch.part
 NON-PARTITION PREDICATES: 17: p_partkey IS NOT NULL
 partitions=1/1
 avgRowSize=33.0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q15.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q15.sql
@@ -68,7 +68,7 @@ OutPut Exchange Id: 22
 |       cardinality: 1
 |
 0:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 NON-PARTITION PREDICATES: 1: s_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=84.0
@@ -203,7 +203,7 @@ OutPut Exchange Id: 09
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
 |
 6:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 36: l_shipdate >= '1995-07-01', 36: l_shipdate < '1995-10-01'
 MIN/MAX PREDICATES: 36: l_shipdate >= '1995-07-01', 36: l_shipdate < '1995-10-01'
 partitions=1/1
@@ -242,7 +242,7 @@ OutPut Exchange Id: 04
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
 |
 1:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 18: l_shipdate >= '1995-07-01', 18: l_shipdate < '1995-10-01'
 MIN/MAX PREDICATES: 18: l_shipdate >= '1995-07-01', 18: l_shipdate < '1995-10-01'
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q16.sql
@@ -150,7 +150,7 @@ OutPut Exchange Id: 08
 |  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 250000.0] ESTIMATE
 |
 6:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 NON-PARTITION PREDICATES: 21: s_comment LIKE '%Customer%Complaints%'
 partitions=1/1
 avgRowSize=105.0
@@ -167,7 +167,7 @@ OutPut Partition: HASH_PARTITIONED: 6: p_partkey
 OutPut Exchange Id: 03
 
 2:HdfsScanNode
-TABLE: part
+TABLE: tpch.part
 NON-PARTITION PREDICATES: 9: p_brand != 'Brand#43', NOT (10: p_type LIKE 'PROMO BURNISHED%'), 11: p_size IN (31, 43, 9, 6, 18, 11, 25, 1)
 MIN/MAX PREDICATES: 11: p_size >= 1, 11: p_size <= 43
 partitions=1/1
@@ -187,7 +187,7 @@ OutPut Partition: HASH_PARTITIONED: 1: ps_partkey
 OutPut Exchange Id: 01
 
 0:HdfsScanNode
-TABLE: partsupp
+TABLE: tpch.partsupp
 NON-PARTITION PREDICATES: 1: ps_partkey IS NOT NULL
 partitions=1/1
 avgRowSize=16.0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q17.sql
@@ -113,7 +113,7 @@ OutPut Exchange Id: 06
 |       cardinality: 20000
 |
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 2: l_partkey IS NOT NULL
 partitions=1/1
 avgRowSize=24.0
@@ -140,7 +140,7 @@ OutPut Exchange Id: 03
 |  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 20000.0] ESTIMATE
 |
 1:HdfsScanNode
-TABLE: part
+TABLE: tpch.part
 NON-PARTITION PREDICATES: 20: p_brand = 'Brand#35', 23: p_container = 'JUMBO CASE'
 MIN/MAX PREDICATES: 20: p_brand <= 'Brand#35', 20: p_brand >= 'Brand#35', 23: p_container <= 'JUMBO CASE', 23: p_container >= 'JUMBO CASE'
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q18.sql
@@ -153,7 +153,7 @@ OutPut Exchange Id: 11
 |  * sum-->[1.0, 1.5E8, 0.0, 8.0, 50.0] ESTIMATE
 |
 9:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 34: l_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=16.0
@@ -216,7 +216,7 @@ OutPut Partition: HASH_PARTITIONED: 1: c_custkey
 OutPut Exchange Id: 05
 
 4:HdfsScanNode
-TABLE: customer
+TABLE: tpch.customer
 NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=33.0
@@ -233,7 +233,7 @@ OutPut Partition: HASH_PARTITIONED: 10: o_custkey
 OutPut Exchange Id: 03
 
 2:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: 10: o_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=28.0
@@ -254,7 +254,7 @@ OutPut Partition: HASH_PARTITIONED: 18: l_orderkey
 OutPut Exchange Id: 01
 
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 18: l_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=16.0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
@@ -71,7 +71,7 @@ OutPut Partition: HASH_PARTITIONED: 17: p_partkey
 OutPut Exchange Id: 04
 
 3:HdfsScanNode
-TABLE: part
+TABLE: tpch.part
 NON-PARTITION PREDICATES: 20: p_brand IN ('Brand#45', 'Brand#11', 'Brand#21'), 22: p_size <= 15, 23: p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG', 'MED BAG', 'MED BOX', 'MED PKG', 'MED PACK', 'LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'), 22: p_size >= 1
 MIN/MAX PREDICATES: 20: p_brand >= 'Brand#11', 20: p_brand <= 'Brand#45', 22: p_size <= 15, 23: p_container >= 'LG BOX', 23: p_container <= 'SM PKG', 22: p_size >= 1
 partitions=1/1
@@ -104,7 +104,7 @@ OutPut Exchange Id: 02
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 5: l_quantity >= 5, 5: l_quantity <= 35, 15: l_shipmode IN ('AIR', 'AIR REG'), 14: l_shipinstruct = 'DELIVER IN PERSON'
 MIN/MAX PREDICATES: 5: l_quantity >= 5, 5: l_quantity <= 35, 15: l_shipmode >= 'AIR', 15: l_shipmode <= 'AIR REG', 14: l_shipinstruct <= 'DELIVER IN PERSON', 14: l_shipinstruct >= 'DELIVER IN PERSON'
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
@@ -223,7 +223,7 @@ OutPut Exchange Id: 17
 |       cardinality: 100000
 |
 11:HdfsScanNode
-TABLE: partsupp
+TABLE: tpch.partsupp
 NON-PARTITION PREDICATES: 17: ps_partkey IS NOT NULL, 18: ps_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=24.0
@@ -252,7 +252,7 @@ OutPut Exchange Id: 14
 |  * p_mfgr-->[-Infinity, Infinity, 0.0, 25.0, 5.0] ESTIMATE
 |
 12:HdfsScanNode
-TABLE: part
+TABLE: tpch.part
 NON-PARTITION PREDICATES: 6: p_size = 12, 5: p_type LIKE '%COPPER'
 MIN/MAX PREDICATES: 6: p_size <= 12, 6: p_size >= 12
 partitions=1/1
@@ -313,7 +313,7 @@ OutPut Exchange Id: 10
 |       cardinality: 5
 |
 0:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 partitions=1/1
 avgRowSize=197.0
 dataCacheOptions={populate: false}
@@ -363,7 +363,7 @@ OutPut Exchange Id: 07
 |       cardinality: 1
 |
 1:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 22: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=33.0
@@ -390,7 +390,7 @@ OutPut Exchange Id: 04
 |  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
 |
 2:HdfsScanNode
-TABLE: region
+TABLE: tpch.region
 NON-PARTITION PREDICATES: 27: r_name = 'AMERICA'
 MIN/MAX PREDICATES: 27: r_name <= 'AMERICA', 27: r_name >= 'AMERICA'
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q20.sql
@@ -97,7 +97,7 @@ OutPut Exchange Id: 22
 |       cardinality: 1
 |
 16:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 NON-PARTITION PREDICATES: 4: s_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=73.0
@@ -125,7 +125,7 @@ OutPut Exchange Id: 19
 |  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
 |
 17:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 9: n_name = 'ARGENTINA'
 MIN/MAX PREDICATES: 9: n_name <= 'ARGENTINA', 9: n_name >= 'ARGENTINA'
 partitions=1/1
@@ -243,7 +243,7 @@ OutPut Exchange Id: 09
 |  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 5000000.0] ESTIMATE
 |
 7:HdfsScanNode
-TABLE: part
+TABLE: tpch.part
 NON-PARTITION PREDICATES: 17: p_partkey IS NOT NULL, 18: p_name LIKE 'sienna%'
 partitions=1/1
 avgRowSize=63.0
@@ -260,7 +260,7 @@ OutPut Partition: HASH_PARTITIONED: 12: ps_partkey
 OutPut Exchange Id: 06
 
 5:HdfsScanNode
-TABLE: partsupp
+TABLE: tpch.partsupp
 NON-PARTITION PREDICATES: 13: ps_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=20.0
@@ -302,7 +302,7 @@ OutPut Exchange Id: 03
 |  * l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
 |
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 29: l_suppkey IS NOT NULL, 37: l_shipdate >= '1993-01-01', 37: l_shipdate < '1994-01-01'
 MIN/MAX PREDICATES: 37: l_shipdate >= '1993-01-01', 37: l_shipdate < '1994-01-01'
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q21.sql
@@ -201,7 +201,7 @@ OutPut Exchange Id: 19
 |  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 |
 8:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 20: l_receiptdate > 19: l_commitdate
 partitions=1/1
 avgRowSize=20.0
@@ -248,7 +248,7 @@ OutPut Exchange Id: 16
 |       cardinality: 1
 |
 10:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 NON-PARTITION PREDICATES: 1: s_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=33.0
@@ -275,7 +275,7 @@ OutPut Exchange Id: 13
 |  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
 |
 11:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 34: n_name = 'CANADA'
 MIN/MAX PREDICATES: 34: n_name <= 'CANADA', 34: n_name >= 'CANADA'
 partitions=1/1
@@ -300,7 +300,7 @@ OutPut Exchange Id: 07
 |  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 5.0E7] ESTIMATE
 |
 5:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: 26: o_orderstatus = 'F'
 MIN/MAX PREDICATES: 26: o_orderstatus <= 'F', 26: o_orderstatus >= 'F'
 partitions=1/1
@@ -329,7 +329,7 @@ OutPut Exchange Id: 04
 |  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 |
 2:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 66: l_receiptdate > 65: l_commitdate
 partitions=1/1
 avgRowSize=20.0
@@ -350,7 +350,7 @@ OutPut Partition: HASH_PARTITIONED: 37: l_orderkey
 OutPut Exchange Id: 01
 
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 37: l_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=12.0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q22.sql
@@ -122,7 +122,7 @@ OutPut Exchange Id: 11
 |       cardinality: 1
 |
 2:HdfsScanNode
-TABLE: customer
+TABLE: tpch.customer
 NON-PARTITION PREDICATES: substring(5: c_phone, 1, 2) IN ('21', '28', '24', '32', '35', '34', '37')
 partitions=1/1
 avgRowSize=31.0
@@ -169,7 +169,7 @@ OutPut Exchange Id: 06
 |  * c_acctbal-->[0.0, 9999.99, 0.0, 8.0, 1086564.0] ESTIMATE
 |
 3:HdfsScanNode
-TABLE: customer
+TABLE: tpch.customer
 NON-PARTITION PREDICATES: 14: c_acctbal > 0.00, substring(13: c_phone, 1, 2) IN ('21', '28', '24', '32', '35', '34', '37')
 MIN/MAX PREDICATES: 14: c_acctbal > 0.00
 partitions=1/1
@@ -187,7 +187,7 @@ OutPut Partition: HASH_PARTITIONED: 20: o_custkey
 OutPut Exchange Id: 01
 
 0:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 partitions=1/1
 avgRowSize=8.0
 dataCacheOptions={populate: false}

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q3.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q3.sql
@@ -116,7 +116,7 @@ OutPut Exchange Id: 09
 |       cardinality: 3000000
 |
 3:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: 13: o_orderdate < '1995-03-11'
 MIN/MAX PREDICATES: 13: o_orderdate < '1995-03-11'
 partitions=1/1
@@ -145,7 +145,7 @@ OutPut Exchange Id: 06
 |  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
 |
 4:HdfsScanNode
-TABLE: customer
+TABLE: tpch.customer
 NON-PARTITION PREDICATES: 7: c_mktsegment = 'HOUSEHOLD'
 MIN/MAX PREDICATES: 7: c_mktsegment <= 'HOUSEHOLD', 7: c_mktsegment >= 'HOUSEHOLD'
 partitions=1/1
@@ -174,7 +174,7 @@ OutPut Exchange Id: 02
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 28: l_shipdate > '1995-03-11'
 MIN/MAX PREDICATES: 28: l_shipdate > '1995-03-11'
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q4.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q4.sql
@@ -98,7 +98,7 @@ OutPut Exchange Id: 05
 |  * o_orderpriority-->[-Infinity, Infinity, 0.0, 15.0, 5.0] ESTIMATE
 |
 3:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: 5: o_orderdate >= '1994-09-01', 5: o_orderdate < '1994-12-01'
 MIN/MAX PREDICATES: 5: o_orderdate >= '1994-09-01', 5: o_orderdate < '1994-12-01'
 partitions=1/1
@@ -124,7 +124,7 @@ OutPut Exchange Id: 02
 |  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 |
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 22: l_receiptdate > 21: l_commitdate
 partitions=1/1
 avgRowSize=16.0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
@@ -138,7 +138,7 @@ OutPut Partition: HASH_PARTITIONED: 1: c_custkey
 OutPut Exchange Id: 19
 
 18:HdfsScanNode
-TABLE: customer
+TABLE: tpch.customer
 NON-PARTITION PREDICATES: 1: c_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=12.0
@@ -164,7 +164,7 @@ OutPut Exchange Id: 17
 |  * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 1.0031873E7] ESTIMATE
 |
 15:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: 13: o_orderdate >= '1995-01-01', 13: o_orderdate < '1996-01-01'
 MIN/MAX PREDICATES: 13: o_orderdate >= '1995-01-01', 13: o_orderdate < '1996-01-01'
 partitions=1/1
@@ -217,7 +217,7 @@ OutPut Exchange Id: 14
 |       cardinality: 200000
 |
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 18: l_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=28.0
@@ -267,7 +267,7 @@ OutPut Exchange Id: 11
 |       cardinality: 5
 |
 1:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 NON-PARTITION PREDICATES: 34: s_suppkey IS NOT NULL, 37: s_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=8.0
@@ -312,7 +312,7 @@ OutPut Exchange Id: 08
 |       cardinality: 1
 |
 2:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 41: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=33.0
@@ -339,7 +339,7 @@ OutPut Exchange Id: 05
 |  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
 |
 3:HdfsScanNode
-TABLE: region
+TABLE: tpch.region
 NON-PARTITION PREDICATES: 46: r_name = 'AFRICA'
 MIN/MAX PREDICATES: 46: r_name <= 'AFRICA', 46: r_name >= 'AFRICA'
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q6.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q6.sql
@@ -36,7 +36,7 @@ OutPut Exchange Id: 03
 |  * l_discount-->[0.02, 0.04, 0.0, 8.0, 11.0] ESTIMATE
 |
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 11: l_shipdate >= '1995-01-01', 11: l_shipdate < '1996-01-01', 7: l_discount >= 0.02, 7: l_discount <= 0.04, 5: l_quantity < 24
 MIN/MAX PREDICATES: 11: l_shipdate >= '1995-01-01', 11: l_shipdate < '1996-01-01', 7: l_discount >= 0.02, 7: l_discount <= 0.04, 5: l_quantity < 24
 partitions=1/1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q7.sql
@@ -113,7 +113,7 @@ OutPut Partition: HASH_PARTITIONED: 33: c_custkey
 OutPut Exchange Id: 19
 
 18:HdfsScanNode
-TABLE: customer
+TABLE: tpch.customer
 NON-PARTITION PREDICATES: 33: c_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=12.0
@@ -224,7 +224,7 @@ OutPut Exchange Id: 14
 |       cardinality: 40000
 |
 2:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 18: l_shipdate >= '1995-01-01', 18: l_shipdate <= '1996-12-31'
 MIN/MAX PREDICATES: 18: l_shipdate >= '1995-01-01', 18: l_shipdate <= '1996-12-31'
 partitions=1/1
@@ -279,7 +279,7 @@ OutPut Exchange Id: 11
 |       cardinality: 1
 |
 3:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 NON-PARTITION PREDICATES: 1: s_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=8.0
@@ -312,7 +312,7 @@ OutPut Exchange Id: 08
 |       cardinality: 25
 |
 4:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 42: n_name IN ('CANADA', 'IRAN')
 MIN/MAX PREDICATES: 42: n_name >= 'CANADA', 42: n_name <= 'IRAN'
 partitions=1/1
@@ -330,7 +330,7 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 06
 
 5:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 46: n_name IN ('IRAN', 'CANADA')
 MIN/MAX PREDICATES: 46: n_name >= 'CANADA', 46: n_name <= 'IRAN'
 partitions=1/1
@@ -348,7 +348,7 @@ OutPut Partition: HASH_PARTITIONED: 24: o_orderkey
 OutPut Exchange Id: 01
 
 0:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: 24: o_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=16.0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
@@ -155,7 +155,7 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 30
 
 29:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 54: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=29.0
@@ -248,7 +248,7 @@ OutPut Exchange Id: 23
 |       cardinality: 133333
 |
 17:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 18: l_partkey IS NOT NULL, 19: l_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=36.0
@@ -277,7 +277,7 @@ OutPut Exchange Id: 20
 |  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 133333.33333333334] ESTIMATE
 |
 18:HdfsScanNode
-TABLE: part
+TABLE: tpch.part
 NON-PARTITION PREDICATES: 5: p_type = 'ECONOMY ANODIZED STEEL'
 MIN/MAX PREDICATES: 5: p_type <= 'ECONOMY ANODIZED STEEL', 5: p_type >= 'ECONOMY ANODIZED STEEL'
 partitions=1/1
@@ -321,7 +321,7 @@ OutPut Exchange Id: 16
 |       cardinality: 3000000
 |
 2:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: 37: o_orderdate >= '1995-01-01', 37: o_orderdate <= '1996-12-31'
 MIN/MAX PREDICATES: 37: o_orderdate >= '1995-01-01', 37: o_orderdate <= '1996-12-31'
 partitions=1/1
@@ -366,7 +366,7 @@ OutPut Exchange Id: 13
 |       cardinality: 5
 |
 3:HdfsScanNode
-TABLE: customer
+TABLE: tpch.customer
 NON-PARTITION PREDICATES: 42: c_custkey IS NOT NULL
 partitions=1/1
 avgRowSize=12.0
@@ -408,7 +408,7 @@ OutPut Exchange Id: 10
 |       cardinality: 1
 |
 4:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 50: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=8.0
@@ -434,7 +434,7 @@ OutPut Exchange Id: 07
 |  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
 |
 5:HdfsScanNode
-TABLE: region
+TABLE: tpch.region
 NON-PARTITION PREDICATES: 59: r_name = 'MIDDLE EAST'
 MIN/MAX PREDICATES: 59: r_name <= 'MIDDLE EAST', 59: r_name >= 'MIDDLE EAST'
 partitions=1/1
@@ -452,7 +452,7 @@ OutPut Partition: HASH_PARTITIONED: 10: s_suppkey
 OutPut Exchange Id: 01
 
 0:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 partitions=1/1
 avgRowSize=8.0
 dataCacheOptions={populate: false}

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q9.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q9.sql
@@ -144,7 +144,7 @@ OutPut Partition: HASH_PARTITIONED: 34: ps_suppkey
 OutPut Exchange Id: 21
 
 20:HdfsScanNode
-TABLE: partsupp
+TABLE: tpch.partsupp
 NON-PARTITION PREDICATES: 34: ps_suppkey IS NOT NULL, 33: ps_partkey IS NOT NULL
 partitions=1/1
 avgRowSize=24.0
@@ -188,7 +188,7 @@ OutPut Exchange Id: 17
 |       cardinality: 25
 |
 12:HdfsScanNode
-TABLE: supplier
+TABLE: tpch.supplier
 partitions=1/1
 avgRowSize=8.0
 dataCacheOptions={populate: false}
@@ -206,7 +206,7 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 14
 
 13:HdfsScanNode
-TABLE: nation
+TABLE: tpch.nation
 NON-PARTITION PREDICATES: 47: n_nationkey IS NOT NULL
 partitions=1/1
 avgRowSize=29.0
@@ -270,7 +270,7 @@ OutPut Partition: HASH_PARTITIONED: 38: o_orderkey
 OutPut Exchange Id: 08
 
 7:HdfsScanNode
-TABLE: orders
+TABLE: tpch.orders
 NON-PARTITION PREDICATES: 38: o_orderkey IS NOT NULL
 partitions=1/1
 avgRowSize=12.0
@@ -324,7 +324,7 @@ OutPut Exchange Id: 06
 |       cardinality: 5000000
 |
 0:HdfsScanNode
-TABLE: lineitem
+TABLE: tpch.lineitem
 NON-PARTITION PREDICATES: 19: l_suppkey IS NOT NULL, 18: l_partkey IS NOT NULL
 partitions=1/1
 avgRowSize=44.0
@@ -355,7 +355,7 @@ OutPut Exchange Id: 03
 |  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 5000000.0] ESTIMATE
 |
 1:HdfsScanNode
-TABLE: part
+TABLE: tpch.part
 NON-PARTITION PREDICATES: 2: p_name LIKE '%peru%'
 partitions=1/1
 avgRowSize=63.0

--- a/fe/fe-core/src/test/resources/sql/scheduler/external/hive/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/external/hive/tpch/q1.sql
@@ -118,7 +118,7 @@ PLAN FRAGMENT 2
   |  <slot 31> : 27: cast * 30: cast
   |  
   0:HdfsScanNode
-     TABLE: lineitem
+     TABLE: tpch.lineitem
      NON-PARTITION PREDICATES: 11: l_shipdate <= '1998-12-01'
      MIN/MAX PREDICATES: 11: l_shipdate <= '1998-12-01'
      partitions=1/1


### PR DESCRIPTION
Fixes #73305

## Why I'm doing this:
`EXPLAIN` includes table names, but `EXPLAIN ANALYZE` (profile output) only included them for Olap scans. Profiles on Hive/Iceberg/Hudi/Kudu/Paimon/DeltaLake/Odps/JDBC queries are very hard to read without a table label.

Also, several upstream external scan nodes (Hive/Hudi/Kudu/Paimon/DeltaLake) print only the bare table name in plain `EXPLAIN`, while `IcebergScanNode` and `OdpsScanNode` already qualify it with the database. This PR brings the others in line so `EXPLAIN` and `EXPLAIN ANALYZE` agree.

## What I'm doing:

### plain `EXPLAIN`

| Scan node             | Before                       | After                                          |
| --------------------- | ---------------------------- | ---------------------------------------------- |
| Olap                  | `TABLE: name`                | `TABLE: name` *(unchanged)*                    |
| Iceberg               | `TABLE: db.name`             | `TABLE: db.name` *(already upstream)*          |
| Odps                  | `TABLE: db.catalogTableName` | `TABLE: db.name` *(getter aligned with other externals; output identical)* |
| **Hive** (`HdfsScanNode`) | `TABLE: name`            | **`TABLE: db.name`**                           |
| **Hudi**              | `TABLE: name`                | **`TABLE: db.name`**                           |
| **Kudu**              | `TABLE: name`                | **`TABLE: db.name`**                           |
| **Paimon**            | `TABLE: name`                | **`TABLE: db.name`**                           |
| **DeltaLake**         | `TABLE: name`                | **`TABLE: db.name`**                           |
| JDBC / MySQL / ES / FileTable / Benchmark | `TABLE: name` | `TABLE: name` *(unchanged)*       |

### `EXPLAIN ANALYZE` (RuntimeProfile via `ProfilingExecPlan`)

| Scan node       | Before              | After                                                 |
| --------------- | ------------------- | ----------------------------------------------------- |
| Olap scan       | `Table: name`       | `Table: name` *(unchanged)*                           |
| Olap sink       | `Table=name`        | `Table=name` *(unchanged)*                            |
| Iceberg         | *(missing)*         | **`Table: db.name`**                                  |
| Hive            | *(missing)*         | **`Table: db.name`**                                  |
| Hudi            | *(missing)*         | **`Table: db.name`**                                  |
| Kudu            | *(missing)*         | **`Table: db.name`**                                  |
| Paimon          | *(missing)*         | **`Table: db.name`**                                  |
| DeltaLake       | *(missing)*         | **`Table: db.name`**                                  |
| Odps            | *(missing)*         | **`Table: db.name`**                                  |
| JDBC            | *(missing)*         | **`Table: db.name`** (falls back to `Table: name` when `getCatalogDBName()` is null) |
| `FILES()` / load planner (scan without an attached table) | *(missing)* | skipped via null-guard |

The external-vs-Olap classification in `ProfilingExecPlan` uses the existing `Table.isExternalTableWithFileSystem() || isOdpsTable() || isJDBCTable()` umbrellas rather than a hard-coded `instanceof` chain, so new external connectors plug in automatically when they're added to those umbrellas.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

