### PR TITLE
[Enhancement] Add storage size property for cloud native partition

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -109,6 +109,8 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
 
     if (!context->status.ok()) {
         _response->add_failed_tablets(context->tablet_id);
+    } else {
+        _success_compaction_input_file_size += context->stats->input_file_size;
     }
 
     // process compact stat
@@ -120,6 +122,7 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
     compact_stat->set_read_bytes_local(context->stats->io_bytes_read_local_disk);
     compact_stat->set_in_queue_time_sec(context->stats->in_queue_time_sec);
     compact_stat->set_sub_task_count(_request->tablet_ids_size());
+    compact_stat->set_total_compact_input_file_size(context->stats->input_file_size);
 
     DCHECK(_request != nullptr);
     _status.update(context->status);
@@ -131,6 +134,7 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
 
     if (_contexts.size() == _request->tablet_ids_size()) { // All tasks finished, send RPC response to FE
         _status.to_protobuf(_response->mutable_status());
+        _response->set_success_compaction_input_file_size(_success_compaction_input_file_size);
         if (_done != nullptr) {
             _done->Run();
             _done = nullptr;

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -99,6 +99,7 @@ private:
     // use lock to protect _last_check_time and prevent multiple rpc called
     mutable std::mutex _txn_valid_check_mutex;
     std::vector<std::unique_ptr<CompactionTaskContext>> _contexts;
+    int64_t _success_compaction_input_file_size = 0;
 };
 
 struct CompactionTaskInfo {

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -41,7 +41,7 @@ Status CompactionTask::execute_index_major_compaction(TxnLogPB* txn_log) {
             metadata->persistent_index_type() == PersistentIndexTypePB::CLOUD_NATIVE) {
             RETURN_IF_ERROR(_tablet.tablet_manager()->update_mgr()->execute_index_major_compaction(*metadata, txn_log));
             if (txn_log->has_op_compaction() && !txn_log->op_compaction().input_sstables().empty()) {
-                size_t total_input_sstable_file_size = 0; 
+                size_t total_input_sstable_file_size = 0;
                 for (const auto& input_sstable : txn_log->op_compaction().input_sstables()) {
                     total_input_sstable_file_size += input_sstable.filesize();
                 }

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -39,7 +39,15 @@ Status CompactionTask::execute_index_major_compaction(TxnLogPB* txn_log) {
         auto metadata = _tablet.metadata();
         if (metadata->enable_persistent_index() &&
             metadata->persistent_index_type() == PersistentIndexTypePB::CLOUD_NATIVE) {
-            return _tablet.tablet_manager()->update_mgr()->execute_index_major_compaction(*metadata, txn_log);
+            RETURN_IF_ERROR(_tablet.tablet_manager()->update_mgr()->execute_index_major_compaction(*metadata, txn_log));
+            if (txn_log->has_op_compaction() && !txn_log->op_compaction().input_sstables().empty()) {
+                size_t total_input_sstable_file_size = 0; 
+                for (const auto& input_sstable : txn_log->op_compaction().input_sstables()) {
+                    total_input_sstable_file_size += input_sstable.filesize();
+                }
+                _context->stats->input_file_size += total_input_sstable_file_size;
+            }
+            return Status::OK();
         }
     }
     return Status::OK();

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -48,6 +48,7 @@ CompactionTaskStats CompactionTaskStats::operator+(const CompactionTaskStats& th
     diff.io_count_remote = io_count_remote + that.io_count_remote;
     diff.in_queue_time_sec = in_queue_time_sec + that.in_queue_time_sec;
     diff.pk_sst_merge_ns = pk_sst_merge_ns + that.pk_sst_merge_ns;
+    diff.input_file_size = input_file_size + that.input_file_size;
     return diff;
 }
 
@@ -63,6 +64,7 @@ CompactionTaskStats CompactionTaskStats::operator-(const CompactionTaskStats& th
     diff.io_count_remote = io_count_remote - that.io_count_remote;
     diff.in_queue_time_sec = in_queue_time_sec - that.in_queue_time_sec;
     diff.pk_sst_merge_ns = pk_sst_merge_ns - that.pk_sst_merge_ns;
+    diff.input_file_size = input_file_size - that.input_file_size;
     return diff;
 }
 
@@ -82,6 +84,7 @@ std::string CompactionTaskStats::to_json_stats() {
                    allocator);
     root.AddMember("in_queue_sec", rapidjson::Value(in_queue_time_sec), allocator);
     root.AddMember("pk_sst_merge_sec", rapidjson::Value(pk_sst_merge_ns / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("input_file_size", rapidjson::Value(input_file_size), allocator);
 
     rapidjson::StringBuffer strbuf;
     rapidjson::Writer<rapidjson::StringBuffer> writer(strbuf);

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -50,6 +50,7 @@ struct CompactionTaskStats {
     int64_t io_count_remote = 0;
     int64_t in_queue_time_sec = 0;
     int64_t pk_sst_merge_ns = 0;
+    int64_t input_file_size = 0;
 
     void collect(const OlapReaderStatistics& reader_stats);
     CompactionTaskStats operator+(const CompactionTaskStats& that) const;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -719,9 +719,12 @@ StatusOr<CompactionTaskPtr> TabletManager::compact(CompactionTaskContext* contex
     ASSIGN_OR_RETURN(auto input_rowsets, compaction_policy->pick_rowsets());
     ASSIGN_OR_RETURN(auto algorithm, compaction_policy->choose_compaction_algorithm(input_rowsets));
     std::vector<uint32_t> input_rowsets_id;
+    size_t total_input_rowsets_file_size = 0;
     for (auto& rowset : input_rowsets) {
         input_rowsets_id.emplace_back(rowset->id());
+        total_input_rowsets_file_size += rowset->data_size();
     }
+    context->stats->input_file_size += total_input_rowsets_file_size;
     ASSIGN_OR_RETURN(auto tablet_schema, get_output_rowset_schema(input_rowsets_id, tablet_metadata.get()));
     if (algorithm == VERTICAL_COMPACTION) {
         return std::make_shared<VerticalCompactionTask>(std::move(tablet), std::move(input_rowsets), context,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -116,6 +116,8 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     @SerializedName(value = "bucketNum")
     private int bucketNum = 0;
+    
+    private volatile long extraFileSize = 0;
 
     private PhysicalPartition() {
 
@@ -210,6 +212,18 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public void setLastSuccVacuumVersion(long lastSuccVacuumVersion) {
         this.lastSuccVacuumVersion = lastSuccVacuumVersion;
+    }
+
+    public long getExtraFileSize() {
+        return extraFileSize;
+    }
+
+    public void setExtraFileSize(long extraFileSize) {
+        this.extraFileSize = extraFileSize;
+    }
+
+    public void incExtraFileSize(long addFileSize) {
+        this.extraFileSize += addFileSize;
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
@@ -60,6 +60,7 @@ public class PartitionsMetaSystemTable {
                         .column("P50_CS", ScalarType.createType(PrimitiveType.DOUBLE))
                         .column("MAX_CS", ScalarType.createType(PrimitiveType.DOUBLE))
                         .column("STORAGE_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("STORAGE_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_PARTITIONS_META);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -121,6 +121,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("DistributionKey")
                     .add("Buckets")
                     .add("DataSize")
+                    .add("StorageSize")
                     .add("RowCount")
                     .add("EnableDataCache")
                     .add("AsyncWrite")
@@ -148,6 +149,7 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("CooldownTime")
                     .add("LastConsistencyCheckTime")
                     .add("DataSize")
+                    .add("StorageSize")
                     .add("IsInMemory")
                     .add("RowCount")
                     .add("DataVersion")
@@ -362,12 +364,14 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(String.valueOf(replicationNum));
 
         long dataSize = physicalPartition.storageDataSize();
+        long extraFileSize = physicalPartition.getExtraFileSize();
         ByteSizeValue byteSizeValue = new ByteSizeValue(dataSize);
         DataProperty dataProperty = tblPartitionInfo.getDataProperty(partition.getId());
         partitionInfo.add(dataProperty.getStorageMedium().name());
         partitionInfo.add(TimeUtils.longToTimeString(dataProperty.getCooldownTimeMs()));
         partitionInfo.add(TimeUtils.longToTimeString(partition.getLastCheckTime()));
         partitionInfo.add(byteSizeValue);
+        partitionInfo.add(new ByteSizeValue(dataSize + extraFileSize));
         partitionInfo.add(tblPartitionInfo.getIsInMemory(partition.getId()));
         partitionInfo.add(physicalPartition.storageRowCount());
 
@@ -398,6 +402,8 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(distributionKeyAsString(table, partition.getDistributionInfo())); // DistributionKey
         partitionInfo.add(partition.getDistributionInfo().getBucketNum()); // Buckets
         partitionInfo.add(new ByteSizeValue(physicalPartition.storageDataSize())); // DataSize
+        long storageSize = physicalPartition.storageDataSize() + physicalPartition.getExtraFileSize();
+        partitionInfo.add(new ByteSizeValue(storageSize)); // StorageSize
         partitionInfo.add(physicalPartition.storageRowCount()); // RowCount
         partitionInfo.add(cacheInfo.isEnabled()); // EnableCache
         partitionInfo.add(cacheInfo.isAsyncWriteBack()); // AsyncWrite

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
@@ -207,4 +207,12 @@ public class CompactionJob {
         }
         return new CompactionProfile(stat).toString();
     }
+
+    public long getSuccessCompactInputFileSize() {
+        long res = 0;
+        for (CompactionTask task : tasks) {
+            res += task.getSuccessCompactInputFileSize();
+        }
+        return res;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -430,6 +430,7 @@ public class CompactionScheduler extends Daemon {
             }
             waiter = transactionMgr.commitTransaction(db.getId(), job.getTxnId(), commitInfoList,
                     Collections.emptyList(), attachment);
+            job.getPartition().incExtraFileSize(job.getSuccessCompactInputFileSize());
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), tableIdList, LockType.WRITE);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
@@ -150,4 +150,16 @@ public class CompactionTask {
             return null;
         }
     }
+
+    public long getSuccessCompactInputFileSize() {
+        if (!isDone()) {
+            return 0;
+        }
+        try {
+            CompactResponse response = responseFuture.get();
+            return response.successCompactionInputFileSize;
+        } catch (Exception e) {
+            return 0;
+        }        
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -241,7 +241,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
                     vacuumedFiles += response.vacuumedFiles;
                     vacuumedFileSize += response.vacuumedFileSize;
                     vacuumedVersion = Math.min(vacuumedVersion, response.vacuumedVersion);
-                    extraFileSize += response.extraFileSize - response.vacuumedFileSize;
+                    extraFileSize += response.extraFileSize;
 
                     if (response.tabletInfos != null) {
                         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
@@ -281,9 +281,10 @@ public class AutovacuumDaemon extends FrontendDaemon {
             partition.setExtraFileSize(extraFileSize + incrementExtraFileSize);
         }
         LOG.info("Vacuumed {}.{}.{} hasError={} vacuumedFiles={} vacuumedFileSize={} " +
-                        "visibleVersion={} minRetainVersion={} minActiveTxnId={} vacuumVersion={} cost={}ms",
+                        "visibleVersion={} minRetainVersion={} minActiveTxnId={} vacuumVersion={} extraFileSize={} cost={}ms",
                 db.getFullName(), table.getName(), partition.getId(), hasError, vacuumedFiles, vacuumedFileSize,
-                visibleVersion, minRetainVersion, minActiveTxnId, vacuumedVersion, System.currentTimeMillis() - startTime);
+                visibleVersion, minRetainVersion, minActiveTxnId, vacuumedVersion, extraFileSize, 
+                System.currentTimeMillis() - startTime);
     }
 
     private static long computeMinActiveTxnId(Database db, Table table) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -190,6 +190,10 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_BRPC_EXEC_PLAN_FRAGMENT;
     public static LongCounterMetric COUNTER_BRPC_EXEC_PLAN_FRAGMENT_ERROR;
 
+    // count file number and total size vacuumed for cloud native
+    public static LongCounterMetric COUNTER_VACUUM_FILES_NUMBER;
+    public static LongCounterMetric COUNTER_VACUUM_FILES_BYTES;
+
     public static Histogram HISTO_QUERY_LATENCY;
     public static Histogram HISTO_EDIT_LOG_WRITE_LATENCY;
     public static Histogram HISTO_JOURNAL_WRITE_LATENCY;
@@ -590,6 +594,13 @@ public final class MetricRepo {
 
             }
         }
+
+        COUNTER_VACUUM_FILES_NUMBER = new LongCounterMetric("vacuum_files_count", MetricUnit.REQUESTS,
+                "total files have been vacuumed");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_VACUUM_FILES_NUMBER);
+        COUNTER_VACUUM_FILES_BYTES = new LongCounterMetric("vacuum_files_bytes", MetricUnit.BYTES,
+                "total file bytes have been vacuumed");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_VACUUM_FILES_BYTES);
 
         // 3. histogram
         HISTO_QUERY_LATENCY = METRIC_REGISTER.histogram(MetricRegistry.name("query", "latency", "ms"));

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -119,6 +119,7 @@ public class VacuumTest {
         mockResponse.vacuumedFiles = 10L;
         mockResponse.vacuumedFileSize = 1024L;
         mockResponse.vacuumedVersion = 5L;
+        mockResponse.extraFileSize = 1024L;
         mockResponse.tabletInfos = new ArrayList<>();
 
         Future<VacuumResponse> mockFuture = mock(Future.class);
@@ -157,6 +158,7 @@ public class VacuumTest {
         mockResponse.vacuumedFiles = 10L;
         mockResponse.vacuumedFileSize = 1024L;
         mockResponse.vacuumedVersion = 5L;
+        mockResponse.extraFileSize = 1024L;
         mockResponse.tabletInfos = new ArrayList<>();
 
         Future<VacuumResponse> mockFuture = mock(Future.class);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
@@ -117,4 +117,25 @@ public class CompactionJobTest {
         String s = job.getExecutionProfile();
         Assert.assertFalse(s.isEmpty());
     }
+
+    @Test
+    public void testSuccessCompactInputFIleSize() {
+        Database db = new Database();
+        Table table = new Table(Table.TableType.CLOUD_NATIVE);
+        PhysicalPartition partition = new PhysicalPartition(0, "", 1, null);
+        CompactionJob job = new CompactionJob(db, table, partition, 10010, true);
+
+        Assert.assertTrue(job.getAllowPartialSuccess());
+        List<CompactionTask> list = new ArrayList<>();
+        list.add(new CompactionTask(100));
+        list.add(new CompactionTask(101));
+        job.setTasks(list);
+        new MockUp<CompactionTask>() {
+            @Mock
+            public CompactionTask.TaskResult getResult() {
+                return CompactionTask.TaskResult.NOT_FINISHED;
+            }
+        };
+        Assert.assertEquals(job.getSuccessCompactInputFileSize(), 0);
+    }
 }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -102,6 +102,7 @@ message CompactStat {
     optional int64 read_bytes_remote = 12;
     optional int64 read_time_local = 13; // ns
     optional int64 read_bytes_local = 14;
+    optional int64 total_compact_input_file_size = 15;
 
     // write
     // TODO
@@ -120,6 +121,7 @@ message CompactResponse {
     // optional int64 num_output_rows = 6;
     optional StatusPB status = 7;
     repeated CompactStat compact_stats = 8;
+    optional int64 success_compaction_input_file_size = 9;
 }
 
 message DropTableRequest {
@@ -283,6 +285,8 @@ message VacuumResponse {
     optional int64 vacuumed_version = 4;
     // The tablet infos of vacuumed tablets.
     repeated TabletInfoPB tablet_infos = 5;
+    // The total file size need to be vacuumed
+    optional int64 extra_file_size = 6;
 }
 
 message VacuumFullRequest {


### PR DESCRIPTION
## Why I'm doing:
StarRocks does not count the data size stored on S3 in shared-data mode. Therefore, it is hard to observe the real progress of the vacuum operation, making it difficult to determine whether the vacuum operation is lagging behind.

## What I'm doing:
Add storage size property for cloud native partition
1. Collect the file size need to be vacuumed during vacuum.
2. Collect the compaction input size.

Combined dataSize and these two file size, we will get the total storage file size. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0