### PR TITLE
[BugFix] fix parquet dict decoder return value process

### DIFF
--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -130,8 +130,8 @@ public:
         T* __restrict__ data = data_column->get_data().data() + cur_size;
 
         auto ret = _rle_batch_reader.GetBatchWithDict(_dict.data(), _dict.size(), data, count);
-        if (UNLIKELY(ret <= 0)) {
-            return Status::InternalError("DictDecoder GetBatchWithDict failed");
+        if (UNLIKELY(ret < 0)) {
+            return Status::InternalError("DictDecoder GetBatchWithDict failed at DictDecoder<T>");
         }
 
         return Status::OK();
@@ -271,8 +271,8 @@ public:
         case VALUE: {
             raw::stl_vector_resize_uninitialized(&_slices, count);
             auto ret = _rle_batch_reader.GetBatchWithDict(_dict.data(), _dict.size(), _slices.data(), count);
-            if (UNLIKELY(ret <= 0)) {
-                return Status::InternalError("DictDecoder GetBatchWithDict failed");
+            if (UNLIKELY(ret < 0)) {
+                return Status::InternalError("DictDecoder GetBatchWithDict failed at DictDecoder<Slice>");
             }
             ret = dst->append_strings_overflow(_slices, _max_value_length);
             if (UNLIKELY(!ret)) {

--- a/be/src/util/rle_encoding.h
+++ b/be/src/util/rle_encoding.h
@@ -1008,7 +1008,7 @@ inline int RleBatchDecoder<T>::GetBatchWithDict(const TV* dictionary, int32_t di
         int32_t num_literals_to_set = std::min(num_literals, batch_num - num_consumed);
         num_literals_to_set = std::min(num_literals_to_set, kBufferSize);
         if (!GetLiteralValues(num_literals_to_set, indices)) {
-            return 0;
+            return -1;
         }
         if (UNLIKELY(!IndicesInRange(indices, num_literals_to_set, dictionary_length))) {
             return -1;


### PR DESCRIPTION
## Why I'm doing:

Hit this case on some customer's parquet file. However I can not reproduce this case yet. 

## What I'm doing:

the thing is
- there could be no value at all, so return value is zero
- but we take (ret <= 0) as error

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0