### PR TITLE
[Enhancement] Capture stack trace if load meets brpc timeout 

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -476,16 +476,22 @@ CONF_mInt32(load_rpc_slow_log_frequency_threshold_seconds, "60");
 // Whether to enable load diagnose. The diagnosis is initiated by OlapTableSink when meeting brpc timeout
 // from LoadChannel. It will send rpc to LoadChannel to check the status.
 CONF_mBool(enable_load_diagnose, "true");
-// If the rpc timeout exceeds this threshold, then diagnostics will be performed every time a timeout occurs;
-// if it is below this threshold, diagnostics will be performed once every 20 timeouts. This is used to avoid
-// frequent diagnostics for real-time loads which have a smaller brpc timeout.
-CONF_mInt32(load_diagnose_small_rpc_timeout_threshold_ms, "60000");
 // The timeout of the diagnosis rpc sent from OlapTableSink to LoadChannel
 CONF_mInt32(load_diagnose_send_rpc_timeout_ms, "2000");
+// If the rpc timeout exceeds this threshold, then profile diagnostics will be performed every time
+// a timeout occurs; if it is below this threshold, diagnostics will be performed once every 20 timeouts.
+// This is used to avoid frequent diagnostics for real-time loads which have a smaller brpc timeout.
+CONF_mInt32(load_diagnose_rpc_timeout_profile_threshold_ms, "60000");
+// If the rpc timeout exceeds this threshold, then stack trace diagnostics will be enabled.
+// OlapTableSink will send stack trace request to the target BE.
+CONF_mInt32(load_diagnose_rpc_timeout_stack_trace_threshold_ms, "600000");
 // Used in load fail point. The brpc timeout used to simulate brpc exception "[E1008]Reached timeout"
 CONF_mInt32(load_fp_brpc_timeout_ms, "-1");
 // Used in load fail point. The block time to simulate TabletsChannel::add_chunk spends much time
 CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
+
+// The interval for performing stack trace to control the frequency.
+CONF_mInt64(diagnose_stack_trace_interval_ms, "1800000");
 
 CONF_Bool(enable_load_segment_parallel, "false");
 CONF_Int32(load_segment_thread_pool_num_max, "128");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -489,6 +489,8 @@ CONF_mInt32(load_diagnose_rpc_timeout_stack_trace_threshold_ms, "600000");
 CONF_mInt32(load_fp_brpc_timeout_ms, "-1");
 // Used in load fail point. The block time to simulate TabletsChannel::add_chunk spends much time
 CONF_mInt32(load_fp_tablets_channel_add_chunk_block_ms, "-1");
+// Used in load fail point. The block time to simulate waiting secondary replica spends much time
+CONF_mInt32(load_fp_tablets_channel_wait_secondary_replica_block_ms, "-1");
 
 // The interval for performing stack trace to control the frequency.
 CONF_mInt64(diagnose_stack_trace_interval_ms, "1800000");

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -1082,7 +1082,7 @@ void NodeChannel::_cancel(int64_t index_id, const Status& err_st) {
     request.release_id();
 }
 
-static std::atomic_int64_t s_small_rpc_timeout_count{0};
+static std::atomic_int64_t s_small_rpc_timeout_profile_count{0};
 
 void NodeChannel::_try_diagnose(const std::string& error_text) {
     if (error_text.find("[E1008]Reached timeout") == std::string::npos) {
@@ -1091,11 +1091,11 @@ void NodeChannel::_try_diagnose(const std::string& error_text) {
     if (!config::enable_load_diagnose || _diagnose_closure != nullptr) {
         return;
     }
-    if (_rpc_timeout_ms <= config::load_diagnose_small_rpc_timeout_threshold_ms) {
-        int64_t count = s_small_rpc_timeout_count.fetch_add(1);
-        if (count % 20) {
-            return;
-        }
+    bool enable_profile = _rpc_timeout_ms > config::load_diagnose_rpc_timeout_profile_threshold_ms ||
+                          (s_small_rpc_timeout_profile_count.fetch_add(1) % 20 == 0);
+    bool enable_stack_trace = _rpc_timeout_ms > config::load_diagnose_rpc_timeout_stack_trace_threshold_ms;
+    if (!enable_profile && !enable_stack_trace) {
+        return;
     }
     _diagnose_closure = std::make_unique<RefCountClosure<PLoadDiagnoseResult>>();
     _diagnose_closure->ref();
@@ -1104,7 +1104,8 @@ void NodeChannel::_try_diagnose(const std::string& error_text) {
     PLoadDiagnoseRequest request;
     request.set_allocated_id(&_parent->_load_id);
     request.set_txn_id(_parent->_txn_id);
-    request.set_profile(true);
+    request.set_profile(enable_profile);
+    request.set_stack_trace(enable_stack_trace);
     _diagnose_closure->ref();
 #ifndef BE_TEST
     _stub->load_diagnose(&_diagnose_closure->cntl, &request, &_diagnose_closure->result, _diagnose_closure.get());
@@ -1114,7 +1115,8 @@ void NodeChannel::_try_diagnose(const std::string& error_text) {
 #endif
     request.release_id();
     VLOG(2) << "NodeChannel[" << _load_info << "] send diagnose request to [" << _node_info->host << ":"
-            << _node_info->brpc_port << "]";
+            << _node_info->brpc_port << "], rpc_timeout_ms: " << _rpc_timeout_ms
+            << ", enable_profile: " << enable_profile << ", enable_stack_trace: " << enable_stack_trace;
 }
 
 bool NodeChannel::_is_diagnose_done() {
@@ -1136,36 +1138,54 @@ void NodeChannel::_wait_diagnose(RuntimeState* state) {
         return;
     }
     PLoadDiagnoseResult& result = _diagnose_closure->result;
+    bool has_profile = _process_diagnose_profile(state, result);
+    bool has_stack_trace = false;
+    if (result.has_stack_trace_status()) {
+        Status status = Status(result.stack_trace_status());
+        if (!status.ok()) {
+            LOG(WARNING) << "NodeChannel[" << _load_info << "] diagnose stack trace failed, node: [" << _node_info->host
+                         << ":" << _node_info->brpc_port << "], error: " << status;
+        } else {
+            has_stack_trace = true;
+        }
+    }
+    VLOG(2) << "NodeChannel[" << _load_info << "] diagnose success, node: [" << _node_info->host << ":"
+            << _node_info->brpc_port << "], has_profile: " << has_profile << ", has_stack_trace: " << has_stack_trace;
+}
+
+bool NodeChannel::_process_diagnose_profile(RuntimeState* state, PLoadDiagnoseResult& result) {
     if (!result.has_profile_status()) {
-        return;
+        return false;
     }
     Status status = Status(result.profile_status());
     if (!status.ok()) {
-        LOG(WARNING) << "NodeChannel[" << _load_info << "] diagnose failed, node: [" << _node_info->host << ":"
+        LOG(WARNING) << "NodeChannel[" << _load_info << "] diagnose profile failed, node: [" << _node_info->host << ":"
                      << _node_info->brpc_port << "], error: " << status;
-        return;
+        return false;
     }
-    if (_diagnose_closure->result.has_profile_data()) {
-        SCOPED_TIMER(_ts_profile->update_load_channel_profile_timer);
-        const auto* buf = (const uint8_t*)(result.profile_data().data());
-        uint32_t len = result.profile_data().size();
-        TRuntimeProfileTree thrift_profile;
-        auto profile_st = deserialize_thrift_msg(buf, &len, TProtocolType::BINARY, &thrift_profile);
-        if (!profile_st.ok()) {
-            LOG(WARNING) << "NodeChannel[" << _load_info << "] diagnose failed, node: [" << _node_info->host << ":"
-                         << _node_info->brpc_port << "], size: " << len << ", error: " << profile_st;
-        } else {
-            RuntimeProfile* load_channel_profile = _runtime_state->load_channel_profile();
-            load_channel_profile->update(thrift_profile);
-            // Query context is only available for pipeline engine
-            auto query_ctx = state->query_ctx();
-            if (query_ctx) {
-                query_ctx->set_enable_profile();
-            }
-            VLOG(2) << "NodeChannel[" << _load_info << "] diagnose success, node: [" << _node_info->host << ":"
-                    << _node_info->brpc_port << "]";
+    if (!result.has_profile_data()) {
+        return false;
+    }
+    SCOPED_TIMER(_ts_profile->update_load_channel_profile_timer);
+    const auto* buf = (const uint8_t*)(result.profile_data().data());
+    uint32_t len = result.profile_data().size();
+    TRuntimeProfileTree thrift_profile;
+    bool has_profile = false;
+    auto profile_st = deserialize_thrift_msg(buf, &len, TProtocolType::BINARY, &thrift_profile);
+    if (!profile_st.ok()) {
+        LOG(WARNING) << "NodeChannel[" << _load_info << "] diagnose profile failed, node: [" << _node_info->host << ":"
+                     << _node_info->brpc_port << "], size: " << len << ", error: " << profile_st;
+    } else {
+        RuntimeProfile* load_channel_profile = state->load_channel_profile();
+        load_channel_profile->update(thrift_profile);
+        // Query context is only available for pipeline engine
+        auto query_ctx = state->query_ctx();
+        if (query_ctx) {
+            query_ctx->set_enable_profile();
         }
+        has_profile = true;
     }
+    return has_profile;
 }
 
 IndexChannel::~IndexChannel() {

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -192,6 +192,7 @@ private:
     void _try_diagnose(const std::string& error_text);
     bool _is_diagnose_done();
     void _wait_diagnose(RuntimeState* state);
+    bool _process_diagnose_profile(RuntimeState* state, PLoadDiagnoseResult& result);
 
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
 

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -270,7 +270,7 @@ private:
     ExprContext* _where_clause = nullptr;
 
     bool _has_primary_replica = false;
-    std::unique_ptr<RefCountClosure<PLoadDiagnoseResult>> _diagnose_closure;
+    RefCountClosure<PLoadDiagnoseResult>* _diagnose_closure = nullptr;
 };
 
 class IndexChannel {

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -107,6 +107,7 @@ set(RUNTIME_FILES
     type_pack.cpp
     customized_result_writer.cpp
     int128_to_double.cpp
+    diagnose_daemon.cpp
 )
 
 set(RUNTIME_FILES ${RUNTIME_FILES}

--- a/be/src/runtime/diagnose_daemon.cpp
+++ b/be/src/runtime/diagnose_daemon.cpp
@@ -45,7 +45,8 @@ static void split_and_log_long_message(const std::string& raw_log) {
     }
     std::string message;
     for (auto& line : lines) {
-        if (message.size() + line.size() + 1 > max_message_size) {
+        auto msg_size = message.size() + line.size() + (message.empty() ? 0 : 1);
+        if (msg_size > max_message_size) {
             if (!message.empty()) {
                 LOG(INFO) << message;
                 message.clear();
@@ -53,10 +54,10 @@ static void split_and_log_long_message(const std::string& raw_log) {
             if (line.size() > max_message_size) {
                 LOG(INFO) << line;
             } else {
-                message = line + "\n";
+                message = line;
             }
         } else {
-            message += line + "\n";
+            message += (message.empty() ? "" : "\n") + line;
         }
     }
     if (!message.empty()) {

--- a/be/src/runtime/diagnose_daemon.cpp
+++ b/be/src/runtime/diagnose_daemon.cpp
@@ -96,7 +96,7 @@ void DiagnoseDaemon::_execute_request(const DiagnoseRequest& request) {
 
 void DiagnoseDaemon::_perform_stack_trace(const std::string& context) {
     int64_t interval = MonotonicMillis() - _last_stack_trace_time_ms;
-    if (interval < config::diagnose_stack_trace_interval_ms) {
+    if (_last_stack_trace_time_ms > 0 && interval < config::diagnose_stack_trace_interval_ms) {
         VLOG(2) << "skip to diagnose stack trace, last time: " << _last_stack_trace_time_ms
                 << " ms, interval: " << interval << " ms";
         return;

--- a/be/src/runtime/diagnose_daemon.cpp
+++ b/be/src/runtime/diagnose_daemon.cpp
@@ -102,10 +102,10 @@ void DiagnoseDaemon::_perform_stack_trace(const std::string& context) {
         return;
     }
     int64_t start_time = MonotonicMillis();
-    _diagnose_id += 1;
-    std::string stack_trace = get_stack_trace_for_all_threads(fmt::format("DIAGNOSE {} - ", _diagnose_id));
+    int64_t id = _diagnose_id.fetch_add(1);
+    std::string stack_trace = get_stack_trace_for_all_threads(fmt::format("DIAGNOSE {} - ", id));
     _last_stack_trace_time_ms = MonotonicMillis();
-    LOG(INFO) << "diagnose stack trace, id: " << _diagnose_id << ", cost: " << (_last_stack_trace_time_ms - start_time)
+    LOG(INFO) << "diagnose stack trace, id: " << id << ", cost: " << (_last_stack_trace_time_ms - start_time)
               << " ms, size: " << stack_trace.size() << ", context: [" << context << "]";
     split_and_log_long_message(stack_trace);
 }

--- a/be/src/runtime/diagnose_daemon.cpp
+++ b/be/src/runtime/diagnose_daemon.cpp
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/diagnose_daemon.h"
+
+#include <fmt/format.h>
+
+#include "common/config.h"
+#include "util/stack_util.h"
+
+namespace starrocks {
+
+static std::string diagnose_type_name(DiagnoseType type) {
+    switch (type) {
+    case DiagnoseType::STACK_TRACE:
+        return "STACK_TRACE";
+    default:
+        return fmt::format("UNKNOWN({})", static_cast<int>(type));
+    }
+}
+
+static std::vector<std::string> split_into_multiple_lines(const std::string& input) {
+    std::vector<std::string> lines;
+    std::istringstream stream(input);
+    std::string line;
+    while (std::getline(stream, line, '\n')) {
+        lines.push_back(line);
+    }
+    return lines;
+}
+
+static void log_into_multiple_messages(const std::string& raw_log) {
+    std::vector<std::string> lines = split_into_multiple_lines(raw_log);
+    const size_t max_message_size = google::LogMessage::kMaxLogMessageLen;
+    std::string message;
+    for (const auto& line : lines) {
+        if (message.size() + line.size() + 1 > max_message_size) {
+            if (!message.empty()) {
+                LOG(INFO) << message;
+                message.clear();
+            }
+            if (line.size() > max_message_size) {
+                LOG(INFO) << line;
+            } else {
+                message = line + "\n";
+            }
+        } else {
+            message += line + "\n";
+        }
+    }
+    if (!message.empty()) {
+        LOG(INFO) << message;
+    }
+}
+
+Status DiagnoseDaemon::init() {
+    return ThreadPoolBuilder("diagnose").set_min_threads(0).set_max_threads(1).build(&_single_thread_pool);
+}
+
+Status DiagnoseDaemon::diagnose(const starrocks::DiagnoseRequest& request) {
+    return _single_thread_pool->submit_func([this, request]() { _execute_request(request); });
+}
+
+void DiagnoseDaemon::stop() {
+    if (_single_thread_pool) {
+        _single_thread_pool->shutdown();
+    }
+}
+
+void DiagnoseDaemon::_execute_request(const starrocks::DiagnoseRequest& request) {
+    switch (request.type) {
+    case DiagnoseType::STACK_TRACE:
+        _perform_stack_trace(request.context);
+        break;
+    default:
+        LOG(WARNING) << "unknown diagnose type: " << diagnose_type_name(request.type)
+                     << ", context: " << request.context;
+    }
+}
+
+void DiagnoseDaemon::_perform_stack_trace(const std::string& context) {
+    int64_t interval = MonotonicMillis() - _last_stack_trace_time_ms;
+    if (interval < config::diagnose_stack_trace_interval_ms) {
+        VLOG(2) << "skip to diagnose stack trace, last time: " << _last_stack_trace_time_ms
+                << " ms, interval: " << interval << " ms";
+        return;
+    }
+    int64_t start_time = MonotonicMillis();
+    _diagnose_id += 1;
+    std::string stack_trace = get_stack_trace_for_all_threads(fmt::format("DIAGNOSE {} - ", _diagnose_id));
+    _last_stack_trace_time_ms = MonotonicMillis();
+    LOG(INFO) << "diagnose stack trace, id: " << _diagnose_id << ", cost: " << (_last_stack_trace_time_ms - start_time)
+              << " ms, size: " << stack_trace.size() << ", context: [" << context << "]";
+    log_into_multiple_messages(stack_trace);
+}
+
+} // namespace starrocks

--- a/be/src/runtime/diagnose_daemon.h
+++ b/be/src/runtime/diagnose_daemon.h
@@ -43,6 +43,8 @@ public:
 
     void stop();
 
+    ThreadPool* thread_pool() { return _single_thread_pool.get(); }
+
 private:
     void _execute_request(const DiagnoseRequest& request);
     void _perform_stack_trace(const std::string& context);

--- a/be/src/runtime/diagnose_daemon.h
+++ b/be/src/runtime/diagnose_daemon.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <list>
 #include <string>
 #include <thread>
@@ -44,7 +45,7 @@ public:
     void stop();
 
     ThreadPool* thread_pool() { return _single_thread_pool.get(); }
-    int64_t diagnose_id() { return _diagnose_id; }
+    int64_t diagnose_id() { return _diagnose_id.load(); }
 
 private:
     void _execute_request(const DiagnoseRequest& request);
@@ -52,7 +53,7 @@ private:
 
     std::unique_ptr<ThreadPool> _single_thread_pool;
     int64_t _last_stack_trace_time_ms = 0;
-    int64_t _diagnose_id = 0;
+    std::atomic<int64_t> _diagnose_id{0};
 };
 
 } // namespace starrocks

--- a/be/src/runtime/diagnose_daemon.h
+++ b/be/src/runtime/diagnose_daemon.h
@@ -44,6 +44,7 @@ public:
     void stop();
 
     ThreadPool* thread_pool() { return _single_thread_pool.get(); }
+    int64_t diagnose_id() { return _diagnose_id; }
 
 private:
     void _execute_request(const DiagnoseRequest& request);

--- a/be/src/runtime/diagnose_daemon.h
+++ b/be/src/runtime/diagnose_daemon.h
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <list>
+#include <string>
+#include <thread>
+
+#include "bthread/condition_variable.h"
+#include "bthread/mutex.h"
+#include "common/status.h"
+#include "util/threadpool.h"
+
+namespace starrocks {
+
+enum class DiagnoseType { STACK_TRACE };
+
+struct DiagnoseRequest {
+    DiagnoseType type;
+    std::string context;
+};
+
+class DiagnoseDaemon {
+public:
+    DiagnoseDaemon() = default;
+    ~DiagnoseDaemon() = default;
+
+    Status init();
+
+    Status diagnose(const DiagnoseRequest& request);
+
+    void stop();
+
+private:
+    void _execute_request(const DiagnoseRequest& request);
+    void _perform_stack_trace(const std::string& context);
+
+    std::unique_ptr<ThreadPool> _single_thread_pool;
+    int64_t _last_stack_trace_time_ms = 0;
+    int64_t _diagnose_id = 0;
+};
+
+} // namespace starrocks

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -64,6 +64,7 @@
 #include "runtime/broker_mgr.h"
 #include "runtime/client_cache.h"
 #include "runtime/data_stream_mgr.h"
+#include "runtime/diagnose_daemon.h"
 #include "runtime/dummy_load_path_mgr.h"
 #include "runtime/external_scan_context_mgr.h"
 #include "runtime/fragment_mgr.h"
@@ -784,6 +785,8 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _spill_dir_mgr = std::make_shared<spill::DirManager>();
     RETURN_IF_ERROR(_spill_dir_mgr->init(config::spill_local_storage_dir));
 
+    _diagnose_daemon = new DiagnoseDaemon();
+    RETURN_IF_ERROR(_diagnose_daemon->init());
 #ifdef STARROCKS_JIT_ENABLE
     auto jit_engine = JITEngine::get_instance();
     status = jit_engine->init();
@@ -888,6 +891,10 @@ void ExecEnv::stop() {
         _dictionary_cache_pool->shutdown();
     }
 
+    if (_diagnose_daemon) {
+        _diagnose_daemon->stop();
+    }
+
 #ifndef BE_TEST
     close_s3_clients();
 #endif
@@ -946,6 +953,7 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_lake_replication_txn_manager);
     SAFE_DELETE(_cache_mgr);
     SAFE_DELETE(_put_combined_txn_log_thread_pool);
+    SAFE_DELETE(_diagnose_daemon);
     _dictionary_cache_pool.reset();
     _automatic_partition_pool.reset();
     _metrics = nullptr;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -91,6 +91,7 @@ class TFileBrokerServiceClient;
 template <class T>
 class ClientCache;
 class HeartbeatFlags;
+class DiagnoseDaemon;
 
 namespace pipeline {
 class DriverExecutor;
@@ -381,6 +382,8 @@ public:
 
     void try_release_resource_before_core_dump();
 
+    DiagnoseDaemon* diagnose_daemon() const { return _diagnose_daemon; }
+
 private:
     void _wait_for_fragments_finish();
     size_t _get_running_fragments_count() const;
@@ -449,6 +452,7 @@ private:
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr;
     std::shared_ptr<spill::DirManager> _spill_dir_mgr;
+    DiagnoseDaemon* _diagnose_daemon = nullptr;
 };
 
 template <>

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -460,6 +460,10 @@ void LoadChannel::diagnose(const std::string& remote_ip, const PLoadDiagnoseRequ
         stack_trace_request.context =
                 fmt::format("load_id: {}, txn_id: {}, remote: {}", print_id(_load_id), _txn_id, remote_ip);
         Status st = ExecEnv::GetInstance()->diagnose_daemon()->diagnose(stack_trace_request);
+        if (!st.ok()) {
+            LOG(WARNING) << "failed to diagnose stack trace, load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
+                         << ", status: " << st;
+        }
         result->mutable_stack_trace_status()->set_status_code(st.code());
         result->mutable_stack_trace_status()->add_error_msgs(st.to_string());
         VLOG(2) << "load channel diagnose stack trace, " << stack_trace_request.context << ", status: " << st;

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -38,6 +38,8 @@
 
 #include "common/closure_guard.h"
 #include "fmt/format.h"
+#include "runtime/diagnose_daemon.h"
+#include "runtime/exec_env.h"
 #include "runtime/lake_tablets_channel.h"
 #include "runtime/load_channel_mgr.h"
 #include "runtime/local_tablets_channel.h"
@@ -440,7 +442,8 @@ void LoadChannel::report_profile(PTabletWriterAddBatchResult* result, bool print
     }
 }
 
-void LoadChannel::diagnose(const PLoadDiagnoseRequest* request, PLoadDiagnoseResult* result) {
+void LoadChannel::diagnose(const std::string& remote_ip, const PLoadDiagnoseRequest* request,
+                           PLoadDiagnoseResult* result) {
     if (request->has_profile() && request->profile()) {
         Status st = _update_and_serialize_profile(result->mutable_profile_data(), config::pipeline_print_profile);
         result->mutable_profile_status()->set_status_code(st.code());
@@ -448,8 +451,18 @@ void LoadChannel::diagnose(const PLoadDiagnoseRequest* request, PLoadDiagnoseRes
         if (!st.ok()) {
             result->clear_profile_data();
         }
-        VLOG(2) << "load channel diagnose profile, load_id: " << _load_id << ", txn_id: " << _txn_id
+        VLOG(2) << "load channel diagnose profile, load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id
                 << ", status: " << st;
+    }
+    if (request->has_stack_trace() && request->stack_trace()) {
+        DiagnoseRequest stack_trace_request;
+        stack_trace_request.type = DiagnoseType::STACK_TRACE;
+        stack_trace_request.context =
+                fmt::format("load_id: {}, txn_id: {}, remote: {}", print_id(_load_id), _txn_id, remote_ip);
+        Status st = ExecEnv::GetInstance()->diagnose_daemon()->diagnose(stack_trace_request);
+        result->mutable_stack_trace_status()->set_status_code(st.code());
+        result->mutable_stack_trace_status()->add_error_msgs(st.to_string());
+        VLOG(2) << "load channel diagnose stack trace, " << stack_trace_request.context << ", status: " << st;
     }
 }
 

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -122,7 +122,7 @@ public:
 
     void report_profile(PTabletWriterAddBatchResult* result, bool print_profile);
 
-    void diagnose(const PLoadDiagnoseRequest* request, PLoadDiagnoseResult* response);
+    void diagnose(const std::string& remote_ip, const PLoadDiagnoseRequest* request, PLoadDiagnoseResult* response);
 
 private:
     void _add_chunk(Chunk* chunk, const MonotonicStopWatch* watch, const PTabletWriterAddChunkRequest& request,

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -34,6 +34,9 @@
 
 #include "runtime/load_channel_mgr.h"
 
+#include <brpc/controller.h>
+#include <butil/endpoint.h>
+
 #include <memory>
 
 #include "common/closure_guard.h"
@@ -222,9 +225,15 @@ void LoadChannelMgr::load_diagnose(brpc::Controller* cntl, const PLoadDiagnoseRe
             response->mutable_profile_status()->set_status_code(TStatusCode::NOT_FOUND);
             response->mutable_profile_status()->add_error_msgs("can't find the load channel");
         }
+        if (request->has_stack_trace() && request->stack_trace()) {
+            response->mutable_stack_trace_status()->set_status_code(TStatusCode::NOT_FOUND);
+            response->mutable_stack_trace_status()->add_error_msgs("can't find the load channel");
+        }
     } else {
-        VLOG(2) << "receive load diagnose, load_id: " << load_id << ", txn_id: " << request->txn_id();
-        channel->diagnose(request, response);
+        std::string remote_ip = butil::ip2str(cntl->remote_side().ip).c_str();
+        VLOG(2) << "receive load diagnose, load_id: " << load_id << ", txn_id: " << request->txn_id()
+                << ", remote: " << remote_ip;
+        channel->diagnose(remote_ip, request, response);
     }
 }
 

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -55,6 +55,7 @@
 namespace starrocks {
 
 DEFINE_FAIL_POINT(tablets_channel_add_chunk_wait_write_block);
+DEFINE_FAIL_POINT(tablets_channel_wait_secondary_replica_block);
 
 std::atomic<uint64_t> LocalTabletsChannel::_s_tablet_writer_count;
 
@@ -347,6 +348,8 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
             // Wait util seconary replica commit/abort by primary
             if (delta_writer->replica_state() == Secondary) {
                 int i = 0;
+                int64_t start_wait_time_ms = MonotonicMillis();
+                bool trigger_diagnose = false;
                 do {
                     auto state = delta_writer->get_state();
                     if (state == kCommitted || state == kAborted || state == kUninitialized) {
@@ -355,6 +358,17 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
                     i++;
                     // only sleep in bthread
                     bthread_usleep(10000); // 10ms
+                    FAIL_POINT_TRIGGER_EXECUTE(tablets_channel_wait_secondary_replica_block, {
+                        int32_t timeout_ms = config::load_fp_tablets_channel_wait_secondary_replica_block_ms;
+                        if (timeout_ms > 0) {
+                            bthread_usleep(timeout_ms * 1000);
+                        }
+                    });
+                    if (!trigger_diagnose && (MonotonicMillis() - start_wait_time_ms >
+                                              config::load_diagnose_rpc_timeout_stack_trace_threshold_ms)) {
+                        _diagnose_primary_replica_stack_trace(tablet_id, request.id(), delta_writer.get());
+                        trigger_diagnose = true;
+                    }
                     auto elapse_time_ms = watch.elapsed_time() / 1000000;
                     if (elapse_time_ms > request.timeout_ms()) {
                         LOG(INFO) << "LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(request.id())
@@ -1155,6 +1169,41 @@ void LocalTabletsChannel::_update_secondary_replica_profile(DeltaWriter* writer,
     ADD_AND_UPDATE_COUNTER(profile, "FlushFinishedTaskCount", TUnit::UNIT, stat.num_finished_tasks);
     ADD_AND_UPDATE_TIMER(profile, "FlushTaskPendingTime", stat.pending_time_ns);
     ADD_AND_UPDATE_TIMER(profile, "FlushTaskExecuteTime", stat.execute_time_ns);
+}
+
+void LocalTabletsChannel::_diagnose_primary_replica_stack_trace(int64_t tablet_id, const PUniqueId& load_id,
+                                                                AsyncDeltaWriter* async_delta_writer) {
+    auto delta_writer = async_delta_writer->writer();
+    if (delta_writer->replica_state() != ReplicaState::Secondary || delta_writer->replicas().empty()) {
+        return;
+    }
+    auto& primary_replica = delta_writer->replicas()[0];
+    auto stub = ExecEnv::GetInstance()->brpc_stub_cache()->get_stub(primary_replica.host(), primary_replica.port());
+    if (stub == nullptr) {
+        LOG(WARNING) << "failed to diagnose primary replica, txn_id: " << _txn_id << ", load_id: " << print_id(load_id)
+                     << ", tablet_id: " << tablet_id << ", primary_replica: [" << primary_replica.host() << ":"
+                     << primary_replica.port() << "]";
+        return;
+    }
+    auto closure = new ReusableClosure<PLoadDiagnoseResult>();
+    closure->cntl.set_timeout_ms(config::load_diagnose_send_rpc_timeout_ms);
+    SET_IGNORE_OVERCROWDED(closure->cntl, load);
+    PLoadDiagnoseRequest request;
+    request.mutable_id()->set_hi(load_id.hi());
+    request.mutable_id()->set_hi(load_id.lo());
+    request.set_txn_id(_txn_id);
+    request.set_stack_trace(true);
+    closure->ref();
+#ifndef BE_TEST
+    // best effort to diagnose so do not wait the result
+    stub->load_diagnose(&closure->cntl, &request, &closure->result, closure);
+#else
+    std::pair<PLoadDiagnoseRequest*, ReusableClosure<PLoadDiagnoseResult>*> rpc_pair{&request, closure};
+    TEST_SYNC_POINT_CALLBACK("LocalTabletsChannel::rpc::load_diagnose_send", &rpc_pair);
+#endif
+    LOG(INFO) << "send request to diagnose primary replica, txn_id: " << _txn_id << ", load_id: " << print_id(load_id)
+              << ", tablet_id: " << tablet_id << ", primary_replica: [" << primary_replica.host() << ":"
+              << primary_replica.port() << "]";
 }
 
 std::shared_ptr<TabletsChannel> new_local_tablets_channel(LoadChannel* load_channel, const TabletsChannelKey& key,

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -185,6 +185,9 @@ private:
     void _update_primary_replica_profile(DeltaWriter* writer, RuntimeProfile* profile);
     void _update_secondary_replica_profile(DeltaWriter* writer, RuntimeProfile* profile);
 
+    void _diagnose_primary_replica_stack_trace(int64_t tablet_id, const PUniqueId& load_id,
+                                               AsyncDeltaWriter* async_delta_writer);
+
     LoadChannel* _load_channel;
 
     TabletsChannelKey _key;

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -67,6 +67,7 @@ struct StackTraceTask {
 #else
             std::tuple<void*, char*, size_t> tuple = {addrs[i], buf, sizeof(buf)};
             TEST_SYNC_POINT_CALLBACK("StackTraceTask::symbolize", &tuple);
+            success = true;
 #endif
             if (success) {
                 snprintf(line, 2048, "%s  %16p  %s\n", line_prefix.c_str(), addrs[i], buf);

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -203,19 +203,18 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
     }
 
     int64_t task_done_count = 0;
-    int64_t max_block_time_us = 0;
-    int64_t min_block_time_us = std::numeric_limits<int64_t>::max();
-    int64_t total_block_time_us = 0;
-
+    int64_t max_task_cost_us = 0;
+    int64_t min_task_cost_us = std::numeric_limits<int64_t>::max();
+    int64_t total_task_cost_us = 0;
     // group threads with same stack trace together
     std::unordered_map<StackTraceTask, std::vector<int>, StackTraceTaskHash> task_map;
     for (int i = 0; i < tids.size(); ++i) {
         if (tasks[i].done) {
             task_map[tasks[i]].push_back(tids[i]);
             task_done_count += 1;
-            max_block_time_us = std::max(max_block_time_us, tasks[i].cost_us);
-            min_block_time_us = std::min(min_block_time_us, tasks[i].cost_us);
-            total_block_time_us += tasks[i].cost_us;
+            max_task_cost_us = std::max(max_task_cost_us, tasks[i].cost_us);
+            min_task_cost_us = std::min(min_task_cost_us, tasks[i].cost_us);
+            total_task_cost_us += tasks[i].cost_us;
         }
     }
     string ret;
@@ -239,19 +238,18 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
         ret += stack_trace;
         ret += "\n";
     }
-    int64_t avg_block_time_us = 0;
+    int64_t avg_task_cost_us = 0;
     if (task_done_count == 0) {
-        min_block_time_us = 0;
-        max_block_time_us = 0;
+        min_task_cost_us = 0;
+        max_task_cost_us = 0;
     } else {
-        avg_block_time_us = total_block_time_us / task_done_count;
+        avg_task_cost_us = total_task_cost_us / task_done_count;
     }
     ret += strings::Substitute(
             "$0total $1 threads, $2 identical groups, finish $3 threads, cost $4 us, thread block(avg/min/max) "
-            "$5/$6/$7 "
-            "us",
+            "$5/$6/$7 us",
             line_prefix, tids.size(), task_map.size(), task_done_count, (MonotonicMicros() - start_us),
-            avg_block_time_us, min_block_time_us, max_block_time_us);
+            avg_task_cost_us, min_task_cost_us, max_task_cost_us);
     return ret;
 }
 

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -218,8 +218,11 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
         }
     }
     string ret;
+    int64_t total_symbolize_cost_us = 0;
     for (auto& e : task_map) {
+        int64_t ts = MonotonicMicros();
         string stack_trace = e.first.to_string(line_prefix);
+        total_symbolize_cost_us += MonotonicMicros() - ts;
         if (!pattern.empty() && stack_trace.find(pattern) == string::npos) {
             continue;
         }
@@ -245,11 +248,11 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
     } else {
         avg_task_cost_us = total_task_cost_us / task_done_count;
     }
-    ret += strings::Substitute(
-            "$0total $1 threads, $2 identical groups, finish $3 threads, cost $4 us, thread block(avg/min/max) "
-            "$5/$6/$7 us",
+    ret += fmt::format(
+            "{}total {} threads, {} identical groups, finish {} threads, total cost {} us, symbolize cost {} us,"
+            " thread block(avg/min/max) {}/{}/{} us, ",
             line_prefix, tids.size(), task_map.size(), task_done_count, (MonotonicMicros() - start_us),
-            avg_task_cost_us, min_task_cost_us, max_task_cost_us);
+            total_symbolize_cost_us, avg_task_cost_us, min_task_cost_us, max_task_cost_us);
     return ret;
 }
 

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -51,15 +51,16 @@ struct StackTraceTask {
     void* addrs[kMaxStackDepth];
     int depth{0};
     bool done = false;
-    string to_string() const {
+    int64_t cost_us = 0;
+    string to_string(const std::string& line_prefix = "") const {
         string ret;
         for (int i = 0; i < depth; ++i) {
             char line[2048];
             char buf[1024];
             if (google::glog_internal_namespace_::Symbolize(addrs[i], buf, sizeof(buf))) {
-                snprintf(line, 2048, "  %16p  %s\n", addrs[i], buf);
+                snprintf(line, 2048, "%s  %16p  %s\n", line_prefix.c_str(), addrs[i], buf);
             } else {
-                snprintf(line, 2048, "  %16p  (unknown)\n", addrs[i]);
+                snprintf(line, 2048, "%s  %16p  (unknown)\n", line_prefix.c_str(), addrs[i]);
             }
             ret += line;
         }
@@ -89,8 +90,12 @@ struct StackTraceTaskHash {
 };
 
 void get_stack_trace_sighandler(int signum, siginfo_t* siginfo, void* ucontext) {
+    int64_t start_us = MonotonicMicros();
     auto task = reinterpret_cast<StackTraceTask*>(siginfo->si_value.sival_ptr);
     task->depth = google::glog_internal_namespace_::GetStackTrace(task->addrs, StackTraceTask::kMaxStackDepth, 2);
+    // get_stack_trace_for_thread first checks done flag then gets the cost.
+    // To ensure the cost is valid, set cost before done flag
+    task->cost_us = MonotonicMicros() - start_us;
     task->done = true;
 }
 
@@ -152,7 +157,8 @@ std::string get_stack_trace_for_thread(int tid, int timeout_ms) {
 }
 
 std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tids, const string& pattern,
-                                                     int timeout_ms) {
+                                                     int timeout_ms, const std::string& line_prefix = "") {
+    int64_t start_us = MonotonicMicros();
     static bool sighandler_installed = false;
     if (!sighandler_installed) {
         if (!install_stack_trace_sighandler()) {
@@ -195,23 +201,33 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
             break;
         }
     }
+
+    int64_t task_done_count = 0;
+    int64_t max_block_time_us = 0;
+    int64_t min_block_time_us = std::numeric_limits<int64_t>::max();
+    int64_t total_block_time_us = 0;
+
     // group threads with same stack trace together
     std::unordered_map<StackTraceTask, std::vector<int>, StackTraceTaskHash> task_map;
     for (int i = 0; i < tids.size(); ++i) {
         if (tasks[i].done) {
             task_map[tasks[i]].push_back(tids[i]);
+            task_done_count += 1;
+            max_block_time_us = std::max(max_block_time_us, tasks[i].cost_us);
+            min_block_time_us = std::min(min_block_time_us, tasks[i].cost_us);
+            total_block_time_us += tasks[i].cost_us;
         }
     }
     string ret;
     for (auto& e : task_map) {
-        string stack_trace = e.first.to_string();
+        string stack_trace = e.first.to_string(line_prefix);
         if (!pattern.empty() && stack_trace.find(pattern) == string::npos) {
             continue;
         }
         if (e.second.size() == 1) {
-            ret += strings::Substitute("tid: $0\n", e.second[0]);
+            ret += strings::Substitute("$0tid: $1\n", line_prefix, e.second[0]);
         } else {
-            ret += strings::Substitute("$0 tids: ", e.second.size());
+            ret += strings::Substitute("$0$1 tids: ", line_prefix, e.second.size());
             for (size_t i = 0; i < e.second.size(); i++) {
                 if (i > 0) {
                     ret += ",";
@@ -223,7 +239,19 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
         ret += stack_trace;
         ret += "\n";
     }
-    ret += strings::Substitute("total $0 threads, $1 identical groups", tids.size(), task_map.size());
+    int64_t avg_block_time_us = 0;
+    if (task_done_count == 0) {
+        min_block_time_us = 0;
+        max_block_time_us = 0;
+    } else {
+        avg_block_time_us = total_block_time_us / task_done_count;
+    }
+    ret += strings::Substitute(
+            "$0total $1 threads, $2 identical groups, finish $3 threads, cost $4 us, thread block(avg/min/max) "
+            "$5/$6/$7 "
+            "us",
+            line_prefix, tids.size(), task_map.size(), task_done_count, (MonotonicMicros() - start_us),
+            avg_block_time_us, min_block_time_us, max_block_time_us);
     return ret;
 }
 
@@ -231,8 +259,8 @@ std::string get_stack_trace_for_threads(const std::vector<int>& tids, int timeou
     return get_stack_trace_for_threads_with_pattern(tids, "", timeout_ms);
 }
 
-std::string get_stack_trace_for_all_threads() {
-    return get_stack_trace_for_threads(get_thread_id_list(), 3000);
+std::string get_stack_trace_for_all_threads(const std::string& line_prefix) {
+    return get_stack_trace_for_threads_with_pattern(get_thread_id_list(), "", 3000, line_prefix);
 }
 
 std::string get_stack_trace_for_function(const std::string& function_pattern) {

--- a/be/src/util/stack_util.h
+++ b/be/src/util/stack_util.h
@@ -32,7 +32,7 @@ std::vector<int> get_thread_id_list();
 bool install_stack_trace_sighandler();
 std::string get_stack_trace_for_thread(int tid, int timeout_ms);
 std::string get_stack_trace_for_threads(const std::vector<int>& tids, int timeout_ms);
-std::string get_stack_trace_for_all_threads();
+std::string get_stack_trace_for_all_threads(const std::string& line_prefix = "");
 // get all thread stack trace, and filter by function pattern
 std::string get_stack_trace_for_function(const std::string& function_pattern);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -377,6 +377,7 @@ set(EXEC_FILES
         ./runtime/datetime_value_test.cpp
         ./runtime/decimalv2_value_test.cpp
         ./runtime/decimalv3_test.cpp
+        ./runtime/diagnose_daemon_test.cpp
         ./runtime/external_scan_context_mgr_test.cpp
         ./runtime/fragment_mgr_test.cpp
         ./runtime/http_result_writer_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -491,6 +491,7 @@ set(EXEC_FILES
         ./util/stack_trace_mutex_test.cpp
         ./util/download_util_test.cpp
         ./util/numeric_types_test.cpp
+        ./util/stack_util_test.cpp
         ./gutil/cpu_test.cc
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp

--- a/be/test/exec/tablet_sink_index_channel_test.cpp
+++ b/be/test/exec/tablet_sink_index_channel_test.cpp
@@ -236,7 +236,7 @@ using RpcLoadDisagnosePair = std::pair<PLoadDiagnoseRequest*, RefCountClosure<PL
 
 void TabletSinkIndexChannelTest::test_load_diagnose_base(const std::string& error_text, bool should_diagnose) {
     TQueryOptions query_options;
-    // let query_timeout / 2 > load_diagnose_small_rpc_timeout_threshold_ms
+    // let query_timeout / 2 > load_diagnose_rpc_timeout_profile_threshold_ms
     query_options.__set_query_timeout(300);
     auto runtime_state = _build_runtime_state(query_options);
     DescriptorTbl* desc_tbl = nullptr;

--- a/be/test/exec/tablet_sink_index_channel_test.cpp
+++ b/be/test/exec/tablet_sink_index_channel_test.cpp
@@ -314,7 +314,7 @@ void TabletSinkIndexChannelTest::test_load_diagnose_base(const std::string& erro
     chunk->get_column_by_index(1)->append_datum(Datum(1L));
     ASSERT_OK(sink->send_chunk(runtime_state.get(), chunk.get()));
     ASSERT_FALSE(sink->close(runtime_state.get(), Status::OK()).ok());
-    ASSERT_EQ((diagnose_profile || diagnose_stack_trace) ? 1 : 0, num_diagnose)
+    ASSERT_EQ((diagnose_profile || diagnose_stack_trace) ? 1 : 0, num_diagnose);
     ASSERT_EQ((diagnose_profile ? 1 : 0), runtime_state->load_channel_profile()->num_children());
 }
 

--- a/be/test/exec/tablet_sink_index_channel_test.cpp
+++ b/be/test/exec/tablet_sink_index_channel_test.cpp
@@ -39,7 +39,8 @@ public:
 
     void test_load_channel_profile_base(RuntimeState* runtime_state, const PLoadChannelProfileConfig& expect_config);
 
-    void test_load_diagnose_base(const std::string& error_text, bool should_diagnose);
+    void test_load_diagnose_base(const std::string& error_text, int64_t rpc_timeout_sec, bool diagnose_profile,
+                                 bool diagnose_stack_trace);
 
 protected:
     std::unique_ptr<RuntimeState> _build_runtime_state(TQueryOptions& query_options) {
@@ -234,10 +235,10 @@ using RpcOpenPair = std::pair<PTabletWriterOpenRequest*, RefCountClosure<PTablet
 using RpcAddChunkPair = std::pair<PTabletWriterAddChunksRequest*, ReusableClosure<PTabletWriterAddBatchResult>*>;
 using RpcLoadDisagnosePair = std::pair<PLoadDiagnoseRequest*, RefCountClosure<PLoadDiagnoseResult>*>;
 
-void TabletSinkIndexChannelTest::test_load_diagnose_base(const std::string& error_text, bool should_diagnose) {
+void TabletSinkIndexChannelTest::test_load_diagnose_base(const std::string& error_text, int64_t rpc_timeout_sec,
+                                                         bool diagnose_profile, bool diagnose_stack_trace) {
     TQueryOptions query_options;
-    // let query_timeout / 2 > load_diagnose_rpc_timeout_profile_threshold_ms
-    query_options.__set_query_timeout(300);
+    query_options.__set_query_timeout(2 * rpc_timeout_sec);
     auto runtime_state = _build_runtime_state(query_options);
     DescriptorTbl* desc_tbl = nullptr;
     ASSERT_OK(DescriptorTbl::create(runtime_state.get(), _object_pool.get(), _desc_tbl, &desc_tbl,
@@ -287,9 +288,17 @@ void TabletSinkIndexChannelTest::test_load_diagnose_base(const std::string& erro
     int32_t num_diagnose = 0;
     SyncPoint::GetInstance()->SetCallBack("NodeChannel::rpc::load_diagnose_send", [&](void* arg) {
         RpcLoadDisagnosePair* rpc_pair = (RpcLoadDisagnosePair*)arg;
+        PLoadDiagnoseRequest* request = rpc_pair->first;
         RefCountClosure<PLoadDiagnoseResult>* closure = rpc_pair->second;
-        closure->result.mutable_profile_status()->set_status_code(TStatusCode::OK);
-        _serialize_load_profile(closure->result.mutable_profile_data());
+        if (diagnose_profile) {
+            EXPECT_TRUE(request->has_profile() && request->profile());
+            closure->result.mutable_profile_status()->set_status_code(TStatusCode::OK);
+            _serialize_load_profile(closure->result.mutable_profile_data());
+        }
+        if (diagnose_stack_trace) {
+            EXPECT_TRUE(request->has_stack_trace() && request->stack_trace());
+            closure->result.mutable_stack_trace_status()->set_status_code(TStatusCode::OK);
+        }
         closure->Run();
     });
     SyncPoint::GetInstance()->SetCallBack("NodeChannel::rpc::load_diagnose_join", [&](void* arg) {
@@ -305,18 +314,22 @@ void TabletSinkIndexChannelTest::test_load_diagnose_base(const std::string& erro
     chunk->get_column_by_index(1)->append_datum(Datum(1L));
     ASSERT_OK(sink->send_chunk(runtime_state.get(), chunk.get()));
     ASSERT_FALSE(sink->close(runtime_state.get(), Status::OK()).ok());
-    if (should_diagnose) {
-        ASSERT_EQ(1, num_diagnose);
-        ASSERT_EQ(1, runtime_state->load_channel_profile()->num_children());
-    } else {
-        ASSERT_EQ(0, num_diagnose);
-        ASSERT_EQ(0, runtime_state->load_channel_profile()->num_children());
-    }
+    ASSERT_EQ((diagnose_profile || diagnose_stack_trace) ? 1 : 0, num_diagnose)
+    ASSERT_EQ((diagnose_profile ? 1 : 0), runtime_state->load_channel_profile()->num_children());
 }
 
 TEST_F(TabletSinkIndexChannelTest, load_diagnose) {
-    test_load_diagnose_base("[E1008]Reached timeout 150000ms@10.128.8.78:8060", true);
-    test_load_diagnose_base("artificial failure", false);
+    // not diagnose because the error is no rpc timeout
+    test_load_diagnose_base("artificial failure", 30, false, false);
+    // only diagnose profile. it's a small rpc timeout which is less than
+    // config::load_diagnose_rpc_timeout_profile_threshold_ms and
+    // config::load_diagnose_rpc_timeout_stack_trace_threshold_ms
+    test_load_diagnose_base("[E1008]Reached timeout 30000ms@10.128.8.78:8060", 30, true, false);
+    // not diagnose profile. it's a small rpc timeout, and only trigger profile every 20 times
+    test_load_diagnose_base("[E1008]Reached timeout 30000ms@10.128.8.78:8060", 30, false, false);
+    // diagnose both profile and stack trace because the timeout is larger than
+    // config::load_diagnose_rpc_timeout_stack_trace_threshold_ms
+    test_load_diagnose_base("[E1008]Reached timeout 1200000ms@10.128.8.78:8060", 1200, true, true);
 }
 
 } // namespace starrocks

--- a/be/test/runtime/diagnose_daemon_test.cpp
+++ b/be/test/runtime/diagnose_daemon_test.cpp
@@ -18,6 +18,7 @@
 
 #include "testutil/assert.h"
 #include "testutil/sync_point.h"
+#include "util/defer_op.h"
 
 namespace starrocks {
 
@@ -39,6 +40,8 @@ protected:
     std::unique_ptr<DiagnoseDaemon> _daemon;
 };
 
+using SymbolizeTuple = std::tuple<void*, char*, size_t>;
+
 TEST_F(DiagnoseDaemonTest, test_stack_trace) {
     SyncPoint::GetInstance()->EnableProcessing();
     DeferOp defer([]() {
@@ -48,7 +51,7 @@ TEST_F(DiagnoseDaemonTest, test_stack_trace) {
 
     SyncPoint::GetInstance()->SetCallBack("StackTraceTask::symbolize", [&](void* arg) {
         SymbolizeTuple* tuple = (SymbolizeTuple*)arg;
-        std::snprintf(std::get<1>(*tuple), std::get<2>(*tuple), std::string(100, 'a').c_str());
+        std::snprintf(std::get<1>(*tuple), std::get<2>(*tuple), "%s", std::string(100, 'a').c_str());
     });
 
     DiagnoseRequest request1;

--- a/be/test/runtime/diagnose_daemon_test.cpp
+++ b/be/test/runtime/diagnose_daemon_test.cpp
@@ -65,7 +65,8 @@ TEST_F(DiagnoseDaemonTest, test_stack_trace) {
     request2.context = "trace2";
     ASSERT_OK(_daemon->diagnose(request2));
 
-    Awaitility().timeout(60000).until([&]() { return _daemon->thread_pool()->total_executed_tasks() == 2; });
+    ASSERT_TRUE(
+            Awaitility().timeout(60000).until([&]() { return _daemon->thread_pool()->total_executed_tasks() == 2; }));
     ASSERT_EQ(1, _daemon->diagnose_id());
 }
 

--- a/be/test/runtime/diagnose_daemon_test.cpp
+++ b/be/test/runtime/diagnose_daemon_test.cpp
@@ -18,6 +18,7 @@
 
 #include "testutil/assert.h"
 #include "testutil/sync_point.h"
+#include "util/await.h"
 #include "util/defer_op.h"
 
 namespace starrocks {
@@ -64,7 +65,7 @@ TEST_F(DiagnoseDaemonTest, test_stack_trace) {
     request2.context = "trace2";
     ASSERT_OK(_daemon->diagnose(request2));
 
-    ASSERT_TRUE(_daemon->thread_pool()->wait_for(MonoDelta::FromSeconds(10)));
+    Awaitility().timeout(60000).until([&]() { return _daemon->thread_pool()->total_executed_tasks() == 2; });
     ASSERT_EQ(1, _daemon->diagnose_id());
 }
 

--- a/be/test/runtime/diagnose_daemon_test.cpp
+++ b/be/test/runtime/diagnose_daemon_test.cpp
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/diagnose_daemon.h"
+
+#include <gtest/gtest.h>
+
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class DiagnoseDaemonTest : public testing::Test {
+public:
+    void SetUp() override {
+        _daemon = std::make_unique<DiagnoseDaemon>();
+        ASSERT_OK(_daemon->init());
+    }
+
+    void TearDown() override {
+        if (_daemon) {
+            _daemon->stop();
+            _daemon.reset();
+        }
+    }
+
+protected:
+    std::unique_ptr<DiagnoseDaemon> _daemon;
+};
+
+TEST_F(DiagnoseDaemonTest, test_stack_trace) {
+    DiagnoseRequest request1;
+    request1.type = DiagnoseType::STACK_TRACE;
+    request1.context = "trace1";
+    ASSERT_OK(_daemon->diagnose(request1));
+
+    DiagnoseRequest request2;
+    request2.type = DiagnoseType::STACK_TRACE;
+    request2.context = "trace2";
+    ASSERT_OK(_daemon->diagnose(request2));
+    _daemon->thread_pool()->wait();
+}
+
+} // namespace starrocks

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -788,6 +788,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_load_diagnose) {
     diagnose_request.mutable_id()->set_hi(0);
     diagnose_request.mutable_id()->set_lo(0);
     diagnose_request.set_profile(true);
+    diagnose_request.set_stack_trace(true);
 
     PLoadDiagnoseResult diagnose_result;
     _load_channel->diagnose("192.168.0.1", &diagnose_request, &diagnose_result);
@@ -795,6 +796,8 @@ TEST_F(LoadChannelTestForLakeTablet, test_load_diagnose) {
     ASSERT_TRUE(diagnose_result.has_profile_status());
     ASSERT_OK(Status(diagnose_result.profile_status()));
     ASSERT_TRUE(diagnose_result.has_profile_data());
+    ASSERT_TRUE(diagnose_result.has_stack_trace_status());
+    ASSERT_OK(Status(diagnose_result.stack_trace_status()));
 
     const auto* buf = (const uint8_t*)(diagnose_result.profile_data().data());
     uint32_t len = diagnose_result.profile_data().size();

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -790,7 +790,7 @@ TEST_F(LoadChannelTestForLakeTablet, test_load_diagnose) {
     diagnose_request.set_profile(true);
 
     PLoadDiagnoseResult diagnose_result;
-    _load_channel->diagnose(&diagnose_request, &diagnose_result);
+    _load_channel->diagnose("192.168.0.1", &diagnose_request, &diagnose_result);
 
     ASSERT_TRUE(diagnose_result.has_profile_status());
     ASSERT_OK(Status(diagnose_result.profile_status()));

--- a/be/test/service/service_be/internal_service_test.cpp
+++ b/be/test/service/service_be/internal_service_test.cpp
@@ -155,12 +155,17 @@ TEST_F(InternalServiceTest, test_load_diagnose) {
     request.mutable_id()->set_hi(0);
     request.mutable_id()->set_lo(0);
     request.set_profile(true);
+    request.set_stack_trace(true);
     PLoadDiagnoseResult response;
     brpc::Controller cntl;
     MockClosure closure;
     service.load_diagnose(&cntl, &request, &response, &closure);
     ASSERT_TRUE(response.has_profile_status());
     auto st = Status(response.profile_status());
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.message().find("can't find the load channel") != std::string::npos);
+    ASSERT_TRUE(response.has_stack_trace_status());
+    st = Status(response.stack_trace_status());
     ASSERT_FALSE(st.ok());
     ASSERT_TRUE(st.message().find("can't find the load channel") != std::string::npos);
 }

--- a/be/test/util/stack_util_test.cpp
+++ b/be/test/util/stack_util_test.cpp
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/stack_util.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+namespace starrocks {
+
+using SymbolizeTuple = std::tuple<void*, char*, size_t>;
+
+void test_get_stack_trace_for_all_threads(const std::string& line_prefix) {
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("StackTraceTask::symbolize");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    int32_t num_symbolize = 0;
+    SyncPoint::GetInstance()->SetCallBack("StackTraceTask::symbolize", [&](void* arg) {
+        SymbolizeTuple* tuple = (SymbolizeTuple*)arg;
+        std::snprintf(std::get<1>(*tuple), std::get<2>(*tuple), "mock_frame_%d", num_symbolize);
+        num_symbolize += 1;
+    });
+    std::string stack_trace = get_stack_trace_for_all_threads(line_prefix);
+
+    std::vector<std::string> lines;
+    std::istringstream stream(stack_trace);
+    std::string buf;
+    while (std::getline(stream, buf, '\n')) {
+        lines.push_back(buf);
+    }
+    int32_t num_frame = 0;
+    for (auto& line : lines) {
+        ASSERT_TRUE(line_prefix.size() <= line.size());
+        ASSERT_TRUE(line.compare(0, line_prefix.size(), line_prefix) == 0);
+        if (line.find("mock_frame_") == std::string::npos) {
+            continue;
+        }
+        ASSERT_TRUE(line.find(fmt::format("mock_frame_{}", num_frame)) != std::string::npos);
+        num_frame += 1;
+    }
+    ASSERT_EQ(num_frame, num_symbolize);
+}
+
+TEST(StackUtilTest, get_stack_trace_for_all_threads) {
+    test_get_stack_trace_for_all_threads("");
+    test_get_stack_trace_for_all_threads("MOCK_PREFIX - ");
+}
+
+} // namespace starrocks

--- a/be/test/util/stack_util_test.cpp
+++ b/be/test/util/stack_util_test.cpp
@@ -19,6 +19,9 @@
 
 #include <utility>
 
+#include "testutil/sync_point.h"
+#include "util/defer_op.h"
+
 namespace starrocks {
 
 using SymbolizeTuple = std::tuple<void*, char*, size_t>;

--- a/be/test/util/stack_util_test.cpp
+++ b/be/test/util/stack_util_test.cpp
@@ -49,6 +49,9 @@ void test_get_stack_trace_for_all_threads(const std::string& line_prefix) {
     }
     int32_t num_frame = 0;
     for (auto& line : lines) {
+        if (line.empty()) {
+            continue;
+        }
         ASSERT_TRUE(line_prefix.size() <= line.size());
         ASSERT_TRUE(line.compare(0, line_prefix.size(), line_prefix) == 0);
         if (line.find("mock_frame_") == std::string::npos) {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -308,19 +308,24 @@ message PTabletWriterCancelRequest {
 message PTabletWriterCancelResult {
 };
 
-// TODO only diagnose from profile currently, and can support more diagnostic methods in the future
 message PLoadDiagnoseRequest {
     optional PUniqueId id = 1;
     optional int64 txn_id = 2;
     // whether to use profile as the diagnose method.
     // If true, will return the profile in the response
     optional bool profile = 3;
+    // whether to use stack trace as the diagnose method.
+    optional bool stack_trace = 4;
 };
 
 message PLoadDiagnoseResult {
-    // The result of the profile diagnose
+    // The result of the profile
     optional StatusPB profile_status = 1;
     optional bytes profile_data = 2;
+    // The result of stack trace. stack trace will be performed asynchronously
+    // and stored on the target BE. The Status::OK only indicates the target
+    // receives the request and will execute it.
+    optional StatusPB stack_trace_status = 3;
 };
 
 message PExecPlanFragmentRequest {

--- a/test/sql/test_profile/R/test_load_brpc_reached_timeout
+++ b/test/sql/test_profile/R/test_load_brpc_reached_timeout
@@ -41,7 +41,7 @@ admin enable failpoint "node_channel_set_brpc_timeout";
 admin enable failpoint "tablets_channel_add_chunk_wait_write_block";
 -- result:
 -- !result
-update information_schema.be_configs set value = "0" where name= "load_diagnose_small_rpc_timeout_threshold_ms";
+update information_schema.be_configs set value = "0" where name= "load_diagnose_rpc_timeout_profile_threshold_ms";
 -- result:
 -- !result
 update information_schema.be_configs set value = "30000" where name= "load_diagnose_send_rpc_timeout_ms";

--- a/test/sql/test_profile/T/test_load_brpc_reached_timeout
+++ b/test/sql/test_profile/T/test_load_brpc_reached_timeout
@@ -27,7 +27,7 @@ function: wait_materialized_view_finish()
 
 admin enable failpoint "node_channel_set_brpc_timeout";
 admin enable failpoint "tablets_channel_add_chunk_wait_write_block";
-update information_schema.be_configs set value = "0" where name= "load_diagnose_small_rpc_timeout_threshold_ms";
+update information_schema.be_configs set value = "0" where name= "load_diagnose_rpc_timeout_profile_threshold_ms";
 update information_schema.be_configs set value = "30000" where name= "load_diagnose_send_rpc_timeout_ms";
 update information_schema.be_configs set value = "2000" where name= "load_fp_brpc_timeout_ms";
 update information_schema.be_configs set value = "10000" where name= "load_fp_tablets_channel_add_chunk_block_ms";


### PR DESCRIPTION
## Why I'm doing:
A common issue encountered during import is brpc timeout, such as `[E1008]Reached timeout 150000ms@10.128.8.78:8060`. The reason may be quite complex, for example
* pk index load takes much time after tablet clone, and blocks the commit operation
* load is waiting for a mutex which is used by an unknown path

In these scenarios, it is usually necessary to capture the stack trace for analysis. The challenge is that by the time we identify the issue (usually reported by users), the scene might no longer be present, making it impossible to retrieve the stack trace from that moment. This PR introduces a mechanism where the system automatically captures and saves the stack trace upon detecting a timeout error, thereby facilitating subsequent issue troubleshooting.


## What I'm doing:
#### when to trigger
When Coordinator BE (OlapTableSink) detects the timeout error, it will send diagnose brpc request to the target BE. This process is same as #55494. The request tells the target BE to capture the stack trace. To reduce the overhead, only large brpc timeout will send the reqeust which is controlled by `config::load_diagnose_rpc_timeout_stack_trace_threshold_ms`

#### how to capture
The target BE replies the request sent by OlapTableSink immediately without waiting the capture to finish. The target BE uses a separate thread to capture the stack trace asynchronously, and stores it in be.INFO. To avoid excessive overhead,  use `config::diagnose_stack_trace_interval_ms` to control the frequency of capture

#### how to use
There may be thousands of threads in BE, so the stack trace can be large, such as 50+KB. From a usability perspective, storing it in a separate file is more convenient. However, this would introduce additional implementation complexity, such as file management (glog does not support to store different info logs to different files). Considering that the frequency of stack trace is relatively low, we temporarily store them together with other logs in `be.INFO`. To facilitate log viewing, add some special prefixes to the stack trace so that we can get a complete stack trace combining with `grep`.
This is an example about how to view the stack trace in be.INFO
1. grep the key words `diagnose stack trace, id` to find the trace matching the time you want
```
grep "diagnose stack trace, id:" be.INFO
```
```
I20250225 23:34:36.215724 139700663744064 diagnose_daemon.cpp:103] diagnose stack trace, id: 1, cost: 4792 ms, size: 53973, context: [load_id: 00a73bb3-f38e-11ef-b346-1a2eb442ad8d, txn_id: 1002, remote: 127.0.0.1]
```
2. from the log you can find the diagnose id, then grep the keywords `DIAGNOSE $id -`, and you can get all logs for this stack trace.
```
grep "DIAGNOSE 1 -" be.INFO > stack_trace.log
```
Some logs looks like
```
I20250225 23:34:36.215919 139700663744064 diagnose_daemon.cpp:50] DIAGNOSE 1 - tid: 3459312
DIAGNOSE 1 -     0x7f128c5c288d  syscall
DIAGNOSE 1 -          0x90c8f93  starrocks::get_stack_trace_for_threads_with_pattern(std::vector<int, std::allocator<int> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::al'
DIAGNOSE 1 -          0x90ca7ff  starrocks::get_stack_trace_for_all_threads(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
DIAGNOSE 1 -          0x8f23a35  starrocks::DiagnoseDaemon::_perform_stack_trace(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
DIAGNOSE 1 -          0x910c133  starrocks::ThreadPool::dispatch_thread()
DIAGNOSE 1 -          0x91037a9  starrocks::Thread::supervise_thread(void*)
DIAGNOSE 1 -     0x7f128c538ac3  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac3)
DIAGNOSE 1 -     0x7f128c5ca850  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x126850)
DIAGNOSE 1 - 3 tids: 3458648,3458653,3458654
DIAGNOSE 1 -     0x7f128c5bcbcf  __poll
DIAGNOSE 1 -          0xcd3d11e  apache::thrift::transport::TSocket::read(unsigned char*, unsigned int)
DIAGNOSE 1 -          0xcd48de1  apache::thrift::transport::TBufferedTransport::readSlow(unsigned char*, unsigned int)
DIAGNOSE 1 -          0x5743ff0  unsigned int apache::thrift::transport::readAll<apache::thrift::transport::TBufferBase>(apache::thrift::transport::TBufferBase&, unsigned char*, unsigned int)
DIAGNOSE 1 -          0x574bf46  apache::thrift::protocol::TVirtualProtocol<apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TTransport, apache::thrift::protocol::TNetworkBigEndian>, apache::thrift::protocol::TProtocolDefaults>::readMessageBegin_virt(std::__cxx11::bas'
DIAGNOSE 1 -          0x9247fc0  apache::thrift::TDispatchProcessor::process(std::shared_ptr<apache::thrift::protocol::TProtocol>, std::shared_ptr<apache::thrift::protocol::TProtocol>, void*)
DIAGNOSE 1 -          0xcd4f119  apache::thrift::server::TConnectedClient::run()
DIAGNOSE 1 -          0xcd50018  apache::thrift::server::TThreadedServer::TConnectedClientRunner::run()
DIAGNOSE 1 -          0xcd528af  apache::thrift::concurrency::Thread::threadMain(std::shared_ptr<apache::thrift::concurrency::Thread>)
DIAGNOSE 1 -          0xcd298d9  std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread> > > >::_M_run()
DIAGNOSE 1 -         0x1061c484  execute_native_thread_routine
DIAGNOSE 1 -     0x7f128c538ac3  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac3)
DIAGNOSE 1 -     0x7f128c5ca850  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x126850)
DIAGNOSE 1 - 48 tids: 3458472,3458473,3458474,3458475,3458476,3458477,3458478,3458479,3458480,3458481,3458482,3458483,3458484,3458485,3458486,3458487,3458488,3458489,3458490,3458491,3458492,3458493,3458494,3458495,3458496,3458497,3458498,3458499,3458500,3458501,3458502,3458503,3458504,3458505,3458506,3458507,3458508,3458509,3458511,3458512,3458513,3458514,3458522,3458523,3458524,3458525,3458526,3458527
DIAGNOSE 1 -     0x7f128c5c9e2e  epoll_wait
DIAGNOSE 1 -          0xce006b5  epoll_dispatch
DIAGNOSE 1 -          0xcdf5ad0  event_base_loop
DIAGNOSE 1 -         0x1061c484  execute_native_thread_routine
DIAGNOSE 1 -     0x7f128c538ac3  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac3)
DIAGNOSE 1 -     0x7f128c5ca850  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x126850)
DIAGNOSE 1 - tid: 3458466
DIAGNOSE 1 -     0x7f128c5c9e2e  epoll_wait
DIAGNOSE 1 -          0xcfc226d  brpc::EventDispatcher::Run()
DIAGNOSE 1 -          0xcfc23bd  brpc::EventDispatcher::RunThis(void*)
DIAGNOSE 1 -          0xcf83437  bthread::TaskGroup::task_runner(long)
DIAGNOSE 1 -          0xcf6c661  bthread_make_fcontext
DIAGNOSE 1 - 2 tids: 3458345,3458528
DIAGNOSE 1 -     0x7f128c5bcbcf  __poll
DIAGNOSE 1 -          0xcd447d5  apache::thrift::transport::TServerSocket::acceptImpl()
DIAGNOSE 1 -          0xcd4bc63  apache::thrift::server::TServerFramework::serve()
DIAGNOSE 1 -          0xcd511d2  apache::thrift::server::TThreadedServer::serve()
DIAGNOSE 1 -          0x90c0bb6  starrocks::ThriftServer::ThriftServerEventProcessor::supervise()
DIAGNOSE 1 -         0x1061c484  execute_native_thread_routine
DIAGNOSE 1 -     0x7f128c538ac3  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac3)
DIAGNOSE 1 -     0x7f128c5ca850  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x126850)
```



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0