### PR TITLE
[BugFix] fix window function first_value/last_value with Shrinking Frame cause result error

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -1608,7 +1608,8 @@ public class WindowTest extends PlanTestBase {
     @Test
     public void testFirstLastValueReverse() throws Exception {
         String sql =
-                "select v1,v2,v3, first_value(v3) over (partition by v1 order by v2 rows between current row and unbounded following) from t0";
+                "select v1,v2,v3, first_value(v3) over (partition by v1 order by v2" +
+                        " rows between current row and unbounded following) from t0";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "2:ANALYTIC\n" +
                 "  |  functions: [, last_value(3: v3), ]\n" +
@@ -1620,7 +1621,8 @@ public class WindowTest extends PlanTestBase {
                 "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 DESC");
 
         sql =
-                "select v1,v2,v3, last_value(v3) over (partition by v1 order by v2 rows between current row and unbounded following) from t0";
+                "select v1,v2,v3, last_value(v3) over (partition by v1 order by v2" +
+                        " rows between current row and unbounded following) from t0";
         plan = getFragmentPlan(sql);
         assertContains(plan, "2:ANALYTIC\n" +
                 "  |  functions: [, first_value(3: v3), ]\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -1604,4 +1604,31 @@ public class WindowTest extends PlanTestBase {
                 "  |  order by: 9: a ASC\n" +
                 "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
     }
+
+    @Test
+    public void testFirstLastValueReverse() throws Exception {
+        String sql =
+                "select v1,v2,v3, first_value(v3) over (partition by v1 order by v2 rows between current row and unbounded following) from t0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "2:ANALYTIC\n" +
+                "  |  functions: [, last_value(3: v3), ]\n" +
+                "  |  partition by: 1: v1\n" +
+                "  |  order by: 2: v2 DESC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                "  |  \n" +
+                "  1:SORT\n" +
+                "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 DESC");
+
+        sql =
+                "select v1,v2,v3, last_value(v3) over (partition by v1 order by v2 rows between current row and unbounded following) from t0";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "2:ANALYTIC\n" +
+                "  |  functions: [, first_value(3: v3), ]\n" +
+                "  |  partition by: 1: v1\n" +
+                "  |  order by: 2: v2 DESC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                "  |  \n" +
+                "  1:SORT\n" +
+                "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 DESC");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
for  Shrinking Frame( end with UNBOUNDED_PRECEDING but not begin  with UNBOUNDED_PRECEDING), window transfrom phase will reverse the sort order and reverse windowFrame from Shrinking Frame to  Growing Frame
. But for first_value and last_value, we should also reverse the function(first->last, last->first).

we already have above logic, but unfortunately, function reverse never take affect before this pr：
`callExpr = new FunctionCallExpr(reversedFnName, callExpr.getParams());`

callExpr is just a reference, change it doesn't change AnalyticExpr::fnCall

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0