### PR TITLE
[BugFix] predicate column usage exist duplicate when cluster has multiple fe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsStorage.java
@@ -48,7 +48,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsStorageTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mockito;
 
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -146,4 +147,42 @@ class PredicateColumnsStorageTest extends PlanTestBase {
         Assertions.assertEquals(usage2, result.get(1));
     }
 
+    @Test
+    public void duplicateColumnUsages() {
+        Database db = starRocksAssert.getDb("test");
+        Table t1 = starRocksAssert.getTable("test", "t1");
+        Column v4 = t1.getColumn("v4");
+        Column v5 = t1.getColumn("v5");
+
+        List<ColumnUsage> duplicatedColumnUsages = new ArrayList<>();
+        ColumnUsage usage1 = new ColumnUsage(ColumnFullId.create(db, t1, v4),
+                TableName.fromString("default_catalog.test.t1"),
+                EnumSet.of(ColumnUsage.UseCase.PREDICATE, ColumnUsage.UseCase.DISTINCT));
+        usage1.setCreated(LocalDateTime.parse("2025-01-01T01:02:03"));
+        usage1.setLastUsed(LocalDateTime.parse("2025-01-02T01:02:03"));
+        duplicatedColumnUsages.add(usage1);
+
+        ColumnUsage usage2 = new ColumnUsage(ColumnFullId.create(db, t1, v4),
+                TableName.fromString("default_catalog.test.t1"),
+                EnumSet.of(ColumnUsage.UseCase.PREDICATE, ColumnUsage.UseCase.JOIN));
+        usage2.setCreated(LocalDateTime.parse("2025-01-01T01:02:03"));
+        usage2.setLastUsed(LocalDateTime.parse("2025-01-02T02:02:03"));
+        duplicatedColumnUsages.add(usage2);
+
+        ColumnUsage usage3 = new ColumnUsage(ColumnFullId.create(db, t1, v5),
+                TableName.fromString("default_catalog.test.t1"),
+                EnumSet.of(ColumnUsage.UseCase.GROUP_BY, ColumnUsage.UseCase.JOIN));
+        usage3.setCreated(LocalDateTime.parse("2025-01-01T01:02:03"));
+        usage3.setLastUsed(LocalDateTime.parse("2025-01-02T03:02:03"));
+        duplicatedColumnUsages.add(usage3);
+
+        List<ColumnUsage> result = PredicateColumnsStorage.getInstance().deduplicateColumnUsages(duplicatedColumnUsages);
+
+        Assertions.assertEquals(2, result.size());
+        ColumnUsage r1 = result.get(1);
+        Assertions.assertEquals(EnumSet.of(ColumnUsage.UseCase.PREDICATE, ColumnUsage.UseCase.JOIN,
+                ColumnUsage.UseCase.DISTINCT), r1.getUseCases());
+        Assertions.assertEquals(LocalDateTime.parse("2025-01-02T02:02:03"), r1.getLastUsed());
+
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsStorageTest.java
@@ -148,7 +148,7 @@ class PredicateColumnsStorageTest extends PlanTestBase {
     }
 
     @Test
-    public void duplicateColumnUsages() {
+    public void testDuplicateColumnUsages() {
         Database db = starRocksAssert.getDb("test");
         Table t1 = starRocksAssert.getTable("test", "t1");
         Column v4 = t1.getColumn("v4");


### PR DESCRIPTION
## Why I'm doing:
Currently we have recorded the predicate column of each fe. When querying it, the same column will have multiple usages. We need to deduplicate.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0