### PR TITLE
[Refactor] Refactor the implement of dump mem_tracker tree.

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -113,7 +113,7 @@ static void dump_trace_info() {
         wt = write(STDERR_FILENO, buffer, res);
         // dump memory usage
         // copy trackers
-        auto& trackers = GlobalEnv::GetInstance()->mem_trackers();
+        auto trackers = GlobalEnv::GetInstance()->mem_trackers();
         for (const auto& tracker : trackers) {
             if (tracker) {
                 size_t len = tracker->debug_string(buffer, sizeof(buffer));

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -160,11 +160,13 @@ void MemTrackerWebPageHandler::handle(MemTracker* mem_tracker, const WebPageHand
             // not in RootMemTrackerTree, so it needs to be added here
             MemTracker* meta_mem_tracker = GlobalEnv::GetInstance()->metadata_mem_tracker();
             auto* meta_item = meta_mem_tracker->get_snapshot(&obj_pool, upper_level);
+            meta_item->parent = root;
 
             // Update memory statistics use the old memory framework,
             // not in RootMemTrackerTree, so it needs to be added here
             MemTracker* update_mem_tracker = GlobalEnv::GetInstance()->update_mem_tracker();
             auto* update_item = update_mem_tracker->get_snapshot(&obj_pool, upper_level);
+            update_item->parent = root;
 
             root->childs.emplace_back(meta_item);
             root->childs.emplace_back(update_item);

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -91,7 +91,25 @@ void config_handler(const WebPageHandler::ArgumentMap& args, std::stringstream* 
     (*output) << "</pre>";
 }
 
-void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::ArgumentMap& args, std::stringstream* output) {
+void print_mem_str(std::stringstream* output, const MemTracker::SimpleItem& item) {
+    std::string level_str = ItoaKMGT(item.level);
+    std::string limit_str = item.limit == -1 ? "none" : ItoaKMGT(item.limit);
+    string current_consumption_str = ItoaKMGT(item.cur_consumption);
+    string peak_consumption_str = ItoaKMGT(item.peak_consumption);
+    std::string parent_label;
+    if (item.parent != nullptr) {
+        parent_label = item.parent->label;
+    }
+    (*output) << strings::Substitute("<tr><td>$0</td><td>$1</td><td>$2</td><td>$3</td><td>$4</td><td>$5</td></tr>\n",
+                                     item.level, item.label, parent_label, limit_str, current_consumption_str,
+                                     peak_consumption_str);
+    for (const auto* child : item.childs) {
+        print_mem_str(output, *child);
+    }
+}
+
+void MemTrackerWebPageHandler::handle(MemTracker* mem_tracker, const WebPageHandler::ArgumentMap& args,
+                                      std::stringstream* output) {
     (*output) << "<h1>Memory Usage Detail</h1>\n";
     (*output) << "<table data-toggle='table' "
                  "       data-pagination='true' "
@@ -122,42 +140,10 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
     MemTracker* start_mem_tracker;
     iter = args.find("type");
     if (iter != args.end()) {
-        if (iter->second == "compaction") {
-            start_mem_tracker = GlobalEnv::GetInstance()->compaction_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "load") {
-            start_mem_tracker = GlobalEnv::GetInstance()->load_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "metadata") {
-            start_mem_tracker = GlobalEnv::GetInstance()->metadata_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "query_pool") {
-            start_mem_tracker = GlobalEnv::GetInstance()->query_pool_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "schema_change") {
-            start_mem_tracker = GlobalEnv::GetInstance()->schema_change_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "clone") {
-            start_mem_tracker = GlobalEnv::GetInstance()->clone_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "page_cache") {
-            start_mem_tracker = GlobalEnv::GetInstance()->page_cache_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "update") {
-            start_mem_tracker = GlobalEnv::GetInstance()->update_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "chunk_allocator") {
-            start_mem_tracker = GlobalEnv::GetInstance()->chunk_allocator_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "passthrough") {
-            start_mem_tracker = GlobalEnv::GetInstance()->passthrough_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "consistency") {
-            start_mem_tracker = GlobalEnv::GetInstance()->consistency_mem_tracker();
-            cur_level = 2;
-        } else if (iter->second == "datacache") {
-            start_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
-            cur_level = 2;
+        auto item = GlobalEnv::GetInstance()->get_mem_tracker_by_type(MemTracker::label_to_type(iter->second));
+        if (item.second != nullptr) {
+            start_mem_tracker = item.second;
+            cur_level = item.first;
         } else {
             start_mem_tracker = mem_tracker;
             cur_level = 1;
@@ -167,44 +153,28 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
         cur_level = 1;
     }
 
+    ObjectPool obj_pool;
+
     std::vector<MemTracker::SimpleItem> items;
 
-    // Metadata memory statistics use the old memory framework,
-    // not in RootMemTrackerTree, so it needs to be added here
-    MemTracker* meta_mem_tracker = GlobalEnv::GetInstance()->metadata_mem_tracker();
-    MemTracker::SimpleItem meta_item{"metadata",
-                                     "process",
-                                     2,
-                                     meta_mem_tracker->limit(),
-                                     meta_mem_tracker->consumption(),
-                                     meta_mem_tracker->peak_consumption()};
-
-    // Update memory statistics use the old memory framework,
-    // not in RootMemTrackerTree, so it needs to be added here
-    MemTracker* update_mem_tracker = GlobalEnv::GetInstance()->update_mem_tracker();
-    MemTracker::SimpleItem update_item{"update",
-                                       "process",
-                                       2,
-                                       update_mem_tracker->limit(),
-                                       update_mem_tracker->consumption(),
-                                       update_mem_tracker->peak_consumption()};
-
     if (start_mem_tracker != nullptr) {
-        start_mem_tracker->list_mem_usage(&items, cur_level, upper_level);
+        MemTracker::SimpleItem* root = start_mem_tracker->get_snapshot(&obj_pool, cur_level, upper_level);
         if (start_mem_tracker == GlobalEnv::GetInstance()->process_mem_tracker()) {
-            items.emplace_back(meta_item);
-            items.emplace_back(update_item);
+            // Metadata memory statistics use the old memory framework,
+            // not in RootMemTrackerTree, so it needs to be added here
+            MemTracker* meta_mem_tracker = GlobalEnv::GetInstance()->metadata_mem_tracker();
+            auto* meta_item = meta_mem_tracker->get_snapshot(&obj_pool, 2, upper_level);
+
+            // Update memory statistics use the old memory framework,
+            // not in RootMemTrackerTree, so it needs to be added here
+            MemTracker* update_mem_tracker = GlobalEnv::GetInstance()->update_mem_tracker();
+            auto* update_item = update_mem_tracker->get_snapshot(&obj_pool, 2, upper_level);
+
+            root->childs.emplace_back(meta_item);
+            root->childs.emplace_back(update_item);
         }
 
-        for (const auto& item : items) {
-            std::string level_str = ItoaKMGT(item.level);
-            std::string limit_str = item.limit == -1 ? "none" : ItoaKMGT(item.limit);
-            string current_consumption_str = ItoaKMGT(item.cur_consumption);
-            string peak_consumption_str = ItoaKMGT(item.peak_consumption);
-            (*output) << strings::Substitute(
-                    "<tr><td>$0</td><td>$1</td><td>$2</td><td>$3</td><td>$4</td><td>$5</td></tr>\n", item.level,
-                    item.label, item.parent_label, limit_str, current_consumption_str, peak_consumption_str);
-        }
+        print_mem_str(output, *root);
     }
 
     (*output) << "</tbody></table>\n";
@@ -256,8 +226,8 @@ void add_default_path_handlers(WebPageHandler* web_page_handler, MemTracker* pro
     web_page_handler->register_page(
             "/mem_tracker", "MemTracker",
             [process_mem_tracker](auto&& PH1, auto&& PH2) {
-                return mem_tracker_handler(process_mem_tracker, std::forward<decltype(PH1)>(PH1),
-                                           std::forward<decltype(PH2)>(PH2));
+                return MemTrackerWebPageHandler::handle(process_mem_tracker, std::forward<decltype(PH1)>(PH1),
+                                                        std::forward<decltype(PH2)>(PH2));
             },
             true);
 }

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -142,7 +142,7 @@ void MemTrackerWebPageHandler::handle(MemTracker* mem_tracker, const WebPageHand
     if (iter != args.end()) {
         auto item = GlobalEnv::GetInstance()->get_mem_tracker_by_type(MemTracker::label_to_type(iter->second));
         if (item.second != nullptr) {
-            start_mem_tracker = item.second;
+            start_mem_tracker = item.second.get();
             cur_level = item.first;
         } else {
             start_mem_tracker = mem_tracker;

--- a/be/src/http/default_path_handlers.h
+++ b/be/src/http/default_path_handlers.h
@@ -18,13 +18,18 @@
 #pragma once
 
 #include <cstdio>
+#include "http/web_page_handler.h"
 
 namespace starrocks {
 
 class MemTracker;
-class WebPageHandler;
 
 // Adds a set of default path handlers to the webserver to display
 // logs and configuration flags
 void add_default_path_handlers(WebPageHandler* web_page_handler, MemTracker* process_mem_tracker);
+
+class MemTrackerWebPageHandler {
+public:
+    static void handle(MemTracker* mem_tracker, const WebPageHandler::ArgumentMap& args, std::stringstream* output);
+};
 } // namespace starrocks

--- a/be/src/http/default_path_handlers.h
+++ b/be/src/http/default_path_handlers.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdio>
+
 #include "http/web_page_handler.h"
 
 namespace starrocks {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -207,7 +207,7 @@ Status GlobalEnv::_init_mem_tracker() {
 
     // Metadata statistics memory statistics do not use new mem statistics framework with hook
     _metadata_mem_tracker = regist_tracker(MemTrackerType::METADATA, -1, nullptr);
-    _connector_scan_pool_mem_tracker->set_level(2);
+    _metadata_mem_tracker->set_level(2);
 
     _tablet_metadata_mem_tracker = regist_tracker(MemTrackerType::TABLET_METADATA, -1, metadata_mem_tracker());
     _rowset_metadata_mem_tracker = regist_tracker(MemTrackerType::ROWSET_METADATA, -1, metadata_mem_tracker());
@@ -231,10 +231,10 @@ Status GlobalEnv::_init_mem_tracker() {
     _jit_cache_mem_tracker = regist_tracker(MemTrackerType::JIT_CACHE, -1, process_mem_tracker());
     int32_t update_mem_percent = std::max(std::min(100, config::update_memory_limit_percent), 0);
     _update_mem_tracker = regist_tracker(MemTrackerType::UPDATE, bytes_limit * update_mem_percent / 100, nullptr);
-    _connector_scan_pool_mem_tracker->set_level(2);
+    _update_mem_tracker->set_level(2);
     _chunk_allocator_mem_tracker = regist_tracker(MemTrackerType::CHUNK_ALLOCATOR, -1, process_mem_tracker());
     _passthrough_mem_tracker = regist_tracker(MemTrackerType::PASSTHROUGH, -1, nullptr);
-    _connector_scan_pool_mem_tracker->set_level(2);
+    _passthrough_mem_tracker->set_level(2);
     _clone_mem_tracker = regist_tracker(MemTrackerType::CLONE, -1, process_mem_tracker());
     int64_t consistency_mem_limit = calc_max_consistency_memory(_process_mem_tracker->limit());
     _consistency_mem_tracker =

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -167,6 +167,8 @@ Status GlobalEnv::init() {
 }
 
 Status GlobalEnv::_init_mem_tracker() {
+    MemTracker::init_type_label_map();
+
     int64_t bytes_limit = 0;
     std::stringstream ss;
     // --mem_limit="" means no memory limit
@@ -190,57 +192,71 @@ Status GlobalEnv::_init_mem_tracker() {
         return Status::InternalError(ss.str());
     }
 
-    _process_mem_tracker = regist_tracker(MemTrackerType::PROCESS, bytes_limit, nullptr);
-    _jemalloc_metadata_tracker = regist_tracker(MemTrackerType::JEMALLOC, -1, process_mem_tracker());
+    _process_mem_tracker = regist_tracker(MemTrackerType::PROCESS, 1, bytes_limit, nullptr);
+    _jemalloc_metadata_tracker = regist_tracker(MemTrackerType::JEMALLOC, 2, -1, process_mem_tracker());
     int64_t query_pool_mem_limit =
             calc_max_query_memory(_process_mem_tracker->limit(), config::query_max_memory_limit_percent);
-    _query_pool_mem_tracker = regist_tracker(MemTrackerType::QUERY_POOL, query_pool_mem_limit, process_mem_tracker());
+    _query_pool_mem_tracker =
+            regist_tracker(MemTrackerType::QUERY_POOL, 2, query_pool_mem_limit, process_mem_tracker());
     int64_t query_pool_spill_limit = query_pool_mem_limit * config::query_pool_spill_mem_limit_threshold;
     _query_pool_mem_tracker->set_reserve_limit(query_pool_spill_limit);
-    _connector_scan_pool_mem_tracker = regist_tracker(MemTrackerType::CONNECTOR_SCAN, query_pool_mem_limit, nullptr);
+    _connector_scan_pool_mem_tracker = regist_tracker(MemTrackerType::CONNECTOR_SCAN, 2, query_pool_mem_limit, nullptr);
 
     int64_t load_mem_limit = calc_max_load_memory(_process_mem_tracker->limit());
-    _load_mem_tracker = regist_tracker(MemTrackerType::LOAD, load_mem_limit, process_mem_tracker());
+    _load_mem_tracker = regist_tracker(MemTrackerType::LOAD, 2, load_mem_limit, process_mem_tracker());
 
     // Metadata statistics memory statistics do not use new mem statistics framework with hook
-    _metadata_mem_tracker = regist_tracker(MemTrackerType::METADATA, -1, nullptr);
+    _metadata_mem_tracker = regist_tracker(MemTrackerType::METADATA, 2, -1, nullptr);
 
-    _tablet_metadata_mem_tracker = regist_tracker(MemTrackerType::TABLET_METADATA, -1, metadata_mem_tracker());
-    _rowset_metadata_mem_tracker = regist_tracker(MemTrackerType::ROWSET_METADATA, -1, metadata_mem_tracker());
-    _segment_metadata_mem_tracker = regist_tracker(MemTrackerType::SEGMENT_METADATA, -1, metadata_mem_tracker());
-    _column_metadata_mem_tracker = regist_tracker(MemTrackerType::COLUMN_METADATA, -1, metadata_mem_tracker());
+    _tablet_metadata_mem_tracker = regist_tracker(MemTrackerType::TABLET_METADATA, 3, -1, metadata_mem_tracker());
+    _rowset_metadata_mem_tracker = regist_tracker(MemTrackerType::ROWSET_METADATA, 3, -1, metadata_mem_tracker());
+    _segment_metadata_mem_tracker = regist_tracker(MemTrackerType::SEGMENT_METADATA, 3, -1, metadata_mem_tracker());
+    _column_metadata_mem_tracker = regist_tracker(MemTrackerType::COLUMN_METADATA, 3, -1, metadata_mem_tracker());
 
-    _tablet_schema_mem_tracker = regist_tracker(MemTrackerType::TABLET_SCHEMA, -1, tablet_metadata_mem_tracker());
-    _segment_zonemap_mem_tracker = regist_tracker(MemTrackerType::SEGMENT_METADATA, -1, segment_metadata_mem_tracker());
-    _short_key_index_mem_tracker = regist_tracker(MemTrackerType::SHORT_KEY_INDEX, -1, segment_metadata_mem_tracker());
+    _tablet_schema_mem_tracker = regist_tracker(MemTrackerType::TABLET_SCHEMA, 3, -1, tablet_metadata_mem_tracker());
+    _segment_zonemap_mem_tracker =
+            regist_tracker(MemTrackerType::SEGMENT_METADATA, 3, -1, segment_metadata_mem_tracker());
+    _short_key_index_mem_tracker =
+            regist_tracker(MemTrackerType::SHORT_KEY_INDEX, 3, -1, segment_metadata_mem_tracker());
     _column_zonemap_index_mem_tracker =
-            regist_tracker(MemTrackerType::COLUMN_ZONEMAP_INDEX, -1, column_metadata_mem_tracker());
-    _ordinal_index_mem_tracker = regist_tracker(MemTrackerType::ORDINAL_INDEX, -1, column_metadata_mem_tracker());
-    _bitmap_index_mem_tracker = regist_tracker(MemTrackerType::BITMAP_INDEX, -1, column_metadata_mem_tracker());
+            regist_tracker(MemTrackerType::COLUMN_ZONEMAP_INDEX, 3, -1, column_metadata_mem_tracker());
+    _ordinal_index_mem_tracker = regist_tracker(MemTrackerType::ORDINAL_INDEX, 3, -1, column_metadata_mem_tracker());
+    _bitmap_index_mem_tracker = regist_tracker(MemTrackerType::BITMAP_INDEX, 3, -1, column_metadata_mem_tracker());
     _bloom_filter_index_mem_tracker =
-            regist_tracker(MemTrackerType::BLOOM_FILTER_INDEX, -1, column_metadata_mem_tracker());
+            regist_tracker(MemTrackerType::BLOOM_FILTER_INDEX, 3, -1, column_metadata_mem_tracker());
 
     int64_t compaction_mem_limit = calc_max_compaction_memory(_process_mem_tracker->limit());
-    _compaction_mem_tracker = regist_tracker(MemTrackerType::COMPACTION, compaction_mem_limit, process_mem_tracker());
-    _schema_change_mem_tracker = regist_tracker(MemTrackerType::SCHEMA_CHANGE, -1, process_mem_tracker());
-    _page_cache_mem_tracker = regist_tracker(MemTrackerType::PAGE_CACHE, -1, process_mem_tracker());
-    _jit_cache_mem_tracker = regist_tracker(MemTrackerType::JIT_CACHE, -1, process_mem_tracker());
+    _compaction_mem_tracker =
+            regist_tracker(MemTrackerType::COMPACTION, 2, compaction_mem_limit, process_mem_tracker());
+    _schema_change_mem_tracker = regist_tracker(MemTrackerType::SCHEMA_CHANGE, 2, -1, process_mem_tracker());
+    _page_cache_mem_tracker = regist_tracker(MemTrackerType::PAGE_CACHE, 2, -1, process_mem_tracker());
+    _jit_cache_mem_tracker = regist_tracker(MemTrackerType::JIT_CACHE, 2, -1, process_mem_tracker());
     int32_t update_mem_percent = std::max(std::min(100, config::update_memory_limit_percent), 0);
-    _update_mem_tracker = regist_tracker(MemTrackerType::UPDATE, bytes_limit * update_mem_percent / 100, nullptr);
-    _chunk_allocator_mem_tracker = regist_tracker(MemTrackerType::CHUNK_ALLOCATOR, -1, process_mem_tracker());
-    _passthrough_mem_tracker = regist_tracker(MemTrackerType::PASSTHROUGH, -1, nullptr);
-    _clone_mem_tracker = regist_tracker(MemTrackerType::CLONE, -1, process_mem_tracker());
+    _update_mem_tracker = regist_tracker(MemTrackerType::UPDATE, 2, bytes_limit * update_mem_percent / 100, nullptr);
+    _chunk_allocator_mem_tracker = regist_tracker(MemTrackerType::CHUNK_ALLOCATOR, 2, -1, process_mem_tracker());
+    _passthrough_mem_tracker = regist_tracker(MemTrackerType::PASSTHROUGH, 2, -1, nullptr);
+    _clone_mem_tracker = regist_tracker(MemTrackerType::CLONE, 2, -1, process_mem_tracker());
     int64_t consistency_mem_limit = calc_max_consistency_memory(_process_mem_tracker->limit());
     _consistency_mem_tracker =
-            regist_tracker(MemTrackerType::CONSISTENCY, consistency_mem_limit, process_mem_tracker());
-    _datacache_mem_tracker = regist_tracker(MemTrackerType::DATACACHE, -1, process_mem_tracker());
-    _poco_connection_pool_mem_tracker = regist_tracker(MemTrackerType::POCO_CONNECTION_POOL, -1, process_mem_tracker());
-    _replication_mem_tracker = regist_tracker(MemTrackerType::POCO_CONNECTION_POOL, -1, process_mem_tracker());
+            regist_tracker(MemTrackerType::CONSISTENCY, 2, consistency_mem_limit, process_mem_tracker());
+    _datacache_mem_tracker = regist_tracker(MemTrackerType::DATACACHE, 2, -1, process_mem_tracker());
+    _poco_connection_pool_mem_tracker =
+            regist_tracker(MemTrackerType::POCO_CONNECTION_POOL, 2, -1, process_mem_tracker());
+    _replication_mem_tracker = regist_tracker(MemTrackerType::REPLICATION, 2, -1, process_mem_tracker());
 
     MemChunkAllocator::init_instance(_chunk_allocator_mem_tracker.get(), config::chunk_reserved_bytes_limit);
 
     _init_storage_page_cache(); // TODO: move to StorageEngine
     return Status::OK();
+}
+
+std::pair<size_t, MemTracker*> GlobalEnv::get_mem_tracker_by_type(MemTrackerType type) {
+    auto iter = _mem_tracker_map.find(type);
+    if (iter != _mem_tracker_map.end()) {
+        return iter->second;
+    } else {
+        return {0, nullptr};
+    }
 }
 
 void GlobalEnv::_reset_tracker() {
@@ -278,9 +294,11 @@ int64_t GlobalEnv::check_storage_page_cache_size(int64_t storage_cache_limit) {
     return storage_cache_limit;
 }
 
-std::shared_ptr<MemTracker> GlobalEnv::regist_tracker(MemTrackerType type, int64_t bytes_limit, MemTracker* parent) {
+std::shared_ptr<MemTracker> GlobalEnv::regist_tracker(MemTrackerType type, size_t level, int64_t bytes_limit,
+                                                      MemTracker* parent) {
     auto mem_tracker = std::make_shared<MemTracker>(type, bytes_limit, MemTracker::type_to_label(type), parent);
     _mem_trackers.emplace_back(mem_tracker);
+    _mem_tracker_map[type] = {level, mem_tracker.get()};
     return mem_tracker;
 }
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -154,7 +154,7 @@ public:
     MemTracker* datacache_mem_tracker() { return _datacache_mem_tracker.get(); }
     MemTracker* poco_connection_pool_mem_tracker() { return _poco_connection_pool_mem_tracker.get(); }
     MemTracker* jemalloc_metadata_traker() { return _jemalloc_metadata_tracker.get(); }
-    std::pair<size_t, std::shared_ptr<MemTracker>> get_mem_tracker_by_type(MemTrackerType type);
+    std::shared_ptr<MemTracker> get_mem_tracker_by_type(MemTrackerType type);
     std::vector<std::shared_ptr<MemTracker>> mem_trackers() const;
 
     int64_t get_storage_page_cache_size();
@@ -169,8 +169,7 @@ private:
 
     void _init_storage_page_cache();
 
-    std::shared_ptr<MemTracker> regist_tracker(MemTrackerType type, size_t level, int64_t bytes_limit,
-                                               MemTracker* parent);
+    std::shared_ptr<MemTracker> regist_tracker(MemTrackerType type, int64_t bytes_limit, MemTracker* parent);
 
     // root process memory tracker
     std::shared_ptr<MemTracker> _process_mem_tracker;
@@ -234,7 +233,7 @@ private:
     // The memory used for poco connection pool
     std::shared_ptr<MemTracker> _poco_connection_pool_mem_tracker;
 
-    std::map<MemTrackerType, std::pair<size_t, std::shared_ptr<MemTracker>>> _mem_tracker_map;
+    std::map<MemTrackerType, std::shared_ptr<MemTracker>> _mem_tracker_map;
 };
 
 // Execution environment for queries/plan fragments.

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -154,8 +154,8 @@ public:
     MemTracker* datacache_mem_tracker() { return _datacache_mem_tracker.get(); }
     MemTracker* poco_connection_pool_mem_tracker() { return _poco_connection_pool_mem_tracker.get(); }
     MemTracker* jemalloc_metadata_traker() { return _jemalloc_metadata_tracker.get(); }
-    std::pair<size_t, MemTracker*> get_mem_tracker_by_type(MemTrackerType type);
-    std::vector<std::shared_ptr<MemTracker>>& mem_trackers() { return _mem_trackers; }
+    std::pair<size_t, std::shared_ptr<MemTracker>> get_mem_tracker_by_type(MemTrackerType type);
+    std::vector<std::shared_ptr<MemTracker>> mem_trackers() const;
 
     int64_t get_storage_page_cache_size();
     int64_t check_storage_page_cache_size(int64_t storage_cache_limit);
@@ -234,8 +234,7 @@ private:
     // The memory used for poco connection pool
     std::shared_ptr<MemTracker> _poco_connection_pool_mem_tracker;
 
-    std::vector<std::shared_ptr<MemTracker>> _mem_trackers;
-    std::map<MemTrackerType, std::pair<size_t, MemTracker*>> _mem_tracker_map;
+    std::map<MemTrackerType, std::pair<size_t, std::shared_ptr<MemTracker>>> _mem_tracker_map;
 };
 
 // Execution environment for queries/plan fragments.

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -169,7 +169,8 @@ private:
 
     void _init_storage_page_cache();
 
-    std::shared_ptr<MemTracker> regist_tracker(MemTrackerType type, size_t level, int64_t bytes_limit, MemTracker* parent);
+    std::shared_ptr<MemTracker> regist_tracker(MemTrackerType type, size_t level, int64_t bytes_limit,
+                                               MemTracker* parent);
 
     // root process memory tracker
     std::shared_ptr<MemTracker> _process_mem_tracker;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -154,6 +154,7 @@ public:
     MemTracker* datacache_mem_tracker() { return _datacache_mem_tracker.get(); }
     MemTracker* poco_connection_pool_mem_tracker() { return _poco_connection_pool_mem_tracker.get(); }
     MemTracker* jemalloc_metadata_traker() { return _jemalloc_metadata_tracker.get(); }
+    std::pair<size_t, MemTracker*> get_mem_tracker_by_type(MemTrackerType type);
     std::vector<std::shared_ptr<MemTracker>>& mem_trackers() { return _mem_trackers; }
 
     int64_t get_storage_page_cache_size();
@@ -168,7 +169,7 @@ private:
 
     void _init_storage_page_cache();
 
-    std::shared_ptr<MemTracker> regist_tracker(MemTrackerType type, int64_t bytes_limit, MemTracker* parent);
+    std::shared_ptr<MemTracker> regist_tracker(MemTrackerType type, size_t level, int64_t bytes_limit, MemTracker* parent);
 
     // root process memory tracker
     std::shared_ptr<MemTracker> _process_mem_tracker;
@@ -233,6 +234,7 @@ private:
     std::shared_ptr<MemTracker> _poco_connection_pool_mem_tracker;
 
     std::vector<std::shared_ptr<MemTracker>> _mem_trackers;
+    std::map<MemTrackerType, std::pair<size_t, MemTracker*>> _mem_tracker_map;
 };
 
 // Execution environment for queries/plan fragments.

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -45,85 +45,71 @@ const std::string MemTracker::PEAK_MEMORY_USAGE = "PeakMemoryUsage";
 const std::string MemTracker::ALLOCATED_MEMORY_USAGE = "AllocatedMemoryUsage";
 const std::string MemTracker::DEALLOCATED_MEMORY_USAGE = "DeallocatedMemoryUsage";
 
+static std::vector<std::pair<MemTrackerType, std::string>> s_mem_types = {
+        {MemTrackerType::PROCESS, "process"},
+        {MemTrackerType::QUERY_POOL, "query_pool"},
+        {MemTrackerType::LOAD, "load"},
+        {MemTrackerType::CONSISTENCY, "consistency"},
+        {MemTrackerType::COMPACTION, "compaction"},
+        {MemTrackerType::SCHEMA_CHANGE, "schema_change"},
+        {MemTrackerType::JEMALLOC, "jemalloc_metadata"},
+        {MemTrackerType::PASSTHROUGH, "passthrough"},
+        {MemTrackerType::CONNECTOR_SCAN, "connector_scan"},
+        {MemTrackerType::METADATA, "metadata"},
+        {MemTrackerType::TABLET_METADATA, "tablet_metadata"},
+        {MemTrackerType::ROWSET_METADATA, "rowset_metadata"},
+        {MemTrackerType::SEGMENT_METADATA, "segment_metadata"},
+        {MemTrackerType::COLUMN_METADATA, "column_metadata"},
+        {MemTrackerType::TABLET_SCHEMA, "tablet_schema"},
+        {MemTrackerType::SEGMENT_ZONEMAP, "segment_zonemap"},
+        {MemTrackerType::SHORT_KEY_INDEX, "short_key_index"},
+        {MemTrackerType::COLUMN_ZONEMAP_INDEX, "column_zonemap_index"},
+        {MemTrackerType::ORDINAL_INDEX, "ordinal_index"},
+        {MemTrackerType::BITMAP_INDEX, "bitmap_index"},
+        {MemTrackerType::BLOOM_FILTER_INDEX, "bloom_filter_index"},
+        {MemTrackerType::PAGE_CACHE, "page_cache"},
+        {MemTrackerType::JIT_CACHE, "jit_cache"},
+        {MemTrackerType::UPDATE, "update"},
+        {MemTrackerType::CHUNK_ALLOCATOR, "chunk_allocator"},
+        {MemTrackerType::CLONE, "clone"},
+        {MemTrackerType::DATACACHE, "datacache"},
+        {MemTrackerType::POCO_CONNECTION_POOL, "poco_connection_pool"},
+        {MemTrackerType::REPLICATION, "replication"},
+        {MemTrackerType::ROWSET_UPDATE_STATE, "rowset_update_state"},
+        {MemTrackerType::INDEX_CACHE, "index_cache"},
+        {MemTrackerType::DEL_VEC_CACHE, "del_vec_cache"},
+        {MemTrackerType::COMPACTION_STATE, "compaction_state"},
+};
+
+static std::map<MemTrackerType, std::string> s_type_to_label_map;
+static std::map<std::string, MemTrackerType> s_label_to_type_map;
+
+std::vector<std::pair<MemTrackerType, std::string>>& MemTracker::mem_types() {
+    return s_mem_types;
+}
+
+void MemTracker::init_type_label_map() {
+    for (const auto& item : s_mem_types) {
+        s_type_to_label_map[item.first] = item.second;
+        s_label_to_type_map[item.second] = item.first;
+    }
+}
+
 std::string MemTracker::type_to_label(MemTrackerType type) {
-    switch (type) {
-    case MemTrackerType::NO_SET:
+    auto iter = s_type_to_label_map.find(type);
+    if (iter != s_type_to_label_map.end()) {
+        return iter->second;
+    } else {
         return "";
-    case MemTrackerType::PROCESS:
-        return "process";
-    case MemTrackerType::QUERY_POOL:
-        return "query_pool";
-    case MemTrackerType::LOAD:
-        return "load";
-    case MemTrackerType::CONSISTENCY:
-        return "consistency";
-    case MemTrackerType::COMPACTION:
-        return "compaction";
-    case MemTrackerType::SCHEMA_CHANGE:
-        return "schema_change";
-    case MemTrackerType::JEMALLOC:
-        return "jemalloc_metadata";
-    case MemTrackerType::PASSTHROUGH:
-        return "passthrough";
-    case MemTrackerType::CONNECTOR_SCAN:
-        return "connector_scan";
-    case MemTrackerType::METADATA:
-        return "metadata";
-    case MemTrackerType::TABLET_METADATA:
-        return "tablet_metadata";
-    case MemTrackerType::ROWSET_METADATA:
-        return "rowset_metadata";
-    case MemTrackerType::SEGMENT_METADATA:
-        return "segment_metadata";
-    case MemTrackerType::COLUMN_METADATA:
-        return "column_metadata";
-    case MemTrackerType::TABLET_SCHEMA:
-        return "tablet_schema";
-    case MemTrackerType::SEGMENT_ZONEMAP:
-        return "segment_zonemap";
-    case MemTrackerType::SHORT_KEY_INDEX:
-        return "short_key_index";
-    case MemTrackerType::COLUMN_ZONEMAP_INDEX:
-        return "column_zonemap_index";
-    case MemTrackerType::ORDINAL_INDEX:
-        return "ordinal_index";
-    case MemTrackerType::BITMAP_INDEX:
-        return "bitmap_index";
-    case MemTrackerType::BLOOM_FILTER_INDEX:
-        return "bloom_filter_index";
-    case MemTrackerType::PAGE_CACHE:
-        return "page_cache";
-    case MemTrackerType::JIT_CACHE:
-        return "jit_cache";
-    case MemTrackerType::UPDATE:
-        return "update";
-    case MemTrackerType::CHUNK_ALLOCATOR:
-        return "chunk_allocator";
-    case MemTrackerType::CLONE:
-        return "clone";
-    case MemTrackerType::DATACACHE:
-        return "datacache";
-    case MemTrackerType::POCO_CONNECTION_POOL:
-        return "poco_connection_pool";
-    case MemTrackerType::REPLICATION:
-        return "replication";
-    case MemTrackerType::ROWSET_UPDATE_STATE:
-        return "rowset_update_state";
-    case MemTrackerType::INDEX_CACHE:
-        return "index_cache";
-    case MemTrackerType::DEL_VEC_CACHE:
-        return "del_vec_cache";
-    case MemTrackerType::COMPACTION_STATE:
-        return "compaction_state";
-    case MemTrackerType::QUERY:
-    case MemTrackerType::RESOURCE_GROUP:
-    case MemTrackerType::RESOURCE_GROUP_BIG_QUERY:
-    case MemTrackerType::COMPACTION_TASK:
-    case MemTrackerType::SCHEMA_CHANGE_TASK:
-        // Use user-defined label
-        return "";
-    default:
-        return "";
+    }
+}
+
+MemTrackerType MemTracker::label_to_type(const std::string& label) {
+    auto iter = s_label_to_type_map.find(label);
+    if (iter != s_label_to_type_map.end()) {
+        return iter->second;
+    } else {
+        return MemTrackerType::NO_SET;
     }
 }
 
@@ -214,6 +200,27 @@ Status MemTracker::check_mem_limit(const std::string& msg) const {
     }
 
     return Status::MemoryLimitExceeded(tracker->err_msg(msg));
+}
+
+MemTracker::SimpleItem* MemTracker::_get_snapshot_internal(ObjectPool* pool, SimpleItem* parent, size_t cur_level,
+                                                           size_t upper_level) const {
+    SimpleItem* item = pool->add(new SimpleItem());
+    item->label = _label;
+    item->parent = parent;
+    item->level = cur_level;
+    item->limit = _limit;
+    item->cur_consumption = _consumption->current_value();
+    item->peak_consumption = _consumption->value();
+
+    if (cur_level < upper_level) {
+        std::lock_guard<std::mutex> l(_child_trackers_lock);
+        item->childs.reserve(_child_trackers.size());
+        for (const auto& child : _child_trackers) {
+            item->childs.emplace_back(child->_get_snapshot_internal(pool, item, cur_level + 1, upper_level));
+        }
+    }
+
+    return item;
 }
 
 std::string MemTracker::err_msg(const std::string& msg, RuntimeState* state) const {

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -128,14 +128,38 @@ public:
     // TODO: use a better name?
     struct SimpleItem {
         std::string label;
-        std::string parent_label;
         size_t level = 0;
         int64_t limit = 0;
         int64_t cur_consumption = 0;
         int64_t peak_consumption = 0;
+        std::vector<SimpleItem*> childs;
+        SimpleItem* parent = nullptr;
+
+        std::string debug_string() const {
+            std::stringstream ss;
+            ss << "{";
+            ss << R"("label:")" << label << "\",";
+            ss << R"("level:")" << level << "\",";
+            ss << R"("limit:")" << limit << "\",";
+            ss << R"("cur_mem_usage:")" << cur_consumption << "\",";
+            ss << R"("peak_mem_usage:")" << peak_consumption << "\",";
+            ss << R"("child":[)";
+            for (size_t i = 0; i < childs.size(); i++) {
+                if (i != 0) {
+                    ss << ",";
+                }
+                ss << childs[i]->debug_string();
+            }
+            ss << "]}";
+            return ss.str();
+        }
     };
 
+    static void init_type_label_map();
+
+    static std::vector<std::pair<MemTrackerType, std::string>>& mem_types();
     static std::string type_to_label(MemTrackerType type);
+    static MemTrackerType label_to_type(const std::string& label);
 
     /// 'byte_limit' < 0 means no limit
     /// 'label' is the label used in the usage string (LogUsage())
@@ -201,27 +225,8 @@ public:
 
     void release_without_root() { return release_without_root(consumption()); }
 
-    void list_mem_usage(std::vector<SimpleItem>* items, size_t cur_level, size_t upper_level) const {
-        SimpleItem item;
-        item.label = _label;
-        if (_parent != nullptr) {
-            item.parent_label = _parent->label();
-        } else {
-            item.parent_label = "";
-        }
-        item.level = cur_level;
-        item.limit = _limit;
-        item.cur_consumption = _consumption->current_value();
-        item.peak_consumption = _consumption->value();
-
-        (*items).emplace_back(item);
-
-        if (cur_level < upper_level) {
-            std::lock_guard<std::mutex> l(_child_trackers_lock);
-            for (const auto& child : _child_trackers) {
-                child->list_mem_usage(items, cur_level + 1, upper_level);
-            }
-        }
+    SimpleItem* get_snapshot(ObjectPool* pool, size_t cur_level, size_t upper_level) const {
+        return _get_snapshot_internal(pool, nullptr, cur_level, upper_level);
     }
 
     /// Increases consumption of this tracker and its ancestors by 'bytes' only if
@@ -416,6 +421,9 @@ private:
         std::lock_guard<std::mutex> l(_child_trackers_lock);
         tracker->_child_tracker_it = _child_trackers.insert(_child_trackers.end(), tracker);
     }
+
+    SimpleItem* _get_snapshot_internal(ObjectPool* pool, SimpleItem* parent, size_t cur_level,
+                                       size_t upper_level) const;
 
     MemTrackerType _type{MemTrackerType::NO_SET};
 

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -177,6 +177,9 @@ public:
                         const std::string& counter_name_prefix = std::string(), int64_t byte_limit = -1,
                         std::string label = std::string(), MemTracker* parent = nullptr);
 
+    void set_level(int64_t level) { _level = level; }
+    int64_t get_level() const { return _level; }
+
     ~MemTracker();
 
     // Removes this tracker from _parent->_child_trackers.
@@ -225,8 +228,8 @@ public:
 
     void release_without_root() { return release_without_root(consumption()); }
 
-    SimpleItem* get_snapshot(ObjectPool* pool, size_t cur_level, size_t upper_level) const {
-        return _get_snapshot_internal(pool, nullptr, cur_level, upper_level);
+    SimpleItem* get_snapshot(ObjectPool* pool, size_t upper_level) const {
+        return _get_snapshot_internal(pool, nullptr, upper_level);
     }
 
     /// Increases consumption of this tracker and its ancestors by 'bytes' only if
@@ -422,11 +425,11 @@ private:
         tracker->_child_tracker_it = _child_trackers.insert(_child_trackers.end(), tracker);
     }
 
-    SimpleItem* _get_snapshot_internal(ObjectPool* pool, SimpleItem* parent, size_t cur_level,
-                                       size_t upper_level) const;
+    SimpleItem* _get_snapshot_internal(ObjectPool* pool, SimpleItem* parent, size_t upper_level) const;
 
     MemTrackerType _type{MemTrackerType::NO_SET};
 
+    int64_t _level = 1;
     int64_t _limit;              // in bytes
     int64_t _reserve_limit = -1; // only used in spillable query
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -206,6 +206,7 @@ set(EXEC_FILES
         ./formats/disk_range_test.cpp
         ./geo/geo_types_test.cpp
         ./geo/wkt_parse_test.cpp
+        ./http/default_path_handlers_test.cpp
         ./http/http_client_test.cpp
         ./http/http_utils_test.cpp
         ./http/message_body_sink_test.cpp

--- a/be/test/exec/pipeline/mem_limited_chunk_queue_test.cpp
+++ b/be/test/exec/pipeline/mem_limited_chunk_queue_test.cpp
@@ -34,7 +34,6 @@ namespace starrocks::pipeline {
 class MemLimitedChunkQueueTest : public ::testing::Test {
 public:
     void SetUp() override {
-        ASSERT_OK(GlobalEnv::GetInstance()->init());
         TUniqueId dummy_query_id = generate_uuid();
         auto path = config::storage_root_path + "/spill_test_data/" + print_id(dummy_query_id);
         auto fs = FileSystem::Default();

--- a/be/test/http/default_path_handlers_test.cpp
+++ b/be/test/http/default_path_handlers_test.cpp
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "http/default_path_handlers.h"
+
+#include <gtest/gtest.h>
+#include "runtime/exec_env.h"
+
+namespace starrocks {
+
+class DefaultPathHandlersTest : public testing::Test {};
+
+TEST_F(DefaultPathHandlersTest, mem_tracker) {
+    WebPageHandler::ArgumentMap args;
+    auto* mem_tracker = GlobalEnv::GetInstance()->process_mem_tracker();
+
+    std::stringstream output1;
+    MemTrackerWebPageHandler::handle(mem_tracker, args, &output1);
+    ASSERT_TRUE(output1.str().find("<tr><td>1</td><td>process</td><td>") != std::string::npos);
+    ASSERT_TRUE(output1.str().find("<tr><td>2</td><td>update</td>") != std::string::npos);
+
+    std::stringstream output2;
+    args["type"] = "metadata";
+    args["upper_level"] = "4";
+    MemTrackerWebPageHandler::handle(mem_tracker, args, &output2);
+    ASSERT_TRUE(output2.str().find("<tr><td>1</td><td>process</td><td>") == std::string::npos);
+    ASSERT_TRUE(output2.str().find("<tr><td>3</td><td>tablet_metadata</td><td>metadata</td>") != std::string::npos);
+}
+}

--- a/be/test/http/default_path_handlers_test.cpp
+++ b/be/test/http/default_path_handlers_test.cpp
@@ -18,6 +18,7 @@
 #include "http/default_path_handlers.h"
 
 #include <gtest/gtest.h>
+
 #include "runtime/exec_env.h"
 
 namespace starrocks {
@@ -40,4 +41,4 @@ TEST_F(DefaultPathHandlersTest, mem_tracker) {
     ASSERT_TRUE(output2.str().find("<tr><td>1</td><td>process</td><td>") == std::string::npos);
     ASSERT_TRUE(output2.str().find("<tr><td>3</td><td>tablet_metadata</td><td>metadata</td>") != std::string::npos);
 }
-}
+} // namespace starrocks

--- a/be/test/runtime/mem_tracker_test.cpp
+++ b/be/test/runtime/mem_tracker_test.cpp
@@ -21,118 +21,152 @@ namespace starrocks {
 class MemTrackerTest : public testing::Test {
 protected:
     void SetUp() override {
-        _process_mem_tracker = std::make_unique<MemTracker>(-1, "process");
-        _query_pool_mem_tracker = std::make_unique<MemTracker>(-1, "query_pool", _process_mem_tracker.get());
-        _query_mem_tracker = std::make_unique<MemTracker>(-1, "query", _query_pool_mem_tracker.get());
+        _process_mem_tracker = std::make_unique<MemTracker>(1024, "process");
+        _query_pool_mem_tracker = std::make_unique<MemTracker>(512, "query_pool", _process_mem_tracker.get());
+        _query_1 = std::make_unique<MemTracker>(128, "query_1", _query_pool_mem_tracker.get());
+        _query_2 = std::make_unique<MemTracker>(128, "query_2", _query_pool_mem_tracker.get());
     }
 
     std::unique_ptr<MemTracker> _process_mem_tracker;
     std::unique_ptr<MemTracker> _query_pool_mem_tracker;
-    std::unique_ptr<MemTracker> _query_mem_tracker;
+    std::unique_ptr<MemTracker> _query_1;
+    std::unique_ptr<MemTracker> _query_2;
+    ObjectPool _pool;
 };
 
+TEST_F(MemTrackerTest, label_type_convert) {
+    const auto& mem_types = MemTracker::mem_types();
+    ASSERT_GT(mem_types.size(), 0);
+
+    for (const auto& item : mem_types) {
+        ASSERT_EQ(MemTracker::type_to_label(item.first), item.second);
+        ASSERT_EQ(MemTracker::label_to_type(item.second), item.first);
+    }
+    ASSERT_EQ(MemTracker::type_to_label(MemTrackerType::QUERY), "");
+    ASSERT_EQ(MemTracker::label_to_type("not_exist_label"), MemTrackerType::NO_SET);
+}
+
+TEST_F(MemTrackerTest, get_snapshot) {
+    _query_1->consume(10);
+    _query_2->consume(20);
+
+    auto* snapshot = _process_mem_tracker->get_snapshot(&_pool, 1, 2);
+    ASSERT_EQ(snapshot->debug_string(),
+              "{\"label:\"process\",\"level:\"1\",\"limit:\"1024\",\"cur_mem_usage:\"30\",\"peak_mem_usage:\"30\","
+              "\"child\":[{\"label:\"query_pool\",\"level:\"2\",\"limit:\"512\",\"cur_mem_usage:\"30\",\"peak_mem_"
+              "usage:\"30\",\"child\":[]}]}");
+
+    snapshot = _process_mem_tracker->get_snapshot(&_pool, 1, 10);
+    ASSERT_EQ(snapshot->debug_string(),
+              "{\"label:\"process\",\"level:\"1\",\"limit:\"1024\",\"cur_mem_usage:\"30\",\"peak_mem_usage:\"30\","
+              "\"child\":[{\"label:\"query_pool\",\"level:\"2\",\"limit:\"512\",\"cur_mem_usage:\"30\",\"peak_mem_"
+              "usage:\"30\",\"child\":[{\"label:\"query_1\",\"level:\"3\",\"limit:\"128\",\"cur_mem_usage:\"10\","
+              "\"peak_mem_usage:\"10\",\"child\":[]},{\"label:\"query_2\",\"level:\"3\",\"limit:\"128\",\"cur_mem_"
+              "usage:\"20\",\"peak_mem_usage:\"20\",\"child\":[]}]}]}");
+}
+
 TEST_F(MemTrackerTest, consume) {
-    _query_mem_tracker->consume(10);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 10);
+    _query_1->consume(10);
+    ASSERT_EQ(_query_1->consumption(), 10);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 10);
     ASSERT_EQ(_process_mem_tracker->consumption(), 10);
 
-    _query_mem_tracker->consume(-30);
-    ASSERT_EQ(_query_mem_tracker->consumption(), -20);
+    _query_1->consume(-30);
+    ASSERT_EQ(_query_1->consumption(), -20);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), -20);
     ASSERT_EQ(_process_mem_tracker->consumption(), -20);
 
-    _query_mem_tracker->consume(0);
-    ASSERT_EQ(_query_mem_tracker->consumption(), -20);
+    _query_1->consume(0);
+    ASSERT_EQ(_query_1->consumption(), -20);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), -20);
     ASSERT_EQ(_process_mem_tracker->consumption(), -20);
 
-    ASSERT_EQ(_query_mem_tracker->peak_consumption(), 10);
+    ASSERT_EQ(_query_1->peak_consumption(), 10);
     ASSERT_EQ(_query_pool_mem_tracker->peak_consumption(), 10);
     ASSERT_EQ(_process_mem_tracker->peak_consumption(), 10);
 }
 
 TEST_F(MemTrackerTest, release) {
-    _query_mem_tracker->release(10);
-    ASSERT_EQ(_query_mem_tracker->consumption(), -10);
+    _query_1->release(10);
+    ASSERT_EQ(_query_1->consumption(), -10);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), -10);
     ASSERT_EQ(_process_mem_tracker->consumption(), -10);
 
-    _query_mem_tracker->release(-30);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 20);
+    _query_1->release(-30);
+    ASSERT_EQ(_query_1->consumption(), 20);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 20);
     ASSERT_EQ(_process_mem_tracker->consumption(), 20);
 
-    _query_mem_tracker->release(0);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 20);
+    _query_1->release(0);
+    ASSERT_EQ(_query_1->consumption(), 20);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 20);
     ASSERT_EQ(_process_mem_tracker->consumption(), 20);
 
-    ASSERT_EQ(_query_mem_tracker->peak_consumption(), 20);
+    ASSERT_EQ(_query_1->peak_consumption(), 20);
     ASSERT_EQ(_query_pool_mem_tracker->peak_consumption(), 20);
     ASSERT_EQ(_process_mem_tracker->peak_consumption(), 20);
 }
 
 TEST_F(MemTrackerTest, consume_without_root) {
-    _query_mem_tracker->consume(10);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 10);
+    _query_1->consume(10);
+    ASSERT_EQ(_query_1->consumption(), 10);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 10);
     ASSERT_EQ(_process_mem_tracker->consumption(), 10);
 
     _process_mem_tracker->consume(10);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 10);
+    ASSERT_EQ(_query_1->consumption(), 10);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 10);
     ASSERT_EQ(_process_mem_tracker->consumption(), 20);
 
-    _query_mem_tracker->consume_without_root(5);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 15);
+    _query_1->consume_without_root(5);
+    ASSERT_EQ(_query_1->consumption(), 15);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 15);
     ASSERT_EQ(_process_mem_tracker->consumption(), 20);
 
-    _query_mem_tracker->consume_without_root(0);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 15);
+    _query_1->consume_without_root(0);
+    ASSERT_EQ(_query_1->consumption(), 15);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 15);
     ASSERT_EQ(_process_mem_tracker->consumption(), 20);
 
     _process_mem_tracker->consume_without_root(10);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 15);
+    ASSERT_EQ(_query_1->consumption(), 15);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 15);
     ASSERT_EQ(_process_mem_tracker->consumption(), 20);
 
-    _query_mem_tracker->consume_without_root(-5);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 10);
+    _query_1->consume_without_root(-5);
+    ASSERT_EQ(_query_1->consumption(), 10);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 10);
     ASSERT_EQ(_process_mem_tracker->consumption(), 20);
 
-    _query_mem_tracker->release_without_root();
-    ASSERT_EQ(_query_mem_tracker->consumption(), 0);
+    _query_1->release_without_root();
+    ASSERT_EQ(_query_1->consumption(), 0);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 0);
     ASSERT_EQ(_process_mem_tracker->consumption(), 20);
 }
 
 TEST_F(MemTrackerTest, release_without_root) {
-    _query_mem_tracker->consume(10);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 10);
+    _query_1->consume(10);
+    ASSERT_EQ(_query_1->consumption(), 10);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 10);
     ASSERT_EQ(_process_mem_tracker->consumption(), 10);
 
-    _query_mem_tracker->release_without_root(5);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 5);
+    _query_1->release_without_root(5);
+    ASSERT_EQ(_query_1->consumption(), 5);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 5);
     ASSERT_EQ(_process_mem_tracker->consumption(), 10);
 
-    _query_mem_tracker->release_without_root(0);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 5);
+    _query_1->release_without_root(0);
+    ASSERT_EQ(_query_1->consumption(), 5);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 5);
     ASSERT_EQ(_process_mem_tracker->consumption(), 10);
 
     _process_mem_tracker->release_without_root(5);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 5);
+    ASSERT_EQ(_query_1->consumption(), 5);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 5);
     ASSERT_EQ(_process_mem_tracker->consumption(), 10);
 
-    _query_mem_tracker->release_without_root(-8);
-    ASSERT_EQ(_query_mem_tracker->consumption(), 13);
+    _query_1->release_without_root(-8);
+    ASSERT_EQ(_query_1->consumption(), 13);
     ASSERT_EQ(_query_pool_mem_tracker->consumption(), 13);
     ASSERT_EQ(_process_mem_tracker->consumption(), 10);
 }

--- a/be/test/runtime/mem_tracker_test.cpp
+++ b/be/test/runtime/mem_tracker_test.cpp
@@ -50,13 +50,13 @@ TEST_F(MemTrackerTest, get_snapshot) {
     _query_1->consume(10);
     _query_2->consume(20);
 
-    auto* snapshot = _process_mem_tracker->get_snapshot(&_pool, 1, 2);
+    auto* snapshot = _process_mem_tracker->get_snapshot(&_pool, 2);
     ASSERT_EQ(snapshot->debug_string(),
               "{\"label:\"process\",\"level:\"1\",\"limit:\"1024\",\"cur_mem_usage:\"30\",\"peak_mem_usage:\"30\","
               "\"child\":[{\"label:\"query_pool\",\"level:\"2\",\"limit:\"512\",\"cur_mem_usage:\"30\",\"peak_mem_"
               "usage:\"30\",\"child\":[]}]}");
 
-    snapshot = _process_mem_tracker->get_snapshot(&_pool, 1, 10);
+    snapshot = _process_mem_tracker->get_snapshot(&_pool, 10);
     ASSERT_EQ(snapshot->debug_string(),
               "{\"label:\"process\",\"level:\"1\",\"limit:\"1024\",\"cur_mem_usage:\"30\",\"peak_mem_usage:\"30\","
               "\"child\":[{\"label:\"query_pool\",\"level:\"2\",\"limit:\"512\",\"cur_mem_usage:\"30\",\"peak_mem_"

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -63,7 +63,6 @@ static std::string k_default_storage_root_path = "";
 
 static void set_up(const std::string& sub_path) {
     config::mem_limit = "10g";
-    CHECK(GlobalEnv::GetInstance()->init().ok());
     k_default_storage_root_path = config::storage_root_path;
     config::storage_root_path = std::filesystem::current_path().string() + "/" + sub_path;
     fs::remove_all(config::storage_root_path);


### PR DESCRIPTION
## Why I'm doing:

Some newly added memory monitoring metrics cannot be queried on the WebPage. Therefore, I refactored the implementation of DumpMemTrackerTree to ensure that this issue will not occur again.

This pr also fixes the following issues: 
* The sub-metrics of `Update` cannot be displayed
* Some second-level metrics such as `REPLICATION` cannot be specified for querying.
* The label of replication_mem_tracker is wrong.

## What I'm doing:

* Add one interface to get_mem_tracker using type.
* Refactor the implementation of dump mem_tracker snapshot.
* Use a unified interface to implement the mapping from label to type.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0