### PR TITLE
[BugFix] Fix edit log hole error caused by JournalWriter throwing uncached exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
@@ -87,9 +87,9 @@ public class JournalWriter {
             protected void runOneCycle() {
                 try {
                     writeOneBatch();
-                } catch (InterruptedException e) {
-                    String msg = "got interrupted exception when trying to write one batch, will exit now.";
-                    LOG.error(msg, e);
+                } catch (Throwable t) {
+                    String msg = "got exception when trying to write one batch, will exit now.";
+                    LOG.error(msg, t);
                     // TODO we should exit gracefully on InterruptedException
                     Util.stdoutWithTime(msg);
                     System.exit(-1);


### PR DESCRIPTION
## Why I'm doing:
Regardless of what exception is thrown by writeOneBatch, the system should exit. If the next round of writeOneBatch is executed successfully, an edit log hole error will be generated because the log data in the queue has been lost.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0