### PR TITLE
[Enhancement] Optimize shard lock acquisition to reduce the holding time

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -985,14 +985,14 @@ Status TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* tabl
 
     size_t max_tablet_rowset_num = 0;
     for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rlock(tablets_shard.lock);
-        for (const auto& [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
+        std::vector<TabletSharedPtr> all_tablets_by_shard = _get_all_tablets_from_shard(tablets_shard);
+        for (const auto& tablet_ptr : all_tablets_by_shard) {
             TTablet t_tablet;
             TTabletInfo tablet_info;
             tablet_ptr->build_tablet_report_info(&tablet_info);
             max_tablet_rowset_num = std::max(max_tablet_rowset_num, tablet_ptr->version_count());
             // find expired transaction corresponding to this tablet
-            TabletInfo tinfo(tablet_id, tablet_ptr->schema_hash(), tablet_ptr->tablet_uid());
+            TabletInfo tinfo(tablet_ptr->tablet_id(), tablet_ptr->schema_hash(), tablet_ptr->tablet_uid());
             auto find = expire_txn_map.find(tinfo);
             if (find != expire_txn_map.end()) {
                 tablet_info.__set_transaction_ids(find->second);
@@ -1001,7 +1001,7 @@ Status TabletManager::report_all_tablets_info(std::map<TTabletId, TTablet>* tabl
             t_tablet.tablet_infos.push_back(tablet_info);
 
             if (!t_tablet.tablet_infos.empty()) {
-                tablets_info->emplace(tablet_id, t_tablet);
+                tablets_info->emplace(tablet_ptr->tablet_id(), t_tablet);
             }
         }
     }
@@ -1180,8 +1180,11 @@ Status TabletManager::delete_shutdown_tablet(int64_t tablet_id) {
 }
 
 Status TabletManager::delete_shutdown_tablet_before_clone(int64_t tablet_id) {
-    std::unique_lock l(_get_tablets_shard_lock(tablet_id));
-    auto old_tablet_ptr = _get_tablet_unlocked(tablet_id, true, nullptr);
+    TabletSharedPtr old_tablet_ptr = nullptr;
+    {
+        std::unique_lock l(_get_tablets_shard_lock(tablet_id));
+        old_tablet_ptr = _get_tablet_unlocked(tablet_id, true, nullptr);
+    }
     if (old_tablet_ptr != nullptr) {
         if (old_tablet_ptr->tablet_state() == TabletState::TABLET_SHUTDOWN) {
             // Must reset old_tablet_ptr, otherwise `delete_shutdown_tablet()` will never success.
@@ -1286,9 +1289,10 @@ void TabletManager::release_schema_change_lock(TTabletId tablet_id) {
 void TabletManager::update_root_path_info(std::map<std::string, DataDirInfo>* path_map, size_t* tablet_count) {
     DCHECK(tablet_count != nullptr);
     *tablet_count = 0;
+    std::vector<TabletSharedPtr> all_tablets_by_shard;
     for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rlock(tablets_shard.lock);
-        for (const auto& [tablet_id, tablet] : tablets_shard.tablet_map) {
+        std::vector<TabletSharedPtr> all_tablets_by_shard = _get_all_tablets_from_shard(tablets_shard);
+        for (const auto& tablet : all_tablets_by_shard) {
             ++(*tablet_count);
             int64_t data_size = tablet->tablet_footprint();
             auto iter = path_map->find(tablet->data_dir()->path());
@@ -1326,10 +1330,10 @@ void TabletManager::do_tablet_meta_checkpoint(DataDir* data_dir) {
 void TabletManager::_build_tablet_stat() {
     _tablet_stat_cache.clear();
     for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rlock(tablets_shard.lock);
-        for (const auto& [tablet_id, tablet] : tablets_shard.tablet_map) {
+        std::vector<TabletSharedPtr> all_tablets_by_shard = _get_all_tablets_from_shard(tablets_shard);
+        for (const auto& tablet : all_tablets_by_shard) {
             TTabletStat stat;
-            stat.tablet_id = tablet_id;
+            stat.tablet_id = tablet->tablet_id();
             if (tablet->updates()) {
                 auto [row_num, data_size] = tablet->updates()->num_rows_and_data_size();
                 stat.__set_row_num(row_num);
@@ -1339,7 +1343,7 @@ void TabletManager::_build_tablet_stat() {
                 stat.__set_row_num(tablet->num_rows());
             }
             stat.__set_version_count(tablet->version_count());
-            _tablet_stat_cache.emplace(tablet_id, stat);
+            _tablet_stat_cache.emplace(tablet->tablet_id(), stat);
         }
     }
 }
@@ -1611,9 +1615,8 @@ void TabletManager::get_tablets_basic_infos(int64_t table_id, int64_t partition_
         }
     } else {
         for (auto& shard : _tablets_shards) {
-            std::shared_lock rlock(shard.lock);
-            for (auto& itr : shard.tablet_map) {
-                auto& tablet = itr.second;
+            std::vector<TabletSharedPtr> all_tablets_by_shard = _get_all_tablets_from_shard(shard);
+            for (auto& tablet : all_tablets_by_shard) {
                 auto table_id_in_meta = tablet->tablet_meta()->table_id();
                 if ((table_id == -1 || table_id_in_meta == table_id) &&
                     (authorized_table_ids == nullptr ||
@@ -1646,6 +1649,15 @@ TabletManager::TabletMap& TabletManager::_get_tablet_map(TTabletId tabletId) {
 
 TabletManager::TabletsShard& TabletManager::_get_tablets_shard(TTabletId tabletId) {
     return _tablets_shards[tabletId & _tablets_shards_mask];
+}
+
+std::vector<TabletSharedPtr> TabletManager::_get_all_tablets_from_shard(const TabletsShard& shard) {
+    std::vector<TabletSharedPtr> all_tablets_by_shard;
+    std::shared_lock rlock(shard.lock);
+    for (const auto& [_, tablet] : shard.tablet_map) {
+        all_tablets_by_shard.push_back(tablet);
+    }
+    return all_tablets_by_shard;
 }
 
 Status TabletManager::create_tablet_from_meta_snapshot(DataDir* store, TTabletId tablet_id, SchemaHash schema_hash,
@@ -1791,8 +1803,8 @@ Status TabletManager::_move_tablet_directories_to_trash(const TabletSharedPtr& t
 std::unordered_map<TTabletId, vector<pair<uint32_t, uint32_t>>> TabletManager::get_tablets_need_repair_compaction() {
     std::unordered_map<TTabletId, std::vector<std::pair<uint32_t, uint32_t>>> ret;
     for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rlock(tablets_shard.lock);
-        for (auto [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
+        std::vector<TabletSharedPtr> all_tablets_by_shard = _get_all_tablets_from_shard(tablets_shard);
+        for (auto& tablet_ptr : all_tablets_by_shard) {
             if (tablet_ptr->updates() == nullptr) {
                 continue;
             }
@@ -1803,7 +1815,7 @@ std::unordered_map<TTabletId, vector<pair<uint32_t, uint32_t>>> TabletManager::g
             if (st.value().empty()) {
                 continue;
             }
-            ret.emplace(tablet_id, std::move(st.value()));
+            ret.emplace(tablet_ptr->tablet_id(), std::move(st.value()));
         }
     }
     return ret;

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1289,7 +1289,6 @@ void TabletManager::release_schema_change_lock(TTabletId tablet_id) {
 void TabletManager::update_root_path_info(std::map<std::string, DataDirInfo>* path_map, size_t* tablet_count) {
     DCHECK(tablet_count != nullptr);
     *tablet_count = 0;
-    std::vector<TabletSharedPtr> all_tablets_by_shard;
     for (const auto& tablets_shard : _tablets_shards) {
         std::vector<TabletSharedPtr> all_tablets_by_shard = _get_all_tablets_from_shard(tablets_shard);
         for (const auto& tablet : all_tablets_by_shard) {

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -277,6 +277,8 @@ private:
     void _add_shutdown_tablet_unlocked(int64_t tablet_id, DroppedTabletInfo&& drop_info);
     void sweep_shutdown_tablet(const DroppedTabletInfo& info, std::vector<DroppedTabletInfo>& finished_tablets);
 
+    std::vector<TabletSharedPtr> _get_all_tablets_from_shard(const TabletsShard& shard);
+
     static Status _remove_tablet_meta(const TabletSharedPtr& tablet);
     static Status _remove_tablet_directories(const TabletSharedPtr& tablet);
     static Status _move_tablet_directories_to_trash(const TabletSharedPtr& tablet);

--- a/be/test/storage/tablet_mgr_test.cpp
+++ b/be/test/storage/tablet_mgr_test.cpp
@@ -516,4 +516,18 @@ TEST_F(TabletMgrTest, RemoveTabletInDiskDisable) {
     StorageEngine::instance()->tablet_manager()->drop_tablets_on_error_root_path(tablet_info_vec);
 }
 
+TEST_F(TabletMgrTest, GetTabletReportInfo) {
+    TTabletId tablet_id = 4251234666;
+    TSchemaHash schema_hash = 3929134666;
+    TCreateTabletReq create_tablet_req = get_create_tablet_request(tablet_id, schema_hash);
+    Status create_st = StorageEngine::instance()->create_tablet(create_tablet_req);
+    ASSERT_TRUE(create_st.ok());
+
+    TReportRequest request;
+    request.__isset.tablets = true;
+    Status st_report = StorageEngine::instance()->tablet_manager()->report_all_tablets_info(&request.tablets);
+    ASSERT_TRUE(st_report.ok());
+    ASSERT_TRUE(request.tablets.size() == 1);
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
In current impl, tablet meta lock or some primary key relative locks will be try to acquired after the shard lock has been holded in some place.
This may cause the shard lock to be held for a long time and cannot be released.

## What I'm doing:
Try to release the shard lock before try to acquire another lock if it is possible.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0