### PR TITLE
[BugFix] fix function signature of array_contains/position([null],null)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -845,6 +845,14 @@ public class FunctionAnalyzer {
                 newFn.setUserVisible(fn.isUserVisible());
                 fn = newFn;
             }
+        } else if (FunctionSet.ARRAY_CONTAINS.equalsIgnoreCase(fnName) || FunctionSet.ARRAY_POSITION.equalsIgnoreCase(fnName)) {
+            Preconditions.checkState(argumentTypes.length == 2);
+            if (argumentTypes[1].isNull() &&
+                    argumentTypes[0].isArrayType() && ((ArrayType) argumentTypes[0]).getItemType().isNull()) {
+                argumentTypes[0] = Type.ARRAY_BOOLEAN;
+                argumentTypes[1] = Type.BOOLEAN;
+                fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_IDENTICAL);
+            }
         }
         // add new argument types
         Arrays.stream(argumentTypes).forEach(newArgumentTypes::add);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -714,6 +714,13 @@ public class ArrayTypeTest extends PlanTestBase {
         assertCContains(plan, "array_slice[([5: d_2, ARRAY<DECIMAL64(4,3)>, true], 1, 3); " +
                 "args: INVALID_TYPE,BIGINT,BIGINT; result: ARRAY<DECIMAL64(4,3)>;");
 
+        sql = "select array_contains([null], null), array_position([null], null)";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  |  output columns:\n" +
+                "  |  2 <-> array_contains[([NULL], NULL); " +
+                "args: INVALID_TYPE,BOOLEAN; result: BOOLEAN; args nullable: true; result nullable: true]\n" +
+                "  |  3 <-> array_position[([NULL], NULL); " +
+                "args: INVALID_TYPE,BOOLEAN; result: INT; args nullable: true; result nullable: true]");
     }
 
     @Test

--- a/test/sql/test_array_fn/R/test_array_contains
+++ b/test/sql/test_array_fn/R/test_array_contains
@@ -2351,3 +2351,7 @@ SELECT id, array_position(array_struct, NULL) FROM test_array_contains_complex_t
 3	None
 4	0
 -- !result
+select array_contains([null], null), array_position([null], null);
+-- result:
+1	1
+-- !result

--- a/test/sql/test_array_fn/T/test_array_contains
+++ b/test/sql/test_array_fn/T/test_array_contains
@@ -538,3 +538,5 @@ SELECT id, array_position(array_struct, row(10, 'hello')) FROM test_array_contai
 SELECT id, array_position(array_struct, row(20, 'world')) FROM test_array_contains_complex_type ORDER BY id;
 SELECT id, array_position(array_struct, row(40, 'database')) FROM test_array_contains_complex_type ORDER BY id;
 SELECT id, array_position(array_struct, NULL) FROM test_array_contains_complex_type ORDER BY id;
+
+select array_contains([null], null), array_position([null], null);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/9273

introduced by #55535

I removed the template specialization that is no longer needed in `array_contains_generic`. (https://github.com/StarRocks/starrocks/pull/55535/files#diff-2c6e44b751d75eb7436cc96537364d73dd7ad9533bcd6c4261b41aeacf8be2ce)

It is expected that `array_contains_generic` will only handle complex types such as array/map/json.
But in `functions.py`, `array_contains(ANY_ARRAY,ANY_ELEMENT)` comes first, which will cause `array_contains(ARRAY<NULL_TYPE>, NULL_TYPE)` to match this signature, and now this function cannot handle boolean type, causing errors.
```python
    [150002, 'array_contains', True, False, 'BOOLEAN', ['ANY_ARRAY', 'ANY_ELEMENT'], 'ArrayFunctions::array_contains_generic'],
    [15000201, 'array_contains', True, False, 'BOOLEAN', ['ARRAY_BOOLEAN', 'BOOLEAN'], 'ArrayFunctions::array_contains_specific<TYPE_BOOLEAN>', 'ArrayFunctions::array_contains_specific_prepare<TYPE_BOOLEAN>', 'ArrayFunctions::array_contains_specific_close<TYPE_BOOLEAN>'],
    [15000202, 'array_contains', True, False, 'BOOLEAN', ['ARRAY_TINYINT', 'TINYINT'], 'ArrayFunctions::array_contains_specific<TYPE_TINYINT>', 'ArrayFunctions::array_contains_specific_prepare<TYPE_TINYINT>', 'ArrayFunctions::array_contains_specific_close<TYPE_TINYINT>'],
  ...
```

In this PR, I forced a rewrite so that these two functions can find the correct signature.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0