### PR TITLE
[Enhancement] Using lru cache to limit the number of starlet filesystem instance

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1047,6 +1047,7 @@ CONF_mInt32(starlet_fslib_s3client_connect_timeout_ms, "1000");
 // NOTE: need to handle the negative value properly
 CONF_Alias(object_storage_request_timeout_ms, starlet_fslib_s3client_request_timeout_ms);
 CONF_mInt32(starlet_delete_files_max_key_in_batch, "1000");
+CONF_mInt32(starlet_filesystem_instance_cache_capacity, "10000");
 #endif
 
 CONF_mInt64(lake_metadata_cache_limit, /*2GB=*/"2147483648");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -368,6 +368,15 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
         UPDATE_STARLET_CONFIG(s3_use_list_objects_v1, fslib_s3client_use_list_objects_v1);
         UPDATE_STARLET_CONFIG(starlet_delete_files_max_key_in_batch, delete_files_max_key_in_batch);
 #undef UPDATE_STARLET_CONFIG
+
+        _config_callback.emplace("starlet_filesystem_instance_cache_capacity", [&]() -> Status {
+            LOG(INFO) << "set starlet_filesystem_instance_cache_capacity:"
+                      << config::starlet_filesystem_instance_cache_capacity;
+            if (g_worker) {
+                g_worker->set_fs_cache_capacity(config::starlet_filesystem_instance_cache_capacity);
+            }
+            return Status::OK();
+        });
 #endif // USE_STAROS
     });
 

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -77,15 +77,22 @@ public:
     // register the listener(callback) when new shard is added to the worker
     void register_add_shard_listener(add_shard_listener listener) { _add_shard_listener = std::move(listener); }
 
+    void set_fs_cache_capacity(int32_t capacity);
+
 private:
     struct ShardInfoDetails {
         ShardInfo shard_info;
-        std::shared_ptr<FileSystem> fs;
+        std::shared_ptr<std::string> fs_cache_key;
 
         ShardInfoDetails(const ShardInfo& info) : shard_info(info) {}
     };
 
-    using CacheValue = std::weak_ptr<FileSystem>;
+    struct CacheValue {
+        std::weak_ptr<std::string> key;
+        std::shared_ptr<FileSystem> fs;
+
+        CacheValue(const std::weak_ptr<std::string>& key, const std::shared_ptr<FileSystem>& fs) : key(key), fs(fs) {}
+    };
 
     // This function can be made static perfectly. The only reason to make it `virtual`
     // is, for unit test MOCK as it is the only interface to interact with g_starlet.
@@ -110,12 +117,20 @@ private:
     uint64_t get_table_id(const ShardInfo& shared_info);
 
     absl::StatusOr<std::shared_ptr<FileSystem>> build_filesystem_on_demand(ShardId id, const Configuration& conf);
-    absl::StatusOr<std::shared_ptr<FileSystem>> build_filesystem_from_shard_info(const ShardInfo& info,
-                                                                                 const Configuration& conf);
-    absl::StatusOr<std::shared_ptr<FileSystem>> new_shared_filesystem(std::string_view scheme,
-                                                                      const Configuration& conf);
+    absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>>
+    build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf);
+    absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>> new_shared_filesystem(
+            std::string_view scheme, const Configuration& conf);
     absl::Status invalidate_fs(const ShardInfo& shard);
 
+    std::shared_ptr<std::string> insert_fs_cache(const std::string& key, const std::shared_ptr<FileSystem>& fs);
+    void erase_fs_cache(const std::string& key);
+    std::shared_ptr<FileSystem> lookup_fs_cache(const std::string& key);
+    std::shared_ptr<FileSystem> lookup_fs_cache(const std::shared_ptr<std::string>& key);
+    absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>> find_fs_cache(
+            const std::string& key);
+
+private:
     mutable std::shared_mutex _mtx;
     std::unordered_map<ShardId, ShardInfoDetails> _shards;
     std::unique_ptr<Cache> _fs_cache;

--- a/be/test/service/staros_worker_test.cpp
+++ b/be/test/service/staros_worker_test.cpp
@@ -15,9 +15,13 @@
 #ifdef USE_STAROS
 #include "service/staros_worker.h"
 
+#include <fslib/configuration.h>
+#include <fslib/fslib_all_initializer.h>
 #include <gtest/gtest.h>
 
 #include <functional>
+
+#include "common/config.h"
 
 namespace starrocks {
 
@@ -60,6 +64,53 @@ TEST(StarOSWorkerTest, test_add_listener) {
     // no change, the shard:2 is already added
     EXPECT_EQ(1, counter);
     EXPECT_EQ(1, ids.size());
+}
+
+TEST(StarOSWorkerTest, test_fs_cache) {
+    staros::starlet::fslib::register_builtin_filesystems();
+    staros::starlet::ShardInfo shard_info;
+    shard_info.id = 1;
+    auto fs_info = shard_info.path_info.mutable_fs_info();
+    fs_info->set_fs_type(staros::FileStoreType::S3);
+    auto s3_fs_info = fs_info->mutable_s3_fs_info();
+    s3_fs_info->set_bucket("test_bucket");
+    s3_fs_info->set_endpoint("test_endpoint");
+    s3_fs_info->set_region("us-east-1");
+    auto credential = s3_fs_info->mutable_credential();
+    auto simple_credential = credential->mutable_simple_credential();
+    simple_credential->set_access_key("test_ak");
+    simple_credential->set_access_key_secret("test_sk");
+    // set full path
+    shard_info.path_info.set_full_path(absl::StrFormat("s3://%s/%d/", s3_fs_info->bucket(), time(NULL)));
+
+    // cache settings
+    shard_info.cache_info.set_enable_cache(false);
+    shard_info.cache_info.set_async_write_back(false);
+
+    auto schema_or = StarOSWorker::build_scheme_from_shard_info(shard_info);
+    EXPECT_TRUE(schema_or.ok());
+    auto schema = schema_or.value();
+
+    auto conf_or = shard_info.fslib_conf_from_this(false, "");
+    EXPECT_TRUE(conf_or.ok());
+    auto conf = conf_or.value();
+
+    auto cache_key = StarOSWorker::get_cache_key(schema, conf);
+
+    auto worker = std::make_shared<StarOSWorker>();
+    g_worker = worker;
+
+    EXPECT_TRUE(worker->add_shard(shard_info).ok());
+
+    EXPECT_FALSE(worker->lookup_fs_cache(cache_key));
+
+    EXPECT_TRUE(worker->get_shard_filesystem(shard_info.id, conf).ok());
+
+    EXPECT_TRUE(worker->lookup_fs_cache(cache_key));
+
+    EXPECT_TRUE(worker->remove_shard(shard_info.id).ok());
+
+    EXPECT_FALSE(worker->lookup_fs_cache(cache_key));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
When there are too many partitions, the starlet filesystem instances also has a lot, this may take too many memory. 

## What I'm doing:
Using lru cache to limit the number of starlet filesystem instance.
Add be config starlet_filesystem_instance_cache_capacity to config the lru cache capacity, default 10000.

Fixes https://github.com/StarRocks/starrocks/issues/55765

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0