### PR TITLE
[Enhancement] support distinct and agg func with group by

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggTest.java
@@ -194,4 +194,23 @@ public class DistinctAggTest extends PlanTestBase {
 
         return argumentsList.stream();
     }
+
+    @Test
+    public void testDistinctWithAgg() throws Exception {
+        String sql = "select distinct v1, count(v2) from t0 group by v1;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, " 1:AGGREGATE (update finalize)\n" +
+                "  |  output: count(2: v2)\n" +
+                "  |  group by: 1: v1");
+
+        sql = "select distinct v1 from t0 having abs(v1) = 1;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "1:AGGREGATE (update finalize)\n" +
+                "  |  group by: 1: v1\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t0\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: abs(1: v1) = 1");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
currently, we don't support distinct columns with group_by or agg_func. 
```
select distinct v1, count(v2) from t0 group by v1
```

for this case, if the group by item contains all distinct column,  the result can be guaranteed to be correct. Our behavior mainly refers to MySQL.

## What I'm doing:
Release some analyze restrictions to support this syntax.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/51714

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0