### PR TITLE
[Enhancement] Use input column statistics for computing IF min/max statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -640,7 +640,11 @@ public class ExpressionStatisticCalculator {
                 case FunctionSet.IF:
                     distinctValues = childColumnStatisticList.get(1).getDistinctValuesCount() +
                             childColumnStatisticList.get(2).getDistinctValuesCount();
-                    return new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 0,
+                    double minValue = Math.min(childColumnStatisticList.get(1).getMinValue(),
+                            childColumnStatisticList.get(2).getMinValue());
+                    double maxValue = Math.max(childColumnStatisticList.get(1).getMaxValue(),
+                            childColumnStatisticList.get(2).getMaxValue());
+                    return new ColumnStatistic(minValue, maxValue, 0,
                             callOperator.getType().getTypeSize(), distinctValues);
                 // use child column statistics for now
                 case FunctionSet.SUBSTRING:

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -632,4 +632,28 @@ public class ExpressionStatisticsCalculatorTest {
         Assert.assertEquals(columnStatistic.getMaxValue(), 2.534021856E11, 0.001);
         Assert.assertEquals(columnStatistic.getMinValue(), -28800.0, 0.001);
     }
+
+    @Test
+    public void testIF() {
+        ColumnRefOperator column = new ColumnRefOperator(1, Type.INT, "column", true);
+        BinaryPredicateOperator condition = new BinaryPredicateOperator(BinaryType.EQ, column, ConstantOperator.createInt(1));
+        ColumnRefOperator left = new ColumnRefOperator(0, Type.INT, "left", true);
+        ColumnRefOperator right = new ColumnRefOperator(1, Type.INT, "right", true);
+
+        ColumnStatistic columnStatistic = new ColumnStatistic(-300, 300, 0, 0, 300);
+        ColumnStatistic leftStatistic = new ColumnStatistic(-100, 100, 0, 0, 100);
+        ColumnStatistic rightStatistic = new ColumnStatistic(100, 200, 0, 0, 100);
+
+        Statistics.Builder builder = Statistics.builder();
+        builder.setOutputRowCount(300);
+        builder.addColumnStatistic(column, columnStatistic);
+        builder.addColumnStatistic(left, leftStatistic);
+        builder.addColumnStatistic(right, rightStatistic);
+
+        CallOperator callOperator = new CallOperator(FunctionSet.IF, Type.INT, Lists.newArrayList(condition, left, right));
+        ColumnStatistic ifStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assert.assertEquals(ifStatistic.getDistinctValuesCount(), 200, 0.001);
+        Assert.assertEquals(ifStatistic.getMaxValue(), 200, 0.001);
+        Assert.assertEquals(ifStatistic.getMinValue(), -100, 0.001);
+    }
 }

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q12.sql
@@ -9,8 +9,8 @@ distribution type: GATHER
 cardinality: 2
 column statistics:
 * l_shipmode-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-* sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-* sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+* sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+* sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 
 PLAN FRAGMENT 1(F03)
 
@@ -24,8 +24,8 @@ OutPut Exchange Id: 10
 |  cardinality: 2
 |  column statistics:
 |  * l_shipmode-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 |
 8:AGGREGATE (merge finalize)
 |  aggregate: sum[([28: sum, BIGINT, true]); args: BIGINT; result: BIGINT; args nullable: true; result nullable: true], sum[([29: sum, BIGINT, true]); args: BIGINT; result: BIGINT; args nullable: true; result nullable: true]
@@ -33,8 +33,8 @@ OutPut Exchange Id: 10
 |  cardinality: 2
 |  column statistics:
 |  * l_shipmode-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 |
 7:EXCHANGE
 distribution type: SHUFFLE
@@ -54,8 +54,8 @@ OutPut Exchange Id: 07
 |  cardinality: 2
 |  column statistics:
 |  * l_shipmode-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 |
 5:Project
 |  output columns:
@@ -65,8 +65,8 @@ OutPut Exchange Id: 07
 |  cardinality: 6125233
 |  column statistics:
 |  * l_shipmode-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * case-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+|  * case-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 |
 4:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
@@ -80,8 +80,8 @@ OutPut Exchange Id: 07
 |  * o_orderpriority-->[-Infinity, Infinity, 0.0, 15.0, 5.0] ESTIMATE
 |  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 6125233.086195324] ESTIMATE
 |  * l_shipmode-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * case-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+|  * case-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 |
 |----3:EXCHANGE
 |       distribution type: BROADCAST

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
@@ -9,15 +9,15 @@ RESULT SINK
 |  30 <-> 100.00 * [28: sum, DECIMAL128(38,4), true] / [29: sum, DECIMAL128(38,4), true]
 |  cardinality: 1
 |  column statistics:
-|  * expr-->[-Infinity, Infinity, 0.0, 16.0, 1.0] ESTIMATE
+|  * expr-->[0.0, 12942.348008385745, 0.0, 16.0, 1.0] ESTIMATE
 |
 9:AGGREGATE (merge finalize)
 |  aggregate: sum[([28: sum, DECIMAL128(38,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([29: sum, DECIMAL128(38,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
-|  * sum-->[-Infinity, Infinity, 0.0, 16.0, 1.0] ESTIMATE
+|  * sum-->[0.0, 104949.5, 0.0, 16.0, 1.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 1.0] ESTIMATE
-|  * expr-->[-Infinity, Infinity, 0.0, 16.0, 1.0] ESTIMATE
+|  * expr-->[0.0, 12942.348008385745, 0.0, 16.0, 1.0] ESTIMATE
 |
 8:EXCHANGE
 distribution type: GATHER
@@ -33,7 +33,7 @@ OutPut Exchange Id: 08
 |  aggregate: sum[(if[(21: p_type LIKE 'PROMO%', [35: multiply, DECIMAL128(31,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(31,4); args nullable: true; result nullable: true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([27: expr, DECIMAL128(31,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
-|  * sum-->[-Infinity, Infinity, 0.0, 16.0, 1.0] ESTIMATE
+|  * sum-->[0.0, 104949.5, 0.0, 16.0, 1.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 1.0] ESTIMATE
 |
 6:Project
@@ -65,7 +65,7 @@ OutPut Exchange Id: 08
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 6653885.645940593] ESTIMATE
 |  * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 16.0, 3736521.0] ESTIMATE
+|  * case-->[0.0, 104949.5, 0.0, 16.0, 3736521.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
 |
 |----4:EXCHANGE

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
@@ -9,9 +9,9 @@ distribution type: GATHER
 cardinality: 2
 column statistics:
 * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-* sum-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+* sum-->[0.0, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
 * sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
-* expr-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+* expr-->[0.0, 129.42348008385744, 0.0, 16.0, 2.0] ESTIMATE
 
 PLAN FRAGMENT 1(F19)
 
@@ -25,9 +25,9 @@ OutPut Exchange Id: 38
 |  cardinality: 2
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
-|  * expr-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+|  * expr-->[0.0, 129.42348008385744, 0.0, 16.0, 2.0] ESTIMATE
 |
 36:Project
 |  output columns:
@@ -36,7 +36,7 @@ OutPut Exchange Id: 38
 |  cardinality: 2
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-|  * expr-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+|  * expr-->[0.0, 129.42348008385744, 0.0, 16.0, 2.0] ESTIMATE
 |
 35:AGGREGATE (merge finalize)
 |  aggregate: sum[([65: sum, DECIMAL128(38,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([64: sum, DECIMAL128(38,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
@@ -44,9 +44,9 @@ OutPut Exchange Id: 38
 |  cardinality: 2
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
-|  * expr-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+|  * expr-->[0.0, 129.42348008385744, 0.0, 16.0, 2.0] ESTIMATE
 |
 34:EXCHANGE
 distribution type: SHUFFLE
@@ -66,7 +66,7 @@ OutPut Exchange Id: 34
 |  cardinality: 2
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
 |
 32:Project
@@ -84,7 +84,7 @@ OutPut Exchange Id: 34
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 242842.78223700626] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 16.0, 242843.78223700626] ESTIMATE
+|  * case-->[0.0, 104949.5, 0.0, 16.0, 242843.78223700626] ESTIMATE
 |
 31:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
@@ -102,7 +102,7 @@ OutPut Exchange Id: 34
 |  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 242842.78223700626] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 16.0, 242843.78223700626] ESTIMATE
+|  * case-->[0.0, 104949.5, 0.0, 16.0, 242843.78223700626] ESTIMATE
 |
 |----30:EXCHANGE
 |       distribution type: BROADCAST

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q12.sql
@@ -9,8 +9,8 @@ distribution type: GATHER
 cardinality: 2
 column statistics:
 * L_SHIPMODE-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-* sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-* sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+* sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+* sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 
 PLAN FRAGMENT 1(F03)
 
@@ -24,8 +24,8 @@ OutPut Exchange Id: 10
 |  cardinality: 2
 |  column statistics:
 |  * L_SHIPMODE-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 |
 8:AGGREGATE (merge finalize)
 |  aggregate: sum[([30: sum, BIGINT, true]); args: BIGINT; result: BIGINT; args nullable: true; result nullable: true], sum[([31: sum, BIGINT, true]); args: BIGINT; result: BIGINT; args nullable: true; result nullable: true]
@@ -33,8 +33,8 @@ OutPut Exchange Id: 10
 |  cardinality: 2
 |  column statistics:
 |  * L_SHIPMODE-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 |
 7:EXCHANGE
 distribution type: SHUFFLE
@@ -54,8 +54,8 @@ OutPut Exchange Id: 07
 |  cardinality: 2
 |  column statistics:
 |  * L_SHIPMODE-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 |
 5:Project
 |  output columns:
@@ -65,8 +65,8 @@ OutPut Exchange Id: 07
 |  cardinality: 6508504
 |  column statistics:
 |  * L_SHIPMODE-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * case-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+|  * case-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 |
 4:HASH JOIN
 |  join op: INNER JOIN (BUCKET_SHUFFLE)
@@ -80,8 +80,8 @@ OutPut Exchange Id: 07
 |  * O_ORDERPRIORITY-->[-Infinity, Infinity, 0.0, 15.0, 5.0] ESTIMATE
 |  * L_ORDERKEY-->[1.0, 6.0E8, 0.0, 8.0, 6508504.027934344] ESTIMATE
 |  * L_SHIPMODE-->[-Infinity, Infinity, 0.0, 10.0, 2.0] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * case-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
+|  * case-->[0.0, 1.0, 0.0, 8.0, 2.0] ESTIMATE
 |
 |----3:EXCHANGE
 |       distribution type: SHUFFLE

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q14.sql
@@ -9,15 +9,15 @@ RESULT SINK
 |  32 <-> 100.0 * [30: sum, DOUBLE, true] / [31: sum, DOUBLE, true]
 |  cardinality: 1
 |  column statistics:
-|  * expr-->[-Infinity, Infinity, 0.0, 8.0, 1.0] ESTIMATE
+|  * expr-->[0.0, 12942.348008385745, 0.0, 8.0, 1.0] ESTIMATE
 |
 8:AGGREGATE (merge finalize)
 |  aggregate: sum[([30: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([31: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 1.0] ESTIMATE
+|  * sum-->[0.0, 104949.5, 0.0, 8.0, 1.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 1.0] ESTIMATE
-|  * expr-->[-Infinity, Infinity, 0.0, 8.0, 1.0] ESTIMATE
+|  * expr-->[0.0, 12942.348008385745, 0.0, 8.0, 1.0] ESTIMATE
 |
 7:EXCHANGE
 distribution type: GATHER
@@ -33,7 +33,7 @@ OutPut Exchange Id: 07
 |  aggregate: sum[(if[(22: P_TYPE LIKE 'PROMO%', [34: multiply, DOUBLE, false], 0.0); args: BOOLEAN,DOUBLE,DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([29: expr, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 1.0] ESTIMATE
+|  * sum-->[0.0, 104949.5, 0.0, 8.0, 1.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 1.0] ESTIMATE
 |
 5:Project
@@ -62,7 +62,7 @@ OutPut Exchange Id: 07
 |  * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |  * P_PARTKEY-->[1.0, 2.0E7, 0.0, 8.0, 7013946.675798152] ESTIMATE
 |  * P_TYPE-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 932378.0] ESTIMATE
+|  * case-->[0.0, 104949.5, 0.0, 8.0, 932378.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 8.0, 932377.0] ESTIMATE
 |
 |----3:EXCHANGE

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q8.sql
@@ -9,9 +9,9 @@ distribution type: GATHER
 cardinality: 2
 column statistics:
 * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-* sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+* sum-->[0.0, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
 * sum-->[810.9, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
-* expr-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+* expr-->[0.0, 129.42348008385744, 0.0, 8.0, 2.0] ESTIMATE
 
 PLAN FRAGMENT 1(F15)
 
@@ -25,9 +25,9 @@ OutPut Exchange Id: 36
 |  cardinality: 2
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
-|  * expr-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * expr-->[0.0, 129.42348008385744, 0.0, 8.0, 2.0] ESTIMATE
 |
 34:Project
 |  output columns:
@@ -36,7 +36,7 @@ OutPut Exchange Id: 36
 |  cardinality: 2
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-|  * expr-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * expr-->[0.0, 129.42348008385744, 0.0, 8.0, 2.0] ESTIMATE
 |
 33:AGGREGATE (merge finalize)
 |  aggregate: sum[([72: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([73: sum, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
@@ -44,9 +44,9 @@ OutPut Exchange Id: 36
 |  cardinality: 2
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
-|  * expr-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * expr-->[0.0, 129.42348008385744, 0.0, 8.0, 2.0] ESTIMATE
 |
 32:EXCHANGE
 distribution type: SHUFFLE
@@ -66,7 +66,7 @@ OutPut Exchange Id: 32
 |  cardinality: 2
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 8.0, 2.0] ESTIMATE
+|  * sum-->[0.0, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 8.0, 2.0] ESTIMATE
 |
 30:Project
@@ -81,7 +81,7 @@ OutPut Exchange Id: 32
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 8.0, 264791.38809599995] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 264792.38809599995] ESTIMATE
+|  * case-->[0.0, 104949.5, 0.0, 8.0, 264792.38809599995] ESTIMATE
 |
 29:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
@@ -99,7 +99,7 @@ OutPut Exchange Id: 32
 |  * R_REGIONKEY-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * expr-->[810.9, 104949.5, 0.0, 8.0, 264791.38809599995] ESTIMATE
-|  * case-->[-Infinity, Infinity, 0.0, 8.0, 264792.38809599995] ESTIMATE
+|  * case-->[0.0, 104949.5, 0.0, 8.0, 264792.38809599995] ESTIMATE
 |
 |----28:EXCHANGE
 |       distribution type: BROADCAST


### PR DESCRIPTION
## Why I'm doing:

Currently the IF function uses the `Double.NEGATIVE_INFINITY` and `Double.POSITIVE_INFINITY` as its min value and max value estimation. This is not ideal for predicate selectivity evaluation and can be easily improved.

## What I'm doing:

Since `if(expr1,expr2,expr3)` returns values from either `expr2` or `expr3` we can use their min and max values to better estimate the output.
For example for `IF(expr1,1,2)` we can set the min value to 1 and the max value to 2.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0