### PR TITLE
[BugFix] Fix rollup add sortkey message

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -470,6 +470,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             }
         }
 
+        long baseIndexId = tbl.getBaseIndexId();
         for (long shadowIdxId : indexIdMap.keySet()) {
             long orgIndexId = indexIdMap.get(shadowIdxId);
             tbl.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId),
@@ -478,8 +479,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     indexSchemaVersionAndHashMap.get(shadowIdxId).schemaHash,
                     indexShortKeyMap.get(shadowIdxId), TStorageType.COLUMN,
                     tbl.getKeysTypeByIndexId(orgIndexId), null, 
-                    originIndexId == baseIndexId ? sortKeyIdxes : null,
-                    originIndexId == baseIndexId ? sortKeyUniqueIds : null);
+                    orgIndexId == baseIndexId ? sortKeyIdxes : null,
+                    orgIndexId == baseIndexId ? sortKeyUniqueIds : null);
             MaterializedIndexMeta orgIndexMeta = tbl.getIndexMetaByIndexId(orgIndexId);
             Preconditions.checkNotNull(orgIndexMeta);
             MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(shadowIdxId);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -477,8 +477,9 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     indexSchemaVersionAndHashMap.get(shadowIdxId).schemaVersion,
                     indexSchemaVersionAndHashMap.get(shadowIdxId).schemaHash,
                     indexShortKeyMap.get(shadowIdxId), TStorageType.COLUMN,
-                    tbl.getKeysTypeByIndexId(orgIndexId), null, sortKeyIdxes,
-                    sortKeyUniqueIds);
+                    tbl.getKeysTypeByIndexId(orgIndexId), null, 
+                    originIndexId == baseIndexId ? sortKeyIdxes : null,
+                    originIndexId == baseIndexId ? sortKeyUniqueIds : null);
             MaterializedIndexMeta orgIndexMeta = tbl.getIndexMetaByIndexId(orgIndexId);
             Preconditions.checkNotNull(orgIndexMeta);
             MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(shadowIdxId);

--- a/test/sql/test_ddl/R/alter_table
+++ b/test/sql/test_ddl/R/alter_table
@@ -115,3 +115,47 @@ select count(1) from test_pk_tbl1;
 -- result:
 2
 -- !result
+-- name: test_alter_with_rollup
+CREATE TABLE dup_test (
+    k1 bigint(20),
+    k2 bigint(20),
+    k3 bigint(20),
+    k4 bigint(20)
+)
+DUPLICATE KEY(k1)
+PARTITION BY (k1)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+ORDER BY(k2)
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1",
+"enable_persistent_index" = "true"
+);
+-- result:
+-- !result
+insert into dup_test values (1,1,1,1),(2,2,2,2);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW rollup_test1 PROPERTIES ('session.query_timeout' = '3600') AS SELECT k1,k3,k4 FROM dup_test WHERE k2=2;
+-- result:
+-- !result
+function: wait_alter_table_finish("ROLLUP", 8)
+-- result:
+None
+-- !result
+alter table dup_test drop column k4;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+alter table dup_test PARTITIONS(p1,p2) DISTRIBUTED BY HASH(k1) BUCKETS 7;
+-- result:
+-- !result
+function: wait_optimize_table_finish()
+-- result:
+None
+-- !result

--- a/test/sql/test_ddl/T/alter_table
+++ b/test/sql/test_ddl/T/alter_table
@@ -51,3 +51,35 @@ select count(1) from test_pk_tbl1;
 ALTER TABLE test_pk_tbl1 modify COLUMN v6 bitmap null;
 function: wait_alter_table_finish()
 select count(1) from test_pk_tbl1;
+
+-- name: test_alter_with_rollup
+CREATE TABLE dup_test (
+    k1 bigint(20),
+    k2 bigint(20),
+    k3 bigint(20),
+    k4 bigint(20)
+)
+DUPLICATE KEY(k1)
+PARTITION BY (k1)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+ORDER BY(k2)
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1",
+"enable_persistent_index" = "true"
+);
+
+insert into dup_test values (1,1,1,1),(2,2,2,2);
+
+CREATE MATERIALIZED VIEW rollup_test1 PROPERTIES ('session.query_timeout' = '3600') AS SELECT k1,k3,k4 FROM dup_test WHERE k2=2;
+function: wait_alter_table_finish("ROLLUP", 8)
+
+alter table dup_test drop column k4;
+function: wait_alter_table_finish()
+
+alter table dup_test PARTITIONS(p1,p2) DISTRIBUTED BY HASH(k1) BUCKETS 7;
+function: wait_optimize_table_finish()
+
+


### PR DESCRIPTION
## Why I'm doing:
Currently, the rollup does not have a sort key. However, when dropping a column from the rollup, the index meta of the rollup will save the sort key information of the base table. If an optimize task is initiated at this time, the following crash stack will be obtained on the BE.
```
*** SIGABRT (@0x3e800004cf9) received by PID 19705 (TID 0x7f9f80cb2700) LWP(21193) from PID 19705; stack trace: ***
    @     0x7fa04499220b __pthread_once_slow
    @          0xae41094 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fa04499b630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @     0x7fa0442f2387 __GI_raise
    @     0x7fa0442f3a78 __GI_abort
    @          0x35c6c0b __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @          0xe30b8c6 __cxxabiv1::__terminate(void (*)())
    @          0x35c6aa3 std::terminate()
    @          0xe30ba43 __cxa_throw
    @          0x35c86f3 std::__throw_out_of_range(char const*)
    @          0x6c090a4 starrocks::TabletSchema::_init_from_pb(starrocks::TabletSchemaPB const&)
    @          0x6c09daa starrocks::TabletSchema::create(starrocks::TabletSchemaPB const&, starrocks::TabletSchemaMap*)
    @          0x6c0e65e starrocks::TabletSchemaMap::emplace(starrocks::TabletSchemaPB const&)
    @          0x6be763b starrocks::TabletMeta::init_from_pb(starrocks::TabletMetaPB*, bool)
    @          0x6be7c70 starrocks::TabletMeta::TabletMeta(long, long, long, int, unsigned long, starrocks::TTabletSchema const&, unsigned int, bool, std::unordered_map<unsigned int, unsigned int, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsig@
    @          0x6be80e0 starrocks::TabletMeta::create(starrocks::TCreateTabletReq const&, starrocks::UniqueId const&, unsigned long, unsigned int, std::unordered_map<unsigned int, unsigned int, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigne@
    @          0x6bda378 starrocks::TabletManager::_create_tablet_meta_unlocked(starrocks::TCreateTabletReq const&, starrocks::DataDir*, bool, starrocks::Tablet const*, std::shared_ptr<starrocks::TabletMeta>*)
    @          0x6bdada7 starrocks::TabletManager::_create_tablet_meta_and_dir_unlocked(starrocks::TCreateTabletReq const&, bool, starrocks::Tablet const*, std::vector<starrocks::DataDir*, std::allocator<starrocks::DataDir*> > const&)
    @          0x6bdbbb5 starrocks::TabletManager::_internal_create_tablet_unlocked(starrocks::AlterTabletType, starrocks::TCreateTabletReq const&, bool, starrocks::Tablet const*, std::vector<starrocks::DataDir*, std::allocator<starrocks::DataDir*> > const&)
    @          0x6bdc888 starrocks::TabletManager::create_tablet(starrocks::TCreateTabletReq const&, std::vector<starrocks::DataDir*, std::allocator<starrocks::DataDir*> >)
    @          0x6b7ab0e starrocks::StorageEngine::create_tablet(starrocks::TCreateTabletReq const&)
    @          0x425fe11 starrocks::run_create_tablet_task(std::shared_ptr<starrocks::AgentTaskRequestWithReqBody<starrocks::TCreateTabletReq> > const&, starrocks::ExecEnv*)
    @          0x3ba79df starrocks::ThreadPool::dispatch_thread()
    @          0x3b9e080 starrocks::Thread::supervise_thread(void*)
    @     0x7fa044993ea5 start_thread
    @     0x7fa0443bab0d __clone
```

The reason is that the rollup index meta is not updated correctly.

## What I'm doing:
Do not keep sort key information in rollup index when doing alter job for rollup.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0