### PR TITLE
[Enhancement] subfield pushdown through table function(backport #55425)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/LogicalPlanPrinter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/LogicalPlanPrinter.java
@@ -178,6 +178,11 @@ public class LogicalPlanPrinter {
         }
 
         @Override
+        public OperatorStr visitLogicalTableFunction(OptExpression optExpression, Integer step) {
+            return visitDefault(optExpression, step);
+        }
+
+        @Override
         public OperatorStr visitLogicalRepeat(OptExpression optExpression, Integer step) {
             int nextStep = step + 1;
             List<OperatorStr> children =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -812,7 +812,7 @@ public class Optimizer {
             ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PRUNE_COLUMNS);
         }
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PruneSubfieldRule());
-
+        deriveLogicalProperty(tree);
         return tree;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
@@ -22,12 +22,14 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
@@ -44,6 +46,7 @@ import com.starrocks.sql.optimizer.task.TaskContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /*
  * Push down subfield expression to scan node
@@ -249,9 +252,12 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
                     childContext.put(context.pushDownExprRefsIndex.get(expr), expr);
                     continue;
                 }
-
-                ColumnRefOperator index = factory.create(expr, expr.getType(), expr.isNullable());
-                childContext.put(index, expr);
+                if (expr.isColumnRef()) {
+                    childContext.put(expr.cast(), expr);
+                } else {
+                    ColumnRefOperator index = factory.create(expr, expr.getType(), expr.isNullable());
+                    childContext.put(index, expr);
+                }
             }
 
             if (childContext.pushDownExprRefs.isEmpty()) {
@@ -356,11 +362,16 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
             // rewrite union node, put all push down column
             LogicalUnionOperator union = optExpression.getOp().cast();
             List<ColumnRefOperator> newOutputColumns = Lists.newArrayList(union.getOutputColumnRefOp());
+            ColumnRefSet alreadyExistsColumnRefs = ColumnRefSet.of();
+            alreadyExistsColumnRefs.union(newOutputColumns);
+
             List<List<ColumnRefOperator>> childOutputColumns = Lists.newArrayList();
 
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : context.pushDownExprRefs.entrySet()) {
                 ColumnRefOperator key = entry.getKey();
-                newOutputColumns.add(key);
+                if (!alreadyExistsColumnRefs.contains(key)) {
+                    newOutputColumns.add(key);
+                }
             }
 
             List<Context> childContexts = Lists.newArrayList();
@@ -525,6 +536,46 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
         @Override
         public OptExpression visitLogicalAssertOneRow(OptExpression optExpression, Context context) {
             return visitChildren(optExpression, context);
+        }
+
+        @Override
+        public OptExpression visitLogicalTableFunction(OptExpression optExpression, Context context) {
+            LogicalTableFunctionOperator tableFuncOp = optExpression.getOp().cast();
+            ColumnRefSet outerColRefSet = ColumnRefSet.of();
+            List<ColumnRefOperator> outerColRefs = tableFuncOp.getOuterColRefs();
+            outerColRefSet.union(outerColRefs);
+            Context localContext = new Context();
+            Context childContext = new Context();
+            ColumnRefSet childSubfieldOutputs = new ColumnRefSet();
+            List<ColumnRefOperator> newOuterColRefs = Lists.newArrayList();
+            ColumnRefSet allUsedColumns = ColumnRefSet.of();
+            for (Map.Entry<ScalarOperator, ColumnRefSet> entry : context.pushDownExprUseColumns.entrySet()) {
+                ScalarOperator expr = entry.getKey();
+                ColumnRefSet useColumns = entry.getValue();
+                allUsedColumns.union(useColumns);
+                if (outerColRefSet.containsAll(useColumns)) {
+                    ColumnRefOperator columnRef = context.pushDownExprRefsIndex.get(expr);
+                    childContext.put(columnRef, expr);
+                    childSubfieldOutputs.union(columnRef);
+                    newOuterColRefs.add(columnRef);
+                } else {
+                    localContext.put(context.pushDownExprRefsIndex.get(expr), expr);
+                }
+            }
+            newOuterColRefs.addAll(outerColRefs.stream().filter(colRef -> !allUsedColumns.contains(colRef)).collect(
+                    Collectors.toList()));
+            Optional<Operator> project = generatePushDownProject(optExpression, childSubfieldOutputs, localContext);
+            OptExpression result = visitChildren(optExpression, childContext);
+            if (!newOuterColRefs.isEmpty()) {
+                LogicalTableFunctionOperator.Builder newTableFuncOpBuilder =
+                        (LogicalTableFunctionOperator.Builder) OperatorBuilderFactory
+                                .build(tableFuncOp)
+                                .withOperator(tableFuncOp);
+                Operator newTableFuncOp = newTableFuncOpBuilder.setOuterColRefs(newOuterColRefs).build();
+                result = OptExpression.create(newTableFuncOp, result.getInputs());
+            }
+            OptExpression finalResult = result;
+            return project.map(operator -> OptExpression.create(operator, finalResult)).orElse(finalResult);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/SubfieldPushDownThroughTableFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/SubfieldPushDownThroughTableFunctionTest.java
@@ -1,0 +1,165 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.sql.plan.PlanTestNoneDBBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SubfieldPushDownThroughTableFunctionTest extends PlanTestNoneDBBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestNoneDBBase.beforeClass();
+        starRocksAssert.withDatabase("test_db0").useDatabase("test_db0");
+        String createTableSql1 = "CREATE TABLE `t1` (\n" +
+                "  `col_date` date DEFAULT NULL,\n" +
+                "  `col_hour` smallint(6) DEFAULT NULL,\n" +
+                "  `col_header` struct < \n" +
+                "    col_uuid varchar(10000),\n" +
+                "    col_timestamp datetime,\n" +
+                "    col_context array < struct < col_type varchar(10000), col_id varchar(10000) > >\n" +
+                "  > DEFAULT NULL COMMENT \"Header Info.\",\n" +
+                "  `col_project` struct < \n" +
+                "    col_id varchar(10000),\n" +
+                "    col_title varchar(10000),\n" +
+                "    col_status boolean,\n" +
+                "    col_criteria array < struct < \n" +
+                "      col_criteria_id varchar(10000), \n" +
+                "      col_condition varchar(10000), \n" +
+                "      col_value varchar(10000), \n" +
+                "      col_operator varchar(10000) \n" +
+                "    > >,\n" +
+                "    col_batches array < struct < \n" +
+                "      col_batch_id varchar(10000),\n" +
+                "      col_batch_name varchar(10000),\n" +
+                "      col_batch_status boolean,\n" +
+                "      col_budget_id varchar(10000),\n" +
+                "      col_pricing struct < \n" +
+                "        col_strategy varchar(10000),\n" +
+                "        col_currency varchar(10000),\n" +
+                "        col_base_bid decimal(15, 2),\n" +
+                "        col_max_bid decimal(15, 2),\n" +
+                "        col_adjustments array < struct < \n" +
+                "          col_adjustment_id varchar(10000),\n" +
+                "          col_criteria struct < \n" +
+                "            col_criteria_id varchar(10000),\n" +
+                "            col_condition varchar(10000),\n" +
+                "            col_value varchar(10000),\n" +
+                "            col_operator varchar(10000) \n" +
+                "          >,\n" +
+                "          col_coefficient decimal(15, 2) \n" +
+                "        > >\n" +
+                "      >,\n" +
+                "      col_delivery varchar(10000),\n" +
+                "      col_views int(11),\n" +
+                "      col_bidding struct < \n" +
+                "        col_goal varchar(10000),\n" +
+                "        col_metric int(11) \n" +
+                "      >,\n" +
+                "      col_criteria array < struct < \n" +
+                "        col_criteria_id varchar(10000),\n" +
+                "        col_condition varchar(10000),\n" +
+                "        col_value varchar(10000),\n" +
+                "        col_operator varchar(10000) \n" +
+                "      > >,\n" +
+                "      col_items array < struct < \n" +
+                "        col_item_id varchar(10000),\n" +
+                "        col_primary_item_id varchar(10000),\n" +
+                "        col_criteria array < struct < \n" +
+                "          col_criteria_id varchar(10000),\n" +
+                "          col_condition varchar(10000),\n" +
+                "          col_value varchar(10000),\n" +
+                "          col_operator varchar(10000) \n" +
+                "        > >,\n" +
+                "        col_content_id varchar(10000),\n" +
+                "        col_type varchar(10000),\n" +
+                "        col_title varchar(10000),\n" +
+                "        col_status boolean \n" +
+                "      > > \n" +
+                "    > >\n" +
+                "  >,\n" +
+                "  `col_account` varchar(10000) DEFAULT NULL\n" +
+                ") \n" +
+                "PROPERTIES (\n" +
+                "  \"replication_num\" = \"1\"\n" +
+                ");";
+        starRocksAssert.withTable(createTableSql1);
+    }
+
+    @Test
+    public void test1() throws Exception {
+        String[] sqlList = new String[] {
+                "select col_header from t1, generate_series(1, 100);",
+                "select t1.* from t1, generate_series(1, 100);"
+        };
+        for (String sql : sqlList) {
+            String plan = UtFrameUtils.getFragmentPlan(connectContext, sql);
+            assertCContains(plan, "generate_series");
+        }
+    }
+
+    @Test
+    public void test2() throws Exception {
+        String sql = "WITH ranked_data AS (\n" +
+                "    SELECT\n" +
+                "      *,\n" +
+                "      ROW_NUMBER() OVER (\n" +
+                "        PARTITION BY CONCAT(col_project.col_id, RAND())\n" +
+                "        ORDER BY (col_header.col_timestamp + RAND() * 10000) DESC\n" +
+                "      ) AS rank\n" +
+                "    FROM\n" +
+                "      t1\n" +
+                "),\n" +
+                "deduped_data AS (\n" +
+                "    SELECT\n" +
+                "      *\n" +
+                "    FROM\n" +
+                "      ranked_data\n" +
+                "    WHERE\n" +
+                "      rank = 1\n" +
+                "),\n" +
+                "processed_data AS (\n" +
+                "    SELECT\n" +
+                "      col_project.col_id AS project_id,\n" +
+                "      col_project.col_title AS project_title,\n" +
+                "      col_batches.col_batch_name AS batch_name,\n" +
+                "      col_batches.col_batch_id AS batch_id,\n" +
+                "      col_items.col_item_id AS item_id,\n" +
+                "      col_items.col_title AS item_title,\n" +
+                "      col_items.col_type AS item_type,\n" +
+                "      col_criteria.col_value AS criteria_value\n" +
+                "    FROM\n" +
+                "      deduped_data\n" +
+                "    CROSS JOIN UNNEST(col_project.col_batches) AS batch_table (col_batches)\n" +
+                "    CROSS JOIN UNNEST(col_batches.col_criteria) AS criteria_table (col_criteria)\n" +
+                "    CROSS JOIN UNNEST(col_batches.col_items) AS items_table (col_items)\n" +
+                "    WHERE col_criteria.col_operator = 'LTE'\n" +
+                ")\n" +
+                "SELECT\n" +
+                "  SUM(MURMUR_HASH3_32(processed_data.project_title)),\n" +
+                "  SUM(MURMUR_HASH3_32(processed_data.batch_name))\n" +
+                "FROM\n" +
+                "  processed_data;\n";
+        String plan = UtFrameUtils.getFragmentPlan(connectContext, sql);
+        assertCContains(plan, "  1:Project\n" +
+                "  |  <slot 11> : concat(4: col_project.col_id[true], CAST(rand() AS VARCHAR))\n" +
+                "  |  <slot 12> : CAST(3: col_header.col_timestamp[true] AS DOUBLE) + rand() * 10000.0\n" +
+                "  |  <slot 32> : 4: col_project.col_title[false]\n" +
+                "  |  <slot 37> : 4: col_project.col_batches[false]\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -706,22 +706,22 @@ public class ExpressionTest extends PlanTestBase {
                 "AS actions FROM action1 GROUP BY uid) AS t ) AS t1) AS t2;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 32> : minutes_add(31: expr, 90)\n" +
-                "  |  <slot 33> : 31: expr != '2020-01-01 00:00:00'\n" +
-                "  |  <slot 22> : array_sort(4: array_agg)\n" +
-                "  |  <slot 23> : array_sortby(5: array_agg, 4: array_agg)\n" +
-                "  |  <slot 24> : array_map((<slot 8>, <slot 9>) -> (<slot 9> = '浏览') " +
-                "AND ((<slot 8> >= '2020-01-02 00:00:00') " +
-                "AND (<slot 8> <= '2020-01-02 23:59:59')), 22: array_sort, 23: array_sortby)\n" +
-                "  |  <slot 25> : array_filter(22: array_sort, 24: array_map)\n" +
-                "  |  <slot 26> : 25: array_filter[1]\n" +
-                "  |  <slot 27> : minutes_add(26: expr, 90)\n" +
-                "  |  <slot 28> : 26: expr != '2020-01-01 00:00:00'\n" +
-                "  |  <slot 29> : array_map((<slot 11>, <slot 12>) -> ((<slot 12> = '下单') " +
-                "AND ((<slot 11> >= 26: expr) AND (<slot 11> <= 27: minutes_add))) " +
-                "AND (28: expr), 22: array_sort, 23: array_sortby)\n" +
-                "  |  <slot 30> : array_filter(22: array_sort, 29: array_map)\n" +
-                "  |  <slot 31> : 30: array_filter[1]");
+                "  |  <slot 20> : array_sort(4: array_agg)\n" +
+                "  |  <slot 21> : array_sortby(5: array_agg, 4: array_agg)\n" +
+                "  |  <slot 22> : array_map((<slot 8>, <slot 9>) -> (<slot 9> = '浏览') " +
+                "AND ((<slot 8> >= '2020-01-02 00:00:00') AND (<slot 8> <= '2020-01-02 23:59:59')), " +
+                "20: array_sort, 21: array_sortby)\n" +
+                "  |  <slot 23> : array_filter(20: array_sort, 22: array_map)\n" +
+                "  |  <slot 24> : 23: array_filter[1]\n" +
+                "  |  <slot 25> : minutes_add(24: expr, 90)\n" +
+                "  |  <slot 26> : 24: expr != '2020-01-01 00:00:00'\n" +
+                "  |  <slot 27> : array_map((<slot 11>, <slot 12>) -> ((<slot 12> = '下单') " +
+                "AND ((<slot 11> >= 24: expr) AND (<slot 11> <= 25: minutes_add))) " +
+                "AND (26: expr), 20: array_sort, 21: array_sortby)\n" +
+                "  |  <slot 28> : array_filter(20: array_sort, 27: array_map)\n" +
+                "  |  <slot 29> : 28: array_filter[1]\n" +
+                "  |  <slot 30> : minutes_add(29: expr, 90)\n" +
+                "  |  <slot 31> : 29: expr != '2020-01-01 00:00:00'");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
@@ -313,9 +313,9 @@ public class GroupingSetTest extends PlanTestBase {
                 "    ) tev,unnest(x2) \n" +
                 ") tev group by GROUPING SETS((u2, r1)) ";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "8:Project\n" +
+        assertContains(plan, "  8:Project\n" +
                 "  |  <slot 10> : 10: unnest\n" +
-                "  |  <slot 11> : datediff(CAST(split(9: array_join, ',')[2] AS DATETIME), CAST(10: unnest AS DATETIME))\n" +
+                "  |  <slot 11> : datediff(CAST(13: expr AS DATETIME), CAST(10: unnest AS DATETIME))\n" +
                 "  |  \n" +
                 "  7:TableValueFunction\n" +
                 "  |  tableFunctionName: unnest\n" +
@@ -324,7 +324,7 @@ public class GroupingSetTest extends PlanTestBase {
                 "  |  \n" +
                 "  6:Project\n" +
                 "  |  <slot 6> : 6: array_agg\n" +
-                "  |  <slot 9> : array_join(7: array_agg, ',')");
+                "  |  <slot 13> : split(array_join(7: array_agg, ','), ',')[2]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -181,7 +181,7 @@ public class LowCardinalityArrayTest extends PlanTestBase {
         String sql = "with cte as (select * from supplier_nullable, unnest(S_ADDRESS)) " +
                 "select * from cte union all select * from cte";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "41: DictDefine(39: S_ADDRESS, [<place-holder>])");
+        assertContains(plan, "39: DictDefine(37: S_ADDRESS, [<place-holder>])");
         connectContext.getSessionVariable().setCboCteReuse(false);
     }
 
@@ -271,13 +271,13 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                 "       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)\n" +
                 "from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;";
         String plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan, plan.contains(" Global Dict Exprs:\n" +
-                "    25: DictDefine(24: a2, [<place-holder>])\n" +
-                "    26: DictDefine(23: a1, [<place-holder>])\n" +
-                "    27: DictDefine(23: a1, [<place-holder>])\n" +
-                "    28: DictDefine(24: a2, [<place-holder>])\n" +
-                "    29: DictDefine(23: a1, [<place-holder>])\n" +
-                "    30: DictDefine(24: a2, [<place-holder>])"));
+        Assert.assertTrue(plan, plan.contains("  Global Dict Exprs:\n" +
+                "    19: DictDefine(18: a2, [<place-holder>])\n" +
+                "    20: DictDefine(17: a1, [<place-holder>])\n" +
+                "    21: DictDefine(17: a1, [<place-holder>])\n" +
+                "    22: DictDefine(18: a2, [<place-holder>])\n" +
+                "    23: DictDefine(17: a1, [<place-holder>])\n" +
+                "    24: DictDefine(18: a2, [<place-holder>])"));
     }
 
     @Test
@@ -331,56 +331,56 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                 "from supplier_nullable xx join[shuffle] table_int t on S_NATIONKEY = id_int " +
                 "where S_ADDRESS[0] = 'a'";
         String plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan, plan.contains(" Global Dict Exprs:\n" +
-                "    32: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
-                "    27: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
-                "    28: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
-                "    29: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
-                "    30: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
-                "    31: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
+        Assert.assertTrue(plan, plan.contains("  Global Dict Exprs:\n" +
+                "    26: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
+                "    27: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
+                "    28: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
+                "    29: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
+                "    30: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
+                "    31: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
                 "\n" +
                 "  1:Project\n" +
                 "  |  output columns:\n" +
                 "  |  4 <-> [4: S_NATIONKEY, INT, false]\n" +
-                "  |  26 <-> [26: S_ADDRESS, ARRAY<INT>, true]\n" +
-                "  |  27 <-> array_max[([35: reverse, ARRAY<INT>, true]); args: INVALID_TYPE; result: INT; args " +
-                "nullable: true; result nullable: true]\n" +
-                "  |  28 <-> 35: reverse[2]\n" +
-                "  |  29 <-> array_min[([26: S_ADDRESS, ARRAY<INT>, true]); args: INVALID_TYPE; result: INT; args " +
-                "nullable: true; result nullable: true]\n" +
-                "  |  30 <-> array_distinct(array_slice(26: S_ADDRESS, 2, 4))[0]\n" +
-                "  |  31 <-> array_slice(26: S_ADDRESS, 1, 2)[0]\n" +
-                "  |  32 <-> array_max[([26: S_ADDRESS, ARRAY<INT>, true]); args: INVALID_TYPE; result: INT; args " +
-                "nullable: true; result nullable: true]\n" +
+                "  |  25 <-> [25: S_ADDRESS, ARRAY<INT>, true]\n" +
+                "  |  26 <-> array_max[([34: reverse, ARRAY<INT>, true]); " +
+                "args: INVALID_TYPE; result: INT; args nullable: true; result nullable: true]\n" +
+                "  |  27 <-> 34: reverse[2]\n" +
+                "  |  28 <-> array_min[([25: S_ADDRESS, ARRAY<INT>, true]); " +
+                "args: INVALID_TYPE; result: INT; args nullable: true; result nullable: true]\n" +
+                "  |  29 <-> array_distinct(array_slice(25: S_ADDRESS, 2, 4))[0]\n" +
+                "  |  30 <-> array_slice(25: S_ADDRESS, 1, 2)[0]\n" +
+                "  |  31 <-> array_max[([25: S_ADDRESS, ARRAY<INT>, true]); " +
+                "args: INVALID_TYPE; result: INT; args nullable: true; result nullable: true]\n" +
                 "  |  common expressions:\n" +
-                "  |  33 <-> reverse[([26: S_ADDRESS, ARRAY<INT>, true]); args: INVALID_TYPE; result: ARRAY<INT>; " +
-                "args nullable: true; result nullable: true]\n" +
-                "  |  34 <-> array_distinct[([33: reverse, ARRAY<INT>, true]); args: INVALID_TYPE; result: " +
-                "ARRAY<INT>; args nullable: true; result nullable: true]\n" +
-                "  |  35 <-> reverse[([34: array_distinct, ARRAY<INT>, true]); args: INVALID_TYPE; result: " +
-                "ARRAY<INT>; args nullable: true; result nullable: true]\n" +
-                "  |  cardinality: 1"));
+                "  |  32 <-> reverse[([25: S_ADDRESS, ARRAY<INT>, true]); " +
+                "args: INVALID_TYPE; result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                "  |  33 <-> array_distinct[([32: reverse, ARRAY<INT>, true]); " +
+                "args: INVALID_TYPE; result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                "  |  34 <-> reverse[([33: array_distinct, ARRAY<INT>, true]); " +
+                "args: INVALID_TYPE; result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                "  |  cardinality: 1\n"));
 
-        assertContains(plan, " Global Dict Exprs:\n" +
-                "    32: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
-                "    27: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
-                "    28: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
-                "    29: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
-                "    30: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
-                "    31: DictDefine(26: S_ADDRESS, [<place-holder>])\n" +
+        assertContains(plan, "  Global Dict Exprs:\n" +
+                "    26: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
+                "    27: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
+                "    28: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
+                "    29: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
+                "    30: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
+                "    31: DictDefine(25: S_ADDRESS, [<place-holder>])\n" +
                 "\n" +
                 "  6:Project\n" +
                 "  |  output columns:\n" +
-                "  |  11 <-> DictDecode(29: array_min, [<place-holder>])\n" +
-                "  |  12 <-> DictDecode(30: expr, [<place-holder>])\n" +
-                "  |  13 <-> DictDecode(31: expr, [hex(<place-holder>)])\n" +
-                "  |  14 <-> DictDecode(32: array_max, [upper(<place-holder>)])\n" +
-                "  |  15 <-> DictDecode(26: S_ADDRESS, [<place-holder>], array_distinct(array_filter(26: S_ADDRESS, " +
-                "[TRUE,FALSE])))\n" +
-                "  |  16 <-> DictDecode(26: S_ADDRESS, [<place-holder>], reverse(array_distinct(reverse(26: " +
-                "S_ADDRESS))))\n" +
-                "  |  17 <-> DictDecode(27: array_max, [<place-holder>])\n" +
-                "  |  18 <-> DictDecode(28: expr, [<place-holder>])\n" +
+                "  |  11 <-> DictDecode(28: array_min, [<place-holder>])\n" +
+                "  |  12 <-> DictDecode(29: expr, [<place-holder>])\n" +
+                "  |  13 <-> DictDecode(30: expr, [hex(<place-holder>)])\n" +
+                "  |  14 <-> DictDecode(31: array_max, [upper(<place-holder>)])\n" +
+                "  |  15 <-> DictDecode(25: S_ADDRESS, [<place-holder>], " +
+                "array_distinct(array_filter(25: S_ADDRESS, [TRUE,FALSE])))\n" +
+                "  |  16 <-> DictDecode(25: S_ADDRESS, [<place-holder>], " +
+                "reverse(array_distinct(reverse(25: S_ADDRESS))))\n" +
+                "  |  17 <-> DictDecode(26: array_max, [<place-holder>])\n" +
+                "  |  18 <-> DictDecode(27: expr, [<place-holder>])\n" +
                 "  |  cardinality: 1");
     }
 
@@ -572,7 +572,8 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                 "group by x1";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan, plan.contains("  1:Project\n" +
-                "  |  <slot 14> : DictDefine(13: S_ADDRESS, [hex(<place-holder>)], array_slice(13: S_ADDRESS, 1, 2)[0])\n" +
+                "  |  <slot 14> : DictDefine(13: S_ADDRESS, [hex(<place-holder>)], " +
+                "array_slice(13: S_ADDRESS, 1, 2)[0])\n" +
                 "  |  <slot 15> : DictDefine(13: S_ADDRESS, [upper(<place-holder>)], array_max(13: S_ADDRESS))"));
     }
 
@@ -597,15 +598,16 @@ public class LowCardinalityArrayTest extends PlanTestBase {
     public void testArrayIfNullArray() throws Exception {
         String sql = "select ifnull(a1, a2), a1, a2 from s2 order by v1";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "ifnull(DictDecode(9: a1, [<place-holder>]), DictDecode(10: a2, [<place-holder>]))");
+        assertContains(plan, "ifnull(DictDecode(6: a1, [<place-holder>]), " +
+                "DictDecode(7: a2, [<place-holder>]))");
     }
 
     @Test
     public void testArrayIfNullString() throws Exception {
         String sql = "select ifnull(a1[1], a2[1]), a1, a2 from s2 order by v1";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "ifnull(DictDecode(10: a1, [<place-holder>], 10: a1[1])," + 
-                " DictDecode(11: a2, [<place-holder>], 11: a2[1]))");
+        assertContains(plan, "ifnull(DictDecode(8: a1, [<place-holder>], 8: a1[1]), " +
+                "DictDecode(9: a2, [<place-holder>], 9: a2[1]))");
     }
 
     @Test
@@ -628,25 +630,28 @@ public class LowCardinalityArrayTest extends PlanTestBase {
     public void testUnnestArray() throws Exception {
         String sql = "select S_ADDRESS[2], col.unnest from supplier_nullable, unnest(S_ADDRESS) col;";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "  1:TableValueFunction\n" +
+        assertContains(plan, "  2:TableValueFunction\n" +
                 "  |  tableFunctionName: unnest\n" +
                 "  |  columns: [unnest]\n" +
                 "  |  returnTypes: [INT]\n");
-        assertContains(plan, "  2:Project\n" +
+        assertContains(plan, "  3:Project\n" +
                 "  |  output columns:\n" +
-                "  |  10 <-> DictDecode(12: S_ADDRESS, [<place-holder>], 12: S_ADDRESS[2])\n" +
-                "  |  13 <-> [13: unnest, INT, true]");
+                "  |  10 <-> DictDecode(14: expr, [<place-holder>])\n" +
+                "  |  13 <-> [13: unnest, INT, true]\n" +
+                "  |  cardinality: 1");
 
         sql = "select S_ADDRESS[2], lower(col.unnest) from supplier_nullable, unnest(S_ADDRESS) col;";
         plan = getVerboseExplain(sql);
-        assertContains(plan, "  1:TableValueFunction\n" +
+        assertContains(plan, "  2:TableValueFunction\n" +
                 "  |  tableFunctionName: unnest\n" +
                 "  |  columns: [unnest]\n" +
-                "  |  returnTypes: [INT]\n");
-        assertContains(plan, "  2:Project\n" +
+                "  |  returnTypes: [INT]\n" +
+                "  |  cardinality: 1");
+        assertContains(plan, "  3:Project\n" +
                 "  |  output columns:\n" +
-                "  |  10 <-> DictDecode(13: S_ADDRESS, [<place-holder>], 13: S_ADDRESS[2])\n" +
-                "  |  11 <-> DictDecode(14: unnest, [lower(<place-holder>)])");
+                "  |  10 <-> DictDecode(15: expr, [<place-holder>])\n" +
+                "  |  11 <-> DictDecode(14: unnest, [lower(<place-holder>)])\n" +
+                "  |  cardinality: 1");
     }
 
     @Test
@@ -654,15 +659,17 @@ public class LowCardinalityArrayTest extends PlanTestBase {
         String sql = "select S_ADDRESS[2], unnest.a, unnest.b " +
                 "from supplier_nullable, unnest(S_ADDRESS, S_PHONE) as unnest(a, b) ;";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "  1:TableValueFunction\n" +
+        assertContains(plan, "  2:TableValueFunction\n" +
                 "  |  tableFunctionName: unnest\n" +
                 "  |  columns: [unnest]\n" +
-                "  |  returnTypes: [INT, CHAR(15)]\n");
-        assertContains(plan, "  2:Project\n" +
+                "  |  returnTypes: [INT, CHAR(15)]\n" +
+                "  |  cardinality: 1");
+        assertContains(plan, "  3:Project\n" +
                 "  |  output columns:\n" +
                 "  |  10 <-> [10: b, CHAR(15), true]\n" +
-                "  |  11 <-> DictDecode(13: S_ADDRESS, [<place-holder>], 13: S_ADDRESS[2])\n" +
-                "  |  14 <-> [14: a, INT, true]");
+                "  |  11 <-> DictDecode(15: expr, [<place-holder>])\n" +
+                "  |  14 <-> [14: a, INT, true]\n" +
+                "  |  cardinality: 1");
 
         sql = "select *" +
                 "from s3, unnest(a1, a2, a3) as unnest(a, b, c) ;";
@@ -672,22 +679,23 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                 "  |  columns: [unnest]\n" +
                 "  |  returnTypes: [INT, INT, INT]");
         assertContains(plan, "  2:Decode\n" +
-                "  |  <dict id 12> : <string id 3>\n" +
-                "  |  <dict id 13> : <string id 5>\n" +
-                "  |  <dict id 14> : <string id 6>\n" +
-                "  |  <dict id 15> : <string id 8>");
+                "  |  <dict id 9> : <string id 3>\n" +
+                "  |  <dict id 10> : <string id 5>\n" +
+                "  |  <dict id 11> : <string id 6>\n" +
+                "  |  <dict id 12> : <string id 8>\n" +
+                "  |  cardinality: 1");
         assertContains(plan, "  Global Dict Exprs:\n" +
-                "    14: DictDefine(12: a1, [<place-holder>])\n" +
-                "    15: DictDefine(13: a3, [<place-holder>])");
+                "    11: DictDefine(9: a1, [<place-holder>])\n" +
+                "    12: DictDefine(10: a3, [<place-holder>])");
 
         sql = "select *" +
                 "from s3, unnest(a1, a2, array_map(x -> concat(x, 'abc'), a3)) as unnest(a, b, c) ;";
         plan = getVerboseExplain(sql);
-        assertContains(plan, "  |  10 <-> array_map[(" +
-                "[9, VARCHAR(65533), true] -> concat[([9, VARCHAR(65533), true], 'abc'); " +
-                "args: VARCHAR; result: VARCHAR; args nullable: true; result nullable: true], " +
-                "DictDecode(15: a3, [<place-holder>])); " +
-                "args: FUNCTION,INVALID_TYPE; result: ARRAY<VARCHAR>; args nullable: true; result nullable: true]");
+        assertContains(plan, "  |  10 <-> array_map[([9, VARCHAR(65533), true] -> concat" +
+                "[([9, VARCHAR(65533), true], 'abc'); args: VARCHAR; result: VARCHAR; args nullable: " +
+                "true; result nullable: true], DictDecode(12: a3, [<place-holder>])); args: " +
+                "FUNCTION,INVALID_TYPE; result: ARRAY<VARCHAR>; args nullable: true; result nullable:" +
+                " true]\n");
         assertContains(plan, "dict_col=a1,a3");
         assertContains(plan, "  2:TableValueFunction\n" +
                 "  |  tableFunctionName: unnest\n" +
@@ -701,25 +709,25 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                 "       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)\n" +
                 "from s4 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;";
         String plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan, plan.contains(" Global Dict Exprs:\n" +
-                "    25: DictDefine(24: a2, [<place-holder>])\n" +
-                "    26: DictDefine(23: a1, [<place-holder>])\n" +
-                "    27: DictDefine(23: a1, [<place-holder>])\n" +
-                "    28: DictDefine(24: a2, [<place-holder>])\n" +
-                "    29: DictDefine(23: a1, [<place-holder>])\n" +
-                "    30: DictDefine(24: a2, [<place-holder>])"));
+        Assert.assertTrue(plan, plan.contains("  Global Dict Exprs:\n" +
+                "    19: DictDefine(18: a2, [<place-holder>])\n" +
+                "    20: DictDefine(17: a1, [<place-holder>])\n" +
+                "    21: DictDefine(17: a1, [<place-holder>])\n" +
+                "    22: DictDefine(18: a2, [<place-holder>])\n" +
+                "    23: DictDefine(17: a1, [<place-holder>])\n" +
+                "    24: DictDefine(18: a2, [<place-holder>])"));
 
         sql = "select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),\n" +
                 "       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)\n" +
                 "from s5 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;";
         plan = getVerboseExplain(sql);
-        Assert.assertTrue(plan, plan.contains("Global Dict Exprs:\n" +
-                "    25: DictDefine(24: a2, [<place-holder>])\n" +
-                "    26: DictDefine(23: a1, [<place-holder>])\n" +
-                "    27: DictDefine(23: a1, [<place-holder>])\n" +
-                "    28: DictDefine(24: a2, [<place-holder>])\n" +
-                "    29: DictDefine(23: a1, [<place-holder>])\n" +
-                "    30: DictDefine(24: a2, [<place-holder>])"));
+        Assert.assertTrue(plan, plan.contains("  Global Dict Exprs:\n" +
+                "    19: DictDefine(18: a2, [<place-holder>])\n" +
+                "    20: DictDefine(17: a1, [<place-holder>])\n" +
+                "    21: DictDefine(17: a1, [<place-holder>])\n" +
+                "    22: DictDefine(18: a2, [<place-holder>])\n" +
+                "    23: DictDefine(17: a1, [<place-holder>])\n" +
+                "    24: DictDefine(18: a2, [<place-holder>])"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -553,6 +553,7 @@ public class PlanTestNoneDBBase {
                 Assert.assertEquals(exceptString.toString(), ex.getMessage());
                 return true;
             }
+            ex.printStackTrace();
             Assert.fail("Planning failed, message: " + ex.getMessage() + ", sql: " + sql);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1251,14 +1251,14 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  9:Project\n" +
                 "  |  <slot 13> : 13: array_slice\n" +
-                "  |  <slot 14> : date(22: expr)\n" +
-                "  |  <slot 16> : coalesce(array_map(<slot 15> -> [<slot 15>[1],<slot 15>[2]], 13: array_slice), " +
-                "CAST([[]] AS ARRAY<ARRAY<VARCHAR(65533)>>))\n" +
-                "  |  <slot 17> : 22: expr\n" +
+                "  |  <slot 14> : date(20: expr)\n" +
+                "  |  <slot 16> : coalesce(array_map(<slot 15> -> [<slot 15>[1],<slot 15>[2]], " +
+                "13: array_slice), CAST([[]] AS ARRAY<ARRAY<VARCHAR(65533)>>))\n" +
+                "  |  <slot 17> : 20: expr\n" +
                 "  |  \n" +
                 "  8:HASH JOIN");
         assertContains(plan, "  1:Project\n" +
-                "  |  <slot 18> : clone(22: expr)\n" +
-                "  |  <slot 22> : 22: expr");
+                "  |  <slot 18> : clone(20: expr)\n" +
+                "  |  <slot 20> : 20: expr");
     }
 }


### PR DESCRIPTION
cp #55823 
## Why I'm doing:

Clone multiple duplicates of entire complex objects like struct instead of its required output subfield in TableFunction Operator is time consuming. so we must support subfield pushdown through table function.

for the query I mentioned in the UT test, this optimization performs well
1. concurrency=1,  speed up 1.799/0.369=4.8X
2. concurrency=10, speed up 10.172/1.610=6.3X


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr



