### PR TITLE
[Enhancement] support touch cache for CACHE SELECT

### DIFF
--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -177,6 +177,15 @@ public:
         }
     }
 
+    Status touch_cache(int64_t offset, size_t length) override {
+        auto stream_st = _file_ptr->stream();
+        if (!stream_st.ok()) {
+            return to_status(stream_st.status());
+        }
+        auto res = (*stream_st)->touch_cache(offset, length);
+        return to_status(res);
+    }
+
     StatusOr<std::unique_ptr<io::NumericStatistics>> get_numeric_statistics() override {
         auto stream_st = _file_ptr->stream();
         if (!stream_st.ok()) {

--- a/be/src/io/seekable_input_stream.h
+++ b/be/src/io/seekable_input_stream.h
@@ -78,6 +78,11 @@ public:
     // to first send a HEAD OBJECT request to get the object size.
     virtual StatusOr<std::string> read_all();
 
+    // if cache in [offset, offset+length] exists, refresh it
+    // if not, read from remote and write to cache system
+    // stream offset will not change
+    virtual Status touch_cache(int64_t offset, size_t length) { return Status::OK(); }
+
     virtual const std::string& filename() const { return _filename; };
 
     virtual bool is_cache_hit() const { return false; };

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1418,7 +1418,6 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         if (buf_size <= 0) {
             buf_size = 1048576; // 1MB
         }
-        std::unique_ptr<char[]> buf(new char[buf_size]);
         for (auto& [cid, stream] : _column_files) {
             ASSIGN_OR_RETURN(auto vec, _column_iterators[cid]->get_io_range_vec(_scan_range));
             for (auto e : vec) {
@@ -1428,7 +1427,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
                 size_t size = e.second + (e.first % buf_size);
                 while (size > 0) {
                     size_t cur_size = std::min(buf_size, size);
-                    RETURN_IF_ERROR(stream->read_at_fully(offset, buf.get(), cur_size));
+                    RETURN_IF_ERROR(stream->touch_cache(offset, cur_size));
                     offset += cur_size;
                     size -= cur_size;
                 }

--- a/be/test/fs/fs_starlet_test.cpp
+++ b/be/test/fs/fs_starlet_test.cpp
@@ -162,6 +162,7 @@ TEST_P(StarletFileSystemTest, test_write_and_read) {
     EXPECT_EQ("hello world!", std::string_view(buf, nr));
 
     ASSIGN_OR_ABORT(nr, rf->read_at(3, buf, sizeof(buf)));
+    EXPECT_OK(rf->touch_cache(0 /* offset */, sizeof("hello world!")));
     EXPECT_EQ("lo world!", std::string_view(buf, nr));
 
     EXPECT_OK(fs->delete_file(uri));


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
add `touch_cache` api to seekable input stream
only need make sure that cache is on disk when running cache select, no need to read cache

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0