### PR TITLE
[BugFix] reset context start time for each hyper query job's sql

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperQueryJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/hyper/HyperQueryJob.java
@@ -134,6 +134,8 @@ public abstract class HyperQueryJob {
             LOG.error(message, e);
             lastFailure = new RuntimeException(message, e);
             return Collections.emptyList();
+        } finally {
+            context.setStartTime();
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
since we have merged both full and sample statistics collecting to partition level and made a big refactor on it. so if the table has a lot of partition and columns, we may collect this table for a long time.  this may cause timeout of queue pending queue.
`com.starrocks.common.StarRocksException: Failed to allocate resource to query: pending timeout [300s], you could modify the session variable [query_queue_pending_timeout_second] to pending more time
`

## What I'm doing:
reset context start time for each hyper query job

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0