### PR TITLE
[Refactor] Modify the memory statistics implement of PageCache.

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -143,6 +143,11 @@ public:
     MemTracker* short_key_index_mem_tracker() { return _short_key_index_mem_tracker.get(); }
     MemTracker* compaction_mem_tracker() { return _compaction_mem_tracker.get(); }
     MemTracker* schema_change_mem_tracker() { return _schema_change_mem_tracker.get(); }
+    // The value of `page_cache_mem_tracker` is manually counted and is attached to the process_mem_tracker tree.
+    // It is not based on the `ThreadLocalMemTracker`.
+    // Therefore, when counting the memory, the `MemTracker::set` interface can be used,
+    // while the consume/release interfaces cannot be used.
+    // Otherwise, it will cause problems in the memory statistics of the process.
     MemTracker* page_cache_mem_tracker() { return _page_cache_mem_tracker.get(); }
     MemTracker* jit_cache_mem_tracker() { return _jit_cache_mem_tracker.get(); }
     MemTracker* update_mem_tracker() { return _update_mem_tracker.get(); }

--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -92,7 +92,6 @@ StoragePageCache::StoragePageCache(MemTracker* mem_tracker, size_t capacity)
 StoragePageCache::~StoragePageCache() = default;
 
 void StoragePageCache::set_capacity(size_t capacity) {
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
     _cache->set_capacity(capacity);
 }
 
@@ -109,7 +108,6 @@ uint64_t StoragePageCache::get_hit_count() {
 }
 
 bool StoragePageCache::adjust_capacity(int64_t delta, size_t min_capacity) {
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
     return _cache->adjust_capacity(delta, min_capacity);
 }
 
@@ -126,7 +124,7 @@ void StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCacheH
 #ifndef BE_TEST
     int64_t mem_size = malloc_usable_size(data.data);
     tls_thread_status.mem_release(mem_size);
-    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
     tls_thread_status.mem_consume(mem_size);
 #else
     int64_t mem_size = data.size;

--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -86,8 +86,7 @@ void StoragePageCache::prune() {
     _cache->prune();
 }
 
-StoragePageCache::StoragePageCache(MemTracker* mem_tracker, size_t capacity)
-        : _mem_tracker(mem_tracker), _cache(new_lru_cache(capacity)) {}
+StoragePageCache::StoragePageCache(MemTracker* mem_tracker, size_t capacity) : _cache(new_lru_cache(capacity)) {}
 
 StoragePageCache::~StoragePageCache() = default;
 
@@ -130,7 +129,7 @@ void StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCacheH
     int64_t mem_size = data.size;
 #endif
 
-    auto deleter = [](const starrocks::CacheKey& key, void* value) { delete[](uint8_t*) value; };
+    auto deleter = [](const starrocks::CacheKey& key, void* value) { delete[] (uint8_t*)value; };
 
     CachePriority priority = CachePriority::NORMAL;
     if (in_memory) {

--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -129,7 +129,7 @@ void StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCacheH
     int64_t mem_size = data.size;
 #endif
 
-    auto deleter = [](const starrocks::CacheKey& key, void* value) { delete[] (uint8_t*)value; };
+    auto deleter = [](const starrocks::CacheKey& key, void* value) { delete[](uint8_t*) value; };
 
     CachePriority priority = CachePriority::NORMAL;
     if (in_memory) {

--- a/be/src/storage/page_cache.h
+++ b/be/src/storage/page_cache.h
@@ -121,7 +121,6 @@ public:
 private:
     static StoragePageCache* _s_instance;
 
-    MemTracker* _mem_tracker = nullptr;
     std::unique_ptr<Cache> _cache = nullptr;
 };
 

--- a/be/src/storage/page_cache.h
+++ b/be/src/storage/page_cache.h
@@ -134,7 +134,6 @@ public:
     PageCacheHandle(Cache* cache, Cache::Handle* handle) : _cache(cache), _handle(handle) {}
     ~PageCacheHandle() {
         if (_handle != nullptr) {
-            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(GlobalEnv::GetInstance()->page_cache_mem_tracker());
             _cache->release(_handle);
         }
     }

--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -299,7 +299,7 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
     auto* e = reinterpret_cast<LRUHandle*>(malloc(sizeof(LRUHandle) - 1 + key.size()));
     e->value = value;
     e->deleter = deleter;
-    e->charge = charge;
+    e->charge = charge + key.size();
     e->key_length = key.size();
     e->hash = hash;
     e->refs = 2; // one for the returned handle, one for LRUCache.

--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -297,10 +297,11 @@ void LRUCache::_evict_one_entry(LRUHandle* e) {
 Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size, size_t charge,
                                 void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
     size_t key_mem_size = sizeof(LRUHandle) - 1 + key.size();
+    size_t kv_mem_size = charge + key_mem_size;
     auto* e = reinterpret_cast<LRUHandle*>(malloc(key_mem_size));
     e->value = value;
     e->deleter = deleter;
-    e->charge = charge + key_mem_size;
+    e->charge = kv_mem_size;
     e->key_length = key.size();
     e->hash = hash;
     e->refs = 2; // one for the returned handle, one for LRUCache.
@@ -315,13 +316,13 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
 
         // Free the space following strict LRU policy until enough space
         // is freed or the lru list is empty
-        _evict_from_lru(charge, &last_ref_list);
+        _evict_from_lru(kv_mem_size, &last_ref_list);
 
         // insert into the cache
         // note that the cache might get larger than its capacity if not enough
         // space was freed
         auto old = _table.insert(e);
-        _usage += charge;
+        _usage += kv_mem_size;
         if (old != nullptr) {
             old->in_cache = false;
             if (_unref(old)) {

--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -296,10 +296,11 @@ void LRUCache::_evict_one_entry(LRUHandle* e) {
 
 Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size, size_t charge,
                                 void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
-    auto* e = reinterpret_cast<LRUHandle*>(malloc(sizeof(LRUHandle) - 1 + key.size()));
+    size_t key_mem_size = sizeof(LRUHandle) -1 + key.size();
+    auto* e = reinterpret_cast<LRUHandle*>(malloc(key_mem_size));
     e->value = value;
     e->deleter = deleter;
-    e->charge = charge + key.size();
+    e->charge = charge + key_mem_size;
     e->key_length = key.size();
     e->hash = hash;
     e->refs = 2; // one for the returned handle, one for LRUCache.

--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -296,7 +296,7 @@ void LRUCache::_evict_one_entry(LRUHandle* e) {
 
 Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t value_size, size_t charge,
                                 void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
-    size_t key_mem_size = sizeof(LRUHandle) -1 + key.size();
+    size_t key_mem_size = sizeof(LRUHandle) - 1 + key.size();
     auto* e = reinterpret_cast<LRUHandle*>(malloc(key_mem_size));
     e->value = value;
     e->deleter = deleter;

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -42,15 +42,15 @@
 #include <cstdio>
 #include <memory>
 
+#include "cache/block_cache/block_cache.h"
 #include "gutil/strings/split.h" // for string split
 #include "gutil/strtoint.h"      //  for atoi64
 #include "io/io_profiler.h"
 #include "jemalloc/jemalloc.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_filter_worker.h"
-#include "util/metrics.h"
-#include "cache/block_cache/block_cache.h"
 #include "storage/page_cache.h"
+#include "util/metrics.h"
 
 namespace starrocks {
 

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -49,6 +49,8 @@
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_filter_worker.h"
 #include "util/metrics.h"
+#include "cache/block_cache/block_cache.h"
+#include "storage/page_cache.h"
 
 namespace starrocks {
 
@@ -292,6 +294,33 @@ void SystemMetrics::_install_memory_metrics(MetricRegistry* registry) {
     registry->register_metric("datacache_mem_bytes", &_memory_metrics->datacache_mem_bytes);
 }
 
+void SystemMetrics::_update_datacache_mem_tracker() {
+    // update datacache mem_tracker
+    int64_t datacache_mem_bytes = 0;
+    auto* datacache_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
+    if (datacache_mem_tracker) {
+        BlockCache* block_cache = BlockCache::instance();
+        if (block_cache->is_initialized()) {
+            auto datacache_metrics = block_cache->cache_metrics();
+            datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
+        }
+#ifdef USE_STAROS
+        if (!config::datacache_unified_instance_enable) {
+            datacache_mem_bytes += staros::starlet::fslib::star_cache_get_memory_usage();
+        }
+#endif
+        datacache_mem_tracker->set(datacache_mem_bytes);
+    }
+}
+
+void SystemMetrics::_update_pagecache_mem_tracker() {
+    auto* pagecache_mem_tracker = GlobalEnv::GetInstance()->page_cache_mem_tracker();
+    auto* page_cache = StoragePageCache::instance();
+    if (pagecache_mem_tracker && page_cache) {
+        pagecache_mem_tracker->set(page_cache->memory_usage());
+    }
+}
+
 void SystemMetrics::_update_memory_metrics() {
 #if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
     LOG(INFO) << "Memory tracking is not available with address sanitizer builds.";
@@ -324,6 +353,9 @@ void SystemMetrics::_update_memory_metrics() {
         _memory_metrics->jemalloc_retained_bytes.set_value(value);
     }
 #endif
+
+    _update_datacache_mem_tracker();
+    _update_pagecache_mem_tracker();
 
 #define SET_MEM_METRIC_VALUE(tracker, key)                                                  \
     if (GlobalEnv::GetInstance()->tracker() != nullptr) {                                   \

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -43,6 +43,9 @@
 #include <memory>
 
 #include "cache/block_cache/block_cache.h"
+#ifdef USE_STAROS
+#include "fslib/star_cache_handler.h"
+#endif
 #include "gutil/strings/split.h" // for string split
 #include "gutil/strtoint.h"      //  for atoi64
 #include "io/io_profiler.h"

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -139,6 +139,9 @@ private:
 
     void _install_io_metrics(MetricRegistry* registry);
 
+    void _update_datacache_mem_tracker();
+    void _update_pagecache_mem_tracker();
+
 private:
     static const char* const _s_hook_name;
 

--- a/be/test/exec/query_cache/query_cache_test.cpp
+++ b/be/test/exec/query_cache/query_cache_test.cpp
@@ -112,22 +112,26 @@ TEST_F(QueryCacheTest, testCacheManager) {
         return value;
     };
 
+    size_t total_key_size = 0;
     for (auto i = 0; i < 10; ++i) {
+        std::string key = strings::Substitute("key_$0", i);
+        size_t key_size = sizeof(LRUHandle) - 1 + key.size();
+        total_key_size += key_size;
         cache_mgr->populate(strings::Substitute("key_$0", i), create_cache_value(96));
     }
 
-    ASSERT_EQ(cache_mgr->memory_usage(), 960);
+    ASSERT_EQ(cache_mgr->memory_usage(), total_key_size + 960);
     for (auto i = 0; i < 10; ++i) {
         auto status = cache_mgr->probe(strings::Substitute("key_$0", i));
         ASSERT_TRUE(status.ok());
     }
 
-    ASSERT_EQ(cache_mgr->memory_usage(), 960);
+    ASSERT_EQ(cache_mgr->memory_usage(), total_key_size + 960);
     for (auto i = 10; i < 20; ++i) {
         auto status = cache_mgr->probe(strings::Substitute("key_$0", i));
         ASSERT_FALSE(status.ok());
     }
-    ASSERT_EQ(cache_mgr->memory_usage(), 960);
+    ASSERT_EQ(cache_mgr->memory_usage(), total_key_size + 960);
 
     for (auto i = 20; i < 30; ++i) {
         cache_mgr->populate(strings::Substitute("key_$0", i), create_cache_value(100));

--- a/be/test/exprs/jit_func_cache_test.cpp
+++ b/be/test/exprs/jit_func_cache_test.cpp
@@ -39,8 +39,8 @@ public:
     }
 
     void mock_insert(string expr_name) {
-        auto* handle =
-                engine->get_func_cache()->insert(expr_name, nullptr, 500, 500, [](const CacheKey& key, void* value) {});
+        auto* handle = engine->get_func_cache()->insert(expr_name, nullptr, 1000, 1000,
+                                                        [](const CacheKey& key, void* value) {});
         if (handle != nullptr) {
             engine->get_func_cache()->release(handle);
         }

--- a/be/test/exprs/jit_func_cache_test.cpp
+++ b/be/test/exprs/jit_func_cache_test.cpp
@@ -39,8 +39,8 @@ public:
     }
 
     void mock_insert(string expr_name) {
-        auto* handle = engine->get_func_cache()->insert(expr_name, nullptr, 1000, 1000,
-                                                        [](const CacheKey& key, void* value) {});
+        auto* handle =
+                engine->get_func_cache()->insert(expr_name, nullptr, 500, 500, [](const CacheKey& key, void* value) {});
         if (handle != nullptr) {
             engine->get_func_cache()->release(handle);
         }

--- a/be/test/storage/rowset/metadata_cache_test.cpp
+++ b/be/test/storage/rowset/metadata_cache_test.cpp
@@ -173,7 +173,7 @@ TEST_F(MetadataCacheTest, test_warmup) {
         }
         // warmup first rowset
         metadata_cache_ptr->refresh_rowset(rowsets[0].get());
-        metadata_cache_ptr->set_capacity(rowsets[0]->segment_memory_usage() * 32);
+        metadata_cache_ptr->set_capacity(rowsets[0]->segment_memory_usage() * 64);
         ASSERT_TRUE(rowsets[0]->segment_memory_usage() > 0);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Later, the `datacache (mem)` and `pagecache` will be unified. Currently, the memory statistics method of the `pagecache` will prone to cumulative errors after using the `starcache`. Therefore, we will uniformly relying on the internal statistics of the cache, and no longer use the method of statistics by the `thread local mem_tracker`.

## What I'm doing:

Modify the memory statistics implement of `PageCache`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0