### PR TITLE
[Enhancement] Support dynamic modification of automated_cluster_snapshot_interval_seconds and max_historical_automated_cluster_snapshot_jobs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3480,7 +3480,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long automated_cluster_snapshot_interval_seconds = 600;
 
-    @ConfField(mutable = false)
+    @ConfField(mutable = true)
     public static int max_historical_automated_cluster_snapshot_jobs = 100;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Daemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Daemon.java
@@ -101,7 +101,7 @@ public class Daemon extends Thread {
             }
 
             try {
-                Thread.sleep(intervalMs);
+                Thread.sleep(getInterval());
             } catch (InterruptedException e) {
                 LOG.error("InterruptedException: ", e);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
@@ -44,6 +44,11 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
     }
 
     @Override
+    public long getInterval() {
+        return Config.automated_cluster_snapshot_interval_seconds * 1000L;
+    }
+
+    @Override
     protected void runAfterCatalogReady() {
         if (!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().isAutomatedSnapshotOn()) {
             return;


### PR DESCRIPTION
## What I'm doing:
Support dynamic modification of fe config:
`automated_cluster_snapshot_interval_seconds` 
`max_historical_automated_cluster_snapshot_jobs`

Fixes https://github.com/StarRocks/starrocks/issues/53867

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0