### PR TITLE
[BugFix]return root cause when query is cancelled

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -108,10 +108,7 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExec
         }
     }
 
-    _query_ctx = exec_env->query_context_mgr()->get_or_register(query_id);
-    if (_query_ctx == nullptr) {
-        return Status::Cancelled("Query has been cancelled");
-    }
+    ASSIGN_OR_RETURN(_query_ctx, exec_env->query_context_mgr()->get_or_register(query_id));
     _query_ctx->set_exec_env(exec_env);
     if (params.__isset.instances_number) {
         _query_ctx->set_total_fragments(params.instances_number);

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -105,6 +105,13 @@ FragmentContextManager* QueryContext::fragment_mgr() {
 
 void QueryContext::cancel(const Status& status) {
     _is_cancelled = true;
+    if (_cancelled_status.load() != nullptr) {
+        return;
+    }
+    Status* old_status = nullptr;
+    if (_cancelled_status.compare_exchange_strong(old_status, &_s_status)) {
+        _s_status = status;
+    }
     _fragment_mgr->cancel(status);
 }
 
@@ -362,17 +369,17 @@ QueryContextManager::~QueryContextManager() {
     }
 }
 
-#define RETURN_NULL_IF_CTX_CANCELLED(query_ctx) \
-    if (query_ctx->is_cancelled()) {            \
-        return nullptr;                         \
-    }                                           \
-    query_ctx->increment_num_fragments();       \
-    if (query_ctx->is_cancelled()) {            \
-        query_ctx->rollback_inc_fragments();    \
-        return nullptr;                         \
+#define RETURN_CANCELLED_STATUS_IF_CTX_CANCELLED(query_ctx) \
+    if (query_ctx->is_cancelled()) {                        \
+        return query_ctx->get_cancelled_status();           \
+    }                                                       \
+    query_ctx->increment_num_fragments();                   \
+    if (query_ctx->is_cancelled()) {                        \
+        query_ctx->rollback_inc_fragments();                \
+        return query_ctx->get_cancelled_status();           \
     }
 
-QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
+StatusOr<QueryContext*> QueryContextManager::get_or_register(const TUniqueId& query_id) {
     size_t i = _slot_idx(query_id);
     auto& mutex = _mutexes[i];
     auto& context_map = _context_maps[i];
@@ -383,7 +390,7 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
         // lookup query context in context_map
         auto it = context_map.find(query_id);
         if (it != context_map.end()) {
-            RETURN_NULL_IF_CTX_CANCELLED(it->second);
+            RETURN_CANCELLED_STATUS_IF_CTX_CANCELLED(it->second);
             return it->second.get();
         }
     }
@@ -393,14 +400,14 @@ QueryContext* QueryContextManager::get_or_register(const TUniqueId& query_id) {
         auto it = context_map.find(query_id);
         auto sc_it = sc_map.find(query_id);
         if (it != context_map.end()) {
-            RETURN_NULL_IF_CTX_CANCELLED(it->second);
+            RETURN_CANCELLED_STATUS_IF_CTX_CANCELLED(it->second);
             return it->second.get();
         } else {
             // lookup query context for the second chance in sc_map
             if (sc_it != sc_map.end()) {
                 auto ctx = std::move(sc_it->second);
                 sc_map.erase(sc_it);
-                RETURN_NULL_IF_CTX_CANCELLED(ctx);
+                RETURN_CANCELLED_STATUS_IF_CTX_CANCELLED(ctx);
                 auto* raw_ctx_ptr = ctx.get();
                 context_map.emplace(query_id, std::move(ctx));
                 return raw_ctx_ptr;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -89,6 +89,11 @@ public:
 
     bool is_cancelled() const { return _is_cancelled; }
 
+    Status get_cancelled_status() const {
+        auto* status = _cancelled_status.load();
+        return status == nullptr ? Status::Cancelled("Query has been cancelled") : *status;
+    }
+
     bool is_dead() const { return _num_active_fragments == 0 && (_num_fragments == _total_fragments || _is_cancelled); }
     // add expired seconds to deadline
     void extend_delivery_lifetime() {
@@ -311,6 +316,8 @@ private:
     std::shared_ptr<starrocks::debug::QueryTrace> _query_trace;
     std::atomic_bool _is_prepared = false;
     std::atomic_bool _is_cancelled = false;
+    std::atomic<Status*> _cancelled_status = nullptr;
+    Status _s_status;
 
     std::once_flag _init_query_once;
     int64_t _query_begin_time = 0;
@@ -376,7 +383,7 @@ public:
     QueryContextManager(size_t log2_num_slots);
     ~QueryContextManager();
     Status init();
-    QueryContext* get_or_register(const TUniqueId& query_id);
+    StatusOr<QueryContext*> get_or_register(const TUniqueId& query_id);
     QueryContextPtr get(const TUniqueId& query_id, bool need_prepared = false);
     size_t size();
     bool remove(const TUniqueId& query_id);

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -65,7 +65,7 @@ public:
         const auto& query_id = params.query_id;
         const auto& fragment_id = params.fragment_instance_id;
 
-        _query_ctx = _exec_env->query_context_mgr()->get_or_register(query_id);
+        ASSIGN_OR_ASSERT_FAIL(_query_ctx, _exec_env->query_context_mgr()->get_or_register(query_id));
         _query_ctx->set_total_fragments(1);
         _query_ctx->set_delivery_expire_seconds(60);
         _query_ctx->set_query_expire_seconds(60);

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -78,7 +78,7 @@ void PipelineTestBase::_prepare() {
     const auto& query_id = params.query_id;
     const auto& fragment_id = params.fragment_instance_id;
 
-    _query_ctx = _exec_env->query_context_mgr()->get_or_register(query_id);
+    ASSIGN_OR_ASSERT_FAIL(_query_ctx, _exec_env->query_context_mgr()->get_or_register(query_id));
     _query_ctx->set_total_fragments(1);
     _query_ctx->set_delivery_expire_seconds(60);
     _query_ctx->set_query_expire_seconds(60);

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -31,7 +31,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
             TUniqueId query_id;
             query_id.hi = 100;
             query_id.lo = i;
-            auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+            ASSIGN_OR_ASSERT_FAIL(auto* query_ctx, query_ctx_mgr->get_or_register(query_id));
             ASSERT_TRUE(query_ctx != nullptr);
             query_ctx->set_delivery_expire_seconds(60);
             query_ctx->set_query_expire_seconds(300);
@@ -71,7 +71,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
         TUniqueId query_id;
         query_id.hi = 100;
         query_id.lo = 1;
-        auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+        ASSIGN_OR_ASSERT_FAIL(auto* query_ctx, query_ctx_mgr->get_or_register(query_id));
         query_ctx->set_total_fragments(8);
         query_ctx->set_delivery_expire_seconds(60);
         query_ctx->set_query_expire_seconds(300);
@@ -81,7 +81,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
         query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
 
         for (int i = 0; i < 7; ++i) {
-            auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+            ASSIGN_OR_ASSERT_FAIL(auto* tmp_query_ctx, query_ctx_mgr->get_or_register(query_id));
             tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
             ASSERT_TRUE(tmp_query_ctx != nullptr);
         }
@@ -100,7 +100,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
         TUniqueId query_id;
         query_id.hi = 100;
         query_id.lo = 2;
-        auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+        ASSIGN_OR_ASSERT_FAIL(auto* query_ctx, query_ctx_mgr->get_or_register(query_id));
         query_ctx->set_total_fragments(8);
         query_ctx->set_delivery_expire_seconds(60);
         query_ctx->set_query_expire_seconds(300);
@@ -110,7 +110,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
         query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
 
         for (int i = 0; i < 3; ++i) {
-            auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+            ASSIGN_OR_ASSERT_FAIL(auto* tmp_query_ctx, query_ctx_mgr->get_or_register(query_id));
             tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
             ASSERT_TRUE(tmp_query_ctx != nullptr);
         }
@@ -122,7 +122,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
         query_ctx_mgr->remove(query_id);
         ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
         for (int i = 0; i < 3; ++i) {
-            auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+            ASSIGN_OR_ASSERT_FAIL(auto* tmp_query_ctx, query_ctx_mgr->get_or_register(query_id));
             tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
             ASSERT_TRUE(query_ctx != nullptr);
             tmp_query_ctx->count_down_fragments();
@@ -131,7 +131,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
             ASSERT_FALSE(tmp_query_ctx->is_dead());
             ASSERT_TRUE(query_ctx_mgr->get(query_id) != nullptr);
         }
-        query_ctx = query_ctx_mgr->get_or_register(query_id);
+        ASSIGN_OR_ASSERT_FAIL(query_ctx, query_ctx_mgr->get_or_register(query_id));
         query_ctx->count_down_fragments();
         query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
         ASSERT_TRUE(query_ctx->is_dead());
@@ -145,7 +145,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
         TUniqueId query_id;
         query_id.hi = 100;
         query_id.lo = 3;
-        auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+        ASSIGN_OR_ASSERT_FAIL(auto* query_ctx, query_ctx_mgr->get_or_register(query_id));
         query_ctx->set_total_fragments(8);
         query_ctx->set_delivery_expire_seconds(60);
         query_ctx->set_query_expire_seconds(300);
@@ -154,7 +154,7 @@ TEST(QueryContextManagerTest, testSingleThreadOperations) {
         query_ctx->count_down_fragments();
         query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
         for (int i = 0; i < 3; ++i) {
-            auto* tmp_query_ctx = query_ctx_mgr->get_or_register(query_id);
+            ASSIGN_OR_ASSERT_FAIL(auto* tmp_query_ctx, query_ctx_mgr->get_or_register(query_id));
             tmp_query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
             ASSERT_TRUE(tmp_query_ctx != nullptr);
         }
@@ -180,7 +180,7 @@ TEST(QueryContextManagerTest, testMulitiThreadOperations) {
     TUniqueId query_id;
     query_id.lo = 100;
     query_id.hi = 2;
-    auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+    ASSIGN_OR_ASSERT_FAIL(auto* query_ctx, query_ctx_mgr->get_or_register(query_id));
     query_ctx->set_total_fragments(202);
     query_ctx->set_delivery_expire_seconds(60);
     query_ctx->set_query_expire_seconds(300);
@@ -197,7 +197,7 @@ TEST(QueryContextManagerTest, testMulitiThreadOperations) {
             std::random_device rd;
             std::uniform_int_distribution<int> dist(1, 100);
             for (int k = 0; k < 20; ++k) {
-                auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+                ASSIGN_OR_ASSERT_FAIL(auto* query_ctx, query_ctx_mgr->get_or_register(query_id));
                 query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
                 ASSERT_TRUE(query_ctx != nullptr);
                 ASSERT_FALSE(query_ctx->is_delivery_expired());
@@ -213,7 +213,7 @@ TEST(QueryContextManagerTest, testMulitiThreadOperations) {
         threads[i].join();
     }
 
-    query_ctx = query_ctx_mgr->get_or_register(query_id);
+    ASSIGN_OR_ASSERT_FAIL(query_ctx, query_ctx_mgr->get_or_register(query_id));
     query_ctx->count_down_fragments();
     query_ctx->init_mem_tracker(parent_mem_tracker->limit(), parent_mem_tracker.get());
     ASSERT_TRUE(query_ctx->is_dead());
@@ -228,7 +228,11 @@ QueryContext* gen_query_ctx(MemTracker* parent_mem_tracker, QueryContextManager*
     query_id.hi = query_id_hi;
     query_id.lo = query_id_lo;
 
-    auto* query_ctx = query_ctx_mgr->get_or_register(query_id);
+    auto res = query_ctx_mgr->get_or_register(query_id);
+    if (!res.ok()) {
+        return nullptr;
+    }
+    auto* query_ctx = res.value();
     query_ctx->set_total_fragments(total_fragments);
     query_ctx->set_delivery_expire_seconds(delivery_expire_seconds);
     query_ctx->set_query_expire_seconds(query_expire_seconds);
@@ -261,7 +265,7 @@ TEST(QueryContextManagerTest, testSetWorkgroup) {
     ASSERT_EQ(1, wg->concurrency_overflow_count());
     // All the fragments comes.
     for (int i = 1; i < query_ctx1->total_fragments(); ++i) {
-        auto* cur_query_ctx = query_ctx_mgr->get_or_register(query_id1);
+        ASSIGN_OR_ASSERT_FAIL(auto* cur_query_ctx, query_ctx_mgr->get_or_register(query_id1));
         ASSERT_EQ(query_ctx1, cur_query_ctx);
     }
     while (!query_ctx1->has_no_active_instances()) {
@@ -281,7 +285,7 @@ TEST(QueryContextManagerTest, testSetWorkgroup) {
     ASSERT_OK(query_ctx2->init_query_once(wg.get(), false)); // None-first invocations have no side-effects.
     ASSERT_EQ(1, wg->num_running_queries());
     for (int i = 2; i < query_ctx2->total_fragments(); ++i) {
-        auto* cur_query_ctx = query_ctx_mgr->get_or_register(query_id2);
+        ASSIGN_OR_ASSERT_FAIL(auto* cur_query_ctx, query_ctx_mgr->get_or_register(query_id2));
         ASSERT_EQ(query_ctx2, cur_query_ctx);
     }
     while (!query_ctx2->has_no_active_instances()) {

--- a/be/test/exec/pipeline/sink/export_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/sink/export_sink_operator_test.cpp
@@ -19,6 +19,7 @@
 
 #include "gen_cpp/RuntimeProfile_types.h"
 #include "gtest/gtest.h"
+#include "testutil/assert.h"
 #include "util/await.h"
 
 namespace starrocks::pipeline {
@@ -36,7 +37,7 @@ TEST(ExportSinkOperatorTest, test_set_finishing) {
     ExecEnv* _exec_env = ExecEnv::GetInstance();
     RuntimeState _runtime_state(_exec_env);
 
-    _query_ctx = _exec_env->query_context_mgr()->get_or_register(query_id);
+    ASSIGN_OR_ASSERT_FAIL(_query_ctx, _exec_env->query_context_mgr()->get_or_register(query_id));
     _query_ctx->set_query_id(query_id);
     _query_ctx->set_total_fragments(1);
     _query_ctx->set_delivery_expire_seconds(60);

--- a/be/test/exec/pipeline/sink/table_function_table_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/sink/table_function_table_sink_operator_test.cpp
@@ -16,6 +16,7 @@
 
 #include "gen_cpp/RuntimeProfile_types.h"
 #include "gtest/gtest.h"
+#include "testutil/assert.h"
 
 namespace starrocks::pipeline {
 class TableFunctionTableSinkOperatorTest : public testing::Test {
@@ -67,7 +68,7 @@ TEST_F(TableFunctionTableSinkOperatorTest, prepare_with_parquet_format) {
     pipeline::FragmentContext* _fragment_ctx;
     ExecEnv* _exec_env = ExecEnv::GetInstance();
 
-    _query_ctx = _exec_env->query_context_mgr()->get_or_register(query_id);
+    ASSIGN_OR_ASSERT_FAIL(_query_ctx, _exec_env->query_context_mgr()->get_or_register(query_id));
     _query_ctx->set_query_id(query_id);
     _query_ctx->set_total_fragments(1);
     _query_ctx->set_delivery_expire_seconds(600);
@@ -123,7 +124,7 @@ TEST_F(TableFunctionTableSinkOperatorTest, prepare_with_orc_format) {
     pipeline::FragmentContext* _fragment_ctx;
     ExecEnv* _exec_env = ExecEnv::GetInstance();
 
-    _query_ctx = _exec_env->query_context_mgr()->get_or_register(query_id);
+    ASSIGN_OR_ASSERT_FAIL(_query_ctx, _exec_env->query_context_mgr()->get_or_register(query_id));
     _query_ctx->set_query_id(query_id);
     _query_ctx->set_total_fragments(1);
     _query_ctx->set_delivery_expire_seconds(600);

--- a/be/test/exec/stream/stream_pipeline_test.cpp
+++ b/be/test/exec/stream/stream_pipeline_test.cpp
@@ -40,7 +40,7 @@ Status StreamPipelineTest::prepare() {
     const auto& query_id = params.query_id;
     const auto& fragment_id = params.fragment_instance_id;
 
-    _query_ctx = _exec_env->query_context_mgr()->get_or_register(query_id);
+    ASSIGN_OR_RETURN(_query_ctx, _exec_env->query_context_mgr()->get_or_register(query_id));
     _query_ctx->set_query_id(query_id);
     _query_ctx->set_total_fragments(1);
     _query_ctx->set_delivery_expire_seconds(600);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
In some case be cancels a query because of some error status, 
and when fe goes to deploy subsequently fragment, it just gets 
an cancelled status without root cause.
But we need root cause to try to retry, In this pr, we recorded 
cancelled status and return it.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0