### PR TITLE
[BugFix] fix inconsistent transaction process if exception thrown

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -341,6 +341,10 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE);
         }
+        if (waiter == null) {
+            throw new TransactionCommitFailedException(String.format("transaction fail to commit, %s",
+                    transactionState.toString()));
+        }
 
         MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
         stopWatch.stop();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. modify transaction state in memory
2. call afterStateTransform
3. persist transaction log

if step 1 succeeds, step 2 must not throw exception, avoid causing inconsistency between memory info(step 1) and disk info(step 3)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0