### PR TITLE
[Enhancement] Estimate numWorkers of connector scan nodes for query queue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -202,6 +202,13 @@ public abstract class ScanNode extends PlanNode {
     public void setScanSampleStrategy(RemoteFilesSampleStrategy strategy) {
     }
 
+    public boolean isConnectorScanNode() {
+        return this instanceof HdfsScanNode || this instanceof IcebergScanNode ||
+                this instanceof HudiScanNode || this instanceof DeltaLakeScanNode ||
+                this instanceof FileTableScanNode || this instanceof PaimonScanNode ||
+                this instanceof OdpsScanNode || this instanceof IcebergMetadataScanNode;
+    }
+
     protected String explainColumnDict(String prefix) {
         StringBuilder output = new StringBuilder();
         if (!appliedDictStringColumns.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/BackendSelectorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/BackendSelectorFactory.java
@@ -14,15 +14,7 @@
 
 package com.starrocks.qe.scheduler.assignment;
 
-import com.starrocks.planner.DeltaLakeScanNode;
-import com.starrocks.planner.FileTableScanNode;
-import com.starrocks.planner.HdfsScanNode;
-import com.starrocks.planner.HudiScanNode;
-import com.starrocks.planner.IcebergMetadataScanNode;
-import com.starrocks.planner.IcebergScanNode;
-import com.starrocks.planner.OdpsScanNode;
 import com.starrocks.planner.OlapScanNode;
-import com.starrocks.planner.PaimonScanNode;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.SchemaScanNode;
 import com.starrocks.qe.BackendSelector;
@@ -68,10 +60,7 @@ public class BackendSelectorFactory {
 
         if (scanNode instanceof SchemaScanNode) {
             return new NormalBackendSelector(scanNode, locations, assignment, workerProvider, false);
-        } else if (scanNode instanceof HdfsScanNode || scanNode instanceof IcebergScanNode ||
-                scanNode instanceof HudiScanNode || scanNode instanceof DeltaLakeScanNode ||
-                scanNode instanceof FileTableScanNode || scanNode instanceof PaimonScanNode
-                || scanNode instanceof OdpsScanNode || scanNode instanceof IcebergMetadataScanNode) {
+        } else if (scanNode.isConnectorScanNode()) {
             return new HDFSBackendSelector(scanNode, locations, assignment, workerProvider,
                     sessionVariable.getForceScheduleLocal(),
                     sessionVariable.getHDFSBackendSelectorScanRangeShuffle(), useIncrementalScanRanges);


### PR DESCRIPTION
## Why I'm doing:

- **Estimate numWorkers of connector scan nodes.**
    - When estimating how many BE nodes a query will use, the query queue did not account for the `ConnectorScanNode`, which caused the estimated number of BE nodes to be fixed at 1.
    - However, the current modification only uses cardinality to estimate the number of BE nodes used for connector scan nodes, without utilizing the file retrieval interface. This is because, at the moment, there are only interfaces to fetch all file metadata, and no lightweight interface to retrieve the file count. In the future, the appropriate interface to retrieve the file count should be used for each catalog metadata format.
- **use `max(planMemCosts, planCpuCosts)` as the estimate for memory.**
    - The estimate of `planMemCosts` is typically an underestimation, often several orders of magnitude smaller than the actual memory usage, whereas `planCpuCosts` tends to be relatively larger. For example, the estimated `planMemCosts` values for the same query on TPC-DS 1T and TPC-DS 10T are similar, with the 10T value even being smaller. Therefore, the maximum value between the two is used as the estimate for memory.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0