### PR TITLE
[Enhancement] avoid call build_slices in ChunksSorterTopn

### DIFF
--- a/be/src/exec/chunks_sorter.h
+++ b/be/src/exec/chunks_sorter.h
@@ -243,7 +243,7 @@ struct SortRuntimeFilterUpdater {
 
         auto data_column = ColumnHelper::get_data_column(column.get());
         auto runtime_data_column = down_cast<RunTimeColumnType<ltype>*>(data_column);
-        auto data = runtime_data_column->get_data()[rid];
+        auto data = GetContainer<ltype>::get_data(runtime_data_column)[rid];
         if (asc) {
             down_cast<RuntimeBloomFilter<ltype>*>(filter)->template update_min_max<false>(data);
         } else {

--- a/be/src/exec/sorting/compare_column.cpp
+++ b/be/src/exec/sorting/compare_column.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "column/array_column.h"
+#include "column/column_helper.h"
 #include "column/column_visitor_adapter.h"
 #include "column/const_column.h"
 #include "column/datum.h"
@@ -186,7 +187,7 @@ public:
 
     template <typename T>
     Status do_visit(const BinaryColumnBase<T>& column) {
-        const auto& lhs_datas = column.get_data();
+        const auto& lhs_datas = column.get_proxy_data();
         Slice rhs_data = _rhs_value.get<Slice>();
 
         if (_sort_order == 1) {
@@ -276,7 +277,7 @@ public:
 
     template <typename T>
     Status do_visit(const BinaryColumnBase<T>& column) {
-        auto& data = column.get_data();
+        auto& data = column.get_proxy_data();
         NullData* null_data = nullptr;
         if (_nullable_column != nullptr) {
             null_data = &_nullable_column->get_data();


### PR DESCRIPTION
## Why I'm doing:

BinaryColumn::get_data will call build_slice. It will use not expected memory.

For SSB100G
```
select lo_shipmode from lineorder order by lo_shipmode limit 50000000, 400;
```

  | walltime | mem
-- | -- | --
baseline | 2m12s | 8.182 GB
patched | 1m41s | 7.312 GB

</figure><br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>

## What I'm doing:

benchmark case: https://github.com/StarRocks/StarRocksBenchmark/pull/512

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0