### PR TITLE
[BugFix]disable chunked upload in aws sdk while we have support it in poco

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -428,6 +428,8 @@ if [ $AWS_SDK_CPP_SOURCE = "aws-sdk-cpp-1.11.267" ]; then
         touch $PATCHED_MARK
     fi
 fi
+cd -
+echo "Finished patching $AWS_SDK_CPP_SOURCE"
 
 # patch jemalloc_hook
 cd $TP_SOURCE_DIR/$JEMALLOC_SOURCE
@@ -468,8 +470,8 @@ cd -
 echo "Finished patching $VPACK_SOURCE"
 
 # patch avro-c
+cd $TP_SOURCE_DIR/$AVRO_SOURCE
 if [ ! -f $PATCHED_MARK ] && [ $AVRO_SOURCE = "avro-release-1.10.2" ]; then
-    touch $PATCHED_MARK
     cd $TP_SOURCE_DIR/$AVRO_SOURCE/lang/c
     patch -p0 < $TP_PATCH_DIR/avro-1.10.2.c.patch
     cd $TP_SOURCE_DIR/$AVRO_SOURCE

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -423,6 +423,10 @@ if [ $AWS_SDK_CPP_SOURCE = "aws-sdk-cpp-1.11.267" ]; then
         bash ./prefetch_crt_dependency.sh
         touch prefetch_crt_dep_ok
     fi
+    if [ ! -f $PATCHED_MARK ]; then
+        patch -p1  < $TP_PATCH_DIR/aws-cpp-sdk-1.11.267-disable-chunked-upload.patch
+        touch $PATCHED_MARK
+    fi
 fi
 
 # patch jemalloc_hook

--- a/thirdparty/patches/aws-cpp-sdk-1.11.267-disable-chunked-upload.patch
+++ b/thirdparty/patches/aws-cpp-sdk-1.11.267-disable-chunked-upload.patch
@@ -1,0 +1,40 @@
+diff --git a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+index ae5407ce76d..96f58aa85fc 100644
+--- a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
++++ b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+@@ -37,7 +37,7 @@ static const char* X_AMZ_SIGNED_HEADERS = "X-Amz-SignedHeaders";
+ static const char* X_AMZ_ALGORITHM = "X-Amz-Algorithm";
+ static const char* X_AMZ_CREDENTIAL = "X-Amz-Credential";
+ static const char* UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD";
+-static const char* STREAMING_UNSIGNED_PAYLOAD_TRAILER = "STREAMING-UNSIGNED-PAYLOAD-TRAILER";
++// static const char* STREAMING_UNSIGNED_PAYLOAD_TRAILER = "STREAMING-UNSIGNED-PAYLOAD-TRAILER";
+ static const char* X_AMZ_SIGNATURE = "X-Amz-Signature";
+ static const char* USER_AGENT = "user-agent";
+ static const char* EMPTY_STRING_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+@@ -263,15 +263,17 @@ bool AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest& request, const char* r
+                 << " http scheme=" << Http::SchemeMapper::ToString(request.GetUri().GetScheme()));
+         if (request.GetRequestHash().second != nullptr)
+         {
+-            payloadHash = STREAMING_UNSIGNED_PAYLOAD_TRAILER;
+-            Aws::String checksumHeaderValue = Aws::String("x-amz-checksum-") + request.GetRequestHash().first;
+-            request.DeleteHeader(checksumHeaderValue.c_str());
+-            request.SetHeaderValue(Http::AWS_TRAILER_HEADER, checksumHeaderValue);
+-            request.SetTransferEncoding(CHUNKED_VALUE);
+-            request.SetHeaderValue(Http::CONTENT_ENCODING_HEADER, Http::AWS_CHUNKED_VALUE);
+-            if (request.HasHeader(Http::CONTENT_LENGTH_HEADER)) {
+-                request.SetHeaderValue(Http::DECODED_CONTENT_LENGTH_HEADER, request.GetHeaderValue(Http::CONTENT_LENGTH_HEADER));
+-                request.DeleteHeader(Http::CONTENT_LENGTH_HEADER);
++            Aws::String checksumHeaderKey = Aws::String("x-amz-checksum-") + request.GetRequestHash().first;
++            const auto headers = request.GetHeaders();
++            if (!request.HasHeader(checksumHeaderKey.c_str()))
++            {
++                // if it is one of the other hashes, we must be careful if there is no content body
++                const auto& body = request.GetContentBody();
++                Aws::String checksumHeaderValue = (body)
++                    ? HashingUtils::Base64Encode(request.GetRequestHash().second->Calculate(*body).GetResult())
++                    : HashingUtils::Base64Encode(request.GetRequestHash().second->Calculate({}).GetResult());
++                request.SetHeaderValue(checksumHeaderKey, checksumHeaderValue);
++                request.SetRequestHash("", nullptr);
+             }
+         }
+     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Fixing the issue when accessing S3 Express One

A community user reported an issue where they encountered an exception 
while creating a table on S3 Express One. Based on our tests, the issue 
occurs with PutObject, while MultiPartUpload works fine when accessing 
S3 Express One.

The root cause is that, even when setting PayloadSigningPolicy::Never, 
requests to S3 Express One still get signed. This results in chunked uploads, 
which are not supported in the Poco client.

I think we can works around this by setting a checksum in the request, 
preventing additional signing and avoiding chunked uploads. However, 
applying this approach in our case would require setting a checksum 
for all PutObject and MultiUpload requests across both starrocks_be 
and staros, which is error-prone.

To address this more reliably, I propose disabling chunked uploads 
via a patch to aws-cpp-sdk.

and once we supported chunked upload, we can remove this patch.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/55685

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0