### PR TITLE
[BugFix] fix load spill writing data size report

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -573,7 +573,7 @@ Status DeltaWriter::flush_memtable_async(bool eos) {
                 auto replicate_token = _replicate_token.get();
                 return _flush_token->submit(
                         std::move(_mem_table), eos,
-                        [replicate_token, this](std::unique_ptr<SegmentPB> seg, bool eos, int64_t flush_data_size) {
+                        [replicate_token, this](SegmentPBPtr seg, bool eos, int64_t flush_data_size) {
                             if (seg) {
                                 _tablet->add_in_writing_data_size(_opt.txn_id, seg->data_size());
                             }
@@ -598,8 +598,7 @@ Status DeltaWriter::flush_memtable_async(bool eos) {
         } else {
             if (_mem_table != nullptr && _mem_table->get_result_chunk() != nullptr) {
                 return _flush_token->submit(
-                        std::move(_mem_table), eos,
-                        [this](std::unique_ptr<SegmentPB> seg, bool eos, int64_t flush_data_size) {
+                        std::move(_mem_table), eos, [this](SegmentPBPtr seg, bool eos, int64_t flush_data_size) {
                             if (seg) {
                                 _tablet->add_in_writing_data_size(_opt.txn_id, seg->data_size());
                             }
@@ -618,23 +617,21 @@ Status DeltaWriter::flush_memtable_async(bool eos) {
         }
     } else if (_replica_state == Peer) {
         if (_mem_table != nullptr && _mem_table->get_result_chunk() != nullptr) {
-            return _flush_token->submit(
-                    std::move(_mem_table), eos,
-                    [this](std::unique_ptr<SegmentPB> seg, bool eos, int64_t flush_data_size) {
-                        if (seg) {
-                            _tablet->add_in_writing_data_size(_opt.txn_id, seg->data_size());
-                        }
-                        if (_opt.immutable_tablet_size > 0 &&
-                            _tablet->data_size() + _tablet->in_writing_data_size() > _opt.immutable_tablet_size) {
-                            _is_immutable.store(true, std::memory_order_relaxed);
-                        }
-                        VLOG(2) << "flush memtable, tablet=" << _tablet->tablet_id() << ", txn=" << _opt.txn_id
-                                << " immutable_tablet_size=" << _opt.immutable_tablet_size
-                                << ", segment_size=" << (seg ? seg->data_size() : 0)
-                                << ", tablet_data_size=" << _tablet->data_size()
-                                << ", in_writing_data_size=" << _tablet->in_writing_data_size()
-                                << ", is_immutable=" << _is_immutable.load(std::memory_order_relaxed);
-                    });
+            return _flush_token->submit(std::move(_mem_table), eos, [this](SegmentPBPtr seg, bool eos, int64_t f) {
+                if (seg) {
+                    _tablet->add_in_writing_data_size(_opt.txn_id, seg->data_size());
+                }
+                if (_opt.immutable_tablet_size > 0 &&
+                    _tablet->data_size() + _tablet->in_writing_data_size() > _opt.immutable_tablet_size) {
+                    _is_immutable.store(true, std::memory_order_relaxed);
+                }
+                VLOG(2) << "flush memtable, tablet=" << _tablet->tablet_id() << ", txn=" << _opt.txn_id
+                        << " immutable_tablet_size=" << _opt.immutable_tablet_size
+                        << ", segment_size=" << (seg ? seg->data_size() : 0)
+                        << ", tablet_data_size=" << _tablet->data_size()
+                        << ", in_writing_data_size=" << _tablet->in_writing_data_size()
+                        << ", is_immutable=" << _is_immutable.load(std::memory_order_relaxed);
+            });
         }
     }
     return Status::OK();

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -55,13 +55,15 @@ public:
 
     DISALLOW_COPY_AND_MOVE(TabletWriterSink);
 
-    Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment = nullptr, bool eos = false) override {
+    Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment = nullptr, bool eos = false,
+                       int64_t* flush_data_size = nullptr) override {
         RETURN_IF_ERROR(_writer->write(chunk, segment));
         return _writer->flush(segment);
     }
 
     Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes,
-                                    starrocks::SegmentPB* segment = nullptr, bool eos = false) override {
+                                    starrocks::SegmentPB* segment = nullptr, bool eos = false,
+                                    int64_t* flush_data_size = nullptr) override {
         RETURN_IF_ERROR(_writer->flush_del_file(deletes));
         RETURN_IF_ERROR(_writer->write(upserts, segment));
         return _writer->flush(segment);
@@ -318,21 +320,25 @@ inline Status DeltaWriterImpl::flush_async() {
         if (_miss_auto_increment_column && _mem_table->get_result_chunk() != nullptr) {
             RETURN_IF_ERROR(fill_auto_increment_id(*_mem_table->get_result_chunk()));
         }
-        st = _flush_token->submit(std::move(_mem_table), _eos, [this](std::unique_ptr<SegmentPB> seg, bool eos) {
-            if (_immutable_tablet_size > 0 && !_is_immutable.load(std::memory_order_relaxed)) {
-                if (seg) {
-                    _tablet_manager->add_in_writing_data_size(_tablet_id, seg->data_size());
-                }
-                if (_tablet_manager->in_writing_data_size(_tablet_id) > _immutable_tablet_size) {
-                    _is_immutable.store(true, std::memory_order_relaxed);
-                }
-                VLOG(2) << "flush memtable, tablet=" << _tablet_id << ", txn=" << _txn_id
-                        << " _immutable_tablet_size=" << _immutable_tablet_size
-                        << ", segment_size=" << (seg ? seg->data_size() : 0)
-                        << ", in_writing_data_size=" << _tablet_manager->in_writing_data_size(_tablet_id)
-                        << ", is_immutable=" << _is_immutable.load(std::memory_order_relaxed);
-            }
-        });
+        st = _flush_token->submit(
+                std::move(_mem_table), _eos, [this](std::unique_ptr<SegmentPB> seg, bool eos, int64_t flush_data_size) {
+                    if (_immutable_tablet_size > 0 && !_is_immutable.load(std::memory_order_relaxed)) {
+                        if (seg) {
+                            _tablet_manager->add_in_writing_data_size(_tablet_id, seg->data_size());
+                        } else if (flush_data_size > 0) {
+                            // When enable load spill, seg is nullptr, so we need to use flush_data_size
+                            _tablet_manager->add_in_writing_data_size(_tablet_id, flush_data_size);
+                        }
+                        if (_tablet_manager->in_writing_data_size(_tablet_id) > _immutable_tablet_size) {
+                            _is_immutable.store(true, std::memory_order_relaxed);
+                        }
+                        VLOG(2) << "flush memtable, tablet=" << _tablet_id << ", txn=" << _txn_id
+                                << " _immutable_tablet_size=" << _immutable_tablet_size
+                                << ", segment_size=" << (seg ? seg->data_size() : 0)
+                                << ", in_writing_data_size=" << _tablet_manager->in_writing_data_size(_tablet_id)
+                                << ", is_immutable=" << _is_immutable.load(std::memory_order_relaxed);
+                    }
+                });
         _mem_table.reset(nullptr);
         _last_write_ts = 0;
     }

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -321,7 +321,7 @@ inline Status DeltaWriterImpl::flush_async() {
             RETURN_IF_ERROR(fill_auto_increment_id(*_mem_table->get_result_chunk()));
         }
         st = _flush_token->submit(
-                std::move(_mem_table), _eos, [this](std::unique_ptr<SegmentPB> seg, bool eos, int64_t flush_data_size) {
+                std::move(_mem_table), _eos, [this](SegmentPBPtr seg, bool eos, int64_t flush_data_size) {
                     if (_immutable_tablet_size > 0 && !_is_immutable.load(std::memory_order_relaxed)) {
                         if (seg) {
                             _tablet_manager->add_in_writing_data_size(_tablet_id, seg->data_size());
@@ -334,7 +334,7 @@ inline Status DeltaWriterImpl::flush_async() {
                         }
                         VLOG(2) << "flush memtable, tablet=" << _tablet_id << ", txn=" << _txn_id
                                 << " _immutable_tablet_size=" << _immutable_tablet_size
-                                << ", segment_size=" << (seg ? seg->data_size() : 0)
+                                << ", flush data size=" << (seg ? seg->data_size() : flush_data_size)
                                 << ", in_writing_data_size=" << _tablet_manager->in_writing_data_size(_tablet_id)
                                 << ", is_immutable=" << _is_immutable.load(std::memory_order_relaxed);
                     }

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -36,6 +36,7 @@ Status LoadSpillOutputDataStream::append(RuntimeState* state, const std::vector<
     // preallocate block
     RETURN_IF_ERROR(_preallocate(total_size));
     // append data
+    _append_bytes += total_size;
     return _block->append(data);
 }
 
@@ -123,7 +124,8 @@ Status SpillMemTableSink::_do_spill(const Chunk& chunk, const spill::SpillOutput
     return Status::OK();
 }
 
-Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment, bool eos) {
+Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment, bool eos,
+                                      int64_t* flush_data_size) {
     if (eos && _block_manager->block_container()->empty()) {
         // If there is only one flush, flush it to segment directly
         RETURN_IF_ERROR(_writer->write(chunk, segment));
@@ -137,11 +139,15 @@ Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* 
     RETURN_IF_ERROR(_do_spill(chunk, output));
     // 3. flush
     RETURN_IF_ERROR(output->flush());
+    // record append bytes to segment pb
+    if (flush_data_size != nullptr) {
+        *flush_data_size = output->append_bytes();
+    }
     return Status::OK();
 }
 
 Status SpillMemTableSink::flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes,
-                                                   starrocks::SegmentPB* segment, bool eos) {
+                                                   starrocks::SegmentPB* segment, bool eos, int64_t* flush_data_size) {
     if (eos && _block_manager->block_container()->empty()) {
         // If there is only one flush, flush it to segment directly
         RETURN_IF_ERROR(_writer->flush_del_file(deletes));
@@ -149,7 +155,7 @@ Status SpillMemTableSink::flush_chunk_with_deletes(const Chunk& upserts, const C
         return _writer->flush(segment);
     }
     // 1. flush upsert
-    RETURN_IF_ERROR(flush_chunk(upserts, segment, eos));
+    RETURN_IF_ERROR(flush_chunk(upserts, segment, eos, flush_data_size));
     // 2. flush deletes
     RETURN_IF_ERROR(_writer->flush_del_file(deletes));
     return Status::OK();

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -139,7 +139,7 @@ Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* 
     RETURN_IF_ERROR(_do_spill(chunk, output));
     // 3. flush
     RETURN_IF_ERROR(output->flush());
-    // record append bytes to segment pb
+    // record append bytes to `flush_data_size`
     if (flush_data_size != nullptr) {
         *flush_data_size = output->append_bytes();
     }

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -40,6 +40,8 @@ public:
 
     bool is_remote() const override;
 
+    int64_t append_bytes() const { return _append_bytes; }
+
 private:
     Status _preallocate(size_t block_size);
 
@@ -49,6 +51,7 @@ private:
 private:
     LoadSpillBlockManager* _block_manager = nullptr;
     spill::BlockPtr _block;
+    int64_t _append_bytes = 0;
 };
 
 class SpillMemTableSink : public MemTableSink {
@@ -56,10 +59,12 @@ public:
     SpillMemTableSink(LoadSpillBlockManager* block_manager, TabletWriter* writer, RuntimeProfile* profile);
     ~SpillMemTableSink() override = default;
 
-    Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment = nullptr, bool eos = false) override;
+    Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment = nullptr, bool eos = false,
+                       int64_t* flush_data_size = nullptr) override;
 
     Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes,
-                                    starrocks::SegmentPB* segment = nullptr, bool eos = false) override;
+                                    starrocks::SegmentPB* segment = nullptr, bool eos = false,
+                                    int64_t* flush_data_size = nullptr) override;
 
     Status merge_blocks_to_segments();
 

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -326,7 +326,7 @@ Status MemTable::finalize() {
     return Status::OK();
 }
 
-Status MemTable::flush(SegmentPB* seg_info, bool eos) {
+Status MemTable::flush(SegmentPB* seg_info, bool eos, int64_t* flush_data_size) {
     if (UNLIKELY(_result_chunk == nullptr)) {
         return Status::OK();
     }
@@ -339,9 +339,9 @@ Status MemTable::flush(SegmentPB* seg_info, bool eos) {
     {
         SCOPED_RAW_TIMER(&duration_ns);
         if (_deletes) {
-            RETURN_IF_ERROR(_sink->flush_chunk_with_deletes(*_result_chunk, *_deletes, seg_info, eos));
+            RETURN_IF_ERROR(_sink->flush_chunk_with_deletes(*_result_chunk, *_deletes, seg_info, eos, flush_data_size));
         } else {
-            RETURN_IF_ERROR(_sink->flush_chunk(*_result_chunk, seg_info, eos));
+            RETURN_IF_ERROR(_sink->flush_chunk(*_result_chunk, seg_info, eos, flush_data_size));
         }
     }
     auto io_stat = scope.current_scoped_tls_io();

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -97,7 +97,7 @@ public:
     // return true suggests caller should flush this memory table
     StatusOr<bool> insert(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size);
 
-    Status flush(SegmentPB* seg_info = nullptr, bool eos = false);
+    Status flush(SegmentPB* seg_info = nullptr, bool eos = false, int64_t* flush_data_size = nullptr);
 
     Status finalize();
 

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -62,6 +62,7 @@ struct FlushStatistic {
 };
 
 std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat);
+using SegmentPBPtr = std::unique_ptr<SegmentPB>;
 
 // A thin wrapper of ThreadPoolToken to submit task.
 // For a tablet, there may be multiple memtables, which will be flushed to disk
@@ -76,7 +77,7 @@ public:
             : _flush_token(std::move(flush_pool_token)), _status() {}
 
     Status submit(std::unique_ptr<MemTable> mem_table, bool eos = false,
-                  std::function<void(std::unique_ptr<SegmentPB>, bool, int64_t)> cb = nullptr);
+                  std::function<void(SegmentPBPtr, bool, int64_t)> cb = nullptr);
 
     // error has happpens, so we cancel this token
     // And remove all tasks in the queue.

--- a/be/src/storage/memtable_flush_executor.h
+++ b/be/src/storage/memtable_flush_executor.h
@@ -76,7 +76,7 @@ public:
             : _flush_token(std::move(flush_pool_token)), _status() {}
 
     Status submit(std::unique_ptr<MemTable> mem_table, bool eos = false,
-                  std::function<void(std::unique_ptr<SegmentPB>, bool)> cb = nullptr);
+                  std::function<void(std::unique_ptr<SegmentPB>, bool, int64_t)> cb = nullptr);
 
     // error has happpens, so we cancel this token
     // And remove all tasks in the queue.
@@ -109,7 +109,7 @@ public:
 private:
     friend class MemtableFlushTask;
 
-    void _flush_memtable(MemTable* memtable, SegmentPB* segment, bool eos);
+    void _flush_memtable(MemTable* memtable, SegmentPB* segment, bool eos, int64_t* flush_data_size);
 
     std::unique_ptr<ThreadPoolToken> _flush_token;
 

--- a/be/src/storage/memtable_rowset_writer_sink.h
+++ b/be/src/storage/memtable_rowset_writer_sink.h
@@ -28,12 +28,13 @@ public:
 
     DISALLOW_COPY(MemTableRowsetWriterSink);
 
-    Status flush_chunk(const Chunk& chunk, SegmentPB* seg_info = nullptr, bool eos = false) override {
+    Status flush_chunk(const Chunk& chunk, SegmentPB* seg_info = nullptr, bool eos = false,
+                       int64_t* flush_data_size = nullptr) override {
         return _rowset_writer->flush_chunk(chunk, seg_info);
     }
 
     Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes, SegmentPB* seg_info = nullptr,
-                                    bool eos = false) override {
+                                    bool eos = false, int64_t* flush_data_size = nullptr) override {
         return _rowset_writer->flush_chunk_with_deletes(upserts, deletes, seg_info);
     }
 

--- a/be/src/storage/memtable_sink.h
+++ b/be/src/storage/memtable_sink.h
@@ -29,9 +29,10 @@ class MemTableSink {
 public:
     virtual ~MemTableSink() = default;
 
-    virtual Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* seg_info = nullptr, bool eos = false) = 0;
+    virtual Status flush_chunk(const Chunk& chunk, starrocks::SegmentPB* seg_info = nullptr, bool eos = false,
+                               int64_t* flush_data_size = nullptr) = 0;
     virtual Status flush_chunk_with_deletes(const Chunk& upserts, const Column& deletes, SegmentPB* seg_info = nullptr,
-                                            bool eos = false) = 0;
+                                            bool eos = false, int64_t* flush_data_size = nullptr) = 0;
 };
 
 } // namespace starrocks

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -585,7 +585,7 @@ TEST_F(LakeAsyncDeltaWriterTest, test_block_merger) {
                                                .set_mem_tracker(_mem_tracker.get())
                                                .set_schema_id(_tablet_schema->id())
                                                .set_profile(&_dummy_runtime_profile)
-                                               .set_immutable_tablet_size(100)
+                                               .set_immutable_tablet_size(10000000)
                                                .build());
     ASSERT_OK(delta_writer->open());
     for (int i = 0; i < 10; i++) {

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -574,9 +574,7 @@ TEST_F(LakeAsyncDeltaWriterTest, test_block_merger) {
     CountDownLatch latch(10);
     // flush multi times and generate spill blocks
     int64_t old_val = config::write_buffer_size;
-    bool old_val2 = config::enable_load_spill;
     config::write_buffer_size = 1;
-    config::enable_load_spill = true;
     ASSIGN_OR_ABORT(auto delta_writer, AsyncDeltaWriterBuilder()
                                                .set_tablet_manager(_tablet_mgr.get())
                                                .set_tablet_id(tablet_id)
@@ -597,15 +595,14 @@ TEST_F(LakeAsyncDeltaWriterTest, test_block_merger) {
     }
     latch.wait();
     config::write_buffer_size = old_val;
-    config::enable_load_spill = old_val2;
     // finish
     CountDownLatch latch2(1);
     delta_writer->finish([&](StatusOr<TxnLogPtr> res) {
         ASSERT_TRUE(res.ok()) << res.ok();
         latch2.count_down();
     });
-    ASSERT_TRUE(_tablet_mgr->in_writing_data_size(tablet_id) > 0);
     latch2.wait();
+    ASSERT_TRUE(_tablet_mgr->in_writing_data_size(tablet_id) > 0);
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -585,6 +585,7 @@ TEST_F(LakeAsyncDeltaWriterTest, test_block_merger) {
                                                .set_mem_tracker(_mem_tracker.get())
                                                .set_schema_id(_tablet_schema->id())
                                                .set_profile(&_dummy_runtime_profile)
+                                               .set_immutable_tablet_size(100)
                                                .build());
     ASSERT_OK(delta_writer->open());
     for (int i = 0; i < 10; i++) {
@@ -603,6 +604,7 @@ TEST_F(LakeAsyncDeltaWriterTest, test_block_merger) {
         ASSERT_TRUE(res.ok()) << res.ok();
         latch2.count_down();
     });
+    ASSERT_TRUE(_tablet_mgr->in_writing_data_size(tablet_id) > 0);
     latch2.wait();
 }
 

--- a/be/test/storage/memtable_flush_executor_test.cpp
+++ b/be/test/storage/memtable_flush_executor_test.cpp
@@ -394,7 +394,7 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlushStatusNotOk) {
     flush_token->set_status(Status::NotSupported("Not Suppoted"));
     ASSERT_FALSE(flush_token->status().ok());
 
-    flush_token->_flush_memtable(nullptr, nullptr, false);
+    flush_token->_flush_memtable(nullptr, nullptr, false, nullptr);
 
     ASSERT_TRUE(MemTableFlushExecutor::calc_max_threads_for_lake_table(data_dirs) > 0);
 }

--- a/be/test/storage/memtable_flush_executor_test.cpp
+++ b/be/test/storage/memtable_flush_executor_test.cpp
@@ -327,7 +327,7 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlushWithSeg) {
     bool ret_eos = true;
     ASSERT_TRUE(flush_token
                         ->submit(std::move(mem_table), false,
-                                 [&](std::unique_ptr<SegmentPB> seg, bool eos) {
+                                 [&](std::unique_ptr<SegmentPB> seg, bool eos, int64_t flush_data_size) {
                                      ret_num_rows = seg->num_rows();
                                      ret_eos = eos;
                                  })
@@ -359,7 +359,7 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlushWithNullSeg) {
     std::unique_ptr<SegmentPB> ret_seg = make_unique<SegmentPB>();
     ASSERT_TRUE(flush_token
                         ->submit(std::move(mem_table), true,
-                                 [&](std::unique_ptr<SegmentPB> seg, bool eos) {
+                                 [&](std::unique_ptr<SegmentPB> seg, bool eos, int64_t flush_data_size) {
                                      ret_seg = std::move(seg);
                                      ret_eos = eos;
                                  })


### PR DESCRIPTION
## Why I'm doing:
In auto bucket table, delta writer will report segment size after memtable flush to trigger new bucket generations. And after bulk load optimization #53954, memtable flush will generate spill block instead of segment files, we need to handle this case.

## What I'm doing:

Fixes #53954

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0