### PR TITLE
[BugFix] fix parquet column chunk reader when n is zero

### DIFF
--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -84,7 +84,7 @@ public:
 
     Status decode_values(size_t n, const uint16_t* is_nulls, ColumnContentType content_type, Column* dst) {
         SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
-        if (_current_row_group_no_null || _current_page_no_null) {
+        if (n > 0 && (_current_row_group_no_null || _current_page_no_null)) {
             return _cur_decoder->next_batch(n, content_type, dst);
         }
         size_t idx = 0;

--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -84,7 +84,7 @@ public:
 
     Status decode_values(size_t n, const uint16_t* is_nulls, ColumnContentType content_type, Column* dst) {
         SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
-        if (n > 0 && (_current_row_group_no_null || _current_page_no_null)) {
+        if (_current_row_group_no_null || _current_page_no_null) {
             return _cur_decoder->next_batch(n, content_type, dst);
         }
         size_t idx = 0;

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -465,7 +465,7 @@ Status RepeatedStoredColumnReader::_read_values_on_levels(size_t num_values,
         _collect_not_null_values(num_values, num_values != _num_values_left_in_cur_page);
         dst->append_default(null_pos);
         return Status::OK();
-    } else {
+    } else if (null_pos != 0) {
         return _reader->decode_values(null_pos, &_is_nulls[0], content_type, dst);
     }
 }

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -467,6 +467,8 @@ Status RepeatedStoredColumnReader::_read_values_on_levels(size_t num_values,
         return Status::OK();
     } else if (null_pos != 0) {
         return _reader->decode_values(null_pos, &_is_nulls[0], content_type, dst);
+    } else {
+        return Status::OK();
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

Hit this case on some customer's parquet file. However I can not reproduce this case yet. 

## What I'm doing:

this optimization is brought in https://github.com/StarRocks/starrocks/pull/44958. 

but it does not consider when `n==0`, where `DictDecoder` will fail.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0