### PR TITLE
[BugFix] Fix table state may not correct caused by LakeRollupJob

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRollupJob.java
@@ -415,7 +415,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
 
             this.jobState = JobState.FINISHED;
             this.finishedTimeMs = System.currentTimeMillis();
-            table.setState(OlapTable.OlapTableState.NORMAL);
+            // There is no need to set the table state to normal,
+            // because it will be set in MaterializedViewHandler `onJobDone`
         }
 
         writeEditLog(this);
@@ -444,7 +445,6 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
             LakeTable table = (db != null) ? db.getTable(tableId) : null;
             if (table != null) {
                 removeRollupIndex(table);
-                table.setState(OlapTable.OlapTableState.NORMAL);
             }
         }
 
@@ -541,10 +541,8 @@ public class LakeRollupJob extends LakeTableSchemaChangeJobBase {
                 updateNextVersion(table);
             } else if (jobState == JobState.FINISHED) {
                 visualiseRollupIndex(table);
-                table.setState(OlapTable.OlapTableState.NORMAL);
             } else if (jobState == JobState.CANCELLED) {
                 removeRollupIndex(table);
-                table.setState(OlapTable.OlapTableState.NORMAL);
             } else {
                 throw new RuntimeException("unknown job state '{}'" + jobState.name());
             }


### PR DESCRIPTION
## Why I'm doing:
After the rollup job completed, the table state will be set to normal in the `onJobDone ` method in MaterialziedViewHandler, but there is sitll a short gap between the completion of the job and the setting of the table to normal. Since the current implementation of `lakeRollupJob` sets the table to normal in the job directly, if another schema change job is submitted during this gap time, an ABA problem will occur, and the table status will be incorrectly set to normal.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0