### PR TITLE
[BugFix] add some defensive codes to table metrics

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1563,4 +1563,6 @@ CONF_mInt32(json_parse_many_batch_size, "1000000");
 CONF_mBool(enable_dynamic_batch_size_for_json_parse_many, "true");
 CONF_mInt32(put_combined_txn_log_thread_pool_num_max, "64");
 CONF_mBool(enable_put_combinded_txn_log_parallel, "false");
+// used to control whether the metrics/ interface collects table metrics
+CONF_mBool(enable_collect_table_metrics, "true");
 } // namespace starrocks::config

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -65,7 +65,6 @@
 #include "util/compression/compression_utils.h"
 #include "util/defer_op.h"
 #include "util/stack_util.h"
-#include "util/starrocks_metrics.h"
 #include "util/thread.h"
 #include "util/thrift_rpc_helper.h"
 #include "util/uid_util.h"

--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -117,6 +117,7 @@ const std::string SimpleCoreMetricsVisitor::MAX_DISK_IO_UTIL_PERCENT = "max_disk
 const std::string SimpleCoreMetricsVisitor::MAX_NETWORK_SEND_BYTES_RATE = "max_network_send_bytes_rate";
 const std::string SimpleCoreMetricsVisitor::MAX_NETWORK_RECEIVE_BYTES_RATE = "max_network_receive_bytes_rate";
 
+const std::string TableMetricsPrefix = "table_";
 void PrometheusMetricsVisitor::visit(const std::string& prefix, const std::string& name, MetricCollector* collector) {
     if (collector->empty() || name.empty()) {
         return;
@@ -126,6 +127,9 @@ void PrometheusMetricsVisitor::visit(const std::string& prefix, const std::strin
         metric_name = name;
     } else {
         metric_name = prefix + "_" + name;
+    }
+    if (!config::enable_collect_table_metrics && name.starts_with(TableMetricsPrefix)) {
+        return;
     }
     // Output metric type
     _ss << "# TYPE " << metric_name << " " << collector->type() << "\n";
@@ -288,6 +292,9 @@ private:
 
 void JsonMetricsVisitor::visit(const std::string& prefix, const std::string& name, MetricCollector* collector) {
     if (collector->empty() || name.empty()) {
+        return;
+    }
+    if (!config::enable_collect_table_metrics && name.starts_with(TableMetricsPrefix)) {
         return;
     }
 

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -81,9 +81,14 @@ StarOSWorker::StarOSWorker() : _mtx(), _shards(), _fs_cache(new_lru_cache(1024))
 
 StarOSWorker::~StarOSWorker() = default;
 
+static const uint64_t kUnknownTableId = UINT64_MAX;
 uint64_t StarOSWorker::get_table_id(const ShardInfo& shard) {
     const auto& properties = shard.properties;
-    CHECK(properties.contains("tableId"));
+    auto iter = properties.find("tableId");
+    if (iter == properties.end()) {
+        DCHECK(false) << "tableId doesn't exist in shard properties";
+        return kUnknownTableId;
+    }
     return std::stoull(properties.at("tableId"));
 }
 

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -89,7 +89,13 @@ uint64_t StarOSWorker::get_table_id(const ShardInfo& shard) {
         DCHECK(false) << "tableId doesn't exist in shard properties";
         return kUnknownTableId;
     }
-    return std::stoull(properties.at("tableId"));
+    const auto& tableId = properties.at("tableId");
+    try {
+        return std::stoull(tableId);
+    } catch (const std::exception& e) {
+        DCHECK(false) << "failed to parse tableId: " << tableId << ", " << e.what();
+        return kUnknownTableId;
+    }
 }
 
 absl::Status StarOSWorker::add_shard(const ShardInfo& shard) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9217

Add some defensive code for table metrics:
1. under shared_data mode, if the tableId cannot be found from the shard property, return a default table id to avoid crash.
2. In some scenarios, the corresponding table id may not be found in _metrics_map (for example, data load and drop tablet concurrently, dropping tablets occurs first, causing metrics to be cleared). in such cases, we can return a blackhole metrics to prevent the subsequent operations works well.
3. When there are so many tables, `metrics/` interfaces may have to return a lot of table metrics, resulting in too large response body. I chose to add a configuration to control whether to return table metrics.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0