### PR TITLE
[Enhancement] Hudi schema should follow the .hoodie/schema record in HDFS

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/HiveMetastoreApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/HiveMetastoreApiConverterTest.java
@@ -72,6 +72,8 @@ public class HiveMetastoreApiConverterTest {
                 Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)), "", null));
         hudiFields.add(new Schema.Field("col2",
                 Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)), "", null));
+        hudiFields.add(new Schema.Field("col3",
+                Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)), "", null));
         hudiSchema = Schema.createRecord(hudiFields);
     }
 
@@ -96,14 +98,14 @@ public class HiveMetastoreApiConverterTest {
         };
 
         List<Column> columns = HiveMetastoreApiConverter.toFullSchemasForHudiTable(table, hudiSchema);
-        Assert.assertEquals(7, columns.size());
+        Assert.assertEquals(8, columns.size());
     }
 
     @Test
     public void testToDataColumnNamesForHudiTable() {
         List<String> partColumns = Lists.newArrayList("col1");
         List<String> dataColumns = HiveMetastoreApiConverter.toDataColumnNamesForHudiTable(hudiSchema, partColumns);
-        Assert.assertEquals(6, dataColumns.size());
+        Assert.assertEquals(7, dataColumns.size());
     }
 
     @Test
@@ -152,8 +154,8 @@ public class HiveMetastoreApiConverterTest {
         Assert.assertEquals(inputFormat, params.get(HUDI_TABLE_INPUT_FOAMT));
         Assert.assertEquals("COPY_ON_WRITE", params.get(HUDI_TABLE_TYPE));
         Assert.assertEquals("_hoodie_commit_time,_hoodie_commit_seqno,_hoodie_record_key," +
-                "_hoodie_partition_path,_hoodie_file_name,col1,col2", params.get(HUDI_TABLE_COLUMN_NAMES));
-        Assert.assertEquals("string#string#string#string#string#bigint#int", params.get(HUDI_TABLE_COLUMN_TYPES));
+                "_hoodie_partition_path,_hoodie_file_name,col1,col2,col3", params.get(HUDI_TABLE_COLUMN_NAMES));
+        Assert.assertEquals("string#string#string#string#string#bigint#int#int", params.get(HUDI_TABLE_COLUMN_TYPES));
 
         final String catalogName = "hudi_catalog";
         new Expectations() {


### PR DESCRIPTION
[Enhancement] Hudi schema should follow the .hoodie/schema record in HDFS
## Why I'm doing:
Some of may have the issue that the schema recorded in .hoodie/schema is different from the schema record in HMS.

For those tables will have `ArrayIndexOutOfBoundsException` issue from the `toFullSchemasForHudiTable`.

And I asked the Spark about how Spark read the Hudi schema.

The answer is that Spark will always follow the schema recorded in .hoodie/schema.

Here I made the change to make it align with Spark.

And also it will be less buggy for some inconsistence case.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0