### PR TITLE
[BugFix] Fix can not modify column with sync mv in shared data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -805,6 +805,7 @@ public class SchemaChangeHandler extends AlterHandler {
             schemaForFinding.set(modColIndex, modColumn);
         }
 
+        List<Column> otherIndexModifiedColumn = new ArrayList<>();
         // check if column being mod
         if (!modColumn.equals(oriColumn)) {
             // column is mod. we have to mod this column in all indices
@@ -880,6 +881,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     } else {
                         otherCol.setAggregationType(null, oldCol.isAggregationTypeImplicit());
                     }
+                    otherIndexModifiedColumn.add(otherCol);
                     otherIndexSchema.set(modColIndex, otherCol);
                 }
             }
@@ -893,8 +895,14 @@ public class SchemaChangeHandler extends AlterHandler {
                 || !oriColumn.getType().isScalarType()
                 || oriColumn.getType().isDecimalOfAnyVersion()
                 || oriColumn.isGeneratedColumn()) {
-            fastSchemaEvolution = false;
+            return false;
         }
+        for (Column column : otherIndexModifiedColumn) {
+            if (column.isKey()) {
+                return false;
+            }
+        }
+
         return fastSchemaEvolution;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeSyncMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeSyncMaterializedViewTest.java
@@ -734,4 +734,45 @@ public class LakeSyncMaterializedViewTest {
         starRocksAssert.dropMaterializedView("mv1");
         starRocksAssert.dropTable("t1");
     }
+
+    public void testModifyColumnWithMV() throws Exception {
+        starRocksAssert.useDatabase("test");
+        starRocksAssert.withTable("CREATE TABLE `t1` " +
+                "( `k1`  date, " +
+                "`k2`  datetime, " +
+                "`k3`  char(20), " +
+                "`k4`  varchar(20), " +
+                "`k5`  boolean, " +
+                "`k6`  tinyint, " +
+                "`k7`  smallint, " +
+                "`k8`  int, " +
+                "`k9`  bigint, " +
+                "`k10` largeint, " +
+                "`k11` float, " +
+                "`k12` double, " +
+                "`k13` decimal(27,9) ) " +
+                "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) " +
+                "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`)");
+        {
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv1\n" +
+                    " AS\n" +
+                    " SELECT\n" +
+                    "   k6,\n" +
+                    "   k7,\n" +
+                    "   k8,\n" +
+                    "   k9,\n" +
+                    "   k10,\n" +
+                    "   k11,\n" +
+                    "   k12,\n" +
+                    "   k13\n" +
+                    " FROM t1;");
+
+            starRocksAssert.alterTable("ALTER TABLE t1 MODIFY COLUMN k7 VARCHAR(20);");
+            starRocksAssert.checkSchemaChangeJob();
+
+            starRocksAssert.dropTable("t1");
+            starRocksAssert.dropMaterializedView("mv1");
+        }
+
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

![image](https://github.com/user-attachments/assets/0eb4eb07-3679-4f55-a9e2-c9e1757a2cbe)

The reason is that the modified column is a non-key column in the base index but a key column in the other materialized index， so that the short key column count has changed in the materialized index.
## What I'm doing:
In this case, fast schema change should not be used.

Fixes https://github.com/StarRocks/StarRocksTest/issues/9283

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0