### PR TITLE
[Enhancement] support breakpoint check when pk apply

### DIFF
--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
@@ -62,4 +62,8 @@ Status LocalPrimaryKeyCompactionConflictResolver::segment_iterator(
     });
 }
 
+Status LocalPrimaryKeyCompactionConflictResolver::breakpoint_check() {
+    return _tablet->update()->breakpoint_check();
+}
+
 } // namespace starrocks

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
@@ -63,7 +63,7 @@ Status LocalPrimaryKeyCompactionConflictResolver::segment_iterator(
 }
 
 Status LocalPrimaryKeyCompactionConflictResolver::breakpoint_check() {
-    return _tablet->update()->breakpoint_check();
+    return _tablet->updates()->breakpoint_check();
 }
 
 } // namespace starrocks

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.h
@@ -43,6 +43,7 @@ public:
             const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
                                        const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler)
             override;
+    Status breakpoint_check() override;
 
 private:
     // input

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -41,6 +41,7 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                 const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>& handle_delvec_result_func) {
                 std::map<uint32_t, DelVectorPtr> rssid_to_delvec;
                 for (size_t segment_id = 0; segment_id < segment_iters.size(); segment_id++) {
+                    RETURN_IF_ERROR(breakpoint_check());
                     // only hold pkey, so can use larger chunk size
                     ChunkUniquePtr chunk_shared_ptr;
                     TRY_CATCH_BAD_ALLOC(chunk_shared_ptr =

--- a/be/src/storage/primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.h
@@ -40,6 +40,7 @@ public:
     virtual ~PrimaryKeyCompactionConflictResolver() = default;
     virtual StatusOr<std::string> filename() const = 0;
     virtual Schema generate_pkey_schema() = 0;
+    virtual Status breakpoint_check() { return Status::OK(); }
     virtual Status segment_iterator(
             const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
                                        const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>&

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1050,8 +1050,11 @@ void TabletUpdates::_wait_apply_done() {
 }
 
 void TabletUpdates::stop_and_wait_apply_done() {
+    int64_t start_time = MonotonicMicros();
     _apply_stopped = true;
     _wait_apply_done();
+    int64_t duration = MonotonicMicros() - start_time;
+    StarRocksMetrics::instance()->primary_key_wait_apply_done_duration_ms.increment(duration / 1000);
 }
 
 Status TabletUpdates::breakpoint_check() {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -889,18 +889,15 @@ bool TabletUpdates::_is_retryable(Status& status) {
 }
 
 bool TabletUpdates::_is_breakpoint(Status& status) {
-    std::string_view msg;
-    std::string lower_msg;
-
-    switch (status.code()) {
-    case TStatusCode::ABORTED:
-        msg = status.message();
+    if (status.code() == TStatusCode::ABORTED) {
+        std::string_view msg = status.message();
+        std::string lower_msg;
         lower_msg.reserve(msg.size());
         for (char ch : msg) {
             lower_msg.push_back(std::tolower(static_cast<unsigned char>(ch)));
         }
         return lower_msg.find(kBreakpointMsg) != std::string::npos;
-    default:
+    } else {
         return false;
     }
 }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1055,6 +1055,7 @@ void TabletUpdates::stop_and_wait_apply_done() {
     _wait_apply_done();
     int64_t duration = MonotonicMicros() - start_time;
     StarRocksMetrics::instance()->primary_key_wait_apply_done_duration_ms.increment(duration / 1000);
+    StarRocksMetrics::instance()->primary_key_wait_apply_done_total.increment(1);
 }
 
 Status TabletUpdates::breakpoint_check() {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -73,7 +73,7 @@
 
 namespace starrocks {
 
-const std::string kBreakpointMsg = "PK apply stopped";
+const std::string kBreakpointMsg = "primary key apply stopped";
 
 std::string EditVersion::to_string() const {
     if (minor_number() == 0) {
@@ -1021,7 +1021,7 @@ void TabletUpdates::do_apply() {
         } else if (_is_breakpoint(apply_st)) {
             // apply stopped, clean states and quit.
             _reset_apply_status(*version_info_apply);
-            VLOG(2) << "apply stopped, clean states and quit tablet id: " << _tablet.tablet_id();
+            LOG(INFO) << "apply stopped, clean states and quit tablet id: " << _tablet.tablet_id();
             break;
         } else {
             if (!apply_st.ok()) {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -388,6 +388,8 @@ public:
 
     void stop_and_wait_apply_done();
 
+    Status breakpoint_check();
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -527,7 +527,8 @@ private:
                                           vector<std::pair<uint32_t, DelVectorPtr>>* delvecs);
 
     bool _check_status_msg(std::string_view msg);
-    bool _is_tolerable(Status& status);
+    bool _is_retryable(Status& status);
+    bool _is_breakpoint(Status& status);
 
     void _reset_apply_status(const EditVersionInfo& version_info_apply);
 

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -111,6 +111,7 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name), _table_metric
     REGISTER_STARROCKS_METRIC(delta_column_group_get_non_pk_hit_cache);
     REGISTER_STARROCKS_METRIC(primary_key_table_error_state_total);
     REGISTER_STARROCKS_METRIC(primary_key_wait_apply_done_duration_ms);
+    REGISTER_STARROCKS_METRIC(primary_key_wait_apply_done_total);
 
     // push request
     _metrics.register_metric("push_requests_total", MetricLabels().add("status", "SUCCESS"),

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -110,6 +110,7 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name), _table_metric
     REGISTER_STARROCKS_METRIC(delta_column_group_get_non_pk_total);
     REGISTER_STARROCKS_METRIC(delta_column_group_get_non_pk_hit_cache);
     REGISTER_STARROCKS_METRIC(primary_key_table_error_state_total);
+    REGISTER_STARROCKS_METRIC(primary_key_wait_apply_done_duration_ms);
 
     // push request
     _metrics.register_metric("push_requests_total", MetricLabels().add("status", "SUCCESS"),

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -279,6 +279,7 @@ public:
     METRIC_DEFINE_INT_COUNTER(delta_column_group_get_non_pk_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(delta_column_group_get_non_pk_hit_cache, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(primary_key_table_error_state_total, MetricUnit::REQUESTS);
+    METRIC_DEFINE_INT_GAUGE(primary_key_wait_apply_done_duration_ms, MetricUnit::MILLISECONDS);
 
     // Gauges
     METRIC_DEFINE_INT_GAUGE(memory_pool_bytes_total, MetricUnit::BYTES);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -279,7 +279,8 @@ public:
     METRIC_DEFINE_INT_COUNTER(delta_column_group_get_non_pk_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(delta_column_group_get_non_pk_hit_cache, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(primary_key_table_error_state_total, MetricUnit::REQUESTS);
-    METRIC_DEFINE_INT_GAUGE(primary_key_wait_apply_done_duration_ms, MetricUnit::MILLISECONDS);
+    METRIC_DEFINE_INT_COUNTER(primary_key_wait_apply_done_duration_ms, MetricUnit::MILLISECONDS);
+    METRIC_DEFINE_INT_COUNTER(primary_key_wait_apply_done_total, MetricUnit::REQUESTS);
 
     // Gauges
     METRIC_DEFINE_INT_GAUGE(memory_pool_bytes_total, MetricUnit::BYTES);

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3941,4 +3941,43 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
     }
 }
 
+void TabletUpdatesTest::test_apply_breakpoint_check(bool enable_persistent_index) {
+    const int N = 10;
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(enable_persistent_index);
+    ASSERT_EQ(1, _tablet->updates()->version_history_count());
+
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.reserve(64);
+    for (int i = 0; i < 64; i++) {
+        rowsets.emplace_back(create_rowset(_tablet, keys, nullptr, false));
+    }
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto version = i + 2;
+        auto st = _tablet->rowset_commit(version, rowsets[i]);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+    }
+    ASSERT_EQ(N, read_tablet(_tablet, rowsets.size() + 1));
+
+    // apply force quit
+    _tablet->updates()->stop_and_wait_apply_done();
+    // commit rowset
+    auto st = _tablet->rowset_commit(rowsets.size() + 2, rowsets[0]);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    // check breakpoint
+    ASSERT_FALSE(_tablet->updates()->breakpoint_check().ok());
+}
+
+TEST_F(TabletUpdatesTest, test_apply_breakpoint_check) {
+    test_apply_breakpoint_check(false);
+}
+
+TEST_F(TabletUpdatesTest, test_apply_breakpoint_check_pindex) {
+    test_apply_breakpoint_check(true);
+}
+
 } // namespace starrocks

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -792,7 +792,7 @@ public:
     void test_load_from_pb(bool enable_persistent_index);
     void test_remove_expired_versions(bool enable_persistent_index);
     void test_apply(bool enable_persistent_index, bool has_merge_condition);
-    void test_apply_with_force_quit(bool enable_persistent_index);
+    void test_apply_breakpoint_check(bool enable_persistent_index);
     void test_condition_update_apply(bool enable_persistent_index);
     void test_concurrent_write_read_and_gc(bool enable_persistent_index);
     void test_compaction_score_not_enough(bool enable_persistent_index);

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -792,6 +792,7 @@ public:
     void test_load_from_pb(bool enable_persistent_index);
     void test_remove_expired_versions(bool enable_persistent_index);
     void test_apply(bool enable_persistent_index, bool has_merge_condition);
+    void test_apply_with_force_quit(bool enable_persistent_index);
     void test_condition_update_apply(bool enable_persistent_index);
     void test_concurrent_write_read_and_gc(bool enable_persistent_index);
     void test_compaction_score_not_enough(bool enable_persistent_index);


### PR DESCRIPTION
## Why I'm doing:
In the current implementation, when the PK table executes the drop tablet operation, it needs to wait for the ongoing apply task to complete before it can exit. If the execution time of this apply task is exceptionally long, it will cause the drop thread to experience prolonged stalling, leading to the following issues:

1. The execution of drop tablet becomes excessively slow.
2. The drop tablet operation itself holds other locks, which can block threads other than drop, such as clone, report, and so on.

BE stack looks like:
```
0x7f8b8c491115  (unknown)
0x7f8b8c493a41  pthread_cond_wait
0xa5c20b0  std::condition_variable::wait()
0x4295d3b  starrocks::TabletUpdates::_stop_and_wait_apply_done()
0x573901c  starrocks::BaseTablet::set_tablet_state()
0x402d569  starrocks::TabletManager::drop_tablet()
0x6769e04  starrocks::run_drop_tablet_task()
0x6b42e7c  starrocks::ThreadPool::dispatch_thread()
0x6b3c38a  starrocks::Thread::supervise_thread()
0x7f8b8c494ac3  (unknown)
0x7f8b8c526850  (unknown)
(nil)  (unknown)
```

## What I'm doing:
Add a breakpoint in the execution path of the apply task, so that when the drop tablet operation occurs, the apply task no longer needs to complete its execution and can exit promptly.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0