### PR TITLE
[BugFix] Fix getRemoteFiles error for paimon system table.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -251,8 +251,13 @@ public class PaimonMetadata implements ConnectorMetadata {
         RemoteFileInfo remoteFileInfo = new RemoteFileInfo();
         PaimonTable paimonTable = (PaimonTable) table;
         long latestSnapshotId = -1L;
-        if (paimonTable.getNativeTable().latestSnapshotId().isPresent()) {
-            latestSnapshotId = paimonTable.getNativeTable().latestSnapshotId().getAsLong();
+        try {
+            if (paimonTable.getNativeTable().latestSnapshotId().isPresent()) {
+                latestSnapshotId = paimonTable.getNativeTable().latestSnapshotId().getAsLong();
+            }
+        } catch (Exception e) {
+            // System table does not have snapshotId, ignore it.
+            LOG.warn("Cannot get snapshot because {}", e.getMessage());
         }
         PredicateSearchKey filter = PredicateSearchKey.of(paimonTable.getCatalogDBName(),
                 paimonTable.getCatalogTableName(), latestSnapshotId, params.getPredicate());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -56,6 +56,7 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.table.system.ManifestsTable;
 import org.apache.paimon.table.system.PartitionsTable;
 import org.apache.paimon.table.system.SchemasTable;
 import org.apache.paimon.table.system.SnapshotsTable;
@@ -193,6 +194,28 @@ public class PaimonMetadataTest {
         };
         Assert.assertFalse(metadata.tableExists("nonexistentDb", "nonexistentTbl"));
         Assert.assertNull(metadata.getTable("nonexistentDb", "nonexistentTbl"));
+    }
+
+    @Test
+    public void testGetSystemTable(@Mocked ManifestsTable paimonSystemTable,
+                                   @Mocked ReadBuilder readBuilder) throws Exception {
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable((Identifier) any);
+                result = paimonSystemTable;
+                paimonSystemTable.latestSnapshotId();
+                result = new Exception("Readonly Table tbl1$manifests does not support currentSnapshot.");
+                paimonSystemTable.newReadBuilder();
+                result = readBuilder;
+                readBuilder.withFilter((List<Predicate>) any).withProjection((int[]) any).newScan().plan().splits();
+                result = splits;
+            }
+        };
+        PaimonTable paimonTable = (PaimonTable) metadata.getTable("db1", "tbl1$manifests");
+        List<String> requiredNames = Lists.newArrayList("file_name", "file_size");
+        List<RemoteFileInfo> result =
+                metadata.getRemoteFiles(paimonTable, GetRemoteFilesParams.newBuilder().setFieldNames(requiredNames).build());
+        Assert.assertEquals(1, result.size());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Fix errors like
```
Readonly Table FilesTable does not support currentSnapshot.
```
for paimon system tables introduced by #55787.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0