### PR TITLE
[BugFix] auto statistics collection uses correct analyze type according to user config

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeJob.java
@@ -153,6 +153,10 @@ public class NativeAnalyzeJob implements AnalyzeJob, Writable {
         return type;
     }
 
+    public void setType(AnalyzeType type) {
+        this.type = type;
+    }
+
     @Override
     public ScheduleType getScheduleType() {
         return scheduleType;


### PR DESCRIPTION
## Why I'm doing:

Once the default analyze job which used to auto collect statistics in the background is created in starrocks. it will persist and won't be dropped. If the user wants to change the auto collection analyze type. the user's config can't take effect.

## What I'm doing:
using correct analyze_type according to user config

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0