### PR TITLE
[BugFix] table fucntion's result used by common subexpression should not be eliminated(backport #56094)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -222,6 +222,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF;
 import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
@@ -3229,6 +3230,18 @@ public class PlanFragmentBuilder {
                     .forEach(expr -> fnResultsRequired.union(expr.getUsedColumns()));
             Optional.ofNullable(physicalTableFunction.getPredicate())
                     .ifPresent(pred -> fnResultsRequired.union(pred.getUsedColumns()));
+
+            // if projection exists, the table function's result may be used by both common sub-expressions and
+            // column ref of projections, so all of them must be take into consideration.
+            Map<ColumnRefOperator, ScalarOperator> commonSubMap =
+                    Optional.ofNullable(physicalTableFunction.getProjection()).map(Projection::getCommonSubOperatorMap)
+                            .orElseGet(Collections::emptyMap);
+            Map<ColumnRefOperator, ScalarOperator> columnRefMap =
+                    Optional.ofNullable(physicalTableFunction.getProjection()).map(Projection::getColumnRefMap)
+                            .orElseGet(Collections::emptyMap);
+            Stream.concat(commonSubMap.values().stream(), columnRefMap.values().stream())
+                    .forEach(expr -> fnResultsRequired.union(expr.getUsedColumns()));
+
             fnResultsRequired.intersect(physicalTableFunction.getFnResultColRefs());
             TableFunctionNode tableFunctionNode = new TableFunctionNode(context.getNextNodeId(),
                     inputFragment.getPlanRoot(),


### PR DESCRIPTION
cp #56094 
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
