### PR TITLE
[Enhancement] record audit stats for all statements

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -229,6 +229,24 @@ public class AuditEvent {
             return this;
         }
 
+        public AuditEventBuilder addScanBytes(long scanBytes) {
+            if (auditEvent.scanBytes == -1) {
+                auditEvent.scanBytes = scanBytes;
+            } else {
+                auditEvent.scanBytes += scanBytes;
+            }
+            return this;
+        }
+
+        public AuditEventBuilder addScanRows(long scanRows) {
+            if (auditEvent.scanRows == -1) {
+                auditEvent.scanRows = scanRows;
+            } else {
+                auditEvent.scanRows += scanRows;
+            }
+            return this;
+        }
+
         /**
          * Cpu cost in nanoseconds
          */
@@ -237,13 +255,30 @@ public class AuditEvent {
             return this;
         }
 
-        public AuditEventBuilder setMemCostBytes(long memCostBytes) {
-            auditEvent.memCostBytes = memCostBytes;
+        public AuditEventBuilder addCpuCostNs(long cpuNs) {
+            if (auditEvent.cpuCostNs == -1) {
+                auditEvent.cpuCostNs = cpuNs;
+            } else {
+                auditEvent.cpuCostNs += cpuNs;
+            }
             return this;
         }
 
-        public AuditEventBuilder setSpilledBytes(long spilledBytes) {
-            auditEvent.spilledBytes = spilledBytes;
+        public AuditEventBuilder addMemCostBytes(long memCostBytes) {
+            if (auditEvent.memCostBytes == -1) {
+                auditEvent.memCostBytes = memCostBytes;
+            } else {
+                auditEvent.memCostBytes = Math.max(auditEvent.memCostBytes, memCostBytes);
+            }
+            return this;
+        }
+
+        public AuditEventBuilder addSpilledBytes(long spilledBytes) {
+            if (auditEvent.spilledBytes == -1) {
+                auditEvent.spilledBytes = spilledBytes;
+            } else {
+                auditEvent.spilledBytes += spilledBytes;
+            }
             return this;
         }
 
@@ -348,6 +383,16 @@ public class AuditEvent {
 
         public AuditEvent build() {
             return this.auditEvent;
+        }
+
+        // Copy execution statistics from another audit event
+        public void copyExecStatsFrom(AuditEvent event) {
+            this.auditEvent.cpuCostNs = event.cpuCostNs;
+            this.auditEvent.memCostBytes = event.memCostBytes;
+            this.auditEvent.scanBytes = event.scanBytes;
+            this.auditEvent.scanRows = event.scanRows;
+            this.auditEvent.spilledBytes = event.spilledBytes;
+            this.auditEvent.returnRows = event.returnRows;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -202,14 +202,6 @@ public class ConnectProcessor {
                 .setStmtId(ctx.getStmtId())
                 .setIsForwardToLeader(isForwardToLeader)
                 .setQueryId(ctx.getQueryId() == null ? "NaN" : ctx.getQueryId().toString());
-        if (statistics != null) {
-            ctx.getAuditEventBuilder().setScanBytes(statistics.scanBytes);
-            ctx.getAuditEventBuilder().setScanRows(statistics.scanRows);
-            ctx.getAuditEventBuilder().setCpuCostNs(statistics.cpuCostNs == null ? -1 : statistics.cpuCostNs);
-            ctx.getAuditEventBuilder().setMemCostBytes(statistics.memCostBytes == null ? -1 : statistics.memCostBytes);
-            ctx.getAuditEventBuilder().setSpilledBytes(statistics.spillBytes == null ? -1 : statistics.spillBytes);
-            ctx.getAuditEventBuilder().setReturnRows(statistics.returnedRows == null ? 0 : statistics.returnedRows);
-        }
 
         if (ctx.getState().isQuery()) {
             MetricRepo.COUNTER_QUERY_ALL.increase(1L);


### PR DESCRIPTION
## Why I'm doing:

Audit fields such as `scanBytes`, `scanRows`, `cpuCostNs`, `memCostBytes`, and `spilledBytes` are currently supported only by SELECT/INSERT statements, which limits cost attribution analysis.

We aim to extend support for these audit fields to all statement types, including `ANALYZE TABLE`, `CREATE TABLE AS SELECT`, and others.


## What I'm doing:


To support this, we modify the execution process of all queries:
1. **Collect statistics from query**: `processQueryStatisticsFromResult`
    - This is already supported by `StmtExecutor::execute`. We now extend the support to `StmtExecutor::executeStmtWithExecPlan`.

2. **Record the statistics into context**: `recordExecStatsIntoContext`
    - For certain statements that issue multiple sub-statements, we need to **accumulate** their statistics into the context.

3. **Copy into foreground context for specific statements**: 
    - For statements like `ANALYZE TABLE`, we copy the statistics into the foreground context.


Fixes #53856

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0