### PR TITLE
[BugFix] Fix fail to do fast schema change on tables with sync mv in shared data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
@@ -314,7 +314,9 @@ public class TabletMetadataUpdateAgentTaskFactory {
                                        boolean createSchemaFile) {
             super(backendId, tablets.hashCode());
             this.tablets = new ArrayList<>(tablets);
-            this.tabletSchema = Objects.requireNonNull(tabletSchema, "tabletSchema is null");
+            // tabletSchema may be null when the table has multi materialized index
+            // and the schema of some materialized indexes are not needed to be updated
+            this.tabletSchema = tabletSchema;
             this.createSchemaFile = createSchemaFile;
         }
 
@@ -330,7 +332,11 @@ public class TabletMetadataUpdateAgentTaskFactory {
             for (Long tabletId : tablets) {
                 TTabletMetaInfo metaInfo = new TTabletMetaInfo();
                 metaInfo.setTablet_id(tabletId);
-                metaInfo.setTablet_schema(tabletSchema);
+
+                if (tabletSchema != null) {
+                    metaInfo.setTablet_schema(tabletSchema);
+                }
+
                 metaInfos.add(metaInfo);
                 metaInfo.setCreate_schema_file(create);
                 create = false;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeSyncMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeSyncMaterializedViewTest.java
@@ -658,4 +658,26 @@ public class LakeSyncMaterializedViewTest {
         }
         starRocksAssert.dropTable("t1");
     }
+
+    @Test
+    public void testDropColumnWithMVByFastSchema() throws Exception {
+        starRocksAssert.useDatabase("test");
+        starRocksAssert.withTable("CREATE TABLE t1 (\n" +
+                "  k1  int,\n" +
+                "  k2  int,\n" +
+                "  k3  int,\n" +
+                "  k4  int)\n" +
+                "  DUPLICATE KEY(k1)\n" +
+                "  DISTRIBUTED BY HASH(k1) BUCKETS 3;");
+        {
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv1 " +
+                    "AS SELECT k1,sum(k2) AS sum_k2 FROM t1 WHERE k3>2 GROUP BY k1;");
+
+            starRocksAssert.alterTable("ALTER TABLE t1 DROP COLUMN k4;");
+            starRocksAssert.checkSchemaChangeJob();
+
+            starRocksAssert.dropTable("t1");
+            starRocksAssert.dropMaterializedView("mv1");
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
when `enable_fast_schema_evolution` is set to true in shared data
```
create database materialized_view_test_db_770f0542_e849_11ef_9e47_00163e0e489a;
use materialized_view_test_db_770f0542_e849_11ef_9e47_00163e0e489a;
CREATE TABLE t1 (
                    k1  int,
                    k2  int,
                    k3  int,
                    k4  int)
                DUPLICATE KEY(k1)
                DISTRIBUTED BY HASH(k1) BUCKETS 3
                PROPERTIES (
                    "replication_num" = "3",
                    "storage_format" = "v2"
                );
INSERT INTO t1 VALUES (1,1,1,1),(2,2,2,2),(3,3,3,3),(4,4,4,4);
CREATE MATERIALIZED VIEW mv1 AS SELECT k1,sum(k2) AS sum_k2 FROM t1 WHERE k3>2 GROUP BY k1;
SHOW ALTER MATERIALIZED VIEW;
SHOW ALTER MATERIALIZED VIEW;
ALTER TABLE t1 DROP COLUMN k4;
SHOW ALTER TABLE COLUMN ORDER BY JobId DESC LIMIT 1;

---alter table always in pending status
mysql> SHOW ALTER TABLE COLUMN ORDER BY JobId DESC;
+--------+-----------+---------------------+------------+-----------+---------+---------------+---------------+---------------+---------+------+----------+---------+-------------------+
| JobId  | TableName | CreateTime          | FinishTime | IndexName | IndexId | OriginIndexId | SchemaVersion | TransactionId | State   | Msg  | Progress | Timeout | Warehouse         |
+--------+-----------+---------------------+------------+-----------+---------+---------------+---------------+---------------+---------+------+----------+---------+-------------------+
| 249836 | t1        | 2025-02-11 16:14:55 | NULL       | t1        | 249819  | 249819        | 1:0           | 14081         | PENDING |      | NULL     | 86400   | default_warehouse |
+--------+-----------+---------------------+------------+-----------+---------+---------------+---------------+---------------+---------+------+----------+---------+-------------------+
1 row in set (0.00 sec)
```
The reason is that when dropping a column, you may only need to modify the schema of partial indexes, and the task generated for the index which are not needed to modify  is null.
![image](https://github.com/user-attachments/assets/005bc7a5-df45-459a-9459-796a38824037)

## What I'm doing:
The task will still be generated for the indexes which are  not needed to modify to increase the version of tablet meta
Fixes 

Fixes https://github.com/StarRocks/StarRocksTest/issues/9226

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0