### PR TITLE
[Refactor] Complete the types of `MemTracker` and add an interface for converting `Type` to `Label`.

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -126,11 +126,12 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
         if (wg != nullptr && big_query_mem_limit > 0 &&
             (query_mem_limit <= 0 || big_query_mem_limit < query_mem_limit)) {
             std::string label = "Group=" + wg->name() + ", " + _profile->name();
-            _mem_tracker = std::make_shared<MemTracker>(MemTracker::RESOURCE_GROUP_BIG_QUERY, big_query_mem_limit,
+            _mem_tracker = std::make_shared<MemTracker>(MemTrackerType::RESOURCE_GROUP_BIG_QUERY, big_query_mem_limit,
                                                         std::move(label), parent);
             _mem_tracker->set_reserve_limit(tracker_reserve_limit);
         } else {
-            _mem_tracker = std::make_shared<MemTracker>(MemTracker::QUERY, query_mem_limit, _profile->name(), parent);
+            _mem_tracker =
+                    std::make_shared<MemTracker>(MemTrackerType::QUERY, query_mem_limit, _profile->name(), parent);
             _mem_tracker->set_reserve_limit(tracker_reserve_limit);
         }
 
@@ -154,7 +155,7 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
                 connector_scan_use_query_mem_ratio = runtime_state->query_options().connector_scan_use_query_mem_ratio;
             }
             _connector_scan_mem_tracker = std::make_shared<MemTracker>(
-                    MemTracker::QUERY, _static_query_mem_limit * connector_scan_use_query_mem_ratio,
+                    MemTrackerType::QUERY, _static_query_mem_limit * connector_scan_use_query_mem_ratio,
                     _profile->name() + "/connector_scan", connector_scan_parent);
         }
     });

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -186,7 +186,7 @@ void WorkGroup::init() {
                                   ? GlobalEnv::GetInstance()->query_pool_mem_tracker()->limit()
                                   : GlobalEnv::GetInstance()->query_pool_mem_tracker()->limit() * _memory_limit;
     _spill_mem_limit_bytes = _spill_mem_limit_threshold * _memory_limit_bytes;
-    _mem_tracker = std::make_shared<MemTracker>(MemTracker::RESOURCE_GROUP, _memory_limit_bytes, _name,
+    _mem_tracker = std::make_shared<MemTracker>(MemTrackerType::RESOURCE_GROUP, _memory_limit_bytes, _name,
                                                 GlobalEnv::GetInstance()->query_pool_mem_tracker());
     _mem_tracker->set_reserve_limit(_spill_mem_limit_bytes);
 
@@ -196,7 +196,7 @@ void WorkGroup::init() {
     _connector_scan_sched_entity.set_queue(workgroup::create_scan_task_queue());
 
     _connector_scan_mem_tracker =
-            std::make_shared<MemTracker>(MemTracker::RESOURCE_GROUP, _memory_limit_bytes, _name + "/connector_scan",
+            std::make_shared<MemTracker>(MemTrackerType::RESOURCE_GROUP, _memory_limit_bytes, _name + "/connector_scan",
                                          GlobalEnv::GetInstance()->connector_scan_pool_mem_tracker());
 }
 

--- a/be/src/http/action/memory_metrics_action.cpp
+++ b/be/src/http/action/memory_metrics_action.cpp
@@ -32,49 +32,20 @@ void MemoryMetricsAction::handle(HttpRequest* req) {
     auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_memory_metrics"));
     MemTracker* process_mem_tracker = GlobalEnv::GetInstance()->process_mem_tracker();
     std::stringstream result;
-    std::vector<std::string> metric_labels_to_print = {"process",
-                                                       "query_pool",
-                                                       "load",
-                                                       "metadata",
-                                                       "tablet_metadata",
-                                                       "rowset_metadata",
-                                                       "segment_metadata",
-                                                       "column_metadata",
-                                                       "tablet_schema",
-                                                       "segment_zonemap",
-                                                       "short_key_index",
-                                                       "column_zonemap_index",
-                                                       "ordinal_index",
-                                                       "bitmap_index",
-                                                       "bloom_filter_index",
-                                                       "compaction",
-                                                       "schema_change",
-                                                       "page_cache",
-                                                       "datacache",
-                                                       "update",
-                                                       "chunk_allocator",
-                                                       "clone",
-                                                       "consistency",
-                                                       "rowset_update_state",
-                                                       "index_cache",
-                                                       "del_vec_cache",
-                                                       "compaction_state"};
     result << "[";
-    getMemoryMetricTree(process_mem_tracker, result, process_mem_tracker->consumption(), metric_labels_to_print);
+    getMemoryMetricTree(process_mem_tracker, result, process_mem_tracker->consumption());
     result << ",";
-    getMemoryMetricTree(GlobalEnv::GetInstance()->metadata_mem_tracker(), result, process_mem_tracker->consumption(),
-                        metric_labels_to_print);
+    getMemoryMetricTree(GlobalEnv::GetInstance()->metadata_mem_tracker(), result, process_mem_tracker->consumption());
     result << ",";
-    getMemoryMetricTree(GlobalEnv::GetInstance()->update_mem_tracker(), result, process_mem_tracker->consumption(),
-                        metric_labels_to_print);
+    getMemoryMetricTree(GlobalEnv::GetInstance()->update_mem_tracker(), result, process_mem_tracker->consumption());
     result << "]";
     req->add_output_header(HttpHeaders::CONTENT_TYPE, "text/plain; version=0.0.4");
     LOG(INFO) << "End collect memory metrics. " << result.str();
 
     HttpChannel::send_reply(req, result.str());
 }
-void MemoryMetricsAction::getMemoryMetricTree(MemTracker* memTracker, std::stringstream& result, int64_t total_size,
-                                              std::vector<std::string> metric_labels_to_print) {
+
+void MemoryMetricsAction::getMemoryMetricTree(MemTracker* memTracker, std::stringstream& result, int64_t total_size) {
     result << "{";
     result << R"("name":")" << memTracker->label() << "\",";
     result << R"("size":")" << memTracker->consumption() << "\",";
@@ -82,14 +53,13 @@ void MemoryMetricsAction::getMemoryMetricTree(MemTracker* memTracker, std::strin
            << static_cast<double>(memTracker->consumption()) / total_size * 100 << "%\",";
     result << "\"child\":[";
     for (const auto& child : memTracker->getChild()) {
-        if (find(metric_labels_to_print.begin(), metric_labels_to_print.end(), child->label()) ==
-            metric_labels_to_print.end()) {
+        if (MemTracker::type_to_label(child->type()) == "") {
             break;
         }
         if (child != memTracker->getChild().front()) {
             result << ",";
         }
-        getMemoryMetricTree(child, result, total_size, metric_labels_to_print);
+        getMemoryMetricTree(child, result, total_size);
     }
 
     result << "]}";

--- a/be/src/http/action/memory_metrics_action.h
+++ b/be/src/http/action/memory_metrics_action.h
@@ -54,8 +54,7 @@ public:
     void handle(HttpRequest* req) override;
 
 private:
-    void getMemoryMetricTree(MemTracker* memTracker, std::stringstream& result, int64_t total_size,
-                             std::vector<std::string> metric_labels_to_print);
+    void getMemoryMetricTree(MemTracker* memTracker, std::stringstream& result, int64_t total_size);
 };
 
 } // namespace starrocks

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -44,6 +44,7 @@
 #include "exec/query_cache/cache_manager.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "runtime/base_load_path_mgr.h"
+#include "runtime/mem_tracker.h"
 #include "storage/options.h"
 #include "util/threadpool.h"
 // NOTE: Be careful about adding includes here. This file is included by many files.
@@ -64,7 +65,6 @@ class LoadStreamMgr;
 class StreamContextMgr;
 class TransactionMgr;
 class BatchWriteMgr;
-class MemTracker;
 class MetricRegistry;
 class StorageEngine;
 class ThreadPool;
@@ -168,8 +168,7 @@ private:
 
     void _init_storage_page_cache();
 
-    template <class... Args>
-    std::shared_ptr<MemTracker> regist_tracker(Args&&... args);
+    std::shared_ptr<MemTracker> regist_tracker(MemTrackerType type, int64_t bytes_limit, MemTracker* parent);
 
     // root process memory tracker
     std::shared_ptr<MemTracker> _process_mem_tracker;

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -33,6 +33,7 @@
 // under the License.
 
 #include "runtime/mem_tracker.h"
+#include "runtime/runtime_state.h"
 
 #include <utility>
 
@@ -43,6 +44,88 @@ namespace starrocks {
 const std::string MemTracker::PEAK_MEMORY_USAGE = "PeakMemoryUsage";
 const std::string MemTracker::ALLOCATED_MEMORY_USAGE = "AllocatedMemoryUsage";
 const std::string MemTracker::DEALLOCATED_MEMORY_USAGE = "DeallocatedMemoryUsage";
+
+std::string MemTracker::type_to_label(MemTrackerType type) {
+    switch (type) {
+    case MemTrackerType::NO_SET:
+        return "";
+    case MemTrackerType::PROCESS:
+        return "process";
+    case MemTrackerType::QUERY_POOL:
+        return "query_pool";
+    case MemTrackerType::LOAD:
+        return "load";
+    case MemTrackerType::CONSISTENCY:
+        return "consistency";
+    case MemTrackerType::COMPACTION:
+        return "compaction";
+    case MemTrackerType::SCHEMA_CHANGE:
+        return "schema_change";
+    case MemTrackerType::JEMALLOC:
+        return "jemalloc_metadata";
+    case MemTrackerType::PASSTHROUGH:
+        return "passthrough";
+    case MemTrackerType::CONNECTOR_SCAN:
+        return "connector_scan";
+    case MemTrackerType::METADATA:
+        return "metadata";
+    case MemTrackerType::TABLET_METADATA:
+        return "tablet_metadata";
+    case MemTrackerType::ROWSET_METADATA:
+        return "rowset_metadata";
+    case MemTrackerType::SEGMENT_METADATA:
+        return "segment_metadata";
+    case MemTrackerType::COLUMN_METADATA:
+        return "column_metadata";
+    case MemTrackerType::TABLET_SCHEMA:
+        return "tablet_schema";
+    case MemTrackerType::SEGMENT_ZONEMAP:
+        return "segment_zonemap";
+    case MemTrackerType::SHORT_KEY_INDEX:
+        return "short_key_index";
+    case MemTrackerType::COLUMN_ZONEMAP_INDEX:
+        return "column_zonemap_index";
+    case MemTrackerType::ORDINAL_INDEX:
+        return "ordinal_index";
+    case MemTrackerType::BITMAP_INDEX:
+        return "bitmap_index";
+    case MemTrackerType::BLOOM_FILTER_INDEX:
+        return "bloom_filter_index";
+    case MemTrackerType::PAGE_CACHE:
+        return "page_cache";
+    case MemTrackerType::JIT_CACHE:
+        return "jit_cache";
+    case MemTrackerType::UPDATE:
+        return "update";
+    case MemTrackerType::CHUNK_ALLOCATOR:
+        return "chunk_allocator";
+    case MemTrackerType::CLONE:
+        return "clone";
+    case MemTrackerType::DATACACHE:
+        return "datacache";
+    case MemTrackerType::POCO_CONNECTION_POOL:
+        return "poco_connection_pool";
+    case MemTrackerType::REPLICATION:
+        return "replication";
+    case MemTrackerType::ROWSET_UPDATE_STATE:
+        return "rowset_update_state";
+    case MemTrackerType::INDEX_CACHE:
+        return "index_cache";
+    case MemTrackerType::DEL_VEC_CACHE:
+        return "del_vec_cache";
+    case MemTrackerType::COMPACTION_STATE:
+        return "compaction_state";
+    case MemTrackerType::QUERY:
+    case MemTrackerType::RESOURCE_GROUP:
+    case MemTrackerType::RESOURCE_GROUP_BIG_QUERY:
+    case MemTrackerType::COMPACTION_TASK:
+    case MemTrackerType::SCHEMA_CHANGE_TASK:
+        // Use user-defined label
+        return "";
+    default:
+        return "";
+    }
+}
 
 MemTracker::MemTracker(int64_t byte_limit, std::string label, MemTracker* parent)
         : _limit(byte_limit),
@@ -59,7 +142,7 @@ MemTracker::MemTracker(int64_t byte_limit, std::string label, MemTracker* parent
     Init();
 }
 
-MemTracker::MemTracker(Type type, int64_t byte_limit, std::string label, MemTracker* parent)
+MemTracker::MemTracker(MemTrackerType type, int64_t byte_limit, std::string label, MemTracker* parent)
         : _type(type),
           _limit(byte_limit),
           _label(std::move(label)),
@@ -133,34 +216,37 @@ Status MemTracker::check_mem_limit(const std::string& msg) const {
     return Status::MemoryLimitExceeded(tracker->err_msg(msg));
 }
 
-std::string MemTracker::err_msg(const std::string& msg) const {
+std::string MemTracker::err_msg(const std::string& msg, RuntimeState* state) const {
     std::stringstream str;
     str << "Memory of " << label() << " exceed limit. " << msg << " ";
     str << "Backend: " << BackendOptions::get_localhost() << ", ";
+    if (state != nullptr) {
+        str << "fragment: " << print_id(state->fragment_instance_id()) << " ";                                  \
+    }
     str << "Used: " << consumption() << ", Limit: " << limit() << ". ";
     switch (type()) {
-    case MemTracker::NO_SET:
+    case MemTrackerType::NO_SET:
         break;
-    case MemTracker::QUERY:
+    case MemTrackerType::QUERY:
         str << "Mem usage has exceed the limit of single query, You can change the limit by "
                "set session variable query_mem_limit.";
         break;
-    case MemTracker::PROCESS:
+    case MemTrackerType::PROCESS:
         str << "Mem usage has exceed the limit of BE";
         break;
-    case MemTracker::QUERY_POOL:
+    case MemTrackerType::QUERY_POOL:
         str << "Mem usage has exceed the limit of query pool";
         break;
-    case MemTracker::LOAD:
+    case MemTrackerType::LOAD:
         str << "Mem usage has exceed the limit of load";
         break;
-    case MemTracker::CONSISTENCY:
+    case MemTrackerType::CONSISTENCY:
         str << "Mem usage has exceed the limit of consistency";
         break;
-    case MemTracker::SCHEMA_CHANGE_TASK:
+    case MemTrackerType::SCHEMA_CHANGE_TASK:
         str << "You can change the limit by modify BE config [memory_limitation_per_thread_for_schema_change]";
         break;
-    case MemTracker::RESOURCE_GROUP:
+    case MemTrackerType::RESOURCE_GROUP:
         // TODO: make default_wg configuable.
         if (label() == "default_wg") {
             str << "Mem usage has exceed the limit of query pool";
@@ -169,7 +255,7 @@ std::string MemTracker::err_msg(const std::string& msg) const {
                 << "You can change the limit by modifying [mem_limit] of this group";
         }
         break;
-    case MemTracker::RESOURCE_GROUP_BIG_QUERY:
+    case MemTrackerType::RESOURCE_GROUP_BIG_QUERY:
         str << "Mem usage has exceed the big query limit of the resource group [" << label() << "]. "
             << "You can change the limit by modifying [big_query_mem_limit] of this group";
         break;

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -33,10 +33,10 @@
 // under the License.
 
 #include "runtime/mem_tracker.h"
-#include "runtime/runtime_state.h"
 
 #include <utility>
 
+#include "runtime/runtime_state.h"
 #include "service/backend_options.h"
 
 namespace starrocks {
@@ -221,7 +221,7 @@ std::string MemTracker::err_msg(const std::string& msg, RuntimeState* state) con
     str << "Memory of " << label() << " exceed limit. " << msg << " ";
     str << "Backend: " << BackendOptions::get_localhost() << ", ";
     if (state != nullptr) {
-        str << "fragment: " << print_id(state->fragment_instance_id()) << " ";                                  \
+        str << "fragment: " << print_id(state->fragment_instance_id()) << " ";
     }
     str << "Used: " << consumption() << ", Limit: " << limit() << ". ";
     switch (type()) {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -212,7 +212,7 @@ void RuntimeState::init_mem_trackers(const TUniqueId& query_id, MemTracker* pare
     }
 
     _query_mem_tracker =
-            std::make_shared<MemTracker>(MemTracker::QUERY, bytes_limit, runtime_profile()->name(), parent);
+            std::make_shared<MemTracker>(MemTrackerType::QUERY, bytes_limit, runtime_profile()->name(), parent);
     _instance_mem_tracker = std::make_shared<MemTracker>(_profile.get(), std::make_tuple(true, true, true), "Instance",
                                                          -1, runtime_profile()->name(), _query_mem_tracker.get());
     _instance_mem_pool = std::make_unique<MemPool>();

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -658,58 +658,11 @@ private:
     bool _enable_event_scheduler = false;
 };
 
-#define LIMIT_EXCEEDED(tracker, state, msg)                                                                         \
-    do {                                                                                                            \
-        stringstream str;                                                                                           \
-        str << "Memory of " << tracker->label() << " exceed limit. " << msg << " ";                                 \
-        str << "Backend: " << BackendOptions::get_localhost() << ", ";                                              \
-        if (state != nullptr) {                                                                                     \
-            str << "fragment: " << print_id(state->fragment_instance_id()) << " ";                                  \
-        }                                                                                                           \
-        str << "Used: " << tracker->consumption() << ", Limit: " << tracker->limit() << ". ";                       \
-        switch (tracker->type()) {                                                                                  \
-        case MemTracker::NO_SET:                                                                                    \
-            break;                                                                                                  \
-        case MemTracker::QUERY:                                                                                     \
-            str << "Mem usage has exceed the limit of single query, You can change the limit by "                   \
-                   "set session variable query_mem_limit.";                                                         \
-            break;                                                                                                  \
-        case MemTracker::PROCESS:                                                                                   \
-            str << "Mem usage has exceed the limit of BE";                                                          \
-            break;                                                                                                  \
-        case MemTracker::QUERY_POOL:                                                                                \
-            str << "Mem usage has exceed the limit of query pool";                                                  \
-            break;                                                                                                  \
-        case MemTracker::LOAD:                                                                                      \
-            str << "Mem usage has exceed the limit of load";                                                        \
-            break;                                                                                                  \
-        case MemTracker::SCHEMA_CHANGE_TASK:                                                                        \
-            str << "You can change the limit by modify BE config [memory_limitation_per_thread_for_schema_change]"; \
-            break;                                                                                                  \
-        case MemTracker::RESOURCE_GROUP:                                                                            \
-            /* TODO: make default_wg configuable. */                                                                \
-            if (tracker->label() == "default_wg") {                                                                 \
-                str << "Mem usage has exceed the limit of query pool";                                              \
-            } else {                                                                                                \
-                str << "Mem usage has exceed the limit of the resource group [" << tracker->label() << "]. "        \
-                    << "You can change the limit by modifying [mem_limit] of this group";                           \
-            }                                                                                                       \
-            break;                                                                                                  \
-        case MemTracker::RESOURCE_GROUP_BIG_QUERY:                                                                  \
-            str << "Mem usage has exceed the big query limit of the resource group [" << tracker->label() << "]. "  \
-                << "You can change the limit by modifying [big_query_mem_limit] of this group";                     \
-            break;                                                                                                  \
-        default:                                                                                                    \
-            break;                                                                                                  \
-        }                                                                                                           \
-        return Status::MemoryLimitExceeded(str.str());                                                              \
-    } while (false)
-
 #define RETURN_IF_LIMIT_EXCEEDED(state, msg)                                                \
     do {                                                                                    \
         MemTracker* tracker = state->instance_mem_tracker()->find_limit_exceeded_tracker(); \
         if (tracker != nullptr) {                                                           \
-            LIMIT_EXCEEDED(tracker, state, msg);                                            \
+            return Status::MemoryLimitExceeded(tracker->err_msg(msg, state));               \
         }                                                                                   \
     } while (false)
 

--- a/be/src/storage/compaction_task_factory.cpp
+++ b/be/src/storage/compaction_task_factory.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<CompactionTask> CompactionTaskFactory::create_compaction_task() 
     compaction_task->set_segment_iterator_num(segment_iterator_num);
     compaction_task->set_tablet_schema(tablet_schema);
     std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(
-            MemTracker::COMPACTION, -1, "Compaction-" + std::to_string(compaction_task->task_id()),
+            MemTrackerType::COMPACTION_TASK, -1, "Compaction-" + std::to_string(compaction_task->task_id()),
             GlobalEnv::GetInstance()->compaction_mem_tracker());
     compaction_task->set_mem_tracker(mem_tracker.release());
     return compaction_task;

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -27,7 +27,7 @@ CompactionTask::CompactionTask(VersionedTablet tablet, std::vector<std::shared_p
         : _txn_id(context->txn_id),
           _tablet(std::move(tablet)),
           _input_rowsets(std::move(input_rowsets)),
-          _mem_tracker(std::make_unique<MemTracker>(MemTracker::COMPACTION, -1,
+          _mem_tracker(std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1,
                                                     "Compaction-" + std::to_string(_tablet.metadata()->id()),
                                                     GlobalEnv::GetInstance()->compaction_mem_tracker())),
           _context(context),

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -81,7 +81,7 @@ SpillMemTableSink::SpillMemTableSink(LoadSpillBlockManager* block_manager, Table
     _spiller_factory = spill::make_spilled_factory();
     std::string tracker_label = "LoadSpillMerge-" + std::to_string(_block_manager->tablet_id()) + "-" +
                                 std::to_string(_block_manager->txn_id());
-    _merge_mem_tracker = std::make_unique<MemTracker>(MemTracker::COMPACTION, -1, std::move(tracker_label),
+    _merge_mem_tracker = std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, std::move(tracker_label),
                                                       GlobalEnv::GetInstance()->compaction_mem_tracker());
 }
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -896,7 +896,7 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir,
     TRACE("found best tablet $0", best_tablet->get_tablet_info().tablet_id);
 
     std::unique_ptr<MemTracker> mem_tracker =
-            std::make_unique<MemTracker>(MemTrackerType::COMPACTION, -1, "", _options.compaction_mem_tracker);
+            std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, "", _options.compaction_mem_tracker);
     CumulativeCompaction cumulative_compaction(mem_tracker.get(), best_tablet);
 
     Status res = cumulative_compaction.compact();
@@ -937,7 +937,7 @@ Status StorageEngine::_perform_base_compaction(DataDir* data_dir, std::pair<int3
     TRACE("found best tablet $0", best_tablet->get_tablet_info().tablet_id);
 
     std::unique_ptr<MemTracker> mem_tracker =
-            std::make_unique<MemTracker>(MemTrackerType::COMPACTION, -1, "", _options.compaction_mem_tracker);
+            std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, "", _options.compaction_mem_tracker);
     BaseCompaction base_compaction(mem_tracker.get(), best_tablet);
 
     Status res = base_compaction.compact();
@@ -1002,7 +1002,7 @@ Status StorageEngine::_perform_update_compaction(DataDir* data_dir) {
         SCOPED_RAW_TIMER(&duration_ns);
 
         std::unique_ptr<MemTracker> mem_tracker =
-                std::make_unique<MemTracker>(MemTrackerType::COMPACTION, -1, "", _options.compaction_mem_tracker);
+                std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, "", _options.compaction_mem_tracker);
         res = best_tablet->updates()->compaction(mem_tracker.get());
     }
     StarRocksMetrics::instance()->update_compaction_duration_us.increment(duration_ns / 1000);

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -896,7 +896,7 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir,
     TRACE("found best tablet $0", best_tablet->get_tablet_info().tablet_id);
 
     std::unique_ptr<MemTracker> mem_tracker =
-            std::make_unique<MemTracker>(MemTracker::COMPACTION, -1, "", _options.compaction_mem_tracker);
+            std::make_unique<MemTracker>(MemTrackerType::COMPACTION, -1, "", _options.compaction_mem_tracker);
     CumulativeCompaction cumulative_compaction(mem_tracker.get(), best_tablet);
 
     Status res = cumulative_compaction.compact();
@@ -937,7 +937,7 @@ Status StorageEngine::_perform_base_compaction(DataDir* data_dir, std::pair<int3
     TRACE("found best tablet $0", best_tablet->get_tablet_info().tablet_id);
 
     std::unique_ptr<MemTracker> mem_tracker =
-            std::make_unique<MemTracker>(MemTracker::COMPACTION, -1, "", _options.compaction_mem_tracker);
+            std::make_unique<MemTracker>(MemTrackerType::COMPACTION, -1, "", _options.compaction_mem_tracker);
     BaseCompaction base_compaction(mem_tracker.get(), best_tablet);
 
     Status res = base_compaction.compact();
@@ -1002,7 +1002,7 @@ Status StorageEngine::_perform_update_compaction(DataDir* data_dir) {
         SCOPED_RAW_TIMER(&duration_ns);
 
         std::unique_ptr<MemTracker> mem_tracker =
-                std::make_unique<MemTracker>(MemTracker::COMPACTION, -1, "", _options.compaction_mem_tracker);
+                std::make_unique<MemTracker>(MemTrackerType::COMPACTION, -1, "", _options.compaction_mem_tracker);
         res = best_tablet->updates()->compaction(mem_tracker.get());
     }
     StarRocksMetrics::instance()->update_compaction_duration_us.increment(duration_ns / 1000);

--- a/be/src/storage/task/engine_alter_tablet_task.cpp
+++ b/be/src/storage/task/engine_alter_tablet_task.cpp
@@ -47,8 +47,8 @@ using std::to_string;
 EngineAlterTabletTask::EngineAlterTabletTask(MemTracker* mem_tracker, const TAlterTabletReqV2& request)
         : _alter_tablet_req(request) {
     size_t mem_limit = static_cast<size_t>(config::memory_limitation_per_thread_for_schema_change) * 1024 * 1024 * 1024;
-    _mem_tracker =
-            std::make_unique<MemTracker>(MemTracker::SCHEMA_CHANGE_TASK, mem_limit, "schema change task", mem_tracker);
+    _mem_tracker = std::make_unique<MemTracker>(MemTrackerType::SCHEMA_CHANGE_TASK, mem_limit, "schema change task",
+                                                mem_tracker);
 }
 
 Status EngineAlterTabletTask::execute() {

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -23,7 +23,7 @@
 namespace starrocks::pipeline {
 
 TEST(QueryContextManagerTest, testSingleThreadOperations) {
-    auto parent_mem_tracker = std::make_shared<MemTracker>(MemTracker::QUERY_POOL, 1073741824L, "parent", nullptr);
+    auto parent_mem_tracker = std::make_shared<MemTracker>(MemTrackerType::QUERY_POOL, 1073741824L, "parent", nullptr);
     {
         auto query_ctx_mgr = std::make_shared<QueryContextManager>(6);
         ASSERT_TRUE(query_ctx_mgr->init().ok());
@@ -174,7 +174,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
 }
 
 TEST(QueryContextManagerTest, testMulitiThreadOperations) {
-    auto parent_mem_tracker = std::make_shared<MemTracker>(MemTracker::QUERY_POOL, 1073741824L, "parent", nullptr);
+    auto parent_mem_tracker = std::make_shared<MemTracker>(MemTrackerType::QUERY_POOL, 1073741824L, "parent", nullptr);
     auto query_ctx_mgr = std::make_shared<QueryContextManager>(6);
     ASSERT_TRUE(query_ctx_mgr->init().ok());
     TUniqueId query_id;
@@ -241,7 +241,7 @@ QueryContext* gen_query_ctx(MemTracker* parent_mem_tracker, QueryContextManager*
 }
 
 TEST(QueryContextManagerTest, testSetWorkgroup) {
-    auto parent_mem_tracker = std::make_shared<MemTracker>(MemTracker::QUERY_POOL, 1073741824L, "parent", nullptr);
+    auto parent_mem_tracker = std::make_shared<MemTracker>(MemTrackerType::QUERY_POOL, 1073741824L, "parent", nullptr);
     auto query_ctx_mgr = std::make_shared<QueryContextManager>(6);
     ASSERT_TRUE(query_ctx_mgr->init().ok());
 


### PR DESCRIPTION
## Why I'm doing:

Complete the types of `MemTracker` and add an interface for converting `Type` to `Label`.
It facilitates the subsequent addition of more detailed memory metrics.

## What I'm doing:

* Complete the types of `MemTracker` and add an interface for converting `Type` to `Label`.
* Remove some useless interfaces.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0