### PR TITLE
[BugFix] Fix the bug of incorrect updates in the vacuum version.

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -347,13 +347,13 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
     }
     auto t1 = butil::gettimeofday_ms();
     g_metadata_travel_latency << (t1 - t0);
-    // if skip_check_grace_timestamp is false which means all tablet metadata files encountered were created after the grace timestamp
-    // so the vacuumed_version will be set to min garbage version
-    *vacuumed_version = skip_check_grace_timestamp ? final_retain_version : version;
     if (!skip_check_grace_timestamp) {
         // All tablet metadata files encountered were created after the grace timestamp, there were no files to delete
+        // The vacuumed_version will be set to min garbage version
+        *vacuumed_version = version;
         return Status::OK();
     }
+    *vacuumed_version = final_retain_version;
     DCHECK_LE(version, final_retain_version);
     for (auto v = version + 1; v < final_retain_version; v++) {
         RETURN_IF_ERROR(metafile_deleter->delete_file(join_path(meta_dir, tablet_metadata_filename(tablet_id, v))));

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -349,8 +349,10 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
     g_metadata_travel_latency << (t1 - t0);
     if (!skip_check_grace_timestamp) {
         // All tablet metadata files encountered were created after the grace timestamp, there were no files to delete
-        // The vacuumed_version will be set to min garbage version
-        *vacuumed_version = version;
+        // The final_retain_version is set to min_retain_version or minmum exist version which has garbage files.
+        // So we set vacuumed_version to `final_retain_version - 1` to avoid the garbage files of final_retain_version can
+        // not be deleted
+        *vacuumed_version = final_retain_version - 1;
         return Status::OK();
     }
     *vacuumed_version = final_retain_version;
@@ -402,7 +404,7 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
         (*vacuumed_files) += datafile_deleter.delete_count();
         (*vacuumed_files) += metafile_deleter.delete_count();
     }
-    *vacuumed_version = final_vacuum_version；
+    *vacuumed_version = final_vacuum_version;
     return Status::OK();
 }
 

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -590,7 +590,7 @@ TEST_P(LakeVacuumTest, test_vacuum_3) {
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
         EXPECT_EQ(0, response.vacuumed_files());
         EXPECT_EQ(0, response.vacuumed_file_size());
-        EXPECT_EQ(2, response.vacuumed_version());
+        EXPECT_EQ(0, response.vacuumed_version());
 
         ensure_all_files_exist();
     }

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1357,6 +1357,7 @@ TEST_P(LakeVacuumTest, test_vacuumed_version) {
                 "data_size": 4096
             }
         ],
+        "prev_garbage_version": 0,
         "commit_time": 1687331159
         }
         )DEL")));
@@ -1419,6 +1420,21 @@ TEST_P(LakeVacuumTest, test_vacuumed_version) {
         request.add_tablet_ids(10001);
         request.add_tablet_ids(10002);
         request.set_min_retain_version(4);
+        request.set_grace_timestamp(1687331158);
+        request.set_min_active_txn_id(12344);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_EQ(0, response.vacuumed_version());
+    }
+
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(true);
+        request.add_tablet_ids(10001);
+        request.add_tablet_ids(10002);
+        request.set_min_retain_version(4);
         request.set_grace_timestamp(1687331161);
         request.set_min_active_txn_id(12344);
         vacuum(_tablet_mgr.get(), request, &response);
@@ -1439,7 +1455,7 @@ TEST_P(LakeVacuumTest, test_vacuumed_version) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-        EXPECT_EQ(4, response.vacuumed_version());
+        EXPECT_EQ(3, response.vacuumed_version());
     }
 }
 

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -590,7 +590,7 @@ TEST_P(LakeVacuumTest, test_vacuum_3) {
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
         EXPECT_EQ(0, response.vacuumed_files());
         EXPECT_EQ(0, response.vacuumed_file_size());
-        EXPECT_EQ(0, response.vacuumed_version());
+        EXPECT_EQ(1, response.vacuumed_version());
 
         ensure_all_files_exist();
     }
@@ -1425,7 +1425,7 @@ TEST_P(LakeVacuumTest, test_vacuumed_version) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-        EXPECT_EQ(0, response.vacuumed_version());
+        EXPECT_EQ(1, response.vacuumed_version());
     }
 
     {


### PR DESCRIPTION
## Why I'm doing:
We add vacuum version into partition to decide one partition need vacuum or not. And only the partition which minRetainVersion is greater than lastSuccessVersion will trigger vacuum. So the lastSuccessVersion will be set to the minimum vacuum success version for all tablets.

However, there exist the following special case:
1. one tablet has 3 metadata which version is 8, 9, 10 and their prev_garbage_version values are all 6.
2. the version 10 is generated by compaction so there exist some garbage files could be deleted.
3. FE send vacuum request to this tablet but all metadata files are created after the grace timestamp, so we won't delete any files [[1]](https://github.com/StarRocks/starrocks/pull/56273/files#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750R353-R355)
4. the vacuum_version of this tablet will be set to 10 because the min_retain_version is 10.  [[1]](https://github.com/StarRocks/starrocks/pull/56273/files#diff-891803f977da48b5a81315b3d324316e8bdd578537dc5bdeef32cf34ebb5f750R353-R355)
5. FE will update lastSuccessVersion to 10 and the compaction input files of version 10 will not be deleted if the tablet is not change anymore.

## What I'm doing:
We should set tablet vacuum version to the earliest pre_garbage_version if we don't delete any files.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.4
  - [x] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0