### PR TITLE
[BugFix] fix rewrite `RewriteSimpleAggToHDFSScanRule` apply infinitely

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -222,6 +222,10 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
             }
         }
 
+        if (aggregationOperator.getAggregations().isEmpty()) {
+            return false;
+        }
+
         boolean allValid = aggregationOperator.getAggregations().values().stream().allMatch(
                 aggregator -> {
                     AggregateFunction aggregateFunction = (AggregateFunction) aggregator.getFunction();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -111,6 +111,18 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 assertNotContains(plan, "___count___");
             }
         }
+        // bad cases
+        {
+            String[] sqlString = {
+                    "select distinct l_shipdate from lineitem_par",
+                    "select count(distinct l_shipdate) from lineitem_par",
+            };
+            for (int i = 0; i < sqlString.length; i++) {
+                String sql = sqlString[i];
+                // just make sure it's not stuck.
+                String plan = getFragmentPlan(sql);
+            }
+        }
         connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(false);
     }
 


### PR DESCRIPTION
## Why I'm doing:

Query like runs forever

> select distinct (parttition_column) from hive_table 

And I find it's because this rule `RewriteSimpleAggToHDFSScanRule` applies inifintely.

## What I'm doing:

Don't apply this rule if `aggregatorOperator.values()` is empty.

Fixes #56066

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0