### PR TITLE
[BugFix] Use correct TabletReader::parse_seek_range for clould native table when tablet_internal_parallel is enabled

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -510,9 +510,9 @@ Status PhysicalSplitMorselQueue::_init_segment() {
                                                                _range_end_op, _range_start_key, _range_end_key,
                                                                &_tablet_seek_ranges, &_mempool));
             } else {
-                RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
-                                                                     _range_end_op, _range_start_key, _range_end_key,
-                                                                     &_tablet_seek_ranges, &_mempool));
+                RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablets[_tablet_idx]->tablet_schema(),
+                                                                     _range_start_op, _range_end_op, _range_start_key,
+                                                                     _range_end_key, &_tablet_seek_ranges, &_mempool));
             }
         }
         // Read a new rowset.
@@ -849,9 +849,9 @@ Status LogicalSplitMorselQueue::_init_tablet() {
                                                            _range_end_op, _range_start_key, _range_end_key,
                                                            &_tablet_seek_ranges, &_mempool));
         } else {
-            RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
-                                                                 _range_end_op, _range_start_key, _range_end_key,
-                                                                 &_tablet_seek_ranges, &_mempool));
+            RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablets[_tablet_idx]->tablet_schema(),
+                                                                 _range_start_op, _range_end_op, _range_start_key,
+                                                                 _range_end_key, &_tablet_seek_ranges, &_mempool));
         }
     }
 

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -21,6 +21,7 @@
 #include "common/statusor.h"
 #include "exec/olap_utils.h"
 #include "storage/chunk_helper.h"
+#include "storage/lake/tablet_reader.h"
 #include "storage/range.h"
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/rowset/rowset.h"
@@ -504,9 +505,15 @@ Status PhysicalSplitMorselQueue::_init_segment() {
         if (0 == _rowset_idx) {
             _tablet_seek_ranges.clear();
             _mempool.clear();
-            RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
-                                                           _range_end_op, _range_start_key, _range_end_key,
-                                                           &_tablet_seek_ranges, &_mempool));
+            if (!_tablets[_tablet_idx]->belonged_to_cloud_native()) {
+                RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
+                                                               _range_end_op, _range_start_key, _range_end_key,
+                                                               &_tablet_seek_ranges, &_mempool));
+            } else {
+                RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
+                                                                     _range_end_op, _range_start_key, _range_end_key,
+                                                                     &_tablet_seek_ranges, &_mempool));
+            }
         }
         // Read a new rowset.
         RETURN_IF_ERROR(_cur_rowset()->load());
@@ -837,9 +844,15 @@ Status LogicalSplitMorselQueue::_init_tablet() {
 
     if (_tablet_idx == 0) {
         // All the tablets have the same schema, so parse seek range with the first table schema.
-        RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
-                                                       _range_end_op, _range_start_key, _range_end_key,
-                                                       &_tablet_seek_ranges, &_mempool));
+        if (!_tablets[_tablet_idx]->belonged_to_cloud_native()) {
+            RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
+                                                           _range_end_op, _range_start_key, _range_end_key,
+                                                           &_tablet_seek_ranges, &_mempool));
+        } else {
+            RETURN_IF_ERROR(lake::TabletReader::parse_seek_range(*_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
+                                                                 _range_end_op, _range_start_key, _range_end_key,
+                                                                 &_tablet_seek_ranges, &_mempool));
+        }
     }
 
     _largest_rowset = _find_largest_rowset(_tablet_rowsets[_tablet_idx]);

--- a/be/src/storage/base_tablet.h
+++ b/be/src/storage/base_tablet.h
@@ -121,6 +121,8 @@ public:
 
     virtual StatusOr<bool> has_delete_predicates(const Version& version) = 0;
 
+    virtual bool belonged_to_cloud_native() const = 0;
+
 protected:
     virtual void on_shutdown() {}
 

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -172,6 +172,8 @@ public:
 
     size_t num_rows() const override;
 
+    bool belonged_to_cloud_native() const override { return true; }
+
 private:
     TabletManager* _mgr;
     int64_t _id;

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -87,6 +87,13 @@ public:
 
     void get_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks) { split_tasks->swap(_split_tasks); }
 
+    static Status parse_seek_range(const TabletSchema& tablet_schema,
+                                   TabletReaderParams::RangeStartOperation range_start_op,
+                                   TabletReaderParams::RangeEndOperation range_end_op,
+                                   const std::vector<OlapTuple>& range_start_key,
+                                   const std::vector<OlapTuple>& range_end_key, std::vector<SeekRange>* ranges,
+                                   MemPool* mempool);
+
 protected:
     Status do_get_next(Chunk* chunk) override;
     Status do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) override;
@@ -108,13 +115,6 @@ private:
 
     static Status to_seek_tuple(const TabletSchema& tablet_schema, const OlapTuple& input, SeekTuple* tuple,
                                 MemPool* mempool);
-
-    static Status parse_seek_range(const TabletSchema& tablet_schema,
-                                   TabletReaderParams::RangeStartOperation range_start_op,
-                                   TabletReaderParams::RangeEndOperation range_end_op,
-                                   const std::vector<OlapTuple>& range_start_key,
-                                   const std::vector<OlapTuple>& range_end_key, std::vector<SeekRange>* ranges,
-                                   MemPool* mempool);
 
     TabletManager* _tablet_mgr;
     std::shared_ptr<const TabletMetadataPB> _tablet_metadata;

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -115,6 +115,8 @@ public:
     size_t version_count() const;
     Version max_version() const;
 
+    bool belonged_to_cloud_native() const override { return false; }
+
     // propreties encapsulated in TabletSchema
     KeysType keys_type() const;
     size_t num_columns_with_max_version() const;


### PR DESCRIPTION
## Why I'm doing:
LogicalSplitMorselQueue/PhysicalSplitMorselQueue does not use correct lake::TabletReader::parse_seek_range or TabletReader::parse_seek_range for different type of tablet which is a risk (It's safe for now).

## What I'm doing:
Make sure LogicalSplitMorselQueue/PhysicalSplitMorselQueue use correct parse_seek_range.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0