### PR TITLE
[BugFix] fix invalid expression usage

### DIFF
--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -423,8 +423,8 @@ requires(!lt_is_date<SlotType>) Status ChunkPredicateBuilder<E, Type>::normalize
             SQLFilterOp op;
             ValueType value;
             ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
-            bool ok =
-                    get_predicate_value<Negative>(_opts.obj_pool, slot, expr_context->root(), expr_context, &value, &op, &status);
+            bool ok = get_predicate_value<Negative>(_opts.obj_pool, slot, get_root_expr(expr_context), expr_context,
+                                                    &value, &op, &status);
             if (ok && range->add_fixed_values(FILTER_IN, std::set<RangeValueType>{value}).ok()) {
                 _normalized_exprs[i] = true;
             }
@@ -534,8 +534,8 @@ requires lt_is_date<SlotType> Status ChunkPredicateBuilder<E, Type>::normalize_i
             SQLFilterOp op;
             DateValue value{0};
             ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
-            bool ok =
-                    get_predicate_value<Negative>(_opts.obj_pool, slot, expr_context->root(), expr_context, &value, &op, &status);
+            bool ok = get_predicate_value<Negative>(_opts.obj_pool, slot, get_root_expr(expr_context), expr_context,
+                                                    &value, &op, &status);
             if (ok && range->add_fixed_values(FILTER_IN, std::set<DateValue>{value}).ok()) {
                 _normalized_exprs[i] = true;
             }
@@ -568,7 +568,8 @@ Status ChunkPredicateBuilder<E, Type>::normalize_binary_predicate(const SlotDesc
         SQLFilterOp op;
         ValueType value;
         ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
-        bool ok = get_predicate_value<Negative>(_opts.obj_pool, slot, expr_context->root(), expr_context, &value, &op, &status);
+        bool ok = get_predicate_value<Negative>(_opts.obj_pool, slot, get_root_expr(expr_context), expr_context, &value,
+                                                &op, &status);
         if (ok && range->add_range(op, static_cast<RangeValueType>(value)).ok()) {
             _normalized_exprs[i] = true;
         }
@@ -771,8 +772,8 @@ Status ChunkPredicateBuilder<E, Type>::normalize_not_in_or_not_equal_predicate(
             SQLFilterOp op;
             ValueType value;
             ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
-            bool ok =
-                    get_predicate_value<Negative>(_opts.obj_pool, slot, expr_context->root(), expr_context, &value, &op, &status);
+            bool ok = get_predicate_value<Negative>(_opts.obj_pool, slot, get_root_expr(expr_context), expr_context,
+                                                    &value, &op, &status);
             if (ok && range->add_fixed_values(FILTER_NOT_IN, std::set<RangeValueType>{value}).ok()) {
                 _normalized_exprs[i] = true;
             }

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -424,7 +424,7 @@ requires(!lt_is_date<SlotType>) Status ChunkPredicateBuilder<E, Type>::normalize
             ValueType value;
             ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
             bool ok =
-                    get_predicate_value<Negative>(_opts.obj_pool, slot, root_expr, expr_context, &value, &op, &status);
+                    get_predicate_value<Negative>(_opts.obj_pool, slot, expr_context->root(), expr_context, &value, &op, &status);
             if (ok && range->add_fixed_values(FILTER_IN, std::set<RangeValueType>{value}).ok()) {
                 _normalized_exprs[i] = true;
             }
@@ -535,7 +535,7 @@ requires lt_is_date<SlotType> Status ChunkPredicateBuilder<E, Type>::normalize_i
             DateValue value{0};
             ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
             bool ok =
-                    get_predicate_value<Negative>(_opts.obj_pool, slot, root_expr, expr_context, &value, &op, &status);
+                    get_predicate_value<Negative>(_opts.obj_pool, slot, expr_context->root(), expr_context, &value, &op, &status);
             if (ok && range->add_fixed_values(FILTER_IN, std::set<DateValue>{value}).ok()) {
                 _normalized_exprs[i] = true;
             }
@@ -568,7 +568,7 @@ Status ChunkPredicateBuilder<E, Type>::normalize_binary_predicate(const SlotDesc
         SQLFilterOp op;
         ValueType value;
         ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
-        bool ok = get_predicate_value<Negative>(_opts.obj_pool, slot, root_expr, expr_context, &value, &op, &status);
+        bool ok = get_predicate_value<Negative>(_opts.obj_pool, slot, expr_context->root(), expr_context, &value, &op, &status);
         if (ok && range->add_range(op, static_cast<RangeValueType>(value)).ok()) {
             _normalized_exprs[i] = true;
         }
@@ -772,7 +772,7 @@ Status ChunkPredicateBuilder<E, Type>::normalize_not_in_or_not_equal_predicate(
             ValueType value;
             ASSIGN_OR_RETURN(auto* expr_context, _exprs[i].expr_context(_opts.obj_pool, _opts.runtime_state));
             bool ok =
-                    get_predicate_value<Negative>(_opts.obj_pool, slot, root_expr, expr_context, &value, &op, &status);
+                    get_predicate_value<Negative>(_opts.obj_pool, slot, expr_context->root(), expr_context, &value, &op, &status);
             if (ok && range->add_fixed_values(FILTER_NOT_IN, std::set<RangeValueType>{value}).ok()) {
                 _normalized_exprs[i] = true;
             }


### PR DESCRIPTION
regression introduced in
https://github.com/StarRocks/starrocks/pull/44588

expr_context(...)
```cpp
        // Copy expr to prevent two ExprContexts from owning the same Expr, which will cause the same Expr to be
        // closed twice.
        // - The ExprContext in the `original _opts.conjunct_ctxs_ptr` will own an Expr and all its children.
        // - The newly created ExprContext here will also own this Expr.
        auto* new_expr = Expr::copy(obj_pool, root_expr);
        new_expr_ctx = obj_pool->add(new ExprContext(new_expr));
        RETURN_IF_ERROR(new_expr_ctx->prepare(state));
        RETURN_IF_ERROR(new_expr_ctx->open(state));
```

create copy of `root_expr` as `new_expr` and `new ExprContext` pupulate `ExprContext._fn_contexts` and update `VectorizedFunctionCallExpr._fn_context_index` inside `new_expr`

after return from function we do call of `get_predicate_value` with `new_expr_ctx` + `root_expr` inside `root_expr` we can have incorrect `VectorizedFunctionCallExpr._fn_context_index`, because indexes apply for another context

as result later we have errors

```
    @         0x16c18359 google::LogMessageFatal::~LogMessageFatal()
    @         0x104f7c96 starrocks::ExprContext::fn_context(int)
    @         0x105b4c11 starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x103a737a starrocks::VectorizedCastToStringExpr<(starrocks::LogicalType)51, false>::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
```

```cpp
    FunctionContext* fn_context(int i) {
        DCHECK_GE(i, 0);
        DCHECK_LT(i, _fn_contexts.size());
        return _fn_contexts[i];
    }
```

for our case `_fn_context_index = 3` and `_fn_contexts.size() = 2`

after fix we will use proper updated expressions with correct expression context

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
The feature introduced only from 3.4 version and unavailable in previous releases
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0