### PR TITLE
[BugFix] fix rpc error for partitions_meta when partitions are too many

### DIFF
--- a/be/src/exec/schema_scanner/schema_partitions_meta_scanner.h
+++ b/be/src/exec/schema_scanner/schema_partitions_meta_scanner.h
@@ -34,8 +34,8 @@ private:
     Status fill_chunk(ChunkPtr* chunk);
 
     cctz::time_zone _ctz;
-    int _partitions_meta_index;
-    TGetPartitionsMetaResponse _partitions_meta_response;
+    size_t _partitions_meta_index;
+    std::vector<TPartitionMetaInfo> _partitions_meta_vec;
 
     static SchemaScanner::ColumnDesc _s_columns[];
 };

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3516,4 +3516,11 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static int max_show_proc_transactions_entry = 2000;
+
+    /**
+     *  max partition meta count will be returned when BE/CN call GetPartitionsMeta
+     *  if one table's partition count exceeds this, it will return all partitions for this table
+     */
+    @ConfField(mutable = true)
+    public static int max_get_partitions_meta_result_count = 100000;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -35,6 +35,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Table.TableType;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.CaseSensibility;
+import com.starrocks.common.Config;
 import com.starrocks.common.PatternMatcher;
 import com.starrocks.common.proc.PartitionsProcDir;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -69,10 +70,12 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 
 public class InformationSchemaDataSource {
@@ -256,63 +259,90 @@ public class InformationSchemaDataSource {
 
         AuthDbRequestResult result = getAuthDbRequestResult(request.getAuth_info());
 
+        class Element {
+            public Element(String dbName, long dbId, Table table) {
+                this.dbName = dbName;
+                this.dbId = dbId;
+                this.table = table;
+            }
+            public long getTableId() {
+                return table.getId();
+            }
+            public String dbName;
+            public long dbId;
+            public Table table;
+        };
+        long startTableIdOffset = request.isSetStart_table_id_offset() ? request.getStart_table_id_offset() : 0;
+        TreeSet<Element> sortedElements = new TreeSet<>(Comparator.comparing(Element::getTableId));
         for (String dbName : result.authorizedDbs) {
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
             if (db == null) {
                 continue;
             }
-            List<Table> allTables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
-            for (Table table : allTables) {
-                try {
-                    Authorizer.checkAnyActionOnTableLikeObject(result.currentUser,
-                            null, dbName, table);
-                } catch (AccessDeniedException e) {
-                    LOG.warn("failed to check db: {} table: {} authorization", dbName, table, e);
+            List<Table> tables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
+            for (Table table : tables) {
+                if (table.getId() < startTableIdOffset) {
                     continue;
                 }
-                if (!table.isNativeTableOrMaterializedView()) {
-                    continue;
-                }
-                // only olap table/mv or cloud table/mv will reach here;
-                // use the same lock level with `SHOW PARTITIONS FROM XXX` to ensure other modification to
-                // partition does not trigger crash
-                Locker locker = new Locker();
-                locker.lockDatabase(db.getId(), LockType.READ);
-                try {
-                    OlapTable olapTable = (OlapTable) table;
-                    PartitionInfo tblPartitionInfo = olapTable.getPartitionInfo();
-                    // normal partition
-                    for (Partition partition : olapTable.getPartitions()) {
-                        for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
-                            TPartitionMetaInfo partitionMetaInfo = new TPartitionMetaInfo();
-                            partitionMetaInfo.setDb_name(dbName);
-                            partitionMetaInfo.setTable_name(olapTable.getName());
-                            genPartitionMetaInfo(db, olapTable, tblPartitionInfo, partition, physicalPartition,
-                                    partitionMetaInfo, false /* isTemp */);
-                            pList.add(partitionMetaInfo);
-                        }
+                sortedElements.add(new Element(dbName, db.getId(), table));
+            }
+        }
+
+        for (Element ele : sortedElements) {
+            Table table = ele.table;
+            if (!table.isNativeTableOrMaterializedView()) {
+                continue;
+            }
+            try {
+                Authorizer.checkAnyActionOnTableLikeObject(result.currentUser,
+                        null, ele.dbName, table);
+            } catch (AccessDeniedException e) {
+                LOG.warn("failed to check db: {} table: {} authorization", ele.dbName, table, e);
+                continue;
+            }
+            // only olap table/mv or cloud table/mv will reach here;
+            // use the same lock level with `SHOW PARTITIONS FROM XXX` to ensure other modification to
+            // partition does not trigger crash
+            Locker locker = new Locker();
+            locker.lockDatabase(ele.dbId, LockType.READ);
+            try {
+                OlapTable olapTable = (OlapTable) table;
+                PartitionInfo tblPartitionInfo = olapTable.getPartitionInfo();
+                // normal partition
+                for (Partition partition : olapTable.getPartitions()) {
+                    for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                        TPartitionMetaInfo partitionMetaInfo = new TPartitionMetaInfo();
+                        partitionMetaInfo.setDb_name(ele.dbName);
+                        partitionMetaInfo.setTable_name(olapTable.getName());
+                        genPartitionMetaInfo(ele.dbId, olapTable, tblPartitionInfo, partition, physicalPartition,
+                                partitionMetaInfo, false /* isTemp */);
+                        pList.add(partitionMetaInfo);
                     }
-                    // temp partition
-                    for (Partition partition : olapTable.getTempPartitions()) {
-                        for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
-                            TPartitionMetaInfo partitionMetaInfo = new TPartitionMetaInfo();
-                            partitionMetaInfo.setDb_name(dbName);
-                            partitionMetaInfo.setTable_name(olapTable.getName());
-                            genPartitionMetaInfo(db, olapTable, tblPartitionInfo, partition, physicalPartition,
-                                    partitionMetaInfo, true /* isTemp */);
-                            pList.add(partitionMetaInfo);
-                        }
-                    }
-                } finally {
-                    locker.unLockDatabase(db.getId(), LockType.READ);
                 }
+                // temp partition
+                for (Partition partition : olapTable.getTempPartitions()) {
+                    for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                        TPartitionMetaInfo partitionMetaInfo = new TPartitionMetaInfo();
+                        partitionMetaInfo.setDb_name(ele.dbName);
+                        partitionMetaInfo.setTable_name(olapTable.getName());
+                        genPartitionMetaInfo(ele.dbId, olapTable, tblPartitionInfo, partition, physicalPartition,
+                                partitionMetaInfo, true /* isTemp */);
+                        pList.add(partitionMetaInfo);
+                    }
+                }
+                if (pList.size() >= Config.max_get_partitions_meta_result_count) {
+                    resp.setNext_table_id_offset(table.getId() + 1);
+                    break;
+                }
+            } finally {
+                locker.unLockDatabase(ele.dbId, LockType.READ);
             }
         }
         resp.partitions_meta_infos = pList;
         return resp;
     }
 
-    private static void genPartitionMetaInfo(Database db, OlapTable table,
+    private static void genPartitionMetaInfo(long dbId, OlapTable table,
                                              PartitionInfo partitionInfo, Partition partition,
                                              PhysicalPartition physicalPartition,
                                              TPartitionMetaInfo partitionMetaInfo, boolean isTemp) {
@@ -356,7 +386,7 @@ public class InformationSchemaDataSource {
         // NEXT_VERSION
         partitionMetaInfo.setNext_version(physicalPartition.getNextVersion());
         if (table.isCloudNativeTableOrMaterializedView()) {
-            PartitionIdentifier identifier = new PartitionIdentifier(db.getId(), table.getId(), physicalPartition.getId());
+            PartitionIdentifier identifier = new PartitionIdentifier(dbId, table.getId(), physicalPartition.getId());
             PartitionStatistics statistics = GlobalStateMgr.getCurrentState().getCompactionMgr().getStatistics(identifier);
             Quantiles compactionScore = statistics != null ? statistics.getCompactionScore() : null;
             // COMPACT_VERSION

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1465,6 +1465,8 @@ struct TGetTablesConfigResponse {
 
 struct TGetPartitionsMetaRequest {
     1: optional TAuthInfo auth_info
+    // get partitions where table id >= start_table_id_offset
+    2: optional i64 start_table_id_offset;
 }
 
 struct TPartitionMetaInfo {
@@ -1500,6 +1502,8 @@ struct TPartitionMetaInfo {
 
 struct TGetPartitionsMetaResponse {
     1: optional list<TPartitionMetaInfo> partitions_meta_infos
+    // max table id in partitions_meta_infos + 1, if set to 0, it means reaches end
+    2: optional i64 next_table_id_offset;
 }
 
 struct TGetTablesInfoRequest {

--- a/test/sql/test_information_schema/R/test_partitions_meta
+++ b/test/sql/test_information_schema/R/test_partitions_meta
@@ -1,5 +1,11 @@
 -- name: test_partitions_meta
-CREATE TABLE `partitions_meta_test` (
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `partitions_meta_test1` (
   `k` int(11) NOT NULL COMMENT "",
   `v` int(11) NOT NULL COMMENT ""
 )engine=olap
@@ -14,9 +20,36 @@ PROPERTIES (
 );
 -- result:
 -- !result
-select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by partition_name;
+CREATE TABLE `partitions_meta_test2` (
+  `k` int(11) NOT NULL COMMENT "",
+  `v` int(11) NOT NULL COMMENT ""
+)engine=olap
+DUPLICATE KEY(`k`)
+PARTITION BY RANGE(`v`)
+(PARTITION p1 VALUES [("-2147483648"), ("0")),
+PARTITION p2 VALUES [("0"), ("10")),
+PARTITION p3 VALUES [("10"), ("2147483647")))
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
 -- result:
-partitions_meta_test	p1	1	TXN_NORMAL
-partitions_meta_test	p2	1	TXN_NORMAL
-partitions_meta_test	p3	1	TXN_NORMAL
+-- !result
+admin set frontend config("max_get_partitions_meta_result_count"="1");
+-- result:
+-- !result
+select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
+-- result:
+partitions_meta_test1	p1	1	TXN_NORMAL
+partitions_meta_test1	p2	1	TXN_NORMAL
+partitions_meta_test1	p3	1	TXN_NORMAL
+partitions_meta_test2	p1	1	TXN_NORMAL
+partitions_meta_test2	p2	1	TXN_NORMAL
+partitions_meta_test2	p3	1	TXN_NORMAL
+-- !result
+admin set frontend config("max_get_partitions_meta_result_count"="100000");
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
 -- !result

--- a/test/sql/test_information_schema/T/test_partitions_meta
+++ b/test/sql/test_information_schema/T/test_partitions_meta
@@ -1,5 +1,7 @@
 -- name: test_partitions_meta
-CREATE TABLE `partitions_meta_test` (
+create database db_${uuid0};
+use db_${uuid0};
+CREATE TABLE `partitions_meta_test1` (
   `k` int(11) NOT NULL COMMENT "",
   `v` int(11) NOT NULL COMMENT ""
 )engine=olap
@@ -8,8 +10,24 @@ PARTITION BY RANGE(`v`)
 (PARTITION p1 VALUES [("-2147483648"), ("0")),
 PARTITION p2 VALUES [("0"), ("10")),
 PARTITION p3 VALUES [("10"), ("2147483647")))
-DISTRIBUTED BY HASH(`k`) BUCKETS 2
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
 PROPERTIES (
 "replication_num" = "1"
 );
-select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by partition_name;
+CREATE TABLE `partitions_meta_test2` (
+  `k` int(11) NOT NULL COMMENT "",
+  `v` int(11) NOT NULL COMMENT ""
+)engine=olap
+DUPLICATE KEY(`k`)
+PARTITION BY RANGE(`v`)
+(PARTITION p1 VALUES [("-2147483648"), ("0")),
+PARTITION p2 VALUES [("0"), ("10")),
+PARTITION p3 VALUES [("10"), ("2147483647")))
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+admin set frontend config("max_get_partitions_meta_result_count"="1");
+select TABLE_NAME, PARTITION_NAME, DATA_VERSION, VERSION_TXN_TYPE from INFORMATION_SCHEMA.PARTITIONS_META where table_name like '%partitions_meta_test%' order by table_name asc, partition_name asc;
+admin set frontend config("max_get_partitions_meta_result_count"="100000");
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
fix https://github.com/StarRocks/starrocks/issues/52254

## What I'm doing:
```
FE RPC failure, address=TNetworkAddress(hostname=[XXX](XXX), port=XXX), reason=MaxMessageSize reached
```
introduce Config.max_get_partitions_meta_result_count, user reports over 700000 partitions when error happens, so 100000 is a safe default value.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0