### PR TITLE
[Enhancement] Set the default value of datacache_tiered_cache_enable to false

### DIFF
--- a/be/src/block_cache/datacache_utils.cpp
+++ b/be/src/block_cache/datacache_utils.cpp
@@ -124,22 +124,6 @@ Status DataCacheUtils::parse_conf_datacache_disk_paths(const std::string& config
     return Status::OK();
 }
 
-Status DataCacheUtils::parse_conf_datacache_disk_spaces(const std::string& config_disk_path,
-                                                        const std::string& config_disk_size, bool ignore_broken_disk,
-                                                        std::vector<DirSpace>* disk_spaces) {
-    std::vector<std::string> paths;
-    RETURN_IF_ERROR(parse_conf_datacache_disk_paths(config_disk_path, &paths, ignore_broken_disk));
-    for (auto& p : paths) {
-        int64_t disk_size = parse_conf_datacache_disk_size(p, config_disk_size, -1);
-        if (disk_size < 0) {
-            LOG(ERROR) << "invalid disk size for datacache: " << disk_size;
-            return Status::InvalidArgument("invalid disk size for datacache");
-        }
-        disk_spaces->push_back({.path = p, .size = static_cast<size_t>(disk_size)});
-    }
-    return Status::OK();
-}
-
 void DataCacheUtils::clean_residual_datacache(const std::string& disk_path) {
     if (!FileSystem::Default()->path_exists(disk_path).ok()) {
         // ignore none existed disk path

--- a/be/src/block_cache/datacache_utils.h
+++ b/be/src/block_cache/datacache_utils.h
@@ -32,10 +32,6 @@ public:
     static Status parse_conf_datacache_disk_paths(const std::string& config_path, std::vector<std::string>* paths,
                                                   bool ignore_broken_disk);
 
-    static Status parse_conf_datacache_disk_spaces(const std::string& config_disk_path,
-                                                   const std::string& config_disk_size, bool ignore_broken_disk,
-                                                   std::vector<DirSpace>* disk_spaces);
-
     static void clean_residual_datacache(const std::string& disk_path);
 
     static Status change_disk_path(const std::string& old_disk_path, const std::string& new_disk_path);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -201,9 +201,6 @@ CONF_Int32(be_service_threads, "64");
 // key=value pair of default query options for StarRocks, separated by ','
 CONF_String(default_query_options, "");
 
-// If non-zero, StarRocks will output memory usage every log_mem_usage_interval'th fragment completion.
-// CONF_Int32(log_mem_usage_interval, "0");
-
 // Controls the number of threads to run work per core.  It's common to pick 2x
 // or 3x the number of cores.  This keeps the cores busy without causing excessive
 // thrashing.
@@ -1183,7 +1180,7 @@ CONF_Double(datacache_scheduler_threads_per_cpu, "0.125");
 // If false, the raw data will be written to disk directly and read from disk without promotion.
 // For object data, such as parquet footer object, which can only be cached in memory are not affected
 // by this configuration.
-CONF_Bool(datacache_tiered_cache_enable, "true");
+CONF_Bool(datacache_tiered_cache_enable, "false");
 // Whether to persist cached data
 CONF_Bool(datacache_persistence_enable, "true");
 // DataCache engines, alternatives: starcache.

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -4028,7 +4028,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 
 ##### datacache_tiered_cache_enable
 
-- Default: true
+- Default: false 
 - Type: Boolean
 - Unit: -
 - Is mutable: No

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -3987,7 +3987,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### datacache_tiered_cache_enable
 
-- 默认值：true
+- 默认值：false
 - 类型：Boolean
 - 单位：-
 - 是否动态：否


### PR DESCRIPTION
## Why I'm doing:

Why i modify this default value:

* Currently, the default value of `datacache_mem_size` is 0. Although `datacache_tiered_cache_enable` is true by default, the mem cache is not actually effective, only disk cache is effective.
* We want to enable the `footer mem cache` by default to address performance issues related to parsing footers in certain user scenarios. Therefore, we need to set `datacache_mem_size` to a non-zero value.` Since datacache_tiered_cache_enable` is true by default, this will cause the mem cache to store not only footers but also data.
* Data of external catalog is generally large in size. If enabled by default and shared with internal tables, it may lead to significant memory eviction. To be cautious, we will first enable only the `footer mem cache`.
* After researching the behavior of other databases, it is generally found that they typically use disk to cache the raw data, while using mem to cache the parsed data.

## What I'm doing:

Set the default value of datacache_tiered_cache_enable to false

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0