### PR TITLE
[Enhancement] Simplify the exception log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -224,7 +224,10 @@ public interface IcebergCatalog extends MemoryTrackable {
                         try {
                             lastUpdated = row.get(7, Long.class);
                         } catch (NullPointerException e) {
-                            logger.error("The table [{}] snapshot [{}] has been expired", nativeTable.name(), snapshotId, e);
+                            // It is a known issue but we do not hanle it right now. If the refresh frequency of 
+                            // the materialized view is very high, an excessive number of error logs will be printed. 
+                            // Therefore, only brief logs are printed now.
+                            logger.error("The table [{}] snapshot [{}] has been expired", nativeTable.name(), snapshotId);
                         }
                         partition = new Partition(lastUpdated);
                         break;


### PR DESCRIPTION
## Why I'm doing:
The exception log is as following:
```
The table [testdb.xxxx] snapshot [tenant_id=15205] has been expired

java.lang.NullPointerException
	at com.starrocks.connector.iceberg.IcebergMetadata.getPartitions(IcebergMetadata.java:479)
	at com.starrocks.connector.CatalogConnectorMetadata.getPartitions(CatalogConnectorMetadata.java:168)
	at com.starrocks.server.MetadataMgr.getPartitions(MetadataMgr.java:773)
	at com.starrocks.connector.partitiontraits.IcebergPartitionTraits.getPartitions(IcebergPartitionTraits.java:64)
	at com.starrocks.connector.partitiontraits.DefaultTraits.getPartitionNameWithPartitionInfo(DefaultTraits.java:116)
	at com.starrocks.connector.partitiontraits.DefaultTraits.getUpdatedPartitionNames(DefaultTraits.java:134)
	at com.starrocks.catalog.MaterializedView.getUpdatedPartitionNamesOfExternalTable(MaterializedView.java:828)
	at com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo(MvRefreshArbiter.java:185)
	at com.starrocks.scheduler.mv.MVPCTRefreshPartitioner.getMvPartitionNamesToRefresh(MVPCTRefreshPartitioner.java:185)
	at com.starrocks.scheduler.mv.MVPCTRefreshRangePartitioner.getMVPartitionsToRefresh(MVPCTRefreshRangePartitioner.java:235)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.getPartitionsToRefreshForMaterializedView(PartitionBasedMvRefreshProcessor.java:974)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.getPartitionsToRefreshForMaterializedView(PartitionBasedMvRefreshProcessor.java:932)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.checkMvToRefreshedPartitions(PartitionBasedMvRefreshProcessor.java:289)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedView(PartitionBasedMvRefreshProcessor.java:439)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doRefreshMaterializedViewWithRetry(PartitionBasedMvRefreshProcessor.java:368)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:327)
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:199)
	at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:272)
	at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:59)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

It is a known issue but we do not hanle it right now. If the refresh frequency of the materialized view is very high, an excessive number of error logs will be printed. 

Therefore, only brief logs are printed now.
```
The table [testdb.xxxx] snapshot [tenant_id=15205] has been expired
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0