### PR TITLE
[Tool] Fix the compile problem of benchmark case

### DIFF
--- a/be/src/bench/get_dict_codes_bench.cpp
+++ b/be/src/bench/get_dict_codes_bench.cpp
@@ -15,7 +15,6 @@
 #include <benchmark/benchmark.h>
 
 #include <map>
-#include <memory>
 #include <random>
 #include <vector>
 
@@ -75,7 +74,7 @@ static void BM_GetDictCodesWithMap(benchmark::State& state) {
         if (column->size() == 0) {
             continue;
         }
-        const std::vector<uint8_t>& null_data = down_cast<NullableColumn*>(column.get())->immutable_null_column_data();
+        const auto& null_data = down_cast<NullableColumn*>(column.get())->immutable_null_column_data();
         bool has_null = column->has_null();
         bool all_null = false;
 
@@ -90,7 +89,7 @@ static void BM_GetDictCodesWithMap(benchmark::State& state) {
 
         auto* dict_nullable_column = down_cast<NullableColumn*>(column.get());
         auto* dict_value_binary_column = down_cast<BinaryColumn*>(dict_nullable_column->data_column().get());
-        std::vector<Slice> dict_values_filtered = dict_value_binary_column->get_data();
+        auto dict_values_filtered = dict_value_binary_column->get_data();
         if (!has_null) {
             dict_codes.reserve(dict_values_filtered.size());
             for (size_t i = 0; i < dict_values_filtered.size(); i++) {

--- a/be/src/bench/parquet_dict_decode_bench.cpp
+++ b/be/src/bench/parquet_dict_decode_bench.cpp
@@ -66,7 +66,7 @@ static void BM_DictDecoder(benchmark::State& state) {
     std::random_device rd;
     std::mt19937 rng(rd());
     std::uniform_int_distribution<int> dist(0, 99);
-    std::vector<int32_t> dict_codes;
+    Buffer<int32_t> dict_codes;
     int count = 0;
 
     for (int i = 0; i < kTestChunkSize; i++) {


### PR DESCRIPTION
## Why I'm doing:

```
[100%] Linking CXX executable output/get_dict_codes_bench                                                                                                                                                           
/root/starrocks/be/src/bench/parquet_dict_decode_bench.cpp: In function ‘void starrocks::parquet::BM_DictDecoder(benchmark::State&)’:                                                                               
/root/starrocks/be/src/bench/parquet_dict_decode_bench.cpp:92:49: error: no matching function for call to ‘starrocks::parquet::DictDecoder<starrocks::Slice>::get_dict_values(std::vector<int>&, starrocks::NullableColumn&, std::__shared_ptr<starrocks::Column, __gnu_cxx::_S_at
omic>::element_type*)’                                                                                                                                                                                              
   92 |         Status st = dict_decoder.get_dict_values(dict_codes, *nulls, column.get());                                                                                                                         
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                          
In file included from /root/starrocks/be/src/bench/parquet_dict_decode_bench.cpp:20:                                                                                                                                
/root/starrocks/be/src/formats/parquet/encoding_dict.h:183:12: note: candidate: ‘virtual starrocks::Status starrocks::parquet::DictDecoder<starrocks::Slice>::get_dict_values(starrocks::Column*)’                  
  183 |     Status get_dict_values(Column* column) override {                                                                                                                                                       
      |            ^~~~~~~~~~~~~~~                                                                                                                                                                                  
/root/starrocks/be/src/formats/parquet/encoding_dict.h:183:12: note:   candidate expects 1 argument, 3 provided                                                                                                     
/root/starrocks/be/src/formats/parquet/encoding_dict.h:191:12: note: candidate: ‘virtual starrocks::Status starrocks::parquet::DictDecoder<starrocks::Slice>::get_dict_values(starrocks::Buffer<int>&, const starrocks::NullableColumn&, starrocks::Column*)’
  191 |     Status get_dict_values(const Buffer<int32_t>& dict_codes, const NullableColumn& nulls, Column* column) override {                                                                                       
      |            ^~~~~~~~~~~~~~~                                                                                                                                                                                  
/root/starrocks/be/src/formats/parquet/encoding_dict.h:191:51: note:   no known conversion for argument 1 from ‘std::vector<int>’ to ‘starrocks::Buffer<int>&’ {aka ‘const std::vector<int, starrocks::ColumnAllocator<int> >&’}
  191 |     Status get_dict_values(const Buffer<int32_t>& dict_codes, const NullableColumn& nulls, Column* column) override {  
```

## What I'm doing:

Fix the compile problem of benchmark case

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0