### PR TITLE
[Enhancement] Support writing partitioned data into Hive based on the…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -386,6 +386,8 @@ public class HiveMetadata implements ConnectorMetadata {
                         partitionColNames.size(), partitionValues.size());
                 if (hmsOps.partitionExists(table, partitionValues)) {
                     mode = isOverwrite ? UpdateMode.OVERWRITE : UpdateMode.APPEND;
+                    Partition partition = hmsOps.getPartition(dbName, tableName, partitionValues);
+                    partitionUpdate.updateTargetPathFromMeta(new Path(partition.getFullPath()));
                 } else {
                     mode = PartitionUpdate.UpdateMode.NEW;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/PartitionUpdate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/PartitionUpdate.java
@@ -32,7 +32,7 @@ public class PartitionUpdate {
     private final String name;
     private UpdateMode updateMode;
     private final Path writePath;
-    private final Path targetPath;
+    private Path targetPath;
     private final List<String> fileNames;
     private final long rowCount;
     private final long totalSizeInBytes;
@@ -81,6 +81,11 @@ public class PartitionUpdate {
 
     public PartitionUpdate setUpdateMode(UpdateMode updateMode) {
         this.updateMode = updateMode;
+        return this;
+    }
+
+    public PartitionUpdate updateTargetPathFromMeta(Path targetPath) {
+        this.targetPath = targetPath;
         return this;
     }
 


### PR DESCRIPTION
## Why I'm doing:
In our production, for Hive partitioned tables, we sometimes directly modify the partition location in MySQL to point to a different HDFS directory. For example, if the partition name is id=1, the path might be tablelocation/id=1. We execute a query like:
UPDATE SDS SET location = 'tablelocation/idback=1' WHERE SD_ID = xx;

However, in this scenario, if the partition is written to again, the data will still be written to the old directory (tablelocation/id=1) instead of the updated one (tablelocation/idback=1).

To address this, we need to adjust the logic in PartitionUpdate to ensure the write operations respect the updated partition location in MySQL.

## What I'm doing:
1.Change the targetPath field in the PartitionUpdate class from final to mutable.
2.In the finishSink method, if the UpdateMode is OVERWRITE or APPEND, get the partition location from the metastore metadata and update the targetPath field in the PartitionUpdate object accordingly.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0