### PR TITLE
[BugFix] fix load spill crash when retry init LoadSpillBlockManager

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -275,7 +275,7 @@ Status DeltaWriterImpl::build_schema_and_writer() {
         if (config::enable_load_spill &&
             !(_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS &&
               (!_merge_condition.empty() || is_partial_update() || _tablet_schema->has_separate_sort_key()))) {
-            if (_load_spill_block_mgr == nullptr) {
+            if (_load_spill_block_mgr == nullptr || !_load_spill_block_mgr->is_initialized()) {
                 _load_spill_block_mgr =
                         std::make_unique<LoadSpillBlockManager>(UniqueId(_load_id).to_thrift(), _tablet_id, _txn_id,
                                                                 _tablet_manager->tablet_root_location(_tablet_id));

--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -100,6 +100,7 @@ Status LoadSpillBlockManager::init() {
                                                                  std::move(remote_block_manager));
     // init block container
     _block_container = std::make_unique<LoadSpillBlockContainer>();
+    _initialized = true;
     return Status::OK();
 }
 

--- a/be/src/storage/lake/load_spill_block_manager.h
+++ b/be/src/storage/lake/load_spill_block_manager.h
@@ -70,6 +70,8 @@ public:
     // Initializes the LoadSpillBlockManager.
     Status init();
 
+    bool is_initialized() const { return _initialized; }
+
     // acquire Block from BlockManager
     StatusOr<spill::BlockPtr> acquire_block(size_t block_size);
     // return Block to BlockManager
@@ -88,6 +90,7 @@ private:
     std::unique_ptr<spill::DirManager> _remote_dir_manager;    // Manager for remote directories.
     std::unique_ptr<spill::BlockManager> _block_manager;       // Manager for blocks.
     std::unique_ptr<LoadSpillBlockContainer> _block_container; // Container for blocks.
+    bool _initialized = false;                                 // Whether the manager is initialized.
 };
 
 } // namespace lake


### PR DESCRIPTION
## Why I'm doing:
When init LoadSpillBlockManager, it could be fail and after retry it, we will skip init because LoadSpillBlockManager isn't nullptr, and it will lead to be crash like:
```
0x71af634 starrocks::lake::SpillMemTableSink::merge_blocks_to_segments()
    @          0x70fdbf8 starrocks::lake::DeltaWriterImpl::finish()
    @          0x70feeaa starrocks::lake::DeltaWriterImpl::finish_with_txnlog(starrocks::lake::DeltaWriterFinishMode)
    @          0x7100604 starrocks::lake::DeltaWriter::finish_with_txnlog(starrocks::lake::DeltaWriterFinishMode)
    @          0x70ed037 starrocks::lake::AsyncDeltaWriterImpl::execute(void*, bthread::TaskIterator<std::shared_ptr<starrocks::lake::AsyncDeltaWriterImpl::Task> >&)
    @          0xb65782c bthread::ExecutionQueueBase::_execute(bthread::TaskNode*, bool, int*)
    @          0xb658847 bthread::ExecutionQueueBase::_execute_tasks(void*)
```

## What I'm doing:

Fixes #53954

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0