### PR TITLE
[Enhancement] Use min_version of tablet to avoid vacuum throwing file not found exception

### DIFF
--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -515,7 +515,7 @@ TEST_P(LakeVacuumTest, test_vacuum_3) {
 
         ensure_all_files_exist();
     }
-    // Invalid request: "tablet_ids()" is empty
+    // Invalid request: "tablet_ids()" and "tablet_infos" are empty
     {
         VacuumRequest request;
         VacuumResponse response;
@@ -526,7 +526,7 @@ TEST_P(LakeVacuumTest, test_vacuum_3) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         ASSERT_NE(0, response.status().status_code());
-        EXPECT_TRUE(MatchPattern(response.status().error_msgs(0), "*tablet_ids is empty*"))
+        EXPECT_TRUE(MatchPattern(response.status().error_msgs(0), "*both tablet_ids and tablet_infos are empty*"))
                 << response.status().error_msgs(0);
         EXPECT_EQ(0, response.vacuumed_files());
         EXPECT_EQ(0, response.vacuumed_file_size());

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
@@ -42,7 +42,7 @@ import java.util.List;
  */
 public class LakeTabletsProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("TabletId").add("BackendId").add("DataSize").add("RowCount")
+            .add("TabletId").add("BackendId").add("DataSize").add("RowCount").add("MinVersion")
             .build();
 
     private final Database db;
@@ -83,6 +83,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                 tabletInfo.add(new Gson().toJson(lakeTablet.getBackendIds(ConnectContext.get().getCurrentWarehouseId())));
                 tabletInfo.add(new ByteSizeValue(lakeTablet.getDataSize(true)));
                 tabletInfo.add(lakeTablet.getRowCount(0L));
+                tabletInfo.add(lakeTablet.getMinVersion());
                 tabletInfos.add(tabletInfo);
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -58,6 +58,8 @@ public class LakeTablet extends Tablet {
     @SerializedName(value = JSON_KEY_DATA_SIZE_UPDATE_TIME)
     private volatile long dataSizeUpdateTime = 0L;
 
+    private volatile long minVersion = 0L;
+
     public long rebuildPindexVersion = 0L;
 
     public LakeTablet(long id) {
@@ -84,6 +86,14 @@ public class LakeTablet extends Tablet {
 
     public long getDataSizeUpdateTime() {
         return dataSizeUpdateTime;
+    }
+
+    public long getMinVersion() {
+        return minVersion;
+    }
+
+    public void setMinVersion(long minVersion) {
+        this.minVersion = minVersion;
     }
 
     // version is not used

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -17,16 +17,21 @@ package com.starrocks.lake.vacuum;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.proto.TabletInfoPB;
 import com.starrocks.proto.VacuumRequest;
 import com.starrocks.proto.VacuumResponse;
 import com.starrocks.rpc.BrpcProxy;
@@ -152,17 +157,19 @@ public class AutovacuumDaemon extends FrontendDaemon {
     }
 
     private void vacuumPartitionImpl(Database db, OlapTable table, PhysicalPartition partition) {
-        List<Tablet> tablets;
+        List<Tablet> tablets = new ArrayList<>();
         long visibleVersion;
         long minRetainVersion;
         long startTime = System.currentTimeMillis();
         long minActiveTxnId = computeMinActiveTxnId(db, table);
-        Map<ComputeNode, List<Long>> nodeToTablets = new HashMap<>();
+        Map<ComputeNode, List<TabletInfoPB>> nodeToTablets = new HashMap<>();
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         try {
-            tablets = partition.getBaseIndex().getTablets();
+            for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                tablets.addAll(index.getTablets());
+            }
             visibleVersion = partition.getVisibleVersion();
             minRetainVersion = partition.getMinRetainVersion();
             if (minRetainVersion <= 0) {
@@ -172,15 +179,19 @@ public class AutovacuumDaemon extends FrontendDaemon {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         }
 
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        Warehouse warehouse = warehouseManager.getBackgroundWarehouse();
         for (Tablet tablet : tablets) {
-            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-            Warehouse warehouse = warehouseManager.getBackgroundWarehouse();
-            ComputeNode node = warehouseManager.getComputeNodeAssignedToTablet(warehouse.getName(), (LakeTablet) tablet);
+            LakeTablet lakeTablet = (LakeTablet) tablet;
+            ComputeNode node = warehouseManager.getComputeNodeAssignedToTablet(warehouse.getId(), lakeTablet);
 
             if (node == null) {
                 return;
             }
-            nodeToTablets.computeIfAbsent(node, k -> Lists.newArrayList()).add(tablet.getId());
+            TabletInfoPB tabletInfo = new TabletInfoPB();
+            tabletInfo.setTabletId(tablet.getId());
+            tabletInfo.setMinVersion(lakeTablet.getMinVersion());
+            nodeToTablets.computeIfAbsent(node, k -> Lists.newArrayList()).add(tabletInfo);
         }
 
         boolean hasError = false;
@@ -189,10 +200,11 @@ public class AutovacuumDaemon extends FrontendDaemon {
         long vacuumedVersion = Long.MAX_VALUE;
         boolean needDeleteTxnLog = true;
         List<Future<VacuumResponse>> responseFutures = Lists.newArrayListWithCapacity(nodeToTablets.size());
-        for (Map.Entry<ComputeNode, List<Long>> entry : nodeToTablets.entrySet()) {
+        for (Map.Entry<ComputeNode, List<TabletInfoPB>> entry : nodeToTablets.entrySet()) {
             ComputeNode node = entry.getKey();
             VacuumRequest vacuumRequest = new VacuumRequest();
-            vacuumRequest.tabletIds = entry.getValue();
+            // vacuumRequest.tabletIds is deprecated, use tabletInfos instead.
+            vacuumRequest.tabletInfos = entry.getValue();
             vacuumRequest.minRetainVersion = minRetainVersion;
             vacuumRequest.graceTimestamp =
                     startTime / MILLISECONDS_PER_SECOND - Config.lake_autovacuum_grace_period_minutes * 60;
@@ -226,6 +238,23 @@ public class AutovacuumDaemon extends FrontendDaemon {
                     vacuumedFiles += response.vacuumedFiles;
                     vacuumedFileSize += response.vacuumedFileSize;
                     vacuumedVersion = Math.min(vacuumedVersion, response.vacuumedVersion);
+
+                    if (response.tabletInfos != null) {
+                        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+                        for (TabletInfoPB tabletInfo : response.tabletInfos) {
+                            TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletInfo.tabletId);
+                            if (tabletMeta != null) {
+                                MaterializedIndex index = partition.getIndex(tabletMeta.getIndexId());
+                                if (index != null) {
+                                    Tablet tablet = index.getTablet(tabletInfo.tabletId);
+                                    if (tablet != null) {
+                                        LakeTablet lakeTablet = (LakeTablet) tablet;
+                                        lakeTablet.setMinVersion(tabletInfo.minVersion);
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             } catch (InterruptedException e) {
                 LOG.warn("thread interrupted");

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.Future;
 
@@ -118,6 +119,7 @@ public class VacuumTest {
         mockResponse.vacuumedFiles = 10L;
         mockResponse.vacuumedFileSize = 1024L;
         mockResponse.vacuumedVersion = 5L;
+        mockResponse.tabletInfos = new ArrayList<>();
 
         Future<VacuumResponse> mockFuture = mock(Future.class);
         when(mockFuture.get()).thenReturn(mockResponse);
@@ -151,6 +153,7 @@ public class VacuumTest {
         mockResponse.vacuumedFiles = 10L;
         mockResponse.vacuumedFileSize = 1024L;
         mockResponse.vacuumedVersion = 5L;
+        mockResponse.tabletInfos = new ArrayList<>();
 
         Future<VacuumResponse> mockFuture = mock(Future.class);
         when(mockFuture.get()).thenReturn(mockResponse);

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -243,9 +243,14 @@ message AbortCompactionResponse {
     optional StatusPB status = 1;
 }
 
+message TabletInfoPB {
+    optional int64 tablet_id = 1;
+    optional int64 min_version = 2;
+}
+
 message VacuumRequest {
-    // All tablets must be in the same partition.
-    repeated int64 tablet_ids = 1;
+    // This field is deprecated, use |tablet_infos| instead.
+    repeated int64 tablet_ids = 1 [deprecated = true]; // deprecated
     // Tablet metadata files with version numbers greater than or equals to min_retain_version
     // will NOT be vacuumed. For tablet metadata files with version numbers less than
     // min_retain_version, decide whether they should be deleted by comparing the create time
@@ -262,6 +267,8 @@ message VacuumRequest {
     optional bool delete_txn_log = 5;
     // ID of the partition the tablet belongs to.
     optional int64 partition_id = 6;
+    // The tablet infos to be vacuumed.
+    repeated TabletInfoPB tablet_infos = 7;
 }
 
 message VacuumResponse {
@@ -272,6 +279,8 @@ message VacuumResponse {
     optional int64 vacuumed_file_size = 3;
     // The versions before vacuumed_version are vacuumed
     optional int64 vacuumed_version = 4;
+    // The tablet infos of vacuumed tablets.
+    repeated TabletInfoPB tablet_infos = 5;
 }
 
 message VacuumFullRequest {


### PR DESCRIPTION
## Why I'm doing:
Vacuum iterates tablet metadata versions until a file not found error occurred, causing following problems:
1. Redundant and useless `getObject` api call, this will increase api cost.
2. Too many file not found exception log when using HDFS as shared-data storage.

## What I'm doing:
Use min_version of tablet to avoid vacuum throwing file not found exception

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0