### PR TITLE
[BugFix] Lake compaction scheduler might trigger redundant transaction which can cause CN crash

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1423,6 +1423,10 @@ public class GlobalStateMgr {
         taskRunStateSynchronizer.start();
 
         if (RunMode.isSharedDataMode()) {
+            // Need to rebuild active lake compaction transactions before lake scheduler starting to run
+            // Lake compactionMgr is started on all FE nodes and scheduler only starts to run when the FE is leader
+            compactionMgr.buildActiveCompactionTransactionMap();
+
             starMgrMetaSyncer.start();
             autovacuumDaemon.start();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
@@ -136,7 +136,7 @@ public class CompactionMgrTest {
 
             }
         };
-        compactionManager.rebuildActiveCompactionTransactionMapOnRestart();
+        compactionManager.buildActiveCompactionTransactionMap();
 
         Set<PartitionIdentifier> allPartitions = compactionManager.getAllPartitions();
         Assert.assertEquals(3, allPartitions.size());
@@ -297,7 +297,7 @@ public class CompactionMgrTest {
         };
 
         CompactionMgr compactionMgr = new CompactionMgr();
-        compactionMgr.rebuildActiveCompactionTransactionMapOnRestart();
+        compactionMgr.buildActiveCompactionTransactionMap();
         ConcurrentHashMap<Long, Long> activeCompactionTransactionMap =
                 compactionMgr.getRemainedActiveCompactionTxnWhenStart();
         Assert.assertEquals(1, activeCompactionTransactionMap.size());


### PR DESCRIPTION
## Why I'm doing:

1. PR #54881 tried to optimize lake compaction scheduler, we wanted to minimize the affect of unfinished compaction transaction blocking compaction scheduler from scheduling
2. We maintained a `active txn id` to `table id` Map in that PR, and the Map was built  on each startup time of FE
3. The lake compaction scheduler would block new compaction scheduling on tables in the Map only, which was our target for that optimization
4. However, we missed to rebuild the Map while leader role transferred to a new FE and the new leader FE doesn't restart. With new leader FE, all tables' compaction scheduling were not blocked, which could introduce duplicate compaction transactions on the same Partition/Tablet, and it can lead BE/CN crash

## What I'm doing:

Fixes #56260

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0