### PR TITLE
[BugFix] Support text base mv rewrite for different dbs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2957,6 +2957,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         materializedView.setViewDefineSql(stmt.getInlineViewDef());
         materializedView.setSimpleDefineSql(stmt.getSimpleViewDef());
         materializedView.setOriginalViewDefineSql(stmt.getOriginalViewDefineSql());
+        materializedView.setOriginalDBName(stmt.getOriginalDBName());
         // set partitionRefTableExprs
         if (stmt.getPartitionRefTableExpr() != null) {
             //avoid to get a list of null inside

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -69,6 +69,8 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     private String simpleViewDef;
     // original view definition of the mv query without any rewrite which can be used in text based rewrite.
     private String originalViewDefineSql;
+    // current db name when creating mv
+    private String originalDBName;
     private List<BaseTableInfo> baseTableInfos;
 
     // Maintenance information
@@ -104,6 +106,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
                                            Map<String, String> properties,
                                            QueryStatement queryStatement,
                                            int queryStartIndex,
+                                           String originalDBName,
                                            NodePosition pos) {
         super(pos);
         this.tableName = tableName;
@@ -118,6 +121,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         this.properties = properties;
         this.queryStartIndex = queryStartIndex;
         this.queryStatement = queryStatement;
+        this.originalDBName = originalDBName;
     }
 
     public TableName getTableName() {
@@ -314,6 +318,9 @@ public class CreateMaterializedViewStatement extends DdlStmt {
 
     public Map<Expr, Expr> getPartitionByExprToAdjustExprMap() {
         return partitionByExprToAdjustExprMap;
+    }
+    public String getOriginalDBName() {
+        return originalDBName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2051,11 +2051,13 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             throw new ParsingException(PARSER_ERROR_MSG.feConfigDisable("enable_experimental_mv"), NodePosition.ZERO);
         }
 
+        String currentDBName = ConnectContext.get() == null ? null : ConnectContext.get().getDatabase();
         return new CreateMaterializedViewStatement(tableName, ifNotExist, colWithComments,
                 context.indexDesc() == null ? null : getIndexDefs(context.indexDesc()),
                 comment,
                 refreshSchemeDesc,
                 partitionByExprs, distributionDesc, sortKeys, properties, queryStatement, queryStartIndex,
+                currentDBName,
                 createPos(context));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTPCDSTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTextBasedRewriteTPCDSTest.java
@@ -36,11 +36,16 @@ public class MaterializedViewTextBasedRewriteTPCDSTest extends MaterializedViewT
     private static final List<List<Arguments>> ARGUMENTS = Lists.newArrayList();
     private static final int N = 5;
 
+    private static final String MATERIALIZED_DB_NAME = "mv_db";
+    private static final String TABLE_DB_NAME = "table_db";
     @BeforeAll
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
         MaterializedViewTestBase.beforeClass();
-        starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
+        starRocksAssert.withDatabase(MATERIALIZED_DB_NAME);
+        starRocksAssert
+                .withDatabase(TABLE_DB_NAME)
+                .useDatabase(TABLE_DB_NAME);
         connectContext.getSessionVariable().setEnableMaterializedViewTextMatchRewrite(true);
         TPCDSTestUtil.prepareTables(starRocksAssert);
         prepareArguments();
@@ -49,7 +54,8 @@ public class MaterializedViewTextBasedRewriteTPCDSTest extends MaterializedViewT
     @ParameterizedTest(name = "Tpcds.{0}")
     @MethodSource("tpcdsSource0")
     public void testTPCDS0(String name, String sql) {
-        testRewriteOK(sql, sql);
+        starRocksAssert.useDatabase(TABLE_DB_NAME);
+        testRewriteOK(MATERIALIZED_DB_NAME, sql, sql, "");
     }
 
     @ParameterizedTest(name = "Tpcds.{0}")


### PR DESCRIPTION
## Why I'm doing:
- If base table and mv are not in the same database, text based mv rewrite cannot be used.

## What I'm doing:
- Fix this by adding `originalDBName` in creating info; If it doesn't exist use `viewDefineSql` rather than `originalViewDefineSql` to parse mv's defined query's ast(Old version).
- Add different dbs tests.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0