### PR TITLE
[Enhancement] Make lake publish operation async in alter job to avoid stuck other job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -400,7 +400,6 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         }
 
         if (!publishVersion()) {
-            LOG.info("publish version failed, will retry later. jobId={}", jobId);
             return;
         }
 
@@ -652,7 +651,7 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
         return true;
     }
 
-    private boolean publishVersion() {
+    protected boolean lakePublishVersion() {
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
             LakeTable table = getTableOrThrow(db, tableId);
             for (long partitionId : physicalPartitionIdToRollupIndex.keySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -186,7 +186,6 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         }
 
         if (!publishVersion()) {
-            LOG.info("publish version failed, will retry later. jobId={}", jobId);
             return;
         }
 
@@ -255,7 +254,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         return true;
     }
 
-    boolean publishVersion() {
+    protected boolean lakePublishVersion() {
         try {
             TxnInfoPB txnInfo = new TxnInfoPB();
             txnInfo.txnId = watershedTxnId;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -720,7 +720,6 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         }
 
         if (!publishVersion()) {
-            LOG.info("publish version failed, will retry later. jobId={}", jobId);
             return;
         }
 
@@ -776,7 +775,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         return true;
     }
 
-    boolean publishVersion() {
+    protected boolean lakePublishVersion() {
         try {
             TxnInfoPB txnInfo = new TxnInfoPB();
             txnInfo.txnId = watershedTxnId;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -266,6 +266,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -304,6 +305,7 @@ public class GlobalStateMgr {
      * Alter Job Manager
      */
     private final AlterJobMgr alterJobMgr;
+    private final ThreadPoolExecutor lakeAlterPublishExecutor;
 
     private final PortConnectivityChecker portConnectivityChecker;
 
@@ -652,6 +654,8 @@ public class GlobalStateMgr {
                 new SchemaChangeHandler(),
                 new MaterializedViewHandler(),
                 new SystemHandler());
+        this.lakeAlterPublishExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
+                Config.lake_publish_version_max_threads, "alter-publish", false);
 
         this.load = new Load();
         this.streamLoadMgr = new StreamLoadMgr();
@@ -2173,6 +2177,10 @@ public class GlobalStateMgr {
 
     public AlterJobMgr getAlterJobMgr() {
         return alterJobMgr;
+    }
+
+    public ThreadPoolExecutor getLakeAlterPublishExecutor() {
+        return lakeAlterPublishExecutor;
     }
 
     public SchemaChangeHandler getSchemaChangeHandler() {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -383,5 +383,6 @@ public class AlterJobV2Test {
                     GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2().get(alterJobV2Old.jobId);
 
         Assert.assertEquals(alterJobV2Old.jobId, alterJobV2New.jobId);
+        Assert.assertTrue(alterJobV2Old.lakePublishVersion());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRollupJobTest.java
@@ -136,7 +136,10 @@ public class LakeRollupJobTest {
         lakeRollupJob.runRunningJob();
         Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, lakeRollupJob.getJobState());
 
-        lakeRollupJob.runFinishedRewritingJob();
+        while (lakeRollupJob.getJobState() != AlterJobV2.JobState.FINISHED) {
+            lakeRollupJob.runFinishedRewritingJob();
+            Thread.sleep(100);
+        }
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, lakeRollupJob.getJobState());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -111,7 +111,10 @@ public class LakeTableAlterMetaJobTest {
         Assert.assertNotEquals(-1L, job.getTransactionId().orElse(-1L).longValue());
         job.runRunningJob();
         Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
-        job.runFinishedRewritingJob();
+        while (job.getJobState() != AlterJobV2.JobState.FINISHED) {
+            job.runFinishedRewritingJob();
+            Thread.sleep(100);
+        }
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
 
         Assert.assertTrue(table.enablePersistentIndex());
@@ -125,7 +128,10 @@ public class LakeTableAlterMetaJobTest {
         Assert.assertNotEquals(-1L, job.getTransactionId().orElse(-1L).longValue());
         job.runRunningJob();
         Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
-        job.runFinishedRewritingJob();
+        while (job.getJobState() != AlterJobV2.JobState.FINISHED) {
+            job.runFinishedRewritingJob();
+            Thread.sleep(100);
+        }
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
         Assert.assertTrue(table.enablePersistentIndex());
         // check persistent index type been set
@@ -144,7 +150,10 @@ public class LakeTableAlterMetaJobTest {
         Assert.assertNotEquals(-1L, job2.getTransactionId().orElse(-1L).longValue());
         job2.runRunningJob();
         Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job2.getJobState());
-        job2.runFinishedRewritingJob();
+        while (job2.getJobState() != AlterJobV2.JobState.FINISHED) {
+            job2.runFinishedRewritingJob();
+            Thread.sleep(100);
+        }
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, job2.getJobState());
         Assert.assertTrue(table.enablePersistentIndex());
         // check persistent index type been set
@@ -167,7 +176,10 @@ public class LakeTableAlterMetaJobTest {
         Assert.assertNotEquals(-1L, job2.getTransactionId().orElse(-1L).longValue());
         job2.runRunningJob();
         Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job2.getJobState());
-        job2.runFinishedRewritingJob();
+        while (job2.getJobState() != AlterJobV2.JobState.FINISHED) {
+            job2.runFinishedRewritingJob();
+            Thread.sleep(100);
+        }
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, job2.getJobState());
         Assert.assertFalse(table2.enablePersistentIndex());
 
@@ -258,8 +270,12 @@ public class LakeTableAlterMetaJobTest {
     }
 
     @Test
-    public void testReplay() {
+    public void testReplay() throws Exception {
         job.run();
+        while (job.getJobState() != AlterJobV2.JobState.FINISHED) {
+            job.run();
+            Thread.sleep(100);
+        }
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
 
         LakeTableAlterMetaJob replayAlterMetaJob = new LakeTableAlterMetaJob(job.jobId,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -89,6 +89,10 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         alterTable(connectContext, sql);
         AlterJobV2 alterJob = getAlterJob(table);
         alterJob.run();
+        while (alterJob.getJobState() != AlterJobV2.JobState.FINISHED) {
+            alterJob.run();
+            Thread.sleep(100);
+        }
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJob.getJobState());
         return alterJob;
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0