### PR TITLE
[Enhancement] optimize the performace for topn with large offset

### DIFF
--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -257,8 +257,8 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Logical
         }
         case MergeSort: {
             sorter = std::make_unique<ChunksSorterTopn>(suite._runtime_state.get(), &sort_exprs, &asc_arr, &null_first,
-                                                        "", 0, limit_rows, TTopNType::ROW_NUMBER,
-                                                        params.max_buffered_chunks);
+                                                        "", 0, limit_rows, TTopNType::ROW_NUMBER, max_buffered_rows,
+                                                        max_buffered_bytes params.max_buffered_chunks);
             expected_rows = limit_rows;
             break;
         }

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -166,6 +166,7 @@ set(EXEC_FILES
     schema_scanner/schema_cluster_snapshot_jobs_scanner.cpp
     jdbc_scanner.cpp
     sorting/compare_column.cpp
+    sorting/merge.cpp
     sorting/merge_column.cpp
     sorting/merge_path.cpp
     sorting/merge_cascade.cpp

--- a/be/src/exec/chunks_sorter.h
+++ b/be/src/exec/chunks_sorter.h
@@ -49,17 +49,6 @@ struct DataSegment {
 
     void init(const std::vector<ExprContext*>* sort_exprs, const ChunkPtr& cnk);
 
-    // There is two compares in the method,
-    // the first is:
-    //     compare every row in every DataSegment of data_segments with `rows_to_sort - 1` row of this DataSegment,
-    //     obtain every row compare result in compare_results_array, if <= 0, mark it with `INCLUDE_IN_SEGMENT`.
-    // the second is:
-    //     compare every row in compare_results_array that <= 0 (i.e. `INCLUDE_IN_SEGMENT` part) with the first row of this DataSegment,
-    //     if < 0, then mark it with `SMALLER_THAN_MIN_OF_SEGMENT`
-    Status get_filter_array(std::vector<DataSegment>& data_segments, size_t rows_to_sort,
-                            std::vector<std::vector<uint8_t>>& filter_array, const SortDescs& sort_order_flags,
-                            uint32_t& least_num, uint32_t& middle_num);
-
     void clear() {
         chunk.reset(std::make_unique<Chunk>().release());
         order_by_columns.clear();
@@ -133,8 +122,6 @@ public:
     // Return accurate output rows of this operator
     virtual size_t get_output_rows() const = 0;
 
-    size_t get_next_output_row() { return _next_output_row; }
-
     virtual int64_t mem_usage() const = 0;
 
     virtual bool is_full() { return false; }
@@ -162,8 +149,6 @@ protected:
     const SortDescs _sort_desc;
     const std::string _sort_keys;
     const bool _is_topn;
-
-    size_t _next_output_row = 0;
 
     RuntimeProfile::Counter* _build_timer = nullptr;
     RuntimeProfile::Counter* _sort_timer = nullptr;

--- a/be/src/exec/chunks_sorter_heap_sort.h
+++ b/be/src/exec/chunks_sorter_heap_sort.h
@@ -272,8 +272,7 @@ private:
 
     const size_t _offset;
     const size_t _limit;
-
-    // std::vector<detail::ChunkRowCursor> _sorted_values;
+    size_t _next_output_row = 0;
 
     RuntimeProfile::Counter* _sort_filter_rows = nullptr;
     RuntimeProfile::Counter* _sort_filter_costs = nullptr;

--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -15,7 +15,9 @@
 #include "chunks_sorter_topn.h"
 
 #include "column/column_helper.h"
+#include "column/datum.h"
 #include "column/type_traits.h"
+#include "column/vectorized_fwd.h"
 #include "exec/sorting/merge.h"
 #include "exec/sorting/sort_permute.h"
 #include "exec/sorting/sorting.h"
@@ -29,11 +31,36 @@
 
 namespace starrocks {
 
+void get_compare_results_colwise(size_t rows_to_sort, const Columns& order_by_columns,
+                                 std::vector<CompareVector>& compare_results_array,
+                                 const std::vector<DataSegment>& data_segments, const SortDescs& sort_desc) {
+    size_t dats_segment_size = data_segments.size();
+
+    for (size_t i = 0; i < dats_segment_size; ++i) {
+        size_t rows = data_segments[i].chunk->num_rows();
+        compare_results_array[i].resize(rows, 0);
+    }
+
+    size_t order_by_column_size = order_by_columns.size();
+
+    for (size_t i = 0; i < dats_segment_size; i++) {
+        Buffer<Datum> rhs_values;
+        auto& segment = data_segments[i];
+        for (size_t col_idx = 0; col_idx < order_by_column_size; col_idx++) {
+            rhs_values.push_back(order_by_columns[col_idx]->get(rows_to_sort));
+        }
+        compare_columns(segment.order_by_columns, compare_results_array[i], rhs_values, sort_desc);
+    }
+}
+
 ChunksSorterTopn::ChunksSorterTopn(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                                    const std::vector<bool>* is_asc_order, const std::vector<bool>* is_null_first,
                                    const std::string& sort_keys, size_t offset, size_t limit,
-                                   const TTopNType::type topn_type, size_t max_buffered_chunks)
+                                   const TTopNType::type topn_type, size_t max_buffered_rows, size_t max_buffered_bytes,
+                                   size_t max_buffered_chunks)
         : ChunksSorter(state, sort_exprs, is_asc_order, is_null_first, sort_keys, true),
+          _max_buffered_rows(max_buffered_rows),
+          _max_buffered_bytes(max_buffered_bytes),
           _max_buffered_chunks(max_buffered_chunks),
           _init_merged_segment(false),
           _limit(limit),
@@ -42,7 +69,8 @@ ChunksSorterTopn::ChunksSorterTopn(RuntimeState* state, const std::vector<ExprCo
     DCHECK_GT(_get_number_of_rows_to_sort(), 0) << "output rows can't be empty";
     DCHECK(_topn_type == TTopNType::ROW_NUMBER || _offset == 0);
     auto& raw_chunks = _raw_chunks.chunks;
-    raw_chunks.reserve(max_buffered_chunks);
+    // avoid too large buffer chunks
+    raw_chunks.reserve(std::min<size_t>(max_buffered_chunks, 256));
 }
 
 ChunksSorterTopn::~ChunksSorterTopn() = default;
@@ -55,6 +83,9 @@ void ChunksSorterTopn::setup_runtime(RuntimeState* state, RuntimeProfile* profil
 
 // Cumulative chunks into _raw_chunks for sorting.
 Status ChunksSorterTopn::update(RuntimeState* state, const ChunkPtr& chunk) {
+    if (_limit == 0) {
+        return Status::OK();
+    }
     auto& raw_chunks = _raw_chunks.chunks;
     size_t chunk_number = raw_chunks.size();
     if (chunk_number <= 0) {
@@ -72,13 +103,29 @@ Status ChunksSorterTopn::update(RuntimeState* state, const ChunkPtr& chunk) {
     }
     _raw_chunks.size_of_rows += chunk->num_rows();
 
-    // When number of Chunks exceeds _limit or _size_of_chunk_batch, run sort and then part of
-    // cached chunks can be dropped, so it can reduce the memory usage.
-    // TopN caches _limit or _size_of_chunk_batch primitive chunks,
-    // performs sorting once, and discards extra rows
+    // Avoid TOPN from using too much memory.
+    bool exceed_mem_limit = _raw_chunks.mem_usage() > _max_buffered_bytes;
+    if (exceed_mem_limit) {
+        return _sort_chunks(state);
+    }
 
-    if (_limit > 0 && (chunk_number >= _limit || chunk_number >= _max_buffered_chunks)) {
-        RETURN_IF_ERROR(_sort_chunks(state));
+    // Try to accumulate more chunks.
+    size_t rows_to_sort = _get_number_of_rows_to_sort();
+    if (_merged_runs.num_rows() + _raw_chunks.size_of_rows < rows_to_sort) {
+        return Status::OK();
+    }
+
+    // We have accumulated rows_to_sort rows to build merged runs.
+    if (_merged_runs.num_rows() <= rows_to_sort) {
+        return _sort_chunks(state);
+    }
+
+    // When number of Chunks exceeds _limit or _max_buffered_chunks, run sort and then part of
+    // cached chunks can be dropped, so it can reduce the memory usage.
+    // TopN caches _limit or _max_buffered_chunks primitive chunks,
+    // performs sorting once, and discards extra rows
+    if (chunk_number >= _max_buffered_chunks || _raw_chunks.size_of_rows > _max_buffered_rows) {
+        return _sort_chunks(state);
     }
 
     return Status::OK();
@@ -93,15 +140,16 @@ Status ChunksSorterTopn::do_done(RuntimeState* state) {
     _rank_pruning();
 
     // Skip top OFFSET rows
-    if (_offset > 0) {
-        if (_offset > _merged_segment.chunk->num_rows()) {
-            _merged_segment.clear();
-            _next_output_row = 0;
+    size_t skip_offset = _offset;
+    while (_merged_runs.num_chunks() != 0 && skip_offset > 0) {
+        auto& run = _merged_runs.front();
+        if (skip_offset >= run.num_rows()) {
+            skip_offset -= run.num_rows();
+            _merged_runs.pop_front();
         } else {
-            _next_output_row += _offset;
+            _merged_runs.front().set_range(skip_offset, run.end_index());
+            skip_offset = 0;
         }
-    } else {
-        _next_output_row = 0;
     }
 
     return Status::OK();
@@ -113,14 +161,26 @@ std::vector<RuntimeFilter*>* ChunksSorterTopn::runtime_filters(ObjectPool* pool)
     }
 
     const size_t max_value_row_id = _get_number_of_rows_to_sort() - 1;
-    const auto& order_by_column = _merged_segment.order_by_columns[0];
 
     // if we want build runtime filter,
     // we should reserve at least "rows_to_sort" rows
-    if (max_value_row_id >= order_by_column->size()) {
+    if (max_value_row_id >= _merged_runs.num_rows()) {
         return nullptr;
     }
-    size_t current_max_value_row_id = _topn_type == TTopNType::RANK ? order_by_column->size() - 1 : max_value_row_id;
+
+    size_t current_max_value_row_id = 0;
+    const ColumnPtr* order_by_column_ptr = nullptr;
+    if (_topn_type == TTopNType::RANK) {
+        const auto& run = _merged_runs.back();
+        order_by_column_ptr = &run.orderby[0];
+        current_max_value_row_id = run.chunk->num_rows() - 1;
+    } else {
+        const auto& [run, max_rid] = _get_run_by_row_id(max_value_row_id);
+        order_by_column_ptr = &run->orderby[0];
+        current_max_value_row_id = max_rid;
+    }
+    const auto& order_by_column = *order_by_column_ptr;
+
     // _topn_type != TTopNType::RANK means we need reserve the max_value
     bool is_close_interval = _topn_type == TTopNType::RANK || _sort_desc.num_columns() != 1;
     bool asc = _sort_desc.descs[0].asc_order();
@@ -146,22 +206,27 @@ std::vector<RuntimeFilter*>* ChunksSorterTopn::runtime_filters(ObjectPool* pool)
 
 Status ChunksSorterTopn::get_next(ChunkPtr* chunk, bool* eos) {
     SCOPED_TIMER(_output_timer);
-    if (_next_output_row >= _merged_segment.chunk->num_rows()) {
+    if (_merged_runs.num_chunks() == 0) {
         *chunk = nullptr;
         *eos = true;
         return Status::OK();
     }
     *eos = false;
-    size_t count = std::min(size_t(_state->chunk_size()), _merged_segment.chunk->num_rows() - _next_output_row);
-    chunk->reset(_merged_segment.chunk->clone_empty(count).release());
-    (*chunk)->append_safe(*_merged_segment.chunk, _next_output_row, count);
-    RETURN_IF_ERROR((*chunk)->downgrade());
-    _next_output_row += count;
+    size_t chunk_size = _state->chunk_size();
+    MergedRun& run = _merged_runs.front();
+    *chunk = run.steal_chunk(chunk_size);
+    if (*chunk != nullptr) {
+        RETURN_IF_ERROR((*chunk)->downgrade());
+    }
+    if (run.empty()) {
+        _merged_runs.pop_front();
+    }
+    *eos = false;
     return Status::OK();
 }
 
 size_t ChunksSorterTopn::get_output_rows() const {
-    return _merged_segment.chunk->num_rows();
+    return _merged_runs.num_rows();
 }
 
 Status ChunksSorterTopn::_sort_chunks(RuntimeState* state) {
@@ -284,21 +349,21 @@ Status ChunksSorterTopn::_filter_and_sort_data(RuntimeState* state, std::pair<Pe
         uint32_t smaller_num, include_num;
 
         // Here are 2 cases:
-        // case 1: _merged_segment.chunk->num_rows() >= rows_to_sort, which means we already have enough rows,
+        // case 1: _merged_runs.num_rows() >= rows_to_sort, which means we already have enough rows,
         // so we can use both index of `0` and `rows_to_sort - 1` as the left and right boundary to filter the coming input chunks
         // into three parts, `SMALLER_THAN_MIN_OF_SEGMENT`, `INCLUDE_IN_SEGMENT` and `LARGER_THAN_MAX_OF_SEGMENT`, and the
         // `LARGER_THAN_MAX_OF_SEGMENT` part is simply dropped
-        // case 2: _merged_segment.chunk->num_rows() < rows_to_sort, which means we haven't have enough rows,
+        // case 2: _merged_runs.num_rows() < rows_to_sort, which means we haven't have enough rows,
         // so we can only use the index of `0` as the left boundary to filter the coming input chunks into two parts, `SMALLER_THAN_MIN_OF_SEGMENT` and `INCLUDE_IN_SEGMENT`
 
-        if (_merged_segment.chunk->num_rows() >= rows_to_sort) {
+        if (_merged_runs.num_rows() >= rows_to_sort) {
             SCOPED_TIMER(_sort_filter_timer);
-            RETURN_IF_ERROR(_merged_segment.get_filter_array(segments, rows_to_sort, filter_array, _sort_desc,
-                                                             smaller_num, include_num));
+            RETURN_IF_ERROR(_build_filter_from_high_low_comparison(segments, filter_array, _sort_desc, smaller_num,
+                                                                   include_num));
         } else {
             SCOPED_TIMER(_sort_filter_timer);
             RETURN_IF_ERROR(
-                    _merged_segment.get_filter_array(segments, 1, filter_array, _sort_desc, smaller_num, include_num));
+                    _build_filter_from_low_comparison(segments, filter_array, _sort_desc, smaller_num, include_num));
         }
 
         size_t filtered_rows = 0;
@@ -368,6 +433,93 @@ Status ChunksSorterTopn::_partial_sort_col_wise(RuntimeState* state, std::pair<P
     return Status::OK();
 }
 
+// TODO: process current_max_row_id
+Status ChunksSorterTopn::_build_filter_from_high_low_comparison(const DataSegments& data_segments,
+                                                                std::vector<std::vector<uint8_t>>& filter_array,
+                                                                const SortDescs& sort_descs, uint32_t& smaller_num,
+                                                                uint32_t& include_num) {
+    DCHECK(_merged_runs.num_rows() > 0);
+    size_t data_segment_size = data_segments.size();
+
+    std::vector<CompareVector> compare_results_array(data_segment_size);
+    // First compare the chunk with last row of this segment.
+    const size_t max_value_row_id = _get_number_of_rows_to_sort() - 1;
+    const auto& [run, max_rid] = _get_run_by_row_id(max_value_row_id);
+    get_compare_results_colwise(max_rid, run->orderby, compare_results_array, data_segments, sort_descs);
+
+    include_num = 0;
+    filter_array.resize(data_segment_size);
+    for (size_t i = 0; i < data_segment_size; ++i) {
+        const DataSegment& segment = data_segments[i];
+        size_t rows = segment.chunk->num_rows();
+        filter_array[i].resize(rows);
+
+        for (size_t j = 0; j < rows; ++j) {
+            if (compare_results_array[i][j] <= 0) {
+                filter_array[i][j] = DataSegment::INCLUDE_IN_SEGMENT;
+                ++include_num;
+            }
+        }
+    }
+
+    // Second compare with first row of this chunk, use rows from first compare.
+    {
+        for (size_t i = 0; i < data_segment_size; i++) {
+            for (auto& cmp : compare_results_array[i]) {
+                if (cmp < 0) {
+                    cmp = 0;
+                }
+            }
+        }
+        get_compare_results_colwise(0, _lowest_merged_run().orderby, compare_results_array, data_segments, sort_descs);
+    }
+
+    smaller_num = 0;
+    for (size_t i = 0; i < data_segment_size; ++i) {
+        const DataSegment& segment = data_segments[i];
+        size_t rows = segment.chunk->num_rows();
+
+        for (size_t j = 0; j < rows; ++j) {
+            if (compare_results_array[i][j] < 0) {
+                filter_array[i][j] = DataSegment::SMALLER_THAN_MIN_OF_SEGMENT;
+                ++smaller_num;
+            }
+        }
+    }
+    include_num -= smaller_num;
+    return Status::OK();
+}
+
+Status ChunksSorterTopn::_build_filter_from_low_comparison(const DataSegments& data_segments,
+                                                           std::vector<std::vector<uint8_t>>& filter_array,
+                                                           const SortDescs& sort_descs, uint32_t& smaller_num,
+                                                           uint32_t& include_num) {
+    DCHECK(_merged_runs.num_rows() > 0);
+    size_t data_segment_size = data_segments.size();
+    std::vector<CompareVector> compare_results_array(data_segment_size);
+
+    get_compare_results_colwise(0, _lowest_merged_run().orderby, compare_results_array, data_segments, sort_descs);
+
+    smaller_num = 0, include_num = 0;
+    filter_array.resize(data_segment_size);
+    for (size_t i = 0; i < data_segment_size; ++i) {
+        size_t rows = data_segments[i].chunk->num_rows();
+        filter_array[i].resize(rows);
+
+        for (size_t j = 0; j < rows; ++j) {
+            if (compare_results_array[i][j] < 0) {
+                filter_array[i][j] = DataSegment::SMALLER_THAN_MIN_OF_SEGMENT;
+                ++smaller_num;
+            } else {
+                filter_array[i][j] = DataSegment::INCLUDE_IN_SEGMENT;
+                ++include_num;
+            }
+        }
+    }
+
+    return Status::OK();
+}
+
 Status ChunksSorterTopn::_merge_sort_data_as_merged_segment(RuntimeState* state,
                                                             std::pair<Permutation, Permutation>& new_permutation,
                                                             DataSegments& segments) {
@@ -391,41 +543,71 @@ Status ChunksSorterTopn::_merge_sort_data_as_merged_segment(RuntimeState* state,
 
 // Take rows_to_sort rows from permutation_second merge-sort with _merged_segment.
 // And take result datas into big_chunk.
-Status ChunksSorterTopn::_merge_sort_common(ChunkPtr& big_chunk, DataSegments& segments, const size_t rows_to_keep,
-                                            size_t sorted_size, Permutation& permutation_second) {
+Status ChunksSorterTopn::_merge_sort_common(MergedRuns* dst, DataSegments& segments, const size_t rows_to_keep,
+                                            Permutation& permutation_second) {
     // Assemble the permutated segments into a chunk
-    std::vector<ChunkPtr> right_chunks;
-    for (auto& segment : segments) {
-        right_chunks.push_back(segment.chunk);
+    size_t right_chunk_size = permutation_second.size();
+    ChunkUniquePtr right_unique_chunk =
+            dst->empty() ? segments[permutation_second[0].chunk_index].chunk->clone_empty(right_chunk_size)
+                         : dst->front().chunk->clone_empty(right_chunk_size);
+    {
+        std::vector<ChunkPtr> right_chunks;
+        for (auto& segment : segments) {
+            right_chunks.push_back(segment.chunk);
+        }
+        materialize_by_permutation(right_unique_chunk.get(), right_chunks, permutation_second);
+        permutation_second = {};
     }
-    ChunkPtr right_chunk = big_chunk->clone_empty(permutation_second.size());
-    materialize_by_permutation(right_chunk.get(), right_chunks, permutation_second);
+
     Columns right_columns;
     // ExprContext::evaluate may report error if input chunk is empty
-    if (right_chunk->is_empty()) {
+    if (right_unique_chunk->is_empty()) {
         right_columns.assign(_sort_exprs->size(), nullptr);
     } else {
         for (auto expr : *_sort_exprs) {
-            auto maybe_column = expr->evaluate(right_chunk.get());
-            RETURN_IF_ERROR(maybe_column);
-            right_columns.push_back(maybe_column.value());
+            ASSIGN_OR_RETURN(auto column, expr->evaluate(right_unique_chunk.get()));
+            right_columns.push_back(std::move(column));
         }
     }
 
-    ChunkPtr left_chunk = _merged_segment.chunk;
-    Columns left_columns = _merged_segment.order_by_columns;
+    if (_merged_runs.num_chunks() > 1 || _merged_runs.mem_usage() > _max_buffered_bytes) {
+        // merge to multi sorted chunks
+        RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _merged_runs, std::move(right_unique_chunk),
+                                            rows_to_keep, dst));
+    } else {
+        // merge to big chunk
+        // prepare left chunk
+        MergedRun merged_run = std::move(_merged_runs.front());
+        _merged_runs.pop_front();
+        ChunkPtr left_chunk = std::move(merged_run.chunk);
+        Columns left_columns = std::move(merged_run.orderby);
 
-    Permutation merged_perm;
-    // avoid exaggerated limit + offset, for an example select * from t order by col limit 9223372036854775800,1
-    merged_perm.reserve(std::min<size_t>(rows_to_keep, 10'000'000ul));
+        // prepare right chunk
+        ChunkPtr right_chunk = std::move(right_unique_chunk);
 
-    RETURN_IF_ERROR(merge_sorted_chunks_two_way(_sort_desc, {left_chunk, left_columns}, {right_chunk, right_columns},
-                                                &merged_perm));
-    CHECK_GE(merged_perm.size(), rows_to_keep);
-    merged_perm.resize(rows_to_keep);
+        Permutation merged_perm;
+        merged_perm.reserve(left_chunk->num_rows() + right_chunk->num_rows());
 
-    std::vector<ChunkPtr> chunks{left_chunk, right_chunk};
-    materialize_by_permutation(big_chunk.get(), chunks, merged_perm);
+        RETURN_IF_ERROR(merge_sorted_chunks_two_way(_sort_desc, {left_chunk, left_columns},
+                                                    {right_chunk, right_columns}, &merged_perm));
+        CHECK_GE(merged_perm.size(), rows_to_keep);
+        merged_perm.resize(rows_to_keep);
+
+        // materialize into the dst runs
+        std::vector<ChunkPtr> chunks{left_chunk, right_chunk};
+        ChunkUniquePtr big_chunk;
+        if (dst->num_chunks() == 0) {
+            big_chunk = segments[permutation_second[0].chunk_index].chunk->clone_empty(rows_to_keep);
+        } else {
+            big_chunk = std::move(dst->front().chunk);
+            dst->pop_front();
+        }
+        materialize_by_permutation(big_chunk.get(), chunks, merged_perm);
+        RETURN_IF_ERROR(big_chunk->upgrade_if_overflow());
+        ASSIGN_OR_RETURN(auto run, MergedRun::build(std::move(big_chunk), *_sort_exprs));
+        dst->push_back(std::move(run));
+    }
+
     return Status::OK();
 }
 
@@ -448,22 +630,24 @@ Status ChunksSorterTopn::_hybrid_sort_common(RuntimeState* state, std::pair<Perm
         rows_to_keep = first_size;
     }
 
-    ChunkPtr big_chunk;
-    std::vector<ChunkPtr> chunks;
-    for (auto& segment : segments) {
-        chunks.push_back(segment.chunk);
-    }
-
     // There are three parts of data
-    // _merged_segment, the previously sorted one
+    // _merged_runs, the previously sorted one
     // the `SMALLER_THAN_MIN_OF_SEGMENT` part
     // the `INCLUDE_IN_SEGMENT` part
 
     // First, we find elements from `SMALLER_THAN_MIN_OF_SEGMENT`
+    MergedRuns merged_runs;
     if (first_size > 0) {
-        big_chunk.reset(segments[new_permutation.first[0].chunk_index].chunk->clone_empty(first_size).release());
+        ChunkUniquePtr big_chunk;
+        std::vector<ChunkPtr> chunks;
+        for (auto& segment : segments) {
+            chunks.push_back(segment.chunk);
+        }
+        big_chunk = segments[new_permutation.first[0].chunk_index].chunk->clone_empty(first_size);
         materialize_by_permutation(big_chunk.get(), chunks, new_permutation.first);
         rows_to_keep -= first_size;
+        ASSIGN_OR_RETURN(auto run, MergedRun::build(std::move(big_chunk), *_sort_exprs));
+        merged_runs.push_back(std::move(run));
     }
 
     // Seoncd, there are two cases:
@@ -472,22 +656,16 @@ Status ChunksSorterTopn::_hybrid_sort_common(RuntimeState* state, std::pair<Perm
     // case2: rows_to_keep > 0, which means `SMALLER_THAN_MIN_OF_SEGMENT` part itself not suffice, we need to get more elements
     // from both `INCLUDE_IN_SEGMENT` part and _merged_segment. And notice that `INCLUDE_IN_SEGMENT` part may be empty
     if (rows_to_keep > 0) {
-        const size_t sorted_size = _merged_segment.chunk->num_rows();
+        const size_t sorted_size = _merged_runs.num_rows();
         rows_to_keep = std::min(rows_to_keep, sorted_size + second_size);
-        if (big_chunk == nullptr) {
-            big_chunk.reset(segments[new_permutation.second[0].chunk_index].chunk->clone_empty(rows_to_keep).release());
-        }
         if (_topn_type == TTopNType::RANK && sorted_size + second_size > rows_to_keep) {
             // For rank type, there may exist a wide equal range, so we need to keep all elements of part2 and part3
             rows_to_keep = sorted_size + second_size;
         }
-        RETURN_IF_ERROR(_merge_sort_common(big_chunk, segments, rows_to_keep, sorted_size, new_permutation.second));
+        RETURN_IF_ERROR(_merge_sort_common(&merged_runs, segments, rows_to_keep, new_permutation.second));
     }
-    RETURN_IF_ERROR(big_chunk->upgrade_if_overflow());
 
-    DataSegment merged_segment;
-    merged_segment.init(_sort_exprs, big_chunk);
-    _merged_segment = std::move(merged_segment);
+    _merged_runs = std::move(merged_runs);
 
     return Status::OK();
 }
@@ -511,8 +689,7 @@ Status ChunksSorterTopn::_hybrid_sort_first_time(RuntimeState* state, Permutatio
         return Status::InternalError(fmt::format("TopN sort exceed rows limit {}", rows_to_keep));
     }
 
-    ChunkPtr big_chunk;
-    big_chunk.reset(segments[new_permutation[0].chunk_index].chunk->clone_empty(rows_to_keep).release());
+    ChunkUniquePtr big_chunk = segments[new_permutation[0].chunk_index].chunk->clone_empty(rows_to_keep);
 
     // Initial this big chunk.
     std::vector<ChunkPtr> chunks;
@@ -523,7 +700,8 @@ Status ChunksSorterTopn::_hybrid_sort_first_time(RuntimeState* state, Permutatio
     materialize_by_permutation(big_chunk.get(), chunks, new_permutation);
 
     RETURN_IF_ERROR(big_chunk->upgrade_if_overflow());
-    _merged_segment.init(_sort_exprs, big_chunk);
+    ASSIGN_OR_RETURN(auto run, MergedRun::build(std::move(big_chunk), *_sort_exprs));
+    _merged_runs.push_back(std::move(run));
 
     return Status::OK();
 }
@@ -535,30 +713,65 @@ void ChunksSorterTopn::_rank_pruning() {
     if (!_init_merged_segment) {
         return;
     }
-    if (_merged_segment.chunk->num_rows() <= _get_number_of_rows_to_sort()) {
+    if (_merged_runs.num_rows() <= _get_number_of_rows_to_sort()) {
         return;
     }
-    DCHECK(!_merged_segment.order_by_columns.empty());
 
-    const auto size = _merged_segment.chunk->num_rows();
     const auto peer_group_start = _get_number_of_rows_to_sort() - 1;
-    size_t peer_group_end = size;
     bool found = false;
 
-    for (int i = peer_group_start + 1; !found && i < size; ++i) {
-        for (auto& column : _merged_segment.order_by_columns) {
-            if (column->compare_at(i, i - 1, *column, 1) != 0) {
-                peer_group_end = i;
-                found = true;
-                break;
+    // value at position peer_group_start + 1
+    size_t target_index = peer_group_start;
+    size_t index_in_runs = 0;
+    size_t index_in_chunk = 0;
+    std::vector<Datum> datums;
+
+    const auto& merged_runs = _merged_runs;
+    for (int i = 0; i < merged_runs.num_chunks(); ++i) {
+        if (target_index > merged_runs.at(i).num_rows()) {
+            target_index -= merged_runs.at(i).num_rows();
+        } else {
+            index_in_runs = i;
+            index_in_chunk = target_index;
+            break;
+        }
+    }
+
+    size_t peer_group_end_index_in_chunk = 0;
+    size_t peer_group_end_index_in_runs = 0;
+
+    auto found_peer_group_end = [&merged_runs, index_in_runs, index_in_chunk](const MergedRun& run, size_t begin,
+                                                                              size_t end) -> std::pair<int, bool> {
+        const auto& target_run = merged_runs.at(index_in_runs);
+        for (int j = begin; j < end; ++j) {
+            for (size_t k = 0; k < run.orderby.size(); ++k) {
+                if (run.orderby[k]->compare_at(j, index_in_chunk, *target_run.orderby[k], 1) != 0) {
+                    return {j, true};
+                }
             }
+        }
+        return {0, false};
+    };
+
+    for (int i = index_in_runs; !found && i < merged_runs.num_chunks(); ++i) {
+        const auto& run = merged_runs.at(i);
+        if (run.empty()) continue;
+        if (i == index_in_runs) {
+            std::tie(peer_group_end_index_in_chunk, found) = found_peer_group_end(run, index_in_chunk, run.end_index());
+        } else {
+            std::tie(peer_group_end_index_in_chunk, found) =
+                    found_peer_group_end(run, run.start_index(), run.end_index());
+        }
+        if (found) {
+            peer_group_end_index_in_runs = i;
+            break;
         }
     }
 
     if (found) {
-        _merged_segment.chunk->set_num_rows(peer_group_end);
-        for (auto& column : _merged_segment.order_by_columns) {
-            column->resize(peer_group_end);
+        _merged_runs.at(peer_group_end_index_in_runs).set_range(0, peer_group_end_index_in_chunk);
+        for (int i = peer_group_end_index_in_runs + 1; i < _merged_runs.num_chunks(); ++i) {
+            _merged_runs.pop_back();
         }
     }
 }

--- a/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
+++ b/be/src/exec/pipeline/sort/local_partition_topn_context.cpp
@@ -180,7 +180,8 @@ Status LocalPartitionTopnContext::push_one_chunk_to_partitioner(RuntimeState* st
             [this, state](size_t partition_idx) {
                 _chunks_sorters.emplace_back(std::make_shared<ChunksSorterTopn>(
                         state, &_sort_exprs, &_is_asc_order, &_is_null_first, _sort_keys, _offset, _partition_limit,
-                        _topn_type, ChunksSorterTopn::tunning_buffered_chunks(_partition_limit)));
+                        _topn_type, ChunksSorterTopn::kDefaultMaxBufferRows, ChunksSorterTopn::kDefaultMaxBufferBytes,
+                        ChunksSorterTopn::tunning_buffered_chunks(_partition_limit)));
                 // create agg state for new partition
                 if (_enable_pre_agg) {
                     AggDataPtr agg_states = _mem_pool->allocate_aligned(_pre_agg->_agg_states_total_size,

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -126,7 +126,8 @@ OperatorPtr PartitionSortSinkOperatorFactory::create(int32_t dop, int32_t driver
             size_t max_buffered_chunks = ChunksSorterTopn::tunning_buffered_chunks(_limit);
             chunks_sorter = std::make_unique<ChunksSorterTopn>(
                     runtime_state(), &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first,
-                    _sort_keys, 0, _limit + _offset, _topn_type, max_buffered_chunks);
+                    _sort_keys, 0, _limit + _offset, _topn_type, _max_buffered_rows, _max_buffered_bytes,
+                    max_buffered_chunks);
         }
     } else {
         chunks_sorter = std::make_unique<ChunksSorterFullSort>(

--- a/be/src/exec/sorting/merge.cpp
+++ b/be/src/exec/sorting/merge.cpp
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/sorting/merge.h"
+
+#include "exec/sorting/sort_permute.h"
+
+namespace starrocks {
+StatusOr<MergedRun> MergedRun::build(ChunkUniquePtr&& chunk, const std::vector<ExprContext*>& exprs) {
+    MergedRun run;
+    DCHECK(chunk);
+    if (!chunk->is_empty()) {
+        for (auto& expr : exprs) {
+            ASSIGN_OR_RETURN(auto column, expr->evaluate(chunk.get()));
+            run.orderby.push_back(column);
+        }
+    }
+    run.range = {0, chunk->num_rows()};
+    run.chunk = std::move(chunk);
+    return run;
+}
+
+ChunkPtr MergedRun::steal_chunk(size_t size) {
+    if (empty()) {
+        return {};
+    }
+
+    size_t reserved_rows = num_rows();
+
+    if (size >= reserved_rows) {
+        ChunkPtr res_chunk;
+        Columns res_orderby;
+        if (range.first == 0 && range.second == chunk->num_rows()) {
+            res_chunk = std::move(chunk);
+
+        } else {
+            res_chunk = chunk->clone_empty(reserved_rows);
+            res_chunk->append(*chunk, range.first, reserved_rows);
+        }
+        range.first = range.second = 0;
+        chunk.reset();
+        orderby.clear();
+        return res_chunk;
+    } else {
+        size_t required_rows = std::min(size, reserved_rows);
+        ChunkPtr res_chunk = chunk->clone_empty(required_rows);
+        Columns res_orderby;
+        res_chunk->append(*chunk, range.first, required_rows);
+        range.first += required_rows;
+        return res_chunk;
+    }
+}
+
+size_t MergedRuns::num_rows() const {
+    if (_num_rows.has_value()) return _num_rows.value();
+    size_t res = 0;
+    for (const auto& chunk : _runs) {
+        res += chunk.num_rows();
+    }
+    _num_rows = res;
+    return res;
+}
+
+int64_t MergedRuns::mem_usage() const {
+    size_t res = 0;
+    for (auto& chunk : _runs) {
+        res += chunk.chunk->memory_usage();
+    }
+    return res;
+}
+
+} // namespace starrocks

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -231,7 +231,8 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
         } else {
             _chunks_sorter = std::make_unique<ChunksSorterTopn>(
                     state, &(_sort_exec_exprs.lhs_ordering_expr_ctxs()), &_is_asc_order, &_is_null_first, _sort_keys,
-                    _offset, _limit, TTopNType::ROW_NUMBER, ChunksSorterTopn::tunning_buffered_chunks(_limit));
+                    _offset, _limit, TTopNType::ROW_NUMBER, ChunksSorterTopn::kDefaultMaxBufferRows,
+                    ChunksSorterTopn::kDefaultMaxBufferBytes, ChunksSorterTopn::tunning_buffered_chunks(_limit));
         }
 
     } else {


### PR DESCRIPTION
## Why I'm doing:

SSB100G dop=4 1BE
```
select lo_shipmode from lineorder order by lo_shipmode limit 50000000, 400
```
baseline:1m42s patched:28s339ms

The reasons why baseline performance is too low are: 
1.The merge operation is too frequent and needs to be done every 256 chunks. But the total input data is too large. This results in too many merge operations.

This PR adds max_buffer_size, which depends on offset + limit /chunk_size, to reduce the frequency of merge operations. But it may result in using more memory.
This PR additionally optimizes memory for merge chunks. It can reduce the peak memory of merge.


## What I'm doing:

1. change the max_buffered_size to chunk_size/4096 when limit greater than 65535
2. Avoid large permutations that take up too much memory.
3. reduce memory when merge large chunks

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0