### PR TITLE
[BugFix] Fix hive catalog parquet table daylight saving time issue caused by Int96ToDateTimeConverter use fixed offset to convert utc time to local time

### DIFF
--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -94,7 +94,7 @@ private:
     // according to session variable "time_zone".
     [[nodiscard]] Timestamp _utc_to_local(Timestamp timestamp) const {
         int64_t days = timestamp::to_julian(timestamp);
-        int64_t seconds_from_epoch = (days - 2440588) * 86400;
+        int64_t seconds_from_epoch = (days - date::UNIX_EPOCH_JULIAN) * 86400;
 
         int64_t microseconds = timestamp::to_time(timestamp);
         seconds_from_epoch += (microseconds / 1000000);

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -93,6 +93,12 @@ private:
     // into UTC time, and when it reads data out, it should be converted to the time
     // according to session variable "time_zone".
     [[nodiscard]] Timestamp _utc_to_local(Timestamp timestamp) const {
+
+        // Ignore the default value 0000-01-01 00:00:00
+        if (timestamp == TimestampValue::MIN_TIMESTAMP_VALUE.timestamp()) {
+            return timestamp;
+        }
+
         const JulianDate days = timestamp::to_julian(timestamp);
         int64_t seconds = (days - 2440588) * 86400;
 

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -739,25 +739,12 @@ Status Int64ToDateTimeConverter::convert(const ColumnPtr& src, Column* dst) {
         dst_null_data[i] = src_null_data[i];
         if (!src_null_data[i]) {
             int64_t seconds = src_data[i] / _second_mask;
-            // int offset = timestamp::get_offset_by_timezone(seconds, _ctz);
             int64_t nanoseconds = (src_data[i] % _second_mask) * _scale_to_nano_factor;
-            // TimestampValue ep;
-            // ep.from_unixtime(seconds, nanoseconds / 1000, _ctz);
 
             std::chrono::system_clock::time_point tp = std::chrono::system_clock::from_time_t(seconds);
             int offset = _ctz.lookup(tp).offset;
             seconds += offset;
-            // std::cout << "offset: " << offset << ",src_data[i]: " << src_data[i] << std::endl;
 
-            // dst_data[i].set_timestamp(ep.timestamp());
-            // std::cout << "dst_data[i]: " << ep.timestamp() << std::endl;
-            // dst_data[i].set_timestamp(src_data[i]/1000000);
-
-            // int64_t second = seconds + timestamp::UNIX_EPOCH_SECONDS;
-            // JulianDate day = second / SECS_PER_DAY;
-            // auto new_value = timestamp::from_julian_and_time(day, (second % SECS_PER_DAY) * USECS_PER_SEC + nanoseconds / NANOSECS_PER_USEC);
-            // std::cout << "seconds: " << seconds << ",nanoseconds[i]: " << nanoseconds << std::endl;
-            // std::cout << "old_value: " << ep.timestamp() << ", new_value: " << new_value << std::endl;
             dst_data[i].set_timestamp(timestamp::of_epoch_second(seconds, nanoseconds));
         }
     }

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -96,10 +96,12 @@ private:
         const JulianDate days = timestamp::to_julian(timestamp);
         int64_t seconds = (days - 2440588) * 86400;
 
-        int64_t nanoseconds = timestamp::to_time(timestamp);
-        seconds += (nanoseconds / 1000000);
+        int64_t microseconds = timestamp::to_time(timestamp);
+        seconds += (microseconds / 1000000);
+        int64_t remaining_microseconds = microseconds % 1000000;
+
         TimestampValue ep;
-        ep.from_unixtime(seconds, (nanoseconds % 1000000), _ctz);
+        ep.from_unixtime(seconds, remaining_microseconds, _ctz);
 
         return ep.timestamp();
     }

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -739,10 +739,26 @@ Status Int64ToDateTimeConverter::convert(const ColumnPtr& src, Column* dst) {
         dst_null_data[i] = src_null_data[i];
         if (!src_null_data[i]) {
             int64_t seconds = src_data[i] / _second_mask;
+            // int offset = timestamp::get_offset_by_timezone(seconds, _ctz);
             int64_t nanoseconds = (src_data[i] % _second_mask) * _scale_to_nano_factor;
-            TimestampValue ep;
-            ep.from_unixtime(seconds, nanoseconds / 1000, _ctz);
-            dst_data[i].set_timestamp(ep.timestamp());
+            // TimestampValue ep;
+            // ep.from_unixtime(seconds, nanoseconds / 1000, _ctz);
+
+            std::chrono::system_clock::time_point tp = std::chrono::system_clock::from_time_t(seconds);
+            int offset = _ctz.lookup(tp).offset;
+            seconds += offset;
+            // std::cout << "offset: " << offset << ",src_data[i]: " << src_data[i] << std::endl;
+
+            // dst_data[i].set_timestamp(ep.timestamp());
+            // std::cout << "dst_data[i]: " << ep.timestamp() << std::endl;
+            // dst_data[i].set_timestamp(src_data[i]/1000000);
+
+            // int64_t second = seconds + timestamp::UNIX_EPOCH_SECONDS;
+            // JulianDate day = second / SECS_PER_DAY;
+            // auto new_value = timestamp::from_julian_and_time(day, (second % SECS_PER_DAY) * USECS_PER_SEC + nanoseconds / NANOSECS_PER_USEC);
+            // std::cout << "seconds: " << seconds << ",nanoseconds[i]: " << nanoseconds << std::endl;
+            // std::cout << "old_value: " << ep.timestamp() << ", new_value: " << new_value << std::endl;
+            dst_data[i].set_timestamp(timestamp::of_epoch_second(seconds, nanoseconds));
         }
     }
     dst_nullable_column->set_has_null(src_nullable_column->has_null());

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -93,16 +93,8 @@ private:
     // into UTC time, and when it reads data out, it should be converted to the time
     // according to session variable "time_zone".
     [[nodiscard]] Timestamp _utc_to_local(Timestamp timestamp) const {
-        int64_t days = timestamp::to_julian(timestamp);
-        int64_t seconds_from_epoch = (days - date::UNIX_EPOCH_JULIAN) * 86400;
-
-        int64_t microseconds = timestamp::to_time(timestamp);
-        seconds_from_epoch += (microseconds / 1000000);
-        int64_t remaining_microseconds = microseconds % 1000000;
-
-        TimestampValue ep;
-        ep.from_unixtime(seconds_from_epoch, remaining_microseconds, _ctz);
-        return ep.timestamp();
+        int offset = timestamp::get_offset_by_timezone(timestamp, _ctz);
+        return timestamp::add<TimeUnit::SECOND>(timestamp, offset);
     }
 
 private:

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -93,7 +93,6 @@ private:
     // into UTC time, and when it reads data out, it should be converted to the time
     // according to session variable "time_zone".
     [[nodiscard]] Timestamp _utc_to_local(Timestamp timestamp) const {
-
         // Ignore the default value 0000-01-01 00:00:00
         if (timestamp == TimestampValue::MIN_TIMESTAMP_VALUE.timestamp()) {
             return timestamp;

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -93,11 +93,19 @@ private:
     // into UTC time, and when it reads data out, it should be converted to the time
     // according to session variable "time_zone".
     [[nodiscard]] Timestamp _utc_to_local(Timestamp timestamp) const {
-        return timestamp::add<TimeUnit::SECOND>(timestamp, _offset);
+        const JulianDate days = timestamp::to_julian(timestamp);
+        int64_t seconds = (days - 2440588) * 86400;
+
+        int64_t nanoseconds = timestamp::to_time(timestamp);
+        seconds += (nanoseconds / 1000000);
+        TimestampValue ep;
+        ep.from_unixtime(seconds, (nanoseconds % 1000000), _ctz);
+
+        return ep.timestamp();
     }
 
 private:
-    int _offset = 0;
+    cctz::time_zone _ctz;
 };
 
 class Int64ToDateTimeConverter final : public ColumnConverter {
@@ -628,14 +636,9 @@ Status parquet::Int32ToDateTimeConverter::convert(const ColumnPtr& src, Column* 
 }
 
 Status Int96ToDateTimeConverter::init(const std::string& timezone) {
-    cctz::time_zone ctz;
-    if (!TimezoneUtils::find_cctz_time_zone(timezone, ctz)) {
+    if (!TimezoneUtils::find_cctz_time_zone(timezone, _ctz)) {
         return Status::InternalError(strings::Substitute("can not find cctz time zone $0", timezone));
     }
-
-    const auto tp = std::chrono::system_clock::now();
-    const cctz::time_zone::absolute_lookup al = ctz.lookup(tp);
-    _offset = al.offset;
 
     return Status::OK();
 }

--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -93,21 +93,15 @@ private:
     // into UTC time, and when it reads data out, it should be converted to the time
     // according to session variable "time_zone".
     [[nodiscard]] Timestamp _utc_to_local(Timestamp timestamp) const {
-        // Ignore the default value 0000-01-01 00:00:00
-        if (timestamp == TimestampValue::MIN_TIMESTAMP_VALUE.timestamp()) {
-            return timestamp;
-        }
-
-        const JulianDate days = timestamp::to_julian(timestamp);
-        int64_t seconds = (days - 2440588) * 86400;
+        int64_t days = timestamp::to_julian(timestamp);
+        int64_t seconds_from_epoch = (days - 2440588) * 86400;
 
         int64_t microseconds = timestamp::to_time(timestamp);
-        seconds += (microseconds / 1000000);
+        seconds_from_epoch += (microseconds / 1000000);
         int64_t remaining_microseconds = microseconds % 1000000;
 
         TimestampValue ep;
-        ep.from_unixtime(seconds, remaining_microseconds, _ctz);
-
+        ep.from_unixtime(seconds_from_epoch, remaining_microseconds, _ctz);
         return ep.timestamp();
     }
 

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -354,9 +354,8 @@ Status LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx
     for (size_t i = 0; i < col->size(); i++) {
         auto offset = timestamp::get_offset_by_timezone(data_col[i]._timestamp, _ctz);
 
-        auto timestamp = use_int96_timestamp_encoding
-                                 ? timestamp::sub<TimeUnit::SECOND>(data_col[i]._timestamp, offset)
-                                 : data_col[i]._timestamp;
+        auto timestamp = use_int96_timestamp_encoding ? timestamp::sub<TimeUnit::SECOND>(data_col[i]._timestamp, offset)
+                                                      : data_col[i]._timestamp;
 
         if constexpr (use_int96_timestamp_encoding) {
             auto date = reinterpret_cast<int32_t*>(values[i].value + 2);

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -352,7 +352,6 @@ Status LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx
     DeferOp defer([&] { delete[] values; });
 
     for (size_t i = 0; i < col->size(); i++) {
-
         int64_t days = timestamp::to_julian(data_col[i]._timestamp);
         int64_t seconds_from_epoch = (days - 2440588) * 86400;
         std::chrono::system_clock::time_point tp = std::chrono::system_clock::from_time_t(seconds_from_epoch);

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -352,13 +352,10 @@ Status LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx
     DeferOp defer([&] { delete[] values; });
 
     for (size_t i = 0; i < col->size(); i++) {
-        int64_t days = timestamp::to_julian(data_col[i]._timestamp);
-        int64_t seconds_from_epoch = (days - date::UNIX_EPOCH_JULIAN) * 86400;
-        std::chrono::system_clock::time_point tp = std::chrono::system_clock::from_time_t(seconds_from_epoch);
-        auto _offset = _ctz.lookup(tp).offset;
+        auto offset = timestamp::get_offset_by_timezone(data_col[i]._timestamp, _ctz);
 
         auto timestamp = use_int96_timestamp_encoding
-                                 ? timestamp::sub<TimeUnit::SECOND>(data_col[i]._timestamp, _offset)
+                                 ? timestamp::sub<TimeUnit::SECOND>(data_col[i]._timestamp, offset)
                                  : data_col[i]._timestamp;
 
         if constexpr (use_int96_timestamp_encoding) {

--- a/be/src/formats/parquet/level_builder.cpp
+++ b/be/src/formats/parquet/level_builder.cpp
@@ -353,7 +353,7 @@ Status LevelBuilder::_write_datetime_column_chunk(const LevelBuilderContext& ctx
 
     for (size_t i = 0; i < col->size(); i++) {
         int64_t days = timestamp::to_julian(data_col[i]._timestamp);
-        int64_t seconds_from_epoch = (days - 2440588) * 86400;
+        int64_t seconds_from_epoch = (days - date::UNIX_EPOCH_JULIAN) * 86400;
         std::chrono::system_clock::time_point tp = std::chrono::system_clock::from_time_t(seconds_from_epoch);
         auto _offset = _ctz.lookup(tp).offset;
 

--- a/be/src/formats/parquet/level_builder.h
+++ b/be/src/formats/parquet/level_builder.h
@@ -174,7 +174,7 @@ private:
     TypeDescriptor _type_desc;
     ::parquet::schema::NodePtr _root;
     std::string _timezone;
-    int _offset{0};
+    cctz::time_zone _ctz;
     bool _use_legacy_decimal_encoding = false;
     bool _use_int96_timestamp_encoding = false;
 };

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -14,12 +14,13 @@
 
 #pragma once
 
+#include <cctz/time_zone.h>
+
 #include <cstdint>
 #include <string>
 
 #include "common/compiler_util.h"
 #include "util/raw_container.h"
-#include <cctz/time_zone.h>
 
 namespace starrocks {
 

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -429,7 +429,9 @@ double timestamp::time_to_literal(double time) {
 Timestamp timestamp::of_epoch_second(int64_t seconds, int64_t nanoseconds) {
     int64_t second = seconds + timestamp::UNIX_EPOCH_SECONDS;
     JulianDate day = second / SECS_PER_DAY;
-    return timestamp::from_julian_and_time(day, second * USECS_PER_SEC + nanoseconds / NANOSECS_PER_USEC);
+
+    int64_t microseconds = (second % SECS_PER_DAY) * USECS_PER_SEC + nanoseconds / NANOSECS_PER_USEC;
+    return timestamp::from_julian_and_time(day, microseconds);
 }
 
 bool timestamp::check_time(int hour, int minute, int second, int microsecond) {

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -215,7 +215,7 @@ public:
 
     inline static bool check(int year, int month, int day, int hour, int minute, int second, int microsecond);
 
-    inline static int get_offset_by_timezone(Timestamp timestamp, const cctz::time_zone &ctz);
+    inline static int get_offset_by_timezone(Timestamp timestamp, const cctz::time_zone& ctz);
 
     template <TimeUnit UNIT>
     static Timestamp add(Timestamp timestamp, int count);
@@ -367,7 +367,7 @@ bool timestamp::check(int year, int month, int day, int hour, int minute, int se
     return date::check(year, month, day) && check_time(hour, minute, second, microsecond);
 }
 
-int timestamp::get_offset_by_timezone(Timestamp timestamp, const cctz::time_zone &ctz) {
+int timestamp::get_offset_by_timezone(Timestamp timestamp, const cctz::time_zone& ctz) {
     int64_t days = timestamp::to_julian(timestamp);
     int64_t seconds_from_epoch = (days - date::UNIX_EPOCH_JULIAN) * SECS_PER_DAY;
 

--- a/be/test/column/date_value_test.cpp
+++ b/be/test/column/date_value_test.cpp
@@ -172,6 +172,30 @@ TEST(DateValueTest, normalTimestamp) {
     }
 }
 
+TEST(DateValueTest, getOffsetByTimezone) {
+    {
+        auto timestampInDST = timestamp::from_datetime(1986, 8, 25, 0, 0, 0, 0);
+        auto timezone = "Asia/Shanghai";
+        cctz::time_zone ctz;
+        TimezoneUtils::find_cctz_time_zone(timezone, ctz);
+
+        auto offset = timestamp::get_offset_by_timezone(timestampInDST, ctz);
+
+        ASSERT_EQ(32400, offset);
+    }
+
+    {
+        auto timestampOutOfDST = timestamp::from_datetime(2004, 8, 25, 0, 0, 0, 0);
+        auto timezone = "Asia/Shanghai";
+        cctz::time_zone ctz;
+        TimezoneUtils::find_cctz_time_zone(timezone, ctz);
+
+        auto offset = timestamp::get_offset_by_timezone(timestampOutOfDST, ctz);
+
+        ASSERT_EQ(28800, offset);
+    }
+}
+
 TEST(DateValueTest, calculate) {
     DateValue dv;
     {

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -564,11 +564,14 @@ TEST_F(ParquetFileWriterTest, TestWriteDatetimeCompatibleWithHiveReader) {
             data_column->append_datum(datum);
             datum.set_timestamp(TimestampValue::create(1999, 9, 11, 2, 2, 2));
             data_column->append_datum(datum);
+            // Daylight Saving Time value
+            datum.set_timestamp(TimestampValue::create(1986, 8, 25, 0, 0, 0));
+            data_column->append_datum(datum);
             data_column->append_default();
         }
 
         auto null_column = UInt8Column::create();
-        std::vector<uint8_t> nulls = {1, 0, 1, 0};
+        std::vector<uint8_t> nulls = {1, 0, 1, 0, 0};
         null_column->append_numbers(nulls.data(), nulls.size());
         auto nullable_column = NullableColumn::create(data_column, null_column);
         chunk->append_column(nullable_column, chunk->num_columns());
@@ -579,11 +582,11 @@ TEST_F(ParquetFileWriterTest, TestWriteDatetimeCompatibleWithHiveReader) {
     auto result = writer->commit();
 
     ASSERT_TRUE(result.io_status.ok());
-    ASSERT_EQ(result.file_statistics.record_count, 4);
+    ASSERT_EQ(result.file_statistics.record_count, 5);
 
     auto read_chunk = _read_chunk(type_descs);
     ASSERT_TRUE(read_chunk != nullptr);
-    ASSERT_EQ(read_chunk->num_rows(), 4);
+    ASSERT_EQ(read_chunk->num_rows(), 5);
     parquet::Utils::assert_equal_chunk(chunk.get(), read_chunk.get());
 }
 

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -546,6 +546,7 @@ TEST_F(ParquetFileWriterTest, TestWriteDatetimeCompatibleWithHiveReader) {
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::ParquetWriterOptions>();
     writer_options->use_int96_timestamp_encoding = true;
+    writer_options->time_zone = "Asia/Shanghai";
     auto writer = std::make_unique<formats::ParquetFileWriter>(
             _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
             TCompressionType::NO_COMPRESSION, writer_options, []() {});


### PR DESCRIPTION
## Why I'm doing:
Fix hive catalog parquet table daylight saving time issue.

## What I'm doing:
Change the logic of Int96ToDateTimeConverter utc_to_local from fixed time offset to cctz:time_zone dynamic offset.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/55893

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0