### PR TITLE
[Enhancement] seperate flag for apply task for submit and running of primary key table

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -953,7 +953,7 @@ void TabletUpdates::do_apply() {
     {
         std::lock_guard<std::mutex> lg(_apply_running_lock);
         DCHECK(_apply_submited) << "illegal state: _apply_submited should be true";
-        DCHECK(!_apply_running) << "illegal state: _apply_submited should be true";
+        DCHECK(!_apply_running) << "illegal state: _apply_running should be true";
         _apply_running = true;
     }
     // only 1 thread at max is running this method

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -951,9 +951,9 @@ void TabletUpdates::do_apply() {
     SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(
             config::enable_pk_strict_memcheck ? StorageEngine::instance()->update_manager()->mem_tracker() : nullptr);
     {
+        std::lock_guard<std::mutex> lg(_apply_running_lock);
         DCHECK(_apply_submited) << "illegal state: _apply_submited should be true";
         DCHECK(!_apply_running) << "illegal state: _apply_submited should be true";
-        std::lock_guard<std::mutex> lg(_apply_running_lock);
         _apply_running = true;
     }
     // only 1 thread at max is running this method

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -550,7 +550,7 @@ private:
     std::map<int64_t, int64_t> _gtid_to_version_map;
 
     // used for async apply, make sure at most 1 thread is submited or doing applying
-    mutable std::mutex _apply_running_lock;
+    mutable std::mutex _apply_begin_lock;
     // make sure at most 1 thread is read or write primary index
     mutable std::shared_timed_mutex _index_lock;
     // apply process is running currently

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -439,7 +439,7 @@ private:
     Status _commit_compaction(std::unique_ptr<CompactionInfo>* info, const RowsetSharedPtr& rowset,
                               EditVersion* commit_version);
 
-    void _wait_apply_done();
+    void _wait_apply_done(bool wait_for_submited);
     void _stop_and_wait_apply_done();
 
     Status _do_compaction(std::unique_ptr<CompactionInfo>* pinfo);
@@ -508,7 +508,7 @@ private:
             _last_compaction_time_ms = UnixMillis();
         }
     }
-    void wait_apply_done() { _wait_apply_done(); }
+    void wait_apply_done() { _wait_apply_done(true); }
     bool is_apply_stop() { return _apply_stopped.load(); }
 
     bool compaction_running() { return _compaction_running; }
@@ -549,12 +549,14 @@ private:
     // gtid -> version
     std::map<int64_t, int64_t> _gtid_to_version_map;
 
-    // used for async apply, make sure at most 1 thread is doing applying
+    // used for async apply, make sure at most 1 thread is submited or doing applying
     mutable std::mutex _apply_running_lock;
     // make sure at most 1 thread is read or write primary index
     mutable std::shared_timed_mutex _index_lock;
     // apply process is running currently
     bool _apply_running = false;
+    // apply process has been submited
+    bool _apply_submited = false;
 
     // used to stop apply thread when shutting-down this tablet
     std::atomic<bool> _apply_stopped = false;


### PR DESCRIPTION
## Why I'm doing:
In current impl, tablet from primary key table will set _apply_running if the task has been submit into apply thread pool. If the all threads are used up, the tasks will stuck in queue of the thread pool and all caller of _stop_and_wait_apply_done will also stuck in this case. But this is not make sense because task has not started yet. _stop_and_wait_apply_done should not be stuck in this case.

## What I'm doing:
seperate flag for apply task for submit and running. If the task has been submited, the submit flag will be set but not running flag. The running flag will be set when the task has started. And the _stop_and_wait_apply_done will wait if the running flag is set.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0