### PR TITLE
[BugFix] Fix iceberg result error when query multi identical tables which have equality delete file

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergGetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergGetRemoteFilesParams.java
@@ -16,10 +16,8 @@ package com.starrocks.connector.iceberg;
 
 import com.starrocks.connector.GetRemoteFilesParams;
 
-import java.util.List;
-
 public class IcebergGetRemoteFilesParams extends GetRemoteFilesParams {
-    private List<IcebergMORParams> tableFullMORParams;
+    private IcebergTableMORParams tableFullMORParams;
     private IcebergMORParams morParams;
 
     private IcebergGetRemoteFilesParams(Builder builder) {
@@ -28,7 +26,7 @@ public class IcebergGetRemoteFilesParams extends GetRemoteFilesParams {
         this.morParams = builder.morParams;
     }
 
-    public List<IcebergMORParams> getTableFullMORParams() {
+    public IcebergTableMORParams getTableFullMORParams() {
         return tableFullMORParams;
     }
 
@@ -37,7 +35,7 @@ public class IcebergGetRemoteFilesParams extends GetRemoteFilesParams {
     }
 
     public static class Builder extends GetRemoteFilesParams.Builder {
-        private List<IcebergMORParams> tableFullMORParams;
+        private IcebergTableMORParams tableFullMORParams;
         private IcebergMORParams morParams;
 
         public IcebergGetRemoteFilesParams.Builder setParams(IcebergMORParams morParams) {
@@ -45,7 +43,7 @@ public class IcebergGetRemoteFilesParams extends GetRemoteFilesParams {
             return this;
         }
 
-        public IcebergGetRemoteFilesParams.Builder setAllParams(List<IcebergMORParams> tableFullMORParams) {
+        public IcebergGetRemoteFilesParams.Builder setAllParams(IcebergTableMORParams tableFullMORParams) {
             this.tableFullMORParams = tableFullMORParams;
             return this;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteFileInfoSourceKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteFileInfoSourceKey.java
@@ -21,14 +21,17 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import java.util.Objects;
 
 public class IcebergRemoteFileInfoSourceKey extends PredicateSearchKey {
+    private final long morId;
     private final IcebergMORParams icebergMORParams;
 
     private IcebergRemoteFileInfoSourceKey(String databaseName,
                                            String tableName,
                                            long snapshotId,
                                            ScalarOperator predicate,
+                                           long morId,
                                            IcebergMORParams icebergMORParams) {
         super(databaseName, tableName, snapshotId, predicate);
+        this.morId = morId;
         this.icebergMORParams = icebergMORParams;
     }
 
@@ -36,9 +39,10 @@ public class IcebergRemoteFileInfoSourceKey extends PredicateSearchKey {
                                                     String tableName,
                                                     long snapshotId,
                                                     ScalarOperator predicate,
+                                                    long morId,
                                                     IcebergMORParams icebergMORParams) {
         predicate = predicate == null ? ConstantOperator.TRUE : predicate;
-        return new IcebergRemoteFileInfoSourceKey(databaseName, tableName, snapshotId, predicate, icebergMORParams);
+        return new IcebergRemoteFileInfoSourceKey(databaseName, tableName, snapshotId, predicate, morId, icebergMORParams);
     }
 
     @Override
@@ -54,11 +58,11 @@ public class IcebergRemoteFileInfoSourceKey extends PredicateSearchKey {
         }
 
         IcebergRemoteFileInfoSourceKey that = (IcebergRemoteFileInfoSourceKey) o;
-        return Objects.equals(icebergMORParams, that.icebergMORParams);
+        return morId == that.morId && Objects.equals(icebergMORParams, that.icebergMORParams);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), icebergMORParams);
+        return Objects.hash(super.hashCode(), morId, icebergMORParams);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteSourceTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRemoteSourceTrigger.java
@@ -24,7 +24,6 @@ import org.apache.iceberg.FileScanTask;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -47,11 +46,11 @@ public class IcebergRemoteSourceTrigger {
     private final boolean needToCheckEqualityIds;
 
     // for incremental scan range
-    public IcebergRemoteSourceTrigger(RemoteFileInfoSource remoteFileInfoSource, List<IcebergMORParams> morParams) {
+    public IcebergRemoteSourceTrigger(RemoteFileInfoSource remoteFileInfoSource, IcebergTableMORParams tableFullMORParams) {
         this.delegate = remoteFileInfoSource;
-        Preconditions.checkArgument(morParams.size() >= 3);
-        this.needToCheckEqualityIds = morParams.size() != 3;
-        for (IcebergMORParams params : morParams) {
+        Preconditions.checkArgument(tableFullMORParams.size() >= 3);
+        this.needToCheckEqualityIds = tableFullMORParams.size() != 3;
+        for (IcebergMORParams params : tableFullMORParams.getMorParamsList()) {
             IcebergMORParams.ScanTaskType type = params.getScanTaskType();
             if (type == DATA_FILE_WITHOUT_EQ_DELETE) {
                 dataFileWithoutEqDeleteQueue = Optional.of(new ArrayDeque<>());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergTableMORParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergTableMORParams.java
@@ -24,6 +24,8 @@ public class IcebergTableMORParams {
     private final long morId;
     private final List<IcebergMORParams> morParamsList;
 
+    public static IcebergTableMORParams EMPTY = new IcebergTableMORParams(-1, List.of());
+
     public IcebergTableMORParams(long id, List<IcebergMORParams> morParamsList) {
         this.morId = id;
         this.morParamsList = morParamsList;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergTableMORParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergTableMORParams.java
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.List;
+
+// Mainly used for table with iceberg equality delete files
+public class IcebergTableMORParams {
+    // Use to identify the unique id for mor params.
+    private final long morId;
+    private final List<IcebergMORParams> morParamsList;
+
+    public IcebergTableMORParams(long id, List<IcebergMORParams> morParamsList) {
+        this.morId = id;
+        this.morParamsList = morParamsList;
+    }
+
+    public boolean isEmpty() {
+        return CollectionUtils.isEmpty(morParamsList);
+    }
+
+    public long getMORId() {
+        return morId;
+    }
+
+    public int size() {
+        return morParamsList.size();
+    }
+
+    public List<IcebergMORParams> getMorParamsList() {
+        return morParamsList;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -33,6 +33,7 @@ import com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource;
 import com.starrocks.connector.iceberg.IcebergGetRemoteFilesParams;
 import com.starrocks.connector.iceberg.IcebergMORParams;
 import com.starrocks.connector.iceberg.IcebergRemoteSourceTrigger;
+import com.starrocks.connector.iceberg.IcebergTableMORParams;
 import com.starrocks.connector.iceberg.QueueIcebergRemoteFileInfoSource;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
@@ -65,12 +66,12 @@ public class IcebergScanNode extends ScanNode {
     private CloudConfiguration cloudConfiguration = null;
     protected Optional<Long> snapshotId;
     private IcebergConnectorScanRangeSource scanRangeSource = null;
-    private final List<IcebergMORParams> tableFullMORParams;
+    private final IcebergTableMORParams tableFullMORParams;
     private final IcebergMORParams morParams;
     private int selectedPartitionCount = -1;
 
     public IcebergScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName,
-                           List<IcebergMORParams> tableFullMORParams, IcebergMORParams morParams) {
+                           IcebergTableMORParams tableFullMORParams, IcebergMORParams morParams) {
         super(id, desc, planNodeName);
         this.icebergTable = (IcebergTable) desc.getTable();
         this.tableFullMORParams = tableFullMORParams;
@@ -188,7 +189,7 @@ public class IcebergScanNode extends ScanNode {
     }
 
     // for unit tests
-    public List<IcebergMORParams> getTableFullMORParams() {
+    public IcebergTableMORParams getTableFullMORParams() {
         return tableFullMORParams;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergEqualityDeleteScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergEqualityDeleteScanOperator.java
@@ -20,12 +20,12 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.iceberg.IcebergMORParams;
+import com.starrocks.connector.iceberg.IcebergTableMORParams;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
-import java.util.List;
 import java.util.Map;
 
 public class LogicalIcebergEqualityDeleteScanOperator extends LogicalScanOperator {
@@ -37,7 +37,7 @@ public class LogicalIcebergEqualityDeleteScanOperator extends LogicalScanOperato
 
     // Mainly used for table with iceberg equality delete files. Record full iceberg mor params in the table,
     // used for the first build to associate multiple scan nodes RemoteFileInfoSource.
-    private List<IcebergMORParams> tableFullMORParams;
+    private IcebergTableMORParams tableFullMORParams;
 
     // Mainly used for table with iceberg equality delete files.
     // Marking this split scan node type after IcebergEqualityDeleteRewriteRule rewriting.
@@ -76,11 +76,11 @@ public class LogicalIcebergEqualityDeleteScanOperator extends LogicalScanOperato
     }
 
 
-    public List<IcebergMORParams> getTableFullMORParams() {
+    public IcebergTableMORParams getTableFullMORParams() {
         return tableFullMORParams;
     }
 
-    public void setTableFullMORParams(List<IcebergMORParams> tableFullMORParams) {
+    public void setTableFullMORParams(IcebergTableMORParams tableFullMORParams) {
         this.tableFullMORParams = tableFullMORParams;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergEqualityDeleteScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergEqualityDeleteScanOperator.java
@@ -37,7 +37,7 @@ public class LogicalIcebergEqualityDeleteScanOperator extends LogicalScanOperato
 
     // Mainly used for table with iceberg equality delete files. Record full iceberg mor params in the table,
     // used for the first build to associate multiple scan nodes RemoteFileInfoSource.
-    private IcebergTableMORParams tableFullMORParams;
+    private IcebergTableMORParams tableFullMORParams = IcebergTableMORParams.EMPTY;
 
     // Mainly used for table with iceberg equality delete files.
     // Marking this split scan node type after IcebergEqualityDeleteRewriteRule rewriting.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
@@ -44,7 +44,7 @@ public class LogicalIcebergScanOperator extends LogicalScanOperator {
 
     // Mainly used for table with iceberg equality delete files. Record full iceberg mor params in the table,
     // used for the first build to associate multiple scan nodes RemoteFileInfoSource.
-    private IcebergTableMORParams tableFullMORParams;
+    private IcebergTableMORParams tableFullMORParams = IcebergTableMORParams.EMPTY;
 
     // Mainly used for table with iceberg equality delete files.
     // Marking this split scan node type after IcebergEqualityDeleteRewriteRule rewriting.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
@@ -21,15 +21,14 @@ import com.starrocks.catalog.Table;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.iceberg.IcebergDeleteSchema;
 import com.starrocks.connector.iceberg.IcebergMORParams;
+import com.starrocks.connector.iceberg.IcebergTableMORParams;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,7 +44,7 @@ public class LogicalIcebergScanOperator extends LogicalScanOperator {
 
     // Mainly used for table with iceberg equality delete files. Record full iceberg mor params in the table,
     // used for the first build to associate multiple scan nodes RemoteFileInfoSource.
-    private List<IcebergMORParams> tableFullMORParams = new ArrayList<>();
+    private IcebergTableMORParams tableFullMORParams;
 
     // Mainly used for table with iceberg equality delete files.
     // Marking this split scan node type after IcebergEqualityDeleteRewriteRule rewriting.
@@ -107,11 +106,11 @@ public class LogicalIcebergScanOperator extends LogicalScanOperator {
         this.deleteSchemas = deleteSchemas;
     }
 
-    public List<IcebergMORParams> getTableFullMORParams() {
+    public IcebergTableMORParams getTableFullMORParams() {
         return tableFullMORParams;
     }
 
-    public void setTableFullMORParams(List<IcebergMORParams> tableFullMORParams) {
+    public void setTableFullMORParams(IcebergTableMORParams tableFullMORParams) {
         this.tableFullMORParams = tableFullMORParams;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergEqualityDeleteScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergEqualityDeleteScanOperator.java
@@ -29,7 +29,7 @@ public class PhysicalIcebergEqualityDeleteScanOperator extends PhysicalScanOpera
 
     private ScalarOperator originPredicate;
 
-    private IcebergTableMORParams tableFullMORParams;
+    private IcebergTableMORParams tableFullMORParams = IcebergTableMORParams.EMPTY;
     private IcebergMORParams morParams;
 
     public PhysicalIcebergEqualityDeleteScanOperator(LogicalIcebergEqualityDeleteScanOperator scanOperator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergEqualityDeleteScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergEqualityDeleteScanOperator.java
@@ -16,6 +16,7 @@
 package com.starrocks.sql.optimizer.operator.physical;
 
 import com.starrocks.connector.iceberg.IcebergMORParams;
+import com.starrocks.connector.iceberg.IcebergTableMORParams;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -24,14 +25,11 @@ import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergEqualityDeleteScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class PhysicalIcebergEqualityDeleteScanOperator extends PhysicalScanOperator {
 
     private ScalarOperator originPredicate;
 
-    private List<IcebergMORParams> tableFullMORParams = new ArrayList<>();
+    private IcebergTableMORParams tableFullMORParams;
     private IcebergMORParams morParams;
 
     public PhysicalIcebergEqualityDeleteScanOperator(LogicalIcebergEqualityDeleteScanOperator scanOperator) {
@@ -46,11 +44,11 @@ public class PhysicalIcebergEqualityDeleteScanOperator extends PhysicalScanOpera
         this.originPredicate = originPredicate;
     }
 
-    public List<IcebergMORParams> getTableFullMORParams() {
+    public IcebergTableMORParams getTableFullMORParams() {
         return tableFullMORParams;
     }
 
-    public void setTableFullMORParams(List<IcebergMORParams> tableFullMORParams) {
+    public void setTableFullMORParams(IcebergTableMORParams tableFullMORParams) {
         this.tableFullMORParams = tableFullMORParams;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergScanOperator.java
@@ -26,7 +26,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 
 public class PhysicalIcebergScanOperator extends PhysicalScanOperator {
     private ScanOperatorPredicates predicates;
-    private IcebergTableMORParams tableFullMORParams;
+    private IcebergTableMORParams tableFullMORParams = IcebergTableMORParams.EMPTY;
     private IcebergMORParams morParams = IcebergMORParams.EMPTY;
 
     public PhysicalIcebergScanOperator(LogicalIcebergScanOperator scanOperator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergScanOperator.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.operator.physical;
 
 import com.starrocks.connector.iceberg.IcebergMORParams;
+import com.starrocks.connector.iceberg.IcebergTableMORParams;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -23,12 +24,9 @@ import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class PhysicalIcebergScanOperator extends PhysicalScanOperator {
     private ScanOperatorPredicates predicates;
-    private List<IcebergMORParams> tableFullMORParams = new ArrayList<>();
+    private IcebergTableMORParams tableFullMORParams;
     private IcebergMORParams morParams = IcebergMORParams.EMPTY;
 
     public PhysicalIcebergScanOperator(LogicalIcebergScanOperator scanOperator) {
@@ -46,11 +44,11 @@ public class PhysicalIcebergScanOperator extends PhysicalScanOperator {
         this.predicates = predicates;
     }
 
-    public List<IcebergMORParams> getTableFullMORParams() {
+    public IcebergTableMORParams getTableFullMORParams() {
         return tableFullMORParams;
     }
 
-    public void setTableFullMORParams(List<IcebergMORParams> tableFullMORParams) {
+    public void setTableFullMORParams(IcebergTableMORParams tableFullMORParams) {
         this.tableFullMORParams = tableFullMORParams;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergEqualityDeletePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergEqualityDeletePlanTest.java
@@ -148,7 +148,7 @@ public class IcebergEqualityDeletePlanTest extends TableTestBase {
                 "     avgRowSize=3.0");
 
         // check iceberg scan node
-        List<IcebergMORParams> tableFullMORParams = Lists.newArrayList(
+        List<IcebergMORParams> morParamsList = Lists.newArrayList(
                 IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE,
                 IcebergMORParams.DATA_FILE_WITH_EQ_DELETE,
                 IcebergMORParams.of(IcebergMORParams.ScanTaskType.EQ_DELETE, Lists.newArrayList(1))
@@ -158,14 +158,14 @@ public class IcebergEqualityDeletePlanTest extends TableTestBase {
         Assert.assertTrue(scanNode instanceof IcebergScanNode);
         IcebergScanNode icebergScanNode = (IcebergScanNode) scanNode;
         Assert.assertEquals(IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE, icebergScanNode.getMORParams());
-        Assert.assertEquals(tableFullMORParams, icebergScanNode.getTableFullMORParams());
+        Assert.assertEquals(morParamsList, icebergScanNode.getTableFullMORParams().getMorParamsList());
         Assert.assertTrue(icebergScanNode.getExtendedColumnSlotIds().isEmpty());
 
         scanNode = pair.second.getFragments().get(2).collectScanNodes().get(new PlanNodeId(3));
         Assert.assertTrue(scanNode instanceof IcebergScanNode);
         icebergScanNode = (IcebergScanNode) scanNode;
         Assert.assertEquals(IcebergMORParams.DATA_FILE_WITH_EQ_DELETE, icebergScanNode.getMORParams());
-        Assert.assertEquals(tableFullMORParams, icebergScanNode.getTableFullMORParams());
+        Assert.assertEquals(morParamsList, icebergScanNode.getTableFullMORParams().getMorParamsList());
         Assert.assertFalse(icebergScanNode.getExtendedColumnSlotIds().isEmpty());
 
         // check iceberg equality scan node

--- a/test/sql/test_iceberg/R/test_iceberg_v2
+++ b/test/sql/test_iceberg/R/test_iceberg_v2
@@ -2,6 +2,9 @@
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
 -- !result
+set enable_connector_incremental_scan_ranges=true;
+-- result:
+-- !result
 /*
  CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_orc_unpartitioned_table` (
   `k1` INT NOT NULL,
@@ -65,7 +68,6 @@ select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_part
 select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table group by k1,k3 having count(1) > 1;
 -- result:
 -- !result
-
 /*
  CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_parquet_unpartitioned_table` (
   `k1` INT NOT NULL,
@@ -93,6 +95,25 @@ select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_
 -- !result
 select k1 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table group by k1 having count(1) > 1;
 -- result:
+-- !result
+select l.k1, sum(length(l.k2)) l_k2, sum(length(r.k2)) r_k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table l
+left join iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table r on l.k1 = r.k1 group by 1 order by 1;
+-- result:
+1	8	8
+2	9	9
+-- !result
+with cte1 as (
+    select l.k1, sum(length(l.k2)) l_k2, sum(length(r.k2)) r_k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table l
+        left join iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table r on l.k1 = r.k1 group by 1
+    ),
+    cte2 as (
+    select l.k1, sum(length(l.k2)) l_k2, sum(length(r.k2)) r_k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table l
+        left join iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table r on l.k1 = r.k1 group by 1
+    )
+select cte1.k1, cte2.k1, cte1.l_k2, cte2.r_k2 from cte1 left join cte2 on cte1.k1 = cte2.k1;
+-- result:
+2	2	9	9
+1	1	8	8
 -- !result
 /*
 CREATE TABLE `hive_catalog`.`iceberg_ci_db`.`iceberg_v2_parquet_partitioned_table` (
@@ -129,7 +150,6 @@ select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_
 select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table group by k1,k3 having count(1) > 1;
 -- result:
 -- !result
-
 drop catalog iceberg_sql_test_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_v2
+++ b/test/sql/test_iceberg/T/test_iceberg_v2
@@ -4,6 +4,7 @@ create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", 
 
 -- Currently only flink can write iceberg equality delete file. The table in the case was created in advance and some test data was inserted using flink. If you want test more cases, you could contact stephen5217@163.com
 
+set enable_connector_incremental_scan_ranges=true;
 
 -- unpartitioned table with orc (eq-delete && pos-delete) 
 /*
@@ -68,6 +69,19 @@ select k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpart
 select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table;
 
 select k1 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table group by k1 having count(1) > 1;
+
+select l.k1, sum(length(l.k2)) l_k2, sum(length(r.k2)) r_k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table l
+left join iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table r on l.k1 = r.k1 group by 1 order by 1;
+
+with cte1 as (
+    select l.k1, sum(length(l.k2)) l_k2, sum(length(r.k2)) r_k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table l
+        left join iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table r on l.k1 = r.k1 group by 1
+    ),
+    cte2 as (
+    select l.k1, sum(length(l.k2)) l_k2, sum(length(r.k2)) r_k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table l
+        left join iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_unpartitioned_table r on l.k1 = r.k1 group by 1
+    )
+select cte1.k1, cte2.k1, cte1.l_k2, cte2.r_k2 from cte1 left join cte2 on cte1.k1 = cte2.k1;
 
 -- partitioned table with parquet (eq-delete && pos-delete)
 /*


### PR DESCRIPTION
## Why I'm doing:
Fix #55887
For iceberg query with enable incremental scan ranges, it would use same RemoteFileInfoSource for same table, result in query result error

## What I'm doing:
add mor id for IcebergRemoteFileInfoSourceKey to avoid use same RemoteFileInfoSource for same table 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0