### PR TITLE
[Enhancement] Optimize the datacache automatical adjustment to support diffrent adjustment size for multiple disks.

### DIFF
--- a/be/src/cache/block_cache/block_cache.cpp
+++ b/be/src/cache/block_cache/block_cache.cpp
@@ -46,8 +46,9 @@ Status BlockCache::init(const CacheOptions& options) {
     if (cache_options.engine == "starcache") {
         _kv_cache = std::make_unique<StarCacheWrapper>();
         _disk_space_monitor = std::make_unique<DiskSpaceMonitor>(this);
-        _disk_space_monitor->adjust_spaces(&cache_options.disk_spaces);
-        LOG(INFO) << "init starcache engine, block_size: " << _block_size;
+        RETURN_IF_ERROR(_disk_space_monitor->init(&cache_options.disk_spaces));
+        LOG(INFO) << "init starcache engine, block_size: " << _block_size
+                  << ", disk_spaces: " << _disk_space_monitor->to_string(cache_options.disk_spaces);
     }
 #endif
     if (!_kv_cache) {
@@ -157,15 +158,6 @@ Status BlockCache::update_disk_spaces(const std::vector<DirSpace>& spaces) {
     Status st = _kv_cache->update_disk_spaces(spaces);
     _refresh_quota();
     return st;
-}
-
-Status BlockCache::adjust_disk_spaces(const std::vector<DirSpace>& spaces) {
-    if (_disk_space_monitor) {
-        auto adjusted_spaces = spaces;
-        _disk_space_monitor->adjust_spaces(&adjusted_spaces);
-        return _disk_space_monitor->adjust_cache_quota(adjusted_spaces);
-    }
-    return update_disk_spaces(spaces);
 }
 
 void BlockCache::record_read_remote(size_t size, int64_t lateny_us) {

--- a/be/src/cache/block_cache/block_cache.h
+++ b/be/src/cache/block_cache/block_cache.h
@@ -70,9 +70,6 @@ public:
     // Update the datacache disk space infomation, such as disk quota or disk path.
     Status update_disk_spaces(const std::vector<DirSpace>& spaces);
 
-    // Adjust the disk spaces, the space quota will be adjusted based on current disk usage before updating.
-    Status adjust_disk_spaces(const std::vector<DirSpace>& spaces);
-
     void record_read_remote(size_t size, int64_t lateny_us);
 
     void record_read_cache(size_t size, int64_t lateny_us);

--- a/be/src/cache/block_cache/disk_space_monitor.cpp
+++ b/be/src/cache/block_cache/disk_space_monitor.cpp
@@ -22,14 +22,160 @@
 namespace starrocks {
 
 #ifndef BE_TEST
-const size_t DiskSpaceMonitor::QUOTA_ALIGN_UNIT = 10uL * 1024 * 1024 * 1024;
+const size_t DiskSpace::kQuotaAlignUnit = 10uL * 1024 * 1024 * 1024;
 #else
-const size_t DiskSpaceMonitor::QUOTA_ALIGN_UNIT = 10uL * 1024 * 1024;
+const size_t DiskSpace::kQuotaAlignUnit = 10uL * 1024 * 1024;
 #endif
 
-const int64_t DiskSpaceMonitor::AUTO_INCREASE_THRESHOLD = 90;
+const double DiskSpace::kAutoIncreaseThreshold = 0.9;
 
-StatusOr<size_t> DiskSpaceMonitor::FileSystemWrapper::directory_size(const std::string& dir) {
+Status DiskSpace::init_spaces(const std::vector<DirSpace>& dir_spaces) {
+    Status st = _update_disk_stats();
+    if (!st.ok()) {
+        LOG(ERROR) << "fail to init disk space, reason: " << st.message();
+        return st;
+    }
+    _dir_spaces = dir_spaces;
+
+    // Revise the original disk space state.
+    // The disk space occupied by old datacache files should be excluded because these space can
+    // be reused by datacache .
+    _revise_disk_stats_by_cache_dir();
+
+    // We check this switch after some infomation are initialized, because even if it is off now,
+    // we still need these infomation once the switch is turn on online.
+    if (!config::datacache_auto_adjust_enable) {
+        return st;
+    }
+
+    double delta_rate = config::datacache_disk_safe_level * 0.01 - _disk_stats.used_rate();
+    size_t cache_avail_bytes = 0;
+    if (delta_rate > 0) {
+        int64_t delta_size = _disk_stats.capacity_bytes * delta_rate;
+        cache_avail_bytes = _check_cache_low_limit(delta_size);
+    }
+    _update_spaces_by_cache_quota(cache_avail_bytes);
+    return st;
+}
+
+bool DiskSpace::adjust_spaces(const AdjustContext& ctx) {
+    Status st = _update_disk_stats();
+    if (!st.ok()) {
+        LOG(ERROR) << "fail to check and adjust cache disk spaces, reason: " << st.message();
+        return false;
+    }
+
+    double used_rate = _disk_stats.used_rate();
+    int64_t cur_level = static_cast<int64_t>(used_rate * 100);
+    if (cur_level < config::datacache_disk_low_level) {
+        _disk_free_period += config::datacache_disk_adjust_interval_seconds;
+        if (!_allow_expansion(ctx)) {
+            return false;
+        }
+    } else if (cur_level <= config::datacache_disk_high_level) {
+        return false;
+    }
+
+    double delta_rate = config::datacache_disk_safe_level * 0.01 - used_rate;
+    int64_t delta_quota = _disk_stats.capacity_bytes * delta_rate;
+    // TODO: Support obtaining the cache usage of each directory in starcache, to make it more accurate.
+    _update_spaces_by_cache_usage(ctx);
+
+    int64_t old_cache_quota = total_cache_quota();
+    int64_t new_cache_quota = old_cache_quota + delta_quota;
+
+    new_cache_quota = _check_cache_low_limit(new_cache_quota);
+    _update_spaces_by_cache_quota(new_cache_quota);
+    _disk_free_period = 0;
+
+    return new_cache_quota != old_cache_quota;
+}
+
+size_t DiskSpace::total_cache_quota() {
+    size_t cache_quota = 0;
+    for (auto& dir : _dir_spaces) {
+        cache_quota += dir.size;
+    }
+    return cache_quota;
+}
+
+Status DiskSpace::_update_disk_stats() {
+    auto ret = _fs->space(_path);
+    if (!ret.ok()) {
+        LOG(WARNING) << "fail to get disk space for path: " << _path << ", reason: " << ret.status().message();
+        return ret.status();
+    }
+    auto& space_info = ret.value();
+    _disk_stats.capacity_bytes = space_info.capacity;
+    _disk_stats.available_bytes = space_info.available;
+    VLOG(2) << "Get disk statistics, capaticy: " << _disk_stats.capacity_bytes
+            << ", available: " << _disk_stats.available_bytes << ", used_rate: " << _disk_stats.used_rate();
+
+    return Status::OK();
+}
+
+void DiskSpace::_revise_disk_stats_by_cache_dir() {
+    for (auto& dir : _dir_spaces) {
+        auto ret = _fs->directory_size(dir.path);
+        if (ret.ok() && ret.value() > 0) {
+            // The space under datacache directories can be reused, so ignore their usage.
+            _disk_stats.available_bytes += ret.value();
+            if (_disk_stats.available_bytes > _disk_stats.capacity_bytes) {
+                _disk_stats.available_bytes = _disk_stats.capacity_bytes;
+            }
+        }
+    }
+}
+
+void DiskSpace::_update_spaces_by_cache_quota(size_t cache_avail_bytes) {
+    size_t avg_dir_size = cache_avail_bytes / _dir_spaces.size() / kQuotaAlignUnit * kQuotaAlignUnit;
+    for (auto& dir : _dir_spaces) {
+        dir.size = avg_dir_size;
+    }
+}
+
+void DiskSpace::_update_spaces_by_cache_usage(const AdjustContext& ctx) {
+    if (ctx.total_cache_quota > 0) {
+        double cache_used_rate = static_cast<double>(ctx.total_cache_usage) / ctx.total_cache_quota;
+        for (auto& dir : _dir_spaces) {
+            dir.size = dir.size * cache_used_rate;
+        }
+    }
+}
+
+bool DiskSpace::_allow_expansion(const AdjustContext& ctx) {
+    if (_disk_free_period < config::datacache_disk_idle_seconds_for_expansion) {
+        return false;
+    }
+    if (ctx.total_cache_quota > 0) {
+        double cache_used_rate = static_cast<double>(ctx.total_cache_usage / ctx.total_cache_quota);
+        if (cache_used_rate < kAutoIncreaseThreshold) {
+            return false;
+        }
+    }
+    return true;
+}
+
+size_t DiskSpace::_check_cache_low_limit(int64_t cache_quota) {
+    if (cache_quota < config::datacache_min_disk_quota_for_adjustment) {
+        if (_disabled) {
+            // If the cache quata is already disabled, skip adjusting it repeatedly.
+            VLOG(1) << "Skip updating the disk cache quota because the target quota is less than"
+                    << " `datacache_min_disk_quota_for_adjustment`, path: " << _path;
+        } else {
+            // This warning log only be printed when the cache disk quota is adjust from a non-zero integer to zero.
+            LOG(WARNING) << "The current available disk space is too small, so disable the disk cache directly."
+                         << " If you still need it, you could reduce the value of"
+                         << " `datacache_min_disk_quota_for_adjustment`, path: " << _path;
+            _disabled = true;
+        }
+        return 0;
+    }
+    _disabled = false;
+    return cache_quota;
+}
+
+StatusOr<size_t> DiskSpace::FileSystemWrapper::directory_size(const std::string& dir) {
     size_t capacity = 0;
     auto st = FileSystem::Default()->iterate_dir2(dir, [&](DirEntry entry) {
         capacity += entry.size.value();
@@ -39,10 +185,48 @@ StatusOr<size_t> DiskSpaceMonitor::FileSystemWrapper::directory_size(const std::
     return capacity;
 }
 
-DiskSpaceMonitor::DiskSpaceMonitor(BlockCache* cache) : _fs(std::make_unique<FileSystemWrapper>()), _cache(cache) {}
+dev_t DiskSpace::FileSystemWrapper::device_id(const std::string& path) {
+    struct stat s;
+    if (stat(path.c_str(), &s) != 0) {
+        return 0;
+    }
+    return s.st_dev;
+}
+
+DiskSpaceMonitor::DiskSpaceMonitor(BlockCache* cache)
+        : _cache(cache), _fs(std::make_shared<DiskSpace::FileSystemWrapper>()) {}
 
 DiskSpaceMonitor::~DiskSpaceMonitor() {
     stop();
+}
+
+Status DiskSpaceMonitor::init(std::vector<DirSpace>* dir_spaces) {
+    if (dir_spaces->empty()) {
+        return Status::OK();
+    }
+
+    std::map<dev_t, std::vector<DirSpace>> disk_to_dir_spaces;
+    for (auto& dir : *dir_spaces) {
+        dev_t device_id = _fs->device_id(dir.path);
+        if (device_id > 0) {
+            disk_to_dir_spaces[device_id].push_back(dir);
+        } else {
+            LOG(ERROR) << "fail to get device id for the path: " << dir.path;
+            return Status::InvalidArgument("fail to get device id");
+        }
+    }
+
+    _disk_spaces.clear();
+    for (auto& disk2spaces : disk_to_dir_spaces) {
+        auto& device_id = disk2spaces.first;
+        auto& dirs = disk2spaces.second;
+        _disk_spaces.emplace_back(device_id, dirs[0].path, _fs);
+        auto& disk_space = _disk_spaces.back();
+        RETURN_IF_ERROR(disk_space.init_spaces(dirs));
+    }
+    *dir_spaces = all_dir_spaces();
+
+    return Status::OK();
 }
 
 void DiskSpaceMonitor::start() {
@@ -50,7 +234,7 @@ void DiskSpaceMonitor::start() {
     if (!_stopped.load(std::memory_order_acquire)) {
         return;
     }
-    if (_dir_spaces.empty()) {
+    if (_disk_spaces.empty()) {
         return;
     }
     _stopped.store(false, std::memory_order_release);
@@ -76,12 +260,15 @@ void DiskSpaceMonitor::_adjust_datacache_callback() {
     while (!is_stopped()) {
         std::unique_lock<std::mutex> lck(_mutex);
         if (config::datacache_enable && config::datacache_auto_adjust_enable &&
-            !_adjusting.load(std::memory_order_acquire)) {
-            _update_disk_stats();
-            _update_cache_stats();
-            if (_adjust_spaces_by_disk_usage(false)) {
-                Status st = adjust_cache_quota(_dir_spaces);
-                LOG_IF(WARNING, !st.ok()) << "fail to adjust datacache disk quota, reason: " << st.message();
+            !_updating.load(std::memory_order_acquire)) {
+            if (_adjust_spaces_by_disk_usage()) {
+                auto dir_spaces = all_dir_spaces();
+                Status st = _update_cache_quota(dir_spaces);
+                if (st.ok()) {
+                    LOG(INFO) << "success to adjust datacache disk spaces to: " << to_string(dir_spaces);
+                } else {
+                    LOG(WARNING) << "fail to adjust datacache disk spaces, reason: " << st.message();
+                }
             }
         }
         lck.unlock();
@@ -96,102 +283,40 @@ void DiskSpaceMonitor::_adjust_datacache_callback() {
     }
 }
 
-bool DiskSpaceMonitor::adjust_spaces(std::vector<DirSpace>* dir_spaces) {
-    std::unique_lock<std::mutex> lck(_mutex);
-    _reset();
-    if (dir_spaces->empty()) {
-        return false;
-    }
+bool DiskSpaceMonitor::_adjust_spaces_by_disk_usage() {
+    _update_cache_stats();
 
-    _dir_spaces = *dir_spaces;
-    _min_disk_dirs = _dir_spaces.size();
-    for (size_t dir_index = 0; dir_index < _dir_spaces.size(); ++dir_index) {
-        auto& dir_space = _dir_spaces[dir_index];
-        int disk_id = _fs->disk_id(dir_space.path);
-        if (_disk_stats.find(disk_id) == _disk_stats.end()) {
-            DiskStats disk;
-            disk.disk_id = disk_id;
-            disk.path = dir_space.path;
-            _disk_stats[disk_id] = disk;
-        }
-        _disk_to_dirs[disk_id].push_back(dir_index);
-    }
-    for (const auto& pair : _disk_to_dirs) {
-        const auto& dirs = pair.second;
-        _max_disk_dirs = std::max(_max_disk_dirs, dirs.size());
-        _min_disk_dirs = std::min(_min_disk_dirs, dirs.size());
-    }
-    _update_disk_stats();
-
-    // We check this switch after some infomation are initialized, such as `_disk_stats`, because
-    // even if it is off now, we still need these infomation once the switch is turn on online.
-    if (!config::datacache_auto_adjust_enable) {
-        return false;
-    }
-
-    _init_spaces_by_cache_dir();
-    if (_adjust_spaces_by_disk_usage(true)) {
-        *dir_spaces = _dir_spaces;
-        return true;
-    }
-    return false;
-}
-
-void DiskSpaceMonitor::_update_disk_stats() {
-    for (auto& pair : _disk_stats) {
-        auto& disk = pair.second;
-        std::string path = disk.path;
-        auto ret = _fs->space(path);
-        if (!ret.ok()) {
-            LOG(WARNING) << ret.status().message();
-            continue;
-        }
-        auto& space_info = ret.value();
-        disk.capacity_bytes = space_info.capacity;
-        disk.available_bytes = space_info.available;
-        VLOG(2) << "Get disk statistics, capaticy: " << disk.capacity_bytes << ", available: " << disk.available_bytes
-                << ", used_rate: " << (disk.capacity_bytes - disk.available_bytes) * 100 / disk.capacity_bytes << "%";
-    }
-}
-
-int64_t DiskSpaceMonitor::_max_disk_used_rate() {
-    int64_t max_used_rate = 0;
-    for (const auto& pair : _disk_to_dirs) {
-        const auto& disk_id = pair.first;
-        const auto& disk = _disk_stats[disk_id];
-        int64_t used_rate = (disk.capacity_bytes - disk.available_bytes) * 100 / disk.capacity_bytes;
-        if (used_rate > max_used_rate) {
-            max_used_rate = used_rate;
+    DiskSpace::AdjustContext ctx = {.total_cache_quota = _total_cache_quota, .total_cache_usage = _total_cache_usage};
+    bool changed = false;
+    for (auto& disk_space : _disk_spaces) {
+        if (disk_space.adjust_spaces(ctx)) {
+            changed = true;
         }
     }
-    return max_used_rate;
+    return changed;
 }
 
-void DiskSpaceMonitor::_init_spaces_by_cache_dir() {
-    _total_cache_usage = 0;
-    for (auto& dir_space : _dir_spaces) {
-        auto ret = _fs->directory_size(dir_space.path);
-        if (ret.ok() && ret.value() > 0) {
-            int disk_id = _fs->disk_id(dir_space.path);
-            auto& disk = _disk_stats[disk_id];
-            // The space under datacache directories can be reused, so ignore their usage.
-            disk.available_bytes += ret.value();
-            if (disk.available_bytes > disk.capacity_bytes) {
-                disk.available_bytes = disk.capacity_bytes;
-            }
+std::vector<DirSpace> DiskSpaceMonitor::all_dir_spaces() {
+    std::vector<DirSpace> result;
+    for (auto& disk_space : _disk_spaces) {
+        auto& dirs = disk_space.dir_spaces();
+        result.insert(result.end(), dirs.begin(), dirs.end());
+    }
+    return result;
+}
+
+std::string DiskSpaceMonitor::to_string(const std::vector<DirSpace>& dir_spaces) {
+    std::stringstream ss;
+    ss << "[";
+    for (size_t index = 0; index < dir_spaces.size(); ++index) {
+        auto& dir = dir_spaces[index];
+        ss << "{ path: " << dir.path << ", size: " << dir.size << " }";
+        if (index + 1 < dir_spaces.size()) {
+            ss << ", ";
         }
-        _total_cache_quota += dir_space.size;
     }
-}
-
-void DiskSpaceMonitor::_update_spaces_by_cache_usage() {
-    if (_total_cache_quota == 0) {
-        return;
-    }
-    double cache_used_rate = static_cast<double>(_total_cache_usage) / _total_cache_quota;
-    for (auto& dir_space : _dir_spaces) {
-        dir_space.size = dir_space.size * cache_used_rate;
-    }
+    ss << "]";
+    return ss.str();
 }
 
 void DiskSpaceMonitor::_update_cache_stats() {
@@ -200,86 +325,10 @@ void DiskSpaceMonitor::_update_cache_stats() {
     _total_cache_quota = metrics.disk_quota_bytes;
 }
 
-bool DiskSpaceMonitor::_adjust_spaces_by_disk_usage(bool immediate) {
-    bool shrink = false;
-    int64_t max_disk_used_rate = _max_disk_used_rate();
-    if (max_disk_used_rate > config::datacache_disk_high_level) {
-        shrink = true;
-    } else if (max_disk_used_rate < config::datacache_disk_low_level) {
-        _disk_free_period += config::datacache_disk_adjust_interval_seconds;
-        if (!immediate && _disk_free_period < config::datacache_disk_idle_seconds_for_expansion) {
-            return false;
-        }
-        if (_total_cache_quota > 0) {
-            double cache_used_rate = 100.0 * _total_cache_usage / _total_cache_quota;
-            if (cache_used_rate < AUTO_INCREASE_THRESHOLD) {
-                return false;
-            }
-        }
-    } else {
-        return false;
-    }
-
-    int64_t delta_rate = 0;
-    if (!shrink) {
-        // Increase cache quota
-        delta_rate = (config::datacache_disk_safe_level - max_disk_used_rate) / _max_disk_dirs;
-        DCHECK_GT(delta_rate, 0);
-    } else {
-        // Decrease cache quota
-        delta_rate = (config::datacache_disk_safe_level - max_disk_used_rate) / _min_disk_dirs;
-        DCHECK_LT(delta_rate, 0);
-    }
-    _update_spaces_by_cache_usage();
-
-    int64_t total_cache_quota = 0;
-    for (const auto& pair : _disk_to_dirs) {
-        const auto& disk_id = pair.first;
-        const auto& dirs = pair.second;
-        const auto& disk = _disk_stats[disk_id];
-        int64_t delta_quota = disk.capacity_bytes / 100 * delta_rate;
-        size_t disk_cache_quota = 0;
-        for (uint32_t dir_index : dirs) {
-            auto& dir_space = _dir_spaces[dir_index];
-            dir_space.size += delta_quota;
-            dir_space.size = dir_space.size / QUOTA_ALIGN_UNIT * QUOTA_ALIGN_UNIT;
-            disk_cache_quota += dir_space.size;
-        }
-        total_cache_quota += disk_cache_quota;
-    }
-
-    _disk_free_period = 0;
-    if (total_cache_quota < config::datacache_min_disk_quota_for_adjustment) {
-        // If the current available disk space is too small, cache quota will be reset to zero to avoid overly frequent
-        // population and eviction.
-        _reset_spaces();
-        if (_total_cache_quota == 0) {
-            // If the cache quata is already zero, skip adjusting it repeatedly.
-            VLOG(1) << "Skip updating the cache quota because the target quota is less than "
-                    << "`datacache_min_disk_quota_for_adjustment`, target cache quota: " << total_cache_quota;
-            total_cache_quota = 0;
-            return false;
-        } else {
-            // This warning log only be printed when the cache disk quota is adjust from a non-zero integer to zero.
-            LOG(WARNING) << "The current available disk space is too small, so disable the disk cache directly. If you "
-                         << "still need it, you could reduce the value of `datacache_min_disk_quota_for_adjustment`";
-            total_cache_quota = 0;
-        }
-    }
-    LOG(INFO) << "Adjusting datacache disk quota from " << _total_cache_quota << " to " << total_cache_quota;
-    return true;
-}
-
-void DiskSpaceMonitor::_reset_spaces() {
-    for (auto& dir_space : _dir_spaces) {
-        dir_space.size = 0;
-    }
-}
-
-Status DiskSpaceMonitor::adjust_cache_quota(const std::vector<DirSpace>& dir_spaces) {
-    _adjusting.store(true, std::memory_order_release);
+Status DiskSpaceMonitor::_update_cache_quota(const std::vector<DirSpace>& dir_spaces) {
+    _updating.store(true, std::memory_order_release);
     Status st = _cache->update_disk_spaces(dir_spaces);
-    _adjusting.store(false, std::memory_order_release);
+    _updating.store(false, std::memory_order_release);
     return st;
 }
 

--- a/be/src/cache/block_cache/disk_space_monitor.h
+++ b/be/src/cache/block_cache/disk_space_monitor.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <sys/stat.h>
+
 #include <atomic>
 #include <mutex>
 #include <thread>
@@ -27,15 +29,9 @@
 namespace starrocks {
 
 class BlockCache;
-class DiskSpaceMonitor {
-public:
-    struct DiskStats {
-        int disk_id = 0;
-        std::string path;
-        size_t capacity_bytes = 0;
-        size_t available_bytes = 0;
-    };
 
+class DiskSpace {
+public:
     // Wrap a new class to make it easy controlled in unittest.
     class FileSystemWrapper {
     public:
@@ -43,13 +39,73 @@ public:
 
         virtual StatusOr<size_t> directory_size(const std::string& dir);
 
-        virtual int disk_id(const std::string& path) { return DiskInfo::disk_id(path.c_str()); }
+        virtual dev_t device_id(const std::string& path);
 
         virtual ~FileSystemWrapper() {}
     };
 
+    struct DiskStats {
+        int64_t capacity_bytes = 0;
+        int64_t available_bytes = 0;
+
+        double used_rate() { return static_cast<double>(capacity_bytes - available_bytes) / capacity_bytes; }
+    };
+
+    struct AdjustContext {
+        size_t total_cache_quota = 0;
+        size_t total_cache_usage = 0;
+    };
+
+    DiskSpace(dev_t device_id, const std::string& path, std::shared_ptr<FileSystemWrapper> fs)
+            : _device_id(device_id), _path(path), _fs(fs) {}
+
+    Status init_spaces(const std::vector<DirSpace>& dir_spaces);
+
+    bool adjust_spaces(const AdjustContext& ctx);
+
+    std::vector<DirSpace>& dir_spaces() { return _dir_spaces; }
+
+    size_t total_cache_quota();
+
+    // The align unit when adjusting cache disk quota. We set it to 10G to keep consistent with underlying cache file size,
+    // which can help reduce processing the specail tail files.
+    const static size_t kQuotaAlignUnit;
+
+    // The cache usage threshold for automatically increase disk quota, if the cache usage is under this level,
+    // the disk expansion will be skipped.
+    // NOTICE: When users update the disk quota manually, this threshold will be ignored.
+    const static double kAutoIncreaseThreshold;
+
+private:
+    Status _update_disk_stats();
+
+    void _revise_disk_stats_by_cache_dir();
+
+    void _update_spaces_by_cache_usage(const AdjustContext& ctx);
+
+    void _update_spaces_by_cache_quota(size_t cache_avalil_bytes);
+
+    bool _allow_expansion(const AdjustContext& ctx);
+
+    size_t _check_cache_low_limit(int64_t cache_quota);
+
+    dev_t _device_id = 0;
+    std::string _path;
+    DiskStats _disk_stats;
+
+    // The datacache can be configured to have multiple data directories on the same physical disk.
+    std::vector<DirSpace> _dir_spaces;
+    std::shared_ptr<FileSystemWrapper> _fs = nullptr;
+    int64_t _disk_free_period = 0;
+    bool _disabled = false;
+};
+
+class DiskSpaceMonitor {
+public:
     DiskSpaceMonitor(BlockCache* cache);
     ~DiskSpaceMonitor();
+
+    Status init(std::vector<DirSpace>* dir_spaces);
 
     void start();
 
@@ -57,61 +113,30 @@ public:
 
     bool is_stopped();
 
-    bool adjust_spaces(std::vector<DirSpace>* dir_spaces);
+    std::vector<DirSpace> all_dir_spaces();
 
-    Status check_spaces();
-
-    Status adjust_cache_quota(const std::vector<DirSpace>& dir_spaces);
-
-    // The align unit when adjusting cache disk quota. We set it to 10G to keep consistent with underlying cache file size,
-    // which can help reduce processing the specail tail files.
-    const static size_t QUOTA_ALIGN_UNIT;
-    // The cache usage threshold for automatically increase disk quota, if the cache usage is under this level,
-    // the disk expansion will be skipped.
-    // NOTICE: When users update the disk quota manually, this threshold will be ignored.
-    const static int64_t AUTO_INCREASE_THRESHOLD;
+    static std::string to_string(const std::vector<DirSpace>& dir_spaces);
 
 private:
-    void _update_disk_stats();
-    void _update_cache_stats();
-    void _reset_spaces();
-    void _init_spaces_by_cache_dir();
-    void _update_spaces_by_cache_usage();
-    bool _adjust_spaces_by_disk_usage(bool immediate);
-
-    int64_t _max_disk_used_rate();
-
     void _adjust_datacache_callback();
 
-    void _reset() {
-        _dir_spaces.clear();
-        _disk_stats.clear();
-        _disk_to_dirs.clear();
-    }
+    bool _adjust_spaces_by_disk_usage();
 
-    std::vector<DirSpace> _dir_spaces;
-    // <disk_id, DiskStats>
-    std::unordered_map<int, DiskStats> _disk_stats;
+    void _update_cache_stats();
 
-    // The datacache can be configured to have multiple data directories on the same physical disk.
-    // <disk_id, dir_space_index_list>
-    std::unordered_map<int, std::vector<uint32_t>> _disk_to_dirs;
-    // Max directory count in one disk
-    size_t _max_disk_dirs = 0;
-    // Minimum directory count in one disk
-    size_t _min_disk_dirs = 0;
+    Status _update_cache_quota(const std::vector<DirSpace>& dir_spaces);
 
-    size_t _total_cache_usage = 0;
-    size_t _total_cache_quota = 0;
-    int64_t _disk_free_period = 0;
+    std::vector<DiskSpace> _disk_spaces;
 
     std::atomic<bool> _stopped = true;
-    std::atomic<bool> _adjusting = false;
+    std::atomic<bool> _updating = false;
     std::thread _adjust_datacache_thread;
     std::mutex _mutex;
 
-    std::unique_ptr<FileSystemWrapper> _fs = nullptr;
+    size_t _total_cache_usage = 0;
+    size_t _total_cache_quota = 0;
     BlockCache* _cache = nullptr;
+    std::shared_ptr<DiskSpace::FileSystemWrapper> _fs = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -129,8 +129,7 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 }
                 space.size = disk_size;
             }
-            Status st = BlockCache::instance()->adjust_disk_spaces(spaces);
-            return st;
+            return BlockCache::instance()->update_disk_spaces(spaces);
         });
         _config_callback.emplace("max_compaction_concurrency", [&]() -> Status {
             if (!config::enable_event_based_compaction_framework) {


### PR DESCRIPTION
## Why I'm doing:
Currently we adjust the cache quota for different disks with a same granularity, which is not friendly for multiple disks with different size. And it will leads to insufficient utilization of remaining disk space. 

## What I'm doing:
* Adjust the cache quota with different adjustment size for multiple disks. Each disk checks its own disk size and current usage, and then calculates a suitable target size for cache quota adjustment.
* Repace the old `disk_id` with `device_id` for disk instances, because the `DiskInfo::disk_id()` may return -1 in some virtualization environments.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0