### PR TITLE
[BugFix] skip the statistics database when decommission

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
@@ -235,7 +235,8 @@ public class SystemHandler extends AlterHandler {
                         LocalMetastore localMetastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
                         for (long dbId : localMetastore.getDbIds()) {
                             Database db = localMetastore.getDb(dbId);
-                            if (db == null) {
+                            if (db == null || db.isStatisticsDatabase()) {
+                                // system database can handle the decommission by themselves
                                 continue;
                             }
                             Locker locker = new Locker();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Decommission a backend not should skip checking the `_statistics_` database, as it can handle the scale by itself.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0