### PR TITLE
[UT] [BugFix] Fix possible NPE querying task_runs schema table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1390,7 +1390,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                         partition.getDefaultPhysicalPartition().getVisibleVersionTime());
                 partitionInfos.put(partition.getName(), basePartitionInfo);
             }
-            LOG.info("Collect olap base table {}'s refreshed partition infos: {}", baseTable.getName(), partitionInfos);
+            LOG.debug("Collect olap base table {}'s refreshed partition infos: {}", baseTable.getName(), partitionInfos);
             return partitionInfos;
         } else if (ConnectorPartitionTraits.isSupportPCTRefresh(baseTable.getType())) {
             return getSelectedPartitionInfos(baseTable, Lists.newArrayList(refreshedPartitionNames), baseTableInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -61,6 +61,8 @@ public class TaskRun implements Comparable<TaskRun> {
     public static final Set<String> TASK_RUN_PROPERTIES = ImmutableSet.of(
             MV_ID, PARTITION_START, PARTITION_END, FORCE, START_TASK_RUN_ID, PARTITION_VALUES);
 
+    public static final int INVALID_TASK_PROGRESS = -1;
+
     // Only used in FE's UT
     public static final String IS_TEST = "__IS_TEST__";
     private boolean isKilled = false;
@@ -314,29 +316,46 @@ public class TaskRun implements Comparable<TaskRun> {
         if (status == null) {
             return null;
         }
-        switch (status.getState()) {
-            case RUNNING:
-                if (runCtx != null) {
-                    StmtExecutor executor = runCtx.getExecutor();
-                    if (executor != null && executor.getCoordinator() != null) {
-                        long jobId = executor.getCoordinator().getLoadJobId();
-                        if (jobId != -1) {
-                            InsertLoadJob job = (InsertLoadJob) GlobalStateMgr.getCurrentState()
-                                    .getLoadMgr().getLoadJob(jobId);
-                            int progress = job.getProgress();
-                            if (progress == 100) {
-                                progress = 99;
-                            }
-                            status.setProgress(progress);
-                        }
-                    }
-                }
-                break;
-            case SUCCESS:
-                status.setProgress(100);
-                break;
+        final int progress = getProgress();
+        if (progress != INVALID_TASK_PROGRESS) {
+            status.setProgress(progress);
         }
         return status;
+    }
+
+    private int getProgress() {
+        if (status == null) {
+            return INVALID_TASK_PROGRESS;
+        }
+
+        if (status.getState().isSuccessState()) {
+            return 100;
+        } else if (status.getState().isFinishState()) {
+            return INVALID_TASK_PROGRESS;
+        } else {
+            if (runCtx == null) {
+                return INVALID_TASK_PROGRESS;
+            }
+            final StmtExecutor executor = runCtx.getExecutor();
+            if (executor == null || executor.getCoordinator() == null) {
+                return INVALID_TASK_PROGRESS;
+            }
+            final long jobId = executor.getCoordinator().getLoadJobId();
+            if (jobId == -1) {
+                return INVALID_TASK_PROGRESS;
+            }
+            final InsertLoadJob job = (InsertLoadJob) GlobalStateMgr.getCurrentState()
+                    .getLoadMgr().getLoadJob(jobId);
+            if (job == null) {
+                return INVALID_TASK_PROGRESS;
+            }
+            int progress = job.getProgress();
+            // if the progress is 100, we should return 99 to avoid the task run is marked as success
+            if (progress == 100) {
+                progress = 99;
+            }
+            return progress;
+        }
     }
 
     public TaskRunStatus initStatus(String queryId, Long createTime) {


### PR DESCRIPTION
## Why I'm doing:

```
 2025-02-11 15:04:24.414+08:00 ERROR (thrift-server-pool-125|2590) [ProcessFunction.process():49] Internal error processing getTaskRuns
 java.lang.NullPointerException: Cannot invoke "com.starrocks.load.loadv2.InsertLoadJob.getProgress()" because "job" is null
        at com.starrocks.scheduler.TaskRun.getStatus(TaskRun.java:326)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
        at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at com.starrocks.scheduler.TaskManager.getMatchedTaskRunStatus(TaskManager.java:615)
        at com.starrocks.catalog.system.information.TaskRunsSystemTable.query(TaskRunsSystemTable.java:192)
        at com.starrocks.service.FrontendServiceImpl.getTaskRuns(FrontendServiceImpl.java:886)
        at com.starrocks.thrift.FrontendService$Processor$getTaskRuns.getResult(FrontendService.java:5617)
        at com.starrocks.thrift.FrontendService$Processor$getTaskRuns.getResult(FrontendService.java:5594)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:40)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:40)
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:311)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
```
## What I'm doing:
- Avoid NPE in `getTaskRunStatus`

Fixes https://github.com/StarRocks/StarRocksTest/issues/9219

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0