### PR TITLE
[BugFix] Fix query report INTERNAL_ERROR when enable phased scheduer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -71,6 +71,9 @@ public class FeConstants {
             "Backend node not found. Check if any backend node is down.";
     public static final String COMPUTE_NODE_NOT_FOUND_ERROR =
             "Compute node not found. Check if any compute node is down.";
+    public static final String QUERY_FINISHED_ERROR = "QueryFinished";
+    public static final String LIMIT_REACH_ERROR = "LimitReach";
+
 
     public static boolean USE_MOCK_DICT_MANAGER = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -376,7 +376,8 @@ public class FragmentInstanceExecState {
                     jobSpec.getQueryId(), instanceId, cancelReason,
                     jobSpec.isEnablePipeline());
         } catch (RpcException e) {
-            LOG.warn("cancel plan fragment get a exception, address={}:{}", brpcAddress.getHostname(), brpcAddress.getPort(), e);
+            LOG.warn("cancel plan fragment get a exception, address={}:{}", brpcAddress.getHostname(),
+                    brpcAddress.getPort(), e);
             SimpleScheduler.addToBlocklist(worker.getId());
             return false;
         }


### PR DESCRIPTION
If a short-circuited query occurs when phased scheduling is turned on, the query context will return QUERY_FINISHED. In this case, prepare will fail and we need to ignore the cancel error.

```
[DefaultCoordinator.scheduleNextTurn():582] schedule fragment:c86ca695-f26f-11ef-b724-00163e16c1f5 next internal error:
com.starrocks.common.StarRocksException: Query has been cancelled backend [id=10002]
at com.starrocks.qe.DefaultCoordinator.handleErrorExecution(DefaultCoordinator.java:747)
at com.starrocks.qe.scheduler.Deployer.waitForDeploymentCompletion(Deployer.java:253)
at com.starrocks.qe.scheduler.Deployer.deployFragments(Deployer.java:121)
at com.starrocks.qe.scheduler.dag.PhasedExecutionSchedule.doDeploy(PhasedExecutionSchedule.java:228)
at com.starrocks.qe.scheduler.dag.PhasedExecutionSchedule.tryScheduleNextTurn(PhasedExecutionSchedule.java:257)
at com.starrocks.qe.DefaultCoordinator.scheduleNextTurn(DefaultCoordinator.java:580)
at com.starrocks.qe.QeProcessorImpl.reportFragmentFinish(QeProcessorImpl.java:311)
at com.starrocks.service.FrontendServiceImpl.reportFragmentFinish(FrontendServiceImpl.java:3056)
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0