### PR TITLE
[Enhancement] support print partition version info in transaction state (backport #55852)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3430,4 +3430,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = false)
     public static int max_historical_automated_cluster_snapshot_jobs = 100;
+
+    @ConfField(mutable = true)
+    public static boolean transaction_state_print_partition_info = true;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
@@ -190,10 +190,9 @@ public class PartitionCommitInfo implements Writable {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("partitionid=");
+        StringBuilder sb = new StringBuilder("partitionId=");
         sb.append(physicalPartitionId);
         sb.append(", version=").append(version);
-        sb.append(", versionHash=").append(0);
         sb.append(", versionTime=").append(versionTime);
         sb.append(", isDoubleWrite=").append(isDoubleWrite);
         return sb.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -835,10 +835,21 @@ public class TransactionState implements Writable {
             sb.append(", newFinish");
         }
         if (txnCommitAttachment != null) {
-            sb.append(" attachment: ").append(txnCommitAttachment);
+            sb.append(", attachment: ").append(txnCommitAttachment);
         }
         if (tabletCommitInfos != null) {
-            sb.append(" tabletCommitInfos size: ").append(tabletCommitInfos.size());
+            sb.append(", tabletCommitInfos size: ").append(tabletCommitInfos.size());
+        }
+        if (Config.transaction_state_print_partition_info && idToTableCommitInfos != null) {
+            sb.append(", partition commit info:[");
+            for (TableCommitInfo tinfo : idToTableCommitInfos.values()) {
+                if (tinfo.getIdToPartitionCommitInfo() != null) {
+                    for (PartitionCommitInfo pinfo : tinfo.getIdToPartitionCommitInfo().values()) {
+                        sb.append(pinfo.toString()).append(",");
+                    }
+                }
+            }
+            sb.append("]");
         }
         return sb.toString();
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
