### PR TITLE
[BugFix] fix array_filter crash

### DIFF
--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -37,7 +37,7 @@ ConstColumn::ConstColumn(ColumnPtr data, size_t size) : _data(std::move(data)), 
 }
 
 void ConstColumn::append(const Column& src, size_t offset, size_t count) {
-    if (_size == 0) {
+    if (_size == 0 && count > 0) {
         const auto& src_column = down_cast<const ConstColumn&>(src);
         _data->append(*src_column.data_column(), 0, 1);
     }
@@ -45,7 +45,9 @@ void ConstColumn::append(const Column& src, size_t offset, size_t count) {
 }
 
 void ConstColumn::append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
-    append(src, indexes[from], size);
+    if (LIKELY(size > 0)) {
+        append(src, indexes[from], size);
+    }
 }
 
 void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {

--- a/be/test/column/const_column_test.cpp
+++ b/be/test/column/const_column_test.cpp
@@ -378,4 +378,26 @@ PARALLEL_TEST(ConstColumnTest, test_reference_memory_usage) {
     }
 }
 
+// NOLINTNEXTLINE
+PARALLEL_TEST(ConstColumnTest, test_append_with_zero_count) {
+    auto data_column = FixedLengthColumn<int32_t>::create();
+    data_column->append(2020);
+
+    auto create_const_column = [](int32_t value, size_t size) {
+        auto c = Int32Column::create();
+        c->append_numbers(&value, sizeof(value));
+        return ConstColumn::create(c, size);
+    };
+
+    auto c1 = create_const_column(1, 3);
+    // append with count==0
+    c1->append(*data_column, 0, 0);
+
+    std::vector<uint32_t> index;
+    c1->append_selective(*data_column, index.data(), 0, 0);
+
+    ASSERT_EQ(true, c1->is_constant());
+    ASSERT_EQ(3, c1->size());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
when array_filter's create dst column as const column, but  all data in src column are filterd, then we will call const_column's append_selective with zero element. But right now const_column's append_selective can't handle empty input.

## What I'm doing:

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/9294)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0