### PR TITLE
[Doc] Fix admonitions syntax

### DIFF
--- a/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/STOP_ROUTINE_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/STOP_ROUTINE_LOAD.md
@@ -12,7 +12,7 @@ Stops a Routine Load job.
 
 <RoutineLoadPrivNote />
 
-::: warning
+:::warning
 
 - A stopped Routine Load job cannot be resumed. Therefore, please proceed with caution when executing this statement.
 - If you only need to pause the Routine Load job, you can execute [PAUSE ROUTINE LOAD](PAUSE_ROUTINE_LOAD.md).

--- a/docs/zh/sql-reference/sql-statements/loading_unloading/routine_load/STOP_ROUTINE_LOAD.md
+++ b/docs/zh/sql-reference/sql-statements/loading_unloading/routine_load/STOP_ROUTINE_LOAD.md
@@ -12,7 +12,7 @@ import RoutineLoadPrivNote from '../../../../_assets/commonMarkdown/RoutineLoadP
 
 <RoutineLoadPrivNote />
 
-::: warning
+:::warning
 
 导入作业停止且无法恢复。因此请谨慎执行该语句。
 


### PR DESCRIPTION
## Why I'm doing:
Wrong admonitions syntax.

<img width="811" alt="截屏2025-02-17 14 25 15" src="https://github.com/user-attachments/assets/097eec95-9b53-4c62-b648-5c27d8065388" />

## What I'm doing:
Fix admonitions syntax.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0