### PR TITLE
[BugFix] Fix ASAN crash when minmax runtime filter evaluate null literal

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -526,8 +526,10 @@ public:
         uint8_t* selection = selection_filter.data();
         if (input_column->is_constant()) {
             const auto* const_column = down_cast<const ConstColumn*>(input_column);
-            if (const_column->only_null() && evaluate_null) {
-                selection[0] = _has_null;
+            if (const_column->only_null()) {
+                if constexpr (evaluate_null) {
+                    selection[0] = _has_null;
+                }
             } else {
                 const auto& input_data = GetContainer<Type>::get_data(const_column->data_column());
                 evaluate_min_max(input_data, selection, 1);

--- a/be/test/exprs/runtime_filter_test.cpp
+++ b/be/test/exprs/runtime_filter_test.cpp
@@ -335,6 +335,13 @@ TEST_F(RuntimeBloomFilterTest, TestJoinRuntimeFilter) {
     chunk.filter(selection);
     // 0 17 34 ... 187
     EXPECT_EQ(chunk.num_rows(), 12);
+
+    auto null_literal = ColumnHelper::create_const_null_column(4096);
+    selection.assign(null_literal->size(), 0);
+    rf->evaluate(null_literal.get(), &ctx);
+    for (auto v : selection) {
+        ASSERT_EQ(1, v);
+    }
 }
 
 TEST_F(RuntimeBloomFilterTest, TestJoinRuntimeFilterSlice) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

close https://github.com/StarRocks/StarRocksTest/issues/9308

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0