### PR TITLE
[BugFix] Fx a JDBC metadata compatible bug

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -315,7 +315,7 @@ public class MysqlSchemaResolverTest {
     }
 
     @Test
-    public void testMysqlInvalidPartition() {
+    public void testMysqlInvalidPartition1() {
         try {
             MockResultSet invalidPartition = new MockResultSet("partitions");
             invalidPartition.addColumn("NAME", Arrays.asList("'20230810'"));
@@ -334,9 +334,35 @@ public class MysqlSchemaResolverTest {
             JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
                     "test", "catalog", properties);
             jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
-            Assert.fail();
+            // different mysql source may have different partition information, so we can ignore partition information parse
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Timestamp format must be yyyy-mm-dd hh:mm:ss"));
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testMysqlInvalidPartition2() {
+        try {
+            MockResultSet invalidPartition = new MockResultSet("partitions");
+            invalidPartition.addColumn("NAME", Arrays.asList("'20230810'"));
+            invalidPartition.addColumn("PARTITION_EXPRESSION", Arrays.asList("`d`"));
+            invalidPartition.addColumn("MODIFIED_TIME", Arrays.asList("NULL"));
+
+            new Expectations() {
+                {
+                    preparedStatement.executeQuery();
+                    result = invalidPartition;
+                    minTimes = 0;
+                }
+            };
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+            List<Column> columns = Arrays.asList(new Column("d", Type.VARCHAR));
+            JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
+                    "test", "catalog", properties);
+            jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
+            // different mysql source may have different partition information, so we can ignore partition information parse
+        } catch (Exception e) {
+            Assert.fail();
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/OracleSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/OracleSchemaResolverTest.java
@@ -250,4 +250,56 @@ public class OracleSchemaResolverTest {
             Assert.fail(e.getMessage());
         }
     }
+
+    @Test
+    public void testMysqlInvalidPartition1() {
+        try {
+            MockResultSet invalidPartition = new MockResultSet("partitions");
+            invalidPartition.addColumn("NAME", Arrays.asList("'20230810'"));
+            invalidPartition.addColumn("PARTITION_EXPRESSION", Arrays.asList("`d`"));
+            invalidPartition.addColumn("MODIFIED_TIME", Arrays.asList("2023-08-01"));
+
+            new Expectations() {
+                {
+                    preparedStatement.executeQuery();
+                    result = invalidPartition;
+                    minTimes = 0;
+                }
+            };
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+            List<Column> columns = Arrays.asList(new Column("d", Type.VARCHAR));
+            JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
+                    "test", "catalog", properties);
+            jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
+            // different mysql source may have different partition information, so we can ignore partition information parse
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testMysqlInvalidPartition2() {
+        try {
+            MockResultSet invalidPartition = new MockResultSet("partitions");
+            invalidPartition.addColumn("NAME", Arrays.asList("'20230810'"));
+            invalidPartition.addColumn("PARTITION_EXPRESSION", Arrays.asList("`d`"));
+            invalidPartition.addColumn("MODIFIED_TIME", Arrays.asList("NULL"));
+
+            new Expectations() {
+                {
+                    preparedStatement.executeQuery();
+                    result = invalidPartition;
+                    minTimes = 0;
+                }
+            };
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+            List<Column> columns = Arrays.asList(new Column("d", Type.VARCHAR));
+            JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
+                    "test", "catalog", properties);
+            jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
+            // different mysql source may have different partition information, so we can ignore partition information parse
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
- Different mysql source may have different `partition` information, so we can ignore partition information parse; so this mysql source can be refreshed in asrynchronized mvs.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0