### PR TITLE
[BugFix] Introduce tablet_schema into MorselQueue for tablet_internal_parallel in clould native table

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -506,13 +506,13 @@ Status PhysicalSplitMorselQueue::_init_segment() {
             _tablet_seek_ranges.clear();
             _mempool.clear();
             if (!_tablets[_tablet_idx]->belonged_to_cloud_native()) {
-                RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
-                                                               _range_end_op, _range_start_key, _range_end_key,
-                                                               &_tablet_seek_ranges, &_mempool));
+                RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablet_schema, _range_start_op, _range_end_op,
+                                                               _range_start_key, _range_end_key, &_tablet_seek_ranges,
+                                                               &_mempool));
             } else {
-                RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablets[_tablet_idx]->tablet_schema(),
-                                                                     _range_start_op, _range_end_op, _range_start_key,
-                                                                     _range_end_key, &_tablet_seek_ranges, &_mempool));
+                RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablet_schema, _range_start_op, _range_end_op,
+                                                                     _range_start_key, _range_end_key,
+                                                                     &_tablet_seek_ranges, &_mempool));
             }
         }
         // Read a new rowset.
@@ -845,13 +845,13 @@ Status LogicalSplitMorselQueue::_init_tablet() {
     if (_tablet_idx == 0) {
         // All the tablets have the same schema, so parse seek range with the first table schema.
         if (!_tablets[_tablet_idx]->belonged_to_cloud_native()) {
-            RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
-                                                           _range_end_op, _range_start_key, _range_end_key,
-                                                           &_tablet_seek_ranges, &_mempool));
+            RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablet_schema, _range_start_op, _range_end_op,
+                                                           _range_start_key, _range_end_key, &_tablet_seek_ranges,
+                                                           &_mempool));
         } else {
-            RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablets[_tablet_idx]->tablet_schema(),
-                                                                 _range_start_op, _range_end_op, _range_start_key,
-                                                                 _range_end_key, &_tablet_seek_ranges, &_mempool));
+            RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablet_schema, _range_start_op, _range_end_op,
+                                                                 _range_start_key, _range_end_key, &_tablet_seek_ranges,
+                                                                 &_mempool));
         }
     }
 
@@ -863,8 +863,7 @@ Status LogicalSplitMorselQueue::_init_tablet() {
     RETURN_IF_ERROR(_largest_rowset->load());
     ASSIGN_OR_RETURN(_segment_group, _create_segment_group(_largest_rowset));
 
-    _short_key_schema =
-            std::make_shared<Schema>(ChunkHelper::get_short_key_schema(_tablets[_tablet_idx]->tablet_schema()));
+    _short_key_schema = std::make_shared<Schema>(ChunkHelper::get_short_key_schema(_tablet_schema));
     const auto tablet_num_rows = std::max<int64_t>({1, static_cast<int64_t>(_tablets[_tablet_idx]->num_rows()),
                                                     _largest_rowset->num_rows(), _segment_group->num_rows()});
     _sample_splitted_scan_blocks = _splitted_scan_rows * _segment_group->num_blocks() / tablet_num_rows;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -360,6 +360,10 @@ public:
     virtual StatusOr<bool> ready_for_next() const { return true; }
     virtual Status append_morsels(Morsels&& morsels);
     virtual Type type() const = 0;
+    void set_tablet_schema(TabletSchemaCSPtr tablet_schema) {
+        DCHECK(tablet_schema != nullptr);
+        _tablet_schema = tablet_schema;
+    }
     bool has_more() const { return _has_more; }
     void set_has_more(bool v) { _has_more = v; }
 
@@ -370,6 +374,7 @@ protected:
     MorselPtr _unget_morsel = nullptr;
     std::vector<BaseTabletSharedPtr> _tablets;
     std::vector<std::vector<BaseRowsetSharedPtr>> _tablet_rowsets;
+    TabletSchemaCSPtr _tablet_schema = nullptr;
 };
 
 // The morsel queue with a fixed number of morsels, which is determined in the constructor.

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -84,7 +84,8 @@ StatusOr<ChunkPtr> OlapScanPrepareOperator::pull_chunk(RuntimeState* state) {
     _morsel_queue->set_tablet_rowsets(std::move(tablet_rowsets));
 
     if ((_morsel_queue->type() == MorselQueue::Type::LOGICAL_SPLIT ||
-         _morsel_queue->type() == MorselQueue::Type::PHYSICAL_SPLIT) && !tablets.empty()) {
+         _morsel_queue->type() == MorselQueue::Type::PHYSICAL_SPLIT) &&
+        !tablets.empty()) {
         _morsel_queue->set_tablet_schema(tablets[0]->tablet_schema());
     }
 

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -83,7 +83,9 @@ StatusOr<ChunkPtr> OlapScanPrepareOperator::pull_chunk(RuntimeState* state) {
     }
     _morsel_queue->set_tablet_rowsets(std::move(tablet_rowsets));
 
-    _morsel_queue->set_tablet_schema(tablets[0]->tablet_schema());
+    if (_morsel_queue->type() == LOGICAL_SPLIT || _morsel_queue->type() == PHYSICAL_SPLIT) {
+        _morsel_queue->set_tablet_schema(tablets[0]->tablet_schema());
+    }
 
     DeferOp defer([&]() {
         _ctx->set_prepare_finished();

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -83,7 +83,8 @@ StatusOr<ChunkPtr> OlapScanPrepareOperator::pull_chunk(RuntimeState* state) {
     }
     _morsel_queue->set_tablet_rowsets(std::move(tablet_rowsets));
 
-    if (_morsel_queue->type() == LOGICAL_SPLIT || _morsel_queue->type() == PHYSICAL_SPLIT) {
+    if ((_morsel_queue->type() == MorselQueue::Type::LOGICAL_SPLIT ||
+         _morsel_queue->type() == MorselQueue::Type::PHYSICAL_SPLIT) && !tablets.empty()) {
         _morsel_queue->set_tablet_schema(tablets[0]->tablet_schema());
     }
 

--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -83,6 +83,8 @@ StatusOr<ChunkPtr> OlapScanPrepareOperator::pull_chunk(RuntimeState* state) {
     }
     _morsel_queue->set_tablet_rowsets(std::move(tablet_rowsets));
 
+    _morsel_queue->set_tablet_schema(tablets[0]->tablet_schema());
+
     DeferOp defer([&]() {
         _ctx->set_prepare_finished();
         _ctx->notify_observers();

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -167,6 +167,7 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
         split_morsel_queue->set_tablet_rowsets(std::move(tablet_rowsets));
         split_morsel_queue->set_key_ranges(read_params.range, read_params.end_range, read_params.start_key,
                                            read_params.end_key);
+        split_morsel_queue->set_tablet_schema(_tablet_schema);
 
         while (true) {
             auto split = split_morsel_queue->try_get().value();


### PR DESCRIPTION
## Why I'm doing:
In current impl tablet_internal_parallel in clould native table, LogicalSplitMorselQueue/PhysicalSplitMorselQueue
will use lake::Tablet::tablet_schema to get tablet_schema info to parse the seek range. But the problem is that,
lake::Tablet::tablet_schema will return nullptr in some case and make BE/CN crash when parse the range.

Beside, lake::Tablet::tablet_schema can not ensure the version of tablet schema is same as the version in lake::TabletReader.

## What I'm doing:
Introduce tablet_schema into MorselQueue by hand instead using (lake::)Tablet::tablet_schema to get tablet_schema.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0