### PR TITLE
[Enhancement] Make exec_plan_fragment rpc timeout configable and add more metrics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -843,6 +843,21 @@ public class Config extends ConfigBase {
     @ConfField
     public static int brpc_idle_wait_max_time = 10000;
 
+    @ConfField(mutable = true)
+    public static int brpc_send_plan_fragment_timeout_ms = 60000;
+
+    @ConfField
+    public static boolean brpc_reuse_addr = true;
+
+    @ConfField
+    public static int brpc_min_evictable_idle_time_ms = 120000;
+
+    @ConfField
+    public static boolean brpc_short_connection = false;
+
+    @ConfField
+    public static boolean brpc_inner_reuse_pool = true;
+
     /**
      * FE mysql server port
      */

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -59,6 +59,7 @@ import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.exception.GlobalDictNotMatchException;
 import com.starrocks.connector.exception.RemoteFileNotFoundException;
 import com.starrocks.datacache.DataCacheSelectMetrics;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
@@ -671,6 +672,7 @@ public class DefaultCoordinator extends Coordinator {
                             this::handleErrorExecution, option.doDeploy);
             scheduler.prepareSchedule(this, deployer, executionDAG);
             this.scheduler.schedule(option);
+            MetricRepo.HISTO_DEPLOY_PLAN_FRAGMENTS_LATENCY.update(ignored.getTotalTime());
             queryProfile.attachExecutionProfiles(executionDAG.getExecutions());
         } finally {
             unlock();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.RuntimeProfile;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PPlanFragmentCancelReason;
@@ -290,9 +291,11 @@ public class FragmentInstanceExecState {
             failure = e;
         }
 
+        MetricRepo.COUNTER_BRPC_EXEC_PLAN_FRAGMENT.increase(1L);
         if (code == TStatusCode.OK) {
             transitionState(State.DEPLOYING, State.EXECUTING);
         } else {
+            MetricRepo.COUNTER_BRPC_EXEC_PLAN_FRAGMENT_ERROR.increase(1L);
             transitionState(State.DEPLOYING, State.FAILED);
 
             if (errMsg == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.rpc;
 
+import com.baidu.jprotobuf.pbrpc.utils.TalkTimeoutController;
 import com.google.common.base.Preconditions;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Timer;
@@ -85,6 +86,7 @@ public class BackendServiceClient {
         Tracers.count(Tracers.Module.SCHEDULER, "DeployDataSize", pRequest.serializedRequest.length);
         try (Timer ignored = Tracers.watchScope(Tracers.Module.SCHEDULER, "DeployAsyncSendTime")) {
             final PBackendService service = BrpcProxy.getBackendService(address);
+            TalkTimeoutController.setTalkTimeout(Config.brpc_send_plan_fragment_timeout_ms);
             return service.execPlanFragmentAsync(pRequest);
         } catch (NoSuchElementException e) {
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BrpcProxy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BrpcProxy.java
@@ -42,6 +42,11 @@ public class BrpcProxy {
         // Therefore, MaxIdleSize shouldn't less than MaxTotal for the async requests.
         rpcOptions.setMaxIdleSize(Config.brpc_connection_pool_size);
         rpcOptions.setMaxWait(Config.brpc_idle_wait_max_time);
+        rpcOptions.setJmxEnabled(true);
+        rpcOptions.setReuseAddress(Config.brpc_reuse_addr);
+        rpcOptions.setMinEvictableIdleTime(Config.brpc_min_evictable_idle_time_ms);
+        rpcOptions.setShortConnection(Config.brpc_short_connection);
+        rpcOptions.setInnerResuePool(Config.brpc_inner_reuse_pool);
 
         rpcClient = new RpcClient(rpcOptions);
         backendServiceMap = new ConcurrentHashMap<>();
@@ -87,14 +92,14 @@ public class BrpcProxy {
         ProtobufRpcProxy<PBackendService> proxy = new ProtobufRpcProxy<>(rpcClient, PBackendService.class);
         proxy.setHost(address.getHostname());
         proxy.setPort(address.getPort());
-        return proxy.proxy();
+        return new PBackendServiceWithMetrics(proxy.proxy());
     }
 
     private LakeService createLakeService(TNetworkAddress address) {
         ProtobufRpcProxy<LakeService> proxy = new ProtobufRpcProxy<>(rpcClient, LakeService.class);
         proxy.setHost(address.getHostname());
         proxy.setPort(address.getPort());
-        return proxy.proxy();
+        return new LakeServiceWithMetrics(proxy.proxy());
     }
 
     private static class SingletonHolder {

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
@@ -1,0 +1,158 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.rpc;
+
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.proto.AbortCompactionRequest;
+import com.starrocks.proto.AbortCompactionResponse;
+import com.starrocks.proto.AbortTxnRequest;
+import com.starrocks.proto.AbortTxnResponse;
+import com.starrocks.proto.CompactRequest;
+import com.starrocks.proto.CompactResponse;
+import com.starrocks.proto.DeleteDataRequest;
+import com.starrocks.proto.DeleteDataResponse;
+import com.starrocks.proto.DeleteTabletRequest;
+import com.starrocks.proto.DeleteTabletResponse;
+import com.starrocks.proto.DeleteTxnLogRequest;
+import com.starrocks.proto.DeleteTxnLogResponse;
+import com.starrocks.proto.DropTableRequest;
+import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.LockTabletMetadataRequest;
+import com.starrocks.proto.LockTabletMetadataResponse;
+import com.starrocks.proto.PublishLogVersionBatchRequest;
+import com.starrocks.proto.PublishLogVersionRequest;
+import com.starrocks.proto.PublishLogVersionResponse;
+import com.starrocks.proto.PublishVersionRequest;
+import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.RestoreSnapshotsRequest;
+import com.starrocks.proto.RestoreSnapshotsResponse;
+import com.starrocks.proto.TabletStatRequest;
+import com.starrocks.proto.TabletStatResponse;
+import com.starrocks.proto.UnlockTabletMetadataRequest;
+import com.starrocks.proto.UnlockTabletMetadataResponse;
+import com.starrocks.proto.UploadSnapshotsRequest;
+import com.starrocks.proto.UploadSnapshotsResponse;
+import com.starrocks.proto.VacuumRequest;
+import com.starrocks.proto.VacuumResponse;
+
+import java.util.concurrent.Future;
+
+public class LakeServiceWithMetrics implements LakeService {
+    final LakeService lakeService;
+    public LakeServiceWithMetrics(LakeService lakeService) {
+        this.lakeService = lakeService;
+    }
+
+    private static void increaseMetrics() {
+        if (MetricRepo.COUNTER_LAKE_SERVICE_RPC != null) {
+            MetricRepo.COUNTER_LAKE_SERVICE_RPC.increase(1L);
+        }
+    }
+
+    @Override
+    public Future<PublishVersionResponse> publishVersion(PublishVersionRequest request) {
+        increaseMetrics();
+        return lakeService.publishVersion(request);
+    }
+
+    @Override
+    public Future<AbortTxnResponse> abortTxn(AbortTxnRequest request) {
+        increaseMetrics();
+        return lakeService.abortTxn(request);
+    }
+
+    @Override
+    public Future<CompactResponse> compact(CompactRequest request) {
+        increaseMetrics();
+        return lakeService.compact(request);
+    }
+
+    @Override
+    public Future<DeleteTabletResponse> deleteTablet(DeleteTabletRequest request) {
+        increaseMetrics();
+        return lakeService.deleteTablet(request);
+    }
+
+    @Override
+    public Future<DeleteDataResponse> deleteData(DeleteDataRequest request) {
+        increaseMetrics();
+        return lakeService.deleteData(request);
+    }
+
+    @Override
+    public Future<DeleteTxnLogResponse> deleteTxnLog(DeleteTxnLogRequest request) {
+        increaseMetrics();
+        return lakeService.deleteTxnLog(request);
+    }
+
+    @Override
+    public Future<TabletStatResponse> getTabletStats(TabletStatRequest request) {
+        increaseMetrics();
+        return lakeService.getTabletStats(request);
+    }
+
+    @Override
+    public Future<DropTableResponse> dropTable(DropTableRequest request) {
+        increaseMetrics();
+        return lakeService.dropTable(request);
+    }
+
+    @Override
+    public Future<PublishLogVersionResponse> publishLogVersion(PublishLogVersionRequest request) {
+        increaseMetrics();
+        return lakeService.publishLogVersion(request);
+    }
+
+    @Override
+    public Future<PublishLogVersionResponse> publishLogVersionBatch(PublishLogVersionBatchRequest request) {
+        increaseMetrics();
+        return lakeService.publishLogVersionBatch(request);
+    }
+
+    @Override
+    public Future<LockTabletMetadataResponse> lockTabletMetadata(LockTabletMetadataRequest request) {
+        increaseMetrics();
+        return lakeService.lockTabletMetadata(request);
+    }
+
+    @Override
+    public Future<UnlockTabletMetadataResponse> unlockTabletMetadata(UnlockTabletMetadataRequest request) {
+        increaseMetrics();
+        return lakeService.unlockTabletMetadata(request);
+    }
+
+    @Override
+    public Future<UploadSnapshotsResponse> uploadSnapshots(UploadSnapshotsRequest request) {
+        increaseMetrics();
+        return lakeService.uploadSnapshots(request);
+    }
+
+    @Override
+    public Future<RestoreSnapshotsResponse> restoreSnapshots(RestoreSnapshotsRequest request) {
+        increaseMetrics();
+        return lakeService.restoreSnapshots(request);
+    }
+
+    @Override
+    public Future<AbortCompactionResponse> abortCompaction(AbortCompactionRequest request) {
+        increaseMetrics();
+        return lakeService.abortCompaction(request);
+    }
+
+    @Override
+    public Future<VacuumResponse> vacuum(VacuumRequest request) {
+        increaseMetrics();
+        return lakeService.vacuum(request);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PBackendServiceWithMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PBackendServiceWithMetrics.java
@@ -1,0 +1,158 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.rpc;
+
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.proto.ExecuteCommandRequestPB;
+import com.starrocks.proto.ExecuteCommandResultPB;
+import com.starrocks.proto.PCancelPlanFragmentRequest;
+import com.starrocks.proto.PCancelPlanFragmentResult;
+import com.starrocks.proto.PCollectQueryStatisticsResult;
+import com.starrocks.proto.PExecBatchPlanFragmentsResult;
+import com.starrocks.proto.PExecPlanFragmentResult;
+import com.starrocks.proto.PExecShortCircuitResult;
+import com.starrocks.proto.PFetchArrowSchemaRequest;
+import com.starrocks.proto.PFetchArrowSchemaResult;
+import com.starrocks.proto.PFetchDataResult;
+import com.starrocks.proto.PGetFileSchemaResult;
+import com.starrocks.proto.PListFailPointResponse;
+import com.starrocks.proto.PMVMaintenanceTaskResult;
+import com.starrocks.proto.PProcessDictionaryCacheRequest;
+import com.starrocks.proto.PProcessDictionaryCacheResult;
+import com.starrocks.proto.PProxyRequest;
+import com.starrocks.proto.PProxyResult;
+import com.starrocks.proto.PPulsarProxyRequest;
+import com.starrocks.proto.PPulsarProxyResult;
+import com.starrocks.proto.PTriggerProfileReportResult;
+import com.starrocks.proto.PUpdateFailPointStatusRequest;
+import com.starrocks.proto.PUpdateFailPointStatusResponse;
+import com.starrocks.proto.PUpdateTransactionStateRequest;
+import com.starrocks.proto.PUpdateTransactionStateResponse;
+
+import java.util.concurrent.Future;
+
+public class PBackendServiceWithMetrics implements PBackendService {
+    final PBackendService pBackendService;
+    PBackendServiceWithMetrics(PBackendService pBackendService) {
+        this.pBackendService = pBackendService;
+    }
+
+    private static void increaseMetrics() {
+        if (MetricRepo.COUNTER_BACKEND_SERVICE_RPC != null) {
+            MetricRepo.COUNTER_BACKEND_SERVICE_RPC.increase(1L);
+        }
+    }
+
+    @Override
+    public Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request) {
+        increaseMetrics();
+        return pBackendService.execPlanFragmentAsync(request);
+    }
+
+    @Override
+    public Future<PExecBatchPlanFragmentsResult> execBatchPlanFragmentsAsync(PExecBatchPlanFragmentsRequest request) {
+        increaseMetrics();
+        return pBackendService.execBatchPlanFragmentsAsync(request);
+    }
+
+    @Override
+    public Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(PCancelPlanFragmentRequest request) {
+        increaseMetrics();
+        return pBackendService.cancelPlanFragmentAsync(request);
+    }
+
+    @Override
+    public Future<PFetchDataResult> fetchDataAsync(PFetchDataRequest request) {
+        increaseMetrics();
+        return pBackendService.fetchDataAsync(request);
+    }
+
+    @Override
+    public Future<PTriggerProfileReportResult> triggerProfileReport(PTriggerProfileReportRequest request) {
+        increaseMetrics();
+        return pBackendService.triggerProfileReport(request);
+    }
+
+    @Override
+    public Future<PCollectQueryStatisticsResult> collectQueryStatistics(PCollectQueryStatisticsRequest request) {
+        increaseMetrics();
+        return pBackendService.collectQueryStatistics(request);
+    }
+
+    @Override
+    public Future<PProxyResult> getInfo(PProxyRequest request) {
+        increaseMetrics();
+        return pBackendService.getInfo(request);
+    }
+
+    @Override
+    public Future<PPulsarProxyResult> getPulsarInfo(PPulsarProxyRequest request) {
+        increaseMetrics();
+        return pBackendService.getPulsarInfo(request);
+    }
+
+    @Override
+    public Future<PGetFileSchemaResult> getFileSchema(PGetFileSchemaRequest request) {
+        increaseMetrics();
+        return pBackendService.getFileSchema(request);
+    }
+
+    @Override
+    public Future<PMVMaintenanceTaskResult> submitMVMaintenanceTaskAsync(PMVMaintenanceTaskRequest request) {
+        increaseMetrics();
+        return pBackendService.submitMVMaintenanceTaskAsync(request);
+    }
+
+    @Override
+    public Future<ExecuteCommandResultPB> executeCommandAsync(ExecuteCommandRequestPB request) {
+        increaseMetrics();
+        return pBackendService.executeCommandAsync(request);
+    }
+
+    @Override
+    public Future<PUpdateFailPointStatusResponse> updateFailPointStatusAsync(PUpdateFailPointStatusRequest request) {
+        increaseMetrics();
+        return pBackendService.updateFailPointStatusAsync(request);
+    }
+
+    @Override
+    public Future<PListFailPointResponse> listFailPointAsync(PListFailPointRequest request) {
+        increaseMetrics();
+        return pBackendService.listFailPointAsync(request);
+    }
+
+    @Override
+    public Future<PExecShortCircuitResult> execShortCircuit(PExecShortCircuitRequest request) {
+        increaseMetrics();
+        return pBackendService.execShortCircuit(request);
+    }
+
+    @Override
+    public Future<PProcessDictionaryCacheResult> processDictionaryCache(PProcessDictionaryCacheRequest request) {
+        increaseMetrics();
+        return pBackendService.processDictionaryCache(request);
+    }
+
+    @Override
+    public Future<PFetchArrowSchemaResult> fetchArrowSchema(PFetchArrowSchemaRequest request) {
+        increaseMetrics();
+        return pBackendService.fetchArrowSchema(request);
+    }
+
+    @Override
+    public Future<PUpdateTransactionStateResponse> updateTransactionState(PUpdateTransactionStateRequest request) {
+        increaseMetrics();
+        return pBackendService.updateTransactionState(request);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
@@ -16,7 +16,9 @@ package com.starrocks.metric;
 
 import com.starrocks.catalog.Table;
 import com.starrocks.http.rest.MetricsAction;
+import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TNetworkAddress;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -27,6 +29,8 @@ public class MetricRepoTest extends PlanTestBase {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        // init brpc so brpc metrics can be collected
+        BrpcProxy.getBackendService(new TNetworkAddress("127.0.0.1", 12345));
         PlanTestBase.beforeClass();
 
         starRocksAssert.withDatabase("test_metric");
@@ -61,6 +65,7 @@ public class MetricRepoTest extends PlanTestBase {
         String json = visitor.build();
         Assert.assertTrue(StringUtils.isNotEmpty(json));
         Assert.assertTrue(json.contains("test_metric"));
+        Assert.assertTrue(json.contains("brpc_pool_numactive"));
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/rpc/LakeServiceWithMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/rpc/LakeServiceWithMetricsTest.java
@@ -1,0 +1,281 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.rpc;
+
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.proto.AbortCompactionRequest;
+import com.starrocks.proto.AbortCompactionResponse;
+import com.starrocks.proto.AbortTxnRequest;
+import com.starrocks.proto.AbortTxnResponse;
+import com.starrocks.proto.CompactRequest;
+import com.starrocks.proto.CompactResponse;
+import com.starrocks.proto.DeleteDataRequest;
+import com.starrocks.proto.DeleteDataResponse;
+import com.starrocks.proto.DeleteTabletRequest;
+import com.starrocks.proto.DeleteTabletResponse;
+import com.starrocks.proto.DeleteTxnLogRequest;
+import com.starrocks.proto.DeleteTxnLogResponse;
+import com.starrocks.proto.DropTableRequest;
+import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.LockTabletMetadataRequest;
+import com.starrocks.proto.LockTabletMetadataResponse;
+import com.starrocks.proto.PublishLogVersionBatchRequest;
+import com.starrocks.proto.PublishLogVersionRequest;
+import com.starrocks.proto.PublishLogVersionResponse;
+import com.starrocks.proto.PublishVersionRequest;
+import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.RestoreSnapshotsRequest;
+import com.starrocks.proto.RestoreSnapshotsResponse;
+import com.starrocks.proto.TabletStatRequest;
+import com.starrocks.proto.TabletStatResponse;
+import com.starrocks.proto.UnlockTabletMetadataRequest;
+import com.starrocks.proto.UnlockTabletMetadataResponse;
+import com.starrocks.proto.UploadSnapshotsRequest;
+import com.starrocks.proto.UploadSnapshotsResponse;
+import com.starrocks.proto.VacuumRequest;
+import com.starrocks.proto.VacuumResponse;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Tested;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertNotNull;
+
+public class LakeServiceWithMetricsTest {
+    @Tested
+    LakeServiceWithMetrics lakeServiceWithMetrics;
+
+    @Injectable
+    LakeService lakeService;
+
+    @BeforeClass
+    public static void setUp() {
+        MetricRepo.init();
+    }
+
+    @Test
+    public void testPublishVersion() throws Exception {
+        new Expectations() {
+            {
+                lakeService.publishVersion((PublishVersionRequest) any);
+                result = CompletableFuture.completedFuture(new PublishVersionResponse());
+            }
+        };
+
+        Future<PublishVersionResponse> result = lakeServiceWithMetrics.publishVersion(new PublishVersionRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testAbortTxn() throws Exception {
+        new Expectations() {
+            {
+                lakeService.abortTxn((AbortTxnRequest) any);
+                result = CompletableFuture.completedFuture(new AbortTxnResponse());
+            }
+        };
+
+        Future<AbortTxnResponse> result = lakeServiceWithMetrics.abortTxn(new AbortTxnRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testCompact() throws Exception {
+        new Expectations() {
+            {
+                lakeService.compact((CompactRequest) any);
+                result = CompletableFuture.completedFuture(new CompactResponse());
+            }
+        };
+
+        Future<CompactResponse> result = lakeServiceWithMetrics.compact(new CompactRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testDeleteTablet() throws Exception {
+        new Expectations() {
+            {
+                lakeService.deleteTablet((DeleteTabletRequest) any);
+                result = CompletableFuture.completedFuture(new DeleteTabletResponse());
+            }
+        };
+
+        Future<DeleteTabletResponse> result = lakeServiceWithMetrics.deleteTablet(new DeleteTabletRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testDeleteData() throws Exception {
+        new Expectations() {
+            {
+                lakeService.deleteData((DeleteDataRequest) any);
+                result = CompletableFuture.completedFuture(new DeleteDataResponse());
+            }
+        };
+
+        Future<DeleteDataResponse> result = lakeServiceWithMetrics.deleteData(new DeleteDataRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testDeleteTxnLog() throws Exception {
+        new Expectations() {
+            {
+                lakeService.deleteTxnLog((DeleteTxnLogRequest) any);
+                result = CompletableFuture.completedFuture(new DeleteTxnLogResponse());
+            }
+        };
+
+        Future<DeleteTxnLogResponse> result = lakeServiceWithMetrics.deleteTxnLog(new DeleteTxnLogRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetTabletStats() throws Exception {
+        new Expectations() {
+            {
+                lakeService.getTabletStats((TabletStatRequest) any);
+                result = CompletableFuture.completedFuture(new TabletStatResponse());
+            }
+        };
+
+        Future<TabletStatResponse> result = lakeServiceWithMetrics.getTabletStats(new TabletStatRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testDropTable() throws Exception {
+        new Expectations() {
+            {
+                lakeService.dropTable((DropTableRequest) any);
+                result = CompletableFuture.completedFuture(new DropTableResponse());
+            }
+        };
+
+        Future<DropTableResponse> result = lakeServiceWithMetrics.dropTable(new DropTableRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testPublishLogVersion() throws Exception {
+        new Expectations() {
+            {
+                lakeService.publishLogVersion((PublishLogVersionRequest) any);
+                result = CompletableFuture.completedFuture(new PublishLogVersionResponse());
+            }
+        };
+
+        Future<PublishLogVersionResponse> result = lakeServiceWithMetrics.publishLogVersion(new PublishLogVersionRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testPublishLogVersionBatch() throws Exception {
+        new Expectations() {
+            {
+                lakeService.publishLogVersionBatch((PublishLogVersionBatchRequest) any);
+                result = CompletableFuture.completedFuture(new PublishLogVersionResponse());
+            }
+        };
+
+        Future<PublishLogVersionResponse> result =
+                lakeServiceWithMetrics.publishLogVersionBatch(new PublishLogVersionBatchRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testLockTabletMetadata() throws Exception {
+        new Expectations() {
+            {
+                lakeService.lockTabletMetadata((LockTabletMetadataRequest) any);
+                result = CompletableFuture.completedFuture(new LockTabletMetadataResponse());
+            }
+        };
+
+        Future<LockTabletMetadataResponse> result =
+                lakeServiceWithMetrics.lockTabletMetadata(new LockTabletMetadataRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testUnlockTabletMetadata() throws Exception {
+        new Expectations() {
+            {
+                lakeService.unlockTabletMetadata((UnlockTabletMetadataRequest) any);
+                result = CompletableFuture.completedFuture(new UnlockTabletMetadataResponse());
+            }
+        };
+
+        Future<UnlockTabletMetadataResponse> result =
+                lakeServiceWithMetrics.unlockTabletMetadata(new UnlockTabletMetadataRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testUploadSnapshots() throws Exception {
+        new Expectations() {
+            {
+                lakeService.uploadSnapshots((UploadSnapshotsRequest) any);
+                result = CompletableFuture.completedFuture(new UploadSnapshotsResponse());
+            }
+        };
+
+        Future<UploadSnapshotsResponse> result = lakeServiceWithMetrics.uploadSnapshots(new UploadSnapshotsRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRestoreSnapshots() throws Exception {
+        new Expectations() {
+            {
+                lakeService.restoreSnapshots((RestoreSnapshotsRequest) any);
+                result = CompletableFuture.completedFuture(new RestoreSnapshotsResponse());
+            }
+        };
+
+        Future<RestoreSnapshotsResponse> result = lakeServiceWithMetrics.restoreSnapshots(new RestoreSnapshotsRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testAbortCompaction() throws Exception {
+        new Expectations() {
+            {
+                lakeService.abortCompaction((AbortCompactionRequest) any);
+                result = CompletableFuture.completedFuture(new AbortCompactionResponse());
+            }
+        };
+
+        Future<AbortCompactionResponse> result = lakeServiceWithMetrics.abortCompaction(new AbortCompactionRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testVacuum() throws Exception {
+        new Expectations() {
+            {
+                lakeService.vacuum((VacuumRequest) any);
+                result = CompletableFuture.completedFuture(new VacuumResponse());
+            }
+        };
+
+        Future<VacuumResponse> result = lakeServiceWithMetrics.vacuum(new VacuumRequest());
+        assertNotNull(result);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/rpc/PBackendServiceWithMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/rpc/PBackendServiceWithMetricsTest.java
@@ -1,0 +1,293 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.rpc;
+
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.proto.ExecuteCommandRequestPB;
+import com.starrocks.proto.ExecuteCommandResultPB;
+import com.starrocks.proto.PCancelPlanFragmentRequest;
+import com.starrocks.proto.PCancelPlanFragmentResult;
+import com.starrocks.proto.PCollectQueryStatisticsResult;
+import com.starrocks.proto.PExecBatchPlanFragmentsResult;
+import com.starrocks.proto.PExecPlanFragmentResult;
+import com.starrocks.proto.PExecShortCircuitResult;
+import com.starrocks.proto.PFetchArrowSchemaRequest;
+import com.starrocks.proto.PFetchArrowSchemaResult;
+import com.starrocks.proto.PFetchDataResult;
+import com.starrocks.proto.PGetFileSchemaResult;
+import com.starrocks.proto.PListFailPointResponse;
+import com.starrocks.proto.PMVMaintenanceTaskResult;
+import com.starrocks.proto.PProcessDictionaryCacheRequest;
+import com.starrocks.proto.PProcessDictionaryCacheResult;
+import com.starrocks.proto.PProxyRequest;
+import com.starrocks.proto.PProxyResult;
+import com.starrocks.proto.PPulsarProxyRequest;
+import com.starrocks.proto.PPulsarProxyResult;
+import com.starrocks.proto.PTriggerProfileReportResult;
+import com.starrocks.proto.PUpdateFailPointStatusRequest;
+import com.starrocks.proto.PUpdateFailPointStatusResponse;
+import com.starrocks.proto.PUpdateTransactionStateRequest;
+import com.starrocks.proto.PUpdateTransactionStateResponse;
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Tested;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertNotNull;
+
+public class PBackendServiceWithMetricsTest {
+    @Tested
+    PBackendServiceWithMetrics pBackendServiceWithMetrics;
+
+    @Injectable
+    PBackendService pBackendService;
+
+    @BeforeClass
+    public static void setUp() {
+        MetricRepo.init();
+    }
+
+    @Test
+    public void testExecPlanFragmentAsync() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.execPlanFragmentAsync((PExecPlanFragmentRequest) any);
+                result = CompletableFuture.completedFuture(new PExecPlanFragmentResult());
+            }
+        };
+
+        Future<PExecPlanFragmentResult> result = pBackendServiceWithMetrics.execPlanFragmentAsync(new PExecPlanFragmentRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testExecBatchPlanFragmentsAsync() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.execBatchPlanFragmentsAsync((PExecBatchPlanFragmentsRequest) any);
+                result = CompletableFuture.completedFuture(new PExecBatchPlanFragmentsResult());
+            }
+        };
+
+        Future<PExecBatchPlanFragmentsResult> result =
+                pBackendServiceWithMetrics.execBatchPlanFragmentsAsync(new PExecBatchPlanFragmentsRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testCancelPlanFragmentAsync() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.cancelPlanFragmentAsync((PCancelPlanFragmentRequest) any);
+                result = CompletableFuture.completedFuture(new PCancelPlanFragmentResult());
+            }
+        };
+
+        Future<PCancelPlanFragmentResult> result =
+                pBackendServiceWithMetrics.cancelPlanFragmentAsync(new PCancelPlanFragmentRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testFetchDataAsync() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.fetchDataAsync((PFetchDataRequest) any);
+                result = CompletableFuture.completedFuture(new PFetchDataResult());
+            }
+        };
+
+        Future<PFetchDataResult> result = pBackendServiceWithMetrics.fetchDataAsync(new PFetchDataRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testTriggerProfileReport() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.triggerProfileReport((PTriggerProfileReportRequest) any);
+                result = CompletableFuture.completedFuture(new PTriggerProfileReportResult());
+            }
+        };
+
+        Future<PTriggerProfileReportResult> result =
+                pBackendServiceWithMetrics.triggerProfileReport(new PTriggerProfileReportRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testCollectQueryStatistics() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.collectQueryStatistics((PCollectQueryStatisticsRequest) any);
+                result = CompletableFuture.completedFuture(new PCollectQueryStatisticsResult());
+            }
+        };
+
+        Future<PCollectQueryStatisticsResult> result =
+                pBackendServiceWithMetrics.collectQueryStatistics(new PCollectQueryStatisticsRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetInfo() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.getInfo((PProxyRequest) any);
+                result = CompletableFuture.completedFuture(new PProxyResult());
+            }
+        };
+
+        Future<PProxyResult> result = pBackendServiceWithMetrics.getInfo(new PProxyRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetPulsarInfo() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.getPulsarInfo((PPulsarProxyRequest) any);
+                result = CompletableFuture.completedFuture(new PPulsarProxyResult());
+            }
+        };
+
+        Future<PPulsarProxyResult> result = pBackendServiceWithMetrics.getPulsarInfo(new PPulsarProxyRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetFileSchema() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.getFileSchema((PGetFileSchemaRequest) any);
+                result = CompletableFuture.completedFuture(new PGetFileSchemaResult());
+            }
+        };
+
+        Future<PGetFileSchemaResult> result = pBackendServiceWithMetrics.getFileSchema(new PGetFileSchemaRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testSubmitMVMaintenanceTaskAsync() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.submitMVMaintenanceTaskAsync((PMVMaintenanceTaskRequest) any);
+                result = CompletableFuture.completedFuture(new PMVMaintenanceTaskResult());
+            }
+        };
+
+        Future<PMVMaintenanceTaskResult> result =
+                pBackendServiceWithMetrics.submitMVMaintenanceTaskAsync(new PMVMaintenanceTaskRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testExecuteCommandAsync() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.executeCommandAsync((ExecuteCommandRequestPB) any);
+                result = CompletableFuture.completedFuture(new ExecuteCommandResultPB());
+            }
+        };
+
+        Future<ExecuteCommandResultPB> result = pBackendServiceWithMetrics.executeCommandAsync(new ExecuteCommandRequestPB());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testUpdateFailPointStatusAsync() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.updateFailPointStatusAsync((PUpdateFailPointStatusRequest) any);
+                result = CompletableFuture.completedFuture(new PUpdateFailPointStatusResponse());
+            }
+        };
+
+        Future<PUpdateFailPointStatusResponse> result =
+                pBackendServiceWithMetrics.updateFailPointStatusAsync(new PUpdateFailPointStatusRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testListFailPointAsync() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.listFailPointAsync((PListFailPointRequest) any);
+                result = CompletableFuture.completedFuture(new PListFailPointResponse());
+            }
+        };
+
+        Future<PListFailPointResponse> result = pBackendServiceWithMetrics.listFailPointAsync(new PListFailPointRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testExecShortCircuit() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.execShortCircuit((PExecShortCircuitRequest) any);
+                result = CompletableFuture.completedFuture(new PExecShortCircuitResult());
+            }
+        };
+
+        Future<PExecShortCircuitResult> result = pBackendServiceWithMetrics.execShortCircuit(new PExecShortCircuitRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testProcessDictionaryCache() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.processDictionaryCache((PProcessDictionaryCacheRequest) any);
+                result = CompletableFuture.completedFuture(new PProcessDictionaryCacheResult());
+            }
+        };
+
+        Future<PProcessDictionaryCacheResult> result =
+                pBackendServiceWithMetrics.processDictionaryCache(new PProcessDictionaryCacheRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testFetchArrowSchema() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.fetchArrowSchema((PFetchArrowSchemaRequest) any);
+                result = CompletableFuture.completedFuture(new PFetchArrowSchemaResult());
+            }
+        };
+
+        Future<PFetchArrowSchemaResult> result = pBackendServiceWithMetrics.fetchArrowSchema(new PFetchArrowSchemaRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testUpdateTransactionState() throws Exception {
+        new Expectations() {
+            {
+                pBackendService.updateTransactionState((PUpdateTransactionStateRequest) any);
+                result = CompletableFuture.completedFuture(new PUpdateTransactionStateResponse());
+            }
+        };
+
+        Future<PUpdateTransactionStateResponse> result =
+                pBackendServiceWithMetrics.updateTransactionState(new PUpdateTransactionStateRequest());
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Saw lot of rpc timeout error on some users env, need more metrics for easy trouble shooting

## What I'm doing:

Make exec_plan_fragment rpc timeout configable, add more metrics in the follwing list:
```
starrocks_fe_brpc_backend_service 2
starrocks_fe_brpc_lake_service 0
starrocks_fe_brpc_total 2
starrocks_fe_brpc_exec_plan_fragment 0
starrocks_fe_brpc_exec_plan_fragment_error 0
starrocks_fe_brpc_pool_numactive{name="pool"} 0
starrocks_fe_brpc_pool_numidle{name="pool"} 2
starrocks_fe_brpc_pool_numwaiters{name="pool"} 0
starrocks_fe_brpc_pool_borrowedcount{name="pool"} 2
starrocks_fe_brpc_pool_returnedcount{name="pool"} 2
starrocks_fe_brpc_pool_createdcount{name="pool"} 2
starrocks_fe_brpc_pool_destroyedcount{name="pool"} 0
starrocks_fe_brpc_pool_meanactivetimemillis{name="pool"} 8
starrocks_fe_brpc_pool_meanidletimemillis{name="pool"} 0
starrocks_fe_brpc_pool_meanborrowwaittimemillis{name="pool"} 39
```
Note: after changes in jprotobuf-rpc jar in the future, the tags '{name="pool"}' will changed to `{name="<host>_<port>"}` to actually mark BE rpc server side addr.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0