### PR TITLE
[BugFix] use StmtExecutor::execute to forward statement on follower

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -96,13 +96,20 @@ public class StatisticUtils {
     }
 
     public static ConnectContext buildConnectContext(TResultSinkType connectType) {
-        ConnectContext context =
-                switch (connectType) {
-                    case MYSQL_PROTOCAL -> ConnectContext.buildInner();
-                    case HTTP_PROTOCAL -> HttpConnectContext.build();
-                    case ARROW_FLIGHT_PROTOCAL -> new ArrowFlightSqlConnectContext();
-                    default -> throw new IllegalStateException("Unexpected value: " + connectType);
-                };
+        ConnectContext context;
+        switch (connectType) {
+            case MYSQL_PROTOCAL:
+                context = ConnectContext.buildInner();
+                break;
+            case HTTP_PROTOCAL:
+                context = HttpConnectContext.build();
+                break;
+            case ARROW_FLIGHT_PROTOCAL:
+                context = new ArrowFlightSqlConnectContext();
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + connectType);
+        }
         // Note: statistics query does not register query id to QeProcessorImpl::coordinatorMap,
         // but QeProcessorImpl::reportExecStatus will check query id,
         // So we must disable report query status from BE to FE

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -47,15 +47,18 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.ConnectorPartitionTraits;
+import com.starrocks.http.HttpConnectContext;
 import com.starrocks.load.pipe.filelist.RepoExecutor;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectContext;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
+import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.transaction.InsertOverwriteJobStats;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.warehouse.Warehouse;
@@ -89,7 +92,17 @@ public class StatisticUtils {
             .add("information_schema").build();
 
     public static ConnectContext buildConnectContext() {
-        ConnectContext context = ConnectContext.buildInner();
+        return buildConnectContext(TResultSinkType.MYSQL_PROTOCAL);
+    }
+
+    public static ConnectContext buildConnectContext(TResultSinkType connectType) {
+        ConnectContext context =
+                switch (connectType) {
+                    case MYSQL_PROTOCAL -> ConnectContext.buildInner();
+                    case HTTP_PROTOCAL -> HttpConnectContext.build();
+                    case ARROW_FLIGHT_PROTOCAL -> new ArrowFlightSqlConnectContext();
+                    default -> throw new IllegalStateException("Unexpected value: " + connectType);
+                };
         // Note: statistics query does not register query id to QeProcessorImpl::coordinatorMap,
         // but QeProcessorImpl::reportExecStatus will check query id,
         // So we must disable report query status from BE to FE

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -102,7 +102,7 @@ public class StatisticUtils {
                 context = ConnectContext.buildInner();
                 break;
             case HTTP_PROTOCAL:
-                context = HttpConnectContext.build();
+                context = new HttpConnectContext();
                 break;
             case ARROW_FLIGHT_PROTOCAL:
                 context = new ArrowFlightSqlConnectContext();

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/filelist/FileListRepoTest.java
@@ -24,7 +24,6 @@ import com.starrocks.load.pipe.PipeFileRecord;
 import com.starrocks.load.pipe.PipeId;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.system.SystemInfoService;
@@ -413,8 +412,6 @@ public class FileListRepoTest {
         RepoExecutor executor = RepoExecutor.getInstance();
 
         Assert.assertTrue(executor.executeDQL("select now()").isEmpty());
-
-        Assert.assertThrows(SemanticException.class, () -> executor.executeDML("insert into a.b values (1) "));
 
         Assert.assertThrows(RuntimeException.class, () -> executor.executeDDL("create table a (id int) "));
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Currently we're using `StmtExecutor::handleDMLStmt` which doesn't forward the DML to leader. It should be replaced with `StmtExecutor::execute`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0