### PR TITLE
[Feature] Support graceful exit for FE

### DIFF
--- a/bin/stop_be.sh
+++ b/bin/stop_be.sh
@@ -42,30 +42,40 @@ export_shared_envvars
 
 pidfile=$PID_DIR/be.pid
 
-sig=9
+SIG=9
+TIME_OUT=20
+
+OPTS=$(getopt \
+  -n $0 \
+  -o gh \
+  -l 'graceful' \
+  -l 'timeout:' \
+  -l 'help' \
+  -- "$@")
+
+eval set -- "$OPTS"
 
 usage() {
     echo "
 This script is used to stop BE process
 Usage:
-    sh stop_be.sh [option]
+    ./stop_be.sh [option]
 
 Options:
     -h, --help              display this usage only
     -g, --graceful          send SIGTERM to BE process instead of SIGKILL
+    --timeout               specify the timeout for graceful exit, the default is 20
 "
     exit 0
 }
 
-for arg in "$@"
-do
-    case $arg in
-        --help|-h)
-            usage
-        ;;
-        --graceful|-g)
-            sig=15
-        ;;
+while true; do
+    case "$1" in
+        --timeout) TIME_OUT=$2 ; shift 2 ;;
+        --help|-h) usage ; shift ;;
+        --graceful|-g) SIG=15 ; shift ;;
+        --) shift ;  break ;;
+        *) echo "Internal error" ; exit 1 ;;
     esac
 done
 
@@ -83,18 +93,28 @@ if [ -f $pidfile ]; then
     pid=`cat $pidfile`
     pidcomm=`ps -p $pid -o comm=`
     if [ "starrocks_be"x != "$pidcomm"x ]; then
-        echo "ERROR: pid process may not be be. "
+        echo "ERROR: pid process may not be BE"
+        exit 1
+    fi
+    
+    kill -${SIG} $pid > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        rm $pidfile
         exit 1
     fi
 
-    if kill -0 $pid >/dev/null 2>&1; then
-        kill -${sig} $pid > /dev/null 2>&1
-        if [ $? -ne 0 ]; then
-            exit 1
-        fi
-        while kill -0 $pid >/dev/null 2>&1; do
+    # Waiting for a process to exit
+    start_ts=$(date +%s)
+    while kill -0 $pid > /dev/null 2>&1; do
+        if [ $(($(date +%s) - $start_ts)) -gt $TIME_OUT ]; then
+            kill -9 $pid
+            echo "graceful exit timeout, forced termination of the process"
+            break
+        else
             sleep 1
-        done
-    fi
+        fi
+    done
+
     rm $pidfile
 fi
+

--- a/bin/stop_be.sh
+++ b/bin/stop_be.sh
@@ -43,7 +43,7 @@ export_shared_envvars
 pidfile=$PID_DIR/be.pid
 
 SIG=9
-TIME_OUT=20
+TIME_OUT=-1
 
 OPTS=$(getopt \
   -n $0 \
@@ -64,7 +64,7 @@ Usage:
 Options:
     -h, --help              display this usage only
     -g, --graceful          send SIGTERM to BE process instead of SIGKILL
-    --timeout               specify the timeout for graceful exit, the default is 20
+    --timeout               specify the timeout for graceful exit
 "
     exit 0
 }
@@ -75,7 +75,6 @@ while true; do
         --help|-h) usage ; shift ;;
         --graceful|-g) SIG=15 ; shift ;;
         --) shift ;  break ;;
-        *) echo "Internal error" ; exit 1 ;;
     esac
 done
 
@@ -106,7 +105,7 @@ if [ -f $pidfile ]; then
     # Waiting for a process to exit
     start_ts=$(date +%s)
     while kill -0 $pid > /dev/null 2>&1; do
-        if [ $(($(date +%s) - $start_ts)) -gt $TIME_OUT ]; then
+        if [ $TIME_OUT -gt 0 ] && [ $(($(date +%s) - $start_ts)) -gt $TIME_OUT ]; then
             kill -9 $pid
             echo "graceful exit timeout, forced termination of the process"
             break

--- a/bin/stop_fe.sh
+++ b/bin/stop_fe.sh
@@ -40,7 +40,7 @@ Usage:
 
 Options:
     -h, --help              display this usage only
-    -g, --graceful          send USER1 to FE process instead of SIGKILL
+    -g, --graceful          send USER1 to FE process instead of SIGTERM
     --timeout               specify the timeout for graceful exit
 "
     exit 0

--- a/bin/stop_fe.sh
+++ b/bin/stop_fe.sh
@@ -19,6 +19,43 @@
 curdir=`dirname "$0"`
 curdir=`cd "$curdir"; pwd`
 
+SIG=15
+TIME_OUT=60
+
+OPTS=$(getopt \
+  -n $0 \
+  -o gh \
+  -l 'graceful' \
+  -l 'timeout:' \
+  -l 'help' \
+  -- "$@")
+
+eval set -- "$OPTS"
+
+usage() {
+    echo "
+This script is used to stop FE process
+Usage:
+    ./stop_fe.sh [option]
+
+Options:
+    -h, --help              display this usage only
+    -g, --graceful          send SIGTERM to BE process instead of SIGKILL
+    --timeout               specify the timeout for graceful exit, the default is 60
+"
+    exit 0
+}
+
+while true; do
+    case "$1" in
+        --timeout) TIME_OUT=$2 ; shift 2 ;;
+        --help|-h) usage ; shift ;;
+        --graceful|-g) SIG=10 ; shift ;;
+        --) shift ;  break ;;
+        *) echo "Internal error" ; exit 1 ;;
+    esac
+done
+
 export STARROCKS_HOME=`cd "$curdir/.."; pwd`
 # compatible with DORIS_HOME: DORIS_HOME still be using in config on the user side, so set DORIS_HOME to the meaningful value in case of wrong envs.
 export DORIS_HOME="$STARROCKS_HOME"
@@ -31,29 +68,33 @@ export_env_from_conf $STARROCKS_HOME/conf/fe.conf
 pidfile=$PID_DIR/fe.pid
 
 if [ -f $pidfile ]; then
-   pid=`cat $pidfile`
-   pidcomm=`ps -p $pid -o comm=`
-   
-   if [ "java" != "$pidcomm" ]; then
-       echo "ERROR: pid process may not be fe. "
-   fi
+    pid=`cat $pidfile`
+    pidcomm=`ps -p $pid -o comm=`
+    if [ "java"x != "$pidcomm"x ]; then
+        echo "ERROR: pid process may not be FE. "
+        exit 1
+    fi
 
-   if kill $pid > /dev/null 2>&1; then
-        while true
-        do
-            # check if fe proc is still alive
-            if ps -p $pid > /dev/null; then
-                echo "waiting fe to stop, pid: $pid"
-                sleep 2
-            else
-                echo "stop $pidcomm, and remove pid file. "
-                # This file will also be deleted within the process
-                if [ -f $pidfile ]; then
-                    rm $pidfile
-                fi
-                break
-            fi
-        done
-   fi
+    kill -${SIG} $pid > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        rm $pidfile
+        exit 1
+    fi
+    
+    # Waiting for a process to exit
+    start_ts=$(date +%s)
+    while kill -0 $pid > /dev/null 2>&1; do
+        if [ $(($(date +%s) - $start_ts)) -gt $TIME_OUT ]; then
+            kill -9 $pid
+            echo "graceful exit timeout, forced termination of the process"
+            break
+        else
+            sleep 1
+        fi
+    done
+
+    if [ -f $pidfile ]; then
+        rm $pidfile
+    fi
 fi
 

--- a/bin/stop_fe.sh
+++ b/bin/stop_fe.sh
@@ -20,7 +20,7 @@ curdir=`dirname "$0"`
 curdir=`cd "$curdir"; pwd`
 
 SIG=15
-TIME_OUT=60
+TIME_OUT=-1
 
 OPTS=$(getopt \
   -n $0 \
@@ -40,8 +40,8 @@ Usage:
 
 Options:
     -h, --help              display this usage only
-    -g, --graceful          send SIGTERM to BE process instead of SIGKILL
-    --timeout               specify the timeout for graceful exit, the default is 60
+    -g, --graceful          send USER1 to FE process instead of SIGKILL
+    --timeout               specify the timeout for graceful exit
 "
     exit 0
 }
@@ -52,7 +52,6 @@ while true; do
         --help|-h) usage ; shift ;;
         --graceful|-g) SIG=10 ; shift ;;
         --) shift ;  break ;;
-        *) echo "Internal error" ; exit 1 ;;
     esac
 done
 
@@ -84,7 +83,7 @@ if [ -f $pidfile ]; then
     # Waiting for a process to exit
     start_ts=$(date +%s)
     while kill -0 $pid > /dev/null 2>&1; do
-        if [ $(($(date +%s) - $start_ts)) -gt $TIME_OUT ]; then
+        if [ $TIME_OUT -gt 0 ] && [ $(($(date +%s) - $start_ts)) -gt $TIME_OUT ]; then
             kill -9 $pid
             echo "graceful exit timeout, forced termination of the process"
             break

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -41,24 +41,31 @@ import com.starrocks.common.Config;
 import com.starrocks.common.Log4jConfig;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.Version;
+import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.ha.StateChangeExecutor;
 import com.starrocks.http.HttpServer;
 import com.starrocks.journal.Journal;
+import com.starrocks.journal.JournalWriter;
 import com.starrocks.journal.bdbje.BDBEnvironment;
 import com.starrocks.journal.bdbje.BDBJEJournal;
 import com.starrocks.journal.bdbje.BDBTool;
 import com.starrocks.journal.bdbje.BDBToolOptions;
 import com.starrocks.lake.snapshot.RestoreClusterSnapshotMgr;
 import com.starrocks.leader.MetaHelper;
+import com.starrocks.qe.ConnectScheduler;
 import com.starrocks.qe.CoordinatorMonitor;
+import com.starrocks.qe.ProxyContextManager;
 import com.starrocks.qe.QeService;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.GracefulExitFlag;
 import com.starrocks.server.RunMode;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.service.FrontendThriftServer;
 import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlService;
 import com.starrocks.staros.StarMgrServer;
+import com.starrocks.system.Frontend;
+import com.starrocks.task.AgentTaskQueue;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -66,12 +73,15 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import sun.misc.Signal;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.management.ManagementFactory;
+import java.net.InetSocketAddress;
 import java.nio.channels.FileLock;
+import java.util.List;
 
 public class StarRocksFE {
     private static final Logger LOG = LogManager.getLogger(StarRocksFE.class);
@@ -180,9 +190,9 @@ public class StarRocksFE {
 
             ThreadPoolManager.registerAllThreadPoolMetric();
 
-            addShutdownHook();
-
             RestoreClusterSnapshotMgr.finishRestoring();
+
+            handleGracefulExit();
 
             LOG.info("FE started successfully");
 
@@ -196,6 +206,105 @@ public class StarRocksFE {
         }
 
         System.exit(0);
+    }
+
+    private static void handleGracefulExit() {
+        // Since the normal exit is using SIGTERM(15),
+        // so we have to choose another signal for the graceful exit, use SIGUSR1(10) here.
+        Signal.handle(new Signal("USR1"), sig -> {
+            if (canGracefulExit()) {
+                long startTime = System.nanoTime();
+                LOG.info("start to handle graceful exit");
+                GracefulExitFlag.markGracefulExit();
+
+                // transfer leader if current node is leader
+                try {
+                    transferLeader();
+                } catch (Exception e) {
+                    LOG.warn("handle graceful exit failed", e);
+                    System.exit(-1);
+                }
+
+                // Wait for queries to complete
+                try {
+                    waitForDraining();
+                } catch (Exception e) {
+                    LOG.warn("handle graceful exit failed", e);
+                    System.exit(-1);
+                }
+
+                long usedTimeMs = (System.nanoTime() - startTime) / 1000000L;
+                if (usedTimeMs < Config.min_graceful_exit_time_second * 1000L) {
+                    try {
+                        Thread.sleep(Config.min_graceful_exit_time_second * 1000L - usedTimeMs);
+                    } catch (InterruptedException ignored) {
+                    }
+                }
+
+                LOG.info("handle graceful exit successfully");
+                System.exit(0);
+            } else {
+                LOG.info("The current number of FEs that are alive cannot match graceful exit condition, " +
+                        "and can only exit forcefully.");
+                System.exit(-1);
+            }
+        });
+    }
+
+    private static void transferLeader() throws InterruptedException {
+        if (GlobalStateMgr.getCurrentState().isLeader()) {
+            JournalWriter journalWriter = GlobalStateMgr.getCurrentState().getJournalWriter();
+            // stop journal writer
+            journalWriter.stopAndWait();
+            Journal journal = GlobalStateMgr.getCurrentState().getJournal();
+
+            // transfer leader
+            if (journal instanceof BDBJEJournal) {
+                BDBEnvironment bdbEnvironment = ((BDBJEJournal) journal).getBdbEnvironment();
+                if (bdbEnvironment != null) {
+                    // close bdb env, leader election will be triggered
+                    bdbEnvironment.close();
+                    // wait for new leader
+                    while (true) {
+                        try {
+                            InetSocketAddress address = GlobalStateMgr.getCurrentState().getHaProtocol().getLeader();
+                            LOG.info("leader is transferred to {}", address);
+                            break;
+                        } catch (Exception e) {
+                            Thread.sleep(100L);
+                        }
+                    }
+                }
+
+                GlobalStateMgr.getCurrentState().markLeaderTransferred();
+            }
+
+            AgentTaskQueue.failForLeaderTransfer();
+        }
+    }
+
+    private static void waitForDraining() throws InterruptedException {
+        ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
+        ProxyContextManager proxyContextManager = ProxyContextManager.getInstance();
+        final long printLogInterval = 1000L;
+        long lastPrintTimeMs = -1L;
+        while (connectScheduler.getTotalConnCount() + proxyContextManager.getTotalConnCount() > 0) {
+            connectScheduler.closeAllIdleConnection();
+            if (System.currentTimeMillis() - lastPrintTimeMs > printLogInterval) {
+                LOG.info("waiting for {} connections to drain",
+                        connectScheduler.getTotalConnCount() + proxyContextManager.getTotalConnCount());
+                lastPrintTimeMs = System.currentTimeMillis();
+            }
+            Thread.sleep(100L);
+        }
+    }
+
+    private static boolean canGracefulExit() {
+        List<Frontend> frontends = GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(FrontendNodeType.FOLLOWER);
+        long aliveCnt = frontends.stream().filter(Frontend::isAlive).count();
+        // We need to ensure that after the node is shut down, there are still enough followers alive
+        // so that the traffic can be switched to other normal nodes.
+        return (aliveCnt - 1) >= (frontends.size()) / 2 + 1;
     }
 
     /*
@@ -372,39 +481,5 @@ public class StarRocksFE {
         }
 
         return false;
-    }
-
-    // NOTE: To avoid dead lock
-    //      1. never call System.exit in shutdownHook
-    //      2. shutdownHook cannot have lock conflict with the function calling System.exit
-    private static void addShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            LOG.info("start to execute shutdown hook");
-            try {
-                Thread t = new Thread(() -> {
-                    try {
-                        Journal journal = GlobalStateMgr.getCurrentState().getJournal();
-                        if (journal instanceof BDBJEJournal) {
-                            BDBEnvironment bdbEnvironment = ((BDBJEJournal) journal).getBdbEnvironment();
-                            if (bdbEnvironment != null) {
-                                bdbEnvironment.flushVLSNMapping();
-                            }
-                        }
-                    } catch (Throwable e) {
-                        LOG.warn("flush vlsn mapping failed", e);
-                    }
-                });
-
-                t.start();
-
-                // it is necessary to set shutdown timeout,
-                // because in addition to kill by user, System.exit(-1) will trigger the shutdown hook too,
-                // if no timeout and shutdown hook blocked indefinitely, Fe will fall into a catastrophic state.
-                t.join(30000);
-            } catch (Throwable e) {
-                LOG.warn("shut down hook failed", e);
-            }
-            LOG.info("shutdown hook end");
-        }));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -259,6 +259,9 @@ public class StarRocksFE {
             }
             if (t.isAlive()) {
                 LOG.warn("graceful exit timeout");
+                System.exit(-1);
+            } else {
+                System.exit(0);
             }
         });
     }

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -190,6 +190,8 @@ public class StarRocksFE {
 
             ThreadPoolManager.registerAllThreadPoolMetric();
 
+            addShutdownHook();
+
             RestoreClusterSnapshotMgr.finishRestoring();
 
             handleGracefulExit();
@@ -496,5 +498,13 @@ public class StarRocksFE {
         }
 
         return false;
+    }
+
+    // Some cleanup work can be done here.
+    // Currently, only one log is printed to distinguish whether it is a normal exit or killed by the operating system.
+    private static void addShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            LOG.info("FE shutdown");
+        }));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3550,4 +3550,18 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = false)
     public static int max_spm_cache_baseline_size = 200;
+
+    /**
+     * The process must be stopped after the load balancing detection becomes Unhealthy,
+     * otherwise the new connection will still be forwarded to the machine where the FE node is located,
+     * causing the connection to fail.
+     */
+    @ConfField(mutable = true)
+    public static long min_graceful_exit_time_second = 15;
+
+    /**
+     * timeout for graceful exit
+     */
+    @ConfField(mutable = true)
+    public static long max_graceful_exit_time_second = 15;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3563,5 +3563,5 @@ public class Config extends ConfigBase {
      * timeout for graceful exit
      */
     @ConfField(mutable = true)
-    public static long max_graceful_exit_time_second = 15;
+    public static long max_graceful_exit_time_second = 60;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Status.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Status.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 public class Status {
     public static final Status OK = new Status();
     public static final Status CANCELLED = new Status(TStatusCode.CANCELLED, "Cancelled");
+    public static final Status LEADER_TRANSFERRED = new Status(TStatusCode.CANCELLED, "Leader Transferred");
 
     public TStatusCode getErrorCode() {
         return errorCode;

--- a/fe/fe-core/src/main/java/com/starrocks/ha/StateChangeExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/StateChangeExecutor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Queues;
 import com.starrocks.common.util.Daemon;
 import com.starrocks.common.util.Util;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.GracefulExitFlag;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -166,11 +167,15 @@ public class StateChangeExecutor extends Daemon {
                     break;
                 }
                 case LEADER: {
-                    // exit if leader changed to any other type
-                    String msg = "transfer FE type from LEADER to " + newType.name() + ". exit";
-                    LOG.error(msg);
-                    Util.stdoutWithTime(msg);
-                    System.exit(-1);
+                    if (GracefulExitFlag.isGracefulExit()) {
+                        break;
+                    } else {
+                        // exit if leader changed to any other type
+                        String msg = "transfer FE type from LEADER to " + newType.name() + ". exit";
+                        LOG.error(msg);
+                        Util.stdoutWithTime(msg);
+                        System.exit(-1);
+                    }
                 }
                 default:
                     break;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
@@ -55,6 +55,7 @@ import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.GracefulExitFlag;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.sql.ast.KillStmt;
 import com.starrocks.sql.ast.QueryStatement;
@@ -159,6 +160,9 @@ public class ExecuteSqlAction extends RestBaseAction {
             // finalize just send 200 for kill, and throw StarRocksHttpException if context's error is set
             finalize(request, response, parsedStmt, context);
 
+            if (GracefulExitFlag.isGracefulExit()) {
+                context.getNettyChannel().close();
+            }
         } catch (StarRocksHttpException e) {
             LOG.warn("fail to process url: {}", request.getRequest().uri(), e);
             RestBaseResult failResult = new RestBaseResult(e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/journal/DrainingJournalTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/DrainingJournalTask.java
@@ -1,0 +1,21 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.journal;
+
+public class DrainingJournalTask extends JournalTask {
+    public DrainingJournalTask() {
+        super(System.nanoTime(), null, 0);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/journal/LeaderTransferException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/LeaderTransferException.java
@@ -1,0 +1,18 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.journal;
+
+public class LeaderTransferException extends RuntimeException {
+}

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -49,7 +49,6 @@ import com.sleepycat.je.rep.NetworkRestore;
 import com.sleepycat.je.rep.NetworkRestoreConfig;
 import com.sleepycat.je.rep.NoConsistencyRequiredPolicy;
 import com.sleepycat.je.rep.NodeType;
-import com.sleepycat.je.rep.RepInternal;
 import com.sleepycat.je.rep.ReplicatedEnvironment;
 import com.sleepycat.je.rep.ReplicationConfig;
 import com.sleepycat.je.rep.ReplicationNode;
@@ -542,13 +541,6 @@ public class BDBEnvironment {
             closing = false;
         }
         return closeSuccess;
-    }
-
-    public void flushVLSNMapping() {
-        if (replicatedEnvironment != null) {
-            RepInternal.getRepImpl(replicatedEnvironment).getVLSNIndex()
-                    .flushToDatabase(Durability.COMMIT_SYNC);
-        }
     }
 
     private SyncPolicy getSyncPolicy(String policy) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -264,6 +264,9 @@ public class ConnectContext {
     // session level SPM storage
     private SQLPlanStorage sqlPlanStorage = SQLPlanStorage.create(false);
 
+    // Whether leader is transferred during executing stmt
+    private boolean isLeaderTransferred = false;
+
     public void setExplicitTxnState(ExplicitTxnState explicitTxnState) {
         this.explicitTxnState = explicitTxnState;
     }
@@ -1295,6 +1298,14 @@ public class ConnectContext {
             getState().setOk(0L, 0,
                     String.format("set session variables from user property failed: %s", e.getMessage()));
         }
+    }
+
+    public boolean isLeaderTransferred() {
+        return isLeaderTransferred;
+    }
+
+    public void setIsLeaderTransferred(boolean isLeaderTransferred) {
+        this.isLeaderTransferred = isLeaderTransferred;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -917,7 +917,7 @@ public class ConnectProcessor {
         ctx.setCommand(MysqlCommand.COM_SLEEP);
     }
 
-    public void loop() {
+    protected void loopForTest() {
         while (!ctx.isKilled()) {
             try {
                 processOnce();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -42,6 +42,7 @@ import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.common.CloseableLock;
 import com.starrocks.common.Pair;
 import com.starrocks.common.ThreadPoolManager;
+import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectContext;
 import com.starrocks.sql.analyzer.Authorizer;
 import org.apache.logging.log4j.LogManager;
@@ -270,5 +271,19 @@ public class ConnectScheduler {
             });
         }
         return sessionIds;
+    }
+
+    public int getTotalConnCount() {
+        return connectionMap.size();
+    }
+
+    public void closeAllIdleConnection() {
+        try (CloseableLock ignored = CloseableLock.lock(this.connStatsLock)) {
+            connectionMap.values().forEach(context -> {
+                if (context.getCommand() == MysqlCommand.COM_SLEEP) {
+                    context.cleanup();
+                }
+            });
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ProxyContextManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ProxyContextManager.java
@@ -64,6 +64,10 @@ public class ProxyContextManager {
         }
     }
 
+    public int getTotalConnCount() {
+        return connectionMaps.size();
+    }
+
     public static class ScopeGuard implements AutoCloseable {
         private ProxyContextManager manager;
         private boolean set = false;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2170,6 +2170,10 @@ public class GlobalStateMgr {
         return journal;
     }
 
+    public JournalWriter getJournalWriter() {
+        return journalWriter;
+    }
+
     // Get the next available, lock-free because nextId is atomic.
     public long getNextId() {
         return idGenerator.getNextId();
@@ -2301,6 +2305,18 @@ public class GlobalStateMgr {
 
     public boolean isLeader() {
         return feType == FrontendNodeType.LEADER;
+    }
+
+    public void markLeaderTransferred() {
+        // Set isReady to false, so that the leader info will be got from HA protocol, see NodeMgr.getLeaderIpAndRpcPort
+        isReady.set(false);
+        feType = FrontendNodeType.FOLLOWER;
+        journalWriter.setLeaderTransferred();
+    }
+
+    public boolean isLeaderTransferred() {
+        return journalWriter != null
+                && journalWriter.isLeaderTransferred();
     }
 
     public void setSynchronizedTime(long time) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GracefulExitFlag.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GracefulExitFlag.java
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.server;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class GracefulExitFlag {
+    private static final AtomicBoolean GRACEFUL_EXIT = new AtomicBoolean(false);
+
+    public static void markGracefulExit() {
+        GRACEFUL_EXIT.set(true);
+    }
+
+    public static boolean isGracefulExit() {
+        return GRACEFUL_EXIT.get();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
@@ -341,4 +341,11 @@ public class AgentTaskQueue {
         }
         return result;
     }
+
+    public static synchronized void failForLeaderTransfer() {
+        Map<Long, Map<Long, AgentTask>> createTasks = tasks.column(TTaskType.CREATE);
+        createTasks.values()
+                .forEach(v -> v.values()
+                        .forEach(task -> ((CreateReplicaTask) task).failForLeaderTransfer()));
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -135,7 +135,14 @@ public class CreateReplicaTask extends AgentTask {
     public void countDownToZero(String errMsg) {
         if (this.latch != null) {
             latch.countDownToZero(new Status(TStatusCode.CANCELLED, errMsg));
-            LOG.debug("CreateReplicaTask download to zero. error msg: {}", errMsg);
+            LOG.debug("CreateReplicaTask count down to zero. error msg: {}", errMsg);
+        }
+    }
+
+    public void failForLeaderTransfer() {
+        if (this.latch != null) {
+            latch.countDownToZero(Status.LEADER_TRANSFERRED);
+            LOG.debug("CreateReplicaTask count down to zero because of leader transferred.");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -29,6 +29,7 @@ import com.starrocks.common.Status;
 import com.starrocks.common.TimeoutException;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -356,6 +357,9 @@ public class TabletTaskExecutor {
         try {
             if (countDownLatch.await(timeout, TimeUnit.SECONDS)) {
                 if (!countDownLatch.getStatus().ok()) {
+                    if (countDownLatch.getStatus() == Status.LEADER_TRANSFERRED && ConnectContext.get() != null) {
+                        ConnectContext.get().setIsLeaderTransferred(true);
+                    }
                     String errMsg = "fail to create tablet: " + countDownLatch.getStatus().getErrorMsg();
                     LOG.warn(errMsg);
                     throw new DdlException(errMsg);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -406,7 +406,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         ConnectContext ctx = initMockContext(mockChannel(pingPacket), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
-        processor.loop();
+        processor.loopForTest();
         Assert.assertEquals(MysqlCommand.COM_PING, myContext.getCommand());
         Assert.assertTrue(myContext.getState().toResponsePacket() instanceof MysqlOkPacket);
         Assert.assertFalse(myContext.isKilled());
@@ -600,7 +600,7 @@ public class ConnectProcessorTest extends DDLTestBase {
         ConnectContext ctx = initMockContext(mockChannel(null), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
-        processor.loop();
+        processor.loopForTest();
         Assert.assertTrue(myContext.isKilled());
     }
 


### PR DESCRIPTION
## Why I'm doing:
Support graceful exit for FE, so that restart of FE will be more safe.

## What I'm doing:

## Implementation Principle
To achieve a graceful shutdown, the following two steps need to be implemented:
1. Remove the node from the load balancer.
2. Clean up existing connections.

### Removing the Node
Currently, the FE (Frontend) supports two external protocols: MySQL protocol and HTTP protocol. All of them can determine the health status by checking the /api/health API. Therefore, returning a 500 status from the /api/health API upon exit can achieve traffic removal.

### Cleaning Up Connections
- For idle connections, close them directly.
- If a connection is executing a SQL query, wait for the SQL to complete before closing the connection.

However, additional steps are required for the leader node:
- First, a new leader must be elected. (If a new leader is not elected, the node will continue to receive write traffic because only the leader can perform write operations.)
- After electing a new leader, forward write operations to the new leader for execution.

## How to Use
1. A load balancer is required to route MySQL protocol and HTTP protocol traffic. The health check for both protocol should probe the `/api/health` API.

2. To shut down the FE, use `./stop_fe.sh -g`. You can also specify a timeout for the graceful shutdown using `--timeout=xxx`, where the unit is seconds. If not specified, the default timeout is 60 seconds.
```
./stop_fe.sh -g --timeout=120
```
The above command indicates that the graceful shutdown should be completed within 120 seconds. If the shutdown is not completed within the timeout period, the system will force a shutdown.


Fixes #56303

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0