### PR TITLE
[Enhancement] Support partial refresh in text based mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -182,6 +182,11 @@ public class QueryOptimizer extends Optimizer {
             try (Timer ignored = Tracers.watchScope("MVTextRewrite")) {
                 logicOperatorTree = new TextMatchBasedRewriteRule(context.getConnectContext(), context.getStatement(),
                         context.getMvTransformerContext()).transform(logicOperatorTree, context).get(0);
+                // NOTE: PruneColum rules will not care projection required columns, so separate project after text match based
+                // rewrite to avoid pruning columns
+                if (context.getQueryMaterializationContext().hasRewrittenSuccess()) {
+                    logicOperatorTree = new SeparateProjectRule().rewrite(logicOperatorTree, context.getTaskContext());
+                }
             }
 
             OptExpression result = optimizerOptions.isRuleBased() ?

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -15,15 +15,12 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
 
-import com.google.api.client.util.Lists;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.ParseNode;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.MvUpdateInfo;
@@ -37,6 +34,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
+import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvRewritePreprocessor;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -54,6 +52,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.transformer.MVTransformerContext;
 import org.apache.commons.collections4.CollectionUtils;
@@ -64,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter.REWRITE_SUCCESS;
@@ -231,30 +231,41 @@ public class TextMatchBasedRewriteRule extends Rule {
                             "stale partitions {}", mv.getName(), mvUpdateInfo);
                     continue;
                 }
-                Set<String> partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPartitionNames();
-                if (!partitionNamesToRefresh.isEmpty()) {
-                    logMVRewrite(context, this, "Partitioned MV {} is outdated which " +
-                                    "contains some partitions to be refreshed: {}, and cannot compensate it to predicate",
-                            mv.getName(), partitionNamesToRefresh);
-                    continue;
-                }
                 OptimizerTraceUtil.logMVRewrite(context, this, "TEXT_BASED_REWRITE: text matched with {}",
                         mv.getName());
-
-                MvPlanContext mvPlanContext = MvUtils.getMVPlanContext(connectContext, mv, true, true);
+                final MvPlanContext mvPlanContext = MvUtils.getMVPlanContext(connectContext, mv, true, true);
                 if (mvPlanContext == null) {
                     logMVRewrite(context, this, "MV {} plan context is invalid", mv.getName());
                     continue;
                 }
 
-                OptExpression mvPlan = mvPlanContext.getLogicalPlan();
+                final OptExpression mvPlan = mvPlanContext.getLogicalPlan();
                 if (mvPlan == null) {
                     logMVRewrite(context, this, "MV {} plan context is null", mv.getName());
                     continue;
                 }
 
-                // do: text match based mv rewrite
-                OptExpression rewritten = doTextMatchBasedRewrite(context, mvPlanContext, mv, input);
+                final Set<Table> queryTables = MvUtils.getAllTables(mvPlan).stream().collect(Collectors.toSet());
+                final MaterializationContext mvContext = MvRewritePreprocessor.buildMaterializationContext(context,
+                        mv, mvPlanContext, mvUpdateInfo, queryTables);
+                final LogicalOlapScanOperator mvScanOperator = mvContext.getScanMvOperator();
+                final List<ColumnRefOperator>  mvPlanOutputColumns = MvUtils.getMvScanOutputColumnRefs(mv, mvScanOperator);
+
+                // if mv is partitioned, and some partitions are outdated, then compensate it
+                final Set<String> partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPartitionNames();
+                OptExpression mvCompensatePlan = null;
+                if (CollectionUtils.isEmpty(partitionNamesToRefresh)) {
+                    mvCompensatePlan = OptExpression.create(mvScanOperator);
+                } else {
+                    logMVRewrite(context, this, "Partitioned MV {} is outdated which " +
+                                    "contains some partitions to be refreshed: {}, and cannot compensate it to predicate",
+                            mv.getName(), partitionNamesToRefresh);
+                    mvCompensatePlan = MvPartitionCompensator.getMvTransparentPlan(mvContext, input, mvPlanOutputColumns);
+                }
+
+                // do text based rewrite
+                OptExpression rewritten = doTextMatchBasedRewrite(context, mvPlanContext, mvPlanOutputColumns, mvCompensatePlan,
+                        input);
                 if (rewritten != null) {
                     IMaterializedViewMetricsEntity mvEntity =
                             MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
@@ -286,77 +297,33 @@ public class TextMatchBasedRewriteRule extends Rule {
         return Pair.create(true, "");
     }
 
+    // MV and query must have the same output order, otherwise match will fail.
+    // TODO: support more patterns later between mv and query:
+    //  - support different output orders
+    //  - support different aliases
+    //  - support query is subset of mv's output
     private OptExpression doTextMatchBasedRewrite(OptimizerContext context,
                                                   MvPlanContext mvPlanContext,
-                                                  MaterializedView mv,
+                                                  List<ColumnRefOperator> mvPlanOutputColumns,
+                                                  OptExpression rewrittenPlan,
                                                   OptExpression input) {
-        final OptExpression mvPlan = mvPlanContext.getLogicalPlan();
-        final LogicalOlapScanOperator mvScanOperator = MvRewritePreprocessor.createScanMvOperator(mv,
-                context.getColumnRefFactory(), Sets.newHashSet());
-
-        // MV and query must have the same output order, otherwise match will fail.
-        // TODO: support more patterns later between mv and query:
-        //  - support different output orders
-        //  - support different aliases
-        //  - support query is subset of mv's output
-        List<Column> mvColumns = mv.getOrderedOutputColumns();
-        Map<String, ColumnRefOperator> mvColRefNameColRefMapping = Maps.newHashMap();
-        mvScanOperator.getOutputColumns().stream().forEach(colRef ->
-                mvColRefNameColRefMapping.put(colRef.getName(), colRef));
-        Preconditions.checkState(mvColRefNameColRefMapping.size() == mvColumns.size());
-
-        // Determine mv's output column refs by mv's define query
-        List<ColumnRefOperator> mvColumnRefs = Lists.newArrayList();
-        for (Column col : mvColumns) {
-            if (!mvColRefNameColRefMapping.containsKey(col.getName())) {
-                logMVRewrite(context, this, "MV column name {} is not found in the mapping {}",
-                        col.getName(), mvColRefNameColRefMapping.keySet().stream().collect(Collectors.toList()));
-                return null;
-            }
-            mvColumnRefs.add(mvColRefNameColRefMapping.get(col.getName()));
-        }
-
+        MvUtils.deriveLogicalProperty(rewrittenPlan);
         MvUtils.deriveLogicalProperty(input);
-
-        // eg: 1, 2, 5 order by col-ref id
-        final List<ColumnRefOperator> mvPlanOutputColumns =
-                mvPlan.getOutputColumns().getColumnRefOperators(mvPlanContext.getRefFactory());
-        Map<ColumnRefOperator, Integer> mvPlanColRefOrderMap = Maps.newHashMap();
-        for (int i = 0; i < mvPlanOutputColumns.size(); i++) {
-            mvPlanColRefOrderMap.put(mvPlanOutputColumns.get(i), i);
-        }
-        // eg: 2, 1, 5 order by user's define
-        final List<ColumnRefOperator> mvPlanRealOutputColumns = mvPlanContext.getOutputColumns();
-        List<Integer> outputOrderIndices = mvPlanRealOutputColumns.stream()
-                .map(colRef -> mvPlanColRefOrderMap.get(colRef))
-                .collect(Collectors.toList());
 
         // mv's output column refs may be not the same with query's output column refs.
         // TODO: How to determine OptExpression's define outputs better?
         final List<ColumnRefOperator> queryPlanOutputColumns =
                 input.getOutputColumns().getColumnRefOperators(context.getColumnRefFactory());
-        // use mvPlanOutputColumns instead of mvPlanRealOutputColumns because one column may repeat multi times.
         Preconditions.checkState(queryPlanOutputColumns.size() == mvPlanOutputColumns.size());
-        List<ColumnRefOperator> queryColumnRefs = outputOrderIndices.stream()
-                .map(i -> queryPlanOutputColumns.get(i))
-                .collect(Collectors.toList());
 
-        Map<ColumnRefOperator, ScalarOperator> newColumnRefMap = Maps.newHashMap();
-        Preconditions.checkState(mvColumnRefs.size() == queryColumnRefs.size());
-        for (int i = 0; i < mvColumnRefs.size(); i++) {
-            newColumnRefMap.put(queryColumnRefs.get(i), mvColumnRefs.get(i));
-        }
-        LogicalProjectOperator logicalProjectOperator = new LogicalProjectOperator(newColumnRefMap);
-
-        final LogicalOlapScanOperator logicalOlapScanOperator = LogicalOlapScanOperator.builder()
-                .withOperator(mvScanOperator)
-                .build();
-        final OptExpression mvScanOptExpression = OptExpression.create(logicalOlapScanOperator);
-        OptExpression mvProjectExpression = OptExpression.create(logicalProjectOperator, mvScanOptExpression);
+        final List<Integer> indexes = getOrderedOutputIndexes(mvPlanContext);
+        final LogicalProjectOperator logicalProjectOperator = getReorderProjection(mvPlanOutputColumns,
+                queryPlanOutputColumns, indexes);
+        final OptExpression mvProjectExpression = OptExpression.create(logicalProjectOperator, rewrittenPlan);
 
         if (input.getOp().getOpType() == OperatorType.LOGICAL_TOPN) {
-            LogicalTopNOperator queryTopNOperator = (LogicalTopNOperator) input.getOp();
-            OptExpression newTopNOptExp = OptExpression.create(new LogicalTopNOperator.Builder()
+            final LogicalTopNOperator queryTopNOperator = (LogicalTopNOperator) input.getOp();
+            final OptExpression newTopNOptExp = OptExpression.create(new LogicalTopNOperator.Builder()
                     .withOperator(queryTopNOperator)
                     .setOrderByElements(queryTopNOperator.getOrderByElements())
                     .build(), mvProjectExpression);
@@ -364,6 +331,34 @@ public class TextMatchBasedRewriteRule extends Rule {
         } else {
             return mvProjectExpression;
         }
+    }
+
+    private List<Integer> getOrderedOutputIndexes(MvPlanContext mvPlanContext) {
+        final OptExpression mvLogicalPlan = mvPlanContext.getLogicalPlan();
+        // eg: 1, 2, 5 order by col-ref id
+        final List<ColumnRefOperator> mvPlanOutputColumns =
+                mvLogicalPlan.getOutputColumns().getColumnRefOperators(mvPlanContext.getRefFactory());
+        final Map<ColumnRefOperator, Integer> mvPlanColRefOrderMap = IntStream.range(0, mvPlanOutputColumns.size())
+                .boxed()
+                .collect(Collectors.toMap(i -> mvPlanOutputColumns.get(i), i -> i));
+        // eg: 2, 1, 5 order by user's define
+        final List<ColumnRefOperator> mvPlanRealOutputColumns = mvPlanContext.getOutputColumns();
+        return mvPlanRealOutputColumns.stream()
+                .map(colRef -> mvPlanColRefOrderMap.get(colRef))
+                .collect(Collectors.toList());
+    }
+
+    private LogicalProjectOperator getReorderProjection(List<ColumnRefOperator> mvPlanOutputColumns,
+                                                        List<ColumnRefOperator> queryPlanOutputColumns,
+                                                        List<Integer> indexes) {
+        Preconditions.checkArgument(mvPlanOutputColumns.size() == queryPlanOutputColumns.size());
+        Preconditions.checkArgument(indexes.size() == queryPlanOutputColumns.size());
+        final Map<ColumnRefOperator, ScalarOperator> newColumnRefMap = IntStream.range(0, indexes.size())
+                .boxed()
+                .map(i -> Pair.create(indexes.get(i), i))
+                .map(p -> Pair.create(queryPlanOutputColumns.get(p.first), mvPlanOutputColumns.get(p.second)))
+                .collect(Collectors.toMap(p -> p.first, p -> p.second));
+        return new LogicalProjectOperator(newColumnRefMap);
     }
 
     class TextBasedRewriteVisitor extends OptExpressionVisitor<OptExpression, ConnectContext> {


### PR DESCRIPTION
## Why I'm doing:
Before text based mv rewrite can only work if MV is valid and refresh complete. But `transparent mv` has been supported, so we can use `transparent mv` to support text based mv rewrite even if mv has been partial refreshed.

## What I'm doing:
- Support partial refresh in text based mv rewrite which means if query matches the defined mv, we can rewrite it by the mv even if the mv is partial updated.
- Remove some unused codes 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0