### PR TITLE
[BugFix] Support catalog name in Show materialized views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -310,7 +310,14 @@ public class ShowExecutor {
         @Override
         public ShowResultSet visitShowMaterializedViewStatement(ShowMaterializedViewsStmt statement, ConnectContext context) {
             String dbName = statement.getDb();
-            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+            String catalogName = statement.getCatalogName();
+            Database db;
+            if (catalogName == null) {
+                db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+            } else {
+                db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+            }
+
             MetaUtils.checkDbNullAndReport(db, dbName);
 
             List<MaterializedView> materializedViews = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -186,6 +186,15 @@ public class ShowStmtAnalyzer {
             String db = node.getDb();
             db = getDatabaseName(db, context);
             node.setDb(db);
+            String catalogName;
+            if (node.getCatalogName() != null) {
+                catalogName = node.getCatalogName();
+            } else {
+                catalogName = context.getCurrentCatalog();
+            }
+            if (!GlobalStateMgr.getCurrentState().getCatalogMgr().catalogExists(catalogName)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_CATALOG_ERROR, catalogName);
+            }
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
@@ -80,24 +80,27 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
 
     private String db;
 
+    private String catalogName;
+
     private final String pattern;
 
     private Expr where;
 
-    public ShowMaterializedViewsStmt(String db) {
-        this(db, null, null, NodePosition.ZERO);
+    public ShowMaterializedViewsStmt(String catalogName, String db) {
+        this(catalogName, db, null, null, NodePosition.ZERO);
     }
 
-    public ShowMaterializedViewsStmt(String db, String pattern) {
-        this(db, pattern, null, NodePosition.ZERO);
+    public ShowMaterializedViewsStmt(String catalogName, String db, String pattern) {
+        this(catalogName, db, pattern, null, NodePosition.ZERO);
     }
 
-    public ShowMaterializedViewsStmt(String db, Expr where) {
-        this(db, null, where, NodePosition.ZERO);
+    public ShowMaterializedViewsStmt(String catalogName, String db, Expr where) {
+        this(catalogName, db, null, where, NodePosition.ZERO);
     }
 
-    public ShowMaterializedViewsStmt(String db, String pattern, Expr where, NodePosition pos) {
+    public ShowMaterializedViewsStmt(String catalogName, String db, String pattern, Expr where, NodePosition pos) {
         super(pos);
+        this.catalogName = catalogName;
         this.db = db;
         this.pattern = pattern;
         this.where = where;
@@ -113,6 +116,10 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
 
     public String getPattern() {
         return pattern;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2082,17 +2082,25 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     public ParseNode visitShowMaterializedViewsStatement(
             StarRocksParser.ShowMaterializedViewsStatementContext context) {
         String database = null;
+        String catalog = null;
         NodePosition pos = createPos(context);
         if (context.qualifiedName() != null) {
-            database = getQualifiedName(context.qualifiedName()).toString();
+            QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
+            List<String> parts = qualifiedName.getParts();
+            if (parts.size() == 2) {
+                catalog = qualifiedName.getParts().get(0);
+                database = qualifiedName.getParts().get(1);
+            } else if (parts.size() == 1) {
+                database = qualifiedName.getParts().get(0);
+            }
         }
         if (context.pattern != null) {
             StringLiteral stringLiteral = (StringLiteral) visit(context.pattern);
-            return new ShowMaterializedViewsStmt(database, stringLiteral.getValue(), null, pos);
+            return new ShowMaterializedViewsStmt(catalog, database, stringLiteral.getValue(), null, pos);
         } else if (context.expression() != null) {
-            return new ShowMaterializedViewsStmt(database, null, (Expr) visit(context.expression()), pos);
+            return new ShowMaterializedViewsStmt(catalog, database, null, (Expr) visit(context.expression()), pos);
         } else {
-            return new ShowMaterializedViewsStmt(database, null, null, pos);
+            return new ShowMaterializedViewsStmt(catalog, database, null, null, pos);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -38,9 +38,18 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.information.MaterializedViewsSystemTable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.CreateCatalogStmt;
+import com.starrocks.sql.ast.DropCatalogStmt;
 import com.starrocks.sql.ast.ShowMaterializedViewsStmt;
+import com.starrocks.sql.ast.ShowStmt;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
@@ -67,18 +76,18 @@ public class ShowMaterializedViewTest {
     public void testNormal() throws Exception {
         ctx.setDatabase("testDb");
 
-        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("");
+        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt(null, "");
 
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.assertEquals("testDb", stmt.getDb());
         checkShowMaterializedViewsStmt(stmt);
 
-        stmt = new ShowMaterializedViewsStmt("abc", (String) null);
+        stmt = new ShowMaterializedViewsStmt(null, "abc", (String) null);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.assertEquals("abc", stmt.getDb());
         checkShowMaterializedViewsStmt(stmt);
 
-        stmt = new ShowMaterializedViewsStmt("abc", "bcd");
+        stmt = new ShowMaterializedViewsStmt(null, "abc", "bcd");
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.assertEquals("bcd", stmt.getPattern());
         Assert.assertEquals("abc", stmt.getDb());
@@ -149,7 +158,30 @@ public class ShowMaterializedViewTest {
     @Test(expected = SemanticException.class)
     public void testNoDb() throws Exception {
         ctx = UtFrameUtils.createDefaultCtx();
-        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("");
+        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt(null, "");
+        com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
+        Assert.fail("No exception throws");
+    }
+
+    @Test
+    public void testCatalogName() throws Exception {
+        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("default_catalog", "testDb");
+
+        com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
+        Assert.assertEquals("testDb", stmt.getDb());
+        Assert.assertEquals("default_catalog", stmt.getCatalogName());
+        checkShowMaterializedViewsStmt(stmt);
+        stmt = (ShowMaterializedViewsStmt) UtFrameUtils.parseStmtWithNewParser(
+                "SHOW MATERIALIZED VIEWS FROM default_catalog.testDb;", ctx);
+
+        Assert.assertEquals("testDb", stmt.getDb());
+        Assert.assertEquals("default_catalog", stmt.getCatalogName());
+    }
+
+    @Test(expected = SemanticException.class)
+    public void testUnknownCatalog() throws Exception {
+        ctx = UtFrameUtils.createDefaultCtx();
+        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("unknown_catalog", "testDb");
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.fail("No exception throws");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -976,7 +976,7 @@ public class ShowExecutorTest {
         ctx.setCurrentUserIdentity(UserIdentity.ROOT);
         ctx.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
 
-        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("testDb", (String) null);
+        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("default_catalog", "testDb", (String) null);
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         verifyShowMaterializedViewResult(resultSet);
@@ -984,7 +984,7 @@ public class ShowExecutorTest {
 
     @Test
     public void testShowMaterializedViewFromUnknownDatabase() throws DdlException, AnalysisException {
-        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("emptyDb", (String) null);
+        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("default_catalog", "emptyDb", (String) null);
 
         expectedEx.expect(SemanticException.class);
         expectedEx.expectMessage("Unknown database 'emptyDb'");
@@ -996,12 +996,12 @@ public class ShowExecutorTest {
         ctx.setCurrentUserIdentity(UserIdentity.ROOT);
         ctx.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
 
-        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("testDb", "bcd%");
+        ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("default_catalog", "testDb", "bcd%");
 
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         Assert.assertFalse(resultSet.next());
 
-        stmt = new ShowMaterializedViewsStmt("testDb", "%test%");
+        stmt = new ShowMaterializedViewsStmt("default_catalog", "testDb", "%test%");
 
         resultSet = ShowExecutor.execute(stmt, ctx);
         verifyShowMaterializedViewResult(resultSet);


### PR DESCRIPTION
## Why I'm doing:
Show Materialized View should honor fully qualified name of database ie.., catalog_name.database_name which fails currently
`mysql>
mysql> show materialized views from default_catalog.test;
ERROR 5501 (3F000): Getting analyzing error. Detail message: Unknown database 'default_catalog.test'.
mysql>
mysql>
`

## What I'm doing:
In this patch the catalog name will be accepted as a part of fully qualified database name in `SHOW MATERIALIZED VIEW`.

Fixes #54134 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0