### PR TITLE
[Enhancement] support alter hive/hudi catalog's properties

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
@@ -59,12 +59,7 @@ public class ConnectorMgr {
     }
 
     public CatalogConnector createHiddenConnector(ConnectorContext context, boolean isReplay) throws StarRocksConnectorException {
-        readLock();
-        try {
-            return ConnectorFactory.createConnector(context, isReplay);
-        } finally {
-            readUnlock();
-        }
+        return ConnectorFactory.createConnector(context, isReplay);
     }
 
     public void addConnector(String catalogName, CatalogConnector connector) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
@@ -58,6 +58,26 @@ public class ConnectorMgr {
         }
     }
 
+    public CatalogConnector createHiddenConnector(ConnectorContext context, boolean isReplay) throws StarRocksConnectorException {
+        readLock();
+        try {
+            return ConnectorFactory.createConnector(context, isReplay);
+        } finally {
+            readUnlock();
+        }
+    }
+
+    public void addConnector(String catalogName, CatalogConnector connector) {
+        writeLock();
+        try {
+            Preconditions.checkState(!connectors.containsKey(catalogName),
+                    "Connector of catalog '%s' already exists", catalogName);
+            connectors.put(catalogName, connector);
+        } finally {
+            writeUnLock();
+        }
+    }
+
     public void removeConnector(String catalogName) {
         readLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -282,30 +282,7 @@ public class CatalogMgr {
             return;
         }
 
-        if (needRecreateCatalog(catalog, alterProperties)) {
-            // recreate catalog
-            reCreatCatalog(catalog, alterProperties, isReplay);
-        } else {
-            String catalogName = catalog.getName();
-            String serviceName = alterProperties.get("ranger.plugin.hive.service.name");
-
-            if (Strings.isNullOrEmpty(serviceName)) {
-                if (Config.access_control.equals("ranger")) {
-                    Authorizer.getInstance().setAccessControl(catalogName, new RangerStarRocksAccessController());
-                } else {
-                    Authorizer.getInstance().setAccessControl(catalogName, new NativeAccessController());
-                }
-            } else {
-                Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
-            }
-
-            catalog.getConfig().putAll(alterProperties);
-        }
-    }
-
-    private boolean needRecreateCatalog(Catalog catalog, Map<String, String> properties) {
-        boolean containsRanger = properties.containsKey("ranger.plugin.hive.service.name");
-        return !containsRanger || properties.size() != 1;
+        reCreatCatalog(catalog, alterProperties, isReplay);
     }
 
     // TODO @caneGuy we should put internal catalog into catalogmgr

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -216,7 +216,11 @@ public class CatalogMgr {
                     Authorizer.getInstance().setAccessControl(catalogName, new RangerHiveAccessController(serviceName));
                 }
 
-                catalog.getConfig().put("ranger.plugin.hive.service.name", serviceName);
+                catalog.getConfig().putAll(properties);
+                if (serviceName == null && !properties.isEmpty()) {
+                    LOG.info("Altering catalog properties (excluding `ranger.plugin.hive.service.name`) " +
+                            "requires restarting all FE nodes to take effect");
+                }
 
                 AlterCatalogLog alterCatalogLog = new AlterCatalogLog(catalogName, properties);
                 GlobalStateMgr.getCurrentState().getEditLog().logAlterCatalog(alterCatalogLog);
@@ -365,7 +369,7 @@ public class CatalogMgr {
             }
 
             Catalog catalog = catalogs.get(catalogName);
-            catalog.getConfig().put("ranger.plugin.hive.service.name", serviceName);
+            catalog.getConfig().putAll(properties);
         } finally {
             writeUnLock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -41,16 +41,8 @@ public class CatalogAnalyzer {
 
     private static final String WHITESPACE = "\\s+";
 
-    private static final Set<String> SUPPORT_ALTER_PROPERTIES = Sets.newHashSet(
-            "ranger.plugin.hive.service.name",
-            "hive.metastore.uris",
-            "enable_metastore_cache",
-            "enable_remote_file_cache",
-            "metastore_cache_refresh_interval_sec",
-            "remote_file_cache_refresh_interval_sec",
-            "metastore_cache_ttl_sec",
-            "remote_file_cache_ttl_sec",
-            "enable_cache_list_names"
+    private static final Set<String> NOT_SUPPORT_ALTER_PROPERTIES = Sets.newHashSet(
+            "type"
     );
 
     public static void analyze(StatementBase stmt, ConnectContext session) {
@@ -140,15 +132,10 @@ public class CatalogAnalyzer {
                         (ModifyTablePropertiesClause) statement.getAlterClause();
                 Map<String, String> properties = modifyTablePropertiesClause.getProperties();
 
-                String catalogType = GlobalStateMgr.getCurrentState().getCatalogMgr().getCatalogType(statement.getCatalogName());
                 for (Map.Entry<String, String> property : properties.entrySet()) {
                     String confName = property.getKey();
 
-                    if (("hive".equals(catalogType) || "hudi".equals(catalogType))) {
-                        if (!SUPPORT_ALTER_PROPERTIES.contains(confName)) {
-                            throw new SemanticException("Not support alter hive/hudi catalog property " + property.getKey());
-                        }
-                    } else if (!"ranger.plugin.hive.service.name".equals(confName)) {
+                    if (NOT_SUPPORT_ALTER_PROPERTIES.contains(confName)) {
                         throw new SemanticException("Not support alter catalog property " + property.getKey());
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -18,7 +18,6 @@ import com.google.common.base.Strings;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterCatalogStmt;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.CreateCatalogStmt;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CatalogAnalyzer.java
@@ -41,9 +41,16 @@ public class CatalogAnalyzer {
 
     private static final String WHITESPACE = "\\s+";
 
-    private static final Set<String> NOT_SUPPORT_ALTER_PROPERTIES = Sets.newHashSet(
-            "type",
-            "hive.metastore.type"
+    private static final Set<String> SUPPORT_ALTER_PROPERTIES = Sets.newHashSet(
+            "ranger.plugin.hive.service.name",
+            "hive.metastore.uris",
+            "enable_metastore_cache",
+            "enable_remote_file_cache",
+            "metastore_cache_refresh_interval_sec",
+            "remote_file_cache_refresh_interval_sec",
+            "metastore_cache_ttl_sec",
+            "remote_file_cache_ttl_sec",
+            "enable_cache_list_names"
     );
 
     public static void analyze(StatementBase stmt, ConnectContext session) {
@@ -138,7 +145,7 @@ public class CatalogAnalyzer {
                     String confName = property.getKey();
 
                     if (("hive".equals(catalogType) || "hudi".equals(catalogType))) {
-                        if (NOT_SUPPORT_ALTER_PROPERTIES.contains(confName)) {
+                        if (!SUPPORT_ALTER_PROPERTIES.contains(confName)) {
                             throw new SemanticException("Not support alter hive/hudi catalog property " + property.getKey());
                         }
                     } else if (!"ranger.plugin.hive.service.name".equals(confName)) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/AlterCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/AlterCatalogTest.java
@@ -64,15 +64,7 @@ public class AlterCatalogTest {
 
         try {
             DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
-                    "alter catalog hive0 set (\"ranger.plugin.hive.service.name2\"  =  \"hive_catalog_2\");",
-                    connectContext), connectContext);
-            Assert.fail();
-        } catch (AnalysisException e) {
-        }
-
-        try {
-            DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
-                    "alter catalog hive0 set (\"hive.metastore.type\"  =  \"glue\");",
+                    "alter catalog hive0 set (\"type\"  =  \"hudi\");",
                     connectContext), connectContext);
             Assert.fail();
         } catch (AnalysisException e) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/AlterCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/AlterCatalogTest.java
@@ -14,6 +14,7 @@
 package com.starrocks.catalog;
 
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
 import com.starrocks.persist.AlterCatalogLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
@@ -68,6 +69,14 @@ public class AlterCatalogTest {
                     connectContext), connectContext);
             Assert.fail();
         } catch (AnalysisException e) {
+        }
+
+        try {
+            DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                    "alter catalog hive0 set (\"hive.metastore.uris\"  =  \"xx\");",
+                    connectContext), connectContext);
+            Assert.fail();
+        } catch (DdlException e) {
         }
 
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/AlterCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/AlterCatalogTest.java
@@ -70,14 +70,26 @@ public class AlterCatalogTest {
         } catch (AnalysisException e) {
         }
 
+        try {
+            DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                    "alter catalog hive0 set (\"hive.metastore.type\"  =  \"glue\");",
+                    connectContext), connectContext);
+            Assert.fail();
+        } catch (AnalysisException e) {
+        }
+
         DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
                 "alter catalog hive0 set (\"ranger.plugin.hive.service.name\"  =  \"hive0\");",
+                connectContext), connectContext);
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "alter catalog hive0 set (\"enable_cache_list_names\"  =  \"true\");",
                 connectContext), connectContext);
 
         Map<String, Catalog> catalogMap = connectContext.getGlobalStateMgr().getCatalogMgr().getCatalogs();
         Catalog catalog = catalogMap.get("hive0");
         Map<String, String> properties = catalog.getConfig();
         Assert.assertEquals("hive0", properties.get("ranger.plugin.hive.service.name"));
+        Assert.assertEquals("true", properties.get("enable_cache_list_names"));
     }
 
     @Test
@@ -91,6 +103,7 @@ public class AlterCatalogTest {
 
         Map<String, String> properties = new HashMap<>();
         properties.put("ranger.plugin.hive.service.name", "hive0");
+        properties.put("enable_cache_list_names", "true");
         AlterCatalogLog log = new AlterCatalogLog("hive0", properties);
         GlobalStateMgr.getCurrentState().getCatalogMgr().replayAlterCatalog(log);
 
@@ -98,6 +111,7 @@ public class AlterCatalogTest {
         Catalog catalog = catalogMap.get("hive0");
         properties = catalog.getConfig();
         Assert.assertEquals("hive0", properties.get("ranger.plugin.hive.service.name"));
+        Assert.assertEquals("true", properties.get("enable_cache_list_names"));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
When the Hive metastore address changes, we need to modify the Hive catalog's properties accordingly.

## What I'm doing:

This PR adds support for modifying Hive/Hudi catalog properties, but requires restarting all FE nodes for the changes to take effect.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0