### PR TITLE
[BugFix] fix use cpuids after erased

### DIFF
--- a/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
+++ b/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
@@ -91,11 +91,11 @@ void ExecutorsManager::reclaim_cpuids_from_worgroup(WorkGroup* wg) {
               << "[cpuids=" << CpuUtil::to_string(cpuids) << "] ";
 
     std::ranges::copy(cpuids, std::back_inserter(_wg_to_cpuids[COMMON_WORKGROUP]));
-    _wg_to_cpuids.erase(wg);
-
     for (auto cpuid : cpuids) {
         _cpu_owners[cpuid].set_wg(COMMON_WORKGROUP);
     }
+
+    _wg_to_cpuids.erase(wg);
 }
 
 const CpuUtil::CpuIds& ExecutorsManager::get_cpuids_of_workgroup(WorkGroup* wg) const {


### PR DESCRIPTION
## Why I'm doing:

`cpuids` is stored in `_wg_to_cpuids[wg]`. After `_wg_to_cpuids.erase(wg)`, `cpuids` cannot be used anymore.

```cpp
void ExecutorsManager::reclaim_cpuids_from_worgroup(WorkGroup* wg) {
    const auto& cpuids = get_cpuids_of_workgroup(wg);
    if (cpuids.empty()) {
        return;
    }
    LOG(INFO) << "[WORKGROUP] reclaim cpuids from workgroup "
              << "[workgroup=" << wg->to_string() << "] "
              << "[cpuids=" << CpuUtil::to_string(cpuids) << "] ";

    std::ranges::copy(cpuids, std::back_inserter(_wg_to_cpuids[COMMON_WORKGROUP]));

    _wg_to_cpuids.erase(wg);              // <----- erase 
    for (auto cpuid : cpuids) {                // <------ use erased cpuids
        _cpu_owners[cpuid].set_wg(COMMON_WORKGROUP);
    }
}
```

The crash stack is as follows:
```
Ignored unknown config: starlet_port
I00000000 00:00:00.000000 140489753276736 vlog_is_on.cc:197] RAW: Set VLOG level for "*" to 10
=================================================================
==2747428==ERROR: AddressSanitizer: heap-use-after-free on address 0x5040001741e0 at pc 0x00000b9de92f bp 0x7fbe362d6420 sp 0x7fbe362d6418
READ of size 8 at 0x5040001741e0 thread T1757
    #0 0xb9de92e in __gnu_cxx::__normal_iterator<unsigned long const*, std::vector<unsigned long, std::allocator<unsigned long> > >::__normal_iterator(unsigned long const* const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/stl_iterator.h:1068
    #1 0xb9d2c3c in std::vector<unsigned long, std::allocator<unsigned long> >::begin() const /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/stl_vector.h:884
    #2 0xfbe0560 in starrocks::workgroup::ExecutorsManager::reclaim_cpuids_from_worgroup(starrocks::workgroup::WorkGroup*) be/src/exec/workgroup/pipeline_executor_set_manager.cpp:96
    #3 0xef46ea5 in starrocks::workgroup::WorkGroupManager::create_workgroup_unlocked(std::shared_ptr<starrocks::workgroup::WorkGroup> const&, std::unique_lock<std::shared_mutex>&) be/src/exec/workgroup/work_group.cpp:555
    #4 0xef4753e in starrocks::workgroup::WorkGroupManager::alter_workgroup_unlocked(std::shared_ptr<starrocks::workgroup::WorkGroup> const&, std::unique_lock<std::shared_mutex>&) be/src/exec/workgroup/work_group.cpp:586
    #5 0xef46564 in starrocks::workgroup::WorkGroupManager::apply(std::vector<starrocks::TWorkGroupOp, std::allocator<starrocks::TWorkGroupOp> > const&) be/src/exec/workgroup/work_group.cpp:526
    #6 0xd318631 in starrocks::ReportWorkgroupTaskWorkerPool::_worker_thread_callback(void*) be/src/agent/task_worker_pool.cpp:767
    #7 0xd347e5d in void* std::__invoke_impl<void*, void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>(std::__invoke_other, void* (*&&)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*&&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:61
    #8 0xd347c83 in std::__invoke_result<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>::type std::__invoke<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>(void* (*&&)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*&&) /opt/rh/gcc-toolset-10
/root/usr/include/c++/14.2.0/bits/invoke.h:96
    #9 0xd347b60 in void* std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:301
    #10 0xd347ae7 in std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> >::operator()() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:308
    #11 0xd347a8b in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> > >::_M_run() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:253
    #12 0x1f5389cf in execute_native_thread_routine ../../../.././libstdc++-v3/src/c++11/thread.cc:104
    #13 0xb68d291 in asan_thread_start ../../.././libsanitizer/asan/asan_interceptors.cpp:234
    #14 0x7fc651e03ac2 in start_thread nptl/pthread_create.c:442
    #15 0x7fc651e9584f in __GI___clone3 (/lib/x86_64-linux-gnu/libc.so.6+0x12684f) (BuildId: cd410b710f0f094c6832edd95931006d883af48e)

0x5040001741e0 is located 16 bytes inside of 40-byte region [0x5040001741d0,0x5040001741f8)
freed by thread T1757 here:
    #0 0xb725de0 in operator delete(void*) ../../.././libsanitizer/asan/asan_new_delete.cpp:152
    #1 0xef60ac7 in std::__new_allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false> >::deallocate(std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false>*, unsigne
d long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/new_allocator.h:172
    #2 0xef5ca1d in std::allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false> >::deallocate(std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false>*, unsigned long
) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/allocator.h:208
    #3 0xef5ca1d in std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false> > >::deallocate(std::allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<uns
igned long> > >, false> >&, std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false>*, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/alloc_traits.h:513
    #4 0xef5ca1d in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false> > >::_M_deallocate_node_ptr(std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::alloca
tor<unsigned long> > >, false>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/hashtable_policy.h:2051
    #5 0xef5863e in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false> > >::_M_deallocate_node(std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<
unsigned long> > >, false>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/hashtable_policy.h:2041
    #6 0xfbeb4cc in std::_Hashtable<starrocks::workgroup::WorkGroup*, std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, std::allocator<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > > >, std::__detail::_Select1st, std::equal_to<st
arrocks::workgroup::WorkGroup*>, std::hash<starrocks::workgroup::WorkGroup*>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_erase(unsigned long, std::__detail::_Hash_node_base*, std::__detail::_Hash_node<std::pair<starrocks::workgro
up::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/hashtable.h:2413
    #7 0xfbe9240 in std::_Hashtable<starrocks::workgroup::WorkGroup*, std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, std::allocator<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > > >, std::__detail::_Select1st, std::equal_to<st
arrocks::workgroup::WorkGroup*>, std::hash<starrocks::workgroup::WorkGroup*>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_erase(std::integral_constant<bool, true>, starrocks::workgroup::WorkGroup* const&) /opt/rh/gcc-toolset-10/ro
ot/usr/include/c++/14.2.0/bits/hashtable.h:2456
    #8 0xfbe7764 in std::_Hashtable<starrocks::workgroup::WorkGroup*, std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, std::allocator<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > > >, std::__detail::_Select1st, std::equal_to<st
arrocks::workgroup::WorkGroup*>, std::hash<starrocks::workgroup::WorkGroup*>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::erase(starrocks::workgroup::WorkGroup* const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/hashtabl
e.h:1024
    #9 0xfbe52ce in std::unordered_map<starrocks::workgroup::WorkGroup*, std::vector<unsigned long, std::allocator<unsigned long> >, std::hash<starrocks::workgroup::WorkGroup*>, std::equal_to<starrocks::workgroup::WorkGroup*>, std::allocator<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > > >
 >::erase(starrocks::workgroup::WorkGroup* const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/unordered_map.h:771
    #10 0xfbe050b in starrocks::workgroup::ExecutorsManager::reclaim_cpuids_from_worgroup(starrocks::workgroup::WorkGroup*) be/src/exec/workgroup/pipeline_executor_set_manager.cpp:94
    #11 0xef46ea5 in starrocks::workgroup::WorkGroupManager::create_workgroup_unlocked(std::shared_ptr<starrocks::workgroup::WorkGroup> const&, std::unique_lock<std::shared_mutex>&) be/src/exec/workgroup/work_group.cpp:555
    #12 0xef4753e in starrocks::workgroup::WorkGroupManager::alter_workgroup_unlocked(std::shared_ptr<starrocks::workgroup::WorkGroup> const&, std::unique_lock<std::shared_mutex>&) be/src/exec/workgroup/work_group.cpp:586
    #13 0xef46564 in starrocks::workgroup::WorkGroupManager::apply(std::vector<starrocks::TWorkGroupOp, std::allocator<starrocks::TWorkGroupOp> > const&) be/src/exec/workgroup/work_group.cpp:526
    #14 0xd318631 in starrocks::ReportWorkgroupTaskWorkerPool::_worker_thread_callback(void*) be/src/agent/task_worker_pool.cpp:767
    #15 0xd347e5d in void* std::__invoke_impl<void*, void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>(std::__invoke_other, void* (*&&)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*&&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:61
    #16 0xd347c83 in std::__invoke_result<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>::type std::__invoke<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>(void* (*&&)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*&&) /opt/rh/gcc-toolset-1
0/root/usr/include/c++/14.2.0/bits/invoke.h:96
    #17 0xd347b60 in void* std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:301
    #18 0xd347ae7 in std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> >::operator()() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:308
    #19 0xd347a8b in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> > >::_M_run() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:253
    #20 0x1f5389cf in execute_native_thread_routine ../../../.././libstdc++-v3/src/c++11/thread.cc:104

previously allocated by thread T1757 here:
    #0 0xb7253a8 in operator new(unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cpp:95
    #1 0xfbeb711 in std::__new_allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false> >::allocate(unsigned long, void const*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/new_allocator.h:151
    #2 0xfbe9833 in std::allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false> >::allocate(unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/allocator.h:196
    #3 0xfbe9833 in std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false> > >::allocate(std::allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsig
ned long> > >, false> >&, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/alloc_traits.h:478
    #4 0xfbe9833 in std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false>* std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, fal
se> > >::_M_allocate_node<std::piecewise_construct_t const&, std::tuple<starrocks::workgroup::WorkGroup* const&>, std::tuple<> >(std::piecewise_construct_t const&, std::tuple<starrocks::workgroup::WorkGroup* const&>&&, std::tuple<>&&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/hashtable_policy.h:2019
    #5 0xfbe7ff7 in std::_Hashtable<starrocks::workgroup::WorkGroup*, std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, std::allocator<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > > >, std::__detail::_Select1st, std::equal_to<st
arrocks::workgroup::WorkGroup*>, std::hash<starrocks::workgroup::WorkGroup*>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_Scoped_node::_Scoped_node<std::piecewise_construct_t const&, std::tuple<starrocks::workgroup::WorkGroup* const
&>, std::tuple<> >(std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, false> > >*, std::piecewise_construct_t const&, std::tuple<starrocks::workgroup::WorkGroup* const&>&&, std::tuple<>&&) /opt/rh/gcc-toolset-10/root/usr
/include/c++/14.2.0/bits/hashtable.h:312
    #6 0xfbe5c5f in std::__detail::_Map_base<starrocks::workgroup::WorkGroup*, std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > >, std::allocator<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > > >, std::__detail::_Select1st, std::eq
ual_to<starrocks::workgroup::WorkGroup*>, std::hash<starrocks::workgroup::WorkGroup*>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true>, true>::operator[](starrocks::workgroup::WorkGroup* const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/1
4.2.0/bits/hashtable_policy.h:843
    #7 0xfbe4832 in std::unordered_map<starrocks::workgroup::WorkGroup*, std::vector<unsigned long, std::allocator<unsigned long> >, std::hash<starrocks::workgroup::WorkGroup*>, std::equal_to<starrocks::workgroup::WorkGroup*>, std::allocator<std::pair<starrocks::workgroup::WorkGroup* const, std::vector<unsigned long, std::allocator<unsigned long> > > >
 >::operator[](starrocks::workgroup::WorkGroup* const&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/unordered_map.h:988
    #8 0xfbdffd3 in starrocks::workgroup::ExecutorsManager::assign_cpuids_to_workgroup(starrocks::workgroup::WorkGroup*) be/src/exec/workgroup/pipeline_executor_set_manager.cpp:76
    #9 0xef4710f in starrocks::workgroup::WorkGroupManager::create_workgroup_unlocked(std::shared_ptr<starrocks::workgroup::WorkGroup> const&, std::unique_lock<std::shared_mutex>&) be/src/exec/workgroup/work_group.cpp:567
    #10 0xef46542 in starrocks::workgroup::WorkGroupManager::apply(std::vector<starrocks::TWorkGroupOp, std::allocator<starrocks::TWorkGroupOp> > const&) be/src/exec/workgroup/work_group.cpp:523
    #11 0xd318631 in starrocks::ReportWorkgroupTaskWorkerPool::_worker_thread_callback(void*) be/src/agent/task_worker_pool.cpp:767
    #12 0xd347e5d in void* std::__invoke_impl<void*, void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>(std::__invoke_other, void* (*&&)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*&&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/invoke.h:61
    #13 0xd347c83 in std::__invoke_result<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>::type std::__invoke<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*>(void* (*&&)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*&&) /opt/rh/gcc-toolset-1
0/root/usr/include/c++/14.2.0/bits/invoke.h:96
    #14 0xd347b60 in void* std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:301
    #15 0xd347ae7 in std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> >::operator()() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:308
    #16 0xd347a8b in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void* (*)(void*), starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>*> > >::_M_run() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.2.0/bits/std_thread.h:253
    #17 0x1f5389cf in execute_native_thread_routine ../../../.././libstdc++-v3/src/c++11/thread.cc:104

Thread T1757 created by T0 here:
    #0 0xb71c86d in pthread_create ../../.././libsanitizer/asan/asan_interceptors.cpp:245
    #1 0x1f538ac8 in __gthread_create /workspace/gcc/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:676
    #2 0x1f538ac8 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) ../../../.././libstdc++-v3/src/c++11/thread.cc:172
    #3 0xd3283b4 in starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>::_spawn_callback_worker_thread(void* (*)(void*)) be/src/agent/task_worker_pool.cpp:279
    #4 0xd326495 in starrocks::TaskWorkerPool<starrocks::AgentTaskRequestWithoutReqBody>::start() be/src/agent/task_worker_pool.cpp:138
    #5 0xd2678bd in starrocks::AgentServer::Impl::init_or_die() be/src/agent/agent_server.cpp:295
    #6 0xd285af9 in starrocks::AgentServer::init_or_die() be/src/agent/agent_server.cpp:801
    #7 0xb99946f in starrocks::ExecEnv::init(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/runtime/exec_env.cpp:575
    #8 0xbf5e440 in starrocks::start_be(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/service/service_be/starrocks_be.cpp:208
    #9 0xb77ded0 in main be/src/service/starrocks_main.cpp:258
    #10 0x7fc651d98d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58


```

## What I'm doing:

Fixes #56237

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0