### PR TITLE
[BugFix] Fix FunctionParams NPE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
@@ -61,7 +61,7 @@ public class FunctionParams implements Writable {
     private List<OrderByElement> orderByElements;
     // c'tor for non-star params
     public FunctionParams(boolean isDistinct, List<Expr> exprs) {
-        if (exprs.stream().anyMatch(e -> e instanceof NamedArgument)) {
+        if (exprs != null && exprs.stream().anyMatch(e -> e instanceof NamedArgument)) {
             this.exprs = exprs.stream().map(e -> (e instanceof NamedArgument ? ((NamedArgument) e).getExpr()
                     : e)).collect(Collectors.toList());
             this.exprsNames = exprs.stream().map(e -> (e instanceof NamedArgument ? ((NamedArgument) e).getName()

--- a/test/sql/test_stream_load/R/test_stream_load_columns
+++ b/test/sql/test_stream_load/R/test_stream_load_columns
@@ -1,0 +1,33 @@
+-- name: test_stream_load_columns
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `c0` int(11) NOT NULL,
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "columns: c0, create_time=now()" -d '1' ${url}/api/db_${uuid0}/t0/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select c0 from db_${uuid0}.t0;
+-- result:
+1
+-- !result

--- a/test/sql/test_stream_load/T/test_stream_load_columns
+++ b/test/sql/test_stream_load/T/test_stream_load_columns
@@ -1,0 +1,18 @@
+-- name: test_stream_load_columns
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `t0` (
+  `c0` int(11) NOT NULL,
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue"  -H "columns: c0, create_time=now()" -d '1' ${url}/api/db_${uuid0}/t0/_stream_load
+sync;
+
+select c0 from db_${uuid0}.t0;


### PR DESCRIPTION
## Why I'm doing:
In stream load `columns` header, using `now()` to set column value throws the following NPE
```
java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because "exprs" is null
        at com.starrocks.analysis.FunctionParams.<init>(FunctionParams.java:64) ~[starrocks-fe.jar:?]
        at com.starrocks.analysis.FunctionParams.<init>(FunctionParams.java:86) ~[starrocks-fe.jar:?]
        at com.starrocks.load.Load.transformHadoopFunctionExpr(Load.java:1059) ~[starrocks-fe.jar:?]
        at com.starrocks.load.Load.initColumns(Load.java:526) ~[starrocks-fe.jar:?]
        at com.starrocks.planner.StreamLoadScanNode.initColumns(StreamLoadScanNode.java:258) ~[starrocks-fe.jar:?]
        at com.starrocks.planner.StreamLoadScanNode.initParams(StreamLoadScanNode.java:252) ~[starrocks-fe.jar:?]
        at com.starrocks.planner.StreamLoadScanNode.init(StreamLoadScanNode.java:207) ~[starrocks-fe.jar:?]
        at com.starrocks.planner.StreamLoadPlanner.plan(StreamLoadPlanner.java:194) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.streamLoadPutImpl(FrontendServiceImpl.java:1739) ~[starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.streamLoadPut(FrontendServiceImpl.java:1676) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$streamLoadPut.getResult(FrontendService.java:5785) ~[starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$streamLoadPut.getResult(FrontendService.java:5762) ~[starrocks-fe.jar:?]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40) ~[libthrift-0.20.0.jar:0.20.0]
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

Reproduce 

```
CREATE TABLE `test_npe` (
   `channel_type` int(11) NOT NULL,
   `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=OLAP
 PROPERTIES (
    "replication_num" = "1"
 );
```
```
curl --location-trusted -u root: \
    -H "Expect:100-continue"  \
    -H "columns:channel_type,create_time=now()" \
    -d "1" \
    -XPUT http://127.0.0.1:8030/api/test/test_npe/_stream_load
```

## What I'm doing:
Introduced by https://github.com/StarRocks/starrocks/pull/36596 since 3.3. Should check the null arguments in FunctionParams constructor


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0