### PR TITLE
[Enhancement] Wait apply finish out of tablet meta lock when set tablet state as SHUTDOWN

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1622,7 +1622,7 @@ Status Tablet::rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uin
 
 void Tablet::on_shutdown() {
     if (_updates) {
-        _updates->_stop_and_wait_apply_done();
+        _updates->stop_and_wait_apply_done();
     }
 }
 

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -407,6 +407,13 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
 
     DroppedTabletInfo drop_info{.tablet = dropped_tablet, .flag = flag};
 
+    // meta lock free shutdown for primary key table. In current impl, TabletUpdates's context
+    // is protected by specified lock defined in TabletUpdates itself but not tablet meta lock
+    // It is safe call _stop_and_wait_apply_done out of tablet meta lock
+    if (dropped_tablet->updates() != nullptr) {
+        dropped_tablet->updates()->on_shutdown();
+    }
+
     if (flag == kDeleteFiles) {
         {
             // NOTE: Other threads may save the tablet meta back to storage again after we
@@ -492,6 +499,13 @@ Status TabletManager::drop_tablets_on_error_root_path(const std::vector<TabletIn
     }
 
     for (const auto& dropped_tablet : dropped_tablets) {
+        // meta lock free shutdown for primary key table. In current impl, TabletUpdates's context
+        // is protected by specified lock defined in TabletUpdates itself but not tablet meta lock
+        // It is safe call _stop_and_wait_apply_done out of tablet meta lock
+        if (dropped_tablet->updates() != nullptr) {
+            dropped_tablet->updates()->on_shutdown();
+        }
+
         // make sure dropped tablet state is TABLET_SHUTDOWN IN MEMORY ONLY!
         // any persistent operation is useless because the disk has failed
         // and the IO operation should be always failed in this case.
@@ -1519,6 +1533,13 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag 
     }
 
     DroppedTabletInfo drop_info{.tablet = dropped_tablet, .flag = flag};
+
+    // meta lock free shutdown for primary key table. In current impl, TabletUpdates's context
+    // is protected by specified lock defined in TabletUpdates itself but not tablet meta lock
+    // It is safe call _stop_and_wait_apply_done out of tablet meta lock
+    if (dropped_tablet->updates() != nullptr) {
+        dropped_tablet->updates()->on_shutdown();
+    }
 
     if (flag == kDeleteFiles) {
         {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -409,9 +409,9 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
 
     // meta lock free shutdown for primary key table. In current impl, TabletUpdates's context
     // is protected by specified lock defined in TabletUpdates itself but not tablet meta lock
-    // It is safe call _stop_and_wait_apply_done out of tablet meta lock
+    // It is safe call stop_and_wait_apply_done out of tablet meta lock
     if (dropped_tablet->updates() != nullptr) {
-        dropped_tablet->updates()->on_shutdown();
+        dropped_tablet->updates()->stop_and_wait_apply_done();
     }
 
     if (flag == kDeleteFiles) {
@@ -501,9 +501,9 @@ Status TabletManager::drop_tablets_on_error_root_path(const std::vector<TabletIn
     for (const auto& dropped_tablet : dropped_tablets) {
         // meta lock free shutdown for primary key table. In current impl, TabletUpdates's context
         // is protected by specified lock defined in TabletUpdates itself but not tablet meta lock
-        // It is safe call _stop_and_wait_apply_done out of tablet meta lock
+        // It is safe call stop_and_wait_apply_done out of tablet meta lock
         if (dropped_tablet->updates() != nullptr) {
-            dropped_tablet->updates()->on_shutdown();
+            dropped_tablet->updates()->stop_and_wait_apply_done();
         }
 
         // make sure dropped tablet state is TABLET_SHUTDOWN IN MEMORY ONLY!
@@ -1536,9 +1536,9 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag 
 
     // meta lock free shutdown for primary key table. In current impl, TabletUpdates's context
     // is protected by specified lock defined in TabletUpdates itself but not tablet meta lock
-    // It is safe call _stop_and_wait_apply_done out of tablet meta lock
+    // It is safe call stop_and_wait_apply_done out of tablet meta lock
     if (dropped_tablet->updates() != nullptr) {
-        dropped_tablet->updates()->on_shutdown();
+        dropped_tablet->updates()->stop_and_wait_apply_done();
     }
 
     if (flag == kDeleteFiles) {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -84,7 +84,7 @@ std::string EditVersion::to_string() const {
 TabletUpdates::TabletUpdates(Tablet& tablet) : _tablet(tablet), _unused_rowsets(UINT64_MAX) {}
 
 TabletUpdates::~TabletUpdates() {
-    _stop_and_wait_apply_done();
+    stop_and_wait_apply_done();
 }
 
 template <class Itr1, class Itr2>
@@ -1028,7 +1028,7 @@ void TabletUpdates::_wait_apply_done() {
     }
 }
 
-void TabletUpdates::_stop_and_wait_apply_done() {
+void TabletUpdates::stop_and_wait_apply_done() {
     _apply_stopped = true;
     _wait_apply_done();
 }
@@ -4912,7 +4912,7 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta, bool rest
             RETURN_IF_ERROR(check_rowset_files(rowset_meta_pb));
         }
         // Stop apply thread.
-        _stop_and_wait_apply_done();
+        stop_and_wait_apply_done();
 
         DeferOp defer([&]() {
             if (!_error.load()) {
@@ -5644,7 +5644,7 @@ Status TabletUpdates::recover() {
     }
     LOG(INFO) << "Tablet " << _tablet.tablet_id() << " begin do recover: " << _error_msg;
     // Stop apply thread.
-    _stop_and_wait_apply_done();
+    stop_and_wait_apply_done();
 
     DeferOp defer([&]() {
         if (!_error.load()) {

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -386,6 +386,8 @@ public:
 
     void rewrite_rs_meta(bool is_fatal);
 
+    void stop_and_wait_apply_done();
+
 private:
     friend class Tablet;
     friend class PrimaryIndex;
@@ -440,7 +442,6 @@ private:
                               EditVersion* commit_version);
 
     void _wait_apply_done();
-    void _stop_and_wait_apply_done();
 
     Status _do_compaction(std::unique_ptr<CompactionInfo>* pinfo);
 


### PR DESCRIPTION
## Why I'm doing:
In current impl, when set state as SHUTDOWN for primary key tablet, BE will wait until apply task has been finished inside the tablet meta lock leading many lock contention problem. But it is no need to hold the tablet meta lock when waiting the finishing of the background apply task.

## What I'm doing:
Lock free for tablet meta lock to wait the apply task before setting the state as SHUTDOWN.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0