### PR TITLE
[BugFix] Fix the bug of jdbc catalog processing json type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -147,8 +147,12 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 primitiveType = PrimitiveType.DATETIME;
                 break;
             default:
-                primitiveType = PrimitiveType.UNKNOWN_TYPE;
-                break;
+                // The mysql-connector-j will convert the JSON type in MySQL to Types.LONGVARCHAR(1073741824).
+                // However, the mariadb-java-client does not handle the JSON type,
+                // so it will be converted to Types.Other. Here, in order to handle JSON, for the Types.Other,
+                // it is uniformly converted to Types.LONGVARCHAR(1073741824).
+                // If later mariadb-java-client support json, this code can be reverted.
+                return ScalarType.createVarcharType(1073741824);
         }
 
         if (primitiveType != PrimitiveType.DECIMAL32) {

--- a/test/sql/test_jdbc_catalog/R/test_json_type
+++ b/test/sql/test_jdbc_catalog/R/test_json_type
@@ -1,0 +1,46 @@
+-- name: test_jdbc_catalog_json_type
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database db_json_${uuid0};'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_json_${uuid0}; CREATE TABLE t1 (c1 int, c2 json);'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_json_${uuid0}; INSERT INTO t1 VALUES (1,"{\"c1\": 1}");'
+-- result:
+0
+
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create external catalog jdbc_catalog_${uuid0}
+properties
+(
+    "type"="jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
+    "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+-- result:
+-- !result
+set catalog jdbc_catalog_${uuid0};
+-- result:
+-- !result
+select * from db_json_${uuid0}.t1;
+-- result:
+1	{"c1": 1}
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database db_json_${uuid0};'
+-- result:
+0
+
+-- !result

--- a/test/sql/test_jdbc_catalog/T/test_json_type
+++ b/test/sql/test_jdbc_catalog/T/test_json_type
@@ -1,0 +1,26 @@
+-- name: test_jdbc_catalog_json_type
+-- create mysql table
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database db_json_${uuid0};'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_json_${uuid0}; CREATE TABLE t1 (c1 int, c2 json);'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_json_${uuid0}; INSERT INTO t1 VALUES (1,"{\"c1\": 1}");'
+
+-- create catalog
+set catalog default_catalog;
+create external catalog jdbc_catalog_${uuid0}
+properties
+(
+    "type"="jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
+    "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+
+-- query
+set catalog jdbc_catalog_${uuid0};
+select * from db_json_${uuid0}.t1;
+set catalog default_catalog;
+
+-- drop mysql table
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database db_json_${uuid0};'


### PR DESCRIPTION
## Why I'm doing:

When upgrade from 3.2 to 3.3, query mysql table with json column will report this error:

```
 com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Datatype of external table column [c2] is not supported!.
        at com.starrocks.sql.analyzer.Scope.resolveField(Scope.java:107)
        at com.starrocks.sql.analyzer.Scope.resolveField(Scope.java:94)
        at com.starrocks.sql.analyzer.Scope.resolveField(Scope.java:90)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer$Visitor.visitSlot(ExpressionAnalyzer.java:434)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer$Visitor.visitSlot(ExpressionAnalyzer.java:376)
        at com.starrocks.analysis.SlotRef.accept(SlotRef.java:532)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:88)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.bottomUpAnalyze(ExpressionAnalyzer.java:372)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.analyze(ExpressionAnalyzer.java:136)
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.analyzeExpression(ExpressionAnalyzer.java:1844)
        at com.starrocks.sql.analyzer.SelectAnalyzer.analyzeExpression(SelectAnalyzer.java:779)
        at com.starrocks.sql.analyzer.SelectAnalyzer.analyzeSelect(SelectAnalyzer.java:250)
        at com.starrocks.sql.analyzer.SelectAnalyzer.analyze(SelectAnalyzer.java:79)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitSelect(QueryAnalyzer.java:378)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitSelect(QueryAnalyzer.java:286)
        at com.starrocks.sql.ast.SelectRelation.accept(SelectRelation.java:232)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.process(QueryAnalyzer.java:291)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitQueryRelation(QueryAnalyzer.java:306)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitQueryStatement(QueryAnalyzer.java:296)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.visitQueryStatement(QueryAnalyzer.java:286)
        at com.starrocks.sql.ast.QueryStatement.accept(QueryStatement.java:72)
        at com.starrocks.sql.analyzer.QueryAnalyzer$Visitor.process(QueryAnalyzer.java:291)
        at com.starrocks.sql.analyzer.QueryAnalyzer.analyze(QueryAnalyzer.java:124)
        at com.starrocks.sql.analyzer.Analyzer$AnalyzerVisitor.visitQueryStatement(Analyzer.java:445)
        at com.starrocks.sql.analyzer.Analyzer$AnalyzerVisitor.visitQueryStatement(Analyzer.java:181)
        at com.starrocks.sql.ast.QueryStatement.accept(QueryStatement.java:72)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:88)
```

The reason for this problem is that we replaced `mysql-connector-j` with `mariadb-java-client` in version 3.3 (https://github.com/StarRocks/starrocks/pull/40573, https://github.com/StarRocks/starrocks/pull/40027). Since `mariadb-java-client` does not support the Type.JSON, it converts it to the Type.Other. StarRocks it will directly report an error when the type is Type.Other. Currently, we will use a temporary fix method, which is to uniformly convert Type.Other to Type.Longtext.

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0