### PR TITLE
[Enhancement] limit max predicate columns when using full analyze predicate column instead of sample all columns on auto collect statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2130,6 +2130,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "If full analyze predicate columns instead of sample all columns")
     public static boolean statistic_auto_collect_use_full_predicate_column_for_sample = true;
 
+    @ConfField(mutable = true, comment = "max columns size of full analyze predicate columns instead of sample all columns")
+    public static int statistic_auto_collect_max_predicate_column_size_on_sample_strategy = 16;
+
     /**
      * Max row count in statistics collect per query
      */

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
@@ -242,5 +242,19 @@ class ColumnUsageTest extends PlanTestBase {
             Assertions.assertEquals(List.of("v1", "v2", "v3"), job0.getColumnNames());
             Config.statistic_auto_collect_predicate_columns_threshold = defaultValue;
         }
+
+        {
+            long defaultSmallTableSize = Config.statistic_auto_collect_small_table_size;
+            Config.statistic_auto_collect_small_table_size = -1;
+            int defaultPredicateColumnSize = Config.statistic_auto_collect_max_predicate_column_size_on_sample_strategy;
+            Config.statistic_auto_collect_max_predicate_column_size_on_sample_strategy = -1;
+            List<StatisticsCollectJob> collectJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(analyzeJob);
+            Assertions.assertEquals(1, collectJobs.size());
+            StatisticsCollectJob job0 = collectJobs.get(0);
+            Assertions.assertEquals(StatsConstants.AnalyzeType.SAMPLE, job0.getType());
+            Assertions.assertEquals(List.of("v1", "v2", "v3"), job0.getColumnNames());
+            Config.statistic_auto_collect_small_table_size = defaultSmallTableSize;
+            Config.statistic_auto_collect_max_predicate_column_size_on_sample_strategy = defaultPredicateColumnSize;
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Currently, we use full analyze predicate column instead of sample all column in the background auto statistics collection. 
If there are too many predicate column in a table, full analyze will also affect the collection performance. So we need to limit the predicate column size.

```
mysql> select table_id, count(1) from predicate_columns where db_id=90081 and usage != 'normal' group by table_id order by table_id;
+----------+----------+
| table_id | count(1) |
+----------+----------+
|    91092 |        5 |
|    91097 |        2 |
|    91102 |        9 |
|    91137 |       20 |
|    91524 |       14 |
|    91547 |        9 |
|    91570 |        9 |
|    91593 |       10 |
|    91606 |        5 |
|    91611 |        3 |
|    91616 |        4 |
|    91683 |       17 |
|    91706 |        5 |
|    91711 |        2 |
|    91716 |        3 |
|    91721 |       16 |
|    91726 |        9 |
|    91749 |       18 |
|    92136 |        5 |
|    92149 |        7 |
|    92154 |        2 |
|    92159 |       12 |
|    92182 |       20 |
|    92569 |        4 |
+----------+----------+
24 rows in set (0.04 sec)
```

This is predicate column size in tpcds sql.  we use 16 as default value.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0