### PR TITLE
[Enhancement] Cancel checkpoint by checkpoint worker node if the worker node is follower

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/CheckpointController.java
@@ -489,8 +489,9 @@ public class CheckpointController extends FrontendDaemon {
 
     public void cancelCheckpoint(String nodeName, String reason) {
         if (nodeName.equals(workerNodeName)) {
+            String leaderNodeName = GlobalStateMgr.getServingState().getNodeMgr().getNodeName();
             result.offer(Pair.create(false, reason));
-            LOG.warn("cancel checkpoint on node: {}, because: {}", nodeName, reason);
+            LOG.warn("cancel checkpoint on leader node: {}, by worker node: {}, because: {}", leaderNodeName, nodeName, reason);
         }
     }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1938,6 +1938,16 @@ struct TFinishCheckpointResponse {
     1: optional Status.TStatus status;
 }
 
+struct TCancelCheckpointRequest {
+    1: optional string node_name;
+    2: optional string reason;
+    3: optional bool is_global_state_mgr;
+}
+
+struct TCancelCheckpointResponse {
+    1: optional Status.TStatus status;
+}
+
 // Batch fetching partition meta info by a list of tablet ids
 // FIXME: add auth info to the request, so the API will be secured
 struct TPartitionMetaRequest {
@@ -2117,5 +2127,7 @@ service FrontendService {
 
     TClusterSnapshotsResponse getClusterSnapshotsInfo(1: TClusterSnapshotsRequest request)
     TClusterSnapshotJobsResponse getClusterSnapshotJobsInfo(1: TClusterSnapshotJobsRequest request)
+
+    TCancelCheckpointResponse cancelCheckpoint(1: TCancelCheckpointRequest request)
 }
 


### PR DESCRIPTION
## Why I'm doing:
If follower is checkpoint worker node and finishCheckpoint failed in worker side, checkpoint controller in leader will stuck in createImage for checkpoint_timeout_seconds(24 * 3600) which is not reasonable.

## What I'm doing:
Cancel checkpoint by checkpoint worker if finishCheckpoint failed.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0