### PR TITLE
[BugFix] fix concurrency issue in lake tablet channel

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -588,7 +588,7 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
 
 int LakeTabletsChannel::_close_sender(const int64_t* partitions, size_t partitions_size) {
     // Notice: `_num_remaining_senders` and `_dirty_partitions` should be protected by same lock,
-    // so we can make sure the last sender request can get the diry partitions from `_dirty_partitions`.
+    // so we can make sure the last sender request can get the dirty partitions from `_dirty_partitions`.
     std::lock_guard l(_dirty_partitions_lock);
     int n = _num_remaining_senders.fetch_sub(1);
     // if sender close means data send finished, we need to decrease _num_initial_senders

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -587,10 +587,12 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
 }
 
 int LakeTabletsChannel::_close_sender(const int64_t* partitions, size_t partitions_size) {
+    // Notice: `_num_remaining_senders` and `_dirty_partitions` should be protected by same lock,
+    // so we can make sure the last sender request can get the diry partitions from `_dirty_partitions`.
+    std::lock_guard l(_dirty_partitions_lock);
     int n = _num_remaining_senders.fetch_sub(1);
     // if sender close means data send finished, we need to decrease _num_initial_senders
     _num_initial_senders.fetch_sub(1);
-    std::lock_guard l(_dirty_partitions_lock);
     for (int i = 0; i < partitions_size; i++) {
         _dirty_partitions.insert(partitions[i]);
     }


### PR DESCRIPTION
## Why I'm doing:
There is a issue which came from concurrency control bug in `LakeTabletsChannel::_close_sender`. There are three paths in 
`LakeTabletsChannel`:
```
void LakeTabletsChannel::add_chunk(...):
if (request.eos()) {
        int unfinished_senders = _close_sender(request.partition_ids().data(), request.partition_ids().size());
        if (unfinished_senders > 0) {
            // path 1
            count_down_latch.count_down(_delta_writers.size());
        } else if (unfinished_senders == 0) {
            ...
            for (auto& [tablet_id, dw] : _delta_writers) {
                if (_dirty_partitions.count(dw->partition_id()) == 0) {
                     // path 2
                     ...
                    count_down_latch.count_down();
                    continue;
                }
                ...
                dw->finish(_finish_mode, [&, id = tablet_id](StatusOr<TxnLogPtr> res) {
                // path 3
                     ...
                }
```

The deduction of` _num_remaining_senders` and the insertion of `_dirty_partitions` are not protected by the same lock,
which may lead to the following scenario:
1. Thread A: The request carries the partition ID, but at this point, `_num_remaining_senders` is not 0, so path 3 cannot be executed, go to path1.
2. Thread B: The request does not carry the partition ID, at which point `_num_remaining_senders` becomes 0 and attempts to execute path 3. However, due to this check:
```
if (_dirty_partitions.count(dw->partition_id()) == 0) {
                     // path 2
```
it has to go to path2.

As a result, path 3 is never executed, causing an exception. which will lead to error like:
```
fail to execute commit task: table 'xxx" has unfinished tablets: [10228]
```

## What I'm doing:

Put the deduction of` _num_remaining_senders` and the insertion of `_dirty_partitions` under same lock.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0